### PR TITLE
test(apollo): gate fetch-failure error on resolved semver version

### DIFF
--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
 
 const axios = require('axios')
+const semver = require('semver')
 const sinon = require('sinon')
 
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants.js')
@@ -74,7 +75,7 @@ describe('Plugin', () => {
   }
 
   describe('@apollo/gateway', () => {
-    withVersions('apollo', '@apollo/gateway', version => {
+    withVersions('apollo', '@apollo/gateway', (version, moduleName, resolvedVersion) => {
       after(() => {
         return agent.close()
       })
@@ -419,7 +420,7 @@ describe('Plugin', () => {
               // the call to  the recordExceptions() method by ApolloGateway
               // in version 2.3.0, there is no recordExceptions method thus we can't ever attach an error to the
               // fetch span but instead the error will be propagated to the request span and be set there
-              if (version > '2.3.0') {
+              if (semver.gt(resolvedVersion, '2.3.0')) {
                 assertObjectContains(traces[0][3], {
                   error: 1,
                   meta: {


### PR DESCRIPTION
## Summary

The `@apollo/gateway` "should instrument fetch failure" test decides whether the
execute span carries the error by comparing the `withVersions` folder key with
`version > '2.3.0'`. That is a lexicographic string comparison: it holds while
the key is `>=2.3.0`, but a bare-major key such as `2` makes `'2' > '2.3.0'`
false, so the test takes the no-error branch even though @apollo/gateway 2.14.0
attaches the error to the execute span via `recordExceptions`. The result is a
hard failure on the pinned-latest gateway (`>=2.3.0 (2.14.0)`):
`AssertionError: 1 !== 0` at `index.spec.js:431`.

This compares the resolved version (the third `withVersions` argument, always a
clean semver) with `semver.gt`, matching the existing `datadog-plugin-undici`
idiom, so the gate stays correct regardless of how the version folder is keyed.

## Test plan

- The `apollo` plugin job, specifically `@apollo/gateway >=2.3.0 (2.14.0) >
  without configuration > should instrument fetch failure`, plus the 2.3.0 and
  2.6.0 cases that pin the no-`recordExceptions` and `recordExceptions` branches.