### PR TITLE
ci: derive oldest Node.js version from package.json engines field

### DIFF
--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -27,7 +27,8 @@ runs:
         }
         case "$VERSION" in
           eol)         version=16 ;;
-          oldest)      version=$(node_version 18) ;;
+          oldest)      oldest_major=$(node -p "require('./package.json').engines.node.match(/\d+/)[0]")
+                       version=$(node_version "$oldest_major") ;;
           maintenance) version=$(node_version 20) ;;
           active)      version=$(node_version 24) ;;
           latest)      version=${LATEST_VERSION:-$(node_version 26)}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `18` in the `oldest` alias with a dynamic read from `engines.node` in root `package.json`
- Ensures the `oldest` alias automatically resolves to the correct minimum Node.js version on each release branch (v5 vs v6) without any YAML changes

## Test plan

- [ ] Verify `oldest` resolves to `18` on `master` (v6, `engines.node: ">=18 <27"`)
- [ ] Verify `oldest` resolves to the correct minimum on a v5 branch

*Generated by Claude Code*