### PR TITLE
fix(iast): Fix ALS leak on NoSQL analyzer

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
@@ -27,19 +27,21 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     // Anything that accesses the storage is context dependent
     const onStart = ({ filters }) => {
       const store = storage('legacy').getStore()
-      if (store && !store.nosqlAnalyzed && filters?.length) {
+      const iastContext = getIastContext(store)
+      if (store && iastContext && !iastContext.nosqlAnalyzed && filters?.length) {
         for (const filter of filters) {
           this.analyze({ filter }, store)
         }
       }
-
       return store
     }
 
-    const onStartAndEnterWithStore = (message) => {
-      const store = onStart(message || {})
-      if (store) {
-        storage('legacy').enterWith({ ...store, nosqlAnalyzed: true, nosqlParentStore: store })
+    const onStartAndSetAnalyzed = (message) => {
+      onStart(message || {})
+      const store = storage('legacy').getStore()
+      const iastContext = getIastContext(store)
+      if (iastContext) {
+        iastContext.nosqlAnalyzed = true
       }
     }
 
@@ -47,18 +49,19 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const onFinish = () => {
       const store = storage('legacy').getStore()
-      if (store?.nosqlParentStore) {
-        storage('legacy').enterWith(store.nosqlParentStore)
+      const iastContext = getIastContext(store)
+      if (iastContext) {
+        iastContext.nosqlAnalyzed = false
       }
     }
 
     this.addSub('datadog:mongodb:collection:filter:start', onStart)
 
-    this.addSub('datadog:mongoose:model:filter:start', onStartAndEnterWithStore)
+    this.addSub('datadog:mongoose:model:filter:start', onStartAndSetAnalyzed)
     this.addSub('datadog:mongoose:model:filter:finish', onFinish)
 
     this.addSub('datadog:mquery:filter:prepare', onStart)
-    this.addSub('tracing:datadog:mquery:filter:start', onStartAndEnterWithStore)
+    this.addSub('tracing:datadog:mquery:filter:start', onStartAndSetAnalyzed)
     this.addSub('tracing:datadog:mquery:filter:asyncEnd', onFinish)
   }
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -8,14 +8,9 @@ const semver = require('semver')
 const { prepareTestServerForIastInExpress } = require('../utils')
 const agent = require('../../../plugins/agent')
 const { withVersions } = require('../../../setup/mocha')
-const { NODE_MAJOR } = require('../../../../../../version')
 
 describe('nosql injection detection in mongodb - whole feature', () => {
-  withVersions('mongoose', 'express', (expressVersion, _moduleName, resolvedExpressVersion) => {
-    // Node 20 + Express 5 loses IAST taint on the per-request `req.query` getter;
-    // passes on Node 18 and Node 24. See APPSEC-66705.
-    if (NODE_MAJOR === 20 && semver.major(resolvedExpressVersion) >= 5) return
-
+  withVersions('mongoose', 'express', expressVersion => {
     withVersions('mongoose', 'mongoose', '>4.0.0', mongooseVersion => {
       const specificMongooseVersion = require(`../../../../../../versions/mongoose@${mongooseVersion}`).version()
 


### PR DESCRIPTION
### What does this PR do?
Sets `nosqlAnalyzed` on the `iastContext` object (not on the ALS store).
The `iastContext` is a per-request plain object shared by reference across all async operations of the same request, so this is properly request-isolated without using `AsyncLocalStorage.enterWith()`, which leaks to sibling async contexts in Node.js >= 20.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


