### PR TITLE
test: adapt plugin specs to the widened version matrix

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -612,7 +612,9 @@ async function createSandbox (
   }
 
   if (cappedDependencies.length > 0) {
-    execHelper(`${BUN} add ${cappedDependencies.join(' ')} ${addFlags.join(' ')}`, addOptions)
+    // knex 1.x pulls in the @vscode/sqlite3 fork, which compiles from source when no prebuilt matches the runner
+    // and routinely runs past the 60s default.
+    execHelper(`${BUN} add ${cappedDependencies.join(' ')} ${addFlags.join(' ')}`, { ...addOptions, timeout: 300_000 })
   }
 
   execHelper(`${BUN} add file:${out} ${[...addFlags, '--ignore-scripts'].join(' ')}`, addOptions)

--- a/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
+++ b/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
@@ -22,9 +22,10 @@ describe('express-mongo-sanitize', () => {
       })
 
       before((done) => {
-        // Highest version of express that supports express-mongo-sanitize is <5
-        // This is defined in externals.js
-        const express = require('../../../versions/express').get()
+        // Highest version of express that supports express-mongo-sanitize is <5 (express 5 makes req.query a
+        // getter-only property). The unversioned `versions/express` folder tracks the latest express (now 5.x), so
+        // pin the <5 range that externals.js installs for this plugin.
+        const express = require('../../../versions/express@>=4 <5').get()
         const expressMongoSanitize = require(`../../../versions/express-mongo-sanitize@${version}`).get()
         const app = express()
 

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -37,6 +37,9 @@ describe('Plugin', () => {
         })
 
         beforeEach(() => {
+          // The legacy `elasticsearch` package emits the deprecated `util._extend` at module load and `util.isArray`
+          // at client construction; allow each before its triggering call so the deprecation guard does not throw.
+          temporaryWarningExceptions.add('The `util._extend` API is deprecated. Please use Object.assign() instead.')
           elasticsearch = metaModule.get()
 
           temporaryWarningExceptions.add('The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.')

--- a/packages/datadog-plugin-grpc/test/invalid.proto
+++ b/packages/datadog-plugin-grpc/test/invalid.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package test;
 
@@ -10,10 +10,14 @@ service TestService {
 }
 
 message Request {
-  string first = 1;
-  int32 second = 2;
+  optional string first = 1;
+  optional int32 second = 2;
 }
 
+// The client loads this fixture while the server answers with the empty `Response`
+// from test.proto. `required first` makes the client fail to decode that empty reply,
+// which is the gRPC protocol error (status 13) this test asserts. It must be proto2:
+// proto3 forbids `required`, so @grpc/proto-loader rejects it at loadSync.
 message Response {
   required string first = 1;
 }

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -11,8 +11,11 @@ const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
+// hapi 19.x and 20.x are EOL and hang CI: on error and 404 replies they crash inside their own
+// `Request._finalize` (null `response.statusCode`) and never finish the request, stalling the
+// worker until the job is cancelled. 21.x fixed it, so the matrix covers 16.x and 21+.
 const versionRange = parseInt(process.versions.node.split('.')[0]) > 14
-  ? '<17 || >18'
+  ? '<17 || >=21'
   : ''
 
 describe('Plugin', () => {

--- a/packages/datadog-plugin-knex/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-knex/test/integration-test/client.spec.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+
+const semver = require('semver')
+
 const {
   sandboxCwd,
   useSandbox,
@@ -12,11 +15,14 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
-withVersions('knex', 'knex', version => {
+withVersions('knex', 'knex', (version, _, resolvedVersion) => {
   describe('ESM', () => {
     let variants, proc, agent
 
-    useSandbox([`'knex@${version}'`, 'express', 'sqlite3'], false,
+    // knex 1.x routes the `sqlite3` client through the @vscode/sqlite3 fork; every other major uses sqlite3.
+    const sqlite3Driver = semver.satisfies(resolvedVersion, '1.x') ? '@vscode/sqlite3' : 'sqlite3'
+
+    useSandbox([`'knex@${version}'`, 'express', sqlite3Driver], false,
       ['./packages/datadog-plugin-knex/test/integration-test/*'])
 
     before(function () {

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -21,8 +21,10 @@ describe('Plugin', () => {
     withVersions('restify', 'restify', version => {
       const pkgVersion = require(`../../../versions/restify@${version}`).version()
 
-      // Some internal code of older versions is not compatible with Node >6
-      if (semver.intersects(pkgVersion, '<5')) return
+      // restify <4 fails to load (its `dtrace-provider` native dep has no prebuilt binding), and 7.x-9.x crash
+      // on load on Node >=18 (they assign the now getter-only `IncomingMessage#closed`). Skip those; the
+      // remaining majors (4-6, 10+) load and run against this suite.
+      if (semver.intersects(pkgVersion, '<4.0.0') || semver.intersects(pkgVersion, '>=7.0.0 <10.0.0')) return
 
       beforeEach(() => {
         tracer = require('../../dd-trace')
@@ -92,7 +94,11 @@ describe('Plugin', () => {
           })
         })
 
-        it('should support routing with async functions and middleware', done => {
+        // restify added async route handler/middleware support in 7.x; older majors never await the
+        // returned promise, so the request hangs. Only assert async routing where the feature exists.
+        it('should support routing with async functions and middleware', function (done) {
+          if (!semver.intersects(pkgVersion, '>=7')) return this.skip()
+
           const server = restify.createServer()
 
           server.get(
@@ -121,7 +127,9 @@ describe('Plugin', () => {
           })
         })
 
-        it('should route without producing any warnings', done => {
+        it('should route without producing any warnings', function (done) {
+          if (!semver.intersects(pkgVersion, '>=7')) return this.skip()
+
           const warningSpy = sinon.spy((_, msg) => {
             // eslint-disable-next-line no-console
             console.error(`route called with warning: ${msg}`)

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -20,8 +20,11 @@ describe('esm', () => {
   let proc
   let variants
 
-  // test against later versions because server.mjs uses newer package syntax
-  withVersions('restify', 'restify', '>3', version => {
+  // restify 7.x-9.x crash on load on this job's Node >=18 matrix: they assign the now getter-only
+  // `IncomingMessage#closed` (`TypeError: Cannot set property closed`). 4.x-6.x predate that assignment
+  // and 10.x+ dropped it, so exercise those and skip only the broken middle majors. (server.mjs's import
+  // syntax already requires >3.)
+  withVersions('restify', 'restify', '>3 <7 || >=10', version => {
     useSandbox([`'restify@${version}'`],
       false, ['./packages/datadog-plugin-restify/test/integration-test/*'])
 


### PR DESCRIPTION
## Summary

The resolver installs majors these specs never previously ran against, exposing version-specific incompatibilities. One commit per plugin:

1. `restify`: skip `<4` (native `dtrace-provider` has no prebuilt) and 7.x-9.x (crash on Node >=18 assigning getter-only `IncomingMessage#closed`); gate the async-routing assertions on `>=7`.
2. `knex`: 1.x routes the sqlite3 client through the `@vscode/sqlite3` fork; install it for 1.x only and raise the sandbox `add` timeout (it builds from source).
3. `grpc`: make `invalid.proto` proto2 so its `required` field survives `loadSync` and still triggers the status-13 decode error.
4. `hapi`: 19.x/20.x are EOL and hang CI inside `Request._finalize`; cover 16.x and 21+.
5. `elasticsearch`: allow the `util._extend` deprecation the legacy client emits at load.
6. `express-mongo-sanitize`: pin the `<5` express folder (express 5 makes `req.query` getter-only).

Independent of the resolver rework: every change is a conditional gate or fixture tweak that holds on the current matrix; the new majors are simply not exercised until it widens.

## Test plan

- [ ] The restify, knex, grpc, hapi, elasticsearch, and express-mongo-sanitize plugin jobs are green on the widened matrix.