### PR TITLE
chore(redis): prepare redis tests for redis v6

### DIFF
--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -27,13 +27,16 @@ describe('Plugin', () => {
         it('should support queue options', async () => {
           tracer = require('../../dd-trace')
           redis = require(`../../../versions/${moduleName}@${version}`).get()
-          const client = redis.createClient({ url: 'redis://127.0.0.1:6379', commandsQueueMaxLength: 1 })
-          const connectPromise = client.connect()
+          const client = redis.createClient({ url: 'redis://127.0.0.1:6379', commandsQueueMaxLength: 5 })
+          await client.connect()
           const passingPromise = client.get('foo')
           await assert.rejects(Promise.all([
             passingPromise,
-            client.get('bar'),
-            connectPromise,
+            client.get('a'),
+            client.get('b'),
+            client.get('c'),
+            client.get('d'),
+            client.get('e'),
           ]), {
             message: /queue/,
           })
@@ -352,7 +355,9 @@ describe('Plugin', () => {
       describe('with filter', () => {
         before(() => {
           return agent.load('redis', {
-            filter: (command) => command !== 'SET' && command !== 'CLIENT',
+            filter: (command) => {
+              return command !== 'SET' && command !== 'CLIENT' && command !== 'HELLO'
+            },
           })
         })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
 Updates failings tests to prepare for redis v6. 
 
### Motivation
<!-- What inspired you to submit this pull request? -->

@redis/client@6.0.0 changed how the client establishes a connection: a handshake sequence (HELLO, CLIENT SETINFO, CLIENT MAINT_NOTIFICATIONS, …) is now sent through the same internal command queue used for user commands. This breaks tests that were written against the older behavior, they either observe handshake commands they didn't expect, or run into queue capacity limits that the handshake now consumes part of.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


