### PR TITLE
fix(graphql): restore graphql-yoga execute spans on CommonJS

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -455,13 +455,23 @@ function finishResolvers ({ fields }) {
   }
 }
 
-addHook({ name: '@graphql-tools/executor', versions: ['>=0.0.14'] }, executor => {
-  // graphql-yoga uses the normalizedExecutor function, so we need to wrap both. There is no risk in wrapping both
-  // since the functions are closely related, and our wrappedExecute function prevents double calls with the
-  // contexts.has(contextValue) check.
-  shimmer.wrap(executor, 'execute', wrapExecute(executor))
-  shimmer.wrap(executor, 'normalizedExecutor', wrapExecute(executor))
+// The CJS package root re-exports `execute` and `normalizedExecutor` as
+// non-configurable tslib `__exportStar` getters that shimmer cannot rewrite in
+// place, so the inner execute.js hook below carries CJS instead: graphql-yoga
+// (`normalizedExecutor`) and direct callers both funnel through that `execute`.
+// Under iitm (ESM) the namespace is settable and the inner-file hook never
+// matches the `esm/` path, so the root wrap is the only option there.
+addHook({ name: '@graphql-tools/executor', versions: ['>=0.0.14'] }, (executor, _version, isIitm) => {
+  if (isIitm) {
+    shimmer.wrap(executor, 'execute', wrapExecute(executor))
+    shimmer.wrap(executor, 'normalizedExecutor', wrapExecute(executor))
+  }
   return executor
+})
+
+addHook({ name: '@graphql-tools/executor', file: 'cjs/execution/execute.js', versions: ['>=0.0.14'] }, execute => {
+  shimmer.wrap(execute, 'execute', wrapExecute(execute))
+  return execute
 })
 
 // TODO(BridgeAR): graphql >=17.0.0-alpha.9 routes execute() through

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -462,6 +462,7 @@ function finishResolvers ({ fields }) {
 // Under iitm (ESM) the namespace is settable and the inner-file hook never
 // matches the `esm/` path, so the root wrap is the only option there.
 addHook({ name: '@graphql-tools/executor', versions: ['>=0.0.14'] }, (executor, _version, isIitm) => {
+  /* istanbul ignore if: covered only by the graphql-yoga ESM integration test (subprocess) */
   if (isIitm) {
     shimmer.wrap(executor, 'execute', wrapExecute(executor))
     shimmer.wrap(executor, 'normalizedExecutor', wrapExecute(executor))

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -209,7 +209,7 @@ describe('Plugin', () => {
   }
 
   describe('graphql', () => {
-    withVersions('graphql', 'graphql', version => {
+    withVersions('graphql', 'graphql', (version, moduleName, graphqlVersion) => {
       before(() => {
         sort = spans => spans.sort((a, b) => {
           const order = [
@@ -232,6 +232,11 @@ describe('Plugin', () => {
       })
 
       describe('graphql-yoga', () => {
+        // graphql-yoga 3.x lists graphql as a `^15.2.0 || ^16.0.0` peer and ships no nested copy, so under an
+        // older outer graphql version it resolves an incompatible graphql off NODE_PATH and never executes,
+        // timing out the assertion. Only register the suite for a graphql release graphql-yoga supports.
+        if (!semver.satisfies(graphqlVersion, '^15.2.0 || ^16.0.0')) return
+
         withVersions('graphql', 'graphql-yoga', version => {
           let graphqlYoga
           let server

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -232,7 +232,7 @@ describe('Plugin', () => {
       })
 
       describe('graphql-yoga', () => {
-        withVersions(plugin, 'graphql-yoga', version => {
+        withVersions('graphql', 'graphql-yoga', version => {
           let graphqlYoga
           let server
           let port

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -281,7 +281,7 @@ describe('Plugin', () => {
             await agent.close()
           })
 
-          it('should instrument graphql-yoga execution', async () => {
+          it('should instrument graphql-yoga execution', () => {
             const query = `
               query MyQuery {
                 hello(name: "world")
@@ -291,32 +291,36 @@ describe('Plugin', () => {
             const assertion = agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].resource, 'query MyQuery{hello(name:"")}')
-              assert.strictEqual(spans[0].type, 'graphql')
-              assert.strictEqual(spans[0].error, 0)
+              assertObjectContains(spans[0], {
+                service: expectedSchema.server.serviceName,
+                name: expectedSchema.server.opName,
+                resource: 'query MyQuery{hello(name:"")}',
+                type: 'graphql',
+                error: 0,
+                meta: {
+                  'graphql.operation.type': 'query',
+                  'graphql.operation.name': 'MyQuery',
+                  component: 'graphql',
+                  '_dd.integration': 'graphql',
+                },
+              })
               assert.ok(!('graphql.source' in spans[0].meta))
-              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
-              assert.strictEqual(spans[0].meta['graphql.operation.name'], 'MyQuery')
-              assert.strictEqual(spans[0].meta.component, 'graphql')
-              assert.strictEqual(spans[0].meta['_dd.integration'], 'graphql')
             }, { spanResourceMatch: /MyQuery/ })
 
-            await axios.post(`http://localhost:${port}/graphql`, { query })
-            await assertion
+            return Promise.all([
+              assertion,
+              axios.post(`http://localhost:${port}/graphql`, { query }),
+            ])
           })
         })
       })
 
       describe('without configuration', () => {
-        before(() => {
-          return agent.load('graphql')
-            .then(() => {
-              tracer = require('../../dd-trace')
-              graphql = require(`../../../versions/graphql@${version}`).get()
-              buildSchema()
-            })
+        before(async () => {
+          await agent.load('graphql')
+          tracer = require('../../dd-trace')
+          graphql = require(`../../../versions/graphql@${version}`).get()
+          buildSchema()
         })
 
         after(() => {
@@ -338,71 +342,67 @@ describe('Plugin', () => {
           }
         )
 
-        it('should instrument parsing', done => {
+        it('should instrument parsing', () => {
           const source = 'query MyQuery { hello(name: "world") }'
           const variableValues = { who: 'world' }
 
-          agent
-            .assertFirstTraceSpan(span => {
-              assertObjectContains(span, {
-                service: 'test',
-                name: 'graphql.parse',
-                resource: 'graphql.parse',
-                type: 'graphql',
-                error: 0,
-                meta: { component: 'graphql' },
-              })
-              assert.ok(!('graphql.source' in span.meta))
-            }, { spanResourceMatch: /^graphql\.parse$/ })
-            .then(done)
-            .catch(done)
-
-          graphql.graphql({ schema, source, variableValues }).catch(done)
-        })
-
-        it('should instrument validation', done => {
-          const source = 'query MyQuery { hello(name: "world") }'
-          const variableValues = { who: 'world' }
-
-          agent
-            .assertFirstTraceSpan(span => {
-              assertObjectContains(span, {
-                service: 'test',
-                name: 'graphql.validate',
-                resource: 'graphql.validate',
-                type: 'graphql',
-                error: 0,
-                meta: { component: 'graphql' },
-              })
-              assert.ok(!('graphql.source' in span.meta))
-            }, { spanResourceMatch: /^graphql\.validate$/ })
-            .then(done)
-            .catch(done)
-
-          graphql.graphql({ schema, source, variableValues }).catch(done)
-        })
-
-        it('should instrument execution', done => {
-          const source = 'query MyQuery { hello(name: "world") }'
-          const variableValues = { who: 'world' }
-
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
-
-              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].resource, 'query MyQuery{hello(name:"")}')
-              assert.strictEqual(spans[0].type, 'graphql')
-              assert.strictEqual(spans[0].error, 0)
-              assert.ok(!('graphql.source' in spans[0].meta))
-              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
-              assert.strictEqual(spans[0].meta['graphql.operation.name'], 'MyQuery')
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+          const assertion = agent.assertFirstTraceSpan(span => {
+            assertObjectContains(span, {
+              service: 'test',
+              name: 'graphql.parse',
+              resource: 'graphql.parse',
+              type: 'graphql',
+              error: 0,
+              meta: { component: 'graphql' },
             })
-            .then(done)
+            assert.ok(!('graphql.source' in span.meta))
+          }, { spanResourceMatch: /^graphql\.parse$/ })
 
-          graphql.graphql({ schema, source, variableValues }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues })])
+        })
+
+        it('should instrument validation', () => {
+          const source = 'query MyQuery { hello(name: "world") }'
+          const variableValues = { who: 'world' }
+
+          const assertion = agent.assertFirstTraceSpan(span => {
+            assertObjectContains(span, {
+              service: 'test',
+              name: 'graphql.validate',
+              resource: 'graphql.validate',
+              type: 'graphql',
+              error: 0,
+              meta: { component: 'graphql' },
+            })
+            assert.ok(!('graphql.source' in span.meta))
+          }, { spanResourceMatch: /^graphql\.validate$/ })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues })])
+        })
+
+        it('should instrument execution', () => {
+          const source = 'query MyQuery { hello(name: "world") }'
+          const variableValues = { who: 'world' }
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+
+            assertObjectContains(spans[0], {
+              service: expectedSchema.server.serviceName,
+              name: expectedSchema.server.opName,
+              resource: 'query MyQuery{hello(name:"")}',
+              type: 'graphql',
+              error: 0,
+              meta: {
+                'graphql.operation.type': 'query',
+                'graphql.operation.name': 'MyQuery',
+                component: 'graphql',
+              },
+            })
+            assert.ok(!('graphql.source' in spans[0].meta))
+          }, { spanResourceMatch: /MyQuery/ })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues })])
         })
 
         it('should instrument every execute even when the args object is reused', async () => {
@@ -493,81 +493,75 @@ describe('Plugin', () => {
             }
           }
 
-          it('emits the execute span for a primitive contextValue', done => {
-            agent
-              .assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-                assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-                assert.strictEqual(spans[0].error, 0)
+          it('emits the execute span for a primitive contextValue', () => {
+            const assertion = agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              assertObjectContains(spans[0], {
+                name: expectedSchema.server.opName,
+                error: 0,
               })
-              .then(done)
-              .catch(done)
+            }, { spanResourceMatch: /ctx:String/ })
 
-            Promise.resolve(graphql.execute({
+            return Promise.all([assertion, Promise.resolve(graphql.execute({
               schema: recordingSchema,
               document: graphql.parse('{ ctx }'),
               contextValue: 'request-1',
-            })).catch(done)
+            }))])
           })
 
-          it('emits resolver spans for a primitive contextValue', done => {
-            agent
-              .assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-                const resolveSpan = spans.find(span => span.name === 'graphql.resolve')
-                assert.ok(resolveSpan, 'graphql.resolve span should be emitted')
-                assert.strictEqual(resolveSpan.meta['graphql.field.name'], 'ctx')
-              })
-              .then(done)
-              .catch(done)
+          it('emits resolver spans for a primitive contextValue', () => {
+            const assertion = agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              const resolveSpan = spans.find(span => span.name === 'graphql.resolve')
+              assert.ok(resolveSpan, 'graphql.resolve span should be emitted')
+              assert.strictEqual(resolveSpan.meta['graphql.field.name'], 'ctx')
+            })
 
-            Promise.resolve(graphql.execute({
+            return Promise.all([assertion, Promise.resolve(graphql.execute({
               schema: recordingSchema,
               document: graphql.parse('{ ctx }'),
               contextValue: 42,
-            })).catch(done)
+            }))])
           })
         })
 
-        it('should not include variables by default', done => {
+        it('should not include variables by default', () => {
           const source = 'query MyQuery($who: String!) { hello(name: $who) }'
           const variableValues = { who: 'world' }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
-              assert.ok(!('graphql.variables' in spans[0].meta))
-            })
-            .then(done)
-            .catch(done)
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+            assert.ok(!('graphql.variables' in spans[0].meta))
+          })
 
-          graphql.graphql({ schema, source, variableValues }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues })])
         })
 
-        it('should instrument schema resolvers', done => {
+        it('should instrument schema resolvers', () => {
           const source = '{ hello(name: "world") }'
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[1].service, 'test')
-              assert.strictEqual(spans[1].name, 'graphql.resolve')
-              assert.strictEqual(spans[1].resource, 'hello:String')
-              assert.strictEqual(spans[1].type, 'graphql')
-              assert.strictEqual(spans[1].error, 0)
-              assert.ok(Number(spans[1].duration) > 0, `Expected ${Number(spans[1].duration)} > 0`)
-              assert.strictEqual(spans[1].meta['graphql.field.name'], 'hello')
-              assert.strictEqual(spans[1].meta['graphql.field.path'], 'hello')
-              assert.strictEqual(spans[1].meta['graphql.field.type'], 'String')
-              assert.ok(!('graphql.source' in spans[1].meta))
-              assert.strictEqual(spans[1].meta.component, 'graphql')
+            assert.strictEqual(spans.length, 2)
+            assertObjectContains(spans[1], {
+              service: 'test',
+              name: 'graphql.resolve',
+              resource: 'hello:String',
+              type: 'graphql',
+              error: 0,
+              meta: {
+                'graphql.field.name': 'hello',
+                'graphql.field.path': 'hello',
+                'graphql.field.type': 'String',
+                component: 'graphql',
+              },
             })
-            .then(done)
-            .catch(done)
+            assert.ok(Number(spans[1].duration) > 0, `Expected ${Number(spans[1].duration)} > 0`)
+            assert.ok(!('graphql.source' in spans[1].meta))
+          }, { spanResourceMatch: /hello:String/ })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('should trace aliased __proto__ fields with default collapsing', async () => {
@@ -670,7 +664,7 @@ describe('Plugin', () => {
             })
         })
 
-        it('should instrument nested field resolvers', done => {
+        it('should instrument nested field resolvers', () => {
           const source = `
             {
               human {
@@ -683,75 +677,74 @@ describe('Plugin', () => {
             }
           `
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
-              assert.strictEqual(spans.length, 6)
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+            assert.strictEqual(spans.length, 6)
 
-              const execute = spans[0]
-              const human = spans[1]
-              const humanName = spans[2]
-              const address = spans[3]
-              const addressCivicNumber = spans[4]
-              const addressStreet = spans[5]
+            const execute = spans[0]
+            const human = spans[1]
+            const humanName = spans[2]
+            const address = spans[3]
+            const addressCivicNumber = spans[4]
+            const addressStreet = spans[5]
 
-              assert.strictEqual(execute.name, expectedSchema.server.opName)
-              assert.strictEqual(execute.error, 0)
-
-              assertObjectContains(human, {
-                name: 'graphql.resolve',
-                resource: 'human:Human',
-                error: 0,
-                meta: {
-                  'graphql.field.path': 'human',
-                },
-              })
-              assert.strictEqual(human.parent_id.toString(), execute.span_id.toString())
-
-              assertObjectContains(humanName, {
-                name: 'graphql.resolve',
-                resource: 'name:String',
-                error: 0,
-                meta: {
-                  'graphql.field.path': 'human.name',
-                },
-              })
-              assert.strictEqual(humanName.parent_id.toString(), human.span_id.toString())
-
-              assertObjectContains(address, {
-                name: 'graphql.resolve',
-                resource: 'address:Address',
-                error: 0,
-                meta: {
-                  'graphql.field.path': 'human.address',
-                },
-              })
-              assert.strictEqual(address.parent_id.toString(), human.span_id.toString())
-
-              assertObjectContains(addressCivicNumber, {
-                name: 'graphql.resolve',
-                resource: 'civicNumber:String',
-                error: 0,
-                meta: {
-                  'graphql.field.path': 'human.address.civicNumber',
-                },
-              })
-              assert.strictEqual(addressCivicNumber.parent_id.toString(), address.span_id.toString())
-
-              assertObjectContains(addressStreet, {
-                name: 'graphql.resolve',
-                resource: 'street:String',
-                error: 0,
-                meta: {
-                  'graphql.field.path': 'human.address.street',
-                },
-              })
-              assert.strictEqual(addressStreet.parent_id.toString(), address.span_id.toString())
+            assertObjectContains(execute, {
+              name: expectedSchema.server.opName,
+              error: 0,
             })
-            .then(done)
-            .catch(done)
 
-          graphql.graphql({ schema, source }).catch(done)
+            assertObjectContains(human, {
+              name: 'graphql.resolve',
+              resource: 'human:Human',
+              error: 0,
+              meta: {
+                'graphql.field.path': 'human',
+              },
+            })
+            assert.strictEqual(human.parent_id.toString(), execute.span_id.toString())
+
+            assertObjectContains(humanName, {
+              name: 'graphql.resolve',
+              resource: 'name:String',
+              error: 0,
+              meta: {
+                'graphql.field.path': 'human.name',
+              },
+            })
+            assert.strictEqual(humanName.parent_id.toString(), human.span_id.toString())
+
+            assertObjectContains(address, {
+              name: 'graphql.resolve',
+              resource: 'address:Address',
+              error: 0,
+              meta: {
+                'graphql.field.path': 'human.address',
+              },
+            })
+            assert.strictEqual(address.parent_id.toString(), human.span_id.toString())
+
+            assertObjectContains(addressCivicNumber, {
+              name: 'graphql.resolve',
+              resource: 'civicNumber:String',
+              error: 0,
+              meta: {
+                'graphql.field.path': 'human.address.civicNumber',
+              },
+            })
+            assert.strictEqual(addressCivicNumber.parent_id.toString(), address.span_id.toString())
+
+            assertObjectContains(addressStreet, {
+              name: 'graphql.resolve',
+              resource: 'street:String',
+              error: 0,
+              meta: {
+                'graphql.field.path': 'human.address.street',
+              },
+            })
+            assert.strictEqual(addressStreet.parent_id.toString(), address.span_id.toString())
+          }, { spanResourceMatch: /human:Human/ })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('publishes resolver finish for every sibling of a collapsed list', async () => {
@@ -828,7 +821,7 @@ describe('Plugin', () => {
           }
         })
 
-        it('should instrument list field resolvers', done => {
+        it('should instrument list field resolvers', () => {
           const source = `{
             friends {
               name
@@ -838,64 +831,61 @@ describe('Plugin', () => {
             }
           }`
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 5)
+            assert.strictEqual(spans.length, 5)
 
-              const execute = spans[0]
-              const friends = spans[1]
-              const friendsName = spans[2]
-              const pets = spans[3]
-              const petsName = spans[4]
+            const execute = spans[0]
+            const friends = spans[1]
+            const friendsName = spans[2]
+            const pets = spans[3]
+            const petsName = spans[4]
 
-              assert.strictEqual(execute.name, expectedSchema.server.opName)
+            assert.strictEqual(execute.name, expectedSchema.server.opName)
 
-              assertObjectContains(friends, {
-                name: 'graphql.resolve',
-                resource: 'friends:[Human]',
-                meta: {
-                  'graphql.field.path': 'friends',
-                  'graphql.field.type': 'Human',
-                },
-              })
-              assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
-
-              assertObjectContains(friendsName, {
-                name: 'graphql.resolve',
-                resource: 'name:String',
-                meta: {
-                  'graphql.field.path': 'friends.*.name',
-                  'graphql.field.type': 'String',
-                },
-              })
-              assert.strictEqual(friendsName.parent_id.toString(), friends.span_id.toString())
-
-              assertObjectContains(pets, {
-                name: 'graphql.resolve',
-                resource: 'pets:[Pet!]',
-                meta: {
-                  'graphql.field.path': 'friends.*.pets',
-                  'graphql.field.type': 'Pet',
-                },
-              })
-              assert.strictEqual(pets.parent_id.toString(), friends.span_id.toString())
-
-              assertObjectContains(petsName, {
-                name: 'graphql.resolve',
-                resource: 'name:String',
-                meta: {
-                  'graphql.field.path': 'friends.*.pets.*.name',
-                  'graphql.field.type': 'String',
-                },
-              })
-              assert.strictEqual(petsName.parent_id.toString(), pets.span_id.toString())
+            assertObjectContains(friends, {
+              name: 'graphql.resolve',
+              resource: 'friends:[Human]',
+              meta: {
+                'graphql.field.path': 'friends',
+                'graphql.field.type': 'Human',
+              },
             })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
 
-          graphql.graphql({ schema, source }).catch(done)
+            assertObjectContains(friendsName, {
+              name: 'graphql.resolve',
+              resource: 'name:String',
+              meta: {
+                'graphql.field.path': 'friends.*.name',
+                'graphql.field.type': 'String',
+              },
+            })
+            assert.strictEqual(friendsName.parent_id.toString(), friends.span_id.toString())
+
+            assertObjectContains(pets, {
+              name: 'graphql.resolve',
+              resource: 'pets:[Pet!]',
+              meta: {
+                'graphql.field.path': 'friends.*.pets',
+                'graphql.field.type': 'Pet',
+              },
+            })
+            assert.strictEqual(pets.parent_id.toString(), friends.span_id.toString())
+
+            assertObjectContains(petsName, {
+              name: 'graphql.resolve',
+              resource: 'name:String',
+              meta: {
+                'graphql.field.path': 'friends.*.pets.*.name',
+                'graphql.field.type': 'String',
+              },
+            })
+            assert.strictEqual(petsName.parent_id.toString(), pets.span_id.toString())
+          }, { spanResourceMatch: /friends:\[Human]/ })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('caches path strings across nested list-of-lists items', async () => {
@@ -923,48 +913,38 @@ describe('Plugin', () => {
           assert.strictEqual(result.data?.matrix?.[0]?.[0]?.value, 42)
         })
 
-        it('should instrument mutations', done => {
+        it('should instrument mutations', () => {
           const source = 'mutation { human { name } }'
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'mutation')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans[0].meta['graphql.operation.type'], 'mutation')
+          })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        it('should instrument subscriptions', done => {
+        it('should instrument subscriptions', () => {
           const source = 'subscription { human { name } }'
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'subscription')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans[0].meta['graphql.operation.type'], 'subscription')
+          })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        it('should handle a circular schema', done => {
+        it('should handle a circular schema', async () => {
           const source = '{ human { pets { owner { name } } } }'
 
-          graphql.graphql({ schema, source })
-            .then((result) => {
-              assert.strictEqual(result.data.human.pets[0].owner.name, 'test')
-            })
-            .then(done)
-            .catch(done)
+          const result = await graphql.graphql({ schema, source })
+          assert.strictEqual(result.data.human.pets[0].owner.name, 'test')
         })
 
-        it('should instrument the default field resolver', done => {
+        it('should instrument the default field resolver', () => {
           const schema = graphql.buildSchema(`
             type Query {
               hello: String
@@ -974,21 +954,18 @@ describe('Plugin', () => {
           const source = '{ hello }'
           const rootValue = { hello: 'world' }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[1].name, 'graphql.resolve')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 2)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            assert.strictEqual(spans[1].name, 'graphql.resolve')
+          })
 
-          graphql.graphql({ schema, source, rootValue }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, rootValue })])
         })
 
-        it('should instrument the execution field resolver without a rootValue resolver', done => {
+        it('should instrument the execution field resolver without a rootValue resolver', () => {
           const schema = graphql.buildSchema(`
             type Query {
               hello: String
@@ -1003,74 +980,73 @@ describe('Plugin', () => {
             return source[info.fieldName]
           }
 
-          agent
-            .assertSomeTraces(traces => {
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+
+            assert.strictEqual(spans.length, 2)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            assert.strictEqual(spans[1].name, 'graphql.resolve')
+          })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source, rootValue, fieldResolver })])
+        })
+
+        it('should not instrument schema resolvers multiple times', () => {
+          const source = '{ hello(name: "world") }'
+
+          const assertion = agent.assertSomeTraces(() => { // skip first call
+            const secondAssertion = agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[1].name, 'graphql.resolve')
             })
-            .then(done)
-            .catch(done)
 
-          graphql.graphql({ schema, source, rootValue, fieldResolver }).catch(done)
-        })
-
-        it('should not instrument schema resolvers multiple times', done => {
-          const source = '{ hello(name: "world") }'
-
-          agent.assertSomeTraces(() => { // skip first call
-            agent
-              .assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-
-                assert.strictEqual(spans.length, 2)
-              })
-              .then(done)
-              .catch(done)
-
-            graphql.graphql({ schema, source }).catch(done)
+            return Promise.all([secondAssertion, graphql.graphql({ schema, source })])
           })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        it('should run parsing, validation and execution in the current context', done => {
+        it('should run parsing, validation and execution in the current context', () => {
           const source = 'query MyQuery { hello(name: "world") }'
           const variableValues = { who: 'world' }
           const span = tracer.startSpan('test.request')
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 5)
+            assert.strictEqual(spans.length, 5)
 
-              assert.strictEqual(spans[0].name, 'test.request')
+            assert.strictEqual(spans[0].name, 'test.request')
 
-              assert.strictEqual(spans[1].service, 'test')
-              assert.strictEqual(spans[1].name, 'graphql.parse')
-
-              assert.strictEqual(spans[2].service, 'test')
-              assert.strictEqual(spans[2].name, 'graphql.validate')
-
-              assert.strictEqual(spans[3].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[3].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[3].resource, 'query MyQuery{hello(name:"")}')
-
-              assert.strictEqual(spans[4].service, 'test')
-              assert.strictEqual(spans[4].name, 'graphql.resolve')
-              assert.strictEqual(spans[4].resource, 'hello:String')
+            assertObjectContains(spans[1], {
+              service: 'test',
+              name: 'graphql.parse',
             })
-            .then(done)
-            .catch(done)
 
-          tracer.scope().activate(span, () => {
-            graphql.graphql({ schema, source, variableValues })
-              .then(() => span.finish())
-              .catch(done)
+            assertObjectContains(spans[2], {
+              service: 'test',
+              name: 'graphql.validate',
+            })
+
+            assertObjectContains(spans[3], {
+              service: expectedSchema.server.serviceName,
+              name: expectedSchema.server.opName,
+              resource: 'query MyQuery{hello(name:"")}',
+            })
+
+            assertObjectContains(spans[4], {
+              service: 'test',
+              name: 'graphql.resolve',
+              resource: 'hello:String',
+            })
+          }, { spanResourceMatch: /test\.request/ })
+
+          const action = tracer.scope().activate(span, () => {
+            return graphql.graphql({ schema, source, variableValues }).then(() => span.finish())
           })
+
+          return Promise.all([assertion, action])
         })
 
         it('should run rootValue resolvers in the current context', done => {
@@ -1133,32 +1109,31 @@ describe('Plugin', () => {
             })
         })
 
-        it('should handle calling low level APIs directly', done => {
+        it('should handle calling low level APIs directly', () => {
           const source = 'query MyQuery { hello(name: "world") }'
 
-          Promise
-            .all([
-              agent.assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-                assert.strictEqual(spans[0].name, 'graphql.parse')
-              }),
-              agent.assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-                assert.strictEqual(spans[0].name, 'graphql.validate')
-              }),
-              agent.assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-                assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-                assert.strictEqual(spans[1].name, 'graphql.resolve')
-              }),
-            ])
-            .then(() => done())
-            .catch(done)
+          const assertion = Promise.all([
+            agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              assert.strictEqual(spans[0].name, 'graphql.parse')
+            }),
+            agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              assert.strictEqual(spans[0].name, 'graphql.validate')
+            }),
+            agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+              assert.strictEqual(spans[1].name, 'graphql.resolve')
+            }),
+          ])
 
           // These are the 3 lower-level steps
           const document = graphql.parse(source)
           graphql.validate(schema, document)
           graphql.execute({ schema, document })
+
+          return assertion
         })
 
         it('should not re-execute thenables from resolvers', async () => {
@@ -1169,147 +1144,144 @@ describe('Plugin', () => {
           assert.strictEqual(result.data.human.oneTime, 'one-time result')
         })
 
-        it('should handle Source objects', done => {
+        it('should handle Source objects', () => {
           const source = 'query MyQuery { hello(name: "world") }'
           const document = graphql.parse(new graphql.Source(source))
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].resource, 'query MyQuery{hello(name:"")}')
-              assert.ok(!('graphql.source' in spans[0].meta))
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+            assert.strictEqual(spans.length, 2)
+            assertObjectContains(spans[0], {
+              service: expectedSchema.server.serviceName,
+              name: expectedSchema.server.opName,
+              resource: 'query MyQuery{hello(name:"")}',
+              meta: { component: 'graphql' },
             })
-            .then(done)
-            .catch(done)
+            assert.ok(!('graphql.source' in spans[0].meta))
+          }, { spanResourceMatch: /MyQuery/ })
 
           graphql.execute({ schema, document })
+
+          return assertion
         })
 
-        it('should handle parsing exceptions', done => {
+        it('should handle parsing exceptions', () => {
           let error
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].service, 'test')
-              assert.strictEqual(spans[0].name, 'graphql.parse')
-              assert.strictEqual(spans[0].error, 1)
-              assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
-              assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(spans[0].meta.component, 'graphql')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].service, 'test')
+            assert.strictEqual(spans[0].name, 'graphql.parse')
+            assert.strictEqual(spans[0].error, 1)
+            assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
+            assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
+            assert.strictEqual(spans[0].meta.component, 'graphql')
+          })
 
           try {
             graphql.parse('invalid')
           } catch (e) {
             error = e
           }
+
+          return assertion
         })
 
-        it('should handle validation exceptions', done => {
+        it('should handle validation exceptions', () => {
           let error
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].service, 'test')
-              assert.strictEqual(spans[0].name, 'graphql.validate')
-              assert.strictEqual(spans[0].error, 1)
-              assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
-              assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(spans[0].meta.component, 'graphql')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].service, 'test')
+            assert.strictEqual(spans[0].name, 'graphql.validate')
+            assert.strictEqual(spans[0].error, 1)
+            assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
+            assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
+            assert.strictEqual(spans[0].meta.component, 'graphql')
+          })
 
           try {
             graphql.validate()
           } catch (e) {
             error = e
           }
+
+          return assertion
         })
 
-        it('should handle validation errors', done => {
+        it('should handle validation errors', () => {
           const source = '{ human { address } }'
           const document = graphql.parse(source)
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].service, 'test')
-              assert.strictEqual(spans[0].name, 'graphql.validate')
-              assert.strictEqual(spans[0].error, 1)
-              assert.strictEqual(spans[0].meta[ERROR_TYPE], errors[0].name)
-              assert.strictEqual(spans[0].meta[ERROR_MESSAGE], errors[0].message)
-              assert.strictEqual(spans[0].meta[ERROR_STACK], errors[0].stack)
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].service, 'test')
+            assert.strictEqual(spans[0].name, 'graphql.validate')
+            assert.strictEqual(spans[0].error, 1)
+            assert.strictEqual(spans[0].meta[ERROR_TYPE], errors[0].name)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], errors[0].message)
+            assert.strictEqual(spans[0].meta[ERROR_STACK], errors[0].stack)
+            assert.strictEqual(spans[0].meta.component, 'graphql')
 
-              const spanEvents = agent.unformatSpanEvents(spans[0])
+            const spanEvents = agent.unformatSpanEvents(spans[0])
 
-              assert.strictEqual(spanEvents.length, 1)
-              assert.ok(('startTime' in spanEvents[0]))
-              assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
-              assert.strictEqual(spanEvents[0].attributes.type, 'GraphQLError')
-              assert.ok(
-                !Object.hasOwn(spanEvents[0].attributes, 'stacktrace'),
-                `Available keys: ${inspect(Object.keys(spanEvents[0].attributes))}`
-              )
-              assert.strictEqual(spanEvents[0].attributes.message, 'Field "address" of ' +
-                'type "Address" must have a selection of subfields. Did you mean "address { ... }"?')
-              assert.strictEqual(spanEvents[0].attributes.locations.length, 1)
-              assert.strictEqual(spanEvents[0].attributes.locations[0], '1:11')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spanEvents.length, 1)
+            assert.ok(('startTime' in spanEvents[0]))
+            assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
+            assert.strictEqual(spanEvents[0].attributes.type, 'GraphQLError')
+            assert.ok(
+              !Object.hasOwn(spanEvents[0].attributes, 'stacktrace'),
+              `Available keys: ${inspect(Object.keys(spanEvents[0].attributes))}`
+            )
+            assert.strictEqual(spanEvents[0].attributes.message, 'Field "address" of ' +
+              'type "Address" must have a selection of subfields. Did you mean "address { ... }"?')
+            assert.strictEqual(spanEvents[0].attributes.locations.length, 1)
+            assert.strictEqual(spanEvents[0].attributes.locations[0], '1:11')
+          })
 
           const errors = graphql.validate(schema, document)
