### PR TITLE
test(appsec): disable remote config in the fastify RASP blocking suite

### DIFF
--- a/packages/dd-trace/test/appsec/rasp/rasp_blocking.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/rasp_blocking.fastify.plugin.spec.js
@@ -16,6 +16,23 @@ const { blockedTemplateJson: blockedJson, setTestBlockingTemplates } = require('
 const { checkRaspExecutedAndNotThreat, checkRaspExecutedAndHasThreat } = require('./utils')
 
 describe('RASP - fastify blocking', () => {
+  // The WAF is driven by a static rasp_rules.json here, so Remote Configuration is not under test.
+  // Disable it so the tracer's RC client never polls `/v0.7/config` (which can otherwise land on this app).
+  let originalRemoteConfigEnabled
+
+  before(() => {
+    originalRemoteConfigEnabled = process.env.DD_REMOTE_CONFIGURATION_ENABLED
+    process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
+  })
+
+  after(() => {
+    if (originalRemoteConfigEnabled === undefined) {
+      delete process.env.DD_REMOTE_CONFIGURATION_ENABLED
+    } else {
+      process.env.DD_REMOTE_CONFIGURATION_ENABLED = originalRemoteConfigEnabled
+    }
+  })
+
   withVersions('fastify', 'fastify', '>=2', (version) => {
     let app, hooks, axios, pool
 


### PR DESCRIPTION
## Summary

`RASP - fastify blocking` asserts its `onSend`/`onResponse`/`onError` hooks fire exactly once per request, but they were intermittently called twice. The extra call is a `POST /v0.7/config` from the tracer's Remote Config client — not a RASP double-invocation.

The RC client's target URL is captured once at tracer init (`proxy.js` → `new RemoteConfig(config)`) and is never updated by `tracer.setUrl`, which only repoints the trace exporter and DSM processor. Across the version matrix the client therefore keeps polling the first block's agent port; once that agent closes and a later `app.listen({ port: 0 })` reuses the freed port, the poll lands on the fastify app, 404s, and fires the response-phase hooks a second time.

## Fix

The suite drives the WAF from a static `rasp_rules.json`, so Remote Configuration is not under test. Disabling it for the suite (`DD_REMOTE_CONFIGURATION_ENABLED=false`, which `agent.load` honors by rebuilding the tracer) stops the `/v0.7/config` poll at the source. The global hooks then fire once per request and the `calledOnce` assertions stand unchanged — no spy filtering.

## Verification

With the real tracer pointed at a mock agent, RC enabled emits `POST /v0.7/config` immediately after init (same method/path/content-type as the stray request in the failing job log); with `DD_REMOTE_CONFIGURATION_ENABLED=false` it emits none. The full integration suite needs the service stack and test agent, so CI across the fastify matrix is the end-to-end check.