### PR TITLE
refactor(express): trace middleware via layer prototype dispatch

### DIFF
--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
-const { createWrapRouterMethod } = require('./router')
+const { createWrapRouterMethod, createLayerDispatchWrappers } = require('./router')
 const { addHook, channel, tracingChannel } = require('./helpers/instrument')
 const { getCompileToRegexp } = require('./path-to-regexp')
 const {
@@ -170,6 +170,18 @@ addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express =>
   shimmer.wrap(express.Router, 'route', wrapRouterMethod)
 
   return express
+})
+
+// Express 4 bundles its own Layer; express 5 delegates to the `router` package
+// (wrapped in router.js). Both keep `layer.handle` the user's function and trace
+// via the prototype dispatch instead.
+addHook({ name: 'express', file: 'lib/router/layer.js', versions: ['4'] }, Layer => {
+  const { wrapLayerRequest, wrapLayerError } = createLayerDispatchWrappers('express')
+
+  shimmer.wrap(Layer.prototype, 'handle_request', wrapLayerRequest)
+  shimmer.wrap(Layer.prototype, 'handle_error', wrapLayerError)
+
+  return Layer
 })
 
 const queryParserReadCh = channel('datadog:query:read:finish')

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -164,8 +164,8 @@ addHook({ name: 'express', versions: ['>=4'], file: 'lib/express.js' }, express 
 // It would otherwise produce spans for router and express, and so duplicating them.
 // We now fall back to router instrumentation
 addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express => {
-  // `wrapLegacyHandle` only fires for express <4.3.0 layers, which have no
-  // prototype dispatch; 4.3.0+ keeps `handle` pristine (wrapped below).
+  // `wrapLegacyHandle` only fires for express <4.6.0 layers, which have no
+  // prototype dispatch; 4.6.0+ keeps `handle` pristine (wrapped below).
   const { wrapLegacyHandle } = createLayerDispatchWrappers('express')
   const wrapRouterMethod = createWrapRouterMethod('express', getCompileToRegexp(), wrapLegacyHandle)
 
@@ -177,7 +177,7 @@ addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express =>
 
 // Express 4 bundles its own Layer; express 5 delegates to the `router` package
 // (wrapped in router.js). Both keep `layer.handle` the user's function and trace
-// via the prototype dispatch. express <4.3.0 has no such dispatch and is traced
+// via the prototype dispatch. express <4.6.0 has no such dispatch and is traced
 // by the legacy handle wrap instead.
 addHook({ name: 'express', file: 'lib/router/layer.js', versions: ['4'] }, Layer => {
   if (typeof Layer.prototype.handle_request !== 'function') return Layer

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -164,7 +164,10 @@ addHook({ name: 'express', versions: ['>=4'], file: 'lib/express.js' }, express 
 // It would otherwise produce spans for router and express, and so duplicating them.
 // We now fall back to router instrumentation
 addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express => {
-  const wrapRouterMethod = createWrapRouterMethod('express', getCompileToRegexp())
+  // `wrapLegacyHandle` only fires for express <4.3.0 layers, which have no
+  // prototype dispatch; 4.3.0+ keeps `handle` pristine (wrapped below).
+  const { wrapLegacyHandle } = createLayerDispatchWrappers('express')
+  const wrapRouterMethod = createWrapRouterMethod('express', getCompileToRegexp(), wrapLegacyHandle)
 
   shimmer.wrap(express.Router, 'use', wrapRouterMethod)
   shimmer.wrap(express.Router, 'route', wrapRouterMethod)
@@ -174,8 +177,11 @@ addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express =>
 
 // Express 4 bundles its own Layer; express 5 delegates to the `router` package
 // (wrapped in router.js). Both keep `layer.handle` the user's function and trace
-// via the prototype dispatch instead.
+// via the prototype dispatch. express <4.3.0 has no such dispatch and is traced
+// by the legacy handle wrap instead.
 addHook({ name: 'express', file: 'lib/router/layer.js', versions: ['4'] }, Layer => {
+  if (typeof Layer.prototype.handle_request !== 'function') return Layer
+
   const { wrapLayerRequest, wrapLayerError } = createLayerDispatchWrappers('express')
 
   shimmer.wrap(Layer.prototype, 'handle_request', wrapLayerRequest)

--- a/packages/datadog-instrumentations/src/helpers/router-helper.js
+++ b/packages/datadog-instrumentations/src/helpers/router-helper.js
@@ -4,7 +4,7 @@ const shimmer = require('../../../datadog-shimmer')
 const { channel } = require('./instrument')
 
 const routerMountPaths = new WeakMap() // to track mount paths for router instances
-const layerMatchers = new WeakMap() // to store layer matchers
+const layerMeta = new WeakMap() // per-layer middleware dispatch metadata (resolved name + route matchers)
 const appMountedRouters = new WeakSet() // to track routers mounted via app.use()
 
 const METHODS = [...require('http').METHODS.map(v => v.toLowerCase()), 'all']
@@ -70,7 +70,7 @@ function collectRoutesFromRouter (router, prefix) {
       // Extract mount path from layer
       const mountPath = typeof layer.path === 'string'
         ? layer.path
-        : getLayerMatchers(layer)?.[0]?.path || ''
+        : getLayerMeta(layer)?.matchers?.[0]?.path || ''
 
       const nestedPrefix = joinPath(prefix, mountPath)
       if (nestedPrefix === null) continue
@@ -121,12 +121,12 @@ function getRouterMountPaths (router) {
   return [...paths]
 }
 
-function setLayerMatchers (layer, matchers) {
-  layerMatchers.set(layer, matchers)
+function setLayerMeta (layer, meta) {
+  layerMeta.set(layer, meta)
 }
 
-function getLayerMatchers (layer) {
-  return layerMatchers.get(layer)
+function getLayerMeta (layer) {
+  return layerMeta.get(layer)
 }
 
 function normalizeMethodName (method) {
@@ -224,8 +224,8 @@ module.exports = {
   setRouterMountPath,
   getRouterMountPaths,
   joinPath,
-  setLayerMatchers,
-  getLayerMatchers,
+  setLayerMeta,
+  getLayerMeta,
   markAppMounted,
   isAppMounted,
   normalizeRoutePath,

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -8,7 +8,8 @@ const { getCompileToRegexp } = require('./path-to-regexp')
 const {
   getRouterMountPaths,
   joinPath,
-  setLayerMatchers,
+  setLayerMeta,
+  getLayerMeta,
   isAppMounted,
   setRouterMountPath,
   extractMountPaths,
@@ -25,149 +26,68 @@ function isFastSlash (layer, matchers) {
   return layer.regexp?.fast_slash ?? matchers.hasSlashPath
 }
 
-// TODO: Move this function to a shared file between Express and Router
 /**
- * @param {string} name Channel namespace (`apm:<name>:middleware:*`).
- * @param {((pattern: string | RegExp) => RegExp | undefined) | undefined} compile
- *   Host-resolved path-to-regexp compile adapter, or undefined when the host
- *   instance ships no path-to-regexp. Captured here so each express/router
- *   instance keeps the dialect it actually loaded.
+ * Cache the per-layer dispatch metadata in a side table instead of replacing
+ * `layer.handle`. Phase-sorting hosts (loopback's `_findLayerByHandler`) map a
+ * layer back to the user handler by scanning the handle, so the handle has to
+ * stay the user's function.
+ *
+ * @param {{ handle: Function, name?: string, path?: string,
+ *   regexp?: { fast_star?: boolean, fast_slash?: boolean } }} layer
+ * @param {Array<{ path?: string, regex?: RegExp }> & { hasStarPath?: boolean, hasSlashPath?: boolean }} matchers
  */
-function createWrapRouterMethod (name, compile) {
+function annotateLayer (layer, matchers) {
+  const handle = layer.handle
+  const name = handle._name || layer.name || handle.name
+
+  let captureRoute
+  let needMultiMatch = false
+  if (matchers.length !== 0 && !isFastStar(layer, matchers) && !isFastSlash(layer, matchers)) {
+    if (matchers.length === 1) {
+      captureRoute = matchers[0].path
+    } else {
+      needMultiMatch = true
+    }
+  }
+
+  setLayerMeta(layer, { name, captureRoute, needMultiMatch, matchers })
+}
+
+/**
+ * Resolve the route for a dispatched layer. Single-pattern layers carry a
+ * constant route; only multi-pattern stacks need the per-request `layer.path`
+ * match the host already computed.
+ *
+ * @param {{ captureRoute?: string, needMultiMatch: boolean,
+ *   matchers: Array<{ path?: string, regex?: RegExp }> }} meta
+ * @param {{ path?: string }} layer
+ * @returns {string | undefined}
+ */
+function resolveLayerRoute (meta, layer) {
+  if (!meta.needMultiMatch) return meta.captureRoute
+
+  for (const matcher of meta.matchers) {
+    if (matcher.regex?.test(layer.path)) return matcher.path
+  }
+}
+
+/**
+ * Build the request/error dispatch wrappers for one host (`express` / `router`).
+ * They wrap the layer's prototype dispatch and read the side-table metadata, so
+ * `layer.handle` is never replaced. The arity guard mirrors the host's own
+ * (`handle_request` skips 4-arg handlers, `handle_error` skips the rest), so a
+ * span is published only for the layer the host actually runs.
+ *
+ * @param {string} name Channel namespace (`apm:<name>:middleware:*`).
+ */
+function createLayerDispatchWrappers (name) {
   const enterChannel = channel(`apm:${name}:middleware:enter`)
   const exitChannel = channel(`apm:${name}:middleware:exit`)
   const finishChannel = channel(`apm:${name}:middleware:finish`)
   const errorChannel = channel(`apm:${name}:middleware:error`)
   const nextChannel = channel(`apm:${name}:middleware:next`)
-  const routeAddedChannel = channel(`apm:${name}:route:added`)
   // Bound per name so express and a bare router keep independent guards.
   const publishError = createErrorPublisher(errorChannel)
-
-  function wrapLayerHandle (layer, original, matchers) {
-    // Resolve `name` once at wrap time: cached on the original for any code
-    // that reads `_name`, captured in the closure so the per-call body avoids
-    // the property-lookup / `||` fallback.
-    const name = original._name || layer.name || original.name
-    original._name = name
-
-    // Wrap-time matcher analysis. The single-pattern case yields a constant
-    // route; only multi-pattern stacks need a per-request layer.path match.
-    let captureRoute
-    let needMultiMatch = false
-    if (matchers.length !== 0 && !isFastStar(layer, matchers) && !isFastSlash(layer, matchers)) {
-      if (matchers.length === 1) {
-        captureRoute = matchers[0].path
-      } else {
-        needMultiMatch = true
-      }
-    }
-
-    // Split by arity: router only ever dispatches 3-arg request handlers
-    // through `Layer.handleRequest` and 4-arg error handlers through
-    // `Layer.handleError`. Specialising lets the per-call body use named
-    // parameters and `.call`, avoiding the rest-spread Array allocation that
-    // the unified shape forced on every middleware invocation.
-    const wrapped = original.length === 4
-      ? shimmer.wrapFunction(original, errorHandlerLayerWrap(layer, name, captureRoute, needMultiMatch, matchers))
-      : shimmer.wrapFunction(original, requestHandlerLayerWrap(layer, name, captureRoute, needMultiMatch, matchers))
-
-    // Workaround for loopback's phase-based middleware sorting. Its
-    // `_findLayerByHandler` maps a layer back to the user handler by scanning
-    // the layer handle's enumerable properties for the original function.
-    // Replacing `layer.handle` with this wrapper hides that handler, so without
-    // the back-reference loopback cannot tag the layer with its phase and
-    // `app.middleware(phase, ...)` handlers run in insertion order instead of
-    // phase order. The property name is part of that contract; keep it stable.
-    wrapped._datadog_orig = original
-
-    return wrapped
-  }
-
-  function requestHandlerLayerWrap (layer, name, captureRoute, needMultiMatch, matchers) {
-    return original => function (req, res, next) {
-      if (!enterChannel.hasSubscribers) return original.call(this, req, res, next)
-
-      const wrappedNext = typeof next === 'function' ? wrapNext(req, next) : next
-
-      let route = captureRoute
-      if (needMultiMatch) {
-        for (const matcher of matchers) {
-          if (matcher.regex?.test(layer.path)) {
-            route = matcher.path
-            break
-          }
-        }
-      }
-
-      enterChannel.publish({ name, req, route, layer })
-
-      try {
-        return original.call(this, req, res, wrappedNext)
-      } catch (error) {
-        publishError({ req, error })
-        nextChannel.publish({ req })
-        finishChannel.publish({ req })
-
-        throw error
-      } finally {
-        exitChannel.publish({ req })
-      }
-    }
-  }
-
-  function errorHandlerLayerWrap (layer, name, captureRoute, needMultiMatch, matchers) {
-    return original => function (error, req, res, next) {
-      if (!enterChannel.hasSubscribers) return original.call(this, error, req, res, next)
-
-      const wrappedNext = typeof next === 'function' ? wrapNext(req, next) : next
-
-      let route = captureRoute
-      if (needMultiMatch) {
-        for (const matcher of matchers) {
-          if (matcher.regex?.test(layer.path)) {
-            route = matcher.path
-            break
-          }
-        }
-      }
-
-      enterChannel.publish({ name, req, route, layer })
-
-      try {
-        return original.call(this, error, req, res, wrappedNext)
-      } catch (caught) {
-        publishError({ req, error: caught })
-        nextChannel.publish({ req })
-        finishChannel.publish({ req })
-
-        throw caught
-      } finally {
-        exitChannel.publish({ req })
-      }
-    }
-  }
-
-  function wrapStack (layers, matchers) {
-    for (const layer of layers) {
-      if (layer.__handle) { // express-async-errors
-        layer.__handle = wrapLayerHandle(layer, layer.__handle, matchers)
-      } else {
-        layer.handle = wrapLayerHandle(layer, layer.handle, matchers)
-      }
-
-      setLayerMatchers(layer, matchers)
-
-      if (layer.route) {
-        for (const method of METHODS) {
-          if (typeof layer.route.stack === 'function') {
-            layer.route.stack = [{ handle: layer.route.stack }]
-          }
-
-          layer.route[method] = wrapMethod(layer.route[method])
-        }
-      }
-    }
-  }
 
   function wrapNext (req, originalNext) {
     // Per layer dispatch, N per request. Named `next`/arity-1 mirrors the
@@ -182,6 +102,75 @@ function createWrapRouterMethod (name, compile) {
 
       original.apply(this, arguments)
     })
+  }
+
+  // A synchronous throw or a rejected promise is turned into `next(error)` by
+  // the host's own dispatch, so passing `wrappedNext` through captures both
+  // without a tracer-side try/catch; only `exit` needs the `finally`.
+  function wrapLayerRequest (originalRequest) {
+    return function (req, res, next) {
+      if (!enterChannel.hasSubscribers) return originalRequest.call(this, req, res, next)
+
+      const meta = getLayerMeta(this)
+      if (meta === undefined || this.handle.length > 3) return originalRequest.call(this, req, res, next)
+
+      const wrappedNext = typeof next === 'function' ? wrapNext(req, next) : next
+      enterChannel.publish({ name: meta.name, req, route: resolveLayerRoute(meta, this), layer: this })
+
+      try {
+        return originalRequest.call(this, req, res, wrappedNext)
+      } finally {
+        exitChannel.publish({ req })
+      }
+    }
+  }
+
+  function wrapLayerError (originalError) {
+    return function (error, req, res, next) {
+      if (!enterChannel.hasSubscribers) return originalError.call(this, error, req, res, next)
+
+      const meta = getLayerMeta(this)
+      if (meta === undefined || this.handle.length !== 4) return originalError.call(this, error, req, res, next)
+
+      const wrappedNext = typeof next === 'function' ? wrapNext(req, next) : next
+      enterChannel.publish({ name: meta.name, req, route: resolveLayerRoute(meta, this), layer: this })
+
+      try {
+        return originalError.call(this, error, req, res, wrappedNext)
+      } finally {
+        exitChannel.publish({ req })
+      }
+    }
+  }
+
+  return { wrapLayerRequest, wrapLayerError }
+}
+
+// TODO: Move this function to a shared file between Express and Router
+/**
+ * @param {string} name Channel namespace (`apm:<name>:middleware:*`).
+ * @param {((pattern: string | RegExp) => RegExp | undefined) | undefined} compile
+ *   Host-resolved path-to-regexp compile adapter, or undefined when the host
+ *   instance ships no path-to-regexp. Captured here so each express/router
+ *   instance keeps the dialect it actually loaded.
+ */
+function createWrapRouterMethod (name, compile) {
+  const routeAddedChannel = channel(`apm:${name}:route:added`)
+
+  function wrapStack (layers, matchers) {
+    for (const layer of layers) {
+      annotateLayer(layer, matchers)
+
+      if (layer.route) {
+        for (const method of METHODS) {
+          if (typeof layer.route.stack === 'function') {
+            layer.route.stack = [{ handle: layer.route.stack }]
+          }
+
+          layer.route[method] = wrapMethod(layer.route[method])
+        }
+      }
+    }
   }
 
   function extractMatchers (fn) {
@@ -304,6 +293,15 @@ addHook({ name: 'router', versions: ['>=1 <2'] }, Router => {
   return Router
 })
 
+addHook({ name: 'router', file: 'lib/layer.js', versions: ['>=1 <2'] }, Layer => {
+  const { wrapLayerRequest, wrapLayerError } = createLayerDispatchWrappers('router')
+
+  shimmer.wrap(Layer.prototype, 'handle_request', wrapLayerRequest)
+  shimmer.wrap(Layer.prototype, 'handle_error', wrapLayerError)
+
+  return Layer
+})
+
 const queryParserReadCh = channel('datadog:query:read:finish')
 
 addHook({ name: 'router', versions: ['>=2'] }, Router => {
@@ -365,6 +363,10 @@ function wrapHandleRequest (original) {
 addHook({
   name: 'router', file: 'lib/layer.js', versions: ['>=2'],
 }, Layer => {
+  const { wrapLayerRequest, wrapLayerError } = createLayerDispatchWrappers('router')
+
+  shimmer.wrap(Layer.prototype, 'handleRequest', wrapLayerRequest)
+  shimmer.wrap(Layer.prototype, 'handleError', wrapLayerError)
   shimmer.wrap(Layer.prototype, 'handleRequest', wrapHandleRequest)
   return Layer
 })
@@ -404,4 +406,4 @@ addHook({
   return router
 })
 
-module.exports = { createWrapRouterMethod }
+module.exports = { createWrapRouterMethod, createLayerDispatchWrappers }

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -92,13 +92,21 @@ function createLayerDispatchWrappers (name) {
   function wrapNext (req, originalNext) {
     // Per layer dispatch, N per request. Named `next`/arity-1 mirrors the
     // router continuation so wrapCallback skips its name/length rewrite.
+    let published = false
     return shimmer.wrapCallback(originalNext, original => function next (error) {
-      if (error && error !== 'route' && error !== 'router') {
-        publishError({ req, error })
-      }
+      // A handler that calls `next()` and then rejects (`next(); await bg()`)
+      // makes the host call this continuation twice. Publish once so the second
+      // pass cannot tag the already-finished span's parent with a late error.
+      if (!published) {
+        published = true
 
-      nextChannel.publish({ req })
-      finishChannel.publish({ req })
+        if (error && error !== 'route' && error !== 'router') {
+          publishError({ req, error })
+        }
+
+        nextChannel.publish({ req })
+        finishChannel.publish({ req })
+      }
 
       original.apply(this, arguments)
     })
@@ -189,6 +197,9 @@ function createLayerDispatchWrappers (name) {
   return { wrapLayerRequest, wrapLayerError, wrapLegacyHandle }
 }
 
+/**
+ * @param {{ handle_request?: unknown, handleRequest?: unknown }} layer
+ */
 function hasLayerDispatch (layer) {
   return typeof layer.handle_request === 'function' || typeof layer.handleRequest === 'function'
 }

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -143,7 +143,41 @@ function createLayerDispatchWrappers (name) {
     }
   }
 
-  return { wrapLayerRequest, wrapLayerError }
+  // express <4.3.0 has no `Layer` prototype dispatch: the router invokes
+  // `layer.handle` directly and routes errors by its arity. There the handle is
+  // replaced in place, with the arity preserved so the host still routes
+  // correctly. Newer express, express 5, and the router package keep `handle`
+  // pristine and are traced through the prototype wraps above.
+  function wrapLegacyHandle (layer, original) {
+    // `annotateLayer` always runs first in `wrapStack`, so the captured meta is
+    // never undefined here (unlike the prototype wraps, where `this` can be any
+    // layer the host dispatches).
+    const meta = getLayerMeta(layer)
+    const wrapped = shimmer.wrapFunction(original, inner => function (...args) {
+      if (!enterChannel.hasSubscribers) return inner.apply(this, args)
+
+      const isErrorHandler = original.length === 4
+      const req = args[isErrorHandler ? 1 : 0]
+      const nextIndex = isErrorHandler ? 3 : 2
+      if (typeof args[nextIndex] === 'function') args[nextIndex] = wrapNext(req, args[nextIndex])
+
+      enterChannel.publish({ name: meta.name, req, route: resolveLayerRoute(meta, layer), layer })
+
+      try {
+        return inner.apply(this, args)
+      } finally {
+        exitChannel.publish({ req })
+      }
+    })
+    Object.defineProperty(wrapped, 'length', { value: original.length, configurable: true })
+    return wrapped
+  }
+
+  return { wrapLayerRequest, wrapLayerError, wrapLegacyHandle }
+}
+
+function hasLayerDispatch (layer) {
+  return typeof layer.handle_request === 'function' || typeof layer.handleRequest === 'function'
 }
 
 // TODO: Move this function to a shared file between Express and Router
@@ -153,13 +187,24 @@ function createLayerDispatchWrappers (name) {
  *   Host-resolved path-to-regexp compile adapter, or undefined when the host
  *   instance ships no path-to-regexp. Captured here so each express/router
  *   instance keeps the dialect it actually loaded.
+ * @param {((layer: object, original: Function) => Function) | undefined} [wrapLegacyHandle]
+ *   Fallback that replaces `layer.handle` for hosts without a `Layer` prototype
+ *   dispatch (express <4.3.0). Omitted for hosts that always ship one.
  */
-function createWrapRouterMethod (name, compile) {
+function createWrapRouterMethod (name, compile, wrapLegacyHandle) {
   const routeAddedChannel = channel(`apm:${name}:route:added`)
 
   function wrapStack (layers, matchers) {
     for (const layer of layers) {
       annotateLayer(layer, matchers)
+
+      if (wrapLegacyHandle !== undefined && !hasLayerDispatch(layer)) {
+        if (layer.__handle) { // express-async-errors
+          layer.__handle = wrapLegacyHandle(layer, layer.__handle)
+        } else {
+          layer.handle = wrapLegacyHandle(layer, layer.handle)
+        }
+      }
 
       if (layer.route) {
         for (const method of METHODS) {

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -104,9 +104,12 @@ function createLayerDispatchWrappers (name) {
     })
   }
 
-  // A synchronous throw or a rejected promise is turned into `next(error)` by
-  // the host's own dispatch, so passing `wrappedNext` through captures both
-  // without a tracer-side try/catch; only `exit` needs the `finally`.
+  // Every host dispatch turns a synchronous throw into `next(error)`, and the
+  // hosts that await the handler (router >=2, express 5, express 4 +
+  // express-async-errors) do the same for a rejected promise. Passing
+  // `wrappedNext` through captures both without a tracer-side try/catch; only
+  // `exit` needs the `finally`. express 4's native dispatch converts only the
+  // synchronous throw — exactly what the pre-refactor handle wrap caught.
   function wrapLayerRequest (originalRequest) {
     return function (req, res, next) {
       if (!enterChannel.hasSubscribers) return originalRequest.call(this, req, res, next)
@@ -410,6 +413,10 @@ addHook({
 }, Layer => {
   const { wrapLayerRequest, wrapLayerError } = createLayerDispatchWrappers('router')
 
+  // `handleRequest` carries two concerns: the middleware dispatch span and the
+  // param-start publish (`wrapHandleRequest`). Wrap the dispatch first so it
+  // sits inner and param-start still fires before `middleware:enter`, matching
+  // the order from when the handle itself was wrapped.
   shimmer.wrap(Layer.prototype, 'handleRequest', wrapLayerRequest)
   shimmer.wrap(Layer.prototype, 'handleError', wrapLayerError)
   shimmer.wrap(Layer.prototype, 'handleRequest', wrapHandleRequest)

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -146,7 +146,7 @@ function createLayerDispatchWrappers (name) {
     }
   }
 
-  // express <4.3.0 has no `Layer` prototype dispatch: the router invokes
+  // express <4.6.0 has no `Layer` prototype dispatch: the router invokes
   // `layer.handle` directly and routes errors by its arity. There the handle is
   // replaced in place, with the arity preserved so the host still routes
   // correctly. Newer express, express 5, and the router package keep `handle`
@@ -168,6 +168,16 @@ function createLayerDispatchWrappers (name) {
 
       try {
         return inner.apply(this, args)
+      } catch (error) {
+        // Unlike the prototype hosts, this router catches a synchronous throw
+        // outside the layer and calls its own `next(error)`, never `wrappedNext`.
+        // Mirror `wrapNext` here so the throwing layer still tags its error and
+        // finishes, rather than lingering on the stack until request finish.
+        publishError({ req, error })
+        nextChannel.publish({ req })
+        finishChannel.publish({ req })
+
+        throw error
       } finally {
         exitChannel.publish({ req })
       }
@@ -192,7 +202,7 @@ function hasLayerDispatch (layer) {
  *   instance keeps the dialect it actually loaded.
  * @param {((layer: object, original: Function) => Function) | undefined} [wrapLegacyHandle]
  *   Fallback that replaces `layer.handle` for hosts without a `Layer` prototype
- *   dispatch (express <4.3.0). Omitted for hosts that always ship one.
+ *   dispatch (express <4.6.0). Omitted for hosts that always ship one.
  */
 function createWrapRouterMethod (name, compile, wrapLegacyHandle) {
   const routeAddedChannel = channel(`apm:${name}:route:added`)

--- a/packages/datadog-instrumentations/test/helpers/router-helper.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/router-helper.spec.js
@@ -18,7 +18,7 @@ const {
   extractMountPaths,
   hasRouterCycle,
   collectRoutesFromRouter,
-  setLayerMatchers,
+  setLayerMeta,
   isAppMounted,
 } = require('../../src/helpers/router-helper')
 
@@ -273,7 +273,7 @@ describe('helpers/router-helper', () => {
         path: undefined,
       }
 
-      setLayerMatchers(layer, [{ path: '/dynamic' }])
+      setLayerMeta(layer, { matchers: [{ path: '/dynamic' }] })
 
       const parentRouter = {
         stack: [layer],
@@ -285,6 +285,29 @@ describe('helpers/router-helper', () => {
         { method: '*', path: '/root/dynamic/details' },
       ])
       assert.deepStrictEqual(getRouterMountPaths(childRouter), ['/root/dynamic'])
+    })
+
+    it('falls back to an empty mount path when the layer has no matcher metadata', () => {
+      const childRouter = {
+        stack: [{
+          route: {
+            path: '/details',
+            methods: { all: true },
+          },
+        }],
+      }
+
+      // Non-string layer path and nothing in the side table: the mount path
+      // resolves to '' and the nested route publishes under the parent prefix.
+      const parentRouter = {
+        stack: [{ handle: childRouter, path: undefined }],
+      }
+
+      collectRoutesFromRouter(parentRouter, '/root')
+
+      assert.deepStrictEqual(published, [
+        { method: '*', path: '/root/details' },
+      ])
     })
   })
 

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -639,6 +639,119 @@ describe('createWrapRouterMethod', () => {
     })
   })
 
+  describe('legacy handle replacement (host without prototype dispatch)', () => {
+    // express <4.3.0 has no `Layer.prototype.handle_request`; the router calls
+    // `layer.handle` directly, so the handle is replaced in place.
+    function legacyUse (path, handler) {
+      this.stack.push({ handle: handler, path: '/foo', regexp: {} })
+    }
+
+    it('replaces layer.handle, preserves request arity, and traces the dispatch', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      function originalHandler (req, res, next) { next() }
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', originalHandler)
+
+      const layer = router.stack[0]
+      assert.notStrictEqual(layer.handle, originalHandler)
+      assert.strictEqual(layer.handle.length, 3)
+
+      const req = {}
+      const downstreamNext = () => events.push({ label: 'downstream-next' })
+      layer.handle(req, {}, downstreamNext)
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'downstream-next', 'exit',
+      ])
+      assertObjectContains(events[0].data, { name: 'originalHandler', req, route: '/foo', layer })
+    })
+
+    it('preserves error-handler arity (4) so the host still routes errors', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function errorHandler (error, req, res, next) { next() })
+
+      const layer = router.stack[0]
+      assert.strictEqual(layer.handle.length, 4)
+
+      const req = {}
+      layer.handle(new Error('e'), req, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.name, 'errorHandler')
+      assert.strictEqual(enterEvent.data.req, req)
+    })
+
+    it('leaves handle pristine when the layer has a prototype dispatch method', () => {
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      function originalHandler (req, res, next) { next() }
+      // `makeFakeUse` produces layers with `handle_request`, so the legacy
+      // fallback must not touch them even though it is available.
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', originalHandler)
+
+      assert.strictEqual(router.stack[0].handle, originalHandler)
+    })
+
+    it('forwards through without tracing when enterChannel has no subscribers', () => {
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      let handlerRan = false
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function (req, res, next) {
+        handlerRan = true
+        next()
+      })
+
+      let nextCalled = false
+      router.stack[0].handle({}, {}, () => { nextCalled = true })
+
+      assert.strictEqual(handlerRan, true)
+      assert.strictEqual(nextCalled, true)
+      assert.strictEqual(events.length, 0)
+    })
+
+    it('wraps __handle instead of handle for express-async-errors layers', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const originalHandle = (req, res, next) => next()
+      function underscoreHandle (req, res, next) {
+        events.push({ label: '__handle-called' })
+        next()
+      }
+
+      const wrappedUse = wrapMethod(function use (path, handler) {
+        this.stack.push({ handle: originalHandle, __handle: underscoreHandle, path: '/foo', regexp: {} })
+      })
+      wrappedUse.call(router, '/foo', () => {})
+
+      const layer = router.stack[0]
+      assert.strictEqual(layer.handle, originalHandle)
+      assert.notStrictEqual(layer.__handle, underscoreHandle)
+
+      layer.__handle({}, {}, () => {})
+
+      assert.ok(events.find(e => e.label === '__handle-called'))
+      assert.ok(events.find(e => e.label === 'enter'))
+    })
+  })
+
   describe('re-entrant error subscriber', () => {
     it('drops the re-entrant publish when an error subscriber re-runs the layer', () => {
       // enterChannel needs a subscriber or the layer dispatch takes the

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -5,34 +5,63 @@ const assert = require('node:assert/strict')
 const dc = require('dc-polyfill')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
-const { createWrapRouterMethod } = require('../src/router')
+const { createWrapRouterMethod, createLayerDispatchWrappers } = require('../src/router')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 
-// `createWrapRouterMethod` is exercised end-to-end by the express and router
-// plugin specs, but those run over real HTTP and only ever dispatch 3-arg
-// request handlers with a single matcher path. The new arity split, the
-// multi-matcher loop, the no-subscriber fast paths, the sync-throw catches,
-// and the `_name` resolution chain need explicit unit coverage so a future
-// regression on any of them shows up here, not in a downstream tracer test.
+// `createWrapRouterMethod` annotates each layer with dispatch metadata;
+// `createLayerDispatchWrappers` wraps the host's `Layer.prototype` dispatch to
+// emit the middleware spans, without ever replacing `layer.handle`. The express
+// and router plugin specs exercise this end-to-end over real HTTP, but only ever
+// dispatch 3-arg request handlers with a single matcher path. The arity gate,
+// the multi-matcher loop, the no-subscriber fast paths, the host-converted error
+// path, and the `name` resolution chain need explicit unit coverage so a
+// regression shows up here, not in a downstream tracer test.
 
 /**
- * Minimal subset of an express/router `Layer` the wrap code reads. `regexp` is
- * the host's compiled mount regex — only `fast_star` / `fast_slash` matter for
- * the wrap-time short-circuit.
- * @typedef {{
- *   handle: Function,
- *   __handle?: Function,
- *   name?: string,
- *   path?: string,
- *   regexp?: { fast_star?: boolean, fast_slash?: boolean },
- * }} FakeLayer
+ * Build an express/router-shaped `Layer` whose prototype dispatch is wrapped by
+ * the tracer. The `handle_request` / `handle_error` bodies mirror express 4 /
+ * router 1.x: the arity gate and the host-owned try/catch that turns a thrown
+ * handler into `next(error)`. The user handler stays on `this.handle`.
  *
- * @typedef {{ stack: FakeLayer[] }} FakeRouter
+ * @param {(original: Function) => Function} wrapLayerRequest
+ * @param {(original: Function) => Function} wrapLayerError
+ * @returns {new (handle: Function, options?: { path?: string, regexp?: object, name?: string }) => object}
  */
+function makeLayerClass (wrapLayerRequest, wrapLayerError) {
+  function FakeLayer (handle, { path = '/some-path', regexp = {}, name } = {}) {
+    this.handle = handle
+    this.path = path
+    this.regexp = regexp
+    if (name !== undefined) this.name = name
+  }
+
+  FakeLayer.prototype.handle_request = wrapLayerRequest(function hostHandleRequest (req, res, next) {
+    const fn = this.handle
+    if (fn.length > 3) return next()
+    try {
+      fn(req, res, next)
+    } catch (error) {
+      next(error)
+    }
+  })
+
+  FakeLayer.prototype.handle_error = wrapLayerError(function hostHandleError (error, req, res, next) {
+    const fn = this.handle
+    if (fn.length !== 4) return next(error)
+    try {
+      fn(error, req, res, next)
+    } catch (caught) {
+      next(caught)
+    }
+  })
+
+  return FakeLayer
+}
 
 describe('createWrapRouterMethod', () => {
   let counter = 0
   let namespace
+  let FakeLayer
   let enterChannel
   let exitChannel
   let nextChannel
@@ -48,6 +77,8 @@ describe('createWrapRouterMethod', () => {
     nextChannel = dc.channel(`apm:${namespace}:middleware:next`)
     finishChannel = dc.channel(`apm:${namespace}:middleware:finish`)
     errorChannel = dc.channel(`apm:${namespace}:middleware:error`)
+    const { wrapLayerRequest, wrapLayerError } = createLayerDispatchWrappers(namespace)
+    FakeLayer = makeLayerClass(wrapLayerRequest, wrapLayerError)
     events = []
     subscriptions = []
   })
@@ -78,9 +109,8 @@ describe('createWrapRouterMethod', () => {
   }
 
   /**
-   * Build a fake `.use`-shaped router method whose body appends one layer per
-   * handler to `this.stack`. `layerPath` is the request-time `layer.path`
-   * value the wrapped handler sees during the multi-matcher loop.
+   * Build a fake `.use`-shaped router method whose body appends one `FakeLayer`
+   * per handler to `this.stack`. `wrapMethod` then annotates each new layer.
    *
    * @param {object} [options]
    * @param {string} [options.layerPath] Request path the layer reports.
@@ -88,17 +118,16 @@ describe('createWrapRouterMethod', () => {
    * @returns {Function} The fake `.use` implementation.
    */
   function makeFakeUse ({ layerPath = '/some-path', regexp = {} } = {}) {
-    function use (...args) {
+    return function use (...args) {
       // Mirror the host shape: the first arg is a path or array of paths, the
       // rest are middleware. Plain handlers (`use(handler)`) start at index 0.
       const startIdx = typeof args[0] === 'function' ? 0 : 1
       for (let i = startIdx; i < args.length; i++) {
         const handler = args[i]
         if (typeof handler !== 'function') continue
-        this.stack.push({ handle: handler, path: layerPath, regexp })
+        this.stack.push(new FakeLayer(handler, { path: layerPath, regexp }))
       }
     }
-    return use
   }
 
   function compileRegex (pattern) {
@@ -107,11 +136,11 @@ describe('createWrapRouterMethod', () => {
     return new RegExp(`^${pattern.replace(/\//g, '\\/')}$`)
   }
 
-  describe('request handler (3-arg) wrap', () => {
+  describe('request handler (3-arg) dispatch', () => {
     it('publishes enter/next/finish/exit and captures the single-pattern route', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', function namedHandler (req, res, next) {
@@ -120,9 +149,10 @@ describe('createWrapRouterMethod', () => {
 
       const req = { url: '/' }
       const res = {}
+      const layer = router.stack[0]
       const downstreamNext = () => events.push({ label: 'downstream-next' })
 
-      router.stack[0].handle.call({}, req, res, downstreamNext)
+      layer.handle_request(req, res, downstreamNext)
 
       assert.deepStrictEqual(events.map(e => e.label), [
         'enter', 'next', 'finish', 'downstream-next', 'exit',
@@ -131,47 +161,44 @@ describe('createWrapRouterMethod', () => {
         name: 'namedHandler',
         req,
         route: '/foo',
-        layer: router.stack[0],
+        layer,
       })
     })
 
     it('matches a multi-pattern path against layer.path and captures the matching route', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/users' }))
       wrappedUse.call(router, ['/users', '/products'], function pickedFromList (req, res, next) {
         next()
       })
 
-      const req = {}
-      router.stack[0].handle.call({}, req, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, '/users')
+      assert.strictEqual(events.find(e => e.label === 'enter').data.route, '/users')
     })
 
     it('leaves route undefined when no multi-pattern matcher matches', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/unrelated' }))
       wrappedUse.call(router, ['/users', '/products'], function noMatch (req, res, next) {
         next()
       })
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, undefined)
+      assert.strictEqual(events.find(e => e.label === 'enter').data.route, undefined)
     })
 
     it('skips matcher analysis when the host passes a handler with no mount path', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       // `.use(handler)` with no mount path produces an empty matchers list.
       const wrappedUse = wrapMethod(makeFakeUse())
@@ -179,75 +206,67 @@ describe('createWrapRouterMethod', () => {
         next()
       })
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, undefined)
+      assert.strictEqual(events.find(e => e.label === 'enter').data.route, undefined)
     })
 
     it('short-circuits the matcher loop on a fast-star (`*`) layer', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ regexp: { fast_star: true } }))
       wrappedUse.call(router, '*', function starHandler (req, res, next) {
         next()
       })
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, undefined)
+      assert.strictEqual(events.find(e => e.label === 'enter').data.route, undefined)
     })
 
     it('short-circuits the matcher loop on a fast-slash (`/`) layer', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ regexp: { fast_slash: true } }))
       wrappedUse.call(router, '/', function slashHandler (req, res, next) {
         next()
       })
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, undefined)
+      assert.strictEqual(events.find(e => e.label === 'enter').data.route, undefined)
     })
 
-    it('skips wrapping work when enterChannel has no subscribers', () => {
+    it('forwards the raw next and publishes nothing when enterChannel has no subscribers', () => {
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
-      // With no subscriber on enterChannel the wrapped handler should forward
-      // `this`, `req`, `res`, `next` and the return value straight through —
-      // no allocation, no wrapNext, no channel publish.
-      const captured = { thisArg: undefined, args: /** @type {unknown[]} */ ([]) }
+      // With no subscriber the wrapped dispatch forwards `req`, `res` and the
+      // raw `next` straight through — no allocation, no wrapNext, no publish.
+      const captured = { args: /** @type {unknown[]} */ ([]) }
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', function (req, res, next) {
-        captured.thisArg = this
         captured.args = [req, res, next]
-        return 'forwarded-return'
       })
 
       const req = {}
       const res = {}
-      const next = () => 'original-next'
-      const ctx = { tag: 'this-arg' }
+      const next = () => {}
 
-      const result = router.stack[0].handle.call(ctx, req, res, next)
+      router.stack[0].handle_request(req, res, next)
 
-      assert.strictEqual(result, 'forwarded-return')
-      assert.strictEqual(captured.thisArg, ctx)
       assert.deepStrictEqual(captured.args, [req, res, next])
+      assert.strictEqual(events.length, 0)
     })
 
     it('passes a non-function next through unchanged', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const captured = { next: /** @type {unknown} */ (undefined) }
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
@@ -255,15 +274,48 @@ describe('createWrapRouterMethod', () => {
         captured.next = next
       })
 
-      router.stack[0].handle.call({}, {}, {}, 'not-a-function')
+      router.stack[0].handle_request({}, {}, 'not-a-function')
 
       assert.strictEqual(captured.next, 'not-a-function')
     })
 
-    it('publishes error/next/finish/exit when the handler throws synchronously', () => {
+    it('forwards through without a span when the layer was never annotated', () => {
+      subscribeAll()
+
+      // A layer the host created but dd-trace never ran through `.use` has no
+      // side-table metadata, so the dispatch forwards straight through.
+      const layer = new FakeLayer(function (req, res, next) { next() }, { path: '/foo' })
+
+      let forwardedNext = false
+      layer.handle_request({}, {}, () => { forwardedNext = true })
+
+      assert.strictEqual(forwardedNext, true)
+      assert.strictEqual(events.length, 0)
+    })
+
+    it('forwards a 4-arg error handler reached via the request path without a span', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function errorHandler (error, req, res, next) {
+        next()
+      })
+
+      // The host dispatches every matching layer through `handle_request`; the
+      // arity gate forwards a 4-arg error handler on without a span.
+      let forwardedNext = false
+      router.stack[0].handle_request({}, {}, () => { forwardedNext = true })
+
+      assert.strictEqual(forwardedNext, true)
+      assert.strictEqual(events.length, 0)
+    })
+
+    it('routes a synchronous throw through next(error) and publishes error/next/finish/exit', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = { stack: [] }
 
       const failure = new Error('boom')
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
@@ -271,26 +323,26 @@ describe('createWrapRouterMethod', () => {
         throw failure
       })
 
+      // The host dispatch catches the throw and converts it to next(error); the
+      // tracer observes it through wrappedNext, never a re-thrown error.
       const req = {}
-      assert.throws(() => {
-        router.stack[0].handle.call({}, req, {}, () => {})
-      }, error => error === failure)
+      let downstreamError
+      router.stack[0].handle_request(req, {}, (error) => { downstreamError = error })
 
-      // The throw skips the wrapped-next path; finish/exit publish via the
-      // catch block before the throw is re-raised.
       assert.deepStrictEqual(events.map(e => e.label), [
         'enter', 'error', 'next', 'finish', 'exit',
       ])
       assert.strictEqual(events[1].data.error, failure)
       assert.strictEqual(events[1].data.req, req)
+      assert.strictEqual(downstreamError, failure)
     })
   })
 
-  describe('error handler (4-arg) wrap', () => {
-    it('publishes enter/next/finish/exit and forwards error/req/res/next to the original', () => {
+  describe('error handler (4-arg) dispatch', () => {
+    it('publishes enter/next/finish/exit and forwards error/req/res/next to the handler', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       const received = /** @type {{ error?: Error, req?: object, res?: object }} */ ({})
@@ -298,8 +350,6 @@ describe('createWrapRouterMethod', () => {
         received.error = error
         received.req = req
         received.res = res
-        // Real error handlers either call next() to continue, or next(error)
-        // to keep propagating; both shapes go through wrappedNext.
         next()
       })
 
@@ -308,7 +358,7 @@ describe('createWrapRouterMethod', () => {
       const res = {}
       const downstreamNext = () => events.push({ label: 'downstream-next' })
 
-      router.stack[0].handle.call({}, failure, req, res, downstreamNext)
+      router.stack[0].handle_error(failure, req, res, downstreamNext)
 
       assert.deepStrictEqual(events.map(e => e.label), [
         'enter', 'next', 'finish', 'downstream-next', 'exit',
@@ -328,64 +378,76 @@ describe('createWrapRouterMethod', () => {
     it('matches a multi-pattern path against layer.path and captures the matching route', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/products' }))
       wrappedUse.call(router, ['/users', '/products'], function (error, req, res, next) {
         next()
       })
 
-      router.stack[0].handle.call({}, new Error('e'), {}, {}, () => {})
+      router.stack[0].handle_error(new Error('e'), {}, {}, () => {})
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, '/products')
+      assert.strictEqual(events.find(e => e.label === 'enter').data.route, '/products')
     })
 
-    it('leaves route undefined when no multi-pattern matcher matches', () => {
+    it('skips work when the layer is a 3-arg handler the host would not run as an error handler', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
-      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/none' }))
-      wrappedUse.call(router, ['/users', '/products'], function (error, req, res, next) {
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function requestHandler (req, res, next) {
         next()
       })
 
-      router.stack[0].handle.call({}, new Error('e'), {}, {}, () => {})
+      // A 3-arg handler reached via the error path: the arity gate forwards the
+      // error to the next layer and publishes nothing.
+      const failure = new Error('e')
+      let forwarded
+      router.stack[0].handle_error(failure, {}, {}, (error) => { forwarded = error })
 
-      const enterEvent = events.find(e => e.label === 'enter')
-      assert.strictEqual(enterEvent.data.route, undefined)
+      assert.strictEqual(forwarded, failure)
+      assert.strictEqual(events.length, 0)
     })
 
-    it('skips wrapping work when enterChannel has no subscribers', () => {
+    it('forwards the raw next and publishes nothing when enterChannel has no subscribers', () => {
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
-      const captured = { thisArg: undefined, args: /** @type {unknown[]} */ ([]) }
+      const captured = { args: /** @type {unknown[]} */ ([]) }
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', function (error, req, res, next) {
-        captured.thisArg = this
         captured.args = [error, req, res, next]
-        return 'forwarded-return'
       })
 
       const failure = new Error('e')
       const req = {}
       const res = {}
       const next = () => {}
-      const ctx = { tag: 'this-arg' }
 
-      const result = router.stack[0].handle.call(ctx, failure, req, res, next)
+      router.stack[0].handle_error(failure, req, res, next)
 
-      assert.strictEqual(result, 'forwarded-return')
-      assert.strictEqual(captured.thisArg, ctx)
       assert.deepStrictEqual(captured.args, [failure, req, res, next])
+      assert.strictEqual(events.length, 0)
+    })
+
+    it('forwards through without a span when the layer was never annotated', () => {
+      subscribeAll()
+
+      const layer = new FakeLayer(function (error, req, res, next) { next(error) }, { path: '/foo' })
+
+      const failure = new Error('e')
+      let forwarded
+      layer.handle_error(failure, {}, {}, (error) => { forwarded = error })
+
+      assert.strictEqual(forwarded, failure)
+      assert.strictEqual(events.length, 0)
     })
 
     it('passes a non-function next through unchanged', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const captured = { next: /** @type {unknown} */ (undefined) }
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
@@ -393,15 +455,15 @@ describe('createWrapRouterMethod', () => {
         captured.next = next
       })
 
-      router.stack[0].handle.call({}, new Error('e'), {}, {}, 'not-a-function')
+      router.stack[0].handle_error(new Error('e'), {}, {}, 'not-a-function')
 
       assert.strictEqual(captured.next, 'not-a-function')
     })
 
-    it('publishes error/next/finish/exit when the handler throws synchronously', () => {
+    it('routes a synchronous throw through next(error) and publishes error/next/finish/exit', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const failure = new Error('throws-in-error-handler')
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
@@ -410,15 +472,15 @@ describe('createWrapRouterMethod', () => {
       })
 
       const req = {}
-      assert.throws(() => {
-        router.stack[0].handle.call({}, new Error('upstream'), req, {}, () => {})
-      }, error => error === failure)
+      let downstreamError
+      router.stack[0].handle_error(new Error('upstream'), req, {}, (error) => { downstreamError = error })
 
       assert.deepStrictEqual(events.map(e => e.label), [
         'enter', 'error', 'next', 'finish', 'exit',
       ])
       assert.strictEqual(events[1].data.error, failure)
       assert.strictEqual(events[1].data.req, req)
+      assert.strictEqual(downstreamError, failure)
     })
   })
 
@@ -426,7 +488,7 @@ describe('createWrapRouterMethod', () => {
     it('prefers `original._name` when it is already set', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const handler = /** @type {Function & { _name?: string }} */ (
         function handlerWithCachedName (req, res, next) { next() }
@@ -436,7 +498,7 @@ describe('createWrapRouterMethod', () => {
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', handler)
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
       assert.strictEqual(events.find(e => e.label === 'enter').data.name, 'pre-cached')
     })
@@ -444,17 +506,14 @@ describe('createWrapRouterMethod', () => {
     it('falls back to `layer.name` when `_name` is missing and `layer.name` is set', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
-      const wrappedUse = wrapMethod((handler) => {
-        router.stack.push({ handle: handler, name: 'layer-named', path: '/foo', regexp: {} })
+      const wrappedUse = wrapMethod(function use (handler) {
+        this.stack.push(new FakeLayer(handler, { name: 'layer-named', path: '/foo' }))
       })
-      // The fake use above doesn't follow the standard signature; pass the
-      // handler at the head of args so extractMatchers sees a function and
-      // returns an empty matcher list.
       wrappedUse.call(router, (req, res, next) => next())
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
       assert.strictEqual(events.find(e => e.label === 'enter').data.name, 'layer-named')
     })
@@ -462,14 +521,14 @@ describe('createWrapRouterMethod', () => {
     it('falls back to `original.name` when both `_name` and `layer.name` are missing', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', function fallbackToOriginalName (req, res, next) {
         next()
       })
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
       assert.strictEqual(
         events.find(e => e.label === 'enter').data.name,
@@ -477,19 +536,21 @@ describe('createWrapRouterMethod', () => {
       )
     })
 
-    it('caches the resolved name on `original._name` so the next wrap reuses it', () => {
+    it('does not mutate the user handler to cache the resolved name', () => {
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const handler = /** @type {Function & { _name?: string }} */ (
         function originalName (req, res, next) { next() }
       )
-      assert.strictEqual(handler._name, undefined)
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', handler)
 
-      assert.strictEqual(handler._name, 'originalName')
+      // The resolved name lives in the layer-meta side table; the user's handler
+      // function is left untouched (no `_name` written back onto it).
+      assert.strictEqual(handler._name, undefined)
+      assert.strictEqual(router.stack[0].handle, handler)
     })
   })
 
@@ -497,12 +558,12 @@ describe('createWrapRouterMethod', () => {
     it('does not publish errorChannel when next is called with no argument', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', (req, res, next) => next())
 
-      router.stack[0].handle.call({}, {}, {}, () => {})
+      router.stack[0].handle_request({}, {}, () => {})
 
       assert.strictEqual(events.some(e => e.label === 'error'), false)
     })
@@ -510,13 +571,13 @@ describe('createWrapRouterMethod', () => {
     it('does not publish errorChannel on next("route")', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', (req, res, next) => next('route'))
 
       let receivedRouteToken
-      router.stack[0].handle.call({}, {}, {}, (token) => { receivedRouteToken = token })
+      router.stack[0].handle_request({}, {}, (token) => { receivedRouteToken = token })
 
       assert.strictEqual(receivedRouteToken, 'route')
       assert.strictEqual(events.some(e => e.label === 'error'), false)
@@ -525,13 +586,13 @@ describe('createWrapRouterMethod', () => {
     it('does not publish errorChannel on next("router")', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', (req, res, next) => next('router'))
 
       let receivedRouterToken
-      router.stack[0].handle.call({}, {}, {}, (token) => { receivedRouterToken = token })
+      router.stack[0].handle_request({}, {}, (token) => { receivedRouterToken = token })
 
       assert.strictEqual(receivedRouterToken, 'router')
       assert.strictEqual(events.some(e => e.label === 'error'), false)
@@ -540,14 +601,14 @@ describe('createWrapRouterMethod', () => {
     it('publishes errorChannel with the error when next is called with an Error', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       const failure = new Error('downstream-error')
       wrappedUse.call(router, '/foo', (req, res, next) => next(failure))
 
       const req = {}
-      router.stack[0].handle.call({}, req, {}, () => {})
+      router.stack[0].handle_request(req, {}, () => {})
 
       const errorEvent = events.find(e => e.label === 'error')
       assert.ok(errorEvent, 'errorChannel should publish on next(error)')
@@ -556,61 +617,42 @@ describe('createWrapRouterMethod', () => {
     })
   })
 
-  describe('layer.__handle (express-async-errors compatibility)', () => {
-    it('wraps `__handle` instead of `handle` when the layer exposes both', () => {
+  describe('pristine layer.handle', () => {
+    it('leaves layer.handle as the user function so phase-sorting hosts can find it', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
-      const originalHandle = (req, res, next) => next()
-      const originalUnderscoreHandle = function patchedHandle (req, res, next) {
-        events.push({ label: '__handle-called' })
-        next()
-      }
+      function userHandler (req, res, next) { next() }
 
-      function fakeUseWithUnderscoreHandle (path, handler) {
-        this.stack.push({
-          handle: originalHandle,
-          __handle: originalUnderscoreHandle,
-          path: '/foo',
-          regexp: {},
-        })
-      }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', userHandler)
 
-      const wrappedUse = wrapMethod(fakeUseWithUnderscoreHandle)
-      wrappedUse.call(router, '/foo', () => {})
+      // The whole point of the prototype-dispatch design: the layer's handle is
+      // never swapped for a wrapper, so loopback's `_findLayerByHandler` can map
+      // the layer back to the user handler.
+      assert.strictEqual(router.stack[0].handle, userHandler)
 
-      // `handle` should be left alone; `__handle` should be the new wrapper.
-      const wrappedLayer = router.stack[0]
-      assert.strictEqual(wrappedLayer.handle, originalHandle)
-      assert.notStrictEqual(wrappedLayer.__handle, originalUnderscoreHandle)
-      assert.strictEqual(typeof wrappedLayer.__handle, 'function')
-
-      const wrappedUnderscoreHandle = /** @type {Function} */ (wrappedLayer.__handle)
-      wrappedUnderscoreHandle.call({}, {}, {}, () => {})
-
-      assert.ok(
-        events.find(e => e.label === '__handle-called'),
-        'the inner __handle should run via the wrap'
-      )
-      assert.ok(events.find(e => e.label === 'enter'), 'enterChannel should publish for __handle')
+      // Tracing still happens, via the wrapped prototype dispatch.
+      router.stack[0].handle_request({}, {}, () => {})
+      assert.ok(events.find(e => e.label === 'enter'))
     })
   })
 
   describe('re-entrant error subscriber', () => {
     it('drops the re-entrant publish when an error subscriber re-runs the layer', () => {
-      // enterChannel needs a subscriber or the layer wrap takes the
+      // enterChannel needs a subscriber or the layer dispatch takes the
       // no-subscriber fast path and never reaches wrapNext.
       const enterListener = () => {}
       enterChannel.subscribe(enterListener)
       subscriptions.push([enterChannel, enterListener])
 
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
-      const router = /** @type {FakeRouter} */ ({ stack: [] })
+      const router = { stack: [] }
 
       const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
       wrappedUse.call(router, '/foo', (req, res, next) => next(new Error('boom')))
-      const handle = router.stack[0].handle
+      const layer = router.stack[0]
 
       // A subscriber that re-runs the same layer while handling the error loops
       // errorChannel -> subscriber -> next(error) -> errorChannel until the
@@ -619,12 +661,12 @@ describe('createWrapRouterMethod', () => {
       const errorListener = () => {
         depth++
         if (depth > 50) return // safety stop: a regressed guard fails the assert, not the runner
-        handle.call({}, {}, {}, () => {})
+        layer.handle_request({}, {}, () => {})
       }
       errorChannel.subscribe(errorListener)
       subscriptions.push([errorChannel, errorListener])
 
-      handle.call({}, {}, {}, () => {})
+      layer.handle_request({}, {}, () => {})
 
       assert.strictEqual(depth, 1)
     })

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -711,6 +711,30 @@ describe('createWrapRouterMethod', () => {
       assert.strictEqual(errorEvent.data.req, req)
       assert.strictEqual(downstreamError, failure)
     })
+
+    it('publishes next/finish once when a handler calls next() and then rejects', async () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = { stack: [] }
+
+      const failure = new Error('late-rejection')
+      const wrappedUse = wrapMethod(asyncErrorsUse)
+      wrappedUse.call(router, '/foo', async function (req, res, next) {
+        next()
+        throw failure
+      })
+
+      const req = {}
+      let downstreamCalls = 0
+      router.stack[0].handle_request(req, {}, () => { downstreamCalls++ })
+
+      await new Promise(resolve => setImmediate(resolve))
+
+      // The clean `next()` finishes the span; the host's rejection pass calls the
+      // same continuation again, but the tracer must not re-tag or re-finish.
+      assert.deepStrictEqual(events.map(e => e.label), ['enter', 'next', 'finish', 'exit'])
+      assert.strictEqual(downstreamCalls, 2)
+    })
   })
 
   describe('legacy handle replacement (host without prototype dispatch)', () => {

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -639,6 +639,80 @@ describe('createWrapRouterMethod', () => {
     })
   })
 
+  describe('express-async-errors on a prototype-dispatch host', () => {
+    // express-async-errors (on express 4.3.0+) redefines `handle` as a
+    // getter/setter that stores a wrapped fn in `__handle` and turns a rejected
+    // promise into `next(error)`. The wrap preserves the handler arity. It
+    // patches `handle` only, never `handle_request`, so the tracer's prototype
+    // dispatch wrap survives and the arity gate still sees the real handler.
+    function asyncErrorsWrap (fn) {
+      const wrapped = function (...args) {
+        const ret = fn.apply(this, args)
+        const next = args.at(-1)
+        if (typeof ret?.catch === 'function') ret.catch(error => next(error))
+        return ret
+      }
+      Object.defineProperty(wrapped, 'length', { value: fn.length, configurable: true })
+      return wrapped
+    }
+
+    // A host `.use` that builds a prototype-dispatch layer carrying the
+    // express-async-errors `handle` getter/setter, so `layer.handle = fn`
+    // stores the wrapped handler in `__handle`.
+    function asyncErrorsUse (path, handler) {
+      const layer = Object.create(FakeLayer.prototype)
+      layer.path = '/foo'
+      layer.regexp = {}
+      Object.defineProperty(layer, 'handle', {
+        enumerable: true,
+        get () { return this.__handle },
+        set (fn) { this.__handle = asyncErrorsWrap(fn) },
+      })
+      layer.handle = handler
+      this.stack.push(layer)
+    }
+
+    it('keeps the handle pristine and the arity gate intact', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = { stack: [] }
+
+      const wrappedUse = wrapMethod(asyncErrorsUse)
+      wrappedUse.call(router, '/foo', function requestHandler (req, res, next) { next() })
+
+      const layer = router.stack[0]
+      // The async-errors wrap is a 3-arg function, so the request gate runs it.
+      assert.strictEqual(layer.handle.length, 3)
+
+      layer.handle_request({}, {}, () => {})
+      assert.ok(events.find(e => e.label === 'enter'), 'middleware:enter should publish')
+    })
+
+    it('routes a rejected promise through wrappedNext and publishes the error', async () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = { stack: [] }
+
+      const failure = new Error('async-boom')
+      const wrappedUse = wrapMethod(asyncErrorsUse)
+      wrappedUse.call(router, '/foo', async function asyncHandler () { throw failure })
+
+      const req = {}
+      let downstreamError
+      router.stack[0].handle_request(req, {}, (error) => { downstreamError = error })
+
+      // The rejection settles on a microtask; the async-errors wrap forwards it
+      // to `next`, which here is the tracer's wrappedNext.
+      await new Promise(resolve => setImmediate(resolve))
+
+      const errorEvent = events.find(e => e.label === 'error')
+      assert.ok(errorEvent, 'the rejected promise should reach wrappedNext -> error')
+      assert.strictEqual(errorEvent.data.error, failure)
+      assert.strictEqual(errorEvent.data.req, req)
+      assert.strictEqual(downstreamError, failure)
+    })
+  })
+
   describe('legacy handle replacement (host without prototype dispatch)', () => {
     // express <4.3.0 has no `Layer.prototype.handle_request`; the router calls
     // `layer.handle` directly, so the handle is replaced in place.

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -714,10 +714,28 @@ describe('createWrapRouterMethod', () => {
   })
 
   describe('legacy handle replacement (host without prototype dispatch)', () => {
-    // express <4.3.0 has no `Layer.prototype.handle_request`; the router calls
+    // express <4.6.0 has no `Layer.prototype.handle_request`; the router calls
     // `layer.handle` directly, so the handle is replaced in place.
     function legacyUse (path, handler) {
       this.stack.push({ handle: handler, path: '/foo', regexp: {} })
+    }
+
+    // Mirror express <4.6.0's `router.handle`: it runs `layer.handle` itself and,
+    // on a synchronous throw, catches *outside* the layer and calls its own
+    // `next(error)` — never the `next` the layer was handed. The tracer cannot
+    // observe the throw through `wrappedNext`, so the legacy handle wrap has to
+    // catch and publish error/next/finish itself before rethrowing.
+    function legacyDispatch (layer, { req = {}, res = {}, error } = {}) {
+      const hostNext = (nextError) => events.push({ label: 'host-next', error: nextError })
+      try {
+        if (error === undefined) {
+          layer.handle(req, res, hostNext)
+        } else {
+          layer.handle(error, req, res, hostNext)
+        }
+      } catch (caught) {
+        hostNext(caught)
+      }
     }
 
     it('replaces layer.handle, preserves request arity, and traces the dispatch', () => {
@@ -762,6 +780,50 @@ describe('createWrapRouterMethod', () => {
       const enterEvent = events.find(e => e.label === 'enter')
       assert.strictEqual(enterEvent.data.name, 'errorHandler')
       assert.strictEqual(enterEvent.data.req, req)
+    })
+
+    it('publishes error/next/finish/exit when a request handler throws and rethrows to the host', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('boom')
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function thrower (req, res, next) { throw failure })
+
+      const req = {}
+      legacyDispatch(router.stack[0], { req })
+
+      // The host catches the rethrown error and routes it through its own next,
+      // but the tracer has already tagged and finished the throwing layer.
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'error', 'next', 'finish', 'exit', 'host-next',
+      ])
+      assert.strictEqual(events[1].data.error, failure)
+      assert.strictEqual(events[1].data.req, req)
+      assert.strictEqual(events.at(-1).error, failure)
+    })
+
+    it('publishes error/next/finish/exit when an error handler throws and rethrows to the host', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('throws-in-error-handler')
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function errorHandler (error, req, res, next) { throw failure })
+
+      const req = {}
+      legacyDispatch(router.stack[0], { req, error: new Error('upstream') })
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'error', 'next', 'finish', 'exit', 'host-next',
+      ])
+      assert.strictEqual(events[1].data.error, failure)
+      assert.strictEqual(events[1].data.req, req)
+      assert.strictEqual(events.at(-1).error, failure)
     })
 
     it('leaves handle pristine when the layer has a prototype dispatch method', () => {


### PR DESCRIPTION
## Summary

loopback's phase-based middleware sorting relies on `_findLayerByHandler` mapping each layer back to the user handler. The router instrumentation replaced `layer.handle` with a wrapper, then (in #9062) re-exposed the handler through an enumerable `_datadog_orig` back-reference so that lookup could still find it — keeping the tracer coupled to loopback's private reflection heuristic, where the property name and its enumerability are both load-bearing.

This replaces that shim: trace middleware by wrapping the host `Layer` prototype dispatch and reading per-layer metadata from a `WeakMap`, leaving `layer.handle` the user's function.

1. `router.js` — `wrapStack` annotates each layer in a `WeakMap` (`annotateLayer`) instead of replacing its handle; a new `createLayerDispatchWrappers(name)` wraps `handle_request`/`handle_error` (and `handleRequest`/`handleError` on router `>=2`). Drops `wrapLayerHandle`, the arity-split wrappers, the `_datadog_orig` back-reference, the `__handle` branch, and the `_name` write-back onto the user handler.
2. `express.js` — wraps express 4's bundled `Layer` prototype; express 5 / standalone router flow through the `router`-package layer hook.

## Why

loopback already works on master via #9062's `_datadog_orig` property, so this is a no-behavior-change refactor. Keeping `layer.handle` pristine makes loopback's first lookup (`layer.handle === handler`) match with no tracer-specific contract, removing the coupling to its `for-in` reflection heuristic entirely. As a side effect the design is lighter: one shared monomorphic dispatch wrapper replaces a per-layer closure, and the hot path drops its `try/catch` (a synchronous throw or rejected promise becomes `next(error)` in the host dispatch, which the wrapped `next` already captures).

## Test plan

- [x] `packages/datadog-instrumentations/test/router.spec.js` rewritten to the dispatch model — 28 passing (pristine handle, arity gates, no-subscriber fast paths, host-converted errors, re-entrancy guard).
- [x] Hot-path microbench: prototype dispatch + `WeakMap` is within noise of (slightly faster than) the per-layer closure — no regression.
- [ ] CI express matrix (4 and 5), `router` matrix (`>=1 <2`, `>=2`), and the loopback 2.x/3.x suite — version matrices are not installable locally; the loopback re-sorting canary (`spans[4]` resource `handleDD`) is the gate.
- [ ] `express-async-errors` compatibility — `handle` is its getter/setter; the dispatch reads `this.handle` and the `.length` arity gate holds, so the `__handle` special case is gone.
- [ ] codecov/patch — the `router`-package `Layer` addHook bodies and the nested-router mount line are covered by the express/router plugin integration jobs, not the unit spec.

Refs: https://github.com/DataDog/dd-trace-js/pull/9062