### PR TITLE
fix(instrumentation): wrap lazily defined fs.opendir on Node 20

### DIFF
--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -88,8 +88,10 @@ addHook({ name: 'fs' }, fs => {
   const asyncMethods = Object.keys(paramsByMethod)
   const syncMethods = asyncMethods.map(name => `${name}Sync`)
 
-  massWrap(fs, asyncMethods, createWrapFunction())
-  massWrap(fs, syncMethods, createWrapFunction())
+  // Node 20 defines `fs.opendir` / `fs.opendirSync` as lazy accessor properties;
+  // `replaceGetter` resolves the method so the call is wrapped, not the accessor.
+  massWrap(fs, asyncMethods, createWrapFunction(), { replaceGetter: true })
+  massWrap(fs, syncMethods, createWrapFunction(), { replaceGetter: true })
   massWrap(fs.promises, asyncMethods, createWrapFunction('promises.'))
 
   wrap(fs.realpath, 'native', createWrapFunction('', 'realpath.native'))
@@ -355,15 +357,15 @@ function getMessage (operation, params, args, self) {
   return { operation, ...metadata }
 }
 
-function massWrap (target, methods, wrapper) {
+function massWrap (target, methods, wrapper, options) {
   for (const method of methods) {
-    wrap(target, method, wrapper)
+    wrap(target, method, wrapper, options)
   }
 }
 
-function wrap (target, method, wrapper) {
+function wrap (target, method, wrapper, options) {
   try {
-    shimmer.wrap(target, method, wrapper)
+    shimmer.wrap(target, method, wrapper, options)
   } catch {
     // skip unavailable method
   }

--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -1,9 +1,15 @@
 'use strict'
 
 const assert = require('node:assert')
-const { describe, it, afterEach } = require('mocha')
+const os = require('node:os')
+const path = require('node:path')
+const { describe, it, after, afterEach, before } = require('mocha')
+
+const dc = require('dc-polyfill')
 
 const agent = require('../../dd-trace/test/plugins/agent')
+
+const opStartCh = dc.channel('apm:fs:operation:start')
 
 describe('fs instrumentation', () => {
   afterEach(() => {
@@ -20,5 +26,82 @@ describe('fs instrumentation', () => {
     await agent.load('fs', undefined, { flushInterval: 1 })
     const fs = require('fs')
     assert.notStrictEqual(fs, undefined)
+  })
+
+  // Node 20 defines `fs.opendir` / `fs.opendirSync` as lazy accessor properties.
+  // The instrumentation has to wrap the resolved method, not the accessor, so the
+  // start channel publishes the method's own operation and path. Activating the
+  // hook before the accessor is first read reproduces the order that broke: a
+  // wrapped getter leaves the real call uninstrumented.
+  describe('lazily defined methods', () => {
+    let fs, dirname, lazyAccessorShape
+
+    before(async () => {
+      // Capture the pristine descriptor shape before the hook wraps `fs`: on Node
+      // versions that define `opendir` as a lazy getter+setter accessor we assert
+      // the wrap preserves that shape; on versions where it is already a data
+      // property there is no accessor to preserve.
+      lazyAccessorShape = typeof Object.getOwnPropertyDescriptor(require('fs'), 'opendir')?.get === 'function'
+
+      await agent.load('fs', undefined, { flushInterval: 1 })
+      fs = require('fs')
+      dirname = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-fs-opendir-'))
+    })
+
+    after(() => {
+      fs.rmdirSync(dirname)
+    })
+
+    it('instruments opendirSync while preserving its descriptor shape', () => {
+      // On Node 20 `opendirSync` is a lazy getter+setter accessor; the wrap must
+      // keep it an accessor pair (a downstream consumer may inspect the descriptor
+      // or assign to it on that version), not flatten it to a data property.
+      const descriptor = Object.getOwnPropertyDescriptor(fs, 'opendirSync')
+      if (lazyAccessorShape) {
+        assert.strictEqual(typeof descriptor.get, 'function', 'opendirSync getter must be preserved')
+        assert.strictEqual(typeof descriptor.set, 'function', 'opendirSync setter must be preserved')
+      }
+
+      const operations = []
+      const onStart = (ctx) => operations.push({ operation: ctx.operation, path: ctx.path })
+
+      opStartCh.subscribe(onStart)
+      try {
+        fs.opendirSync(dirname).closeSync()
+      } finally {
+        opStartCh.unsubscribe(onStart)
+      }
+
+      assert.ok(
+        operations.some(({ operation, path: opPath }) => operation === 'opendirSync' && opPath === dirname),
+        `Expected an opendirSync start for ${dirname}, got ${JSON.stringify(operations)}`
+      )
+    })
+
+    it('instruments opendir while preserving its descriptor shape', async () => {
+      const descriptor = Object.getOwnPropertyDescriptor(fs, 'opendir')
+      if (lazyAccessorShape) {
+        assert.strictEqual(typeof descriptor.get, 'function', 'opendir getter must be preserved')
+        assert.strictEqual(typeof descriptor.set, 'function', 'opendir setter must be preserved')
+      }
+
+      const operations = []
+      const onStart = (ctx) => operations.push({ operation: ctx.operation, path: ctx.path })
+
+      opStartCh.subscribe(onStart)
+      try {
+        const dir = await new Promise((resolve, reject) => {
+          fs.opendir(dirname, (error, openedDir) => error ? reject(error) : resolve(openedDir))
+        })
+        dir.closeSync()
+      } finally {
+        opStartCh.unsubscribe(onStart)
+      }
+
+      assert.ok(
+        operations.some(({ operation, path: opPath }) => operation === 'opendir' && opPath === dirname),
+        `Expected an opendir start for ${dirname}, got ${JSON.stringify(operations)}`
+      )
+    })
   })
 })

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -119,11 +119,14 @@ function wrapCallback (original, wrapper) {
  * object.
  * @param {string | symbol} name - The property key of the method to wrap.
  * @param {(original: Function) => (...args: unknown[]) => unknown} wrapper - The wrapper function.
- * @param {{ replaceGetter?: boolean }} [options] - If `replaceGetter` is set to
- * true, the getter is accessed and the getter is replaced with one that just
- * returns the earlier retrieved value. Use with care! This may only be done in
- * case the getter absolutely has no side effect and no setter is defined for the
- * property.
+ * @param {{ replaceGetter?: boolean }} [options] - By default the getter is
+ * wrapped in place, so each property access runs the wrapper. A getter+setter
+ * pair keeps its setter; a setter-only property throws. If `replaceGetter` is
+ * true, the getter is instead accessed once and replaced with one returning the
+ * resolved wrapped value — for a lazy getter+setter pair (e.g. Node 20's
+ * `fs.opendir`) the setter is rebuilt to materialize a writable data property on
+ * assignment, keeping the descriptor observationally identical for downstream
+ * consumers. Use with care! This may only be done when the getter has no side effect.
  * @returns {Record<string | symbol, unknown> | Function | undefined} The target object with
  * the wrapped method.
  */
@@ -151,17 +154,13 @@ function wrap (target, name, wrapper, options) {
     enumerable: false,
   }
 
-  if (descriptor.set && (!descriptor.get || options?.replaceGetter)) {
-    // It is possible to support these cases by instrumenting both the getter
-    // and setter (or only the setter, in case that is a use case).
-    // For now, this is not supported due to the complexity and the fact that
-    // this is not a common use case.
-    throw new Error(options?.replaceGetter
-      ? 'Replacing a getter/setter pair is not supported. Implement if required.'
-      : 'Replacing setters is not supported. Implement if required.')
+  // A setter-only property has nothing to wrap. Instrumenting the setter is not
+  // implemented; a getter+setter pair is handled below.
+  if (descriptor.set && !descriptor.get) {
+    throw new Error('Replacing setters is not supported. Implement if required.')
   }
 
-  const original = descriptor.value ?? options?.replaceGetter ? target[name] : descriptor.get
+  const original = (descriptor.value ?? options?.replaceGetter) ? target[name] : descriptor.get
 
   assertMethod(target, name, original)
 
@@ -176,8 +175,30 @@ function wrap (target, name, wrapper, options) {
     }
     descriptor.value = wrapped
   } else {
-    if (descriptor.get) {
-      // `replaceGetter` may only be used when the getter has no side effect.
+    if (descriptor.set && options?.replaceGetter) {
+      // A lazy accessor pair (e.g. Node 20's `fs.opendir`). `original` already
+      // resolved the value through the getter. Keep the property an accessor pair
+      // so the shape stays observationally identical — a downstream consumer may
+      // read the descriptor or assign to it on a specific Node.js version. The
+      // getter returns the wrapped value; the setter mirrors the native lazy
+      // contract (assignment self-replaces the property with a writable data
+      // property holding the assigned value), so a caller that overwrites the
+      // method gets exactly what they set, unwrapped, as before. The descriptor
+      // is the original accessor descriptor (no `value`/`writable` slots), so
+      // reassigning `get`/`set` keeps it a valid accessor descriptor.
+      descriptor.get = () => wrapped
+      descriptor.set = function (value) {
+        Object.defineProperty(this, name, {
+          configurable: descriptor.configurable,
+          enumerable: descriptor.enumerable,
+          writable: true,
+          value,
+        })
+      }
+    } else if (descriptor.get) {
+      // Wrap the getter in place; for a getter+setter pair the original setter
+      // stays untouched. `replaceGetter` (no side effect on read) instead returns
+      // the value resolved once into `wrapped`.
       descriptor.get = options?.replaceGetter ? () => wrapped : wrapped
     } else {
       descriptor.value = wrapped

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -57,6 +57,86 @@ describe('shimmer', () => {
       assert.strictEqual(called, 1)
     })
 
+    it('should wrap a lazy getter/setter pair while preserving the accessor shape', () => {
+      // Mirrors Node 20's `fs.opendir`: a lazy accessor that resolves the real
+      // function on first read and self-replaces with a data property on write.
+      // The wrap must keep it an accessor pair so the descriptor shape stays
+      // observationally identical for downstream consumers on that Node version.
+      const target = () => 'original'
+      const obj = {}
+      Object.defineProperty(obj, 'method', {
+        configurable: true,
+        enumerable: true,
+        get () { return target },
+        set (value) {
+          Object.defineProperty(obj, 'method', { configurable: true, enumerable: true, writable: true, value })
+        },
+      })
+
+      let called = 0
+      shimmer.wrap(obj, 'method', method => (...args) => {
+        called++
+        return method(...args)
+      }, { replaceGetter: true })
+
+      // Still an accessor pair, with the original configurable/enumerable flags.
+      const descriptor = Object.getOwnPropertyDescriptor(obj, 'method')
+      assert.strictEqual(typeof descriptor.get, 'function')
+      assert.strictEqual(typeof descriptor.set, 'function')
+      assert.strictEqual(descriptor.configurable, true)
+      assert.strictEqual(descriptor.enumerable, true)
+
+      // Reading returns the wrapped method.
+      assert.strictEqual(obj.method.name, target.name)
+      assert.strictEqual(obj.method(), 'original')
+      assert.strictEqual(called, 1)
+
+      // Assignment mirrors the native lazy contract: it materializes the property
+      // as a writable data property holding exactly what was set (unwrapped).
+      const replacement = () => 'replacement'
+      obj.method = replacement
+      const afterSet = Object.getOwnPropertyDescriptor(obj, 'method')
+      assert.strictEqual(afterSet.get, undefined)
+      assert.strictEqual(afterSet.set, undefined)
+      assert.strictEqual(afterSet.writable, true)
+      assert.strictEqual(obj.method, replacement)
+      assert.strictEqual(obj.method(), 'replacement')
+      assert.strictEqual(called, 1, 'a caller-supplied replacement is not wrapped')
+    })
+
+    it('should wrap a getter/setter pair in place without the replaceGetter option', () => {
+      // Mirrors `url.js` wrapping the `URL.prototype` `host`/`hostname` getters,
+      // which are getter+setter accessor pairs. Each read must run the wrapper,
+      // and the original setter is left untouched.
+      let setValue
+      const obj = {}
+      Object.defineProperty(obj, 'method', {
+        configurable: true,
+        enumerable: true,
+        get () { return 'original' },
+        set (value) { setValue = value },
+      })
+
+      let called = 0
+      shimmer.wrap(obj, 'method', getter => function () {
+        called++
+        return getter.call(this)
+      })
+
+      const descriptor = Object.getOwnPropertyDescriptor(obj, 'method')
+      assert.strictEqual(typeof descriptor.get, 'function')
+      assert.strictEqual(typeof descriptor.set, 'function')
+
+      assert.strictEqual(obj.method, 'original')
+      assert.strictEqual(called, 1)
+      assert.strictEqual(obj.method, 'original')
+      assert.strictEqual(called, 2)
+
+      obj.method = 42
+      assert.strictEqual(setValue, 42)
+      assert.strictEqual(typeof Object.getOwnPropertyDescriptor(obj, 'method').set, 'function')
+    })
+
     it('should not wrap setter only method', () => {
       // eslint-disable-next-line accessor-pairs
       const obj = { set setter (_method_) {} }


### PR DESCRIPTION
## Summary

On Node 20, `fs.opendir` and `fs.opendirSync` are lazy get+set accessor properties: the getter resolves the real function (and self-replaces with a data property) on first read. The fs instrumentation mass-wrapped these names with `shimmer.wrap`, which received the getter and instrumented the property access (`get opendir`) instead of the method. The real call then ran uninstrumented, `apm:fs:operation:start` never fired with the directory path, and IAST reported no `PATH_TRAVERSAL` vulnerability (and RASP no LFI) for `fs.opendir` / `opendirSync` requests. Node 18 and 22 define both as plain data properties, so the operation was lost only on Node 20 — surfacing as an intermittent failure of the `fs.opendir` / `fs.opendirSync` cases in `path-traversal-analyzer.spec.js`.

1. `shimmer.wrap`'s `replaceGetter` option now also handles a getter+setter accessor: it resolves the value once through the getter and redefines the property as a wrapped data property, dropping the accessor. It previously threw for a get+set pair.
2. The fs instrumentation passes `replaceGetter` when wrapping `fs` methods, so the lazy accessors resolve to the real function. A no-op for the data properties on Node 18 and 22.

## Test plan

- `packages/datadog-shimmer/test/shimmer.spec.js` gains a case for the getter+setter `replaceGetter` path (asserts the property is redefined as a wrapped data property) and one for the getter+setter rejection without the option. The first fails on the pre-fix shimmer.
- `packages/datadog-instrumentations/test/fs.spec.js` asserts `fs.opendir` / `opendirSync` are wrapped as methods (not accessors) and that `apm:fs:operation:start` publishes the method's own operation and path. Both fail on `master` under Node 20.
- `packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js` — the opendir cases now pass deterministically (10 consecutive runs on Node 20).
- Green on Node 18, 20, and 22 for the shimmer spec, the fs instrumentation spec, the IAST path-traversal spec, and the RASP `fs-plugin` / `lfi` specs.