### PR TITLE
test(test-optimization): handle 5xx retry in getKnownTests error test

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -766,7 +766,14 @@ describe('CI Visibility Exporter', () => {
       })
 
       it('should return an error if the request fails', (done) => {
+        // A 5xx triggers one jittered 5–7.5 s retry in the request helper, so the endpoint is
+        // hit twice and the retry delay must collapse to 0 ms to stay under the mocha timeout.
+        const realSetTimeout = setTimeout
+        sinon.stub(global, 'setTimeout').callsFake((fn, delay, ...args) =>
+          realSetTimeout(fn, delay > 100 ? 0 : delay, ...args))
         const scope = nock(url)
+          .post('/api/v2/ci/libraries/tests')
+          .reply(500)
           .post('/api/v2/ci/libraries/tests')
           .reply(500)
         const ciVisibilityExporter = new CiVisibilityExporter({ url })


### PR DESCRIPTION
## Summary

The `getKnownTests` "should return an error if the request fails" test timed
out on a clean `master`. The request helper retries once on a 5xx with a
5–7.5 s jittered delay, but the test mocked a single `500` interceptor and used
real timers. The retried request had no interceptor and its retry timer always
exceeded mocha's 5 s timeout, so the callback never fired.

The fix collapses the retry delay to 0 ms (the same `setTimeout` stub the
dedicated `request.spec.js` already uses) and adds a second `500` interceptor,
so the test exercises the real retry path and asserts both requests are
consumed. No production code changes.

## Test plan

- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js --grep "getKnownTests"` → 10 passing (was 9 passing, 1 failing on master).