### PR TITLE
fix(guardrails): load package.json at module level for proxyquire compat on Node 26

### DIFF
--- a/packages/dd-trace/src/guardrails/index.js
+++ b/packages/dd-trace/src/guardrails/index.js
@@ -4,6 +4,7 @@ var path = require('path')
 var Module = require('module')
 
 var nodeVersion = require('../../../../version')
+var pkg = require('../../../../package.json')
 var isTrue = require('./util').isTrue
 var log = require('./log')
 var telemetry = require('./telemetry')
@@ -14,7 +15,6 @@ function guard (fn) {
   var initBailout = false
   var clobberBailout = false
   var forced = isTrue(process.env.DD_INJECT_FORCE)
-  var pkg = require('../../../../package.json')
   var engines = pkg.engines
   var versions = engines.node.match(/^>=(\d+)$/)
   var minMajor = versions[1]


### PR DESCRIPTION
## Summary

- Moves `require('../../../../package.json')` from inside the `guard()` function body to module level in `packages/dd-trace/src/guardrails/index.js`
- Fixes the `unit-guardrails` CI failure introduced in #9095 on Node.js v26

## Root Cause

Node.js v26 changed how `require()` inside function bodies is wired — it no longer calls `module.require` dynamically. Proxyquire stubs modules by patching `module.require` via the `require.extensions['.js']` handler at load time. Since the `require('../../../../package.json')` call was inside `guard()` (called after load), proxyquire's patch had no effect on Node 26. The real `package.json` (`nodeMaxMajor: 27`) was used instead of the test stub, so `NODE_MAJOR (26) >= 27` evaluated to `false`, the guard didn't abort, and the test failed.

Moving the require to module level ensures it runs during the window when proxyquire's patch is active, fixing the test on all Node versions. It's also a minor perf improvement (reads `package.json` once instead of on every `guard()` call).

## Test plan

- [x] `mocha packages/dd-trace/test/guardrails/index.spec.js` — 1 passing
- [x] `eslint packages/dd-trace/src/guardrails/index.js` — 0 errors

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)