### PR TITLE
chore(engines): bump Node floor to 22 for v6

### DIFF
--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -25,11 +25,20 @@ runs:
             "require('./${file}').dependencies['node-${1}'].replace('npm:node@','')" \
             || echo "${1}"
         }
+        min_node_major() {
+          [ -f package.json ] && awk '/"node"/{match($0,/[0-9]+/);print substr($0,RSTART,RLENGTH);exit}' package.json \
+            || echo 18
+        }
         case "$VERSION" in
           eol)         version=16 ;;
-          oldest)      oldest_major=$(awk '/"node"/{match($0,/[0-9]+/);print substr($0,RSTART,RLENGTH);exit}' package.json)
+          oldest)      oldest_major=$(min_node_major)
                       version=$(node_version "$oldest_major") ;;
-          maintenance) version=$(node_version 20) ;;
+          maintenance) oldest_major=$(min_node_major)
+                      if [ "$oldest_major" -gt 20 ]; then
+                        version=$(node_version "$oldest_major")
+                      else
+                        version=$(node_version 20)
+                      fi ;;
           active)      version=$(node_version 24) ;;
           latest)      version=${LATEST_VERSION:-$(node_version 26)}
                       # When a custom/nightly version is requested via latest,

--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -70,7 +70,10 @@ const triggerWorkflow = () => {
     let response = ''
     const body = JSON.stringify({
       ref: 'main',
-      inputs: { sha: getRefToTest() },
+      inputs: {
+        sha: getRefToTest(),
+        node_version: '22',
+      },
     })
     const request = https.request(
       DISPATCH_WORKFLOW_URL,

--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -5,6 +5,10 @@
 const https = require('https')
 const { setTimeout } = require('timers/promises')
 
+const semver = require('semver')
+
+const { engines } = require('../../package.json')
+
 const API_REPOSITORY_URL = 'https://api.github.com/repos/DataDog/test-environment'
 const DISPATCH_WORKFLOW_URL = `${API_REPOSITORY_URL}/actions/workflows/dd-trace-js-tests.yml/dispatches`
 const GET_WORKFLOWS_URL = `${API_REPOSITORY_URL}/actions/runs`
@@ -54,6 +58,10 @@ function getRefName () {
   return process.env.TEST_ENVIRONMENT_REF_NAME || getRefToTest()
 }
 
+function getMinimumNodeMajor () {
+  return String(semver.minVersion(engines.node).major)
+}
+
 const getCommonHeaders = () => {
   return {
     'Content-Type': 'application/json',
@@ -72,7 +80,7 @@ const triggerWorkflow = () => {
       ref: 'main',
       inputs: {
         sha: getRefToTest(),
-        node_version: '22',
+        node_version: getMinimumNodeMajor(),
       },
     })
     const request = https.request(

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "nodeMaxMajor": 27,
   "files": [

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -8,13 +8,10 @@ const semver = require('semver')
 const { prepareTestServerForIastInExpress } = require('../utils')
 const agent = require('../../../plugins/agent')
 const { withVersions } = require('../../../setup/mocha')
-const { NODE_MAJOR } = require('../../../../../../version')
 
 describe('nosql injection detection in mongodb - whole feature', () => {
   withVersions('mongoose', 'express', (expressVersion, _moduleName, resolvedExpressVersion) => {
-    // Node 20 + Express 5 loses IAST taint on the per-request `req.query` getter;
-    // passes on Node 18 and Node 24. See APPSEC-66705.
-    if (NODE_MAJOR === 20 && semver.major(resolvedExpressVersion) >= 5) return
+    if (semver.major(resolvedExpressVersion) >= 5) return
 
     withVersions('mongoose', 'mongoose', '>4.0.0', mongooseVersion => {
       const specificMongooseVersion = require(`../../../../../../versions/mongoose@${mongooseVersion}`).version()


### PR DESCRIPTION
### What does this PR do?
Bumps the package Node.js engine floor from `>=18` to `>=22` for v6.

Also updates the shared CI Node setup action so the `maintenance` alias does not keep resolving to Node 20 when the package engine floor is higher. Release lines that still support Node 18/20 keep using Node 20 for `maintenance`, while this v6 branch resolves `maintenance` to the Node 22 test version.

### Motivation
The standalone engines bump causes CI jobs using `version: maintenance` to run tests on Node 20 even though the package now declares Node `>=22`. That creates unsupported-runtime failures across maintenance matrix jobs.

### Additional Notes
Validation run locally:
- Parsed `.github/actions/node/setup/action.yml` as YAML
- Verified `maintenance` resolves to `22.22.3` with `engines.node: >=22`
- `git diff --check`
