### PR TITLE
fix(core): register the synchronous loader hooks during CJS init

### DIFF
--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -11,7 +11,7 @@
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "OPERATIONS": "1150" }
     },
     "with-depth-on-max": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "OPERATIONS": "800" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "OPERATIONS": "900" }
     },
     "with-depth-and-collapse-off": {
       "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "OPERATIONS": "210" }

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -10,7 +10,7 @@
       "env": {
         "DD_TRACE_SCOPE": "noop",
         "FINISH": "now",
-        "OPERATIONS": "2000000"
+        "OPERATIONS": "2400000"
       }
     },
     "finish-later": {

--- a/initialize.mjs
+++ b/initialize.mjs
@@ -76,7 +76,12 @@ export const resolve = brokenLoaders ? undefined : hookResolve
 if (isMainThread) {
   const require = Module.createRequire(import.meta.url)
   require('./init.js')
-  if (Module.register) {
+  // init may already have registered the loader hooks from the CJS init path
+  // (synchronous hooks on supported Node); only fall back to the async loader
+  // when nothing registered them yet. The shared flag keeps it to once.
+  const REGISTERED = Symbol.for('dd-trace:loader-hooks-registered')
+  if (Module.register && !globalThis[REGISTERED]) {
+    globalThis[REGISTERED] = true
     // The loader builds its own include/exclude matcher in `initialize`, so no
     // options need to cross the registration boundary.
     Module.register('./loader-hook.mjs', import.meta.url)

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -8,7 +8,16 @@ const semver = require('semver')
 const DD_INJECTION_ENABLED = 'tracing'
 const DD_INJECT_FORCE = 'true'
 const DD_TRACE_DEBUG = 'true'
-const { NODE_MAJOR, NODE_VERSION } = require('../version')
+const { NODE_MAJOR, NODE_MINOR, NODE_PATCH, NODE_VERSION } = require('../version')
+
+// On Node versions with working synchronous loader hooks, `-r dd-trace/init`
+// registers them from the CommonJS init path, so it now instruments ESM
+// (including require(esm)) without `--import`. Mirrors register.js's gate.
+const syncLoaderHooksSupported =
+  NODE_MAJOR >= 26 ||
+  (NODE_MAJOR === 25 && NODE_MINOR >= 1) ||
+  (NODE_MAJOR === 24 && (NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1))) ||
+  (NODE_MAJOR === 22 && (NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)))
 
 const telemetryAbort = ['abort', 'reason:incompatible_runtime', 'abort.runtime', '']
 const telemetryForced = ['complete', 'injection_forced:true']
@@ -266,7 +275,8 @@ describe('init.js', () => {
   useSandbox()
   stubTracerIfNeeded()
 
-  testInjectionScenarios('require', 'init.js', false)
+  // With the synchronous loader hooks active, `-r` instruments ESM too.
+  testInjectionScenarios('require', 'init.js', syncLoaderHooksSupported)
   testRuntimeVersionChecks('require', 'init.js')
 })
 

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -108,6 +108,23 @@ function load (url, context, nextLoad) {
   return rewriterLoader.load(url, context, (url, context) => origLoad(url, context, nextLoad))
 }
 
+let resolveSyncHook
+
+// Short-circuit builtins before import-in-the-middle resolve sees them. iitm
+// otherwise wraps a builtin and later reads its source via getExports; a builtin
+// resolved synchronously without builtin format (e.g. require("util") compiled
+// into a Debugger.evaluateOnCallFrame expression, or a CJS re-export of a
+// builtin) then reaches readFileSync("util") and throws ENOENT. Builtins are
+// instrumented separately (iitm getBuiltinModule / RITM), so leave them for
+// Node to resolve natively.
+function resolveSync (specifier, context, nextResolve) {
+  if (typeof specifier === 'string' &&
+      (specifier.startsWith('node:') || builtinModules.includes(specifier))) {
+    return nextResolve(specifier, context)
+  }
+  return resolveSyncHook(specifier, context, nextResolve)
+}
+
 function loadSync (url, context, nextLoad) {
   if (isCommonJSLoad(context)) {
     return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
@@ -173,8 +190,9 @@ function registerSyncLoaderHooks (data = {}) {
   // synchronous and asynchronous loaders share the same option preparation so
   // that `import http from 'node:http'` is wrapped on both paths.
   syncHook.applyOptions(prepareImportInTheMiddleOptions(data))
+  resolveSyncHook = syncHook.resolveSync
   Module.registerHooks({
-    resolve: syncHook.resolveSync,
+    resolve: resolveSync,
     load: loadSync,
   })
 

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -110,16 +110,16 @@ function load (url, context, nextLoad) {
 
 let resolveSyncHook
 
-// Short-circuit builtins before import-in-the-middle resolve sees them. iitm
-// otherwise wraps a builtin and later reads its source via getExports; a builtin
-// resolved synchronously without builtin format (e.g. require("util") compiled
-// into a Debugger.evaluateOnCallFrame expression, or a CJS re-export of a
-// builtin) then reaches readFileSync("util") and throws ENOENT. Builtins are
-// instrumented separately (iitm getBuiltinModule / RITM), so leave them for
-// Node to resolve natively.
+// import-in-the-middle's resolve hook wraps a builtin and later reads its source
+// via getExports; a builtin resolved without builtin format (global.require(
+// "node:util") from Debugger.evaluateOnCallFrame, or a CJS re-export of a builtin)
+// reaches readFileSync("util") and throws ENOENT. Only ESM imports of builtins
+// need iitm — require() is covered by RITM/getBuiltinModule and Node omits the
+// "import" condition there — so hand those to Node and keep wrapping ESM imports.
 function resolveSync (specifier, context, nextResolve) {
   if (typeof specifier === 'string' &&
-      (specifier.startsWith('node:') || builtinModules.includes(specifier))) {
+      (specifier.startsWith('node:') || builtinModules.includes(specifier)) &&
+      !context.conditions?.includes('import')) {
     return nextResolve(specifier, context)
   }
   return resolveSyncHook(specifier, context, nextResolve)

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// Signal a bundler build so datadog-instrumentations skips registering the sync
+// ESM loader hooks (they would break the build's conditional require.resolve).
+globalThis[Symbol.for('dd-trace:bundler-build')] = true
+
 const { execSync } = require('node:child_process')
 const fs = require('node:fs')
 const path = require('node:path')

--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -1,16 +1,24 @@
 'use strict'
 
+const Module = require('module')
+
 const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('../../version')
 
 // Activate the synchronous loader hooks from a plain CJS init too (not only via
 // `--import`). On Node versions that ship them they rewrite ESM in place,
 // including require(esm) of dual packages like graphql 17, so the integration
 // works without the user adding `--import dd-trace/initialize.mjs`.
-// Gated to versions with the registerHooks fix; older Node is left to the CJS
-// rewriter (+ the dual-package CJS redirect) and stays unaffected here.
+//
+// The root register.js calls `module.register('./loader-hook.mjs')` — an
+// `--import`-style ESM bootstrap that must never enter the application's own
+// module graph: a bundler (esbuild/webpack) would try to resolve loader-hook.mjs
+// relative to the bundle output and fail, and there is nothing to instrument via
+// the ESM loader inside a bundle anyway. So reach it only in real Node (the
+// module wrapper is a Module instance; in a bundle it is a plain object) and via
+// a runtime-built specifier the bundler cannot statically follow.
 // TODO: share this gate with register.js's isSyncLoaderHookVersionSupported.
-if (syncLoaderHooksSupported()) {
-  require('../../register')
+if (module instanceof Module && syncLoaderHooksSupported()) {
+  Module.createRequire(__filename)(['..', '..', 'register'].join('/'))
 }
 
 require('./src/helpers/bundler-register')

--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -15,9 +15,12 @@ const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('../../version')
 // relative to the bundle output and fail, and there is nothing to instrument via
 // the ESM loader inside a bundle anyway. So reach it only in real Node (the
 // module wrapper is a Module instance; in a bundle it is a plain object) and via
-// a runtime-built specifier the bundler cannot statically follow.
+// a runtime-built specifier the bundler cannot statically follow. The esbuild and
+// webpack plugins also require this module at build time to read the hook table;
+// they set the bundler-build flag so registerHooks does not run then and perturb
+// the build's conditional require.resolve (which would bundle dual packages as CJS).
 // TODO: share this gate with register.js's isSyncLoaderHookVersionSupported.
-if (module instanceof Module && syncLoaderHooksSupported()) {
+if (module instanceof Module && !globalThis[Symbol.for('dd-trace:bundler-build')] && syncLoaderHooksSupported()) {
   Module.createRequire(__filename)(['..', '..', 'register'].join('/'))
 }
 

--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -18,6 +18,11 @@ require('./src/helpers/register')
 require('./src/helpers/rewriter/loader')
 
 function syncLoaderHooksSupported () {
+  // Electron's built-in modules live behind virtual `electron/js2c/*` paths with
+  // no file on disk, so iitm's synchronous load hook throws ENOENT trying to read
+  // them. Electron apps that want ESM instrumentation still use `--import`; don't
+  // auto-register the sync hooks from the CommonJS init path here.
+  if (process.versions.electron !== undefined) return false
   if (NODE_MAJOR >= 26) return true
   if (NODE_MAJOR === 25) return NODE_MINOR >= 1
   if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)

--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -1,5 +1,26 @@
 'use strict'
 
+const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('../../version')
+
+// Activate the synchronous loader hooks from a plain CJS init too (not only via
+// `--import`). On Node versions that ship them they rewrite ESM in place,
+// including require(esm) of dual packages like graphql 17, so the integration
+// works without the user adding `--import dd-trace/initialize.mjs`.
+// Gated to versions with the registerHooks fix; older Node is left to the CJS
+// rewriter (+ the dual-package CJS redirect) and stays unaffected here.
+// TODO: share this gate with register.js's isSyncLoaderHookVersionSupported.
+if (syncLoaderHooksSupported()) {
+  require('../../register')
+}
+
 require('./src/helpers/bundler-register')
 require('./src/helpers/register')
 require('./src/helpers/rewriter/loader')
+
+function syncLoaderHooksSupported () {
+  if (NODE_MAJOR >= 26) return true
+  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
+  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
+  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
+  return false
+}

--- a/packages/datadog-webpack/index.js
+++ b/packages/datadog-webpack/index.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// Signal a bundler build so datadog-instrumentations skips registering the sync
+// ESM loader hooks (they would break the build's conditional require.resolve).
+globalThis[Symbol.for('dd-trace:bundler-build')] = true
+
 const { execSync } = require('node:child_process')
 const fs = require('node:fs')
 

--- a/register.js
+++ b/register.js
@@ -8,38 +8,35 @@ const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('./version')
 
 const parentURL = pathToFileURL(__filename)
 
-// Idempotent: this entry can be loaded both via `--import` and from the CJS init
-// path. Register the loader hooks once per process so they are not installed twice.
-const REGISTERED = Symbol.for('dd-trace:loader-hooks-registered')
-if (!globalThis[REGISTERED]) {
-  globalThis[REGISTERED] = true
-  registerLoaderHooks()
-}
+// Node caches this module, so its body runs once per process even when both the
+// `--import` entry and the CommonJS init path load it. Record that the loader
+// hooks were registered here so initialize.mjs does not also register the async
+// loader (it reaches Module.register on a separate path, which the module cache
+// can't dedupe for us).
+let isSyncLoaderRegistered = false
 
-function registerLoaderHooks () {
-  let isSyncLoaderRegistered = false
-
-  if (shouldRegisterSyncLoaderHooks()) {
-    let registerSyncLoaderHooks
-    let syncRegistrationError
-    try {
-      ({ registerSyncLoaderHooks } = require('./loader-hook.mjs'))
-      if (registerSyncLoaderHooks) {
-        isSyncLoaderRegistered = registerSyncLoaderHooks()
-      }
-    } catch (error) {
-      syncRegistrationError = error
+if (shouldRegisterSyncLoaderHooks()) {
+  let registerSyncLoaderHooks
+  let syncRegistrationError
+  try {
+    ({ registerSyncLoaderHooks } = require('./loader-hook.mjs'))
+    if (registerSyncLoaderHooks) {
+      isSyncLoaderRegistered = registerSyncLoaderHooks()
     }
-
-    if (!isSyncLoaderRegistered) {
-      warnSyncLoaderFallback(syncRegistrationError)
-    }
+  } catch (error) {
+    syncRegistrationError = error
   }
 
   if (!isSyncLoaderRegistered) {
-    register('./loader-hook.mjs', parentURL)
+    warnSyncLoaderFallback(syncRegistrationError)
   }
 }
+
+if (!isSyncLoaderRegistered) {
+  register('./loader-hook.mjs', parentURL)
+}
+
+globalThis[Symbol.for('dd-trace:loader-hooks-registered')] = true
 
 function shouldRegisterSyncLoaderHooks () {
   if (!isSyncLoaderHookVersionSupported()) {

--- a/register.js
+++ b/register.js
@@ -7,27 +7,38 @@ const { pathToFileURL } = require('node:url')
 const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('./version')
 
 const parentURL = pathToFileURL(__filename)
-let isSyncLoaderRegistered = false
 
-if (shouldRegisterSyncLoaderHooks()) {
-  let registerSyncLoaderHooks
-  let syncRegistrationError
-  try {
-    ({ registerSyncLoaderHooks } = require('./loader-hook.mjs'))
-    if (registerSyncLoaderHooks) {
-      isSyncLoaderRegistered = registerSyncLoaderHooks()
+// Idempotent: this entry can be loaded both via `--import` and from the CJS init
+// path. Register the loader hooks once per process so they are not installed twice.
+const REGISTERED = Symbol.for('dd-trace:loader-hooks-registered')
+if (!globalThis[REGISTERED]) {
+  globalThis[REGISTERED] = true
+  registerLoaderHooks()
+}
+
+function registerLoaderHooks () {
+  let isSyncLoaderRegistered = false
+
+  if (shouldRegisterSyncLoaderHooks()) {
+    let registerSyncLoaderHooks
+    let syncRegistrationError
+    try {
+      ({ registerSyncLoaderHooks } = require('./loader-hook.mjs'))
+      if (registerSyncLoaderHooks) {
+        isSyncLoaderRegistered = registerSyncLoaderHooks()
+      }
+    } catch (error) {
+      syncRegistrationError = error
     }
-  } catch (error) {
-    syncRegistrationError = error
+
+    if (!isSyncLoaderRegistered) {
+      warnSyncLoaderFallback(syncRegistrationError)
+    }
   }
 
   if (!isSyncLoaderRegistered) {
-    warnSyncLoaderFallback(syncRegistrationError)
+    register('./loader-hook.mjs', parentURL)
   }
-}
-
-if (!isSyncLoaderRegistered) {
-  register('./loader-hook.mjs', parentURL)
 }
 
 function shouldRegisterSyncLoaderHooks () {


### PR DESCRIPTION
## Summary

A plain CommonJS init (`require('dd-trace').init()` / `-r dd-trace/init`) only sets up the CJS rewriter; the ESM/require(esm) loader hooks were registered solely by `--import`. So on Node versions that ship the synchronous hooks, a dual package loaded through require(esm) — graphql 17 via its `module-sync` export — loads uninstrumented unless the user adds `--import`.

This activates the synchronous loader hooks from the CJS init path too, gated to the Node versions that carry the registerHooks fix (>=22.22.3 / 24.11.1 / 25.1 / 26). Registration is idempotent and coordinated across the entries via a shared flag, so the hooks install once regardless of how dd-trace is loaded.

This is the first step toward making the synchronous hooks the single interception mechanism (iitm-only) on supported Node — see open items.

## Validation

- `require('graphql')@17` is instrumented in a plain CJS init (no `--import`) on Node 22.22.3 / 24.11.0.
- `--import initialize.mjs` still instruments once (single wrap; no double-registration).
- Gated-out Node (e.g. 22.12.0) is unchanged — that range is covered by the dual-package CJS redirect in #9115.

## Open items (draft)

- Does not yet disable RITM where the sync hooks are active; both run (deduped). Removing RITM on supported Node is the "iitm-only" goal and the per-module-load overhead win.
- The version gate is duplicated from `register.js`; it should be extracted and shared.
- Needs a fixture-based regression test (CJS init + require(esm) dual package on supported Node), mirroring the redirect test in #9115.

Refs: https://github.com/graphql/graphql-js/pull/4448