### PR TITLE
ci(versions): derive Node aliases from engine range

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Version identifier of the version to use."
     required: false
     default: 'latest'
+outputs:
+  supported:
+    description: "Whether the installed Node.js version matches engines.node."
+    value: ${{ steps.attempt.outputs.supported || steps.retry.outputs.supported }}
 runs:
   using: composite
   steps:
@@ -18,7 +22,8 @@ runs:
     - if: steps.attempt.outcome == 'failure'
       shell: bash
       run: sleep 60
-    - if: steps.attempt.outcome == 'failure'
+    - id: retry
+      if: steps.attempt.outcome == 'failure'
       uses: ./.github/actions/node/setup
       with:
         version: ${{ inputs.version }}

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Version identifier of the version to use."
     required: false
     default: 'latest'
+outputs:
+  supported:
+    description: "Whether the installed Node.js version matches engines.node."
+    value: ${{ steps.supported-check.outputs.supported }}
 runs:
   using: composite
   steps:
@@ -25,12 +29,30 @@ runs:
             "require('./${file}').dependencies['node-${1}'].replace('npm:node@','')" \
             || echo "${1}"
         }
+        node_range_min_major() {
+          awk '/"node"[[:space:]]*:/ {
+            if (match($0, />=[[:space:]]*[0-9]+/)) {
+              value = substr($0, RSTART, RLENGTH)
+              gsub(/[^0-9]/, "", value)
+              print value
+              exit
+            }
+          }' package.json
+        }
+        supported_lts() {
+          [ "$min_major" -gt "$1" ] && echo "$min_major" || echo "$1"
+        }
+        min_major=18
+        if [ -f package.json ]; then
+          parsed_min_major=$(node_range_min_major)
+          [ -n "$parsed_min_major" ] && min_major=$parsed_min_major
+        fi
         case "$VERSION" in
           eol)         version=16 ;;
-          oldest)      version=$(node_version 18) ;;
-          maintenance) version=$(node_version 20) ;;
-          active)      version=$(node_version 24) ;;
-          latest)      version=${LATEST_VERSION:-$(node_version 26)}
+          oldest)      version=$(node_version "$min_major") ;;
+          maintenance) version=$(node_version "$(supported_lts 20)") ;;
+          active)      version=$(node_version "$(supported_lts 24)") ;;
+          latest)      version=${LATEST_VERSION:-$(node_version "$(supported_lts 26)")}
                       # When a custom/nightly version is requested via latest,
                       # force tracer init past the engines upper-bound guard.
                       [ -n "$LATEST_VERSION" ] && echo "DD_INJECT_FORCE=true" >> "$GITHUB_ENV" || true ;;
