### PR TITLE
fix(instrumentation): test __non_webpack_require__ in optional-peer guard

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/require-optional-peer.js
+++ b/packages/datadog-instrumentations/src/helpers/require-optional-peer.js
@@ -12,6 +12,6 @@
  */
 module.exports = function requireOptionalPeer (request) {
   // eslint-disable-next-line camelcase, no-undef
-  const runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require
+  const runtimeRequire = typeof __non_webpack_require__ === 'function' ? __non_webpack_require__ : require
   return runtimeRequire(request)
 }

--- a/packages/datadog-instrumentations/test/helpers/require-optional-peer.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/require-optional-peer.spec.js
@@ -35,4 +35,13 @@ describe('requireOptionalPeer', () => {
     assert.deepStrictEqual(loadCalls, [PEER])
     assert.strictEqual(peer, require(PEER))
   })
+
+  it('falls back to `require` when `__non_webpack_require__` is absent', () => {
+    globalThis.__webpack_require__ = () => {
+      throw new Error('webpack require must not run for an optional peer')
+    }
+
+    assert.strictEqual(typeof globalThis.__non_webpack_require__, 'undefined')
+    assert.strictEqual(requireOptionalPeer(PEER), require(PEER))
+  })
 })


### PR DESCRIPTION
## Summary

The optional-peer runtime fallback in `requireOptionalPeer` guarded on `__webpack_require__` but dereferenced `__non_webpack_require__`. In any context that exposes the former without the latter, the helper throws `ReferenceError: __non_webpack_require__ is not defined` instead of falling back to plain `require`. Testing the identifier the branch actually consumes — the bundler escape hatch it relies on — makes the fallback the safe default.

The existing tests miss this: the "outside a bundler" case never enters the true branch, and the "under a bundler" case sets both globals, so the mismatched guard coincidentally works. The added regression test pins the distinguishing permutation (`__webpack_require__` present, `__non_webpack_require__` absent), which throws on the unfixed code and falls back to `require` after the fix.

Refs: https://github.com/DataDog/dd-trace-js/pull/8999#discussion_r3469899674