### PR TITLE
fix(types): expose resource, tags and maxPerSecond on SamplingRule

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -70,7 +70,9 @@ tracer.init({
   rateLimit: 1000,
   samplingRules: [
     { sampleRate: 0.5, service: 'foo', name: 'foo.request' },
-    { sampleRate: 0.1, service: /foo/, name: /foo\.request/ }
+    { sampleRate: 0.1, service: /foo/, name: /foo\.request/ },
+    { sampleRate: 0, resource: 'GET /health', maxPerSecond: 5 },
+    { sampleRate: 0, tags: { 'http.url': '*/spam*', 'span.kind': /server/ } }
   ],
   spanSamplingRules: [
     { sampleRate: 1.0, service: 'foo', name: 'foo.request', maxPerSecond: 5 },

--- a/index.d.ts
+++ b/index.d.ts
@@ -413,7 +413,7 @@ declare namespace tracer {
    */
   export interface SamplingRule {
     /**
-     * Sampling rate for this rule. Use `0` to drop every matching trace.
+     * Sampling rate for this rule. A range between 0 and 1 representing the percent of traces sampled.
      */
     sampleRate: number
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -413,7 +413,7 @@ declare namespace tracer {
    */
   export interface SamplingRule {
     /**
-     * Sampling rate for this rule.
+     * Sampling rate for this rule. Use `0` to drop every matching trace.
      */
     sampleRate: number
 
@@ -426,6 +426,22 @@ declare namespace tracer {
      * Operation name on which to apply this rule. The rule will apply to all operation names if not provided.
      */
     name?: string | RegExp
+
+    /**
+     * Resource name on which to apply this rule. The rule will apply to all resource names if not provided.
+     */
+    resource?: string | RegExp
+
+    /**
+     * Span tags on which to apply this rule, keyed by tag name. Each value is a glob pattern or regular
+     * expression, and the rule only applies when every entry matches the span's tags.
+     */
+    tags?: { [key: string]: string | RegExp }
+
+    /**
+     * Maximum number of traces matching this rule to sample per second.
+     */
+    maxPerSecond?: number
   }
 
   /**
@@ -607,10 +623,10 @@ declare namespace tracer {
     rateLimit?: number,
 
     /**
-     * Sampling rules to apply to priority sampling. Each rule is a JSON,
-     * consisting of `service` and `name`, which are regexes to match against
-     * a trace's `service` and `name`, and a corresponding `sampleRate`. If not
-     * specified, will defer to global sampling rate for all spans.
+     * Sampling rules to apply to priority sampling. Each rule matches against a trace's
+     * `service`, `name`, `resource`, and `tags`, and applies the rule's `sampleRate`. Use a
+     * `sampleRate` of `0` to drop matching traces (for example to filter out unwanted resources).
+     * If not specified, will defer to global sampling rate for all spans.
      * @default []
      * @env DD_TRACE_SAMPLING_RULES
      * Programmatic configuration takes precedence over the environment variables listed above.

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -426,7 +426,7 @@ declare namespace tracer {
    */
   export interface SamplingRule {
     /**
-     * Sampling rate for this rule.
+     * Sampling rate for this rule. Use `0` to drop every matching trace.
      */
     sampleRate: number
 
@@ -439,6 +439,22 @@ declare namespace tracer {
      * Operation name on which to apply this rule. The rule will apply to all operation names if not provided.
      */
     name?: string | RegExp
+
+    /**
+     * Resource name on which to apply this rule. The rule will apply to all resource names if not provided.
+     */
+    resource?: string | RegExp
+
+    /**
+     * Span tags on which to apply this rule, keyed by tag name. Each value is a glob pattern or regular
+     * expression, and the rule only applies when every entry matches the span's tags.
+     */
+    tags?: { [key: string]: string | RegExp }
+
+    /**
+     * Maximum number of traces matching this rule to sample per second.
+     */
+    maxPerSecond?: number
   }
 
   /**
@@ -620,10 +636,10 @@ declare namespace tracer {
     rateLimit?: number,
 
     /**
-     * Sampling rules to apply to priority sampling. Each rule is a JSON,
-     * consisting of `service` and `name`, which are regexes to match against
-     * a trace's `service` and `name`, and a corresponding `sampleRate`. If not
-     * specified, will defer to global sampling rate for all spans.
+     * Sampling rules to apply to priority sampling. Each rule matches against a trace's
+     * `service`, `name`, `resource`, and `tags`, and applies the rule's `sampleRate`. Use a
+     * `sampleRate` of `0` to drop matching traces (for example to filter out unwanted resources).
+     * If not specified, will defer to global sampling rate for all spans.
      * @default []
      * @env DD_TRACE_SAMPLING_RULES
      * Programmatic configuration takes precedence over the environment variables listed above.

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -426,7 +426,7 @@ declare namespace tracer {
    */
   export interface SamplingRule {
     /**
-     * Sampling rate for this rule. Use `0` to drop every matching trace.
+     * Sampling rate for this rule. A range between 0 and 1 representing the percent of traces sampled.
      */
     sampleRate: number
 


### PR DESCRIPTION
## Summary

The priority sampler matches sampling rules on `resource` and `tags` and honors `maxPerSecond`, but the public `SamplingRule` type only declared `service`, `name`, and `sampleRate`. TypeScript users had no typed way to discover that a rule with `sampleRate: 0` drops traces by tag or resource — the trace filtering requested in #2552.

This adds the missing optional fields to both the v6 (`index.d.ts`) and v5 (`index.d.v5.ts`) type definitions, clarifies the `samplingRules` description, and exercises the new fields in the `docs/test.ts` type fixture. No runtime change — the sampler already accepted these fields via `SamplingRule.from({ ...rule })`.

## Test plan

- `tsc -p docs` (the v6 type fixture) compiles with the new fields.

Fixes: https://github.com/DataDog/dd-trace-js/issues/2552