+
+          return assertion
         })
 
-        it('should handle execution exceptions', done => {
+        it('should handle execution exceptions', () => {
           const source = '{ hello }'
           const document = graphql.parse(source)
 
           let error
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].error, 1)
-              assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
-              assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(spans[0].meta.component, 'graphql')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            assert.strictEqual(spans[0].error, 1)
+            assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
+            assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
+            assert.strictEqual(spans[0].meta.component, 'graphql')
+          })
 
           try {
             graphql.execute(null, document)
           } catch (e) {
             error = e
           }
+
+          return assertion
         })
 
-        it('should handle execution errors', done => {
+        it('should handle execution errors', () => {
           const source = '{ hello }'
           const document = graphql.parse(source)
 
@@ -1327,48 +1299,47 @@ describe('Plugin', () => {
 
           let error
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].error, 1)
-              assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
-              assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+            assert.strictEqual(spans.length, 2)
+            assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            assert.strictEqual(spans[0].error, 1)
+            assert.strictEqual(spans[0].meta[ERROR_TYPE], error.name)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
+            assert.strictEqual(spans[0].meta[ERROR_STACK], error.stack)
+            assert.strictEqual(spans[0].meta.component, 'graphql')
 
-              const spanEvents = agent.unformatSpanEvents(spans[0])
+            const spanEvents = agent.unformatSpanEvents(spans[0])
 
-              assert.strictEqual(spanEvents.length, 1)
-              assert.ok(
-                Object.hasOwn(spanEvents[0], 'startTime'),
-                `Available keys: ${inspect(Object.keys(spanEvents[0]))}`
-              )
-              assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
-              assert.strictEqual(spanEvents[0].attributes.type, 'GraphQLError')
-              assert.ok(
-                Object.hasOwn(spanEvents[0].attributes, 'stacktrace'),
-                `Available keys: ${inspect(Object.keys(spanEvents[0].attributes))}`
-              )
-              assert.strictEqual(spanEvents[0].attributes.message, 'test')
-              assert.strictEqual(spanEvents[0].attributes.locations.length, 1)
-              assert.strictEqual(spanEvents[0].attributes.locations[0], '1:3')
-              assert.strictEqual(spanEvents[0].attributes.path.length, 1)
-              assert.strictEqual(spanEvents[0].attributes.path[0], 'hello')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spanEvents.length, 1)
+            assert.ok(
+              Object.hasOwn(spanEvents[0], 'startTime'),
+              `Available keys: ${inspect(Object.keys(spanEvents[0]))}`
+            )
+            assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
+            assert.strictEqual(spanEvents[0].attributes.type, 'GraphQLError')
+            assert.ok(
+              Object.hasOwn(spanEvents[0].attributes, 'stacktrace'),
+              `Available keys: ${inspect(Object.keys(spanEvents[0].attributes))}`
+            )
+            assert.strictEqual(spanEvents[0].attributes.message, 'test')
+            assert.strictEqual(spanEvents[0].attributes.locations.length, 1)
+            assert.strictEqual(spanEvents[0].attributes.locations[0], '1:3')
+            assert.strictEqual(spanEvents[0].attributes.path.length, 1)
+            assert.strictEqual(spanEvents[0].attributes.path[0], 'hello')
+          })
 
-          Promise.resolve(graphql.execute({ schema, document, rootValue }))
+          const action = Promise.resolve(graphql.execute({ schema, document, rootValue }))
             .then(res => {
               error = res.errors[0]
             })
+
+          return Promise.all([assertion, action])
         })
 
