### PR TITLE
refactor(config): resolve per-major config entries from a major selector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -551,6 +551,30 @@ Important fields:
 - `deprecated`: emits a deprecation warning when used.
 - `description`: developer-facing note in the JSON.
 - `implementation`: metadata only in the current flow.
+- `major`: restricts the entry to a major selector. See [Version-specific entries](#version-specific-entries).
+
+## Version-specific entries
+
+Most configurations share a single entry across all majors. When an entry has to differ between release lines, add one entry per major and tag each with a `major` selector rather than branching on `DD_MAJOR` at runtime. The selector is either an exact major (`"5"`) or a lower bound (`">5"`); an entry without a selector applies to every major. At load time only the entry matching the running major survives, so the rest of the config system keeps seeing exactly one entry per name.
+
+```json
+"DD_TRACE_STARTUP_LOGS": [
+  {
+    "major": ">5",
+    "type": "boolean",
+    "configurationNames": ["startupLogs"],
+    "default": "true"
+  },
+  {
+    "major": "5",
+    "type": "boolean",
+    "configurationNames": ["startupLogs"],
+    "default": "false"
+  }
+]
+```
+
+An entry tagged `"major": "5"` with no `">5"` counterpart exists on v5 and is dropped entirely on v6 and later.
 
 ## Runtime Flow
 

--- a/eslint-rules/eslint-env-aliases.mjs
+++ b/eslint-rules/eslint-env-aliases.mjs
@@ -17,7 +17,10 @@ for (const [canonical, entries] of Object.entries(supportedConfigurations)) {
     if (entry.aliases && !entry.deprecated) {
       for (const alias of entry.aliases) {
         aliasToCanonical[alias] ??= []
-        aliasToCanonical[alias].push(canonical)
+        // Per-major entries repeat a shared alias, so only the distinct canonical counts.
+        if (!aliasToCanonical[alias].includes(canonical)) {
+          aliasToCanonical[alias].push(canonical)
+        }
       }
     }
   }

--- a/eslint-rules/eslint-env-aliases.test.mjs
+++ b/eslint-rules/eslint-env-aliases.test.mjs
@@ -32,5 +32,15 @@ ruleTester.run('eslint-env-aliases', rule, {
           "instead of alias 'DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED'",
       }],
     },
+    {
+      // Shared by both per-major entries of DD_API_SECURITY_ENABLED: the canonical must appear once,
+      // not duplicated into the message and autofix.
+      code: "const env = 'DD_EXPERIMENTAL_API_SECURITY_ENABLED'",
+      output: "const env = 'DD_API_SECURITY_ENABLED'",
+      errors: [{
+        message: "Use canonical environment variable name 'DD_API_SECURITY_ENABLED' " +
+          "instead of alias 'DD_EXPERIMENTAL_API_SECURITY_ENABLED'",
+      }],
+    },
   ],
 })

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -14,6 +14,7 @@
  * @property {string} [allowed]
  * @property {string|boolean} [deprecated]
  * @property {boolean} [sensitive] Excludes the configuration value from configuration telemetry.
+ * @property {string} [major] Restricts the entry to a major selector ("5" or ">5"); resolved by major-overrides.
  */
 
 /**

--- a/packages/dd-trace/src/config/major-overrides.js
+++ b/packages/dd-trace/src/config/major-overrides.js
@@ -4,95 +4,40 @@
  * @typedef {import('./helper').SupportedConfigurationsJson['supportedConfigurations']} SupportedConfigurations
  */
 
