### PR TITLE
test(llmobs): use DD_LLMOBS_ENABLED in tagger sampling fixtures

### DIFF
--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -196,7 +196,7 @@ describe('tagger', () => {
         })
 
         it('records a DROPPED decision on a root span when sampleRate is 0', () => {
-          tagger = new Tagger({ llmobs: { enabled: true, mlApp: 'my-default-ml-app', sampleRate: 0 } })
+          tagger = new Tagger({ llmobs: { DD_LLMOBS_ENABLED: true, mlApp: 'my-default-ml-app', sampleRate: 0 } })
           tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
           const tags = Tagger.tagMap.get(span)
@@ -206,7 +206,7 @@ describe('tagger', () => {
 
         it('truncates a longer rate to at most 6 decimals', () => {
           // 1/3 = 0.3333... which must be capped at 6 decimal places.
-          tagger = new Tagger({ llmobs: { enabled: true, mlApp: 'my-default-ml-app', sampleRate: 1 / 3 } })
+          tagger = new Tagger({ llmobs: { DD_LLMOBS_ENABLED: true, mlApp: 'my-default-ml-app', sampleRate: 1 / 3 } })
           tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
           assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.sample_rate'], '0.333333')
@@ -214,7 +214,7 @@ describe('tagger', () => {
 
         it('strips trailing zeros from a fractional rate', () => {
           // 0.25 -> "0.250000" via toFixed(6), which must be stripped back to "0.25".
-          tagger = new Tagger({ llmobs: { enabled: true, mlApp: 'my-default-ml-app', sampleRate: 0.25 } })
+          tagger = new Tagger({ llmobs: { DD_LLMOBS_ENABLED: true, mlApp: 'my-default-ml-app', sampleRate: 0.25 } })
           tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
           assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.sample_rate'], '0.25')
@@ -253,7 +253,7 @@ describe('tagger', () => {
           // The tagger reads sampleRate from config on each root decision, so a
           // mutation (such as a future remote config update) takes effect without
           // re-instantiating the tagger.
-          const config = { llmobs: { enabled: true, mlApp: 'my-default-ml-app', sampleRate: 1 } }
+          const config = { llmobs: { DD_LLMOBS_ENABLED: true, mlApp: 'my-default-ml-app', sampleRate: 1 } }
           tagger = new Tagger(config)
 
           tagger.registerLLMObsSpan(span, { kind: 'llm' })


### PR DESCRIPTION
## Summary

Four tagger sampling test fixtures added by #9030 build their own `Tagger` instances with `{ llmobs: { enabled: true } }`. PR #8943 renamed that key to `DD_LLMOBS_ENABLED` across the rest of `tagger.spec.js`, but both PRs were in flight at the same time — #8943 never saw the new fixtures.

On master the tagger reads `this.#config.llmobs.DD_LLMOBS_ENABLED`, finds it `undefined` in these four fixtures, and returns early before registering the span. `Tagger.tagMap.get(span)` yields `undefined`; the "DROPPED at sampleRate 0" test then throws synchronously, aborting the whole `test:llmobs:sdk:ci` run with exit 7.

Refs: #9030, #8943