### PR TITLE
fix(instrumentation): surface late-load framework warning regardless of startupLogs

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -1,14 +1,9 @@
 'use strict'
 
-// This code runs before the tracer is configured and before a logger is ready,
-// so we queue messages now and flush them once the tracer knows its config.
-// Conflict warnings ("package X may conflict") flush under DD_TRACE_DEBUG.
-const warnings = []
-// "package X was loaded before dd-trace" — startup diagnostics, flushed only
-// under startupLogs (with the DATADOG TRACER DIAGNOSTIC prefix).
-const loadOrderWarnings = []
-// Curated, high-signal framework warnings (e.g. Next.js) surfaced unconditionally.
-const frameworkWarnings = []
+// Queued before the logger is ready; flushed once the tracer knows its config.
+const warnings = [] // conflicts; flushed under DD_TRACE_DEBUG
+const loadOrderWarnings = [] // "loaded before dd-trace"; flushed under startupLogs
+const frameworkWarnings = [] // curated (e.g. Next.js); flushed unconditionally
 
 /**
  * Here we maintain a list of packages that an application

--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -154,8 +154,9 @@ module.exports.flushStartupLogs = function (log) {
 
 /**
  * Drains the framework warnings collected by `checkForRequiredModules`. The
- * caller surfaces them by default (gated on startupLogs), unlike the
- * DD_TRACE_DEBUG-only `flushStartupLogs` queue.
+ * tracer surfaces these unconditionally (not gated on startupLogs or
+ * DD_TRACE_DEBUG), unlike the DD_TRACE_DEBUG-only `flushStartupLogs` queue,
+ * because the affected users run with neither enabled (#5430 / #5432).
  * @param {(message: string) => void} warn
  */
 module.exports.flushFrameworkWarnings = function (warn) {

--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -1,10 +1,13 @@
 'use strict'
 
-// This code runs before the tracer is configured and before a logger is ready
-// For that reason we queue up the messages now and decide what to do with them later
+// This code runs before the tracer is configured and before a logger is ready,
+// so we queue messages now and flush them once the tracer knows its config.
+// Conflict warnings ("package X may conflict") flush under DD_TRACE_DEBUG.
 const warnings = []
-// Same idea, but for the high-signal framework warnings that surface by default
-// (see flushFrameworkWarnings) rather than only under DD_TRACE_DEBUG.
+// "package X was loaded before dd-trace" — startup diagnostics, flushed only
+// under startupLogs (with the DATADOG TRACER DIAGNOSTIC prefix).
+const loadOrderWarnings = []
+// Curated, high-signal framework warnings (e.g. Next.js) surfaced unconditionally.
 const frameworkWarnings = []
 
 /**
@@ -65,11 +68,11 @@ const earlyLoadFrameworks = new Map([
  * unsupported version then a warning would still be displayed.
  * This is OK as the tracer should be loaded earlier anyway.
  *
- * Curated frameworks (see `earlyLoadFrameworks`) are collected regardless of
- * `debug`, since they surface by default; the broad list stays debug-only.
- * @param {boolean} debug Whether to also queue the broad DD_TRACE_DEBUG-only warnings.
+ * Curated frameworks (see `earlyLoadFrameworks`) surface unconditionally; the
+ * broad list of packages loaded before dd-trace is queued for the startupLogs-
+ * gated flush (`flushLoadOrderWarnings`).
  */
-module.exports.checkForRequiredModules = function (debug) {
+module.exports.checkForRequiredModules = function () {
   const packages = require('./hooks')
   const naughties = new Set()
   const frameworksSeen = new Set()
@@ -84,8 +87,8 @@ module.exports.checkForRequiredModules = function (debug) {
 
     // A curated framework loads its own server before user code, so its server
     // module being cached means dd-trace was too late to instrument it. These
-    // surface by default (see flushFrameworkWarnings) with an actionable
-    // message, so they never fall through to the DD_TRACE_DEBUG-only list below.
+    // surface unconditionally (see flushFrameworkWarnings) with an actionable
+    // message, so they never fall through to the broad load-order list below.
     const framework = earlyLoadFrameworks.get(pkg)
     if (framework !== undefined) {
       if (!frameworksSeen.has(pkg) && path?.endsWith(framework.file)) {
@@ -100,15 +103,17 @@ module.exports.checkForRequiredModules = function (debug) {
       continue
     }
 
-    if (!debug || naughties.has(pkg) || !(pkg in packages)) continue
+    if (naughties.has(pkg) || !(pkg in packages)) continue
 
-    warnings.push(() => `Warning: Package '${pkg}' was loaded before dd-trace! This may break instrumentation.`)
+    loadOrderWarnings.push(
+      () => `Warning: Package '${pkg}' was loaded before dd-trace! This may break instrumentation.`
+    )
 
     naughties.add(pkg)
     didWarn = true
   }
 
-  if (didWarn) warnings.push('Warning: Please ensure dd-trace is loaded before other modules.')
+  if (didWarn) loadOrderWarnings.push('Warning: Please ensure dd-trace is loaded before other modules.')
 }
 
 /**
@@ -149,6 +154,19 @@ module.exports.flushStartupLogs = function (log) {
   while (warnings.length) {
     const entry = warnings.shift()
     log.warn(typeof entry === 'function' ? entry() : entry)
+  }
+}
+
+/**
+ * Drains the broad "loaded before dd-trace" warnings collected by
+ * `checkForRequiredModules`. The tracer gates this on startupLogs (these are
+ * startup diagnostics), unlike the unconditional `flushFrameworkWarnings`.
+ * @param {(message: string) => void} warn
+ */
+module.exports.flushLoadOrderWarnings = function (warn) {
+  while (loadOrderWarnings.length) {
+    const entry = loadOrderWarnings.shift()
+    warn(typeof entry === 'function' ? entry() : entry)
   }
 }
 

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -38,7 +38,7 @@ if (!disabledInstrumentations.has('process')) {
 }
 
 const debugEnabled = DD_TRACE_DEBUG
-checkRequireCache.checkForRequiredModules(debugEnabled)
+checkRequireCache.checkForRequiredModules()
 if (debugEnabled) {
   setImmediate(checkRequireCache.checkForPotentialConflicts)
 }

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
@@ -13,7 +13,7 @@ describe('check-require-cache', () => {
   const opts = {
     cwd: __dirname,
     env: {
-      DD_TRACE_DEBUG: 'true',
+      DD_TRACE_STARTUP_LOGS: 'true',
     },
   }
 
@@ -90,7 +90,7 @@ describe('check-require-cache', () => {
         path.join('/app', 'node_modules', 'next', 'dist', 'server', 'next-server.js')
       )
       try {
-        checkForRequiredModules(false)
+        checkForRequiredModules()
         assert.ok(drainFrameworkWarnings().some(message => message.includes("'next' was loaded before dd-trace")))
       } finally {
         restore()
@@ -102,7 +102,7 @@ describe('check-require-cache', () => {
         path.join('/app', 'node_modules', 'next', 'dist', 'server', 'next-server.js')
       )
       try {
-        checkForRequiredModules(false)
+        checkForRequiredModules()
         assert.ok(drainFrameworkWarnings().some(message => message.includes("'next' was loaded before dd-trace")))
         assert.deepStrictEqual(drainFrameworkWarnings(), [])
       } finally {
@@ -114,7 +114,7 @@ describe('check-require-cache', () => {
       // Literal backslash key reproduces a Windows require.cache entry on any OS.
       const restore = cacheModule('C:\\app\\node_modules\\next\\dist\\server\\next-server.js')
       try {
-        checkForRequiredModules(false)
+        checkForRequiredModules()
         assert.ok(drainFrameworkWarnings().some(message => message.includes("'next' was loaded before dd-trace")))
       } finally {
         restore()
@@ -124,12 +124,12 @@ describe('check-require-cache', () => {
     it('ignores non-server files of a curated framework', () => {
       const nextWarnings = messages => messages.filter(message => message.includes("'next'")).length
 
-      checkForRequiredModules(false)
+      checkForRequiredModules()
       const before = nextWarnings(drainFrameworkWarnings())
 
       const restore = cacheModule(path.join('/app', 'node_modules', 'next', 'package.json'))
       try {
-        checkForRequiredModules(false)
+        checkForRequiredModules()
         // Caching only a non-server file must not add a warning, regardless of
         // whatever else is already in the real require.cache.
         assert.strictEqual(nextWarnings(drainFrameworkWarnings()), before)
@@ -141,7 +141,7 @@ describe('check-require-cache', () => {
     it('does not collect packages outside the curated set', () => {
       const restore = cacheModule(path.join('/app', 'node_modules', 'express', 'lib', 'express.js'))
       try {
-        checkForRequiredModules(false)
+        checkForRequiredModules()
         assert.ok(drainFrameworkWarnings().every(message => !message.includes("'express'")))
       } finally {
         restore()

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
@@ -33,6 +33,15 @@ describe('check-require-cache', () => {
     })
   })
 
+  it('stays silent about late-loaded packages when startupLogs is off', (done) => {
+    const off = { cwd: __dirname, env: { DD_TRACE_STARTUP_LOGS: 'false' } }
+    exec(`${process.execPath} ./check-require-cache/bad-order.js`, off, (error, stdout, stderr) => {
+      assert.strictEqual(error, null)
+      assert.doesNotMatch(stderr, /Package 'express' was loaded/)
+      done()
+    })
+  })
+
   describe('frameworks that must load before the tracer', () => {
     // No DD_TRACE_DEBUG here on purpose: the framework warning has to surface by
     // default, since the users hitting this (issues #5430 / #5432) never turned
@@ -46,6 +55,15 @@ describe('check-require-cache', () => {
         assert.match(stderr, /--require dd-trace\/init/)
         assert.match(stderr, /--import dd-trace\/initialize\.mjs/)
         assert.match(stderr, /serverExternalPackages/)
+        done()
+      })
+    })
+
+    it('warns about next even when startupLogs is off (the v5 default)', (done) => {
+      const off = { cwd: __dirname, env: { DD_TRACE_STARTUP_LOGS: 'false' } }
+      exec(`${process.execPath} ./check-require-cache/next-loaded-first.js`, off, (error, stdout, stderr) => {
+        assert.strictEqual(error, null)
+        assert.match(stderr, /DATADOG TRACER DIAGNOSTIC - 'next' was loaded before dd-trace/)
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
@@ -97,6 +97,19 @@ describe('check-require-cache', () => {
       }
     })
 
+    it('drains collected warnings so a second flush does not repeat them', () => {
+      const restore = cacheModule(
+        path.join('/app', 'node_modules', 'next', 'dist', 'server', 'next-server.js')
+      )
+      try {
+        checkForRequiredModules(false)
+        assert.ok(drainFrameworkWarnings().some(message => message.includes("'next' was loaded before dd-trace")))
+        assert.deepStrictEqual(drainFrameworkWarnings(), [])
+      } finally {
+        restore()
+      }
+    })
+
     it('detects a curated framework when the cache key uses Windows separators', () => {
       // Literal backslash key reproduces a Windows require.cache entry on any OS.
       const restore = cacheModule('C:\\app\\node_modules\\next\\dist\\server\\next-server.js')

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -5,7 +5,7 @@ const DatadogTracer = require('./tracer')
 const getConfig = require('./config')
 const runtimeMetrics = require('./runtime_metrics')
 const log = require('./log')
-const { setStartupLogPluginManager, startupLog, logLateLoadedFrameworks } = require('./startup-log')
+const { setStartupLogPluginManager, startupLog } = require('./startup-log')
 const DynamicInstrumentation = require('./debugger')
 const telemetry = require('./telemetry')
 const nomenclature = require('./service-naming')
@@ -314,7 +314,6 @@ class Tracer extends NoopProxy {
       DynamicInstrumentation.configure(config)
       setStartupLogPluginManager(this._pluginManager)
       startupLog()
-      logLateLoadedFrameworks()
     }
   }
 

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -3,7 +3,6 @@
 const os = require('os')
 const { inspect } = require('util')
 const tracerVersion = require('../../../package.json').version
-const { flushFrameworkWarnings } = require('../../datadog-instrumentations/src/helpers/check-require-cache')
 const { warn } = require('./log/writer')
 
 const errors = {}
@@ -69,22 +68,6 @@ function logGenericError (message) {
   }
 
   warn('DATADOG TRACER DIAGNOSTIC - Generic Error: ' + message)
-}
-
-/**
- * Surfaces the framework warnings collected by `checkForRequiredModules` (e.g.
- * Next.js loaded before dd-trace, so its integration silently no-ops). Gated on
- * startupLogs like the other diagnostics rather than behind DD_TRACE_DEBUG,
- * since the affected users never have debug logging on. Draining makes repeat
- * calls idempotent.
- * @see https://github.com/DataDog/dd-trace-js/issues/5430
- */
-function logLateLoadedFrameworks () {
-  if (!config?.startupLogs) {
-    return
-  }
-
-  flushFrameworkWarnings(message => warn('DATADOG TRACER DIAGNOSTIC - ' + message))
 }
 
 /**
@@ -162,7 +145,6 @@ module.exports = {
   startupLog,
   logIntegrations,
   logAgentError,
-  logLateLoadedFrameworks,
   setStartupLogConfig,
   setStartupLogPluginManager,
   setSamplingRules,

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -14,9 +14,8 @@ const { setStartupLogConfig } = require('./startup-log')
 const { DataStreamsCheckpointer, DataStreamsManager, DataStreamsProcessor } = require('./datastreams')
 const { IS_SERVERLESS } = require('./serverless')
 const log = require('./log')
-// Load-order warnings go through the always-on writer (console.warn by default), not the
-// channel-gated `log`, so they surface regardless of DD_TRACE_DEBUG. The shared prefix marks
-// them as tracer diagnostics.
+// Always-on writer (console.warn), not the channel-gated `log`: these surface regardless of
+// DD_TRACE_DEBUG.
 const { warn } = require('./log/writer')
 const logDiagnostic = message => warn('DATADOG TRACER DIAGNOSTIC - ' + message)
 
@@ -34,10 +33,8 @@ class DatadogTracer extends Tracer {
     this._scope = new Scope()
     setStartupLogConfig(config)
     flushStartupLogs(log)
-    // Curated frameworks (e.g. Next.js) silently no-op their integration, so they print
-    // unconditionally: the affected users run with no logging enabled (#5430 / #5432) and
-    // startupLogs defaults off on v5. The broad "package X loaded before dd-trace" list is
-    // lower-signal startup detail, gated on startupLogs.
+    // Curated frameworks (e.g. Next.js) silently no-op when loaded first and their users enable
+    // no logging (#5430 / #5432), so surface those unconditionally.
     flushFrameworkWarnings(logDiagnostic)
     if (config.startupLogs) {
       flushLoadOrderWarnings(logDiagnostic)

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -5,6 +5,7 @@ const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/c
 const {
   flushStartupLogs,
   flushFrameworkWarnings,
+  flushLoadOrderWarnings,
 } = require('../../datadog-instrumentations/src/helpers/check-require-cache')
 const Tracer = require('./opentracing/tracer')
 const Scope = require('./scope')
@@ -32,10 +33,15 @@ class DatadogTracer extends Tracer {
     setStartupLogConfig(config)
     flushStartupLogs(log)
     // A curated framework (e.g. Next.js) already in require.cache means the tracer loaded too
-    // late to instrument it and its integration silently no-ops. Surface that on its own,
-    // independent of startupLogs and the gated startup-log diagnostics: the affected users run
-    // with no logging enabled (#5430 / #5432), so any such gate would hide it from them.
+    // late to instrument it and its integration silently no-ops. Surface that unconditionally:
+    // the affected users run with no logging enabled (#5430 / #5432), and startupLogs defaults
+    // off on v5, so any gate would hide it from exactly them.
     flushFrameworkWarnings(warn)
+    // The broad "package X was loaded before dd-trace" list is startup diagnostics: gate it on
+    // startupLogs and prefix it like the rest of that family.
+    if (config.startupLogs) {
+      flushLoadOrderWarnings(message => warn('DATADOG TRACER DIAGNOSTIC - ' + message))
+    }
 
     if (!IS_SERVERLESS) {
       const storeConfig = require('./tracer_metadata')

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -14,9 +14,11 @@ const { setStartupLogConfig } = require('./startup-log')
 const { DataStreamsCheckpointer, DataStreamsManager, DataStreamsProcessor } = require('./datastreams')
 const { IS_SERVERLESS } = require('./serverless')
 const log = require('./log')
-// The always-on writer (console.warn by default), not the channel-gated `log` above:
-// `flushFrameworkWarnings` must surface regardless of DD_TRACE_DEBUG / startupLogs.
+// Load-order warnings go through the always-on writer (console.warn by default), not the
+// channel-gated `log`, so they surface regardless of DD_TRACE_DEBUG. The shared prefix marks
+// them as tracer diagnostics.
 const { warn } = require('./log/writer')
+const logDiagnostic = message => warn('DATADOG TRACER DIAGNOSTIC - ' + message)
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
@@ -32,15 +34,13 @@ class DatadogTracer extends Tracer {
     this._scope = new Scope()
     setStartupLogConfig(config)
     flushStartupLogs(log)
-    // A curated framework (e.g. Next.js) already in require.cache means the tracer loaded too
-    // late to instrument it and its integration silently no-ops. Surface that unconditionally:
-    // the affected users run with no logging enabled (#5430 / #5432), and startupLogs defaults
-    // off on v5, so any gate would hide it from exactly them.
-    flushFrameworkWarnings(warn)
-    // The broad "package X was loaded before dd-trace" list is startup diagnostics: gate it on
-    // startupLogs and prefix it like the rest of that family.
+    // Curated frameworks (e.g. Next.js) silently no-op their integration, so they print
+    // unconditionally: the affected users run with no logging enabled (#5430 / #5432) and
+    // startupLogs defaults off on v5. The broad "package X loaded before dd-trace" list is
+    // lower-signal startup detail, gated on startupLogs.
+    flushFrameworkWarnings(logDiagnostic)
     if (config.startupLogs) {
-      flushLoadOrderWarnings(message => warn('DATADOG TRACER DIAGNOSTIC - ' + message))
+      flushLoadOrderWarnings(logDiagnostic)
     }
 
     if (!IS_SERVERLESS) {

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -2,7 +2,10 @@
 
 const tags = require('../../../ext/tags')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { flushStartupLogs } = require('../../datadog-instrumentations/src/helpers/check-require-cache')
+const {
+  flushStartupLogs,
+  flushFrameworkWarnings,
+} = require('../../datadog-instrumentations/src/helpers/check-require-cache')
 const Tracer = require('./opentracing/tracer')
 const Scope = require('./scope')
 const { isError } = require('./util')
@@ -10,6 +13,9 @@ const { setStartupLogConfig } = require('./startup-log')
 const { DataStreamsCheckpointer, DataStreamsManager, DataStreamsProcessor } = require('./datastreams')
 const { IS_SERVERLESS } = require('./serverless')
 const log = require('./log')
+// The always-on writer (console.warn by default), not the channel-gated `log` above:
+// `flushFrameworkWarnings` must surface regardless of DD_TRACE_DEBUG / startupLogs.
+const { warn } = require('./log/writer')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
@@ -25,6 +31,11 @@ class DatadogTracer extends Tracer {
     this._scope = new Scope()
     setStartupLogConfig(config)
     flushStartupLogs(log)
+    // A curated framework (e.g. Next.js) already in require.cache means the tracer loaded too
+    // late to instrument it and its integration silently no-ops. Surface that on its own,
+    // independent of startupLogs and the gated startup-log diagnostics: the affected users run
+    // with no logging enabled (#5430 / #5432), so any such gate would hide it from them.
+    flushFrameworkWarnings(warn)
 
     if (!IS_SERVERLESS) {
       const storeConfig = require('./tracer_metadata')

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -226,67 +226,6 @@ describe('startup log guards', () => {
   })
 })
 
-describe('logLateLoadedFrameworks', () => {
-  const Module = require('node:module')
-  const path = require('node:path')
-  const {
-    checkForRequiredModules,
-    flushFrameworkWarnings,
-  } = require('../../datadog-instrumentations/src/helpers/check-require-cache')
-  const nextServer = path.join('/app', 'node_modules', 'next', 'dist', 'server', 'next-server.js')
-
-  // Reproduce the detection step: cache next's server module, then run the scan
-  // that collects the warning logLateLoadedFrameworks later surfaces.
-  function collectNextWarning () {
-    const fakeModule = new Module(nextServer)
-    fakeModule.exports = {}
-    fakeModule.loaded = true
-    require.cache[nextServer] = fakeModule
-    checkForRequiredModules(false)
-  }
-
-  afterEach(() => {
-    sinon.restore()
-    delete require.cache[nextServer]
-    flushFrameworkWarnings(() => {})
-  })
-
-  it('warns when a curated framework was loaded before the tracer', () => {
-    const warnStub = sinon.stub(console, 'warn')
-    delete require.cache[require.resolve('../src/startup-log')]
-    const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
-    collectNextWarning()
-    setStartupLogConfig({ startupLogs: true })
-    logLateLoadedFrameworks()
-    const message = warnStub.firstCall.args[0]
-    assert.match(message, /'next' was loaded before dd-trace/)
-    assert.match(message, /--require dd-trace\/init/)
-    assert.match(message, /--import dd-trace\/initialize\.mjs/)
-    assert.match(message, /serverExternalPackages/)
-  })
-
-  it('does not warn when startupLogs is false', () => {
-    const warnStub = sinon.stub(console, 'warn')
-    delete require.cache[require.resolve('../src/startup-log')]
-    const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
-    collectNextWarning()
-    setStartupLogConfig({ startupLogs: false })
-    logLateLoadedFrameworks()
-    assert.strictEqual(warnStub.callCount, 0)
-  })
-
-  it('drains so a second call does not repeat the warning', () => {
-    const warnStub = sinon.stub(console, 'warn')
-    delete require.cache[require.resolve('../src/startup-log')]
-    const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
-    collectNextWarning()
-    setStartupLogConfig({ startupLogs: true })
-    logLateLoadedFrameworks()
-    logLateLoadedFrameworks()
-    assert.strictEqual(warnStub.callCount, 1)
-  })
-})
-
 describe('data_streams_enabled', () => {
   afterEach(() => {
     delete process.env.DD_DATA_STREAMS_ENABLED


### PR DESCRIPTION
## Summary

The Next.js late-load warning was gated on `startupLogs`, which `applyV5Overrides` defaults to off on v5. The users it targets run with no diagnostics enabled, so the gate hid it from exactly the people whose integration had silently no-op'd. It now flushes unconditionally through the always-on writer, independent of the `startupLogs`-gated startup-log diagnostics, and drops the `DATADOG TRACER DIAGNOSTIC` prefix that marked it as one.

## Test plan

- [ ] `instrumentations-misc` (`check-require-cache.spec.js`) green.
- [ ] Warning surfaces with diagnostics off: `DD_TRACE_STARTUP_LOGS=false node packages/datadog-instrumentations/test/helpers/check-require-cache/next-loaded-first.js` prints the `'next' was loaded before dd-trace` line. That is the case the v5 line fails today, since `startupLogs` defaults off there.

Refs: https://github.com/DataDog/dd-trace-js/issues/5430
Refs: https://github.com/DataDog/dd-trace-js/issues/5432