-const EXPERIMENTAL_APPSEC_PREFIX = 'experimental.appsec'
-const EXPERIMENTAL_IAST_PREFIX = 'experimental.iast'
-const INGESTION_PREFIX = 'ingestion.'
-
 /**
+ * Collapses each configuration's per-major entries to the single entry that applies to
+ * `majorVersion`. An entry's optional `major` selector is either an exact major ("5") or a
+ * lower-bounded range (">5"); an entry without a selector applies to every major. A configuration
+ * left without any matching entry is dropped for this major.
+ *
  * @param {SupportedConfigurations} supportedConfigurations Mutated in place.
  * @param {number} majorVersion
  */
 function applyMajorOverrides (supportedConfigurations, majorVersion) {
-  if (majorVersion < 6) {
-    applyV5Overrides(supportedConfigurations)
-    return
-  }
-
-  for (const entries of Object.values(supportedConfigurations)) {
-    for (const entry of entries) {
-      if (Array.isArray(entry.configurationNames)) {
-        entry.configurationNames = entry.configurationNames.filter(
-          (name) =>
-            name !== EXPERIMENTAL_APPSEC_PREFIX &&
-            name !== EXPERIMENTAL_IAST_PREFIX &&
-            !name.startsWith(`${EXPERIMENTAL_APPSEC_PREFIX}.`) &&
-            !name.startsWith(`${EXPERIMENTAL_IAST_PREFIX}.`) &&
-            !name.startsWith(INGESTION_PREFIX)
-        )
-        if (entry.configurationNames.length === 0) delete entry.configurationNames
-      }
+  for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) {
+    const selected = entries.filter((entry) => entry.major === undefined || majorMatches(entry.major, majorVersion))
+    if (selected.length === 0) {
+      delete supportedConfigurations[canonicalName]
+      continue
+    }
+    for (const entry of selected) {
+      delete entry.major
+    }
+    if (selected.length !== entries.length) {
+      supportedConfigurations[canonicalName] = selected
     }
   }
-  delete supportedConfigurations.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED
-  delete supportedConfigurations.DD_TRACE_EXPERIMENTAL_B3_ENABLED
-
-  /* eslint-disable eslint-rules/eslint-env-aliases */
-  for (const name of [
-    'DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED',
-    'DD_PROFILING_EXPERIMENTAL_CPU_ENABLED',
-    'DD_PROFILING_EXPERIMENTAL_ENDPOINT_COLLECTION_ENABLED',
-    'DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED',
-  ]) {
-    delete supportedConfigurations[name]
-  }
-  /* eslint-enable eslint-rules/eslint-env-aliases */
-  for (const canonical of [
-    'DD_PROFILING_CODEHOTSPOTS_ENABLED',
-    'DD_PROFILING_CPU_ENABLED',
-    'DD_PROFILING_ENDPOINT_COLLECTION_ENABLED',
-    'DD_PROFILING_TIMELINE_ENABLED',
-  ]) {
-    dropAlias(supportedConfigurations[canonical], (alias) => alias.startsWith('DD_PROFILING_EXPERIMENTAL_'))
-  }
-
-  delete supportedConfigurations.DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED
-  // eslint-disable-next-line eslint-rules/eslint-env-aliases
-  dropAlias(supportedConfigurations.DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED, 'DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED')
 }
 
 /**
- * @param {SupportedConfigurations} supportedConfigurations Mutated in place.
+ * @param {string} selector Exact major ("5") or a lower-bounded range (">5").
+ * @param {number} majorVersion
  */
-function applyV5Overrides (supportedConfigurations) {
-  const startupLogsEntry = supportedConfigurations.DD_TRACE_STARTUP_LOGS?.[0]
-  if (startupLogsEntry) {
-    startupLogsEntry.default = 'false'
+function majorMatches (selector, majorVersion) {
+  if (selector[0] === '>') {
+    return majorVersion > Number(selector.slice(1))
   }
-
-  const iastEntry = supportedConfigurations.DD_IAST_SECURITY_CONTROLS_CONFIGURATION?.[0]
-  if (!iastEntry) return
-
-  iastEntry.configurationNames = [
-    iastEntry.internalPropertyName || iastEntry.configurationNames?.[0],
-    `${EXPERIMENTAL_IAST_PREFIX}.securityControlsConfiguration`,
-  ]
-  delete iastEntry.internalPropertyName
-}
-
-/**
- * @param {import('./helper').SupportedConfigurationEntry[] | undefined} entries
- * @param {string | ((alias: string) => boolean)} dropPredicate
- */
-function dropAlias (entries, dropPredicate) {
-  const entry = entries?.[0]
-  if (entry?.aliases === undefined) return
-  const matches = typeof dropPredicate === 'string'
-    ? (alias) => alias === dropPredicate
-    : dropPredicate
-  entry.aliases = entry.aliases.filter((alias) => !matches(alias))
-  if (entry.aliases.length === 0) {
-    delete entry.aliases
-  }
+  return majorVersion === Number(selector)
 }
 
 module.exports = applyMajorOverrides

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1,5 +1,4 @@
 {
-  "version": "2",
   "supportedConfigurations": {
     "DD_ACTION_EXECUTION_ID": [
       {
@@ -117,6 +116,19 @@
     ],
     "DD_API_SECURITY_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.apiSecurity.enabled"
+        ],
+        "default": "true",
+        "aliases": [
+          "DD_EXPERIMENTAL_API_SECURITY_ENABLED"
+        ]
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -131,6 +143,16 @@
     ],
     "DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.apiSecurity.endpointCollectionEnabled"
+        ],
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -142,6 +164,16 @@
     ],
     "DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "appsec.apiSecurity.endpointCollectionMessageLimit"
+        ],
+        "default": "300"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -206,6 +238,19 @@
     ],
     "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE": [
       {
+        "major": ">5",
+        "implementation": "E",
+        "type": "string",
+        "configurationNames": [
+          "appsec.eventTracking.mode"
+        ],
+        "default": "identification",
+        "aliases": [
+          "DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING"
+        ]
+      },
+      {
+        "major": "5",
         "implementation": "E",
         "type": "string",
         "configurationNames": [
@@ -220,6 +265,17 @@
     ],
     "DD_APPSEC_COLLECT_ALL_HEADERS": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.extendedHeadersCollection.enabled"
+        ],
+        "default": "false",
+        "deprecated": true
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -232,6 +288,17 @@
     ],
     "DD_APPSEC_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "C",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.enabled",