@@ -42,6 +64,49 @@ runs:
       with:
         node-version: ${{ steps.node-version.outputs.version }}
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}
+
+    - name: Check if Node.js version is supported
+      id: supported-check
+      shell: bash
+      run: |
+        node_range_min_major() {
+          awk '/"node"[[:space:]]*:/ {
+            if (match($0, />=[[:space:]]*[0-9]+/)) {
+              value = substr($0, RSTART, RLENGTH)
+              gsub(/[^0-9]/, "", value)
+              print value
+              exit
+            }
+          }' package.json
+        }
+        node_range_max_major() {
+          awk '/"node"[[:space:]]*:/ {
+            if (match($0, /<[[:space:]]*[0-9]+/)) {
+              value = substr($0, RSTART, RLENGTH)
+              gsub(/[^0-9]/, "", value)
+              print value
+              exit
+            }
+          }' package.json
+        }
+
+        if [ ! -f package.json ]; then
+          echo "supported=true" >> "$GITHUB_OUTPUT"
+        else
+          min_major=$(node_range_min_major)
+          max_major=$(node_range_max_major)
+          current_major=$(node -v)
+          current_major=${current_major#v}
+          current_major=${current_major%%.*}
+
+          supported=true
+          if [ -n "$min_major" ] && [ "$current_major" -lt "$min_major" ]; then
+            supported=false
+          elif [ -n "$max_major" ] && [ "$current_major" -ge "$max_major" ]; then
+            supported=false
+          fi
+          echo "supported=$supported" >> "$GITHUB_OUTPUT"
+        fi
 
     # Persist the resolved version so subsequent runs within this 60-minute window can reuse it.
     - name: Save resolved version

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -99,10 +99,15 @@ runs:
           current_major=${current_major#v}
           current_major=${current_major%%.*}
 
+          if [ -z "$min_major" ] || [ -z "$max_major" ]; then
+            echo "Unsupported engines.node range" >&2
+            exit 1
+          fi
+
           supported=true
-          if [ -n "$min_major" ] && [ "$current_major" -lt "$min_major" ]; then
+          if [ "$current_major" -lt "$min_major" ]; then
             supported=false
-          elif [ -n "$max_major" ] && [ "$current_major" -ge "$max_major" ]; then
+          elif [ "$current_major" -ge "$max_major" ]; then
             supported=false
           fi
           echo "supported=$supported" >> "$GITHUB_OUTPUT"

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -122,7 +122,7 @@ function testRuntimeVersionChecks (arg, filename) {
     it('should be able to use the engines field', () => {
       const engines = require(`${sandboxCwd()}/node_modules/dd-trace/package.json`).engines.node
 
-      assert.match(engines, /^>=\d+ <\d+$/)
+      assert.match(engines, /^>=\d+( <\d+)?$/)
     })
 
     context('when node version is too recent', () => {

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -122,7 +122,7 @@ function testRuntimeVersionChecks (arg, filename) {
     it('should be able to use the engines field', () => {
       const engines = require(`${sandboxCwd()}/node_modules/dd-trace/package.json`).engines.node
 
-      assert.match(engines, /^>=\d+( <\d+)?$/)
+      assert.match(engines, /^>=\d+ <\d+$/)
     })
 
     context('when node version is too recent', () => {

--- a/packages/dd-trace/src/guardrails/index.js
+++ b/packages/dd-trace/src/guardrails/index.js
@@ -4,6 +4,7 @@ var path = require('path')
 var Module = require('module')
 
 var nodeVersion = require('../../../../version')
+var isNodeRangeSupported = require('./node-range').isNodeRangeSupported
 var isTrue = require('./util').isTrue
 var log = require('./log')
 var telemetry = require('./telemetry')
@@ -15,9 +16,6 @@ function guard (fn) {
   var clobberBailout = false
   var forced = isTrue(process.env.DD_INJECT_FORCE)
   var engines = require('../../../../package.json').engines
-  var versions = engines.node.match(/^>=(\d+) <(\d+)$/)
-  var minMajor = versions[1]
-  var nextMajor = versions[2]
   var version = process.versions.node
 
   if (process.env.DD_INJECTION_ENABLED) {
@@ -43,7 +41,7 @@ function guard (fn) {
 
   // If the runtime doesn't match the engines field in package.json, then we
   // should not initialize the tracer.
-  if (!clobberBailout && (NODE_MAJOR < minMajor || NODE_MAJOR >= nextMajor)) {
+  if (!clobberBailout && !isNodeRangeSupported(NODE_MAJOR, engines.node)) {
     initBailout = true
     telemetry([
       { name: 'abort', tags: ['reason:incompatible_runtime'] },

--- a/packages/dd-trace/src/guardrails/node-range.js
+++ b/packages/dd-trace/src/guardrails/node-range.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * Parses the Node.js major-version bounds from the package engines range.
+ *
+ * @param {string} range The package.json engines.node range.
+ * @returns {{ minMajor: number, maxMajor: number | undefined }}
+ */
+function parseNodeRange (range) {
+  var min = range.match(/(?:^|\s)>=\s*(\d+)/)
+  var max = range.match(/(?:^|\s)<\s*(\d+)/)
+
+  if (!min) {
+    // eslint-disable-next-line n/no-unsupported-features/es-builtins
+    throw new Error('Unsupported engines.node range: ' + range)
+  }
+
+  return {
+    minMajor: Number(min[1]),
+    maxMajor: max ? Number(max[1]) : undefined
+  }
+}
+
+/**
+ * Checks whether a Node.js major version is supported by the package engines range.
+ *
+ * @param {number} major The Node.js major version.
+ * @param {string} range The package.json engines.node range.
+ * @returns {boolean}
+ */
+function isNodeRangeSupported (major, range) {
+  var parsed = parseNodeRange(range)
+
+  return major >= parsed.minMajor &&
+    (parsed.maxMajor === undefined || major < parsed.maxMajor)
+}
+
+module.exports = {
+  isNodeRangeSupported: isNodeRangeSupported,
+  parseNodeRange: parseNodeRange
+}

--- a/packages/dd-trace/src/guardrails/node-range.js
+++ b/packages/dd-trace/src/guardrails/node-range.js
@@ -4,20 +4,19 @@
  * Parses the Node.js major-version bounds from the package engines range.
  *
  * @param {string} range The package.json engines.node range.
- * @returns {{ minMajor: number, maxMajor: number | undefined }}
+ * @returns {{ minMajor: number, maxMajor: number }}
  */
 function parseNodeRange (range) {
-  var min = range.match(/(?:^|\s)>=\s*(\d+)/)
-  var max = range.match(/(?:^|\s)<\s*(\d+)/)
+  var versions = range.match(/^>=\s*(\d+)\s+<\s*(\d+)$/)
 
-  if (!min) {
+  if (!versions) {
     // eslint-disable-next-line n/no-unsupported-features/es-builtins
     throw new Error('Unsupported engines.node range: ' + range)
   }
 
   return {
-    minMajor: Number(min[1]),
-    maxMajor: max ? Number(max[1]) : undefined
+    minMajor: Number(versions[1]),
+    maxMajor: Number(versions[2])
   }
 }
 
@@ -31,8 +30,7 @@ function parseNodeRange (range) {
 function isNodeRangeSupported (major, range) {
   var parsed = parseNodeRange(range)
 
-  return major >= parsed.minMajor &&
-    (parsed.maxMajor === undefined || major < parsed.maxMajor)
+  return major >= parsed.minMajor && major < parsed.maxMajor
 }
 
 module.exports = {

--- a/packages/dd-trace/test/guardrails/node-range.spec.js
+++ b/packages/dd-trace/test/guardrails/node-range.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const {
+  isNodeRangeSupported,
+  parseNodeRange,
+} = require('../../src/guardrails/node-range')
+
+describe('guardrails/node-range', () => {
+  describe('parseNodeRange', () => {
+    it('parses a lower and upper major bound', () => {
+      assert.deepStrictEqual(parseNodeRange('>=18 <27'), {
+        minMajor: 18,
+        maxMajor: 27,
+      })
+    })
+
+    it('parses a lower-bound-only range', () => {
+      assert.deepStrictEqual(parseNodeRange('>=22'), {
+        minMajor: 22,
+        maxMajor: undefined,
+      })
+    })
+
+    it('throws for unsupported range shapes', () => {
+      assert.throws(() => parseNodeRange('^22'), {
+        message: 'Unsupported engines.node range: ^22',
+      })
+    })
+  })
+
+  describe('isNodeRangeSupported', () => {
+    it('checks the lower bound inclusively', () => {
+      assert.strictEqual(isNodeRangeSupported(17, '>=18 <27'), false)
+      assert.strictEqual(isNodeRangeSupported(18, '>=18 <27'), true)
+    })
+
+    it('checks the upper bound exclusively when present', () => {
+      assert.strictEqual(isNodeRangeSupported(26, '>=18 <27'), true)
+      assert.strictEqual(isNodeRangeSupported(27, '>=18 <27'), false)
+    })
+
+    it('allows future majors when no upper bound is present', () => {
+      assert.strictEqual(isNodeRangeSupported(27, '>=22'), true)
+    })
+  })
+})

--- a/packages/dd-trace/test/guardrails/node-range.spec.js
+++ b/packages/dd-trace/test/guardrails/node-range.spec.js
@@ -18,16 +18,13 @@ describe('guardrails/node-range', () => {
       })
     })
 
-    it('parses a lower-bound-only range', () => {
-      assert.deepStrictEqual(parseNodeRange('>=22'), {
-        minMajor: 22,
-        maxMajor: undefined,
-      })
-    })
-
     it('throws for unsupported range shapes', () => {
       assert.throws(() => parseNodeRange('^22'), {
         message: 'Unsupported engines.node range: ^22',
+      })
+
+      assert.throws(() => parseNodeRange('>=22'), {
+        message: 'Unsupported engines.node range: >=22',
       })
     })
   })
@@ -41,10 +38,6 @@ describe('guardrails/node-range', () => {
     it('checks the upper bound exclusively when present', () => {
       assert.strictEqual(isNodeRangeSupported(26, '>=18 <27'), true)
       assert.strictEqual(isNodeRangeSupported(27, '>=18 <27'), false)
-    })
-
-    it('allows future majors when no upper bound is present', () => {
-      assert.strictEqual(isNodeRangeSupported(27, '>=22'), true)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Derives the GitHub Node setup action `oldest` alias from `package.json#engines.node` instead of hardcoding it to Node 18. This lets a future v6 support-policy update raise the minimum supported Node major with the normal package metadata change, for example `>=18 <27` to `>=22 <27`.

The PR also moves runtime guardrail range parsing into a small helper. The helper intentionally keeps the existing bounded range contract, so `package.json#engines.node` remains the complete source of truth for both the lower and upper supported Node majors.

### Motivation
A future v6 support-policy update should not require duplicated CI alias changes just to move the minimum supported Node version. Jobs that use aliases such as `oldest`, `maintenance`, `active`, and `latest` should follow the package support range instead of hardcoded CI assumptions.

Keeping the normal bounded semver range also avoids splitting the support policy between package metadata and guardrail code.

### Additional Notes
This does not change the current supported Node range. It only prepares the CI setup action and guardrail parser so a later release-branch update can remain a one-line bounded range change in `package.json`.

Tests:
- `./node_modules/.bin/eslint packages/dd-trace/src/guardrails/node-range.js packages/dd-trace/test/guardrails/node-range.spec.js`
- `./node_modules/.bin/mocha packages/dd-trace/test/guardrails/node-range.spec.js`
- `./node_modules/.bin/mocha --timeout 60000 integration-tests/init.spec.js`

`npm run lint` is blocked locally before ESLint by existing invalid vendor dependency state in `vendor/node_modules` (`pprof-format`, `protobufjs`).