-        it('should handle resolver exceptions', done => {
+        it('should handle resolver exceptions', () => {
           const error = new Error('test')
 
           const schema = graphql.buildSchema(`
@@ -1385,24 +1356,21 @@ describe('Plugin', () => {
             },
           }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[1].error, 1)
-              assert.strictEqual(spans[1].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(spans[1].meta[ERROR_MESSAGE], error.message)
-              assert.strictEqual(spans[1].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(spans[1].meta.component, 'graphql')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 2)
+            assert.strictEqual(spans[1].error, 1)
+            assert.strictEqual(spans[1].meta[ERROR_TYPE], error.name)
+            assert.strictEqual(spans[1].meta[ERROR_MESSAGE], error.message)
+            assert.strictEqual(spans[1].meta[ERROR_STACK], error.stack)
+            assert.strictEqual(spans[1].meta.component, 'graphql')
+          })
 
-          graphql.graphql({ schema, source, rootValue }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, rootValue })])
         })
 
-        it('should handle rejected promises', done => {
+        it('should handle rejected promises', () => {
           const error = new Error('test')
 
           const schema = graphql.buildSchema(`
@@ -1419,21 +1387,18 @@ describe('Plugin', () => {
             },
           }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[1].error, 1)
-              assert.strictEqual(spans[1].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(spans[1].meta[ERROR_MESSAGE], error.message)
-              assert.strictEqual(spans[1].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(spans[1].meta.component, 'graphql')
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 2)
+            assert.strictEqual(spans[1].error, 1)
+            assert.strictEqual(spans[1].meta[ERROR_TYPE], error.name)
+            assert.strictEqual(spans[1].meta[ERROR_MESSAGE], error.message)
+            assert.strictEqual(spans[1].meta[ERROR_STACK], error.stack)
+            assert.strictEqual(spans[1].meta.component, 'graphql')
+          })
 
-          graphql.graphql({ schema, source, rootValue }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, rootValue })])
         })
 
         it('throws AbortError when the execute abortController is aborted before execute runs', async () => {
@@ -1505,7 +1470,7 @@ describe('Plugin', () => {
           }
         })
 
-        it('should support multiple executions with the same contextValue', done => {
+        it('should support multiple executions with the same contextValue', async () => {
           const schema = graphql.buildSchema(`
             type Query {
               hello: String
@@ -1520,10 +1485,8 @@ describe('Plugin', () => {
 
           const contextValue = {}
 
-          graphql.graphql({ schema, source, rootValue, contextValue })
-            .then(() => graphql.graphql({ schema, source, rootValue, contextValue }))
-            .then(() => done())
-            .catch(done)
+          await graphql.graphql({ schema, source, rootValue, contextValue })
+          await graphql.graphql({ schema, source, rootValue, contextValue })
         })
 
         it('should support multiple executions on a pre-parsed document', () => {
@@ -1558,7 +1521,7 @@ describe('Plugin', () => {
           graphql.validate(schema, document)
         })
 
-        it('should support multi-operations documents', done => {
+        it('should support multi-operations documents', () => {
           const source = `
             query FirstQuery { hello(name: "world") }
             query SecondQuery { hello(name: "world") }
@@ -1567,25 +1530,26 @@ describe('Plugin', () => {
           const operationName = 'SecondQuery'
           const variableValues = { who: 'world' }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].resource, 'query SecondQuery{hello(name:"")}')
-              assert.ok(!('graphql.source' in spans[0].meta))
-              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
-              assert.strictEqual(spans[0].meta['graphql.operation.name'], 'SecondQuery')
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+            assertObjectContains(spans[0], {
+              service: expectedSchema.server.serviceName,
+              name: expectedSchema.server.opName,
+              resource: 'query SecondQuery{hello(name:"")}',
+              meta: {
+                'graphql.operation.type': 'query',
+                'graphql.operation.name': 'SecondQuery',
+                component: 'graphql',
+              },
             })
-            .then(() => done())
-            .catch(done)
+            assert.ok(!('graphql.source' in spans[0].meta))
+          }, { spanResourceMatch: /SecondQuery/ })
 
-          graphql.graphql({ schema, source, variableValues, operationName }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues, operationName })])
         })
 
