### PR TITLE
ci: add nightly version-coverage check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -279,6 +279,7 @@
 /.github/workflows/custom-node-version-dispatch.yml @Datadog/lang-platform-js
 /.github/workflows/project.yml @Datadog/lang-platform-js
 /.github/workflows/stale.yml @Datadog/lang-platform-js
+/.github/workflows/version-coverage.yml @Datadog/lang-platform-js
 /scripts/check-no-mcr-images.js @Datadog/lang-platform-js
 
 /.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       - run: npm run test:release
+      - run: npm run test:scripts
 
   generated-config-types:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-coverage.yml
+++ b/.github/workflows/version-coverage.yml
@@ -1,0 +1,23 @@
+name: Version Coverage
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-coverage:
+    name: Check version coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/install
+      - run: node scripts/check-version-coverage.js

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "test:integration:plugins:coverage": "yarn services && node ./integration-tests/coverage/run-suite.js \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/${SPEC:-*}*.spec.js\"",
     "test:unit:plugins": "mocha \"packages/datadog-instrumentations/test/@(${PLUGINS}).spec.js\" \"packages/datadog-plugin-@(${PLUGINS})/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/*.spec.js\"",
     "test:release": "mocha \"scripts/release/**/*.spec.js\"",
+    "test:scripts": "mocha \"scripts/helpers/**/*.spec.js\"",
     "test:shimmer": "mocha \"packages/datadog-shimmer/test/**/*.spec.js\"",
     "test:shimmer:ci": "nyc --silent node init && nyc -- npm run test:shimmer",
     "verify:workflow-job-names": "node scripts/verify-workflow-job-names.js",