+          "appsec"
+        ],
+        "default": null
+      },
+      {
+        "major": "5",
         "implementation": "C",
         "type": "boolean",
         "configurationNames": [
@@ -245,6 +312,17 @@
     ],
     "DD_APPSEC_GRAPHQL_BLOCKED_TEMPLATE_JSON": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "string",
+        "configurationNames": [
+          "appsec.blockedTemplateGraphql"
+        ],
+        "default": null,
+        "transform": "readFilePath"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "string",
         "configurationNames": [
@@ -257,6 +335,17 @@
     ],
     "DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.extendedHeadersCollection.redaction"
+        ],
+        "default": "true",
+        "deprecated": true
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -269,6 +358,17 @@
     ],
     "DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "appsec.blockedTemplateHtml"
+        ],
+        "default": null,
+        "transform": "readFilePath"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "string",
         "configurationNames": [
@@ -281,6 +381,17 @@
     ],
     "DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "appsec.blockedTemplateJson"
+        ],
+        "default": null,
+        "transform": "readFilePath"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "string",
         "configurationNames": [
@@ -293,6 +404,17 @@
     ],
     "DD_APPSEC_MAX_COLLECTED_HEADERS": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "appsec.extendedHeadersCollection.maxHeaders"
+        ],
+        "default": "50",
+        "deprecated": true
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -305,6 +427,19 @@
     ],
     "DD_APPSEC_MAX_STACK_TRACES": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "appsec.stackTrace.maxStackTraces"
+        ],
+        "aliases": [
+          "DD_APPSEC_MAX_STACKTRACES"
+        ],
+        "default": "2"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -319,6 +454,19 @@
     ],
     "DD_APPSEC_MAX_STACK_TRACE_DEPTH": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "appsec.stackTrace.maxDepth"
+        ],
+        "aliases": [
+          "DD_APPSEC_MAX_STACKTRACE_DEPTH"
+        ],
+        "default": "32"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -333,6 +481,16 @@
     ],
     "DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "appsec.obfuscatorKeyRegex"
+        ],
+        "default": "(?i)pass|pw(?:or)?d|secret|(?:api|private|public|access)[_-]?key|token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\\.net[_-]sessionid|sid|jwt"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "string",
         "configurationNames": [
@@ -344,6 +502,16 @@
     ],
     "DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP": [
       {
+        "major": ">5",
+        "implementation": "G",
+        "type": "string",
+        "configurationNames": [
+          "appsec.obfuscatorValueRegex"
+        ],
+        "default": "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key(?:[_-]?id)?|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|jsessionid|phpsessid|asp\\.net(?:[_-]|-)sessionid|sid|jwt)(?:\\s*=([^;&]+)|\"\\s*:\\s*(\"[^\"]+\"|\\d+))|bearer\\s+([a-z0-9\\._\\-]+)|token\\s*:\\s*([a-z0-9]{13})|gh[opsu]_([0-9a-zA-Z]{36})|ey[I-L][\\w=-]+\\.(ey[I-L][\\w=-]+(?:\\.[\\w.+\\/=-]+)?)|[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}([^\\-]+)[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY|ssh-rsa\\s*([a-z0-9\\/\\.+]{100,})"
+      },
+      {
+        "major": "5",
         "implementation": "G",
         "type": "string",
         "configurationNames": [
@@ -355,6 +523,17 @@
     ],
     "DD_APPSEC_RASP_COLLECT_REQUEST_BODY": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.rasp.bodyCollection"
+        ],
+        "default": "false",
+        "deprecated": true
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -367,6 +546,16 @@
     ],
     "DD_APPSEC_RASP_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.rasp.enabled"