-        it('should include used fragments in the source', done => {
+        it('should include used fragments in the source', () => {
           const source = `
             query WithFragments {
               human {
@@ -1597,82 +1561,82 @@ describe('Plugin', () => {
             }
           `
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              const resource = 'query WithFragments{human{...firstFields}}fragment firstFields on Human{name}'
+            const resource = 'query WithFragments{human{...firstFields}}fragment firstFields on Human{name}'
 
-              assert.strictEqual(spans[0].service, 'test')
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].resource, resource)
-              assert.ok(!('graphql.source' in spans[0].meta))
-              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
-              assert.strictEqual(spans[0].meta['graphql.operation.name'], 'WithFragments')
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+            assertObjectContains(spans[0], {
+              service: 'test',
+              name: expectedSchema.server.opName,
+              resource,
+              meta: {
+                'graphql.operation.type': 'query',
+                'graphql.operation.name': 'WithFragments',
+                component: 'graphql',
+              },
             })
-            .then(done)
-            .catch(done)
+            assert.ok(!('graphql.source' in spans[0].meta))
+          }, { spanResourceMatch: /WithFragments/ })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        it('should handle single fragment definitions', done => {
+        it('should handle single fragment definitions', () => {
           const source = `
             fragment firstFields on Human {
               name
             }
           `
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].service, 'test')
-              assert.strictEqual(spans[0].name, 'graphql.parse')
-              assert.strictEqual(spans[0].resource, 'graphql.parse')
-              assert.ok(!('graphql.source' in spans[0].meta))
-              assert.ok(!('graphql.operation.type' in spans[0].meta))
-              assert.ok(!('graphql.operation.name' in spans[0].meta))
-              assert.strictEqual(spans[0].meta.component, 'graphql')
+            assertObjectContains(spans[0], {
+              service: 'test',
+              name: 'graphql.parse',
+              resource: 'graphql.parse',
+              meta: { component: 'graphql' },
             })
-            .then(done)
-            .catch(done)
+            assert.ok(!('graphql.source' in spans[0].meta))
+            assert.ok(!('graphql.operation.type' in spans[0].meta))
+            assert.ok(!('graphql.operation.name' in spans[0].meta))
+          }, { spanResourceMatch: /^graphql\.parse$/ })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         // https://github.com/graphql/graphql-js/pull/2904
         if (!semver.intersects(version, '>=16')) {
-          it('should instrument using positional arguments', done => {
+          it('should instrument using positional arguments', () => {
             const source = 'query MyQuery { hello(name: "world") }'
             const variableValues = { who: 'world' }
 
-            agent
-              .assertSomeTraces(traces => {
-                const spans = sort(traces[0])
+            const assertion = agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
 
-                assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-                assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-                assert.strictEqual(spans[0].resource, 'query MyQuery{hello(name:"")}')
-                assert.strictEqual(spans[0].type, 'graphql')
-                assert.ok(!('graphql.source' in spans[0].meta))
-                assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
-                assert.strictEqual(spans[0].meta['graphql.operation.name'], 'MyQuery')
-                assert.strictEqual(spans[0].meta.component, 'graphql')
+              assertObjectContains(spans[0], {
+                service: expectedSchema.server.serviceName,
+                name: expectedSchema.server.opName,
+                resource: 'query MyQuery{hello(name:"")}',
+                type: 'graphql',
+                meta: {
+                  'graphql.operation.type': 'query',
+                  'graphql.operation.name': 'MyQuery',
+                  component: 'graphql',
+                },
               })
-              .then(done)
-              .catch(done)
+              assert.ok(!('graphql.source' in spans[0].meta))
+            }, { spanResourceMatch: /MyQuery/ })
 
-            graphql.graphql(schema, source, null, null, variableValues).catch(done)
+            return Promise.all([assertion, graphql.graphql(schema, source, null, null, variableValues)])
           })
         } else {
-          it('should not support positional arguments', done => {
+          it('should not support positional arguments', () => {
             const source = 'query MyQuery { hello(name: "world") }'
             const variableValues = { who: 'world' }
 
-            graphql.graphql(schema, source, null, null, variableValues)
-              .then(() => done(new Error('Expected error.')), () => done())
+            return assert.rejects(() => graphql.graphql(schema, source, null, null, variableValues))
           })
         }
 
@@ -1734,28 +1698,33 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should be configured with the correct values', done => {
+        it('should be configured with the correct values', () => {
           const source = '{ hello(name: "world") }'
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 2)
-              assert.strictEqual(spans[0].service, 'custom')
-              assert.strictEqual(spans[1].service, 'custom')
-              assert.strictEqual(spans[0].meta['graphql.source'], '{ hello(name: "world") }')
-              assert.strictEqual(spans[0].meta.component, 'graphql')
-              assert.strictEqual(spans[1].meta['graphql.source'], 'hello(name: "world")')
-              assert.strictEqual(spans[1].meta.component, 'graphql')
+            assert.strictEqual(spans.length, 2)
+            assertObjectContains(spans[0], {
+              service: 'custom',
+              meta: {
+                'graphql.source': '{ hello(name: "world") }',
+                component: 'graphql',
+              },
             })
-            .then(done)
-            .catch(done)
+            assertObjectContains(spans[1], {
+              service: 'custom',
+              meta: {
+                'graphql.source': 'hello(name: "world")',
+                component: 'graphql',
+              },
+            })
+          }, { spanResourceMatch: /hello:String/ })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        it('should apply the filter callback to the variables', done => {
+        it('should apply the filter callback to the variables', () => {
           const source = `
             query MyQuery($title: String!, $who: String!) {
               hello(title: $title, name: $who)
@@ -1763,19 +1732,24 @@ describe('Plugin', () => {
           `
           const variableValues = { title: 'planet', who: 'world' }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].meta['graphql.variables.title'], 'planet')
-              assert.strictEqual(spans[0].meta['graphql.variables.who'], 'REDACTED')
-              assert.strictEqual(spans[1].meta['graphql.variables.title'], 'planet')
-              assert.strictEqual(spans[1].meta['graphql.variables.who'], 'REDACTED')
+            assertObjectContains(spans[0], {
+              meta: {
+                'graphql.variables.title': 'planet',
+                'graphql.variables.who': 'REDACTED',
+              },
             })
-            .then(done)
-            .catch(done)
+            assertObjectContains(spans[1], {
+              meta: {
+                'graphql.variables.title': 'planet',
+                'graphql.variables.who': 'REDACTED',
+              },
+            })
+          }, { spanResourceMatch: /MyQuery/ })
 
-          graphql.graphql({ schema, source, variableValues }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues })])
         })
       })
 