--- a/packages/dd-trace/test/plugins/versions.spec.js
+++ b/packages/dd-trace/test/plugins/versions.spec.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+const { coerce, major } = require('semver')
+
+const { getVersionList, resolvePluginVersions } = require('./versions')
+
+const latests = require('./versions/package.json').dependencies
+
+const keys = (name, versions, nonConsecutive) =>
+  getVersionList(name, versions, nonConsecutive).map(({ versionKey }) => versionKey)
+
+const latestMajorKey = name => String(major(coerce(latests[name])))
+
+describe('getVersionList', () => {
+  it('collapses the wildcard to the latest major', () => {
+    assert.deepEqual(keys('mongodb', ['*']), [latestMajorKey('mongodb')])
+  })
+
+  it('collapses equivalent exact-version notations to a single key', () => {
+    assert.deepEqual(keys('mongodb', ['1.2.3', '=1.2.3', 'v1.2.3']), ['1.2.3'])
+  })
+
+  it('pins the floor and the major for a single-major range', () => {
+    // `<3` caps the range to major 2, so only the pinned floor and the latest of major 2 are keys.
+    assert.deepEqual(keys('mongodb', ['>=2 <3']), ['2.0.0', '2'])
+  })
+
+  it('covers the floor major and every major up to the range top', () => {
+    // `<5` caps the top at major 4; the floor (2.0.0) is pinned and majors 2-4 each resolve to their latest.
+    assert.deepEqual(keys('mongodb', ['>=2 <5']), ['2.0.0', '2', '3', '4'])
+  })
+
+  it('covers every major from the floor to the capped top', () => {
+    // `<6` caps the top at major 5; the floor major's latest (1) is covered too, not only the newest of the range.
+    assert.deepEqual(keys('mongodb', ['>=1 <6']), ['1.0.0', '1', '2', '3', '4', '5'])
+  })
+
+  it('de-duplicates a shared floor across multiple ranges', () => {
+    assert.deepEqual(keys('mongodb', ['>=2 <3', '^2.0.0']), ['2.0.0', '2'])
+  })
+
+  it('consolidates the floor with the top major when the floor is the pinned latest', () => {
+    // `>=<pinned latest>` floors at the newest version, so the bare top-major key resolves to that same version and is
+    // dropped; the pinned package.json is what proves the two keys identical.
+    assert.deepEqual(keys('mongodb', [`>=${latests.mongodb}`]), [latests.mongodb])
+  })
+
+  it('adds the floor, the floor major and the top major for non-consecutive packages', () => {
+    // The middle majors may be unpublished, but the floor major (1) and the top major (5) both exist and are tested.
+    assert.deepEqual(keys('mongodb', ['>=1 <6'], new Set(['mongodb'])), ['1.0.0', '1', '5'])
+  })
+
+  it('treats the built-in non-consecutive packages as floor + floor major + top major', () => {
+    // graphql jumps from 0.x to 14.x; 1.x–13.x are skipped, but the latest 0.x and the newest major are still tested.
+    assert.deepEqual(keys('graphql', ['>=0.10']), ['0.10.0', '0', latestMajorKey('graphql')])
+  })
+
+  it('throws on an unparseable range', () => {
+    assert.throws(() => getVersionList('mongodb', ['not-a-version']), /Invalid version range/)
+  })
+
+  it('throws on an empty entry', () => {
+    assert.throws(() => getVersionList('mongodb', ['', '>=2 <3']), /Empty version entry/)
+  })
+})
+
+describe('resolvePluginVersions', () => {
+  const versionKeys = result => result.versionList.map(({ versionKey }) => versionKey)
+
+  it('expands the declared versions and points the unversioned folder at the newest in-scope key', () => {
+    const result = resolvePluginVersions({ name: 'mongodb', declaredVersions: ['>=2 <5'], env: {} })
+
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
+  })
+
+  it('filters the installed keys by RANGE and follows the filtered tail', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=1 <6'],
+      env: { RANGE: '>=2.0.0 <4.0.0' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['2', '3'])
+    assert.equal(result.unversioned, '3')
+  })
+
+  it('replaces the declared versions with PACKAGE_VERSION_RANGE when the module is honoured', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <5'],
+      env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['3.0.0', '3'])
+    assert.equal(result.unversioned, '>=3 <4')
+  })
+
+  it('ignores PACKAGE_VERSION_RANGE for a sibling external that must not be sharded', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <5'],
+      honourEnvRange: false,
+      env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
+  })
+
+  it('keeps the unversioned folder on the raw shard while RANGE narrows the installed keys', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=1 <6'],
+      env: { PACKAGE_VERSION_RANGE: '>=2 <5', RANGE: '>=3.0.0 <4.0.0' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['3'])
+    assert.equal(result.unversioned, '>=2 <5')
+  })
+
+  it('reports nothing in scope when no version is declared', () => {
+    const result = resolvePluginVersions({ name: 'mongodb', declaredVersions: [], env: {} })
+
+    assert.deepEqual(result.versionList, [])
+    assert.equal(result.unversioned, undefined)
+  })
+
+  it('reports nothing in scope when RANGE excludes every declared key', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <3'],
+      env: { RANGE: '>=9.0.0 <10.0.0' },
+    })
+
+    assert.deepEqual(result.versionList, [])
+    assert.equal(result.unversioned, undefined)
+  })
+})

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -1,9 +1,19 @@
 'use strict'
 
-const { subset } = require('semver')
+const { clean, coerce, intersects, subset } = require('semver')
+
 const latests = require('./package.json').dependencies
 
 const exactVersionExp = /^=?\d+\.\d+\.\d+/
