### PR TITLE
fix(benchmarks): surface variant errors and narrow non-benchmark change gate

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -174,7 +174,9 @@ for D in "${DIRS[@]}"; do
       export SIRUN_VARIANT=$V
 
       (
-        if time node ../run-one-variant.js >> ../results.ndjson; then
+        # Capture output so we can surface it when the variant fails.
+        VARIANT_OUT=$(mktemp)
+        if time node ../run-one-variant.js >> ../results.ndjson 2>"${VARIANT_OUT}"; then
           echo "${D}/${V} finished."
           if [[ -n "${RECORD_CANDIDATE_PASS}" ]]; then echo "${D}/${V}" >> "$CANDIDATE_PASSED_FILE"; fi
         elif [[ -n "${SKIP_BASELINE_FAILURES}" ]] && grep -Fqx "${D}/${V}" "$CANDIDATE_PASSED_FILE" 2>/dev/null; then
@@ -184,8 +186,10 @@ for D in "${DIRS[@]}"; do
           echo "${D}/${V}" >> "$SKIPPED_FILE"
         else
           echo "${D}/${V} FAILED on core ${CPU_AFFINITY}" >&2
+          cat "${VARIANT_OUT}" >&2
           echo "${D}/${V}" >> "$FAILURES_FILE"
         fi
+        rm -f "${VARIANT_OUT}"
       ) &
       ((CPU_AFFINITY=CPU_AFFINITY+1))
     fi
@@ -221,17 +225,27 @@ if [[ "${SKIPPED_COUNT}" -gt 0 ]]; then
   echo "${SKIPPED_COUNT} benchmark variant(s) failed on the baseline source and were skipped:" >&2
   sed 's/^/  - /' "$SKIPPED_FILE" >&2
 
-  # We want to separate the source code change from a benchmark in case it is not
-  # possible to run the new benchmark on the baseline.
+  # A skipped variant means the new benchmark code cannot run on the older baseline
+  # source, which is expected for a PR that adds a new benchmark. That PR also
+  # changing non-benchmark source (loader, plugins, etc.) makes the A/B comparison
+  # incomplete: the candidate result may reflect both the benchmark change and the
+  # source change, so the comparison cannot attribute the delta to the benchmark
+  # alone. Only block when the PR changes *both* benchmark and non-benchmark source.
+  # A PR that changes only non-benchmark source cannot introduce a new benchmark,
+  # so any skipped variants are pre-existing baseline failures unrelated to this PR.
+  BENCH_SOURCE_CHANGED=""
   NON_BENCH_SOURCE_CHANGED=""
   if [[ -d /app/candidate/.git && -n "${COMMIT_SHA:-}" && -n "${CI_COMMIT_SHA:-}" ]]; then
-    NON_BENCH_SOURCE_CHANGED="$(git -C /app/candidate diff --name-only "${COMMIT_SHA}..${CI_COMMIT_SHA}" \
+    ALL_CHANGED="$(git -C /app/candidate diff --name-only "${COMMIT_SHA}..${CI_COMMIT_SHA}" || true)"
+    BENCH_SOURCE_CHANGED="$(echo "${ALL_CHANGED}" \
+      | grep -E '^benchmark/' | grep -vE '(^benchmark/sirun/runall\.sh$|\.md$)' || true)"
+    NON_BENCH_SOURCE_CHANGED="$(echo "${ALL_CHANGED}" \
       | grep -vE '(^benchmark/|^docs/|^\.github/|^\.gitlab/|\.md$|(^|/)CODEOWNERS$|^test/|/test/|/__tests__/|\.spec\.[jt]s$|\.test\.[jt]s$)' || true)"
   fi
 
-  if [[ -n "${NON_BENCH_SOURCE_CHANGED}" ]]; then
+  if [[ -n "${BENCH_SOURCE_CHANGED}" && -n "${NON_BENCH_SOURCE_CHANGED}" ]]; then
     echo "" >&2
-    echo "This PR also changes non-benchmark source, so the A/B comparison is incomplete." >&2
+    echo "This PR changes both benchmark and non-benchmark source, so the A/B comparison is incomplete." >&2
     echo "Land the benchmark change separately first, then rebase. Changed source files:" >&2
     echo "${NON_BENCH_SOURCE_CHANGED}" | sed 's/^/  - /' >&2
     exit 1


### PR DESCRIPTION
## Summary

Two bugs in `benchmark/sirun/runall.sh`:

1. **Wrong blocking condition for non-benchmark source changes.** When a baseline variant was skipped (passed on candidate, failed on the older baseline — the expected case for a new benchmark), the script blocked the run whenever the PR also changed *any* non-benchmark source. A PR that changes only loader/plugin source with no new benchmark code still tripped this, because a pre-existing or transiently-failing variant ended up in the skip list. The gate now only fires when the PR changes **both** benchmark source and non-benchmark source — the only case where the A/B delta is genuinely ambiguous.

2. **Actual failure reason not visible in CI output.** The stderr of a failing `run-one-variant.js` was discarded; only the variant name appeared in the summary. The real error (`startup-guard: load+setup was 15.2% of the run (max 15%)`) was invisible. The subshell now captures stderr to a temp file and prints it before recording the failure.

## Test plan

Shell-level: the two conditions in the failing code path are covered by the diff and are straightforward to verify by reading. The benchmark CI on this PR (which changes no benchmark source) should no longer produce the misleading "A/B comparison is incomplete" message if a variant happens to skip.