### PR TITLE
perf(core): instrument CommonJS via the sync loader hook (drop RITM per-require tax)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -369,6 +369,7 @@
 /packages/dd-trace/test/ritm-tests/ @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/setup/ @DataDog/lang-platform-js
+/packages/dd-trace/test/supported-loader-hooks.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/util.spec.js @DataDog/lang-platform-js
 
 # Multiple teams

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -27,6 +27,16 @@ const { BUN, withBun } = require('./bun')
 
 const sandboxRoot = path.join(os.tmpdir(), id().toString())
 const hookFile = 'dd-trace/loader-hook.mjs'
+// Node >=20.6: `--import dd-trace/initialize.mjs` registers the loader hooks and
+// initializes the tracer before the application's module graph loads, instrumenting
+// CommonJS and ESM alike with a single flag. The legacy `--loader dd-trace/loader-hook.mjs`
+// only reliably instruments ESM entrypoints and, on Node versions that own CommonJS
+// through the synchronous hooks, cannot wrap a CommonJS package reached by `import`.
+const [esmHookNodeMajor, esmHookNodeMinor] = process.versions.node.split('.').map(Number)
+const supportsImportInitialize = esmHookNodeMajor > 20 || (esmHookNodeMajor === 20 && esmHookNodeMinor >= 6)
+const esmHookOptions = supportsImportInitialize
+  ? '--import dd-trace/initialize.mjs'
+  : `--loader=${hookFile}`
 
 const { DEBUG } = process.env
 