+
+// Packages whose published majors are not contiguous. `getVersionList()` must not auto-fill their in-between majors:
+// the missing majors were never published, so installing them fails. A failing install of a multi-major range is the
+// signal to add a package here (the install script's error points back to this list). New entries must explain the gap
+// so the next reader does not "fix" it by removing the entry.
+const nonConsecutiveMajorPackages = new Set([
+  'graphql', // jumps from 0.x straight to 14.x (no 1.x–13.x); 14.x–17.x are covered via the apollo externals entries
+  '@redis/client', // jumps from 2.x to 5.x (no 3.x–4.x)
+])
 
 /**
  * @param {string} name
@@ -40,6 +50,150 @@ function capSubrange (name, subrange) {
   return `${subrange} <=${latests[name]}`
 }
 
+/**
+ * Expand a module's declared version entries into the de-duplicated set of version keys to install and test. Each key
+ * maps to a `versions/<name>@<key>` workspace folder; the install script and `withVersions()` share this so the set of
+ * installed folders and the set of tested folders never drift apart.
+ *
+ * Per declared range this yields the lowest supported version (pinned exactly) and the newest version of every major
+ * the range spans, keyed by the bare major so the key resolves to that major's latest. Covering each major explicitly
+ * (rather than emitting the raw range, which resolves only to the newest version of the whole range) makes sure the
+ * floor major's latest is tested too. The top major is derived from the pinned latest in `package.json` rather than a
+ * registry lookup, so a major that was never published makes the install fail loudly — the signal to add the package
+ * to `nonConsecutiveMajorPackages`.
+ *
+ * Notations that resolve to the same exact version (`1.2.3`, `=1.2.3`, `v1.2.3`) collapse to a single key, and `*`
+ * collapses to the latest major (the same version an open-ended range resolves to), so a version is never installed
+ * twice under different spellings. A floor that equals the pinned latest also drops the redundant top-major key,
+ * since the pinned `package.json` proves they resolve to the same version.
+ *
+ * @param {string} name The module name, e.g. `mongodb`.
+ * @param {string[]} versions The declared version entries, e.g. `['>=3.3 <5', '5', '>=6']`.
+ * @param {Set<string>} [nonConsecutiveMajors] Module names whose majors are not contiguous; injectable for testing.
+ * @returns {Array<{ versionKey: string, range: string }>} Ordered, de-duplicated entries. `versionKey` is the folder
+ *   suffix; `range` is the declaring entry it came from.
+ */
+function getVersionList (name, versions, nonConsecutiveMajors = nonConsecutiveMajorPackages) {
+  /** @type {Map<string, { versionKey: string, range: string }>} */
+  const entries = new Map()
+
+  const add = (versionKey, range) => {
+    if (!entries.has(versionKey)) entries.set(versionKey, { versionKey, range })
+  }
+
+  for (const range of versions) {
+    // An empty entry is a setup mistake (a stray comma or an undefined slot); fail loudly rather than skip silently.
+    if (!range) {
+      throw new Error(`Empty version entry declared for '${name}'. Each declared version must be a non-empty range.`)
+    }
+
+    if (range === '*') {
+      add(latestMajor(name), range)
+      continue
+    }
+
+    // Exact-version notations collapse to one key so the same version is never installed twice.
+    const exact = clean(range)
+    if (exact) {
+      add(exact, range)
+      continue
+    }
+
+    const floor = coerce(range)
+    if (!floor) throw new Error(`Invalid version range for '${name}': ${range}`)
+
+    add(floor.version, range)
+
+    const topMajor = highestMajor(name, range, floor.major)
+    if (nonConsecutiveMajors.has(name)) {
+      // Only the in-between majors were never published. The floor major and the top major both exist, so add the
+      // latest of each (skipping the uncertain middle, which is what would make the install fail).
+      add(String(floor.major), range)
+      if (topMajor > floor.major) add(String(topMajor), range)
+    } else {
+      for (let major = floor.major; major <= topMajor; major++) {
+        if (intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) add(String(major), range)
+      }
+    }
+  }
+
+  // The bare-major key for the pinned latest's major resolves to the pin itself, so when a declared floor already pins
+  // that exact version the major key would install the same thing. Drop it. This is the only such redundancy the
+  // pinned upper bound lets us prove; for lower majors the newest published version is unknown without the registry.
+  const pinned = coerce(latests[name])
+  if (pinned && entries.has(pinned.version)) entries.delete(String(pinned.major))
+
+  return [...entries.values()]
+}
+
+/**
+ * The latest major of `name` as a bare-major version key. `*` resolves here so it de-duplicates against an open-ended
+ * range whose top resolves to the same newest version.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function latestMajor (name) {
+  const latest = coerce(latests[name])
+  if (!latest) {
+    throw new Error(
+      `Latest version for '${name}' needs to be defined in 'packages/dd-trace/test/plugins/versions/package.json'.`
+    )
+  }
+  return String(latest.major)
+}
+
+/**
+ * Highest major still spanned by `range`, capped at the pinned latest. Iterates down from the latest so the first
+ * intersecting major is the top; nothing above the pinned latest is installed.
+ *
+ * @param {string} name
+ * @param {string} range
+ * @param {number} floorMajor
+ * @returns {number}
+ */
+function highestMajor (name, range, floorMajor) {
+  const latest = coerce(latests[name])
+  if (!latest) return floorMajor
+  for (let major = latest.major; major > floorMajor; major--) {
+    if (intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) return major
+  }
+  return floorMajor
+}
+
+/**
+ * Resolve which version keys to install and test for a module, plus which key the unversioned
+ * `versions/<name>` folder points at. `scripts/install_plugin_modules.js` and `withVersions()` both call this so the
+ * installed folder set and the tested folder set are derived from one place and cannot drift.
+ *
+ * @param {object} options
+ * @param {string} options.name The module name, e.g. `fastify`.
+ * @param {string[]} options.declaredVersions The declared version entries to expand.
+ * @param {boolean} [options.honourEnvRange] Whether `PACKAGE_VERSION_RANGE` applies to this module. False for sibling
+ *   externals that must stay on their declared versions while the matrix shards a different package.
+ * @param {NodeJS.ProcessEnv} [options.env] Injectable for testing.
+ * @returns {{ versionList: Array<{ versionKey: string, range: string }>, unversioned: string|undefined }} The ordered,
+ *   `RANGE`-filtered key set, and the key the default `versions/<name>` folder resolves to (the newest in-scope entry,
+ *   or `undefined` when nothing is in scope).
+ */
+function resolvePluginVersions ({ name, declaredVersions, honourEnvRange = true, env = process.env }) {
+  const useEnvRange = Boolean(env.PACKAGE_VERSION_RANGE) && honourEnvRange
+  const versions = useEnvRange ? [env.PACKAGE_VERSION_RANGE] : declaredVersions
+
+  let versionList = getVersionList(name, versions)
+  if (env.RANGE) {
+    versionList = versionList.filter(({ versionKey }) => subset(versionKey, env.RANGE))
+  }
+
+  // With `PACKAGE_VERSION_RANGE` the shard itself is the target, so the unversioned folder keeps the raw range even
+  // when `RANGE` narrows the installed keys; otherwise it follows the newest in-scope key.
+  const unversioned = useEnvRange ? env.PACKAGE_VERSION_RANGE : versionList.at(-1)?.versionKey
+
+  return { versionList, unversioned }
+}
+
 module.exports = {
-  getCappedRange
+  getCappedRange,
+  getVersionList,
+  resolvePluginVersions,
 }

