### PR TITLE
ci(release): support promoting pre-release to stable on v6.x

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    env:
+      RELEASE_LINES: 5 6
     outputs:
       release-lines: ${{ steps.check.outputs.release-lines }}
     steps:
@@ -25,7 +27,7 @@ jobs:
       - id: check
         run: |
           lines=()
-          for line in 5 6; do
+          for line in $RELEASE_LINES; do
             if git ls-remote --heads \
               "https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/DataDog/dd-trace-js.git" \
               "refs/heads/v${line}.x" | grep -q .; then

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -24,17 +24,30 @@ jobs:
         with:
           scope: DataDog/dd-trace-js
           policy: release-proposal
+      - id: check-branch
+        run: |
+          if git ls-remote --heads \
+            "https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/DataDog/dd-trace-js.git" \
+            "refs/heads/v${{ matrix.release-line }}.x" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.check-branch.outputs.exists == 'true'
         with:
           fetch-depth: 0
           token: ${{ steps.octo-sts.outputs.token }}
       - uses: ./.github/actions/node
+        if: steps.check-branch.outputs.exists == 'true'
         with:
           version: ""
       - uses: ./.github/actions/install/branch-diff
+        if: steps.check-branch.outputs.exists == 'true'
         with:
           token: ${{ steps.octo-sts.outputs.token }}
       - id: proposal
+        if: steps.check-branch.outputs.exists == 'true'
         run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -10,11 +10,37 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    outputs:
+      release-lines: ${{ steps.check.outputs.release-lines }}
+    steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-js
+          policy: release-proposal
+      - id: check
+        run: |
+          lines=()
+          for line in 5 6; do
+            if git ls-remote --heads \
+              "https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/DataDog/dd-trace-js.git" \
+              "refs/heads/v${line}.x" | grep -q .; then
+              lines+=("\"${line}\"")
+            fi
+          done
+          echo "release-lines=[$(IFS=,; echo "${lines[*]}")]" >> "$GITHUB_OUTPUT"
+
   create-proposal:
+    needs: check-branches
+    if: needs.check-branches.outputs.release-lines != '[]'
     strategy:
       fail-fast: false
       matrix:
