### PR TITLE
test(instrumentations): run and cover the .mjs rewriter loader spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:webpack:ci": "nyc --silent node init && nyc -- npm run test:webpack",
     "test:instrumentations": "mocha \"packages/datadog-instrumentations/test/@(${PLUGINS}).spec.js\"",
     "test:instrumentations:ci": "yarn services && nyc --silent node init && nyc -- npm run test:instrumentations",
-    "test:instrumentations:misc": "mocha \"packages/datadog-instrumentations/test/*/**/*.spec.js\"",
+    "test:instrumentations:misc": "mocha \"packages/datadog-instrumentations/test/*/**/*.spec.{js,mjs}\"",
     "test:instrumentations:misc:ci": "nyc --silent node init && nyc -- npm run test:instrumentations:misc",
     "test:core": "node scripts/mocha-parallel-files.js --expose-gc --timeout 30000 -- \"packages/datadog-core/test/**/*.spec.js\"",
     "test:core:ci": "nyc --silent node init && nyc -- npm run test:core",

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -1,20 +1,38 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { supportsSyncHooks } from 'import-in-the-middle/create-hook.mjs'
-import { describe, it } from 'mocha'
+import { before, describe, it } from 'mocha'
 
-import { load, loadSync } from '../../../src/helpers/rewriter/loader.mjs'
-
+const require = createRequire(import.meta.url)
 const source = 'export function getTracer () { return "tracer" }\n'
 const testDirectory = dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = resolve(testDirectory, '../../../../..')
 
 describe('rewriter loader', () => {
+  let load
+  let loadSync
+
+  before(async () => {
+    // require(esm) keeps the loader on nyc's CommonJS instrumentation path so its
+    // transforms count as covered; runtimes without require(esm) fall back to a
+    // dynamic import and still exercise the behaviour.
+    let rewriterLoader
+    try {
+      rewriterLoader = require('../../../src/helpers/rewriter/loader.mjs')
+    } catch (error) {
+      if (error?.code !== 'ERR_REQUIRE_ESM') throw error
+      rewriterLoader = await import('../../../src/helpers/rewriter/loader.mjs')
+    }
+    load = rewriterLoader.load
+    loadSync = rewriterLoader.loadSync
+  })
+
   it('rewrites async loader results', async () => {
     const url = createAiModuleUrl()
     const result = await load(url, { format: 'module' }, () => ({ format: 'module', source }))

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -349,6 +349,7 @@ function findTestFiles (repoRoot) {
 
   const files = [
     ...globSyncCached('**/*.spec.js', commonGlobOpts),
+    ...globSyncCached('**/*.spec.mjs', commonGlobOpts),
     ...globSyncCached('**/*.test.mjs', commonGlobOpts),
   ]
 


### PR DESCRIPTION
## Summary

The rewriter loader spec is the repository's only `.spec.mjs`, and no CI job ran it: the `test:instrumentations:misc` glob matched `.spec.js` only, and `verify-exercised-tests` tracked `.spec.js`/`.test.mjs` but not `.spec.mjs`, so the gate could not flag the orphan.

1. Match `*.spec.{js,mjs}` in `test:instrumentations:misc` so the spec runs.
2. Track `**/*.spec.mjs` in `verify-exercised-tests` so an unrun `.spec.mjs` fails the gate.
3. Load the loader through `require(esm)` in the spec so its async and sync transforms land on nyc's CommonJS instrumentation path; the top-level import bypassed coverage entirely.

## Test plan

- `node scripts/verify-exercised-tests.js` passes and now lists the `.spec.mjs`; reverting only the glob makes it fail naming `loader.spec.mjs`.
- `mocha packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs` passes (4 passing, 1 pending).
- `nyc` on `rewriter/loader.mjs` via that spec reports 100% lines, with the async `load` path now covered.