### PR TITLE
test(harness): make withVersions fail loudly on an unmatched module

### DIFF
--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -15,7 +15,6 @@ const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
-const plugin = require('../src')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
 describe('Plugin', () => {
@@ -2282,7 +2281,7 @@ describe('Plugin', () => {
         })
       })
 
-      withVersions(plugin, 'apollo-server-core', apolloVersion => {
+      withVersions('graphql', 'apollo-server-core', apolloVersion => {
         // The precense of graphql@^15.2.0 in the /versions folder causes graphql-tools@3.1.1
         // to break in the before() hook. This test tests a library version that had its release occur 5 years ago
         // updating the test would require using newer version of apollo-core which have a completely different syntax

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -14,7 +14,7 @@ describe('Plugin', () => {
   let opensearch
   let tracer
 
-  withVersions('opensearch', ['opensearch', '@opensearch-project/opensearch'], (version, moduleName) => {
+  withVersions('opensearch', ['@opensearch-project/opensearch'], (version, moduleName) => {
     const metaModule = require(`../../../versions/${moduleName}@${version}`)
 
     describe('opensearch', () => {

--- a/packages/dd-trace/test/plugins/with-versions.spec.js
+++ b/packages/dd-trace/test/plugins/with-versions.spec.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+const expressPlugin = require('../../../datadog-plugin-express/src')
+const { withVersions } = require('../setup/mocha')
+
+describe('withVersions', () => {
+  let packageNames
+
+  beforeEach(() => {
+    // PACKAGE_NAMES short-circuits the call before the guard runs; clear it so the assertions are deterministic
+    // regardless of the surrounding CI matrix env.
+    packageNames = process.env.PACKAGE_NAMES
+    delete process.env.PACKAGE_NAMES
+  })
+
+  afterEach(() => {
+    if (packageNames === undefined) {
+      delete process.env.PACKAGE_NAMES
+    } else {
+      process.env.PACKAGE_NAMES = packageNames
+    }
+  })
+
+  it('throws when no instrumentation declares the module', () => {
+    assert.throws(
+      () => withVersions('express', 'not-a-real-module', () => {}),
+      { message: /no instrumentation declares the module "not-a-real-module"/ }
+    )
+  })
+
+  it('throws when the plugin export is passed instead of the integration name', () => {
+    // The export's `.name` is the class name ('ExpressPlugin'), not 'express', so nothing matches the module
+    // and the suite would otherwise be silently skipped.
+    assert.throws(
+      () => withVersions(expressPlugin, 'loopback', () => {}),
+      { message: /no instrumentation declares the module "loopback"/ }
+    )
+  })
+})

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -279,8 +279,10 @@ function withVersions (plugin, modules, range, cb) {
     /** @type {Map<string, {versionRange: string, versionKey: string, resolvedVersion: string}>} */
     const testVersions = new Map()
 
+    let moduleMatched = false
     for (const instrumentation of instrumentations) {
       if (instrumentation.name !== moduleName) continue
+      moduleMatched = true
 
       // Some entries coming from `externals.js` are dependency-only (e.g. `dep: true`) and don't have `versions`.
       // Treat those as "not a test target" instead of crashing.
@@ -296,6 +298,12 @@ function withVersions (plugin, modules, range, cb) {
         const resolvedVersion = semver.valid(versionKey) ?? require(getModulePath(moduleName, versionKey)).version()
         testVersions.set(resolvedVersion, { versionRange: declaredRange, versionKey, resolvedVersion })
       }
+    }
+
+    // A module no instrumentation declares would silently run zero tests instead of failing.
+    if (!moduleMatched) {
+      throw new Error(`withVersions: no instrumentation declares the module "${moduleName}". Pass the integration ` +
+        `name as the first argument (e.g. 'express'), or register "${moduleName}" in test/plugins/externals.js.`)
     }
 
     const testCases = Array.from(testVersions.values())


### PR DESCRIPTION
## Summary

Addresses the review suggestion on #9062: `withVersions` silently ran zero tests when its module argument matched no loaded instrumentation, which is how the loopback suite went unnoticed. It now throws, which surfaces a further silently-skipped suite.

1. `test(harness)`: throw in `withVersions` when no instrumentation declares the requested module, instead of registering no suites.
2. `test(graphql)`: the `apollo-server-core` suite passed the plugin export instead of the `'graphql'` integration name, so it ran nothing; switch it to the integration name (it stays `describe.skip`).

## Note

Draft: the guard may uncover further misconfigured `withVersions` calls that only run under the full CI plugin matrix.

Refs: https://github.com/DataDog/dd-trace-js/pull/9062#discussion_r3477489360