### PR TITLE
test(setup): arm a 120s watchdog to turn exit-hangs into fast failures

### DIFF
--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -413,6 +413,12 @@ function insertVersionDep (dir, pkgName, version) {
 
 const ORIGINAL_PROCESS_EXIT = process.exit
 
+// The watchdog fires if the process fails to exit after all suites have finished. The typical cause is a `before`
+// hook that throws after starting the tracer — the `agent.load` / RC socket stays open, mocha drains no further,
+// and the job silently times out. 120 s is well above the longest real per-suite teardown (≤30 s observed) so clean
+// runs always exit before it triggers; only a leaked handle — the actual bug — fires it.
+const EXIT_WATCHDOG_MS = 120_000
+
 exports.mochaHooks = {
   beforeAll () {
     process.exit = (code) => {
@@ -421,6 +427,20 @@ exports.mochaHooks = {
   },
   afterAll () {
     process.exit = ORIGINAL_PROCESS_EXIT
+
+    // Arm the watchdog after restoring process.exit so it can call it.
+    const watchdog = setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[dd-trace test watchdog] Process did not exit ${EXIT_WATCHDOG_MS / 1000}s after all suites completed.`,
+        'Active handles keeping the event loop alive:',
+        process._getActiveHandles?.()?.map(h => h?.constructor?.name ?? String(h))
+      )
+      ORIGINAL_PROCESS_EXIT(1)
+    }, EXIT_WATCHDOG_MS)
+
+    // Unref so a clean run (no leak) always exits without waiting for the timer.
+    watchdog.unref()
   },
   afterEach () {
     if (_agent) _agent.reset()


### PR DESCRIPTION
## Summary

A `before` hook that throws after calling `agent.load` starts the tracer, which
opens an RC socket and arms background timers. Mocha (run without `--exit`)
waits for the event loop to drain; the leaked handles prevent that, and the job
runs to the 45-minute GitHub Actions timeout rather than reporting the real
error. The real error is the last line before the stall — not a hang.

This arms a 120 s watchdog in `mochaHooks.afterAll`, which runs after every
suite's teardown is complete. If the process has not exited by then, the watchdog
logs the active handles (so the actual leak is named) and exits non-zero,
converting a 45-minute silent timeout into a ~2-minute loud failure. It is
`unref()`'d so a clean run always exits without waiting for the timer.

120 s gives 4× headroom over the longest observed test timeout (30 s) and starts
only after all `after` hooks have run, so no legitimate teardown races it.

## Test plan

- `yarn mocha packages/dd-trace/test/plugins/versions.spec.js` passes (clean
  exit before watchdog fires).
- Lint clean on mocha.js.
- The bedrock hang that prompted this would have shown: `BedrockRuntimeClient`
  constructor + RC socket as the active handles, failing in ~2 min.