### PR TITLE
ci(release): improve release changelog readability and dependency scope

### DIFF
--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -13,7 +13,22 @@ const CONVENTIONAL_PATTERN = new RegExp(
     String.raw`(feat|fix|docs|style|refactor|perf|test|bench|build|ci|chore)(?:\(([^)]+)\))?(!)?: (.+)$`
 )
 const PULL_REQUEST_PATTERN = /\s+\(#([0-9]+)\)$/
-const INTERNAL_TYPES = new Set(['bench', 'build', 'chore', 'ci', 'refactor', 'style', 'test'])
+const REFERENCE_PATTERN = /#([0-9]+)/g
+const GITHUB_URL = 'https://github.com'
+const REPO_URL = `${GITHUB_URL}/DataDog/dd-trace-js`
+const UNCATEGORIZED_PRODUCT = 'Other'
+const DEPENDENCY_PRODUCT = 'Dependencies'
+// Dependabot tags the commit scope `deps-dev` for development dependencies and
+// `deps` for production ones, but the `deps` manifests under test/benchmark/docs
+// directories are not shipped. The shipped manifests are the repo root and the
+// bundled `/vendor` tree; only those (and the matching production groups from
+// `.github/dependabot.yml`) reach customers. Keep this set in sync with the
+// `dependency-type: "production"` groups there.
+const PRODUCTION_DEPENDENCY_GROUPS = new Set([
+  'runtime-minor-and-patch-dependencies',
+  'vendor-minor-and-patch-dependencies',
+  'security-production',
+])
 
 const CATEGORY_BY_TYPE = {
   docs: 'Documentation',
@@ -120,9 +135,9 @@ for (const [product, scopes] of PRODUCTS) {
  * @property {string} category
  * @property {string} product
  * @property {string} subject
- * @property {string} pr
- * @property {boolean} internal
+ * @property {string} pr Bare pull request number, e.g. `8012`, or `''` when absent.
  * @property {boolean} revert
+ * @property {boolean} [drop] Set when the entry is intentionally omitted from the changelog.
  * @property {string} [warning]
  */
 
@@ -139,6 +154,7 @@ function createReleaseChangelog (entries) {
   for (const entry of entries) {
     const change = parseChange(entry)
 
+    if (change.drop) continue
     if (change.warning) warnings.push(change.warning)
     if (change.category === 'Features' && !change.revert) isMinor = true
     if (entry.author) contributors.add(entry.author)
@@ -169,27 +185,49 @@ function parseChange (entry) {
   if (!parsed) {
     return {
       category: INTERNAL_CATEGORY,
-      product: 'Other',
+      product: UNCATEGORIZED_PRODUCT,
       subject: subjectWithPullRequest.subject,
       pr: subjectWithPullRequest.pr,
-      internal: true,
       revert: false,
       warning: `Non-conventional release-note subject for ${entry.sha}: ${entry.subject}`,
     }
   }
 
-  const category = CATEGORY_BY_TYPE[parsed.type] || INTERNAL_CATEGORY
-  const internal = INTERNAL_TYPES.has(parsed.type)
-  const product = selectProduct(parsed.scopes)
+  const dependency = classifyDependencyBump(parsed.scopes, parsed.subject)
+  if (dependency === 'other') {
+    return { drop: true }
+  }
 
   return {
-    category,
-    product,
+    category: CATEGORY_BY_TYPE[parsed.type] || INTERNAL_CATEGORY,
+    product: dependency === 'production' ? DEPENDENCY_PRODUCT : selectProduct(parsed.scopes),
     subject: parsed.subject,
     pr: subjectWithPullRequest.pr,
-    internal,
     revert: parsed.isRevert,
   }
+}
+
+/**
+ * Classify a Dependabot dependency bump as shipped (`production`) or not
+ * (`other`, dropped from the changelog), or `undefined` when the commit is not
+ * a dependency bump at all. Development dependencies and the instrumented-library
+ * support ranges under test/benchmark/docs directories never reach customers.
+ *
+ * @param {string[]} scopes
+ * @param {string} subject
+ * @returns {'production'|'other'|undefined}
+ */
+function classifyDependencyBump (scopes, subject) {
+  if (!scopes.includes('deps') && !scopes.includes('deps-dev')) return
+  if (scopes.includes('deps-dev')) return 'other'
+
+  const directory = subject.match(/\bin (\/\S+)/)
+  if (directory && directory[1] !== '/vendor') return 'other'
+
+  const group = subject.match(/\bthe (\S+) group\b/)
+  if (group && !PRODUCTION_DEPENDENCY_GROUPS.has(group[1])) return 'other'
+
+  return 'production'
 }
 
 /**
@@ -203,7 +241,7 @@ function parsePullRequest (subject) {
 
   return {
     subject: subject.slice(0, match.index),
-    pr: `#${match[1]}`,
+    pr: match[1],
   }
 }
 
@@ -299,11 +337,8 @@ function renderMarkdown (sections, contributors) {
   }
 
   if (contributors.size > 0) {
-    lines.push('<b>Contributors</b>')
-    for (const contributor of [...contributors].sort(compareContributors)) {
-      lines.push(`- ${contributor}`)
-    }
-    lines.push('')
+    const badges = [...contributors].sort(compareContributors).map(renderContributor)
+    lines.push('### Contributors', '', badges.join(' '), '')
   }
 
   return lines.join('\n')
@@ -314,24 +349,21 @@ function renderMarkdown (sections, contributors) {
  */
 function renderHeading (category) {
   if (category === INTERNAL_CATEGORY) {
-    return `<b>${category}</b> (CI, Testing, Benchmarking)`
+    return `### ${category} (CI, Testing, Benchmarking)`
   }
 
-  return `<b>${category}</b>`
+  return `### ${category}`
 }
 
 /**
- * Groups same-product entries together; the internal section carries no product,
- * so it falls through to a plain subject sort.
+ * Groups same-product entries together, then orders by subject within a product.
  *
  * @param {Change} a
  * @param {Change} b
  */
 function compareChanges (a, b) {
-  if (!a.internal) {
-    const byProduct = a.product.toLowerCase().localeCompare(b.product.toLowerCase())
-    if (byProduct !== 0) return byProduct
-  }
+  const byProduct = a.product.toLowerCase().localeCompare(b.product.toLowerCase())
+  if (byProduct !== 0) return byProduct
 
   return a.subject.toLowerCase().localeCompare(b.subject.toLowerCase())
 }
@@ -345,15 +377,48 @@ function compareContributors (a, b) {
 }
 
 /**
+ * Renders a GitHub avatar that links to the contributor's profile. Display
+ * strings that are not a `@handle` (a plain git author name) have no profile to
+ * link, so they render verbatim.
+ *
+ * @param {string} contributor
+ */
+function renderContributor (contributor) {
+  if (!contributor.startsWith('@')) return contributor
+
+  const login = contributor.slice(1)
+  return `[<img src="${GITHUB_URL}/${login}.png?size=48" width="24" height="24" ` +
+    `alt="${contributor}" title="${contributor}" />](${GITHUB_URL}/${login})`
+}
+
+/**
  * @param {Change} change
  */
 function renderChange (change) {
-  const suffix = change.pr ? ` ${change.pr}` : ''
-  if (change.internal) {
-    return `- ${change.subject}${suffix}`
+  const subject = linkifyReferences(change.subject)
+  const suffix = change.pr ? ` ${renderPullRequest(change.pr)}` : ''
+  if (change.product === UNCATEGORIZED_PRODUCT) {
+    return `- ${subject}${suffix}`
   }
 
-  return `- <b>${change.product}</b> ${change.subject}${suffix}`
+  return `- **${change.product}:** ${subject}${suffix}`
+}
+
+/**
+ * Wraps inline `#1234` references in an explicit link so GitHub renders them as
+ * plain links instead of expanding each one into a pull request preview.
+ *
+ * @param {string} text
+ */
+function linkifyReferences (text) {
+  return text.replaceAll(REFERENCE_PATTERN, (_, number) => renderPullRequest(number))
+}
+
+/**
+ * @param {string} number Bare pull request number.
+ */
+function renderPullRequest (number) {
+  return `[#${number}](${REPO_URL}/pull/${number})`
 }
 
 module.exports = {

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -4,6 +4,10 @@ const assert = require('node:assert/strict')
 
 const { createReleaseChangelog } = require('./changelog')
 
+const prLink = (number) => `[#${number}](https://github.com/DataDog/dd-trace-js/pull/${number})`
+const avatar = (login) => `[<img src="https://github.com/${login}.png?size=48" width="24" height="24" ` +
+  `alt="@${login}" title="@${login}" />](https://github.com/${login})`
+
 describe('release changelog', () => {
   it('renders conventional commits in the release changelog format', () => {
     const entries = [
@@ -80,35 +84,35 @@ describe('release changelog', () => {
 
     assert.strictEqual(changelog.isMinor, true)
     assert.strictEqual(changelog.markdown, [
-      '<b>Features</b>',
-      '- <b>AppSec</b> Add AppSec integrations to Laminas Framework ' +
-        '(http.route, endpoint collection, login events) #3716',
-      '- <b>General</b> Add Node.js 26 support #8429',
-      '- <b>LLM Observability</b> Support Bedrock Converse and ConverseStream #8079',
-      '- <b>OpenTelemetry</b> Add support for OTLP Runtime Metrics #8357',
+      '### Features',
+      '- **AppSec:** Add AppSec integrations to Laminas Framework ' +
+        `(http.route, endpoint collection, login events) ${prLink(3716)}`,
+      `- **General:** Add Node.js 26 support ${prLink(8429)}`,
+      `- **LLM Observability:** Support Bedrock Converse and ConverseStream ${prLink(8079)}`,
+      `- **OpenTelemetry:** Add support for OTLP Runtime Metrics ${prLink(8357)}`,
       '',
-      '<b>Fixes</b>',
-      '- <b>AppSec</b> Avoid the possibility of sensitive data going to the telemetry logs backend ' +
-        'via WAF strings #3884',
-      '- <b>AppSec</b> Treat cleared shared memory as no-config rather than an error in AppSec helper #3876',
-      '- <b>General</b> Encoder JSON number type fix #38799',
-      '- <b>LLM Observability</b> Revert "Fan array-valued user tags out into one wire entry per element ' +
-        '(#8689)" #8790',
-      '- <b>Profiling</b> Prevent panics in profiling encoding under out-of-memory and out-of-bounds ' +
-        'conditions #3888',
-      '- <b>unknown-scope</b> Handle strange thing #9999',
+      '### Fixes',
+      '- **AppSec:** Avoid the possibility of sensitive data going to the telemetry logs backend ' +
+        `via WAF strings ${prLink(3884)}`,
+      '- **AppSec:** Treat cleared shared memory as no-config rather than an error in AppSec helper ' +
+        `${prLink(3876)}`,
+      `- **General:** Encoder JSON number type fix ${prLink(38_799)}`,
+      '- **LLM Observability:** Revert "Fan array-valued user tags out into one wire entry per element ' +
+        `(${prLink(8689)})" ${prLink(8790)}`,
+      '- **Profiling:** Prevent panics in profiling encoding under out-of-memory and out-of-bounds ' +
+        `conditions ${prLink(3888)}`,
+      `- **unknown-scope:** Handle strange thing ${prLink(9999)}`,
       '',
-      '<b>Performance</b>',
-      '- <b>General</b> Reduce per-span format and encode overhead #8754',
+      '### Performance',
+      `- **General:** Reduce per-span format and encode overhead ${prLink(8754)}`,
       '',
-      '<b>Documentation</b>',
-      '- <b>General</b> Note that startSpan does not activate the returned span #8771',
+      '### Documentation',
+      `- **General:** Note that startSpan does not activate the returned span ${prLink(8771)}`,
       '',
-      '<b>Internal</b> (CI, Testing, Benchmarking)',
-      '- Add the startup guard to the writer encode loop #8755',
-      '- Bump the serverless group across 1 directory with 8 updates #8782',
-      '- Cap proposal at 100 commits and notify guild at 50 #8711',
-      '- Fixes APMS-19181: sets the service discovery logs to respect the log level #8677',
+      '### Internal (CI, Testing, Benchmarking)',
+      `- **LLM Observability:** Add the startup guard to the writer encode loop ${prLink(8755)}`,
+      `- Fixes APMS-19181: sets the service discovery logs to respect the log level ${prLink(8677)}`,
+      `- **release:** Cap proposal at 100 commits and notify guild at 50 ${prLink(8711)}`,
       '',
     ].join('\n'))
     assert.deepStrictEqual(changelog.warnings, [
@@ -131,11 +135,11 @@ describe('release changelog', () => {
 
     assert.strictEqual(changelog.isMinor, false)
     assert.strictEqual(changelog.markdown, [
-      '<b>Features</b>',
-      '- <b>AppSec</b> Revert "Add experimental detection (#8689)" #8790',
+      '### Features',
+      `- **AppSec:** Revert "Add experimental detection (${prLink(8689)})" ${prLink(8790)}`,
       '',
-      '<b>Fixes</b>',
-      '- <b>Profiling</b> Correct sample counts #8791',
+      '### Fixes',
+      `- **Profiling:** Correct sample counts ${prLink(8791)}`,
       '',
     ].join('\n'))
   })
@@ -153,11 +157,11 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Features</b>',
-      '- <b>OpenTelemetry</b> Add breaking OpenTelemetry behavior',
+      '### Features',
+      '- **OpenTelemetry:** Add breaking OpenTelemetry behavior',
       '',
-      '<b>Fixes</b>',
-      '- <b>General</b> Keep request tagging stable',
+      '### Fixes',
+      '- **General:** Keep request tagging stable',
       '',
     ].join('\n'))
   })
@@ -171,8 +175,8 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Fixes</b>',
-      '- <b>AppSec</b> Trim empty scope segments #1234',
+      '### Fixes',
+      `- **AppSec:** Trim empty scope segments ${prLink(1234)}`,
       '',
     ].join('\n'))
   })
@@ -184,11 +188,11 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Features</b>',
-      '- <b>aws-sdk</b> Create SQS consumer spans #8827',
+      '### Features',
+      `- **aws-sdk:** Create SQS consumer spans ${prLink(8827)}`,
       '',
-      '<b>Fixes</b>',
-      '- <b>redis</b> Drop db.name placeholder #8402',
+      '### Fixes',
+      `- **redis:** Drop db.name placeholder ${prLink(8402)}`,
       '',
     ].join('\n'))
     assert.deepStrictEqual(changelog.warnings, [])
@@ -200,8 +204,8 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Fixes</b>',
-      '- <b>redis, iovalkey</b> Align reconnect handling #8001',
+      '### Fixes',
+      `- **redis, iovalkey:** Align reconnect handling ${prLink(8001)}`,
       '',
     ].join('\n'))
   })
@@ -219,40 +223,99 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Fixes</b>',
-      '- <b>AI Guard</b> Tighten prompt evaluation #9002',
-      '- <b>AppSec</b> Block on suspicious request #9001',
-      '- <b>Data Streams Monitoring</b> Track message lineage #9003',
-      '- <b>Database Monitoring</b> Propagate trace context to SQL comments #9004',
-      '- <b>Feature Flags</b> Record exposure events #9006',
-      '- <b>General</b> Route agentless spans to the regional intake #9005',
-      '- <b>Test Optimization</b> Dedupe known tests #9007',
-      '- <b>Test Optimization</b> Stabilize worker handoff #9008',
+      '### Fixes',
+      `- **AI Guard:** Tighten prompt evaluation ${prLink(9002)}`,
+      `- **AppSec:** Block on suspicious request ${prLink(9001)}`,
+      `- **Data Streams Monitoring:** Track message lineage ${prLink(9003)}`,
+      `- **Database Monitoring:** Propagate trace context to SQL comments ${prLink(9004)}`,
+      `- **Feature Flags:** Record exposure events ${prLink(9006)}`,
+      `- **General:** Route agentless spans to the regional intake ${prLink(9005)}`,
+      `- **Test Optimization:** Dedupe known tests ${prLink(9007)}`,
+      `- **Test Optimization:** Stabilize worker handoff ${prLink(9008)}`,
       '',
     ].join('\n'))
     assert.deepStrictEqual(changelog.warnings, [])
   })
 