--- a/scripts/check-version-coverage.js
+++ b/scripts/check-version-coverage.js
@@ -1,0 +1,181 @@
+'use strict'
+
+/* eslint-disable no-console */
+
+// Registry-aware coverage check: for every package the plugin test matrix installs, ask the npm
+// registry which majors are published and flag any that fall inside the declared support range but
+// that no installed folder ever resolves to. It catches the silent drift where upstream ships a new
+// major (or the pinned `latests` falls behind) and the matrix keeps testing the old set. Run nightly
+// rather than per-PR: it is network-bound and its result changes when upstream publishes, not when we
+// push.
+
+const fs = require('fs')
+const { builtinModules } = require('module')
+const path = require('path')
+
+// eslint-disable-next-line n/no-restricted-require
+const semver = require('semver')
+
+const { getVersionList } = require('../packages/dd-trace/test/plugins/versions')
+const { getInstrumentation } = require('../packages/dd-trace/test/setup/helpers/load-inst')
+const externals = require('../packages/dd-trace/test/plugins/externals')
+const mapWithConcurrency = require('./helpers/concurrency')
+
+const REGISTRY = 'https://registry.npmjs.org'
+const CONCURRENCY = 12
+const builtins = new Set(builtinModules)
+
+/**
+ * Collect the declared version ranges for every npm package the matrix installs, merging the
+ * `addHook` declarations (the source of truth for supported versions) with the auxiliary anchors
+ * declared in externals.js.
+ *
+ * @returns {Map<string, Set<string>>} Package name to the set of declared ranges.
+ */
+function collectDeclaredVersions () {
+  const declared = new Map()
+  /**
+   * @param {string} name
+   * @param {string[]|undefined} versions
+   */
+  const addRanges = (name, versions) => {
+    if (!versions) return
+    const ranges = declared.get(name) ?? new Set()
+    for (const range of versions) {
+      if (range) ranges.add(range)
+    }
+    declared.set(name, ranges)
+  }
+
+  const instrumentationsDir = path.join(__dirname, '../packages/datadog-instrumentations/src')
+  for (const file of fs.readdirSync(instrumentationsDir)) {
+    if (!file.endsWith('.js')) continue
+    let instrumentations
+    try {
+      instrumentations = getInstrumentation(file.slice(0, -3))
+    } catch {
+      continue
+    }
+    for (const instrumentation of instrumentations) {
+      addRanges(instrumentation.name, instrumentation.versions)
+    }
+  }
+
+  for (const name of Object.keys(externals)) {
+    for (const entry of externals[name]) {
+      addRanges(entry.name, entry.versions)
+    }
+  }
+
+  return declared
+}
+
+/**
+ * Fetch the published, non-prerelease versions of an npm package.
+ *
+ * @param {string} name
+ * @returns {Promise<string[]|undefined>} The versions, or `undefined` when the package is not on the registry.
+ */
+async function fetchPublishedVersions (name) {
+  const response = await fetch(`${REGISTRY}/${name.replaceAll('/', '%2f')}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  })
+  if (response.status === 404) return
+  if (!response.ok) throw new Error(`registry responded ${response.status}`)
+  const body = await response.json()
+  return Object.keys(body.versions ?? {}).filter(version => !semver.prerelease(version))
+}
+
+/**
+ * Compare the declared range against the majors the matrix actually resolves to, and report the
+ * published majors that sit inside the declared range but that no installed folder covers.
+ *
+ * @param {string} name
+ * @param {Set<string>} ranges
+ * @param {string[]} published
+ * @returns {{ supportedRange: string, testedMajors: number[], untestedMajors: number[] }}
+ */
+function analyzeCoverage (name, ranges, published) {
+  const declaredVersions = [...ranges]
+  const supportedRange = declaredVersions.join(' || ')
+
+  const testedMajors = new Set()
+  for (const { versionKey } of getVersionList(name, declaredVersions)) {
+    const resolved = semver.maxSatisfying(published, versionKey)
+    if (resolved) testedMajors.add(semver.major(resolved))
+  }
+
+  const untestedMajors = new Set()
+  for (const version of published) {
+    const major = semver.major(version)
+    if (!testedMajors.has(major) && semver.satisfies(version, supportedRange)) {
+      untestedMajors.add(major)
+    }
+  }
+
+  return {
+    supportedRange,
+    testedMajors: [...testedMajors].sort((first, second) => first - second),
+    untestedMajors: [...untestedMajors].sort((first, second) => first - second),
+  }
+}
+
+async function main () {
+  const declared = [...collectDeclaredVersions()].filter(([name]) => !builtins.has(name))
+
+  const results = await mapWithConcurrency(declared, CONCURRENCY, async ([name, ranges]) => {
+    try {
+      const published = await fetchPublishedVersions(name)
+      if (!published?.length) return { name, skipped: true }
+      return { name, ...analyzeCoverage(name, ranges, published) }
+    } catch (error) {
+      return { name, error: error.message }
+    }
+  })
+
+  const gaps = []
+  const errors = []
+  const skipped = []
+  for (const result of results) {
+    if (result.error) errors.push(result)
+    else if (result.skipped) skipped.push(result)
+    else if (result.untestedMajors?.length) gaps.push(result)
+  }
+
+  for (const { name, supportedRange, testedMajors, untestedMajors } of gaps) {
+    console.log(
+      `${name}: published major(s) ${untestedMajors.join(', ')} are within the declared range ` +
+      `"${supportedRange}" but the matrix only resolves majors ${testedMajors.join(', ')}`
+    )
+  }
+
+  if (errors.length) {
+    console.log(`\nCould not reach the registry for ${errors.length} package(s):`)
+    for (const { name, error } of errors) {
+      console.log(`  ${name}: ${error}`)
+    }
+  }
+
+  if (skipped.length) {
+    console.log(`\nNot on the public registry, skipped: ${skipped.map(({ name }) => name).join(', ')}`)
+  }
+
+  console.log(`\nChecked ${declared.length} packages (${skipped.length} not on the public registry, ` +
+    `${errors.length} errored).`)
+
+  if (gaps.length) {
+    console.log(
+      `\n${gaps.length} package(s) publish a supported major the test matrix never resolves to. ` +
+      'Cover the major (bump the pinned latest or add the range), or cap the addHook range if the major is ' +
+      'intentionally unsupported.'
+    )
+    process.exitCode = 1
+  } else {
+    console.log('\nEvery published major within the declared ranges is covered by the test matrix.')
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/helpers/concurrency.js
+++ b/scripts/helpers/concurrency.js
@@ -1,0 +1,36 @@
+'use strict'
+
+/**
+ * Run an async worker over every item with at most `concurrency` workers in flight. Used to bound the number of open
+ * file handles while generating workspace folders and patching peer dependencies (an unbounded `Promise.all` over the
+ * whole `versions/` tree exhausts file descriptors / `EMFILE`). Results preserve input order; the first worker error
+ * rejects the returned promise.
+ *
+ * @template T, R
+ * @param {T[]} items
+ * @param {number} concurrency Maximum number of workers running at once; must be >= 1.
+ * @param {(item: T, index: number) => Promise<R> | R} worker
+ * @returns {Promise<R[]>}
+ */
+async function mapWithConcurrency (items, concurrency, worker) {
+  if (concurrency < 1) throw new RangeError(`concurrency must be >= 1, got ${concurrency}`)
+
+  const results = new Array(items.length)
+  let nextIndex = 0
+
+  const runWorker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex
+      nextIndex += 1
+      // Sequential within a worker is intended: concurrency comes from running several workers in parallel.
+      // eslint-disable-next-line no-await-in-loop
+      results[index] = await worker(items[index], index)
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, runWorker))
+
+  return results
+}
+
+module.exports = mapWithConcurrency

--- a/scripts/helpers/concurrency.spec.js
+++ b/scripts/helpers/concurrency.spec.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { setTimeout: delay } = require('node:timers/promises')
+
+const { describe, it } = require('mocha')
+
+const mapWithConcurrency = require('./concurrency')
+
+describe('mapWithConcurrency', () => {
+  it('resolves to an empty array for no items', async () => {
+    assert.deepEqual(await mapWithConcurrency([], 4, () => assert.fail('should not run')), [])
+  })
+
+  it('preserves input order regardless of completion order', async () => {
+    const results = await mapWithConcurrency([30, 10, 20], 3, async (ms, index) => {
+      await delay(ms)
+      return index
+    })
+    assert.deepEqual(results, [0, 1, 2])
+  })
+
+  it('runs every item exactly once', async () => {
+    const seen = []
+    await mapWithConcurrency([1, 2, 3, 4, 5], 2, item => {
+      seen.push(item)
+    })
+    assert.deepEqual(seen.sort(), [1, 2, 3, 4, 5])
+  })
+
+  it('never exceeds the concurrency limit', async () => {
+    let active = 0
+    let peak = 0
+    await mapWithConcurrency(Array.from({ length: 10 }, (_, i) => i), 3, async () => {
+      active += 1
+      peak = Math.max(peak, active)
+      await delay(5)
+      active -= 1
+    })
+    assert.equal(peak, 3)
+  })
+
+  it('rejects with the first error and stops scheduling new work', async () => {
+    let started = 0
+    await assert.rejects(
+      mapWithConcurrency([1, 2, 3, 4, 5, 6], 1, async item => {
+        started += 1
+        if (item === 2) throw new Error('boom')
+        await delay(1)
+      }),
+      /boom/
+    )
+    // With concurrency 1 the failure on item 2 prevents items 3-6 from starting.
+    assert.equal(started, 2)
+  })
+
+  it('rejects for an invalid concurrency', async () => {
+    await assert.rejects(mapWithConcurrency([1], 0, () => {}), RangeError)
+  })
+})


### PR DESCRIPTION
## Summary

Catches the silent drift where upstream ships a new major (or the pinned `latests` falls behind) that sits inside a plugin's declared support range but that no installed folder resolves to, so the matrix keeps testing the old set. It queries the npm registry per package and compares against the majors the shared resolver produces, naming the concrete packages with gaps, registry errors, and ones skipped as not published. Runs nightly because it is network-bound and changes when upstream publishes, not on push.

## Test plan

- [ ] `node scripts/check-version-coverage.js` reports gaps and exits non-zero when a declared range outpaces the matrix; exits zero when every published major is covered.

Stacked on #9021 (resolver) → #9019 (concurrency).