### PR TITLE
test(child_process): load the mock agent once per suite

### DIFF
--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const events = require('node:events')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
@@ -528,19 +529,19 @@ describe('Child process plugin', () => {
 
           methods.forEach(({ methodName, async }) => {
             describe(methodName, () => {
-              it('should be instrumented', (done) => {
-                const expected = {
-                  type: 'system',
-                  name: 'command_execution',
-                  error: 0,
-                  meta: {
-                    component: 'subprocess',
-                    'cmd.shell': 'ls',
-                    'cmd.exit_code': '0',
-                  },
-                }
+              const lsExpected = {
+                type: 'system',
+                name: 'command_execution',
+                error: 0,
+                meta: {
+                  component: 'subprocess',
+                  'cmd.shell': 'ls',
+                  'cmd.exit_code': '0',
+                },
+              }
 
-                expectSomeSpan(agent, expected).then(done, done)
+              it('should be instrumented', (done) => {
+                expectSomeSpan(agent, lsExpected).then(done, done)
 
                 const res = childProcess[methodName]('ls')
                 if (async) {
@@ -548,27 +549,29 @@ describe('Child process plugin', () => {
                 }
               })
 
-              it('should maintain previous span after the execution', (done) => {
+              it('should maintain previous span after the execution', async () => {
+                const drained = expectSomeSpan(agent, lsExpected)
+
                 const res = childProcess[methodName]('ls')
-                const span = storage('legacy').getStore()?.span
-                assert.strictEqual(span, parentSpan)
+                assert.strictEqual(storage('legacy').getStore()?.span, parentSpan)
                 if (async) {
-                  res.on('close', () => {
-                    assert.strictEqual(span, parentSpan)
-                    done()
-                  })
+                  await Promise.all([drained, (async () => {
+                    await events.once(res, 'close')
+                    assert.strictEqual(storage('legacy').getStore()?.span, parentSpan)
+                  })()])
                 } else {
-                  done()
+                  await drained
                 }
               })
 
               if (async) {
-                it('should maintain previous span in the callback', (done) => {
-                  childProcess[methodName]('ls', () => {
-                    const span = storage('legacy').getStore()?.span
-                    assert.strictEqual(span, parentSpan)
-                    done()
-                  })
+                it('should maintain previous span in the callback', async () => {
+                  await Promise.all([expectSomeSpan(agent, lsExpected), new Promise(resolve => {
+                    childProcess[methodName]('ls', () => {
+                      assert.strictEqual(storage('legacy').getStore()?.span, parentSpan)
+                      resolve()
+                    })
+                  })])
                 })
               }
 

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -389,20 +389,23 @@ describe('Child process plugin', () => {
     let originalPromise
     let Bluebird
 
-    beforeEach(async () => {
+    before(async () => {
       tracer = await agent.load('child_process', undefined, { flushInterval: 1 })
       childProcess = require('child_process')
       util = require('util')
       tracer.use('child_process', { enabled: true })
       Bluebird = require('../../../versions/bluebird').get()
+    })
 
+    after(() => agent.close())
+
+    beforeEach(() => {
       originalPromise = global.Promise
       global.Promise = Bluebird
     })
 
     afterEach(() => {
       global.Promise = originalPromise
-      return agent.close()
     })
 
     it('should not crash with "this._then is not a function" when using Bluebird promises', async () => {
@@ -494,13 +497,14 @@ describe('Child process plugin', () => {
       const execSyncMethods = ['execSync']
       let childProcess, tracer
 
-      beforeEach(async () => {
+      before(async () => {
         tracer = await agent.load('child_process', undefined, { flushInterval: 1 })
         childProcess = require('child_process')
         tracer.use('child_process', { enabled: true })
       })
 
-      afterEach(() => agent.close())
+      after(() => agent.close())
+
       const parentSpanList = [true, false]
       parentSpanList.forEach(hasParentSpan => {
         let parentSpan
@@ -637,13 +641,14 @@ describe('Child process plugin', () => {
       const execSyncMethods = ['execFileSync', 'spawnSync']
       let childProcess, tracer
 
-      beforeEach(async () => {
+      before(async () => {
         tracer = await agent.load('child_process', undefined, { flushInterval: 1 })
         childProcess = require('child_process')
         tracer.use('child_process', { enabled: true })
       })
 
-      afterEach(() => agent.close())
+      after(() => agent.close())
+
       const parentSpanList = [true, false]
       parentSpanList.forEach(parentSpan => {
         describe(`${parentSpan ? 'with' : 'without'} parent span`, () => {


### PR DESCRIPTION
## Summary

The Integration and Bluebird suites in `packages/datadog-plugin-child_process/test/index.spec.js` called `agent.load` / `agent.close` in `beforeEach` / `afterEach`, tearing down the mock agent and standing a new one up on a fresh port between every test. Async child processes spawned in a test finish on their own `close` event, which can fire after the test resolves — during the teardown gap. The leaked `command_execution` span then flushed to the previous test's now-closed port (`ECONNREFUSED`), and a stale assertion handler matched the leftover manual `parent` span (`_dd.integration: opentracing`) instead, so the next test timed out. Under CI load the first miss cascaded across the whole suite (the run linked below failed 47 tests on newest-maintenance-lts).

Loading the agent once per describe block in `before` / `after` keeps a single port alive for every test in the block, so a span flushed slightly late lands on the still-open agent. The Bluebird `global.Promise` swap stays per-test in `beforeEach` / `afterEach`.

## Why

`flushInterval: 1` on its own isn't the cause — the span can finish (and flush synchronously even at `flushInterval: 0`) inside the window between one test's `agent.close()` and the next test's `agent.load()`. Removing the per-test agent churn is what closes that window.

## Test plan

Reproduced by running the suite under parallel load (the contention CI's `nyc` + busy runner provides):

- master: ~6–9% of runs fail with the `ECONNREFUSED` + wrong-`parent`-span signature (10/160 at 4 concurrent, 15/160 at 8).
- this branch: 0 failures over 520 runs at the same contention.

Fixes: https://github.com/DataDog/dd-trace-js/actions/runs/28281208791