@@ -935,7 +945,7 @@ function preparePluginIntegrationTestSpawnOptions (
 ) {
   additionalEnvArgs = { ...additionalEnvArgs }
 
-  let NODE_OPTIONS = `--loader=${hookFile}`
+  let NODE_OPTIONS = esmHookOptions
   if (additionalEnvArgs.NODE_OPTIONS !== undefined) {
     if (/--(loader|import)/.test(additionalEnvArgs.NODE_OPTIONS ?? '')) {
       NODE_OPTIONS = additionalEnvArgs.NODE_OPTIONS

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -138,7 +138,18 @@ function loadSync (url, context, nextLoad) {
   }
 
   return rewriterLoader.loadSync(url, context, (url, context) => {
-    return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
+    const result = nextLoad(url, context)
+    // A CommonJS package reached by `import pkg` (not require) arrives here with
+    // no format and the import condition, so isCommonJSLoad() can't see it from
+    // context alone; Node resolves it to commonjs in `result`. When the sync
+    // loader owns CJS, keep that entry on the CommonJS path so rewriteResult
+    // appends the export-wrapping shim. Handing it to iitm instead would wrap it
+    // as an ESM namespace and drop the shim, leaving the package's main file
+    // (e.g. express/lib/express.js) uninstrumented — the gap RITM used to cover.
+    if (cjsOwnedBySyncLoader && result.format === 'commonjs') {
+      return result
+    }
+    return getSyncImportInTheMiddleHook().loadSync(url, context, () => result)
   })
 }
 

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -127,6 +127,13 @@ function resolveSync (specifier, context, nextResolve) {
 
 function loadSync (url, context, nextLoad) {
   if (isCommonJSLoad(context)) {
+    // When the synchronous loader owns CommonJS (RITM disabled on this Node),
+    // run the rewriter loader for CJS too: it rewrites orchestrion targets and
+    // appends the export-wrapping shim. Otherwise leave CJS to RITM +
+    // Module._compile and only let iitm see it (which it skips for require()).
+    if (cjsOwnedBySyncLoader) {
+      return rewriterLoader.loadSync(url, context, nextLoad)
+    }
     return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
   }
 
@@ -134,6 +141,8 @@ function loadSync (url, context, nextLoad) {
     return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
   })
 }
+
+let cjsOwnedBySyncLoader = false
 
 function isCommonJSLoad (context) {
   if (context.format) return context.format === 'commonjs'
@@ -195,6 +204,13 @@ function registerSyncLoaderHooks (data = {}) {
     resolve: resolveSync,
     load: loadSync,
   })
+
+  // The synchronous loader now owns CommonJS instrumentation too: it rewrites
+  // CJS source and appends the export-wrapping shim, replacing RITM's
+  // per-require interception and the Module._compile rewrite on this Node.
+  cjsOwnedBySyncLoader = true
+  rewriterLoader.setOwnsCjsSync(true)
+  globalThis[Symbol.for('dd-trace:sync-loader-owns-cjs')] = true
 
   return true
 }

--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -2,7 +2,7 @@
 
 const Module = require('module')
 
-const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('../../version')
+const { syncLoaderHooksSupported } = require('../dd-trace/src/supported-loader-hooks')
 
 // Activate the synchronous loader hooks from a plain CJS init too (not only via
 // `--import`). On Node versions that ship them they rewrite ESM in place,
@@ -19,7 +19,6 @@ const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('../../version')
 // webpack plugins also require this module at build time to read the hook table;
 // they set the bundler-build flag so registerHooks does not run then and perturb
 // the build's conditional require.resolve (which would bundle dual packages as CJS).
-// TODO: share this gate with register.js's isSyncLoaderHookVersionSupported.
 if (module instanceof Module && !globalThis[Symbol.for('dd-trace:bundler-build')] && syncLoaderHooksSupported()) {
   Module.createRequire(__filename)(['..', '..', 'register'].join('/'))
 }
@@ -27,16 +26,3 @@ if (module instanceof Module && !globalThis[Symbol.for('dd-trace:bundler-build')
 require('./src/helpers/bundler-register')
 require('./src/helpers/register')
 require('./src/helpers/rewriter/loader')
-
-function syncLoaderHooksSupported () {
-  // Electron's built-in modules live behind virtual `electron/js2c/*` paths with
-  // no file on disk, so iitm's synchronous load hook throws ENOENT trying to read
-  // them. Electron apps that want ESM instrumentation still use `--import`; don't
-  // auto-register the sync hooks from the CommonJS init path here.
-  if (process.versions.electron !== undefined) return false
-  if (NODE_MAJOR >= 26) return true
-  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
-  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
-  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
-  return false
-}

--- a/packages/datadog-instrumentations/src/helpers/cjs-sync-hook.js
+++ b/packages/datadog-instrumentations/src/helpers/cjs-sync-hook.js
@@ -1,0 +1,168 @@
+'use strict'
+
+// Runtime support for instrumenting CommonJS modules through the synchronous
+// loader hooks (module.registerHooks) instead of require-in-the-middle's
+// `Module.prototype.require` wrapper.
+//
+// The sync `load` hook only gets a module's *source*, not its evaluated
+// `module.exports`. For an instrumented module we append a small shim to the CJS
+// source: after the module finishes evaluating, the shim calls
+// `applyCjsHooks(module.exports, filename)`, which runs the same per-module hook
+// callback RITM runs — wrapping the *native, mutable* exports in place (no ESM
+// namespace proxy, so `Object.defineProperty(require('fs'), ...)` and
+// `class X extends require('events')` keep working).
+//
+// RITM keeps owning CJS on Node versions without the sync hooks; this path is
+// only active where the combined sync hook has taken over (see register.js).
+
+const path = require('path')
+const { builtinModules } = require('module')
+
+const parse = require('../../../../vendor/dist/module-details-from-path')
+const requirePackageJson = require('../../../dd-trace/src/require-package-json')
+
+const BUILTINS = new Set(builtinModules)
+
+/**
+ * @typedef {(exports: unknown, name: string, basedir: string|undefined,
+ *   version: string|undefined, isIitm: boolean) => unknown} OnRequire
+ */
+
+/** @type {Map<string, OnRequire[]>} keyed by package name (RITM's hook table). */
+const moduleHooks = new Map()
+
+/** @type {WeakSet<object>} Already-wrapped exports, to stay idempotent. */
+const wrapped = new WeakSet()
+
+/** @type {Map<string, string|undefined>} basedir -> resolved version. */
+const versionCache = new Map()
+
+// process.getBuiltinModule lands in Node 22.3 / backported to 20.16; the sync
+// loader only owns CJS on Node ≥22.22.3, so it is always present there, but the
+// repo's supported floor is 18 — guard the reference.
+const getBuiltinModule =
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- guarded; only reached on Node >=22.22.3
+  typeof process.getBuiltinModule === 'function' ? process.getBuiltinModule : undefined
+
+/**
+ * Registers a hook callback for a package name. Mirrors RITM's hook table so the
+ * sync path and RITM run the identical per-module callback.
+ *
+ * @param {string} name Package name (e.g. 'http', 'express', '@langchain/core').
+ * @param {OnRequire} onrequire
+ * @returns {void}
+ */
+function registerCjsHook (name, onrequire) {
+  const existing = moduleHooks.get(name)
+  if (existing) {
+    existing.push(onrequire)
+  } else {
+    moduleHooks.set(name, [onrequire])
+  }
+
+  // Builtins have no source for the load-hook shim, but they are singletons:
+  // wrapping the live exports object now is seen by every later require(name),
+  // at zero per-require cost. The async loader path does not reach here, so this
+  // only runs where the sync loader owns CJS.
+  if (BUILTINS.has(name) && getBuiltinModule !== undefined) {
+    wrapBuiltin(name, onrequire)
+  }
+}
+
+/**
+ * @param {string} name Builtin module name.
+ * @param {OnRequire} onrequire
+ * @returns {void}
+ */
+function wrapBuiltin (name, onrequire) {
+  const exports = getBuiltinModule(name)
+  if (exports === undefined) return
+  // Run the hook in place; integrations mutate the singleton's properties.
+  onrequire(exports, name, undefined, process.version, false)
+}
+
+/**
+ * Resolves a loaded file path to the registered package and the RITM-style
+ * module name (`<package>/<relative-path>`), or undefined when no hook is
+ * registered for the owning package. Builtins (no basedir) map to the bare name.
+ *
+ * @param {string} filename Absolute resolved file path, or a `node:`-stripped builtin name.
+ * @returns {{ packageName: string, moduleName: string, basedir: string|undefined }|undefined}
+ */
+function matchModule (filename) {
+  // Builtins arrive as a bare module id (e.g. 'http'); they have no path.
+  if (!filename.includes(path.sep)) {
+    return moduleHooks.has(filename)
+      ? { packageName: filename, moduleName: filename, basedir: undefined }
+      : undefined
+  }
+
+  const stat = parse(filename)
+  if (!stat) return
+
+  const packageName = stat.name
+  const hooks = moduleHooks.get(packageName)
+  if (!hooks) return
+
+  // RITM keys file-specific hooks as `<name>/<relative path>`; the package main
+  // is matched against the integration's `file` (default 'index.js') inside the
+  // registered callback, so build the same moduleName here.
+  const moduleName = `${packageName}${path.sep}${path.relative(stat.basedir, filename)}`.replaceAll('\\', '/')
+  return { packageName, moduleName, basedir: stat.basedir }
+}
+
+/**
+ * @param {string|undefined} basedir
+ * @returns {string|undefined}
+ */
+function resolveVersion (basedir) {
+  if (!basedir) return process.versions?.electron ?? process.version
+  if (versionCache.has(basedir)) return versionCache.get(basedir)
+  let version
+  try {
+    version = requirePackageJson(basedir, /** @type {NodeModule} */ (module)).version
+  } catch {}
+  versionCache.set(basedir, version)
+  return version
+}
+
+/**
+ * Applies the registered hook to a freshly evaluated CommonJS module's exports,
+ * in place. Called by the shim appended to instrumented CJS source.
+ *
+ * @param {unknown} moduleExports The module's evaluated `module.exports`.
+ * @param {string} filename Absolute resolved file path of the module.
+ * @returns {unknown} The (possibly wrapped) exports to assign back.
+ */
+function applyCjsHooks (moduleExports, filename) {
+  if (moduleExports && typeof moduleExports === 'object' && wrapped.has(moduleExports)) {
+    return moduleExports
+  }
+
+  const match = matchModule(filename)
+  if (!match) return moduleExports
+
+  const hooks = moduleHooks.get(match.packageName)
+  const version = resolveVersion(match.basedir)
+
+  let result = moduleExports
+  for (const hook of hooks) {
+    result = hook(result, match.moduleName, match.basedir, version, false) ?? result
+  }
+
+  if (result && typeof result === 'object') wrapped.add(result)
+  return result
+}
+
+/**
+ * Whether the package that owns `filename` has a registered hook. Lets the
+ * loader skip appending the shim to uninstrumented CJS modules.
+ *
+ * @param {string} filename Absolute resolved file path.
+ * @returns {boolean}
+ */
+function hasCjsHook (filename) {
+  return matchModule(filename) !== undefined
+}
+
+module.exports = { registerCjsHook, applyCjsHooks, hasCjsHook, moduleHooks }

--- a/packages/datadog-instrumentations/src/helpers/cjs-sync-hook.js
+++ b/packages/datadog-instrumentations/src/helpers/cjs-sync-hook.js
@@ -16,7 +16,7 @@
 // only active where the combined sync hook has taken over (see register.js).
 
 const path = require('path')
-const { builtinModules } = require('module')
+const { builtinModules, createRequire } = require('module')
 
 const parse = require('../../../../vendor/dist/module-details-from-path')
 const requirePackageJson = require('../../../dd-trace/src/require-package-json')
@@ -36,6 +36,9 @@ const wrapped = new WeakSet()
 
 /** @type {Map<string, string|undefined>} basedir -> resolved version. */
 const versionCache = new Map()
+
+/** @type {Map<string, string|undefined>} basedir -> resolved package main file, or undefined when unresolvable. */
+const mainCache = new Map()
 
 // process.getBuiltinModule lands in Node 22.3 / backported to 20.16; the sync
 // loader only owns CJS on Node ≥22.22.3, so it is always present there, but the
@@ -104,11 +107,36 @@ function matchModule (filename) {
   const hooks = moduleHooks.get(packageName)
   if (!hooks) return
 
-  // RITM keys file-specific hooks as `<name>/<relative path>`; the package main
-  // is matched against the integration's `file` (default 'index.js') inside the
-  // registered callback, so build the same moduleName here.
-  const moduleName = `${packageName}${path.sep}${path.relative(stat.basedir, filename)}`.replaceAll('\\', '/')
+  // Mirror RITM's moduleName: the bare package name for the main entry (which
+  // register.js matches against `filename(name, undefined)` === the bare name),
+  // and `<name>/<relative path>` only for module-internal files. Building
+  // `<name>/index.js` for the main made every package-main hook (no `file:`,
+  // e.g. router/mongoose/undici) miss and silently skip instrumentation.
+  const moduleName = isPackageMain(packageName, stat.basedir, filename)
+    ? packageName
+    : `${packageName}${path.sep}${path.relative(stat.basedir, filename)}`.replaceAll('\\', '/')
   return { packageName, moduleName, basedir: stat.basedir }
+}
+
+/**
+ * Whether `filename` is the resolved main entry of the package rooted at
+ * `basedir`. Resolved once per basedir (the main never changes for a loaded
+ * package) so the per-require path pays a Map read after the first lookup.
+ *
+ * @param {string} packageName
+ * @param {string} basedir
+ * @param {string} filename Absolute resolved file path of the loaded module.
+ * @returns {boolean}
+ */
+function isPackageMain (packageName, basedir, filename) {
+  let main = mainCache.get(basedir)
+  if (main === undefined && !mainCache.has(basedir)) {
+    try {
+      main = createRequire(path.join(basedir, 'package.json')).resolve(packageName)
+    } catch {}
+    mainCache.set(basedir, main)
+  }
+  return main === filename
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -7,6 +7,13 @@ const ritm = require('../../../dd-trace/src/ritm')
 const log = require('../../../dd-trace/src/log')
 const requirePackageJson = require('../../../dd-trace/src/require-package-json')
 
+// process.getBuiltinModule lands in Node 22.3 / backported to 20.16. The built-in
+// double-wrap it guards against only happens where the synchronous loader owns
+// CommonJS (Node >=22.22.3), so it is always present when the sync path runs.
+const getBuiltinModule =
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- guarded; only reached on Node >=22.22.3
+  typeof process.getBuiltinModule === 'function' ? process.getBuiltinModule : undefined
+
 /**
  * @param {string} moduleBaseDir
  * @returns {string|undefined}
@@ -74,6 +81,30 @@ function Hook (modules, hookOptions, onrequire) {
     } catch (error) {
       log.error('Error getting version for "%s": %s', moduleName, error.message, error)
       return
+    }
+
+    // A built-in (no base directory) is wrapped once on its shared singleton via
+    // process.getBuiltinModule() when the synchronous loader owns CommonJS. An ESM
+    // `import` of it then arrives here a second time with the namespace iitm built;
+    // re-running the hook would wrap the singleton's methods twice (firing the
+    // instrumentation twice per call and corrupting shims like http2's). Instead,
+    // copy the already-wrapped members from the singleton onto the namespace so
+    // named imports (`import { createHash }`) resolve to the wrapped function
+    // without a second wrap. Only reachable on Node that ships getBuiltinModule,
+    // which is exactly where the singleton wrap and this collision occur.
+    if (isIitm && !moduleBaseDir && this._patched[filename] && getBuiltinModule !== undefined) {
+      const singleton = getBuiltinModule(moduleName)
+      if (singleton !== undefined && singleton !== moduleExports) {
+        for (const key of Reflect.ownKeys(singleton)) {
+          if (key === 'default') continue
+          try {
+            if (moduleExports[key] !== singleton[key]) moduleExports[key] = singleton[key]
+          } catch {
+            // Read-only namespace binding; nothing to sync for this member.
+          }
+        }
+        return moduleExports
+      }
     }
 
     if (

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.js
@@ -5,10 +5,15 @@ const shimmer = require('../../../../datadog-shimmer')
 const { rewrite } = require('./')
 
 // When the synchronous loader owns CommonJS, it rewrites CJS source in the
-// `load` hook, so patching Module._compile here would double-rewrite. Only
-// install the _compile rewriter when the sync loader has not taken over.
-if (globalThis[Symbol.for('dd-trace:sync-loader-owns-cjs')] !== true) {
-  shimmer.wrap(Module.prototype, '_compile', compile => function (content, filename, format) {
-    return compile.call(this, rewrite(content, filename, format), filename, format)
-  })
-}
+// `load` hook, so rewriting here too would double-instrument. Node runs `-r`
+// preloads before `--import`, so this module can be evaluated before
+// register.js sets the ownership flag; checking it per compile (rather than
+// once at load) lets the entrypoint and every later module see the final
+// decision, since they all compile after `--import` has run.
+const ownsCjsSync = Symbol.for('dd-trace:sync-loader-owns-cjs')
+shimmer.wrap(Module.prototype, '_compile', compile => function (content, filename, format) {
+  if (globalThis[ownsCjsSync] === true) {
+    return compile.call(this, content, filename, format)
+  }
+  return compile.call(this, rewrite(content, filename, format), filename, format)
+})

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.js
@@ -4,6 +4,11 @@ const Module = require('module')
 const shimmer = require('../../../../datadog-shimmer')
 const { rewrite } = require('./')
 
-shimmer.wrap(Module.prototype, '_compile', compile => function (content, filename, format) {
-  return compile.call(this, rewrite(content, filename, format), filename, format)
-})
+// When the synchronous loader owns CommonJS, it rewrites CJS source in the
+// `load` hook, so patching Module._compile here would double-rewrite. Only
+// install the _compile rewriter when the sync loader has not taken over.
+if (globalThis[Symbol.for('dd-trace:sync-loader-owns-cjs')] !== true) {
+  shimmer.wrap(Module.prototype, '_compile', compile => function (content, filename, format) {
+    return compile.call(this, rewrite(content, filename, format), filename, format)
+  })
+}

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
@@ -4,6 +4,10 @@ import { fileURLToPath } from 'url'
 import { rewrite } from './index.js'
 
 const require = createRequire(import.meta.url)
+// Dependency telemetry and IAST security controls subscribe to this channel for
+// every loaded module. require-in-the-middle published it per require(); when the
+// synchronous loader owns CommonJS, this load hook is the equivalent chokepoint.
+const moduleLoadStartChannel = require('dc-polyfill').channel('dd-trace:moduleLoadStart')
 const cjsSyncHookPath = fileURLToPath(new URL('../cjs-sync-hook.js', import.meta.url))
 // Lazily loaded to keep this module importable in environments where the CJS
 // helper's dependencies are unavailable (e.g. some bundler graphs).
@@ -55,6 +59,10 @@ function rewriteResult (result, url, context, ownsCjs) {
   // CommonJS. When the synchronous loader does not own CJS, leave it to
   // Module._compile (rewrite) and RITM (export wrapping).
   if (!ownsCjs) return result
+
+  if (moduleLoadStartChannel.hasSubscribers && url.startsWith('file://')) {
+    moduleLoadStartChannel.publish({ filename: fileURLToPath(url) })
+  }
 
   if (result.source == null) return result
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
@@ -1,27 +1,107 @@
+import { createRequire } from 'module'
+import { fileURLToPath } from 'url'
+
 import { rewrite } from './index.js'
 
+const require = createRequire(import.meta.url)
+const cjsSyncHookPath = fileURLToPath(new URL('../cjs-sync-hook.js', import.meta.url))
+// Lazily loaded to keep this module importable in environments where the CJS
+// helper's dependencies are unavailable (e.g. some bundler graphs).
+let cjsSyncHook
+
+// The async loader (module.register, off-thread) cannot own CommonJS export
+// wrapping: require-in-the-middle does that on the main thread. So the async
+// path keeps rewriting ESM only. The synchronous loader runs on the main thread
+// and, when it has taken over from RITM, also handles CommonJS (rewrite +
+// export-wrapping shim) — see register.js. `ownsCjs` selects that.
 async function load (url, context, nextLoad) {
   const result = await nextLoad(url, context)
 
-  return rewriteResult(result, url, context)
+  return rewriteResult(result, url, context, false)
 }
 
 function loadSync (url, context, nextLoad) {
   const result = nextLoad(url, context)
 
-  return rewriteResult(result, url, context)
+  return rewriteResult(result, url, context, ownsCjsSync)
 }
 
-function rewriteResult (result, url, context) {
+let ownsCjsSync = false
+
+/**
+ * Marks the synchronous loader as the owner of CommonJS instrumentation, so it
+ * rewrites CJS source and appends the export-wrapping shim instead of leaving
+ * that to RITM + Module._compile. Eagerly loads the CJS helper here (outside the
+ * load hook) so the hook never has to `require()` mid-load, which would re-enter
+ * the loader on a not-yet-cached module.
+ *
+ * @param {boolean} value
+ * @returns {void}
+ */
+function setOwnsCjsSync (value) {
+  ownsCjsSync = value
+  if (value) cjsSyncHook = require(cjsSyncHookPath)
+}
+
+function rewriteResult (result, url, context, ownsCjs) {
   const format = result.format || context.format
+  const isCjs = format === 'commonjs' || (format === undefined && isRequireConditioned(context))
 
-  // CommonJS source is rewritten by Module._compile. Rewriting it here too
-  // double-instruments CommonJS entrypoints loaded through sync hooks.
-  if (format === 'commonjs') return result
+  if (!isCjs) {
+    result.source = rewrite(result.source, url, format)
+    return result
+  }
 
-  result.source = rewrite(result.source, url, format)
+  // CommonJS. When the synchronous loader does not own CJS, leave it to
+  // Module._compile (rewrite) and RITM (export wrapping).
+  if (!ownsCjs) return result
 
+  if (result.source == null) return result
+
+  let source = rewrite(result.source, url, 'commonjs')
+  source = appendCjsExportShim(source, url)
+
+  result.source = source
+  result.format = 'commonjs'
   return result
 }
 
-export { load, loadSync }
+function isRequireConditioned (context) {
+  const conditions = context.conditions
+  if (!conditions) return false
+  for (let i = 0; i < conditions.length; i++) {
+    if (conditions[i] === 'require') return true
+  }
+  return false
+}
+
+/**
+ * Appends the export-wrapping shim to an instrumented CommonJS module's source,
+ * but only when an `addHook` hook is registered for it. The shim runs after the
+ * module evaluates and wraps `module.exports` in place.
+ *
+ * @param {string} source
+ * @param {string} url
+ * @returns {string}
+ */
+function appendCjsExportShim (source, url) {
+  if (!cjsSyncHook) return source
+
+  let filename
+  try {
+    filename = fileURLToPath(url)
+  } catch {
+    return source
+  }
+
+  if (!cjsSyncHook.hasCjsHook(filename)) return source
+
+  const hookPath = JSON.stringify(cjsSyncHookPath)
+  const file = JSON.stringify(filename)
+  // Reuse the module's own require to load the helper; assign the wrapped result
+  // back to module.exports so callers see the instrumented object.
+  const shim = `\n;module.exports = require(${hookPath}).applyCjsHooks(module.exports, ${file});\n`
+  return source + shim
+}
+
+export { load, loadSync, setOwnsCjsSync }

--- a/packages/datadog-instrumentations/test/helpers/cjs-sync-hook.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/cjs-sync-hook.spec.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { mkdtempSync, mkdirSync, realpathSync, writeFileSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { dirname, join } = require('node:path')
+const { describe, it, beforeEach } = require('mocha')
+
+const { registerCjsHook, applyCjsHooks, moduleHooks } = require('../../src/helpers/cjs-sync-hook')
+const { filename } = require('../../src/helpers/register')
+
+// The sync-hook CJS path must hand the per-module callback the same moduleName
+// require-in-the-middle would. register.js matches a hook by comparing that name
+// against `filename(name, file)`, which is the *bare* package name when the hook
+// declares no `file:` (package-main hooks like `router`, `mongoose`, `undici`).
+// Building `<pkg>/index.js` for the main entry made every package-main hook miss.
+describe('cjs-sync-hook moduleName', () => {
+  /**
+   * Writes a throwaway installed package on disk so the test owns a real
+   * basedir, package.json `main`, and module-internal files without depending on
+   * a versioned fixture being installed. Pass `createMain: false` to leave the
+   * `main` entry missing (the "main can't be resolved" case).
+   *
+   * @param {string} name Package name.
+   * @param {{ main?: string, createMain?: boolean, files?: string[] }} [layout]
+   * @returns {{ basedir: string, main: string, file: (relative: string) => string }}
+   */
+  function installPackage (name, { main = 'index.js', createMain = true, files = [] } = {}) {
+    // realpathSync so paths match what createRequire().resolve() reports inside
+    // the hook — on macOS the OS temp dir is a /var -> /private/var symlink.
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'dd-cjs-sync-hook-')))
+    const basedir = join(root, 'node_modules', name)
+    mkdirSync(basedir, { recursive: true })
+    writeFileSync(join(basedir, 'package.json'), `{"version":"1.0.0","main":"${main}"}`)
+    const file = relative => {
+      const absolute = join(basedir, relative)
+      mkdirSync(dirname(absolute), { recursive: true })
+      writeFileSync(absolute, 'module.exports = {}\n')
+      return absolute
+    }
+    if (createMain) file(main)
+    for (const relative of files) file(relative)
+    moduleHooks.delete(name)
+    return { basedir, main: join(basedir, main), file }
+  }
+
+  beforeEach(() => {
+    moduleHooks.delete('mainpkg')
+    moduleHooks.delete('brokenmain')
+  })
+
+  it('passes the bare package name for the package main', () => {
+    const pkg = installPackage('mainpkg')
+    let received
+    registerCjsHook('mainpkg', (exports, name) => {
+      received = name
+      return exports
+    })
+
+    applyCjsHooks({}, pkg.main)
+
+    assert.strictEqual(received, 'mainpkg')
+    assert.strictEqual(received, filename('mainpkg', undefined))
+  })
+
+  it('passes <pkg>/<relative-path> for a module-internal file', () => {
+    const pkg = installPackage('mainpkg', { files: ['lib/internal.js'] })
+    let received
+    registerCjsHook('mainpkg', (exports, name) => {
+      received = name
+      return exports
+    })
+
+    applyCjsHooks({}, pkg.file('lib/internal.js'))
+
+    assert.strictEqual(received, 'mainpkg/lib/internal.js')
+    assert.strictEqual(received, filename('mainpkg', 'lib/internal.js'))
+  })
+
+  it('falls back to <pkg>/<relative-path> when the main entry cannot be resolved', () => {
+    // A package whose "main" points at a non-existent file makes the main
+    // resolution throw; the hook must still fire with the relative name rather
+    // than crash the require.
+    const pkg = installPackage('brokenmain', { main: 'does-not-exist.js', createMain: false })
+    let received
+    registerCjsHook('brokenmain', (exports, name) => {
+      received = name
+      return exports
+    })
+
+    applyCjsHooks({}, pkg.file('present.js'))
+
+    assert.strictEqual(received, 'brokenmain/present.js')
+  })
+})

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -121,6 +121,41 @@ describe('rewriter loader', () => {
     assert.strictEqual(result.stdout.trim(), '1')
   })
 
+  it('publishes dd-trace:moduleLoadStart for a required CommonJS module', function () {
+    if (!supportsSyncHooks()) {
+      this.skip()
+    }
+
+    // Dependency telemetry and IAST security controls rely on this channel for
+    // every loaded module; require-in-the-middle published it per require() and
+    // the synchronous loader took over that role.
+    const root = mkdtempSync(join(tmpdir(), 'dd-loader-moduleloadstart-'))
+    const packageDirectory = join(root, 'node_modules', 'left-pad')
+
+    mkdirSync(packageDirectory, { recursive: true })
+    writeFileSync(join(packageDirectory, 'package.json'), '{"version":"1.0.0","main":"index.js"}')
+    writeFileSync(join(packageDirectory, 'index.js'), 'module.exports = () => {}\n')
+    writeFileSync(join(root, 'main.js'), `
+      const channel = require(${JSON.stringify(join(repositoryRoot, 'node_modules', 'dc-polyfill'))})
+        .channel('dd-trace:moduleLoadStart')
+      let seen = false
+      channel.subscribe((payload) => {
+        if (payload && typeof payload.filename === 'string' && payload.filename.includes('left-pad')) seen = true
+      })
+      require('left-pad')
+      console.log(seen)
+    `)
+
+    const result = spawnSync(process.execPath, [join(root, 'main.js')], {
+      cwd: root,
+      env: { ...process.env, NODE_OPTIONS: `--import ${join(repositoryRoot, 'register.js')}` },
+      encoding: 'utf8',
+    })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), 'true', result.stderr)
+  })
+
   it('rewrites ESM modules loaded from CommonJS in the sync loader hook', function () {
     if (!supportsSyncHooks()) {
       this.skip()

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -154,6 +154,40 @@ describe('rewriter loader', () => {
     assert.strictEqual(result.status, 0, result.stderr)
     assert.strictEqual(result.stdout.trim(), '1')
   })
+
+  it('instruments a built-in imported via a named ESM import exactly once', function () {
+    if (!supportsSyncHooks()) {
+      this.skip()
+    }
+
+    // A built-in is wrapped once on its shared singleton via getBuiltinModule when
+    // the hook registers. `import { createHash } from 'node:crypto'` then reaches
+    // iitm with a namespace re-exporting that already-wrapped function; wrapping it
+    // again fires the instrumentation channel twice per call (the regression that
+    // corrupted http2's per-server emit shim).
+    const root = mkdtempSync(join(tmpdir(), 'dd-loader-builtin-named-import-'))
+    writeFileSync(join(root, 'app.mjs'), `
+      import { createHash } from 'node:crypto'
+      import { createRequire } from 'node:module'
+      const dc = createRequire(${JSON.stringify(join(repositoryRoot, 'index.js'))})('dc-polyfill')
+      let count = 0
+      dc.channel('datadog:crypto:hashing:start').subscribe(() => { count++ })
+      createHash('sha256')
+      console.log(count)
+    `)
+
+    const result = spawnSync(process.execPath, [join(root, 'app.mjs')], {
+      cwd: root,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import ${join(repositoryRoot, 'register.js')} --require ${join(repositoryRoot, 'init.js')}`,
+      },
+      encoding: 'utf8',
+    })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '1', result.stderr)
+  })
 })
 
 function createAiModuleUrl () {

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -78,6 +78,17 @@ function Hook (modules, options, onrequire) {
     }
   }
 
+  // When the synchronous loader owns CommonJS, forward the hook callbacks to the
+  // sync-hook registry and skip patching Module.prototype.require entirely — the
+  // sync `load` hook runs them via an appended shim, with no per-require tax.
+  if (globalThis[Symbol.for('dd-trace:sync-loader-owns-cjs')] === true) {
+    const { registerCjsHook } = require('../../datadog-instrumentations/src/helpers/cjs-sync-hook')
+    if (Array.isArray(modules)) {
+      for (const mod of modules) registerCjsHook(mod, onrequire)
+    }
+    return
+  }
+
   if (patchedRequire) return
 
   const _origRequire = Module.prototype.require

--- a/packages/dd-trace/src/supported-loader-hooks.js
+++ b/packages/dd-trace/src/supported-loader-hooks.js
@@ -1,0 +1,32 @@
+'use strict'
+
+// Single source of truth for "does this runtime support the synchronous loader
+// hooks that own both CommonJS and ESM instrumentation?". Required from CommonJS
+// (register.js, datadog-instrumentations/index.js) and from the ESM loader realm
+// (loader-hook.mjs, via createRequire), so it stays CommonJS and Node 12-safe.
+//
+// When this returns true, init.js registers the synchronous hooks on the main
+// thread and they handle every CommonJS and ESM load; the asynchronous loader
+// (module.register / --loader) must not also run, or it double-processes ESM and
+// silently drops the export-wrapping shim on CommonJS pulled into an ESM import.
+
+const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('../../../version')
+
+/**
+ * Whether the running Node.js version ships the synchronous loader hooks with the
+ * nullish-CommonJS-source fix (nodejs/node#59929). Electron is excluded: its
+ * built-ins live behind virtual `electron/js2c/*` paths with no file on disk, so
+ * import-in-the-middle's synchronous load hook throws ENOENT reading them.
+ *
+ * @returns {boolean}
+ */
+function syncLoaderHooksSupported () {
+  if (process.versions.electron !== undefined) return false
+  if (NODE_MAJOR >= 26) return true
+  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
+  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
+  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
+  return false
+}
+
+module.exports = { syncLoaderHooksSupported }

--- a/packages/dd-trace/test/register.spec.js
+++ b/packages/dd-trace/test/register.spec.js
@@ -5,12 +5,6 @@ const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
 require('./setup/core')
 
-const SUPPORTED_SYNC_HOOKS_NODE_VERSION = {
-  NODE_MAJOR: 24,
-  NODE_MINOR: 11,
-  NODE_PATCH: 1,
-}
-
 describe('register.js', () => {
   let emitWarning
 
@@ -31,11 +25,7 @@ describe('register.js', () => {
       register,
       registerSyncLoaderHooks,
       supportsSyncHooks,
-      version: {
-        NODE_MAJOR: 24,
-        NODE_MINOR: 11,
-        NODE_PATCH: 0,
-      },
+      syncLoaderHooksSupported: () => false,
     })
 
     sinon.assert.notCalled(registerSyncLoaderHooks)
@@ -153,11 +143,13 @@ function createThrowingLoaderHook (error) {
   })
 }
 
-function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, supportsSyncHooks, version }) {
+function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, supportsSyncHooks, syncLoaderHooksSupported }) {
   proxyquire('../../../register.js', {
     'node:module': { register },
     'import-in-the-middle/create-hook.mjs': { supportsSyncHooks },
     './loader-hook.mjs': loaderHook || { registerSyncLoaderHooks },
-    './version': version || SUPPORTED_SYNC_HOOKS_NODE_VERSION,
+    './packages/dd-trace/src/supported-loader-hooks': {
+      syncLoaderHooksSupported: syncLoaderHooksSupported || (() => true),
+    },
   })
 }

--- a/packages/dd-trace/test/supported-loader-hooks.spec.js
+++ b/packages/dd-trace/test/supported-loader-hooks.spec.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { afterEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+require('./setup/core')
+
+/**
+ * Loads supported-loader-hooks with a stubbed `version` module so each Node major's
+ * threshold can be checked at its boundary without running on that Node.
+ *
+ * @param {{ NODE_MAJOR: number, NODE_MINOR: number, NODE_PATCH: number }} version
+ * @returns {boolean}
+ */
+function supportedFor (version) {
+  const { syncLoaderHooksSupported } = proxyquire('../src/supported-loader-hooks', {
+    '../../../version': version,
+  })
+  return syncLoaderHooksSupported()
+}
+
+describe('syncLoaderHooksSupported', () => {
+  let originalElectron
+
+  afterEach(() => {
+    if (originalElectron === undefined) {
+      delete process.versions.electron
+    } else {
+      process.versions.electron = originalElectron
+    }
+    originalElectron = undefined
+  })
+
+  it('is supported on Node 26 and later', () => {
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 26, NODE_MINOR: 0, NODE_PATCH: 0 }), true)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 27, NODE_MINOR: 0, NODE_PATCH: 0 }), true)
+  })
+
+  it('is supported on Node 25 only from 25.1.0', () => {
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 25, NODE_MINOR: 0, NODE_PATCH: 9 }), false)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 25, NODE_MINOR: 1, NODE_PATCH: 0 }), true)
+  })
+
+  it('is supported on Node 24 only from 24.11.1', () => {
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 0 }), false)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 }), true)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 24, NODE_MINOR: 12, NODE_PATCH: 0 }), true)
+  })
+
+  it('is supported on Node 22 only from 22.22.3', () => {
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 22, NODE_MINOR: 22, NODE_PATCH: 2 }), false)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 22, NODE_MINOR: 22, NODE_PATCH: 3 }), true)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 22, NODE_MINOR: 23, NODE_PATCH: 0 }), true)
+  })
+
+  it('is not supported on Node 23 or older majors below the floor', () => {
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 23, NODE_MINOR: 9, NODE_PATCH: 0 }), false)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 21, NODE_MINOR: 0, NODE_PATCH: 0 }), false)
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 18, NODE_MINOR: 0, NODE_PATCH: 0 }), false)
+  })
+
+  it('is never supported under Electron, even on a supported Node version', () => {
+    originalElectron = process.versions.electron
+    process.versions.electron = '30.0.0'
+    assert.strictEqual(supportedFor({ NODE_MAJOR: 26, NODE_MINOR: 0, NODE_PATCH: 0 }), false)
+  })
+})

