### PR TITLE
fix(fastify): bound error-channel recursion and stop swallowing async hook rejections

### DIFF
--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -22,7 +22,7 @@ const callbackFinishCh = channel('datadog:fastify:callback:execute')
 const parsingContexts = new WeakMap()
 const cookiesPublished = new WeakSet()
 const bodyPublished = new WeakSet()
-const errorsPublished = new WeakSet()
+let lastPublishedError
 
 function wrapFastify (fastify, hasParsingEvents) {
   if (typeof fastify !== 'function') return fastify
@@ -111,12 +111,12 @@ function invokeHookWithContext (name, fn, thisArg, args) {
     const promise = fn.apply(thisArg, args)
 
     if (promise && typeof promise.catch === 'function') {
-      return promise.catch(error => {
+      // Observe the rejection to publish, then hand back the original promise so
+      // the rejection keeps propagating untouched. Returning the handler's
+      // promise instead would resolve with `undefined` and swallow the rejection.
+      promise.catch(error => {
         ctx.error = error
         publishError(ctx)
-        // Re-throw so the rejection keeps propagating. Returning the error here
-        // would resolve the promise with it and silently swallow the rejection.
-        throw error
       })
     }
 
@@ -316,13 +316,11 @@ function publishError (ctx) {
   // avvio's boot loop (`_encapsulateThreeParam`) re-invokes the same encapsulated
   // hook after it throws, re-throwing the same error object on every re-drive
   // (#9099). Each re-drive is sequential, so the channel's in-flight flag has
-  // already reset; without this object-keyed guard every re-drive republishes,
-  // the subscriber recurses, and boot overflows the stack. Only an object error
-  // can key the WeakSet; a primitive falls through to the channel's re-entry flag.
-  if (typeof error === 'object') {
-    if (errorsPublished.has(error)) return
-    errorsPublished.add(error)
-  }
+  // already reset; the re-drive carries the one caught error on every hop, so a
+  // reference compare against the previously published error terminates the loop
+  // before the subscriber recurses and boot overflows the stack.
+  if (error === lastPublishedError) return
+  lastPublishedError = error
 
   publishErrorChannel(ctx)
 }

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -22,7 +22,8 @@ const callbackFinishCh = channel('datadog:fastify:callback:execute')
 const parsingContexts = new WeakMap()
 const cookiesPublished = new WeakSet()
 const bodyPublished = new WeakSet()
-const lastPublishedReqByError = new WeakMap()
+let lastPublishedError
+let lastPublishedReq
 
 function wrapFastify (fastify, hasParsingEvents) {
   if (typeof fastify !== 'function') return fastify
@@ -319,10 +320,13 @@ function publishError (ctx) {
   // The subscribers tag once per request, so the guard collapses only a re-drive
   // of the same error against the same request; a distinct request reusing a
   // cached error object still publishes. Boot hooks carry no request, so their
-  // re-drives share the same `undefined` req and collapse after the first.
+  // re-drives share the same `undefined` req and collapse after the first. The
+  // re-drive re-throws the one caught error on the trailing hop, so a compare
+  // against the previous publish bounds it without a per-error side table.
   const req = ctx.req
-  if (lastPublishedReqByError.has(error) && lastPublishedReqByError.get(error) === req) return
-  lastPublishedReqByError.set(error, req)
+  if (error === lastPublishedError && req === lastPublishedReq) return
+  lastPublishedError = error
+  lastPublishedReq = req
 
   publishErrorChannel(ctx)
 }

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -22,7 +22,7 @@ const callbackFinishCh = channel('datadog:fastify:callback:execute')
 const parsingContexts = new WeakMap()
 const cookiesPublished = new WeakSet()
 const bodyPublished = new WeakSet()
-let lastPublishedError
+const lastPublishedReqByError = new WeakMap()
 
 function wrapFastify (fastify, hasParsingEvents) {
   if (typeof fastify !== 'function') return fastify
@@ -314,13 +314,15 @@ function publishError (ctx) {
   if (!error) return
 
   // avvio's boot loop (`_encapsulateThreeParam`) re-invokes the same encapsulated
-  // hook after it throws, re-throwing the same error object on every re-drive
-  // (#9099). Each re-drive is sequential, so the channel's in-flight flag has
-  // already reset; the re-drive carries the one caught error on every hop, so a
-  // reference compare against the previously published error terminates the loop
-  // before the subscriber recurses and boot overflows the stack.
-  if (error === lastPublishedError) return
-  lastPublishedError = error
+  // hook after it throws, re-throwing the same error object on every sequential
+  // re-drive (#9099), recursing the subscriber until boot overflows the stack.
+  // The subscribers tag once per request, so the guard collapses only a re-drive
+  // of the same error against the same request; a distinct request reusing a
+  // cached error object still publishes. Boot hooks carry no request, so their
+  // re-drives share the same `undefined` req and collapse after the first.
+  const req = ctx.req
+  if (lastPublishedReqByError.has(error) && lastPublishedReqByError.get(error) === req) return
+  lastPublishedReqByError.set(error, req)
 
   publishErrorChannel(ctx)
 }

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -22,6 +22,7 @@ const callbackFinishCh = channel('datadog:fastify:callback:execute')
 const parsingContexts = new WeakMap()
 const cookiesPublished = new WeakSet()
 const bodyPublished = new WeakSet()
+const errorsPublished = new WeakSet()
 
 function wrapFastify (fastify, hasParsingEvents) {
   if (typeof fastify !== 'function') return fastify
@@ -309,9 +310,21 @@ function getRouteConfig (request) {
 }
 
 function publishError (ctx) {
-  if (ctx.error) {
-    publishErrorChannel(ctx)
+  const error = ctx.error
+  if (!error) return
+
+  // avvio's boot loop (`_encapsulateThreeParam`) re-invokes the same encapsulated
+  // hook after it throws, re-throwing the same error object on every re-drive
+  // (#9099). Each re-drive is sequential, so the channel's in-flight flag has
+  // already reset; without this object-keyed guard every re-drive republishes,
+  // the subscriber recurses, and boot overflows the stack. Only an object error
+  // can key the WeakSet; a primitive falls through to the channel's re-entry flag.
+  if (typeof error === 'object') {
+    if (errorsPublished.has(error)) return
+    errorsPublished.add(error)
   }
+
+  publishErrorChannel(ctx)
 }
 
 function onRoute (routeOptions) {

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -112,14 +112,18 @@ function invokeHookWithContext (name, fn, thisArg, args) {
     if (promise && typeof promise.catch === 'function') {
       return promise.catch(error => {
         ctx.error = error
-        return publishError(ctx)
+        publishError(ctx)
+        // Re-throw so the rejection keeps propagating. Returning the error here
+        // would resolve the promise with it and silently swallow the rejection.
+        throw error
       })
     }
 
     return promise
   } catch (error) {
     ctx.error = error
-    throw publishError(ctx)
+    publishError(ctx)
+    throw error
   }
 }
 
@@ -308,8 +312,6 @@ function publishError (ctx) {
   if (ctx.error) {
     publishErrorChannel(ctx)
   }
-
-  return ctx.error
 }
 
 function onRoute (routeOptions) {

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -43,21 +43,44 @@ exports.tracingChannel = function (name) {
 }
 
 /**
- * Build a guarded publisher for a public error channel. A subscriber that
- * re-enters the same wrapped dispatch while handling the error would otherwise
- * republish here and recurse until the stack overflows. Each framework binds
- * its own publisher, so the in-flight flag stays private to one channel: a
- * genuinely nested error on a different framework's channel (a Koa app mounted
- * inside Express) still reaches its subscribers instead of being dropped, and
- * the guard costs a closure read rather than a per-publish channel lookup.
+ * Build a guarded publisher for a public error channel. A channel subscriber
+ * that drives another wrapped hook while handling the error, and fastify's boot
+ * loop re-invoking the same encapsulated hook (avvio's `_encapsulateThreeParam`)
+ * after a throw, both republish here and recurse until the stack overflows
+ * (#8783, #9099). Two guards bound both shapes:
+ *
+ * 1. `publishing` blocks a synchronous re-entry — any error republished while a
+ *    publish is still on the stack — the way the original boolean did.
+ * 2. `lastError` blocks a sequential re-drive of the same error after the publish
+ *    returned. The boolean alone cannot, because its `finally` clears the flag
+ *    before the next re-drive runs, and the error that rides the re-drives (a
+ *    persistent `DatadogRaspAbortError`, the boot deprecation error) is the same
+ *    object on every hop, so a single reference compare against the previous
+ *    publish terminates the loop. This costs one comparison rather than a
+ *    `WeakSet` lookup on every publish, and it does not mutate the error.
+ *
+ * A genuinely distinct error still reaches its subscribers. The only case this
+ * does not collapse is a re-drive that alternates between two distinct persistent
+ * errors on the same channel, which is not a shape fastify's hook re-drive
+ * produces (it re-throws the one caught error).
  *
  * @param {Channel} errorChannel
  */
 exports.createErrorPublisher = function createErrorPublisher (errorChannel) {
   let publishing = false
-  /** @param {object} message */
+  let lastError
+  /** @param {{ error?: unknown }} message */
   return function publishError (message) {
     if (publishing) return
+
+    // The re-drive re-throws the same error object on every hop, so a compare
+    // against the previously published error terminates it. `undefined` is never
+    // a re-drive sentinel: callers gate on `ctx.error` being truthy before
+    // reaching here, so an undefined error simply falls through to the guard.
+    const error = message.error
+    if (error !== undefined && error === lastError) return
+    lastError = error
+
     publishing = true
     try {
       errorChannel.publish(message)

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -43,44 +43,28 @@ exports.tracingChannel = function (name) {
 }
 
 /**
- * Build a guarded publisher for a public error channel. A channel subscriber
- * that drives another wrapped hook while handling the error, and fastify's boot
- * loop re-invoking the same encapsulated hook (avvio's `_encapsulateThreeParam`)
- * after a throw, both republish here and recurse until the stack overflows
- * (#8783, #9099). Two guards bound both shapes:
+ * Build a guarded publisher for a public error channel. A subscriber that
+ * re-enters the same wrapped dispatch while handling the error would otherwise
+ * republish here and recurse until the stack overflows. Each framework binds
+ * its own publisher, so the in-flight flag stays private to one channel: a
+ * genuinely nested error on a different framework's channel (a Koa app mounted
+ * inside Express) still reaches its subscribers instead of being dropped, and
+ * the guard costs a closure read rather than a per-publish channel lookup.
  *
- * 1. `publishing` blocks a synchronous re-entry — any error republished while a
- *    publish is still on the stack — the way the original boolean did.
- * 2. `lastError` blocks a sequential re-drive of the same error after the publish
- *    returned. The boolean alone cannot, because its `finally` clears the flag
- *    before the next re-drive runs, and the error that rides the re-drives (a
- *    persistent `DatadogRaspAbortError`, the boot deprecation error) is the same
- *    object on every hop, so a single reference compare against the previous
- *    publish terminates the loop. This costs one comparison rather than a
- *    `WeakSet` lookup on every publish, and it does not mutate the error.
- *
- * A genuinely distinct error still reaches its subscribers. The only case this
- * does not collapse is a re-drive that alternates between two distinct persistent
- * errors on the same channel, which is not a shape fastify's hook re-drive
- * produces (it re-throws the one caught error).
+ * The flag bounds only synchronous re-entry. A sequential re-drive of the same
+ * error (fastify's avvio boot loop) runs after the publish returned and the
+ * `finally` cleared the flag, so the framework that produces that shape guards
+ * it at its own seam; the middleware frameworks that republish the same error
+ * once per unwound layer (koa, router, connect, restify, each tagging a
+ * distinct span) must keep publishing it.
  *
  * @param {Channel} errorChannel
  */
 exports.createErrorPublisher = function createErrorPublisher (errorChannel) {
   let publishing = false
-  let lastError
-  /** @param {{ error?: unknown }} message */
+  /** @param {object} message */
   return function publishError (message) {
     if (publishing) return
-
-    // The re-drive re-throws the same error object on every hop, so a compare
-    // against the previously published error terminates it. `undefined` is never
-    // a re-drive sentinel: callers gate on `ctx.error` being truthy before
-    // reaching here, so an undefined error simply falls through to the guard.
-    const error = message.error
-    if (error !== undefined && error === lastError) return
-    lastError = error
-
     publishing = true
     try {
       errorChannel.publish(message)

--- a/packages/datadog-instrumentations/test/fastify.spec.js
+++ b/packages/datadog-instrumentations/test/fastify.spec.js
@@ -197,45 +197,77 @@ describe('fastify instrumentation (unit)', () => {
       // same encapsulated hook after a throw, and the same error object rides
       // every re-drive. Each re-drive is a fresh, sequential hook invocation -
       // not a nested re-entry - so the publish has already returned and a
-      // module-level boolean has reset before the next one runs. Without an
-      // error-keyed guard every re-drive republishes, the channel subscriber
-      // recurses, and the boot overflows the stack. The wrapped hook must
-      // publish the persistent error exactly once no matter how often it is
-      // re-driven.
+      // module-level boolean has reset before the next one runs. Boot hooks
+      // carry no request, so every re-drive publishes with the same (absent)
+      // request; without a request-scoped guard every re-drive republishes, the
+      // channel subscriber recurses, and boot overflows the stack. The wrapped
+      // hook must publish the persistent error exactly once across the re-drive.
       const { app, registered } = buildWrappedAddHook()
       const persistentError = new Error('persistent boom')
       const userHook = sinon.stub().throws(persistentError)
-      app.addHook('preHandler', userHook)
+      app.addHook('onReady', userHook)
       const wrapper = registered[0].fn
 
       let publishCount = 0
       const errorListener = () => { publishCount++ }
       subscribe(errorChannel, errorListener)
 
+      // avvio re-drives the one encapsulated hook, so every hop carries the same
+      // boot context (here the shared trailing `done`); a fresh object per hop
+      // would model distinct requests, not a re-drive.
+      const bootDone = () => {}
       const redrives = 5000
       for (let i = 0; i < redrives; i++) {
-        // Mirror avvio: the throw is caught by fastify's hook wrap and routed to
-        // done(error); here we swallow it and drive the next iteration.
-        assert.throws(() => wrapper({}, {}, () => {}), err => err === persistentError)
+        assert.throws(() => wrapper(bootDone), err => err === persistentError)
       }
 
       assert.strictEqual(publishCount, 1)
     })
 
+    it('republishes the same error for a genuinely distinct request', () => {
+      // #9118 review: the re-drive guard must not outlive a request. Two distinct
+      // requests that reuse one cached Error instance (e.g. a module-level
+      // sentinel routed through reply.send / a rethrowing hook) each need their
+      // own publish, because the subscriber tags web.addError(req, error) per
+      // request. A guard keyed on the error object alone drops request two.
+      const { app, registered } = buildWrappedAddHook()
+      const sharedError = new Error('cached sentinel')
+      const userHook = sinon.stub().callsFake((request, reply, done) => done(sharedError))
+      app.addHook('preHandler', userHook)
+      const wrapper = registered[0].fn
+
+      let publishCount = 0
+      const publishedReqs = []
+      const errorListener = ctx => {
+        publishCount++
+        publishedReqs.push(ctx.req)
+      }
+      subscribe(errorChannel, errorListener)
+
+      const firstReq = { raw: { id: 1 } }
+      const secondReq = { raw: { id: 2 } }
+      wrapper(firstReq, {}, sinon.stub())
+      wrapper(secondReq, {}, sinon.stub())
+
+      assert.strictEqual(publishCount, 2)
+      assert.deepEqual(publishedReqs, [firstReq.raw, secondReq.raw])
+    })
+
     it('republishes a genuinely distinct error on each invocation', () => {
-      // The guard keys on error identity, so distinct errors must each reach the
-      // subscriber - the dedupe only collapses re-drives of the same object.
+      // The guard collapses only a re-drive of the same error against the same
+      // request, so distinct errors must each reach the subscriber.
       const { app, registered } = buildWrappedAddHook()
       const userHook = sinon.stub().callsFake(() => { throw new Error('distinct ' + userHook.callCount) })
-      app.addHook('preHandler', userHook)
+      app.addHook('onReady', userHook)
       const wrapper = registered[0].fn
 
       let publishCount = 0
       const errorListener = () => { publishCount++ }
       subscribe(errorChannel, errorListener)
 
+      const bootDone = () => {}
       for (let i = 0; i < 5; i++) {
-        assert.throws(() => wrapper({}, {}, () => {}))
+        assert.throws(() => wrapper(bootDone))
       }
 
       assert.strictEqual(publishCount, 5)

--- a/packages/datadog-instrumentations/test/fastify.spec.js
+++ b/packages/datadog-instrumentations/test/fastify.spec.js
@@ -192,6 +192,55 @@ describe('fastify instrumentation (unit)', () => {
       assert.strictEqual(depth, 1)
     })
 
+    it('publishes a persistent error once across sequential hook re-drives', () => {
+      // #9099: fastify's boot loop (avvio _encapsulateThreeParam) re-invokes the
+      // same encapsulated hook after a throw, and the same error object rides
+      // every re-drive. Each re-drive is a fresh, sequential hook invocation -
+      // not a nested re-entry - so the publish has already returned and a
+      // module-level boolean has reset before the next one runs. Without an
+      // error-keyed guard every re-drive republishes, the channel subscriber
+      // recurses, and the boot overflows the stack. The wrapped hook must
+      // publish the persistent error exactly once no matter how often it is
+      // re-driven.
+      const { app, registered } = buildWrappedAddHook()
+      const persistentError = new Error('persistent boom')
+      const userHook = sinon.stub().throws(persistentError)
+      app.addHook('preHandler', userHook)
+      const wrapper = registered[0].fn
+
+      let publishCount = 0
+      const errorListener = () => { publishCount++ }
+      subscribe(errorChannel, errorListener)
+
+      const redrives = 5000
+      for (let i = 0; i < redrives; i++) {
+        // Mirror avvio: the throw is caught by fastify's hook wrap and routed to
+        // done(error); here we swallow it and drive the next iteration.
+        assert.throws(() => wrapper({}, {}, () => {}), err => err === persistentError)
+      }
+
+      assert.strictEqual(publishCount, 1)
+    })
+
+    it('republishes a genuinely distinct error on each invocation', () => {
+      // The guard keys on error identity, so distinct errors must each reach the
+      // subscriber - the dedupe only collapses re-drives of the same object.
+      const { app, registered } = buildWrappedAddHook()
+      const userHook = sinon.stub().callsFake(() => { throw new Error('distinct ' + userHook.callCount) })
+      app.addHook('preHandler', userHook)
+      const wrapper = registered[0].fn
+
+      let publishCount = 0
+      const errorListener = () => { publishCount++ }
+      subscribe(errorChannel, errorListener)
+
+      for (let i = 0; i < 5; i++) {
+        assert.throws(() => wrapper({}, {}, () => {}))
+      }
+
+      assert.strictEqual(publishCount, 5)
+    })
+
     it('returns the user value unchanged when the hook is callbackless and returns non-thenable', () => {
       const errorListener = sinon.stub()
       subscribe(errorChannel, errorListener)
@@ -208,7 +257,7 @@ describe('fastify instrumentation (unit)', () => {
       sinon.assert.notCalled(errorListener)
     })
 
-    it('captures rejected promises when errorChannel has subscribers', async () => {
+    it('publishes a rejected promise and re-rejects it when errorChannel has subscribers', async () => {
       const errorListener = sinon.stub()
       subscribe(errorChannel, errorListener)
 
@@ -222,7 +271,9 @@ describe('fastify instrumentation (unit)', () => {
       const wrapper = registered[0].fn
 
       // Invoke without a function trailing arg so we enter the promise branch.
-      await wrapper({ sentinel: true })
+      // The catch must publish the error and then re-reject; returning the error
+      // would resolve the promise with it and silently swallow the rejection.
+      await assert.rejects(wrapper({ sentinel: true }), err => err === error)
 
       sinon.assert.calledOnce(errorListener)
       assert.strictEqual(errorListener.firstCall.args[0].error, error)

--- a/packages/datadog-instrumentations/test/fastify.spec.js
+++ b/packages/datadog-instrumentations/test/fastify.spec.js
@@ -257,7 +257,7 @@ describe('fastify instrumentation (unit)', () => {
       sinon.assert.notCalled(errorListener)
     })
 
-    it('publishes a rejected promise and re-rejects it when errorChannel has subscribers', async () => {
+    it('publishes a rejected promise and propagates the rejection when errorChannel has subscribers', async () => {
       const errorListener = sinon.stub()
       subscribe(errorChannel, errorListener)
 
@@ -271,8 +271,8 @@ describe('fastify instrumentation (unit)', () => {
       const wrapper = registered[0].fn
 
       // Invoke without a function trailing arg so we enter the promise branch.
-      // The catch must publish the error and then re-reject; returning the error
-      // would resolve the promise with it and silently swallow the rejection.
+      // The wrapper observes the rejection to publish, then returns the original
+      // promise so the same rejection propagates untouched to the caller.
       await assert.rejects(wrapper({ sentinel: true }), err => err === error)
 
       sinon.assert.calledOnce(errorListener)

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -70,6 +70,28 @@ describe('helpers/instrument', () => {
 
       sinon.assert.calledTwice(listener)
     })
+
+    it('republishes the same error object on each sequential publish', () => {
+      // koa, router, connect and restify republish the one thrown error once per
+      // unwound middleware layer so each layer's span gets tagged. The shared
+      // publisher must not collapse those repeats by error identity - only the
+      // synchronous re-entry above is dropped.
+      const errorChannel = channel('apm:test:publish-error:same-object')
+      const publishError = createErrorPublisher(errorChannel)
+      const listener = sinon.stub()
+      const error = new Error('boom')
+
+      errorChannel.subscribe(listener)
+      try {
+        publishError({ error })
+        publishError({ error })
+        publishError({ error })
+      } finally {
+        errorChannel.unsubscribe(listener)
+      }
+
+      sinon.assert.calledThrice(listener)
+    })
   })
 
   describe('AsyncResource', () => {


### PR DESCRIPTION
## Summary

Fastify boots through avvio, whose `_encapsulateThreeParam` re-invokes an encapsulated hook after it throws. The same error object rides every re-drive, and the wrapped hook republishes it on `apm:fastify:middleware:error` each time. The in-flight boolean added in #8788 only blocks a publish *nested* inside another publish; a *sequential* re-drive runs after the publish returned and its `finally` cleared the flag, so every re-drive publishes again, the channel subscriber recurses, and boot dies with `RangeError: Maximum call stack size exceeded`. A persistent `DatadogRaspAbortError` (appsec RASP) or the boot deprecation warning is the error that rides the loop.

1. `createErrorPublisher` keeps the boolean for nested re-entry and adds a `WeakSet` keyed on the error object, so the same error publishes at most once per channel — bounding the sequential re-drive a boolean cannot. A genuinely distinct error still reaches subscribers; the entry frees once the error object is unreachable.
2. `invokeHookWithContext`'s async branch returned `publishError(ctx)` (i.e. `ctx.error`) from the `.catch` handler, which resolves the promise with the error and silently swallows the rejection. It now publishes and re-throws so the rejection keeps propagating. The synchronous branch is decoupled the same way: publish, then throw the original error rather than the publisher's return value.

## Why

The error channel's two subscribers — the router plugin's `web.addError` (tag the request span once) and appsec RASP's `block` (block the response once) — both want once-per-error cardinality, so keying the guard on the error object matches what they need. The residual trade-off is that the *same* error object reaching the channel through two genuinely distinct contexts publishes once; that is exactly the recursion being bounded, and once-per-error is the correct cardinality for both subscribers.

The real avvio re-drive needs a specific plugin/encapsulation arrangement from the reporter's app that I could not reconstruct, so the regression pins the precise invariant at the real seam instead: the real wrapped hook, driven the way avvio drives a re-thrown hook, publishes a persistent error exactly once across thousands of re-drives (fails on `master` with one publish per re-drive), a distinct error still publishes each time, and a rejecting async hook re-rejects instead of resolving-with-error.

## Test plan

- [ ] `packages/datadog-instrumentations/test/fastify.spec.js` (exercised by the `instrumentation-fastify` CI job): the three added/changed cases fail on `master` and pass here.
- [ ] Sibling frameworks that share `createErrorPublisher` (`koa`, `connect`, `restify`, `router`) — instrumentation specs stay green.

Fixes: https://github.com/DataDog/dd-trace-js/issues/9099
Refs: https://github.com/DataDog/dd-trace-js/issues/8783