@@ -1797,7 +1771,7 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should only include the configured variables', done => {
+        it('should only include the configured variables', () => {
           const source = `
             query MyQuery($title: String!, $who: String!) {
               hello(title: $title, name: $who)
@@ -1805,17 +1779,14 @@ describe('Plugin', () => {
           `
           const variableValues = { title: 'planet', who: 'world' }
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].meta['graphql.variables.title'], 'planet')
-              assert.ok(!('graphql.variables.who' in spans[0].meta))
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans[0].meta['graphql.variables.title'], 'planet')
+            assert.ok(!('graphql.variables.who' in spans[0].meta))
+          })
 
-          graphql.graphql({ schema, source, variableValues }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source, variableValues })])
         })
       })
 
@@ -1835,7 +1806,7 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should only instrument the execution', done => {
+        it('should only instrument the execution', () => {
           const source = `
             {
               human {
@@ -1848,17 +1819,14 @@ describe('Plugin', () => {
             }
           `
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+          })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('should run the resolvers in the execution scope', done => {
@@ -1905,7 +1873,7 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should only instrument up to the specified depth', done => {
+        it('should only instrument up to the specified depth', () => {
           const source = `
             {
               human {
@@ -1921,23 +1889,20 @@ describe('Plugin', () => {
             }
           `
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
-              const ignored = spans.filter(span => {
-                return [
-                  'human.address.civicNumber',
-                  'human.address.street',
-                ].indexOf(span.resource) !== -1
-              })
-
-              assert.strictEqual(spans.length, 5)
-              assert.strictEqual(ignored.length, 0)
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+            const ignored = spans.filter(span => {
+              return [
+                'human.address.civicNumber',
+                'human.address.street',
+              ].indexOf(span.resource) !== -1
             })
-            .then(done)
-            .catch(done)
 
-          graphql.graphql({ schema, source }).catch(done)
+            assert.strictEqual(spans.length, 5)
+            assert.strictEqual(ignored.length, 0)
+          })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('publishes apm:graphql:resolve:start for every resolver, including depth-gated ones', async () => {
@@ -2002,53 +1967,50 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should not collapse list field resolvers', done => {
+        it('should not collapse list field resolvers', () => {
           const source = '{ friends { name } }'
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 4)
+            assert.strictEqual(spans.length, 4)
 
-              const execute = spans[0]
-              const friends = spans[1]
-              const friend0Name = spans[2]
-              const friend1Name = spans[3]
+            const execute = spans[0]
+            const friends = spans[1]
+            const friend0Name = spans[2]
+            const friend1Name = spans[3]
 
-              assert.strictEqual(execute.name, expectedSchema.server.opName)
+            assert.strictEqual(execute.name, expectedSchema.server.opName)
 
-              assertObjectContains(friends, {
-                name: 'graphql.resolve',
-                resource: 'friends:[Human]',
-                meta: {
-                  'graphql.field.path': 'friends',
-                },
-              })
-              assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
-
-              assertObjectContains(friend0Name, {
-                name: 'graphql.resolve',
-                resource: 'name:String',
-                meta: {
-                  'graphql.field.path': 'friends.0.name',
-                },
-              })
-              assert.strictEqual(friend0Name.parent_id.toString(), friends.span_id.toString())
-
-              assertObjectContains(friend1Name, {
-                name: 'graphql.resolve',
-                resource: 'name:String',
-                meta: {
-                  'graphql.field.path': 'friends.1.name',
-                },
-              })
-              assert.strictEqual(friend1Name.parent_id.toString(), friends.span_id.toString())
+            assertObjectContains(friends, {
+              name: 'graphql.resolve',
+              resource: 'friends:[Human]',
+              meta: {
+                'graphql.field.path': 'friends',
+              },
             })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
 
-          graphql.graphql({ schema, source }).catch(done)
+            assertObjectContains(friend0Name, {
+              name: 'graphql.resolve',
+              resource: 'name:String',
+              meta: {
+                'graphql.field.path': 'friends.0.name',
+              },
+            })
+            assert.strictEqual(friend0Name.parent_id.toString(), friends.span_id.toString())
+
+            assertObjectContains(friend1Name, {
+              name: 'graphql.resolve',
+              resource: 'name:String',
+              meta: {
+                'graphql.field.path': 'friends.1.name',
+              },
+            })
+            assert.strictEqual(friend1Name.parent_id.toString(), friends.span_id.toString())
+          }, { spanResourceMatch: /friends:\[Human]/ })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('should trace aliased __proto__ fields when collapsing is disabled', async () => {
@@ -2067,7 +2029,7 @@ describe('Plugin', () => {
                   'graphql.field.path': '__proto__',
                 },
               })
-            }),
+            }, { spanResourceMatch: /hello:String/ }),
             graphql.graphql({ schema, source }),
           ])
 