+        ],
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -378,6 +567,16 @@
     ],
     "DD_APPSEC_RULES": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "appsec.rules"
+        ],
+        "default": null
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "string",
         "configurationNames": [
@@ -397,6 +596,16 @@
     ],
     "DD_APPSEC_STACK_TRACE_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "appsec.stackTrace.enabled"
+        ],
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -408,6 +617,16 @@
     ],
     "DD_APPSEC_TRACE_RATE_LIMIT": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "appsec.rateLimit"
+        ],
+        "default": "100"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -419,6 +638,16 @@
     ],
     "DD_APPSEC_WAF_TIMEOUT": [
       {
+        "major": ">5",
+        "implementation": "E",
+        "type": "int",
+        "configurationNames": [
+          "appsec.wafTimeout"
+        ],
+        "default": "5000"
+      },
+      {
+        "major": "5",
         "implementation": "E",
         "type": "int",
         "configurationNames": [
@@ -758,6 +987,7 @@
     ],
     "DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED": [
       {
+        "major": "5",
         "implementation": "B",
         "type": "boolean",
         "default": "false",
@@ -989,6 +1219,16 @@
     ],
     "DD_IAST_DB_ROWS_TO_TAINT": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "iast.dbRowsToTaint"
+        ],
+        "default": "1"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -1000,6 +1240,16 @@
     ],
     "DD_IAST_DEDUPLICATION_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "iast.deduplicationEnabled"
+        ],
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -1011,6 +1261,17 @@
     ],
     "DD_IAST_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "boolean",
+        "configurationNames": [
+          "iast.enabled",
+          "iast"
+        ],
+        "default": "false"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "boolean",
         "configurationNames": [
@@ -1024,6 +1285,16 @@
     ],
     "DD_IAST_MAX_CONCURRENT_REQUESTS": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "iast.maxConcurrentRequests"
+        ],
+        "default": "2"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -1035,6 +1306,16 @@
     ],
     "DD_IAST_MAX_CONTEXT_OPERATIONS": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "iast.maxContextOperations"
+        ],
+        "default": "2"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -1046,6 +1327,16 @@
     ],
     "DD_IAST_REDACTION_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "iast.redactionEnabled"
+        ],
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -1057,6 +1348,16 @@
     ],
     "DD_IAST_REDACTION_NAME_PATTERN": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "string",
+        "configurationNames": [
+          "iast.redactionNamePattern"
+        ],
+        "default": "(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|(?:sur|last)name|user(?:name)?|address|e?mail)"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "string",
         "configurationNames": [
@@ -1068,6 +1369,16 @@
     ],
     "DD_IAST_REDACTION_VALUE_PATTERN": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "string",
+        "configurationNames": [
+          "iast.redactionValuePattern"
+        ],
+        "default": "(?:bearer\\s+[a-z0-9\\._\\-]+|glpat-[\\w\\-]{20}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\\w=\\-]+\\.ey[I-L][\\w=\\-]+(?:\\.[\\w.+/=\\-]+)?|(?:[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY[\\-]{5}|ssh-rsa\\s*[a-z0-9/\\.+]{100,})|[\\w\\.-]+@[a-zA-Z\\d\\.-]+\\.[a-zA-Z]{2,})"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "string",
         "configurationNames": [
@@ -1079,6 +1390,18 @@
     ],
     "DD_IAST_REQUEST_SAMPLING": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "iast.requestSampling"
