### PR TITLE
test(selenium): stabilize selenium browser profiles

### DIFF
--- a/integration-tests/ci-visibility/features-selenium/support/steps.js
+++ b/integration-tests/ci-visibility/features-selenium/support/steps.js
@@ -4,21 +4,29 @@ const assert = require('assert')
 
 const { When, Then, Before, After } = require('@cucumber/cucumber')
 const { By, Builder } = require('selenium-webdriver')
-const chrome = require('selenium-webdriver/chrome')
+const { cleanChromeOptions, createChromeOptions } = require('../../selenium-options')
 let driver
+let userDataDir
 let title
 let helloWorldText
 
-const options = new chrome.Options()
-options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage')
-
 Before(async function () {
-  const build = new Builder().forBrowser('chrome').setChromeOptions(options)
+  const chromeOptions = createChromeOptions()
+  userDataDir = chromeOptions.userDataDir
+  const build = new Builder().forBrowser('chrome').setChromeOptions(chromeOptions.options)
   driver = await build.build()
 })
 
 After(async function () {
-  await driver.quit()
+  try {
+    if (driver !== undefined) {
+      await driver.quit()
+    }
+  } finally {
+    cleanChromeOptions(userDataDir)
+    driver = undefined
+    userDataDir = undefined
+  }
 })
 
 Then('I should have run selenium', async function () {

--- a/integration-tests/ci-visibility/selenium-options.js
+++ b/integration-tests/ci-visibility/selenium-options.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const { mkdtempSync, rmSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const path = require('node:path')
+
+const chrome = require('selenium-webdriver/chrome')
+
+/**
+ * Creates Chrome options with a dedicated profile directory for one browser session.
+ *
+ * @returns {{ options: import('selenium-webdriver/chrome').Options, userDataDir: string }}
+ */
+function createChromeOptions () {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'dd-trace-selenium-'))
+  const options = new chrome.Options()
+
+  options.addArguments(
+    '--headless=new',
+    '--no-sandbox',
+    '--disable-dev-shm-usage',
+    `--user-data-dir=${userDataDir}`
+  )
+
+  return { options, userDataDir }
+}
+
+/**
+ * Removes a Chrome profile directory created for a browser session.
+ *
+ * @param {string|undefined} userDataDir
+ * @returns {void}
+ */
+function cleanChromeOptions (userDataDir) {
+  if (userDataDir !== undefined) {
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+}
+
+module.exports = {
+  cleanChromeOptions,
+  createChromeOptions,
+}

--- a/integration-tests/ci-visibility/test/selenium-no-framework.js
+++ b/integration-tests/ci-visibility/test/selenium-no-framework.js
@@ -1,25 +1,36 @@
 'use strict'
 
 const { By, Builder } = require('selenium-webdriver')
-const chrome = require('selenium-webdriver/chrome')
+const { cleanChromeOptions, createChromeOptions } = require('../selenium-options')
 
 async function run () {
-  const options = new chrome.Options()
-  options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage')
-  const build = new Builder().forBrowser('chrome').setChromeOptions(options)
-  const driver = await build.build()
+  let driver
+  let userDataDir
 
-  await driver.get(process.env.WEB_APP_URL)
+  try {
+    const chromeOptions = createChromeOptions()
+    userDataDir = chromeOptions.userDataDir
+    const build = new Builder().forBrowser('chrome').setChromeOptions(chromeOptions.options)
+    driver = await build.build()
 
-  await driver.getTitle()
+    await driver.get(process.env.WEB_APP_URL)
 
-  await driver.manage().setTimeouts({ implicit: 500 })
+    await driver.getTitle()
 
-  const helloWorld = await driver.findElement(By.className('hello-world'))
+    await driver.manage().setTimeouts({ implicit: 500 })
 
-  await helloWorld.getText()
+    const helloWorld = await driver.findElement(By.className('hello-world'))
 
-  return driver.quit()
+    await helloWorld.getText()
+  } finally {
+    try {
+      if (driver !== undefined) {
+        await driver.quit()
+      }
+    } finally {
+      cleanChromeOptions(userDataDir)
+    }
+  }
 }
 
 run()

--- a/integration-tests/ci-visibility/test/selenium-test.js
+++ b/integration-tests/ci-visibility/test/selenium-test.js
@@ -3,15 +3,16 @@
 const assert = require('assert')
 
 const { By, Builder } = require('selenium-webdriver')
-const chrome = require('selenium-webdriver/chrome')
-const options = new chrome.Options()
-options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage')
+const { cleanChromeOptions, createChromeOptions } = require('../selenium-options')
 
 describe('selenium', function () {
   let driver
+  let userDataDir
 
   beforeEach(async function () {
-    const build = new Builder().forBrowser('chrome').setChromeOptions(options)
+    const chromeOptions = createChromeOptions()
+    userDataDir = chromeOptions.userDataDir
+    const build = new Builder().forBrowser('chrome').setChromeOptions(chromeOptions.options)
     driver = await build.build()
   })
 
@@ -30,5 +31,15 @@ describe('selenium', function () {
     assert.strictEqual(value, 'Hello World')
   })
 
-  afterEach(async () => await driver.quit())
+  afterEach(async () => {
+    try {
+      if (driver !== undefined) {
+        await driver.quit()
+      }
+    } finally {
+      cleanChromeOptions(userDataDir)
+      driver = undefined
+      userDataDir = undefined
+    }
+  })
 })

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -165,7 +165,7 @@ versionRange.forEach(version => {
       )
 
       childProcess.on('exit', (code) => {
-        assert.strictEqual(code, 0)
+        assert.strictEqual(code, 0, `Process exited with code ${code}.\n${testOutput}`)
         assert.doesNotMatch(testOutput, /InvalidArgumentError/)
         done()
       })


### PR DESCRIPTION
### What does this PR do?
Adds a shared Selenium Chrome options helper for Test Optimization integration tests. Each browser session now gets a fresh Chrome user-data directory, uses modern headless mode, and cleans the profile up after the driver quits. The no-framework parent test assertion also includes child process output when the child exits nonzero.

### Motivation
Two `Test Optimization / integration-selenium (oldest)` jobs failed flakes while running `yarn test:integration:selenium:coverage`:

- https://github.com/DataDog/dd-trace-js/actions/runs/27756991368/job/82121247625
- https://github.com/DataDog/dd-trace-js/actions/runs/27771488522/job/82172409170

The exact job logs only showed the parent assertion receiving child exit code `1`, because the failing child output was not included in the assertion message. A local Selenium 4.44.0 reproduction of the no-framework child hit Chrome startup failure (`DevToolsActivePort file does not exist`). Running the same flow with a per-session Chrome profile and `--headless=new` exited successfully.

### Additional Notes
Validated with targeted syntax checks, targeted ESLint, `git diff --check`, helper option inspection with Selenium 4.44.0, and the local no-framework repro/manual fixed flow. I could not complete the full Docker-backed Selenium integration command locally because the Docker daemon/socket is not available in this workspace.