### PR TITLE
ci(release): fix branch-diff Infinity crash on scientific notation SHAs

### DIFF
--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -101,10 +101,14 @@ try {
     process.exit(0)
   }
 
+  // Expand to full SHA to avoid minimist scientific notation coercion in branch-diff.
+  // Abbreviated SHAs like "980e663509" match JS float syntax and become Infinity.
+  const upperBoundRef = capture(`git rev-parse ${upperBoundSha}`)
+
   // notesShas is scoped to upperBoundSha so isMinor and release notes only reflect
   // the capped commits actually included in the proposal, not deferred ones.
   // Excludes semver-major (gated behind a flag, not user-visible).
-  const notesShas = capture(`${notesDiffCmd} --format=sha --reverse v${releaseLine}.x ${upperBoundSha}`)
+  const notesShas = capture(`${notesDiffCmd} --format=sha --reverse v${releaseLine}.x ${upperBoundRef}`)
     .split('\n').filter(Boolean)
   const contributorBySha = getContributorsBySha(`v${releaseLine}.x`, upperBoundSha)
   const notesEntries = []
@@ -155,7 +159,7 @@ try {
 
   if (shasToApply.length > 0) {
     // Show only commits being applied; upperBoundSha is the last main SHA that fits.
-    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${upperBoundSha}`)
+    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${upperBoundRef}`)
     const truncationNote = truncated
       ? `\n\n⚠️  Applying ${shasToApply.length} of ${proposalShas.length} available commits` +
         ` (GitHub limit: ${MAX_CHERRY_PICKS}). Remaining commits require a separate release.`


### PR DESCRIPTION
## Summary

- `branch-diff --format=sha` returns abbreviated SHAs (e.g. `980e663509`) that can match JavaScript's scientific notation float syntax
- `branch-diff` uses `minimist` to parse CLI args, which auto-coerces such positional arguments to numbers — `980e663509` becomes `Infinity`
- This causes `git merge-base v5.x Infinity` to fail with exit code 128
- Fix: expand `upperBoundSha` to its full 40-char SHA via `git rev-parse` before passing it as a positional argument back to `branch-diff`; a full SHA almost always contains a hex letter (`a-f`) past position 10, breaking minimist's float regex

Triggered by the release proposal CI run: https://github.com/DataDog/dd-trace-js/actions/runs/28264161038/job/83746751389

## Test plan

- [ ] Re-run the Release Proposal workflow for v5 and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)