+        ],
+        "default": "30",
+        "allowed": "100|[1-9]?\\d",
+        "transform": "iastRequestSampling"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -1092,14 +1415,35 @@
     ],
     "DD_IAST_SECURITY_CONTROLS_CONFIGURATION": [
       {
+        "major": ">5",
         "implementation": "B",
         "type": "string",
         "internalPropertyName": "iast.securityControlsConfiguration",
         "default": null
+      },
+      {
+        "major": "5",
+        "implementation": "B",
+        "type": "string",
+        "default": null,
+        "configurationNames": [
+          "iast.securityControlsConfiguration",
+          "experimental.iast.securityControlsConfiguration"
+        ]
       }
     ],
     "DD_IAST_STACK_TRACE_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "boolean",
+        "configurationNames": [
+          "iast.stackTrace.enabled"
+        ],
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "boolean",
         "configurationNames": [
@@ -1111,6 +1455,16 @@
     ],
     "DD_IAST_TELEMETRY_VERBOSITY": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "iast.telemetryVerbosity"
+        ],
+        "default": "INFORMATION"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "string",
         "configurationNames": [
@@ -1346,6 +1700,13 @@
     ],
     "DD_PROFILING_CODEHOTSPOTS_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1356,6 +1717,7 @@
     ],
     "DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED": [
       {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1367,6 +1729,13 @@
     ],
     "DD_PROFILING_CPU_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1377,6 +1746,7 @@
     ],
     "DD_PROFILING_EXPERIMENTAL_CPU_ENABLED": [
       {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1421,6 +1791,13 @@
     ],
     "DD_PROFILING_ENDPOINT_COLLECTION_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1431,6 +1808,7 @@
     ],
     "DD_PROFILING_EXPERIMENTAL_ENDPOINT_COLLECTION_ENABLED": [
       {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1512,6 +1890,13 @@
     ],
     "DD_PROFILING_TIMELINE_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "default": "true"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1522,6 +1907,7 @@
     ],
     "DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED": [
       {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "default": "true",
@@ -1630,6 +2016,16 @@
     ],
     "DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "runtimeMetricsRuntimeId"
+        ],
+        "default": "false"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -1651,6 +2047,7 @@
     ],
     "DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED": [
       {
+        "major": "5",
         "implementation": "B",
         "type": "boolean",
         "default": "false",
@@ -2559,6 +2956,7 @@
     ],
     "DD_TRACE_EXPERIMENTAL_B3_ENABLED": [
       {
+        "major": "5",
         "implementation": "A",
         "type": "boolean",
         "configurationNames": [
@@ -3554,6 +3952,16 @@
     ],
     "DD_TRACE_RATE_LIMIT": [
       {
+        "major": ">5",
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "rateLimit"
+        ],
+        "default": "100"
+      },
+      {
+        "major": "5",
         "implementation": "A",
         "type": "int",
         "configurationNames": [
@@ -3649,6 +4057,17 @@
     ],
     "DD_TRACE_SAMPLE_RATE": [
       {
+        "major": ">5",
+        "implementation": "B",
+        "type": "decimal",
+        "configurationNames": [
+          "sampleRate"
+        ],
+        "default": null,
+        "transform": "sampleRate"
+      },
+      {
+        "major": "5",
         "implementation": "B",
         "type": "decimal",
         "configurationNames": [
@@ -3741,12 +4160,22 @@
     ],
     "DD_TRACE_STARTUP_LOGS": [
       {
+        "major": ">5",
         "implementation": "C",
         "type": "boolean",
         "configurationNames": [
           "startupLogs"
         ],
         "default": "true"
+      },
+      {
+        "major": "5",
+        "implementation": "C",
+        "type": "boolean",
+        "configurationNames": [
+          "startupLogs"
+        ],
+        "default": "false"
       }
     ],
     "DD_TRACE_STATS_COMPUTATION_ENABLED": [

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -206,44 +206,77 @@ describe('Config', () => {
       )
     })
 
-    itV6Filter('applyMajorOverrides is idempotent on the same supportedConfigurations object', () => {
-      const fresh = proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
+    const applyMajorOverridesForMajor = (major) => {
+      const { supportedConfigurations } =
+        proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
       const applyMajorOverrides = proxyquire.noPreserveCache()('../../src/config/major-overrides', {})
-      const supported = fresh.supportedConfigurations
-      assert.ok('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in supported)
-      supported.DD_PROFILING_CPU_ENABLED[0].aliases.push('DD_PROFILING_TEST_ALIAS')
-      applyMajorOverrides(supported, 6)
-      assert.strictEqual('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in supported, false)
-      assert.strictEqual('DD_TRACE_EXPERIMENTAL_B3_ENABLED' in supported, false)
-      assert.strictEqual('DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED' in supported, false)
-      const cpuEntry = supported.DD_PROFILING_CPU_ENABLED[0]
-      assert.ok(
-        !cpuEntry.aliases?.some((alias) => alias.startsWith('DD_PROFILING_EXPERIMENTAL_')),
-        `Got: ${inspect(cpuEntry.aliases)}`
-      )
-      assert.deepStrictEqual(cpuEntry.aliases, ['DD_PROFILING_TEST_ALIAS'])
-      const runtimeIdEntry = supported.DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED[0]
-      assert.strictEqual(runtimeIdEntry.aliases, undefined)
+      applyMajorOverrides(supportedConfigurations, major)
+      return supportedConfigurations
+    }
 
-      const beforeKeyCount = Object.keys(supported).length
-      applyMajorOverrides(supported, 6)
-      assert.strictEqual(Object.keys(supported).length, beforeKeyCount)
-    })
+    it('selects the v5 entry for each diverging configuration', () => {
+      const v5 = applyMajorOverridesForMajor(5)
 
-    it('applyMajorOverrides is idempotent for v5 security controls', () => {
-      const fresh = proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
-      const applyMajorOverrides = proxyquire.noPreserveCache()('../../src/config/major-overrides', {})
-      const supported = fresh.supportedConfigurations
-      const iastEntry = supported.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0]
-
-      applyMajorOverrides(supported, 5)
-      applyMajorOverrides(supported, 5)
-
-      assert.deepStrictEqual(iastEntry.configurationNames, [
+      // Every surviving entry has its selector stripped and resolves to a single entry.
+      for (const [name, entries] of Object.entries(v5)) {
+        assert.strictEqual(entries.length, 1, `${name} should resolve to a single entry`)
+        assert.strictEqual(entries[0].major, undefined, `${name} should not keep its major selector`)
+      }
+      // Default override.
+      assert.strictEqual(v5.DD_TRACE_STARTUP_LOGS[0].default, 'false')
+      // configurationNames keep the experimental alias.
+      assert.deepStrictEqual(v5.DD_API_SECURITY_ENABLED[0].configurationNames, [
+        'appsec.apiSecurity.enabled',
+        'experimental.appsec.apiSecurity.enabled',
+      ])
+      // Canonical keeps its deprecated alias.
+      assert.deepStrictEqual(v5.DD_PROFILING_CPU_ENABLED[0].aliases, ['DD_PROFILING_EXPERIMENTAL_CPU_ENABLED'])
+      // Security controls expose configurationNames rather than internalPropertyName.
+      assert.deepStrictEqual(v5.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].configurationNames, [
         'iast.securityControlsConfiguration',
         'experimental.iast.securityControlsConfiguration',
       ])
-      assert.strictEqual(iastEntry.internalPropertyName, undefined)
+      assert.strictEqual(v5.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].internalPropertyName, undefined)
+      // v5-only experimental keys stay registered.
+      assert.ok('DD_TRACE_EXPERIMENTAL_B3_ENABLED' in v5)
+      assert.ok('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in v5)
+    })
+
+    it('selects the v6 entry and drops v5-only configurations', () => {
+      const v6 = applyMajorOverridesForMajor(6)
+
+      for (const [name, entries] of Object.entries(v6)) {
+        assert.strictEqual(entries.length, 1, `${name} should resolve to a single entry`)
+        assert.strictEqual(entries[0].major, undefined, `${name} should not keep its major selector`)
+      }
+      assert.strictEqual(v6.DD_TRACE_STARTUP_LOGS[0].default, 'true')
+      assert.deepStrictEqual(v6.DD_API_SECURITY_ENABLED[0].configurationNames, ['appsec.apiSecurity.enabled'])
+      assert.strictEqual(v6.DD_PROFILING_CPU_ENABLED[0].aliases, undefined)
+      assert.strictEqual(v6.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].internalPropertyName,
+        'iast.securityControlsConfiguration')
+      assert.strictEqual(v6.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].configurationNames, undefined)
+      assert.strictEqual('DD_TRACE_EXPERIMENTAL_B3_ENABLED' in v6, false)
+      assert.strictEqual('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in v6, false)
+      assert.strictEqual('DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED' in v6, false)
+    })
+
+    it('treats a ">5" selector as forward-compatible for the next major', () => {
+      const v6 = applyMajorOverridesForMajor(6)
+      const v7 = applyMajorOverridesForMajor(7)
+      assert.deepStrictEqual(v7, v6)
+    })
+
+    it('is idempotent when applied repeatedly to the shared object', () => {
+      // helper.js and defaults.js call applyMajorOverrides on the same cached require, so a
+      // second pass must be a no-op rather than re-collapsing already-resolved entries.
+      const { supportedConfigurations } =
+        proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
+      const applyMajorOverrides = proxyquire.noPreserveCache()('../../src/config/major-overrides', {})
+
+      applyMajorOverrides(supportedConfigurations, 6)
+      const afterFirst = structuredClone(supportedConfigurations)
+      applyMajorOverrides(supportedConfigurations, 6)
+      assert.deepStrictEqual(supportedConfigurations, afterFirst)
     })
 
     it('loads v5 config repeatedly after security controls are restored', () => {

--- a/scripts/generate-config-types.js
+++ b/scripts/generate-config-types.js
@@ -270,18 +270,12 @@ function generateConfigTypes () {
   const root = createTreeNode()
 
   for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) {
-    if (entries.length !== 1) {
-      throw new Error(
-        `Multiple entries found for canonical name: ${canonicalName}. ` +
-        'This is currently not supported and must be implemented, if needed.'
-      )
+    for (const entry of entries) {
+      const propertyName = getPropertyName(canonicalName, entry)
+      const type = getTypeForEntry(propertyName, entry)
+
+      addProperty(root, propertyName, type)
     }
-
-    const [entry] = entries
-    const propertyName = getPropertyName(canonicalName, entry)
-    const type = getTypeForEntry(propertyName, entry)
-
-    addProperty(root, propertyName, type)
   }
 
   return (


### PR DESCRIPTION
## Summary

The v5/v6 configuration divergence lived as imperative deletes and field rewrites in `major-overrides.js`, applied against the shared `supported-configurations` table after it was read from JSON. The set of affected configuration names lived in code, so the data could not show which configurations diverge, and the two consumers (`helper.js`, `defaults.js`) reading the same cached `require` had to replay the same mutations in the same order.

Every per-major difference now lives in the data. Each diverging configuration carries one entry per major tagged with a `major` selector, and `major-overrides.js` is reduced to a pure selector.

1. The `major` selector is either an exact major (`"5"`) or a lower bound (`">5"`); an entry with no selector applies to every major. At load time the resolver keeps the entry matching the running major and drops a configuration that has none.
2. All 48 diverging configurations were migrated, covering the five shapes the imperative code handled: the `experimental.appsec.*` / `experimental.iast.*` / `ingestion.*` configurationName strip, the profiling and runtime-id alias drops, the seven v5-only experimental deletes, the `DD_TRACE_STARTUP_LOGS` default, and the `DD_IAST_SECURITY_CONTROLS_CONFIGURATION` rewrite.
3. `major-overrides.js` drops from 102 lines of hardcoded config names to a 40-line selector with no per-config knowledge.
4. `scripts/generate-config-types.js` iterates per-major entries; `CONTRIBUTING.md` documents the `major` selector.

## Why

The resolved table is **byte-identical to the previous imperative output for both v5 and v6** (verified with a `deepStrictEqual` over the full table for each major). A hypothetical v7 inherits the `">5"` shape rather than resolving to nothing, which an exact-match selector would have broken.

The env-alias lint rule now records a canonical once per alias: per-major entries repeat a shared alias (e.g. `DD_EXPERIMENTAL_API_SECURITY_ENABLED` on both `DD_API_SECURITY_ENABLED` entries), which otherwise doubled the canonical in the rule's message and autofix. A regression test pins this.

## Test plan

- [ ] `node packages/dd-trace/test/config/index.spec.js` (v6) and the same with `DD_MAJOR` forced to 5
- [ ] `node eslint-rules/eslint-env-aliases.test.mjs`
- [ ] `npm run verify:config:types`