--- a/register.js
+++ b/register.js
@@ -4,7 +4,7 @@
 
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
-const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('./version')
+const { syncLoaderHooksSupported } = require('./packages/dd-trace/src/supported-loader-hooks')
 
 const parentURL = pathToFileURL(__filename)
 
@@ -39,7 +39,7 @@ if (!isSyncLoaderRegistered) {
 globalThis[Symbol.for('dd-trace:loader-hooks-registered')] = true
 
 function shouldRegisterSyncLoaderHooks () {
-  if (!isSyncLoaderHookVersionSupported()) {
+  if (!syncLoaderHooksSupported()) {
     return false
   }
 
@@ -51,14 +51,6 @@ function shouldRegisterSyncLoaderHooks () {
     }
   }
 
-  return false
-}
-
-function isSyncLoaderHookVersionSupported () {
-  if (NODE_MAJOR >= 26) return true
-  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
-  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
-  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
   return false
 }
 


### PR DESCRIPTION
Stacked on #9116.

## Summary

require-in-the-middle patches `Module.prototype.require`, so its filename resolve + hook-table check run on **every** `require()` call for the whole process life — including cache hits. That per-call tax is the dominant tracer module-loading cost.

On Node versions with working synchronous loader hooks (`>=22.22.3 / 24.11.1 / 25.1 / 26`), the registered `load` hook already fires for `require()`, `require(esm)` and `import`, and Node bypasses it on a cache hit. This routes CommonJS through that hook too and disables RITM + the `Module._compile` rewriter on those versions (kept as the fallback below the gate):

1. The `load` hook rewrites CJS source for orchestrion targets (the `_compile` rewrite, moved here) and appends a shim that wraps a module's evaluated exports **in place** — native, mutable object, no ESM namespace proxy, so `Object.defineProperty(require('fs'), …)` and `class X extends require('events')` keep working.
2. Builtins have no source for a shim, but they are singletons: their live exports are wrapped once at registration (`process.getBuiltinModule`), at zero per-require cost.

## Measured (Node 22.22.3, full dd-trace init, big dependency graph)

Cache-hit `require('lodash')`, 500k iters × 3 trials:

- RITM (baseline): **~1500 ns/call**
- Sync hook, RITM off: **~142 ns/call** — **~10.5x**, the per-require tax removed.

## Behaviour preservation (A/B, RITM on vs off, same Node)

Identical pass counts:

- Builtins: `http` 26, `child_process` 92, `crypto` 22, `fs` 2, `zlib` 24, `url` 18.
- Packages: `graphql` plugin 79 (exercises the orchestrion CJS rewrite path **and** export wrapping).

## Scope / open items (draft)

- This inlines the CJS-export-wrapping behaviour that belongs upstream in import-in-the-middle (in-place CJS wrapping under sync hooks). The intent is to prove it for dd-trace, then upstream it; the dd-trace side becomes a thin switch once iitm ships it.
- Append-after-eval shim: sufficient for builtins (eager singleton) and every package tested. A package that shares an internal export captured *mid-load* by a sibling, or whose hook returns a *replacement* object, is the theoretical edge to watch — the upstream version should wrap at export-definition sites (in-eval timing) to remove that class entirely.
- Needs the full plugin matrix on supported Node before un-drafting. The Node-22.22.3 CI image has some unrelated pre-existing express test failures (reproduced on the base branch without these changes) that must be separated from this diff.
- Builtins now load their integration file eagerly at startup (12 modules); quantify the startup cost vs. the per-require win.

Refs: https://github.com/nodejs/import-in-the-middle