-        release-line: ["5", "6"]
+        release-line: ${{ fromJSON(needs.check-branches.outputs.release-lines) }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -24,30 +50,17 @@ jobs:
         with:
           scope: DataDog/dd-trace-js
           policy: release-proposal
-      - id: check-branch
-        run: |
-          if git ls-remote --heads \
-            "https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/DataDog/dd-trace-js.git" \
-            "refs/heads/v${{ matrix.release-line }}.x" | grep -q .; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: steps.check-branch.outputs.exists == 'true'
         with:
           fetch-depth: 0
           token: ${{ steps.octo-sts.outputs.token }}
       - uses: ./.github/actions/node
-        if: steps.check-branch.outputs.exists == 'true'
         with:
           version: ""
       - uses: ./.github/actions/install/branch-diff
-        if: steps.check-branch.outputs.exists == 'true'
         with:
           token: ${{ steps.octo-sts.outputs.token }}
       - id: proposal
-        if: steps.check-branch.outputs.exists == 'true'
         run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release-line: ["5"]
+        release-line: ["5", "6"]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -51,6 +51,13 @@ try {
 
   const currentBranch = capture('git rev-parse --abbrev-ref HEAD')
 
+  // Exit cleanly when the release branch has not been created yet.
+  const remoteBranch = capture(`git ls-remote --heads origin refs/heads/v${releaseLine}.x`)
+  if (!remoteBranch) {
+    pass(`skipped (v${releaseLine}.x does not exist yet)`)
+    process.exit(0)
+  }
+
   // Restore current branch on success.
   process.once('exit', code => {
     if (code !== 0) return
@@ -67,16 +74,19 @@ try {
 
   pass(`v${releaseLine}.x`)
 
+  const { DD_MAJOR, DD_MINOR, DD_PATCH, VERSION } = require('../../version')
+  const stableVersion = `${DD_MAJOR}.${DD_MINOR}.${DD_PATCH}`
+  const isPreRelease = VERSION !== stableVersion
+
   // Notes exclude semver-major (gated behind a flag, not user-visible).
-  // Cherry-pick includes semver-major; only only-land-on-next is fully excluded.
+  // Cherry-pick includes semver-major; only only-land-on-next is fully excluded,
+  // except when promoting a pre-release to stable (that's what "next" means).
   const notesDiffCmd = 'branch-diff --user DataDog --repo dd-trace-js' +
-    ' --exclude-label=semver-major --exclude-label=only-land-on-next'
+    (isPreRelease ? '' : ' --exclude-label=semver-major --exclude-label=only-land-on-next')
   const cherryPickDiffCmd = 'branch-diff --user DataDog --repo dd-trace-js' +
-    ' --exclude-label=only-land-on-next'
+    (isPreRelease ? '' : ' --exclude-label=only-land-on-next')
 
   start('Determine version increment')
-
-  const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
 
   // GitHub rebase limit is 100 commits; reserve one slot for the version bump.
   const MAX_CHERRY_PICKS = 99
@@ -116,11 +126,12 @@ try {
   const isMinor = notes.isMinor
   const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
   const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
-  const newVersion = isMinor ? newMinor : newPatch
+  const newVersion = isPreRelease ? stableVersion : (isMinor ? newMinor : newPatch)
   const notesDir = path.join(tmpdir, 'release_notes')
   const notesFile = path.join(notesDir, `v${newVersion}.md`)
 
-  pass(`${isMinor ? 'minor' : 'patch'} (${DD_MAJOR}.${DD_MINOR}.${DD_PATCH} -> ${newVersion})`)
+  const incrementType = isPreRelease ? 'release' : (isMinor ? 'minor' : 'patch')
+  pass(`${incrementType} (${VERSION} -> ${newVersion})`)
 
   start('Checkout release proposal branch')
 
@@ -211,19 +222,27 @@ try {
 
   let previousPullRequest
 
-  if (isMinor) {
+  if (isPreRelease) {
     try {
-      previousPullRequest = JSON.parse(capture(`gh pr view ${newMinor} --json isDraft,url`))
+      previousPullRequest = JSON.parse(capture(`gh pr view ${newVersion} --json isDraft,url`))
     } catch {
-      // No existing PR for minor release proposal.
+      // No existing PR for release proposal.
     }
-  }
+  } else {
+    if (isMinor) {
+      try {
+        previousPullRequest = JSON.parse(capture(`gh pr view ${newMinor} --json isDraft,url`))
+      } catch {
+        // No existing PR for minor release proposal.
+      }
+    }
 
-  if (!previousPullRequest) {
-    try {
-      previousPullRequest = JSON.parse(capture(`gh pr view ${newPatch} --json isDraft,url`))
-    } catch {
-      // No existing PR for patch release proposal.
+    if (!previousPullRequest) {
+      try {
+        previousPullRequest = JSON.parse(capture(`gh pr view ${newPatch} --json isDraft,url`))
+      } catch {
+        // No existing PR for patch release proposal.
+      }
     }
   }
 
@@ -259,7 +278,7 @@ try {
   const pullRequest = JSON.parse(capture('gh pr view --json number,url'))
 
   // Close PR and delete branch for any patch proposal if new proposal is minor.
-  if (isMinor) {
+  if (!isPreRelease && isMinor) {
     try {
       run(`gh pr close v${newPatch}-proposal --delete-branch --comment "Superseded by #${pullRequest.number}."`)
     } catch {

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -51,13 +51,6 @@ try {
 
   const currentBranch = capture('git rev-parse --abbrev-ref HEAD')
 
-  // Exit cleanly when the release branch has not been created yet.
-  const remoteBranch = capture(`git ls-remote --heads origin refs/heads/v${releaseLine}.x`)
-  if (!remoteBranch) {
-    pass(`skipped (v${releaseLine}.x does not exist yet)`)
-    process.exit(0)
-  }
-
   // Restore current branch on success.
   process.once('exit', code => {
     if (code !== 0) return

--- a/scripts/release/validate.js
+++ b/scripts/release/validate.js
@@ -58,7 +58,12 @@ try {
 
   pass()
 
-  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=only-land-on-next'
+  const { DD_MAJOR, DD_MINOR, DD_PATCH, VERSION } = require('../../version')
+  const stableVersion = `${DD_MAJOR}.${DD_MINOR}.${DD_PATCH}`
+  const isPreRelease = VERSION !== stableVersion
+
+  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js' +
+    (isPreRelease ? '' : ' --exclude-label=only-land-on-next')
 
   start('Validate differences between proposal and main branch.')
 


### PR DESCRIPTION
## Summary

- Adds `"6"` to the release-proposal workflow matrix
- Detects pre-release versions (e.g. `6.0.0-pre`) on the release branch and resolves `newVersion` to the stable form (`6.0.0`) instead of incrementing patch/minor
- Includes `semver-major` and `only-land-on-next` commits in both notes and cherry-picks for a release run — these are the breaking changes gated behind the major and the commits specifically intended for the next major
- Labels the increment type as `release` in the step output
- Exits cleanly when the release branch doesn't exist yet, so the v6 matrix entry doesn't cause CI failures before `v6.x` is created
- Scopes the existing PR lookup and close-patch logic to non-pre-release runs

## Test plan

- [ ] Verify the workflow runs without failures on the v5.x line (existing behaviour unchanged)
- [ ] Verify a manual `workflow_dispatch` with `release-line: 6` exits cleanly before `v6.x` is created
- [ ] Once `v6.x` is created with `6.0.0-pre`, verify the proposal targets `6.0.0`, includes `semver-major`/`only-land-on-next` commits, and labels the increment `release`

> Generated by Claude Code