### PR TITLE
fix(aws-sdk): allow EventBridge context injection up to 1mb

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
@@ -2,6 +2,34 @@
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
+// EventBridge enforces this limit over the whole PutEvents request (the sum of
+// every entry), not over a single entry. 1 MiB == 1,048,576 bytes.
+const MAX_PUT_EVENTS_BYTES = 1024 * 1024
+
+/**
+ * Size a single `PutEventsRequestEntry` the way EventBridge does server-side:
+ * the UTF-8 byte length of `Source`, `DetailType`, `Detail`, and each
+ * `Resources` ARN, plus a flat 14 bytes when `Time` is set.
+ *
+ * @param {object} entry a single PutEvents request entry
+ * @param {string} [detail] overrides `entry.Detail`, used to size the entry as
+ *   it would be sent with the injected `_datadog` context
+ * @returns {number}
+ * @see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevents.html
+ */
+function putEventEntrySize (entry, detail = entry.Detail) {
+  let size = entry.Time == null ? 0 : 14
+  if (entry.Source != null) size += Buffer.byteLength(entry.Source)
+  if (entry.DetailType != null) size += Buffer.byteLength(entry.DetailType)
+  if (detail != null) size += Buffer.byteLength(detail)
+  if (entry.Resources != null) {
+    for (const resource of entry.Resources) {
+      if (resource != null) size += Buffer.byteLength(resource)
+    }
+  }
+  return size
+}
+
 class EventBridge extends BaseAwsSdkPlugin {
   static id = 'eventbridge'
   static isPayloadReporter = true
@@ -25,7 +53,8 @@ class EventBridge extends BaseAwsSdkPlugin {
    * Docs: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEventsRequestEntry.html
    * We cannot use the traceHeader field as that's reserved for X-Ray.
    * Detail must be a valid JSON string
-   * Max size per event is 1mb (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
+   * Max PutEvents request size is 1mb, summed over all entries
+   * (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
    */
   requestInject (span, request) {
     const operation = request.operation
@@ -34,6 +63,7 @@ class EventBridge extends BaseAwsSdkPlugin {
       request.params.Entries &&
       request.params.Entries.length > 0 &&
       request.params.Entries[0].Detail) {
+      const entries = request.params.Entries
       const injected = {}
       this.tracer.inject(span, 'text_map', injected)
 
@@ -42,19 +72,26 @@ class EventBridge extends BaseAwsSdkPlugin {
       // it so the rest of the body stays in V8's optimisable surface.
       let finalData
       try {
-        finalData = BaseAwsSdkPlugin.injectFieldIntoJsonObject(
-          request.params.Entries[0].Detail, '_datadog', injected
-        )
+        finalData = BaseAwsSdkPlugin.injectFieldIntoJsonObject(entries[0].Detail, '_datadog', injected)
       } catch (error) {
         log.error('EventBridge error injecting request', error)
         return
       }
 
-      if (Buffer.byteLength(finalData) >= 1024 * 1024) {
+      // EventBridge applies the 1 MiB cap to the whole request, so size every
+      // entry as it would be sent (the first with `_datadog` injected) and skip
+      // rather than tip a request AWS would otherwise accept over the limit. The
+      // running total only needs to clear the cap, so stop summing the moment it
+      // does instead of byte-counting the rest of a batch we already know is over.
+      let requestSize = putEventEntrySize(entries[0], finalData)
+      for (let i = 1; requestSize < MAX_PUT_EVENTS_BYTES && i < entries.length; i++) {
+        requestSize += putEventEntrySize(entries[i])
+      }
+      if (requestSize >= MAX_PUT_EVENTS_BYTES) {
         log.info('Payload size too large to pass context')
         return
       }
-      request.params.Entries[0].Detail = finalData
+      entries[0].Detail = finalData
     }
   }
 }

--- a/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
@@ -25,7 +25,7 @@ class EventBridge extends BaseAwsSdkPlugin {
    * Docs: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEventsRequestEntry.html
    * We cannot use the traceHeader field as that's reserved for X-Ray.
    * Detail must be a valid JSON string
-   * Max size per event is 256kb (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
+   * Max size per event is 1mb (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
    */
   requestInject (span, request) {
     const operation = request.operation
@@ -50,7 +50,7 @@ class EventBridge extends BaseAwsSdkPlugin {
         return
       }
 
-      if (Buffer.byteLength(finalData) >= 1024 * 256) {
+      if (Buffer.byteLength(finalData) >= 1024 * 1024) {
         log.info('Payload size too large to pass context')
         return
       }

--- a/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { randomBytes } = require('node:crypto')
 
 const { before, describe, it } = require('mocha')
 const sinon = require('sinon')
@@ -9,6 +8,35 @@ const sinon = require('sinon')
 const EventBridge = require('../src/services/eventbridge')
 const tracer = require('../../dd-trace')
 const { withAwsSdkVersions } = require('./spec_helpers')
+
+const EVENTBRIDGE_EVENT_MAX_BYTES = 1024 * 1024
+const TEST_TRACE_ID = '456853219676779160'
+const TEST_SPAN_ID = '456853219676779160'
+const TEST_PARENT_ID = '0000000000000000'
+const TEST_DATADOG_CONTEXT = {
+  'x-datadog-trace-id': TEST_TRACE_ID,
+  'x-datadog-parent-id': TEST_SPAN_ID,
+  'x-datadog-sampling-priority': '1',
+}
+const EVENTBRIDGE_CONTEXT_BYTES = Buffer.byteLength(`,"_datadog":${JSON.stringify(TEST_DATADOG_CONTEXT)}`)
+
+/**
+ * @param {number} size
+ * @returns {string}
+ */
+function makeEventDetail (size) {
+  const prefix = '{"myGreatData":"'
+  const suffix = '"}'
+  return `${prefix}${'a'.repeat(size - Buffer.byteLength(prefix) - Buffer.byteLength(suffix))}${suffix}`
+}
+
+/**
+ * @param {number} size
+ * @returns {string}
+ */
+function makeEventDetailForInjectedSize (size) {
+  return makeEventDetail(size - EVENTBRIDGE_CONTEXT_BYTES)
+}
 
 describe('EventBridge', () => {
   let span
@@ -90,9 +118,9 @@ describe('EventBridge', () => {
         operation: 'putEvents',
       }
 
-      traceId = '456853219676779160'
-      spanId = '456853219676779160'
-      parentId = '0000000000000000'
+      traceId = TEST_TRACE_ID
+      spanId = TEST_SPAN_ID
+      parentId = TEST_PARENT_ID
       eventbridge.requestInject(span.context(), request)
 
       assert.deepStrictEqual(request.params, {
@@ -106,24 +134,48 @@ describe('EventBridge', () => {
       })
     })
 
-    it('skips injecting trace context to Eventbridge if message is full', () => {
+    it('injects trace context to Eventbridge putEvents when payload stays below 1mb', () => {
       const eventbridge = new EventBridge(tracer)
       const request = {
         params: {
           Entries: [
             {
-              Detail: JSON.stringify({ myGreatData: randomBytes(256000).toString('base64') }),
+              Detail: makeEventDetailForInjectedSize(EVENTBRIDGE_EVENT_MAX_BYTES - 1),
             },
           ],
         },
         operation: 'putEvents',
       }
 
-      traceId = '456853219676779160'
-      spanId = '456853219676779160'
-      parentId = '0000000000000000'
+      traceId = TEST_TRACE_ID
+      spanId = TEST_SPAN_ID
+      parentId = TEST_PARENT_ID
       eventbridge.requestInject(span.context(), request)
-      assert.deepStrictEqual(request.params, request.params)
+
+      assert.strictEqual(Buffer.byteLength(request.params.Entries[0].Detail), EVENTBRIDGE_EVENT_MAX_BYTES - 1)
+      assert.deepStrictEqual(JSON.parse(request.params.Entries[0].Detail)._datadog, TEST_DATADOG_CONTEXT)
+    })
+
+    it('skips injecting trace context to Eventbridge if message is full', () => {
+      const eventbridge = new EventBridge(tracer)
+      const request = {
+        params: {
+          Entries: [
+            {
+              Detail: makeEventDetailForInjectedSize(EVENTBRIDGE_EVENT_MAX_BYTES),
+            },
+          ],
+        },
+        operation: 'putEvents',
+      }
+
+      traceId = TEST_TRACE_ID
+      spanId = TEST_SPAN_ID
+      parentId = TEST_PARENT_ID
+      const originalDetail = request.params.Entries[0].Detail
+      eventbridge.requestInject(span.context(), request)
+
+      assert.strictEqual(request.params.Entries[0].Detail, originalDetail)
     })
 
     it('returns undefined when params is null', () => {

--- a/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
@@ -178,6 +178,76 @@ describe('EventBridge', () => {
       assert.strictEqual(request.params.Entries[0].Detail, originalDetail)
     })
 
+    it('skips injecting when the batched entries exceed 1mb in total', () => {
+      const eventbridge = new EventBridge(tracer)
+      const request = {
+        params: {
+          Entries: [
+            { Detail: makeEventDetailForInjectedSize(550 * 1024) },
+            { Detail: makeEventDetail(550 * 1024) },
+            { Detail: makeEventDetail(100 * 1024) },
+          ],
+        },
+        operation: 'putEvents',
+      }
+
+      traceId = TEST_TRACE_ID
+      spanId = TEST_SPAN_ID
+      parentId = TEST_PARENT_ID
+      const originalDetails = request.params.Entries.map((entry) => entry.Detail)
+      eventbridge.requestInject(span.context(), request)
+
+      assert.deepStrictEqual(request.params.Entries.map((entry) => entry.Detail), originalDetails)
+    })
+
+    it('accounts for Source, DetailType, Time, and Resources when sizing the request', () => {
+      const eventbridge = new EventBridge(tracer)
+      const request = {
+        params: {
+          Entries: [
+            {
+              Detail: makeEventDetailForInjectedSize(EVENTBRIDGE_EVENT_MAX_BYTES - 50),
+              Source: 'my.svc',
+              DetailType: 'my.type',
+              Time: new Date(),
+              Resources: ['a'.repeat(100), null],
+            },
+          ],
+        },
+        operation: 'putEvents',
+      }
+
+      traceId = TEST_TRACE_ID
+      spanId = TEST_SPAN_ID
+      parentId = TEST_PARENT_ID
+      const originalDetail = request.params.Entries[0].Detail
+      eventbridge.requestInject(span.context(), request)
+
+      assert.strictEqual(request.params.Entries[0].Detail, originalDetail)
+    })
+
+    it('injects trace context when the full batched request stays below 1mb', () => {
+      const eventbridge = new EventBridge(tracer)
+      const request = {
+        params: {
+          Entries: [
+            { Detail: makeEventDetailForInjectedSize(400 * 1024) },
+            { Detail: makeEventDetail(EVENTBRIDGE_EVENT_MAX_BYTES - 1 - 400 * 1024) },
+          ],
+        },
+        operation: 'putEvents',
+      }
+
+      traceId = TEST_TRACE_ID
+      spanId = TEST_SPAN_ID
+      parentId = TEST_PARENT_ID
+      const originalSecondDetail = request.params.Entries[1].Detail
+      eventbridge.requestInject(span.context(), request)
+
+      assert.deepStrictEqual(JSON.parse(request.params.Entries[0].Detail)._datadog, TEST_DATADOG_CONTEXT)
+      assert.strictEqual(request.params.Entries[1].Detail, originalSecondDetail)
+    })
+
     it('returns undefined when params is null', () => {
       const eventbridge = new EventBridge(tracer)
       assert.strictEqual(eventbridge.generateTags(null, 'putEvent', {}), undefined)


### PR DESCRIPTION
## Summary

This updates the EventBridge trace-context injection guard to match the current AWS PutEvents 1 MiB payload limit, so valid events above the old 256 KiB limit can still carry Datadog context.

## Test plan

- [x] `./node_modules/.bin/mocha packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js`
- [x] `./node_modules/.bin/nyc --reporter=json --reporter=text-summary --include \"packages/datadog-plugin-aws-sdk/src/services/eventbridge.js\" ./node_modules/.bin/mocha packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js`
- [x] `node /Users/ruben.bridgewater/.cursor/skills/bridgear-coding-style/coverage-diff.js`
- [x] `PATH=\"$HOME/.nvm/versions/node/v22.22.3/bin:$HOME/.yarn/switch/bin:$PATH\" npm run lint`

Refs: https://github.com/DataDog/dd-trace-js/pull/7591
Refs: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevents.html