-  it('lists unique contributors sorted case-insensitively after the change sections', () => {
+  it('keeps production dependency bumps and drops development and instrumented ones', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'chore(deps): bump form-data from 4.0.5 to 4.0.6 (#8918)' },
+      {
+        sha: 'abc002',
+        subject: 'chore(deps): bump protobufjs from 8.4.2 to 8.6.0 in /vendor in the ' +
+          'vendor-minor-and-patch-dependencies group across 1 directory (#8851)',
+      },
+      {
+        sha: 'abc003',
+        subject: 'chore(deps): bump the runtime-minor-and-patch-dependencies group across 1 directory ' +
+          'with 3 updates (#8920)',
+      },
+      {
+        sha: 'abc004',
+        subject: 'chore(deps-dev): bump the dev-minor-and-patch-dependencies group across 1 directory ' +
+          'with 4 updates (#8854)',
+      },
+      {
+        sha: 'abc005',
+        subject: 'chore(deps): bump @anthropic-ai/sdk from 0.101.0 to 0.102.0 in ' +
+          '/packages/dd-trace/test/plugins/versions in the ai-and-llm group across 1 directory (#8852)',
+      },
+      { sha: 'abc006', subject: 'chore(deps): bump the serverless group across 1 directory with 8 updates (#8929)' },
+      { sha: 'abc007', subject: 'chore(deps): bump markdown-it from 14.1.1 to 14.2.0 in /docs (#8932)' },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      '### Internal (CI, Testing, Benchmarking)',
+      `- **Dependencies:** Bump form-data from 4.0.5 to 4.0.6 ${prLink(8918)}`,
+      '- **Dependencies:** Bump protobufjs from 8.4.2 to 8.6.0 in /vendor in the ' +
+        `vendor-minor-and-patch-dependencies group across 1 directory ${prLink(8851)}`,
+      '- **Dependencies:** Bump the runtime-minor-and-patch-dependencies group across 1 directory ' +
+        `with 3 updates ${prLink(8920)}`,
+      '',
+    ].join('\n'))
+  })
+
+  it('renders pull request references as explicit links to keep GitHub from expanding them', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'fix(redis): drop placeholder (#8402)' },
+    ])
+
+    assert.ok(changelog.markdown.includes('[#8402](https://github.com/DataDog/dd-trace-js/pull/8402)'))
+  })
+
+  it('links inline pull request references inside a subject', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'revert: fix(core): undo change (#8689) (#8790)' },
+    ])
+
+    assert.ok(changelog.markdown.includes(
+      'Revert "Undo change ([#8689](https://github.com/DataDog/dd-trace-js/pull/8689))" ' +
+      '[#8790](https://github.com/DataDog/dd-trace-js/pull/8790)'
+    ))
+  })
+
+  it('renders contributor avatars on a single line and leaves non-handle names as text', () => {
     const changelog = createReleaseChangelog([
       { sha: 'abc001', subject: 'feat(appsec): add thing (#1)', author: '@Zoe' },
       { sha: 'abc002', subject: 'fix(profiling): fix thing (#2)', author: '@alice' },
       { sha: 'abc003', subject: 'ci(release): tweak the workflow (#3)', author: '@Zoe' },
+      { sha: 'abc004', subject: 'fix(core): another thing (#4)', author: 'Jane Doe' },
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Features</b>',
-      '- <b>AppSec</b> Add thing #1',
+      '### Features',
+      `- **AppSec:** Add thing ${prLink(1)}`,
       '',
-      '<b>Fixes</b>',
-      '- <b>Profiling</b> Fix thing #2',
+      '### Fixes',
+      `- **General:** Another thing ${prLink(4)}`,
+      `- **Profiling:** Fix thing ${prLink(2)}`,
       '',
-      '<b>Internal</b> (CI, Testing, Benchmarking)',
-      '- Tweak the workflow #3',
+      '### Internal (CI, Testing, Benchmarking)',
+      `- **release:** Tweak the workflow ${prLink(3)}`,
       '',
-      '<b>Contributors</b>',
-      '- @alice',
-      '- @Zoe',
+      '### Contributors',
+      '',
+      `${avatar('alice')} ${avatar('Zoe')} Jane Doe`,
       '',
     ].join('\n'))
   })