@@ -2094,7 +2056,7 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should count only string segments when collapsing is disabled', done => {
+        it('should count only string segments when collapsing is disabled', () => {
           const source = `
             {
               friends {
@@ -2106,24 +2068,21 @@ describe('Plugin', () => {
             }
           `
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
-              const resolveSpans = spans.filter(span => span.name === 'graphql.resolve')
-              const paths = resolveSpans.map(span => span.meta['graphql.field.path']).sort()
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+            const resolveSpans = spans.filter(span => span.name === 'graphql.resolve')
+            const paths = resolveSpans.map(span => span.meta['graphql.field.path']).sort()
 
-              assert.deepStrictEqual(paths, [
-                'friends',
-                'friends.0.name',
-                'friends.0.pets',
-                'friends.1.name',
-                'friends.1.pets',
-              ])
-            })
-            .then(done)
-            .catch(done)
+            assert.deepStrictEqual(paths, [
+              'friends',
+              'friends.0.name',
+              'friends.0.pets',
+              'friends.1.name',
+              'friends.1.pets',
+            ])
+          })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
       })
 
@@ -2143,20 +2102,19 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should fallback to the operation type and name', done => {
+        it('should fallback to the operation type and name', () => {
           const source = 'query WithoutSignature { friends { name } }'
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              assert.strictEqual(spans[0].resource, 'query WithoutSignature')
+            assertObjectContains(spans[0], {
+              name: expectedSchema.server.opName,
+              resource: 'query WithoutSignature',
             })
-            .then(done)
-            .catch(done)
+          }, { spanResourceMatch: /WithoutSignature/ })
 
