### PR TITLE
test: key plugin version folders by single-digit major

### DIFF
--- a/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
+++ b/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
@@ -25,7 +25,7 @@ describe('express-mongo-sanitize', () => {
         // Highest version of express that supports express-mongo-sanitize is <5 (express 5 makes req.query a
         // getter-only property). The unversioned `versions/express` folder tracks the latest express (now 5.x), so
         // pin the <5 range that externals.js installs for this plugin.
-        const express = require('../../../versions/express@>=4 <5').get()
+        const express = require('../../../versions/express@4').get()
         const expressMongoSanitize = require(`../../../versions/express-mongo-sanitize@${version}`).get()
         const app = express()
 

--- a/packages/datadog-instrumentations/test/express-multi-version.spec.js
+++ b/packages/datadog-instrumentations/test/express-multi-version.spec.js
@@ -11,7 +11,7 @@ const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 
 const express4Dir = join(__dirname, '..', '..', '..', 'versions', 'express@4')
-const express5Dir = join(__dirname, '..', '..', '..', 'versions', 'express@>=5.0.0')
+const express5Dir = join(__dirname, '..', '..', '..', 'versions', 'express@5')
 
 const describeOrSkip = existsSync(express4Dir) && existsSync(express5Dir)
   ? describe

--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
 
 const axios = require('axios')
+const semver = require('semver')
 const sinon = require('sinon')
 
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants.js')
@@ -74,7 +75,7 @@ describe('Plugin', () => {
   }
 
   describe('@apollo/gateway', () => {
-    withVersions('apollo', '@apollo/gateway', version => {
+    withVersions('apollo', '@apollo/gateway', (version, moduleName, resolvedVersion) => {
       after(() => {
         return agent.close()
       })
@@ -419,7 +420,7 @@ describe('Plugin', () => {
               // the call to  the recordExceptions() method by ApolloGateway
               // in version 2.3.0, there is no recordExceptions method thus we can't ever attach an error to the
               // fetch span but instead the error will be propagated to the request span and be set there
-              if (version > '2.3.0') {
+              if (semver.gt(resolvedVersion, '2.3.0')) {
                 assertObjectContains(traces[0][3], {
                   error: 1,
                   meta: {

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
@@ -25,7 +25,7 @@ describe('Plugin', () => {
 
         before(function () {
           this.timeout(10_000)
-          const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0'
+          const requireVersion = version === '3.0.0' ? '3.422.0' : '3'
           AWS = require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`).get()
           const NodeHttpHandler =
             require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`)

--- a/packages/datadog-plugin-langchain/test/index.spec.js
+++ b/packages/datadog-plugin-langchain/test/index.spec.js
@@ -122,7 +122,7 @@ describe('Plugin', () => {
           .get('@langchain/core/tools')
 
         if (semifies(realVersion, '>=1.0')) {
-          MemoryVectorStore = require('../../../versions/@langchain/classic@>=1.0')
+          MemoryVectorStore = require('../../../versions/@langchain/classic@1')
             .get('@langchain/classic/vectorstores/memory')
             .MemoryVectorStore
         } else {

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0'
+          const requireVersion = version === '3.0.0' ? '3.422.0' : '3'
           AWS = require(`../../../../../../versions/${bedrockRuntimeClientName}@${requireVersion}`).get()
           const NodeHttpHandler =
             require(`../../../../../../versions/${bedrockRuntimeClientName}@${requireVersion}`)

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -164,7 +164,7 @@ describe('integrations', () => {
             .tool
 
           if (semifies(realVersion, '>=1.0')) {
-            MemoryVectorStore = require('../../../../../../versions/@langchain/classic@>=1.0')
+            MemoryVectorStore = require('../../../../../../versions/@langchain/classic@1')
               .get('@langchain/classic/vectorstores/memory')
               .MemoryVectorStore
           } else {

--- a/packages/dd-trace/test/plugins/versions.spec.js
+++ b/packages/dd-trace/test/plugins/versions.spec.js
@@ -38,6 +38,17 @@ describe('getVersionList', () => {
     assert.deepEqual(keys('mongodb', ['>=1 <6']), ['1.0.0', '1', '2', '3', '4', '5'])
   })
 
+  it('keeps the declared range for a top major the range caps mid-way', () => {
+    // `<=3.0.0` stops inside major 3, so a bare `3` (which resolves to the major's latest) would overshoot the
+    // ceiling; the declared range is kept instead so it resolves to the newest version `<=3.0.0`.
+    assert.deepEqual(keys('mongodb', ['>=2.1 <=3.0.0']), ['2.1.0', '2', '>=2.1 <=3.0.0'])
+  })
+
+  it('keeps a sub-major range as its own key', () => {
+    // `>=4.0.0 <4.3.0` never spans major 4 in full, so there is no safe bare major; the floor and the range cover it.
+    assert.deepEqual(keys('mongodb', ['>=4.0.0 <4.3.0']), ['4.0.0', '>=4.0.0 <4.3.0'])
+  })
+
   it('de-duplicates a shared floor across multiple ranges', () => {
     assert.deepEqual(keys('mongodb', ['>=2 <3', '^2.0.0']), ['2.0.0', '2'])
   })

--- a/packages/dd-trace/test/plugins/versions.spec.js
+++ b/packages/dd-trace/test/plugins/versions.spec.js
@@ -3,61 +3,67 @@
 const assert = require('node:assert/strict')
 
 const { describe, it } = require('mocha')
+const { coerce, major } = require('semver')
 
 const { getVersionList, resolvePluginVersions } = require('./versions')
+
+const latests = require('./versions/package.json').dependencies
 
 const keys = (name, versions, nonConsecutive) =>
   getVersionList(name, versions, nonConsecutive).map(({ versionKey }) => versionKey)
 
+const latestMajorKey = name => String(major(coerce(latests[name])))
+
 describe('getVersionList', () => {
-  it('returns the wildcard untouched', () => {
-    assert.deepEqual(keys('mongodb', ['*']), ['*'])
+  it('collapses the wildcard to the latest major', () => {
+    assert.deepEqual(keys('mongodb', ['*']), [latestMajorKey('mongodb')])
   })
 
   it('collapses equivalent exact-version notations to a single key', () => {
     assert.deepEqual(keys('mongodb', ['1.2.3', '=1.2.3', 'v1.2.3']), ['1.2.3'])
   })
 
-  it('pins the floor and keeps the range for a single-major range', () => {
-    // `<3` caps the range below any plausible pinned latest, so there is no in-between major to fill.
-    assert.deepEqual(keys('mongodb', ['>=2 <3']), ['2.0.0', '>=2 <3'])
+  it('pins the floor and the major for a single-major range', () => {
+    // `<3` caps the range to major 2, so only the pinned floor and the latest of major 2 are keys.
+    assert.deepEqual(keys('mongodb', ['>=2 <3']), ['2.0.0', '2'])
   })
 
-  it('fills every in-between major between the floor and the range top', () => {
-    // `<5` caps the top at major 4, so only major 3 sits strictly in between major 2 and major 4.
-    assert.deepEqual(keys('mongodb', ['>=2 <5']), ['2.0.0', '>=3.0.0 <4.0.0', '>=2 <5'])
+  it('covers the floor major and every major up to the range top', () => {
+    // `<5` caps the top at major 4; the floor (2.0.0) is pinned and majors 2-4 each resolve to their latest.
+    assert.deepEqual(keys('mongodb', ['>=2 <5']), ['2.0.0', '2', '3', '4'])
   })
 
-  it('orders fills ascending and keeps the declared range last (the top major is covered by the range itself)', () => {
-    // `<6` caps the top at major 5, which the `>=1 <6` range resolves to; only majors 2-4 are filled in between.
-    assert.deepEqual(keys('mongodb', ['>=1 <6']), [
-      '1.0.0',
-      '>=2.0.0 <3.0.0',
-      '>=3.0.0 <4.0.0',
-      '>=4.0.0 <5.0.0',
-      '>=1 <6',
-    ])
+  it('covers every major from the floor to the capped top', () => {
+    // `<6` caps the top at major 5; the floor major's latest (1) is covered too, not only the newest of the range.
+    assert.deepEqual(keys('mongodb', ['>=1 <6']), ['1.0.0', '1', '2', '3', '4', '5'])
   })
 
   it('de-duplicates a shared floor across multiple ranges', () => {
-    assert.deepEqual(keys('mongodb', ['>=2 <3', '^2.0.0']), ['2.0.0', '>=2 <3', '^2.0.0'])
+    assert.deepEqual(keys('mongodb', ['>=2 <3', '^2.0.0']), ['2.0.0', '2'])
   })
 
-  it('does not fill in-between majors for non-consecutive packages', () => {
-    assert.deepEqual(keys('mongodb', ['>=1 <6'], new Set(['mongodb'])), ['1.0.0', '>=1 <6'])
+  it('consolidates the floor with the top major when the floor is the pinned latest', () => {
+    // `>=<pinned latest>` floors at the newest version, so the bare top-major key resolves to that same version and is
+    // dropped; the pinned package.json is what proves the two keys identical.
+    assert.deepEqual(keys('mongodb', [`>=${latests.mongodb}`]), [latests.mongodb])
   })
 
-  it('treats the built-in non-consecutive packages as floor + range only', () => {
-    // graphql jumps from 0.x to 14.x; auto-filling 1.x–13.x would fail the install.
-    assert.deepEqual(keys('graphql', ['>=0.10']), ['0.10.0', '>=0.10'])
+  it('adds the floor, the floor major and the top major for non-consecutive packages', () => {
+    // The middle majors may be unpublished, but the floor major (1) and the top major (5) both exist and are tested.
+    assert.deepEqual(keys('mongodb', ['>=1 <6'], new Set(['mongodb'])), ['1.0.0', '1', '5'])
+  })
+
+  it('treats the built-in non-consecutive packages as floor + floor major + top major', () => {
+    // graphql jumps from 0.x to 14.x; 1.x–13.x are skipped, but the latest 0.x and the newest major are still tested.
+    assert.deepEqual(keys('graphql', ['>=0.10']), ['0.10.0', '0', latestMajorKey('graphql')])
   })
 
   it('throws on an unparseable range', () => {
     assert.throws(() => getVersionList('mongodb', ['not-a-version']), /Invalid version range/)
   })
 
-  it('ignores empty entries', () => {
-    assert.deepEqual(keys('mongodb', ['', undefined, '>=2 <3']), ['2.0.0', '>=2 <3'])
+  it('throws on an empty entry', () => {
+    assert.throws(() => getVersionList('mongodb', ['', '>=2 <3']), /Empty version entry/)
   })
 })
 
@@ -67,8 +73,8 @@ describe('resolvePluginVersions', () => {
   it('expands the declared versions and points the unversioned folder at the newest in-scope key', () => {
     const result = resolvePluginVersions({ name: 'mongodb', declaredVersions: ['>=2 <5'], env: {} })
 
-    assert.deepEqual(versionKeys(result), ['2.0.0', '>=3.0.0 <4.0.0', '>=2 <5'])
-    assert.equal(result.unversioned, '>=2 <5')
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
   })
 
   it('filters the installed keys by RANGE and follows the filtered tail', () => {
@@ -78,8 +84,8 @@ describe('resolvePluginVersions', () => {
       env: { RANGE: '>=2.0.0 <4.0.0' },
     })
 
-    assert.deepEqual(versionKeys(result), ['>=2.0.0 <3.0.0', '>=3.0.0 <4.0.0'])
-    assert.equal(result.unversioned, '>=3.0.0 <4.0.0')
+    assert.deepEqual(versionKeys(result), ['2', '3'])
+    assert.equal(result.unversioned, '3')
   })
 
   it('replaces the declared versions with PACKAGE_VERSION_RANGE when the module is honoured', () => {
@@ -89,7 +95,7 @@ describe('resolvePluginVersions', () => {
       env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
     })
 
-    assert.deepEqual(versionKeys(result), ['3.0.0', '>=3 <4'])
+    assert.deepEqual(versionKeys(result), ['3.0.0', '3'])
     assert.equal(result.unversioned, '>=3 <4')
   })
 
@@ -101,8 +107,8 @@ describe('resolvePluginVersions', () => {
       env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
     })
 
-    assert.deepEqual(versionKeys(result), ['2.0.0', '>=3.0.0 <4.0.0', '>=2 <5'])
-    assert.equal(result.unversioned, '>=2 <5')
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
   })
 
   it('keeps the unversioned folder on the raw shard while RANGE narrows the installed keys', () => {
@@ -112,7 +118,7 @@ describe('resolvePluginVersions', () => {
       env: { PACKAGE_VERSION_RANGE: '>=2 <5', RANGE: '>=3.0.0 <4.0.0' },
     })
 
-    assert.deepEqual(versionKeys(result), ['>=3.0.0 <4.0.0'])
+    assert.deepEqual(versionKeys(result), ['3'])
     assert.equal(result.unversioned, '>=2 <5')
   })
 

--- a/packages/dd-trace/test/plugins/versions.spec.js
+++ b/packages/dd-trace/test/plugins/versions.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 const { coerce, major } = require('semver')
 
-const { getVersionList, resolvePluginVersions } = require('./versions')
+const { getVersionList, resolvePluginVersions, brokenVersionReason } = require('./versions')
 
 const latests = require('./versions/package.json').dependencies
 
@@ -149,5 +149,18 @@ describe('resolvePluginVersions', () => {
 
     assert.deepEqual(result.versionList, [])
     assert.equal(result.unversioned, undefined)
+  })
+})
+
+describe('brokenVersionReason', () => {
+  const broken = { ai: [{ range: '>=4.1.0 <5.0.0', reason: 'no cassette' }] }
+
+  it('returns the reason for a version inside a broken range', () => {
+    assert.equal(brokenVersionReason('ai', '4.3.19', broken), 'no cassette')
+  })
+
+  it('returns undefined outside every broken range and for unlisted modules', () => {
+    assert.equal(brokenVersionReason('ai', '4.0.0', broken), undefined)
+    assert.equal(brokenVersionReason('mongodb', '4.3.19', broken), undefined)
   })
 })

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { clean, coerce, intersects, subset } = require('semver')
+const { clean, coerce, intersects, satisfies, subset } = require('semver')
 
 const latests = require('./package.json').dependencies
 
@@ -62,6 +62,12 @@ function capSubrange (name, subrange) {
  * registry lookup, so a major that was never published makes the install fail loudly — the signal to add the package
  * to `nonConsecutiveMajorPackages`.
  *
+ * A bare-major key resolves to that major's newest published version, so it can only be used where the declared range
+ * spans the major in full. When the range caps inside its top major (an upper bound below `<${major + 1}.0.0`), the
+ * top major keeps the declared range instead, which resolves to the newest version the range still allows — a bare
+ * key there would overshoot the ceiling (`>=2.1 <=3.0.0` keyed `3` installs the major's latest, a version above the
+ * declared `<=3.0.0` that the plugin never supported).
+ *
  * Notations that resolve to the same exact version (`1.2.3`, `=1.2.3`, `v1.2.3`) collapse to a single key, and `*`
  * collapses to the latest major (the same version an open-ended range resolves to), so a version is never installed
  * twice under different spellings. A floor that equals the pinned latest also drops the redundant top-major key,
@@ -105,14 +111,26 @@ function getVersionList (name, versions, nonConsecutiveMajors = nonConsecutiveMa
     add(floor.version, range)
 
     const topMajor = highestMajor(name, range, floor.major)
+
+    const addMajor = (major) => {
+      if (!intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) return
+      // The top major is the only one the range can cap inside; lower majors are always spanned in full. A capped top
+      // keeps the declared range so it resolves below the ceiling instead of jumping to the major's latest.
+      if (major === topMajor && !reachesMajorCeiling(major, range)) {
+        add(range, range)
+      } else {
+        add(String(major), range)
+      }
+    }
+
     if (nonConsecutiveMajors.has(name)) {
       // Only the in-between majors were never published. The floor major and the top major both exist, so add the
       // latest of each (skipping the uncertain middle, which is what would make the install fail).
-      add(String(floor.major), range)
-      if (topMajor > floor.major) add(String(topMajor), range)
+      addMajor(floor.major)
+      if (topMajor > floor.major) addMajor(topMajor)
     } else {
       for (let major = floor.major; major <= topMajor; major++) {
-        if (intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) add(String(major), range)
+        addMajor(major)
       }
     }
   }
@@ -124,6 +142,22 @@ function getVersionList (name, versions, nonConsecutiveMajors = nonConsecutiveMa
   if (pinned && entries.has(pinned.version)) entries.delete(String(pinned.major))
 
   return [...entries.values()]
+}
+
+// Higher than any real release within a major. A range that still admits it does not cap inside the major, so a
+// bare-major key is safe; a range that excludes it ends mid-major and must keep its own upper bound.
+const MAJOR_CEILING_PROBE = 999_999
+
+/**
+ * Whether `range` admits versions all the way to the top of `major` (a clean `<${major + 1}.0.0` upper bound, or none).
+ * When it does not, a bare-major key would resolve past the declared ceiling, so the caller keeps the declared range.
+ *
+ * @param {number} major
+ * @param {string} range
+ * @returns {boolean}
+ */
+function reachesMajorCeiling (major, range) {
+  return satisfies(`${major}.${MAJOR_CEILING_PROBE}.${MAJOR_CEILING_PROBE}`, range)
 }
 
 /**

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -15,14 +15,20 @@ const nonConsecutiveMajorPackages = new Set([
   '@redis/client', // jumps from 2.x to 5.x (no 3.x–4.x)
 ])
 
-// Versions the matrix still installs but must not run, keyed by module name. `withVersions()` skips any resolved version
-// matching a range here and surfaces the reason as a pending test. Each entry is a stop-gap: keep the reason a TODO so a
-// fixed version drops the entry instead of letting it rot, and scope the range as narrowly as the break warrants.
+// Versions the matrix installs but must not run, keyed by module name. `withVersions()` skips any resolved
+// version matching a range here and surfaces the reason as a pending test. Each entry is a stop-gap: keep the reason
+// a TODO so a fixed version drops the entry instead of rotting, and scope the range as narrowly as the break warrants.
 /** @type {Record<string, Array<{ range: string, reason: string }>>} */
 const brokenVersions = {
   // TODO: record VCR cassettes for the ai 4.x line; `versions/ai@4` resolves to the newest 4.x, which has no cassette,
   // so the test would hit the live API. 4.0.x (cassetted) and 5.x/6.x stay covered.
   ai: [{ range: '>=4.1.0 <5.0.0', reason: 'no VCR cassette for the ai 4.x latest (TODO: record cassettes)' }],
+  // TODO: record VCR cassettes for the @langchain/core 0.x line above 0.1. `@langchain/core@0` resolves to the newest
+  // 0.x (0.3.x), which has no cassette, so the LLMObs langchain specs hit the live API. The 0.1.0 floor and the 1.x
+  // latest stay covered.
+  '@langchain/core': [
+    { range: '>=0.2.0 <1.0.0', reason: 'no VCR cassette for the @langchain/core 0.x latest (TODO: record cassettes)' },
+  ],
 }
 
 /**

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -55,13 +55,17 @@ function capSubrange (name, subrange) {
  * maps to a `versions/<name>@<key>` workspace folder; the install script and `withVersions()` share this so the set of
  * installed folders and the set of tested folders never drift apart.
  *
- * Per range, this yields the lowest supported version (pinned exactly), the latest of every major in between, and the
- * range itself (which resolves to the newest supported version). The top major is derived from the pinned latest in
- * `package.json` rather than a registry lookup, so a major that does not exist makes the install fail loudly instead of
- * silently skipping versions — which is the signal to mark the range as non-consecutive (see `consecutiveMajors`).
+ * Per declared range this yields the lowest supported version (pinned exactly) and the newest version of every major
+ * the range spans, keyed by the bare major so the key resolves to that major's latest. Covering each major explicitly
+ * (rather than emitting the raw range, which resolves only to the newest version of the whole range) makes sure the
+ * floor major's latest is tested too. The top major is derived from the pinned latest in `package.json` rather than a
+ * registry lookup, so a major that was never published makes the install fail loudly — the signal to add the package
+ * to `nonConsecutiveMajorPackages`.
  *
- * Notations that resolve to the same exact version (`1.2.3`, `=1.2.3`, `v1.2.3`) collapse to a single key, so a version
- * is never installed twice under different spellings.
+ * Notations that resolve to the same exact version (`1.2.3`, `=1.2.3`, `v1.2.3`) collapse to a single key, and `*`
+ * collapses to the latest major (the same version an open-ended range resolves to), so a version is never installed
+ * twice under different spellings. A floor that equals the pinned latest also drops the redundant top-major key,
+ * since the pinned `package.json` proves they resolve to the same version.
  *
  * @param {string} name The module name, e.g. `mongodb`.
  * @param {string[]} versions The declared version entries, e.g. `['>=3.3 <5', '5', '>=6']`.
@@ -78,10 +82,13 @@ function getVersionList (name, versions, nonConsecutiveMajors = nonConsecutiveMa
   }
 
   for (const range of versions) {
-    if (!range) continue
+    // An empty entry is a setup mistake (a stray comma or an undefined slot); fail loudly rather than skip silently.
+    if (!range) {
+      throw new Error(`Empty version entry declared for '${name}'. Each declared version must be a non-empty range.`)
+    }
 
     if (range === '*') {
-      add('*', range)
+      add(latestMajor(name), range)
       continue
     }
 
@@ -97,17 +104,43 @@ function getVersionList (name, versions, nonConsecutiveMajors = nonConsecutiveMa
 
     add(floor.version, range)
 
-    if (!nonConsecutiveMajors.has(name)) {
-      const topMajor = highestMajor(name, range, floor.major)
-      for (let major = floor.major + 1; major < topMajor; major++) {
-        add(`>=${major}.0.0 <${major + 1}.0.0`, range)
+    const topMajor = highestMajor(name, range, floor.major)
+    if (nonConsecutiveMajors.has(name)) {
+      // Only the in-between majors were never published. The floor major and the top major both exist, so add the
+      // latest of each (skipping the uncertain middle, which is what would make the install fail).
+      add(String(floor.major), range)
+      if (topMajor > floor.major) add(String(topMajor), range)
+    } else {
+      for (let major = floor.major; major <= topMajor; major++) {
+        if (intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) add(String(major), range)
       }
     }
-
-    add(range, range)
   }
 
+  // The bare-major key for the pinned latest's major resolves to the pin itself, so when a declared floor already pins
+  // that exact version the major key would install the same thing. Drop it. This is the only such redundancy the
+  // pinned upper bound lets us prove; for lower majors the newest published version is unknown without the registry.
+  const pinned = coerce(latests[name])
+  if (pinned && entries.has(pinned.version)) entries.delete(String(pinned.major))
+
   return [...entries.values()]
+}
+
+/**
+ * The latest major of `name` as a bare-major version key. `*` resolves here so it de-duplicates against an open-ended
+ * range whose top resolves to the same newest version.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function latestMajor (name) {
+  const latest = coerce(latests[name])
+  if (!latest) {
+    throw new Error(
+      `Latest version for '${name}' needs to be defined in 'packages/dd-trace/test/plugins/versions/package.json'.`
+    )
+  }
+  return String(latest.major)
 }
 
 /**

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -15,6 +15,16 @@ const nonConsecutiveMajorPackages = new Set([
   '@redis/client', // jumps from 2.x to 5.x (no 3.x–4.x)
 ])
 
+// Versions the matrix still installs but must not run, keyed by module name. `withVersions()` skips any resolved version
+// matching a range here and surfaces the reason as a pending test. Each entry is a stop-gap: keep the reason a TODO so a
+// fixed version drops the entry instead of letting it rot, and scope the range as narrowly as the break warrants.
+/** @type {Record<string, Array<{ range: string, reason: string }>>} */
+const brokenVersions = {
+  // TODO: record VCR cassettes for the ai 4.x line; `versions/ai@4` resolves to the newest 4.x, which has no cassette,
+  // so the test would hit the live API. 4.0.x (cassetted) and 5.x/6.x stay covered.
+  ai: [{ range: '>=4.1.0 <5.0.0', reason: 'no VCR cassette for the ai 4.x latest (TODO: record cassettes)' }],
+}
+
 /**
  * @param {string} name
  * @param {string} range
@@ -226,7 +236,22 @@ function resolvePluginVersions ({ name, declaredVersions, honourEnvRange = true,
   return { versionList, unversioned }
 }
 
+/**
+ * The reason `version` of `name` is marked broken (and must be skipped), or `undefined` when it is testable.
+ *
+ * @param {string} name
+ * @param {string} version A concrete, resolved version.
+ * @param {Record<string, Array<{ range: string, reason: string }>>} [broken] Injectable for testing.
+ * @returns {string|undefined}
+ */
+function brokenVersionReason (name, version, broken = brokenVersions) {
+  for (const { range, reason } of broken[name] ?? []) {
+    if (satisfies(version, range)) return reason
+  }
+}
+
 module.exports = {
+  brokenVersionReason,
   getCappedRange,
   getVersionList,
   resolvePluginVersions,

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -14,7 +14,7 @@ const sinon = require('sinon')
 require('./core')
 
 const externals = require('../plugins/externals')
-const { resolvePluginVersions } = require('../plugins/versions')
+const { resolvePluginVersions, brokenVersionReason } = require('../plugins/versions')
 const runtimeMetrics = require('../../src/runtime_metrics')
 const Nomenclature = require('../../src/service-naming')
 const { SVC_SRC_KEY } = require('../../src/constants')
@@ -303,6 +303,16 @@ function withVersions (plugin, modules, range, cb) {
       .sort(({ resolvedVersion }) => resolvedVersion.localeCompare(resolvedVersion))
 
     for (const testCase of testCases) {
+      const brokenReason = brokenVersionReason(moduleName, testCase.resolvedVersion)
+      if (brokenReason) {
+        // The version is installed but deliberately not exercised; surface it as a pending test so the skip is visible
+        // in CI rather than silently absent.
+        describe(`with ${moduleName} ${testCase.versionRange} (${testCase.resolvedVersion})`, () => {
+          it.skip(`skipped — known broken: ${brokenReason}`, () => {})
+        })
+        continue
+      }
+
       const absBasePath = path.resolve(__dirname, getModulePath(moduleName, testCase.versionKey))
       const absNodeModulesPath = `${absBasePath}/node_modules`
 

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -245,11 +245,16 @@ async function patchPeerDependencies ({ folder, externalName }) {
         if (dep === externalName) {
           versionPkgJson.dependencies[name] = pkgJson.version
         } else {
-          versionPkgJson.dependencies[name] = pkgJson[section][name].includes('||')
-            // Use the first version in the list (as npm does by default)
-            ? pkgJson[section][name].split('||')[0].trim()
-            // Only one version available so use that.
-            : pkgJson[section][name]
+          const declared = pkgJson[section][name]
+          versionPkgJson.dependencies[name] = declared.startsWith('workspace:')
+            // A `workspace:` protocol leaked into the published manifest (some monorepo packages publish it raw); it
+            // cannot resolve outside the source repo, so fall back to the pinned compatible version.
+            ? (latests[name] ?? '*')
+            : declared.includes('||')
+              // Use the first version in the list (as npm does by default)
+              ? declared.split('||')[0].trim()
+              // Only one version available so use that.
+              : declared
         }
         break
       }


### PR DESCRIPTION
## Summary

Key plugin version folders by the bare major again (`versions/mongodb@3`) rather
than a bounded range (`versions/mongodb@>=3.0.0 <4.0.0`). The bare major reads
cleanly as a folder name and covers each major's latest, including the floor
major's, which the range form dropped. Follows the shared resolver that landed
in #9019.

Bare keys regressed capped ranges in the original attempt: a key like `3`
resolves to the major's newest version, so `microgateway-core >=2.1 <=3.0.0`
installed 3.3.7 and the span came back `web.request` instead of
`microgateway.request`. The top major now keeps the declared range whenever the
range stops short of the major's ceiling (`>=2.1 <=3.0.0`, `>=4.0.0 <4.3.0`),
resolving to the newest version the range allows; fully-spanned majors and every
lower major stay bare single-digit keys.

## Test plan

- `yarn test:scripts` runs the resolver unit spec, including the capped-top and
  sub-major cases.
- Draft: the broader coverage now tests each major's latest, including floor
  majors not previously installed (e.g. knex 0.x). Holding for the APM
  Integrations matrix to confirm green and to triage any version it surfaces.