@@ -263,8 +326,8 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Fixes</b>',
-      '- <b>AppSec</b> Handle thing #1',
+      '### Fixes',
+      `- **AppSec:** Handle thing ${prLink(1)}`,
       '',
     ].join('\n'))
   })
@@ -278,8 +341,8 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      '<b>Internal</b> (CI, Testing, Benchmarking)',
-      '- deps(express): bump express #1234',
+      '### Internal (CI, Testing, Benchmarking)',
+      `- deps(express): bump express ${prLink(1234)}`,
       '',
     ].join('\n'))
     assert.deepStrictEqual(changelog.warnings, [


### PR DESCRIPTION
## Summary

1. Render pull request references as explicit `[#1234](…/pull/1234)` links, inline ones included, so GitHub no longer expands each reference into a preview card or adds a back-reference to the linked PR on every release.
2. Drop development and instrumented-library dependency bumps; only the repo root and the bundled `/vendor` tree ship, so the rest is changelog noise.
3. Carry the commit scope on internal entries like every other category.

Section headings switch from bold to Markdown `###` headings with a bold, colon-separated product label, and contributors render as one line of linked avatars.

## Test plan

- [ ] Run the changelog unit tests (`mocha scripts/release/changelog.spec.js`) — they cover link rendering, inline and revert-message PR refs, production-only dependency filtering, internal-scope retention, and the contributor avatar line.
- [ ] Generate a sample changelog over a recent release range and eyeball the rendered Markdown on GitHub.