### PR TITLE
refactor(profiling): make profiling exporter fields private

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -88,6 +88,9 @@ function computeRetries (uploadTimeout) {
 }
 
 class AgentExporter extends EventSerializer {
+  #backoffTime
+  #backoffTries
+
   constructor (config = {}) {
     super(config)
     const { url, uploadTimeout } = config
@@ -95,8 +98,8 @@ class AgentExporter extends EventSerializer {
 
     const [backoffTries, backoffTime] = computeRetries(uploadTimeout)
 
-    this._backoffTime = backoffTime
-    this._backoffTries = backoffTries
+    this.#backoffTime = backoffTime
+    this.#backoffTries = backoffTries
   }
 
   export (exportSpec) {
@@ -128,8 +131,8 @@ class AgentExporter extends EventSerializer {
     return new Promise((resolve, reject) => {
       const operation = retry.operation({
         randomize: true,
-        minTimeout: this._backoffTime,
-        retries: this._backoffTries,
+        minTimeout: this.#backoffTime,
+        retries: this.#backoffTries,
         unref: true,
       })
 
@@ -148,7 +151,7 @@ class AgentExporter extends EventSerializer {
             'DD-EVP-ORIGIN-VERSION': version,
             ...form.getHeaders(),
           },
-          timeout: this._backoffTime * 2 ** attempt,
+          timeout: this.#backoffTime * 2 ** attempt,
         }
 
         docker.inject(options.headers)

--- a/packages/dd-trace/src/profiling/exporters/event_serializer.js
+++ b/packages/dd-trace/src/profiling/exporters/event_serializer.js
@@ -9,13 +9,20 @@ const { availableParallelism, libuvThreadPoolSize } = require('../libuv-size')
 const processTags = require('../../process-tags')
 
 class EventSerializer {
+  #activation
+  #appVersion
+  #env
+  #host
+  #libraryInjected
+  #service
+
   constructor ({ env, host, service, version, libraryInjected, activation } = {}) {
-    this._env = env
-    this._host = host
-    this._service = service
-    this._appVersion = version
-    this._libraryInjected = libraryInjected
-    this._activation = activation || 'unknown'
+    this.#env = env
+    this.#host = host
+    this.#service = service
+    this.#appVersion = version
+    this.#libraryInjected = libraryInjected
+    this.#activation = activation || 'unknown'
   }
 
   typeToFile (type) {
@@ -43,21 +50,21 @@ class EventSerializer {
       endpoint_counts: endpointCounts,
       info: {
         application: {
-          env: this._env,
-          service: this._service,
+          env: this.#env,
+          service: this.#service,
           start_time: new Date(perf.nodeTiming.nodeStart + perf.timeOrigin).toISOString(),
-          version: this._appVersion,
+          version: this.#appVersion,
         },
         platform: {
-          hostname: this._host,
+          hostname: this.#host,
           kernel_name: os.type(),
           kernel_release: os.release(),
           kernel_version: os.version(),
         },
         profiler: {
-          activation: this._activation,
+          activation: this.#activation,
           ssi: {
-            mechanism: this._libraryInjected ? 'injected_agent' : 'none',
+            mechanism: this.#libraryInjected ? 'injected_agent' : 'none',
           },
           version,
           ...infos,

--- a/packages/dd-trace/src/profiling/exporters/file.js
+++ b/packages/dd-trace/src/profiling/exporters/file.js
@@ -14,10 +14,12 @@ function formatDateTime (t) {
 }
 
 class FileExporter extends EventSerializer {
+  #pprofPrefix
+
   constructor (config = {}) {
     super(config)
     const { pprofPrefix } = config
-    this._pprofPrefix = pprofPrefix || ''
+    this.#pprofPrefix = pprofPrefix || ''
   }
 
   export (exportSpec) {
@@ -25,7 +27,7 @@ class FileExporter extends EventSerializer {
     const types = Object.keys(profiles)
     const dateStr = formatDateTime(end)
     const tasks = types.map(type => {
-      return writeFile(`${this._pprofPrefix}${type}_worker_${threadId}_${dateStr}.pprof`, profiles[type])
+      return writeFile(`${this.#pprofPrefix}${type}_worker_${threadId}_${dateStr}.pprof`, profiles[type])
     })
     tasks.push(writeFile(`event_worker_${threadId}_${dateStr}.json`, this.getEventJSON(exportSpec)))
     return Promise.all(tasks)


### PR DESCRIPTION
## Summary
The `EventSerializer`, `AgentExporter`, and `FileExporter` state is read only inside each class, yet stayed underscore-prefixed. Promote it to `#private` so the runtime enforces the boundary instead of the convention.

`AgentExporter._url` stays a plain underscore property: the profiling config spec asserts the resolved intake URL through `config.exporters[0]._url`, so it is part of a reachable surface rather than purely internal.

## Test plan
- [ ] `packages/dd-trace/test/profiling/**/*.spec.js`