### PR TITLE
fix(express): restore loopback middleware phase ordering

### DIFF
--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -67,9 +67,20 @@ function createWrapRouterMethod (name, compile) {
     // `Layer.handleError`. Specialising lets the per-call body use named
     // parameters and `.call`, avoiding the rest-spread Array allocation that
     // the unified shape forced on every middleware invocation.
-    return original.length === 4
+    const wrapped = original.length === 4
       ? shimmer.wrapFunction(original, errorHandlerLayerWrap(layer, name, captureRoute, needMultiMatch, matchers))
       : shimmer.wrapFunction(original, requestHandlerLayerWrap(layer, name, captureRoute, needMultiMatch, matchers))
+
+    // Workaround for loopback's phase-based middleware sorting. Its
+    // `_findLayerByHandler` maps a layer back to the user handler by scanning
+    // the layer handle's enumerable properties for the original function.
+    // Replacing `layer.handle` with this wrapper hides that handler, so without
+    // the back-reference loopback cannot tag the layer with its phase and
+    // `app.middleware(phase, ...)` handlers run in insertion order instead of
+    // phase order. The property name is part of that contract; keep it stable.
+    wrapped._datadog_orig = original
+
+    return wrapped
   }
 
   function requestHandlerLayerWrap (layer, name, captureRoute, needMultiMatch, matchers) {

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -14,8 +14,8 @@ const { NODE_MAJOR } = require('../../../version')
 const { storage } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
+const { temporaryWarningExceptions } = require('../../dd-trace/test/setup/core')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
-const plugin = require('../src')
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
 describe('Plugin', () => {
@@ -1492,12 +1492,15 @@ describe('Plugin', () => {
           })
         })
 
-        withVersions(plugin, 'loopback', loopbackVersion => {
+        withVersions('express', 'loopback', loopbackVersion => {
           let loopback
 
           beforeEach(function () {
             this.timeout(5000)
 
+            // Legacy loopback emits the deprecated `util._extend` at module
+            // load; allow it so the harness deprecation guard does not throw.
+            temporaryWarningExceptions.add('The `util._extend` API is deprecated. Please use Object.assign() instead.')
             loopback = require(`../../../versions/loopback@${loopbackVersion}`).get()
           })
 


### PR DESCRIPTION
## Summary

The loopback integration test suite was silently skipped because the
`withVersions` call passed the plugin export instead of the `'express'`
integration name, so no installed version ever matched. Enabling it surfaced a
real regression: dd-trace replaces each express `layer.handle` with a tracing
wrapper, which hides the original handler from loopback's `_findLayerByHandler`.
That lookup is how loopback tags a layer with its phase, so the tag was never
set and `app.middleware('final', ...)` handlers ran in insertion order ahead of
the route handlers instead of last.

1. `fix(express)`: restore the `_datadog_orig` back-reference on the wrapped
   layer handle (dropped in the router instrumentation rewrite) so loopback can
   map the layer back to the user handler and sort by phase again.
2. `test(express)`: switch the suite to the `'express'` name so it runs, and
   allowlist legacy loopback's deprecated `util._extend` load-time warning that
   the harness deprecation guard would otherwise throw on.

## Note

I am working on a better fix, while that turned out to be quite a massive amount
of work, so I am suggesting we just land this as stop gap.

Refs: https://github.com/DataDog/dd-trace-js/pull/643