### PR TITLE
fix(mariadb): stop tcp.connect spans leaking from 3.4.1 pools

### DIFF
--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -160,14 +160,16 @@ addHook({ name, file: 'lib/cmd/execute.js', versions: ['>=3'] }, (Execute) => {
   return wrapCommand(Execute)
 })
 
-// in 3.4.1 getConnection method start to use callbacks instead of promises
+// mariadb 3.4.1 refactored the pool: getConnection switched from promises to
+// callbacks and _createConnection was renamed to _createPoolConnection.
 addHook({ name, file: 'lib/pool.js', versions: ['>=3.4.1'] }, (Pool) => {
   shimmer.wrap(Pool.prototype, 'getConnection', wrapPoolGetConnectionMethod)
+  shimmer.wrap(Pool.prototype, '_createPoolConnection', wrapPoolMethod)
 
   return Pool
 })
 
-addHook({ name, file: 'lib/pool.js', versions: ['>=3'] }, (Pool) => {
+addHook({ name, file: 'lib/pool.js', versions: ['>=3 <3.4.1'] }, (Pool) => {
   shimmer.wrap(Pool.prototype, '_createConnection', wrapPoolMethod)
 
   return Pool

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -16,6 +16,26 @@ const { expectedSchema, rawExpectedSchema } = require('./naming')
 // https://github.com/mariadb-corporation/mariadb-connector-nodejs/commit/0a90b71ab20ab4e8b6a86a77ba291bba8ba6a34e
 const range = semver.gte(process.version, '15.0.0') ? '>=2.5.1' : '>=2'
 
+// A pool created inside an active span must not attach its connection-setup
+// `tcp.connect` span to that trace. Accumulate span names across every payload
+// and assert once the root `test` span flushed: a single trace from one payload
+// lets a late partial flush (a lone `mariadb.query`) pass while the leaked
+// `tcp.connect` rode an earlier payload — the source of this test's flakiness.
+function assertNoConnectionSpanLeak () {
+  const names = new Set()
+
+  return agent.assertSomeTraces(traces => {
+    for (const trace of traces) {
+      for (const span of trace) {
+        names.add(span.name)
+      }
+    }
+
+    assert.ok(names.has('test'), 'root span has not flushed yet')
+    assert.strictEqual(names.has('tcp.connect'), false, 'tcp.connect leaked into the request trace')
+  })
+}
+
 describe('Plugin', () => {
   describe('mariadb', () => {
     withVersions('mariadb', 'mariadb', range, version => {
@@ -797,10 +817,7 @@ describe('Plugin', () => {
         })
 
         it('should not instrument connections to avoid leaks from internal queue', done => {
-          agent.assertSomeTraces((traces) => {
-            assert.strictEqual(traces.length, 1)
-            assert.strictEqual(traces[0].find(span => span.name === 'tcp.connect'), undefined)
-          }).then(done, done)
+          assertNoConnectionSpanLeak().then(done, done)
 
           const span = tracer.startSpan('test')
 
@@ -844,10 +861,7 @@ describe('Plugin', () => {
           it('should not instrument connections to avoid leaks from internal queue', async () => {
             const span = tracer.startSpan('test')
 
-            const assertion = agent.assertSomeTraces((traces) => {
-              assert.strictEqual(traces.length, 1)
-              assert.strictEqual(traces[0].find(s => s.name === 'tcp.connect'), undefined)
-            })
+            const assertion = assertNoConnectionSpanLeak()
 
             await tracer.scope().activate(span, async () => {
               pool = pool || mariadb.createPool({

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -11,11 +11,16 @@ class MySQLPlugin extends DatabasePlugin {
   constructor () {
     super(...arguments)
 
+    // Capture into `currentStore` (not `parentStore`) so connection:finish can
+    // restore the caller context even when the connection resolves inside an
+    // instrumentation skip (a noop store), as the mariadb pool does: the store
+    // binding only honors an explicit `currentStore` through a noop store.
+    // Without a skip (mysql/mysql2) this is unchanged.
     this.addSub(`apm:${this.component}:connection:start`, ctx => {
-      ctx.parentStore = storage('legacy').getStore()
+      ctx.currentStore = storage('legacy').getStore()
     })
 
-    this.addBind(`apm:${this.component}:connection:finish`, ctx => ctx.parentStore)
+    this.addBind(`apm:${this.component}:connection:finish`, ctx => ctx.currentStore)
   }
 
   bindStart (ctx) {


### PR DESCRIPTION
## Summary

mariadb 3.4.1 renamed the pool's `_createConnection` to `_createPoolConnection`, so the skip wrap targeted a method that no longer exists: `shimmer.wrap` threw, the skip never applied, and connection-establishment `tcp.connect` spans leaked into the active request trace (intermittently failing the pool leak test).

1. Wrap `_createPoolConnection` for >=3.4.1 and keep `_createConnection` for >=3 <3.4.1, so the connection skip applies on both pool layouts.
2. Capture the pooled connection context as `currentStore` so the connection:finish binding restores the caller's span through the skip's noop store; without it the skip drops the active span for queued pool-query callbacks.

## Test plan

- mariadb plugin suite on 3.0.0 / 3.4.0 / 3.4.1: the pool leak test and the queued pool-query context tests pass, and the leak test is stable across repeated runs.
- mysql and mysql2 plugin suites: pooled-query context unchanged. The shared connection capture switching from `parentStore` to `currentStore` is a no-op without a skip store.

Refs: https://github.com/DataDog/dd-trace-js/pull/8826