### PR TITLE
fix(config): stop exposing deprecated alias entries as Config properties

### DIFF
--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -216,6 +216,14 @@ for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) 
     )
   }
   for (const entry of entries) {
+    // A deprecated entry that only aliases a canonical option must not surface as
+    // its own Config property/default: the canonical entry already owns the value
+    // and the alias is resolved by helper.js. helper.js drops these from the shared
+    // supported-configurations object (after registering the deprecation), but that
+    // mutation is order-dependent on which module loads first. Skip here too so
+    // `defaults` is identical regardless of load order (it differed in v5, where
+    // major-overrides keeps these entries instead of deleting them outright).
+    if (entry.deprecated && entry.aliases) continue
     if (entry.sensitive) {
       sensitiveConfigurations.add(canonicalName)
     }
@@ -283,7 +291,7 @@ for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) 
 
 // Replace the alias with the canonical property name.
 for (const [fullPropertyName, alias] of fallbackConfigurations) {
-  if (configurationsTable[alias].property) {
+  if (configurationsTable[alias]?.property) {
     fallbackConfigurations.set(fullPropertyName, configurationsTable[alias].property)
   }
 }


### PR DESCRIPTION
## Summary

A deprecated entry that only aliases a canonical option (`DD_PROFILING_EXPERIMENTAL_*`, `DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED`) must not surface as its own Config property. `helper.js` deletes these from the shared supported-configurations object after registering the deprecation; `defaults.js` read the same object without the matching skip, so whether they became own properties depended on which module required the JSON first. In v5 the config spec builds defaults before helper, so Config gained `DD_PROFILING_EXPERIMENTAL_*` keys the property-surface test flagged as unknown; v6 passed only because major-overrides removes the entries outright.

The fallback resolution is guarded too, since the skipped entries are no longer in the configurations table.

## Test plan

- [ ] `packages/dd-trace/test/config/index.spec.js` — the `property surface` test passes under both v5 and v6
- [ ] `packages/dd-trace/test/profiling/config.spec.js` — the deprecated `DD_PROFILING_EXPERIMENTAL_*` aliases still feed their canonical option and still emit a deprecation warning

Targets master; needs a backport to `v5.x`, where the failure currently shows (e.g. the v5.110.0 proposal `test:trace:core` job).