-          graphql.graphql({ schema, source }).catch(done)
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
         it('should fallback to the operation type', async () => {
@@ -2207,7 +2165,7 @@ describe('Plugin', () => {
 
         after(() => agent.close())
 
-        it('should run the execute hook before graphql.execute span is finished', done => {
+        it('should run the execute hook before graphql.execute span is finished', () => {
           const document = graphql.parse(source)
 
           graphql.validate(schema, document)
@@ -2227,97 +2185,95 @@ describe('Plugin', () => {
 
           let result
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-              sinon.assert.calledOnce(config.hooks.execute)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            sinon.assert.calledOnce(config.hooks.execute)
 
-              const span = config.hooks.execute.firstCall.args[0]
-              const args = config.hooks.execute.firstCall.args[1]
-              const res = config.hooks.execute.firstCall.args[2]
+            const span = config.hooks.execute.firstCall.args[0]
+            const args = config.hooks.execute.firstCall.args[1]
+            const res = config.hooks.execute.firstCall.args[2]
 
-              assert.strictEqual(span.context()._name, expectedSchema.server.opName)
+            assert.strictEqual(span.context()._name, expectedSchema.server.opName)
 
-              // These two properties are circular structures.
-              assert.deepStrictEqual(args.document, params.document)
-              assert.deepStrictEqual(args.schema, params.schema)
+            // These two properties are circular structures.
+            assert.deepStrictEqual(args.document, params.document)
+            assert.deepStrictEqual(args.schema, params.schema)
 
-              // The helper can not handle circular structures properly.
-              assertObjectContains(args, {
-                rootValue: params.rootValue,
-                contextValue: params.contextValue,
-                variableValues: params.variableValues,
-                operationName: params.operationName,
-                typeResolver: params.typeResolver,
-              })
-              assert.strictEqual(typeof args.fieldResolver, 'function')
-              assert.notStrictEqual(args.fieldResolver, params.fieldResolver)
-              assert.strictEqual(res, result)
+            // The helper can not handle circular structures properly.
+            assertObjectContains(args, {
+              rootValue: params.rootValue,
+              contextValue: params.contextValue,
+              variableValues: params.variableValues,
+              operationName: params.operationName,
+              typeResolver: params.typeResolver,
             })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(typeof args.fieldResolver, 'function')
+            assert.notStrictEqual(args.fieldResolver, params.fieldResolver)
+            assert.strictEqual(res, result)
+          }, { spanResourceMatch: /MyQuery/ })
 
-          Promise.resolve(graphql.execute(params))
+          const action = Promise.resolve(graphql.execute(params))
             .then(res => {
               result = res
             })
+
+          return Promise.all([assertion, action])
         })
 
-        it('should run the validate hook before graphql.validate span is finished', done => {
+        it('should run the validate hook before graphql.validate span is finished', () => {
           const document = graphql.parse(source)
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].name, 'graphql.validate')
-              sinon.assert.calledOnce(config.hooks.validate)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, 'graphql.validate')
+            sinon.assert.calledOnce(config.hooks.validate)
 
-              const span = config.hooks.validate.firstCall.args[0]
-              const hookDocument = config.hooks.validate.firstCall.args[1]
-              const hookErrors = config.hooks.validate.firstCall.args[2]
+            const span = config.hooks.validate.firstCall.args[0]
+            const hookDocument = config.hooks.validate.firstCall.args[1]
+            const hookErrors = config.hooks.validate.firstCall.args[2]
 
-              assert.strictEqual(span.context()._name, 'graphql.validate')
+            assert.strictEqual(span.context()._name, 'graphql.validate')
 
-              assert.strictEqual(hookDocument, document)
-              assert.strictEqual(hookErrors, errors)
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(hookDocument, document)
+            assert.strictEqual(hookErrors, errors)
+          })
+
           const errors = graphql.validate(schema, document)
+
+          return assertion
         })
 
-        it('should run the parse hook before graphql.parse span is finished', done => {
+        it('should run the parse hook before graphql.parse span is finished', () => {
           let document
 
-          agent
-            .assertSomeTraces(traces => {
-              const spans = sort(traces[0])
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
 
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].name, 'graphql.parse')
-              sinon.assert.calledOnce(config.hooks.parse)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, 'graphql.parse')
+            sinon.assert.calledOnce(config.hooks.parse)
 
-              const span = config.hooks.parse.firstCall.args[0]
-              const hookSource = config.hooks.parse.firstCall.args[1]
-              const hookDocument = config.hooks.parse.firstCall.args[2]
+            const span = config.hooks.parse.firstCall.args[0]
+            const hookSource = config.hooks.parse.firstCall.args[1]
+            const hookDocument = config.hooks.parse.firstCall.args[2]
 
-              assert.strictEqual(span.context()._name, 'graphql.parse')
+            assert.strictEqual(span.context()._name, 'graphql.parse')
 
-              assert.strictEqual(hookSource, source)
-              assert.strictEqual(hookDocument, document)
-            })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(hookSource, source)
+            assert.strictEqual(hookDocument, document)
+          })
 
-          Promise.resolve(graphql.parse(source))
+          const action = Promise.resolve(graphql.parse(source))
             .then(res => {
               document = res
             })
+
+          return Promise.all([assertion, action])
         })
       })
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -237,75 +237,74 @@ describe('Plugin', () => {
           let server
           let port
 
-          before(() => {
+          // A generous hook timeout absorbs the one-off cost of loading the
+          // graphql-yoga tree and building the envelop execution pipeline under
+          // coverage on CI, keeping the assertion below on a fast hot path.
+          before(async function () {
+            this.timeout(10000)
+
             tracer = require('../../dd-trace')
-            return agent.load('graphql')
-              .then(() => {
-                graphqlYoga = require(`../../../versions/graphql-yoga@${version}`).get()
+            await agent.load('graphql')
 
-                const typeDefs = `
-                  type Query {
-                    hello(name: String): String
-                  }
-                `
+            graphqlYoga = require(`../../../versions/graphql-yoga@${version}`).get()
 
-                const resolvers = {
-                  Query: {
-                    hello: (_, { name }) => {
-                      return `Hello, ${name || 'world'}!`
-                    },
-                  },
-                }
+            const typeDefs = `
+              type Query {
+                hello(name: String): String
+              }
+            `
 
-                const schema = graphqlYoga.createSchema({
-                  typeDefs, resolvers,
-                })
+            const resolvers = {
+              Query: {
+                hello: (_, { name }) => {
+                  return `Hello, ${name || 'world'}!`
+                },
+              },
+            }
 
-                const yoga = graphqlYoga.createYoga({ schema })
+            const schema = graphqlYoga.createSchema({ typeDefs, resolvers })
+            const yoga = graphqlYoga.createYoga({ schema })
 
-                server = http.createServer(yoga)
-              })
-          })
+            server = http.createServer(yoga)
+            await new Promise(resolve => server.listen(0, resolve))
+            port = (/** @type {import('net').AddressInfo} */ (server.address())).port
 
-          before(done => {
-            server.listen(0, () => {
-              port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-              done()
+            // The first request primes the lazily built execution pipeline so
+            // the timed assertion does not race a cold request on CI.
+            await axios.post(`http://localhost:${port}/graphql`, {
+              query: 'query Warmup { hello(name: "warmup") }',
             })
           })
 
-          after(() => {
+          after(async () => {
             server.close()
-            return agent.close()
+            await agent.close()
           })
 
-          it('should instrument graphql-yoga execution', done => {
-            agent
-              .assertSomeTraces(traces => {
-                const spans = sort(traces[0])
-
-                assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
-                assert.strictEqual(spans[0].name, expectedSchema.server.opName)
-                assert.strictEqual(spans[0].resource, 'query MyQuery{hello(name:"")}')
-                assert.strictEqual(spans[0].type, 'graphql')
-                assert.strictEqual(spans[0].error, 0)
-                assert.ok(!('graphql.source' in spans[0].meta))
-                assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
-                assert.strictEqual(spans[0].meta['graphql.operation.name'], 'MyQuery')
-                assert.strictEqual(spans[0].meta.component, 'graphql')
-                assert.strictEqual(spans[0].meta['_dd.integration'], 'graphql')
-              })
-              .then(done)
-
+          it('should instrument graphql-yoga execution', async () => {
             const query = `
               query MyQuery {
                 hello(name: "world")
               }
             `
 
-            axios.post(`http://localhost:${port}/graphql`, {
-              query,
-            }).catch(done)
+            const assertion = agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+
+              assert.strictEqual(spans[0].service, expectedSchema.server.serviceName)
+              assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+              assert.strictEqual(spans[0].resource, 'query MyQuery{hello(name:"")}')
+              assert.strictEqual(spans[0].type, 'graphql')
+              assert.strictEqual(spans[0].error, 0)
+              assert.ok(!('graphql.source' in spans[0].meta))
+              assert.strictEqual(spans[0].meta['graphql.operation.type'], 'query')
+              assert.strictEqual(spans[0].meta['graphql.operation.name'], 'MyQuery')
+              assert.strictEqual(spans[0].meta.component, 'graphql')
+              assert.strictEqual(spans[0].meta['_dd.integration'], 'graphql')
+            }, { spanResourceMatch: /MyQuery/ })
+
+            await axios.post(`http://localhost:${port}/graphql`, { query })
+            await assertion
           })
         })
       })


### PR DESCRIPTION
## Summary

graphql-yoga and `@apollo/gateway` lose every `graphql.execute` and `graphql.resolve` span under CommonJS. `@graphql-tools/executor` exposes `execute` and `normalizedExecutor` at its package root as non-configurable tslib `__exportStar` getters, so the root hook's second `shimmer.wrap` throws `TypeError: Cannot redefine property: normalizedExecutor` (shimmer clones the module exports on the first wrap and then cannot redefine the copied getter). `register.js` catches that throw, so the wrap is silently dropped.

1. **Production fix** (`datadog-instrumentations/src/graphql.js`): #8510 removed the inner `cjs/execution/execute.js` hook that actually wrapped the `execute` `normalizedExecutor` funnels through, on the (incorrect) assumption that the root wrap already covered it. Restore the inner hook for CJS and gate the root wrap to iitm, where the module namespace is settable and the inner-file hook never matches the `esm/` path.
2. **Test fix** (`datadog-plugin-graphql/test/index.spec.js`): the graphql-yoga suite passed the plugin class (`.name === 'GraphQLPlugin'`) to `withVersions` instead of `'graphql'`, so `externals` resolved zero versions and the describe registered nothing — which is why CI never caught the regression. Passing `'graphql'` drives the executor again.

## Why

The leaf `cjs/execution/execute.js` exports `execute` as a writable value, so the inner hook patches it in place and every public path (`normalizedExecutor`, direct `executor.execute`) reaches the wrapped function through the root getter. ESM keeps working through the root wrap because iitm hands shimmer a settable namespace.

## Test plan

- [ ] CJS: `PLUGINS=graphql npm run test:plugins:ci` — the `graphql-yoga` describe now produces a `graphql.execute` span (8 cases across the graphql × graphql-yoga matrix; fails on master with a timeout, passes here).
- [ ] ESM: graphql-yoga ESM integration test still passes (root wrap under iitm).

Refs: https://github.com/DataDog/dd-trace-js/pull/8510