### PR TITLE
fix(datastreams): flush on write when flushInterval is 0

### DIFF
--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -235,7 +235,11 @@ class DataStreamsProcessor {
     this._schemaSamplers = {}
     this._checkpointRegistry = new CheckpointRegistry()
 
-    if (this.enabled) {
+    // `flushInterval === 0` is the "flush on write" sentinel the trace exporter already honors
+    // (agent exporter `export()`); a background timer of `0` would instead fire on every event-loop
+    // tick, decoupled from when checkpoints are recorded, and a single tick landing while the agent
+    // is unreachable drops the bucket for good (it is cleared on serialize). Push on record instead.
+    if (this.enabled && flushInterval !== 0) {
       this.timer = setInterval(this.onInterval.bind(this), flushInterval)
       this.timer.unref?.()
     }
@@ -282,6 +286,7 @@ class DataStreamsProcessor {
       // StatsPoint already converted the 8-byte Buffer hash to a uint64 BigInt.
       span.setTag(PATHWAY_HASH, statsPoint.hash.toString())
     }
+    if (this.flushInterval === 0) this.onInterval()
   }
 
   setCheckpoint (edgeTags, span, ctx, payloadSize = 0) {
@@ -356,8 +361,9 @@ class DataStreamsProcessor {
 
   recordOffset ({ timestamp, ...backlogData }) {
     if (!this.enabled) return
-    return this.bucketFromTimestamp(timestamp)
-      .forBacklog(backlogData)
+    const backlog = this.bucketFromTimestamp(timestamp).forBacklog(backlogData)
+    if (this.flushInterval === 0) this.onInterval()
+    return backlog
   }
 
   setOffset (offsetObj) {
@@ -400,6 +406,8 @@ class DataStreamsProcessor {
 
     // Number() cast is safe here: 10s bucket granularity tolerates ~0.5ns precision loss
     this.bucketFromTimestamp(Number(timestampNs)).addTransaction(entry)
+
+    if (this.flushInterval === 0) this.onInterval()
 
     if (span) {
       span.setTag(DSM_TRANSACTION_ID, transactionId)

--- a/packages/dd-trace/test/datastreams/flush_on_write.spec.js
+++ b/packages/dd-trace/test/datastreams/flush_on_write.spec.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+require('../setup/core')
+
+const writer = {
+  flush: sinon.stub(),
+}
+const DataStreamsWriter = sinon.stub().returns(writer)
+const { DataStreamsProcessor } = proxyquire('../../src/datastreams/processor', {
+  './writer': { DataStreamsWriter },
+})
+
+const DEFAULT_TIMESTAMP = Number(new Date('2023-04-20T16:20:00.000Z'))
+
+const baseConfig = {
+  dsmEnabled: true,
+  hostname: '127.0.0.1',
+  port: 8126,
+  url: new URL('http://127.0.0.1:8126'),
+  env: 'test',
+  version: 'v1',
+  service: 'service1',
+  tags: { foo: 'foovalue', bar: 'barvalue' },
+}
+
+const checkpoint = {
+  currentTimestamp: DEFAULT_TIMESTAMP,
+  hash: Buffer.from('e858212fd11a41e5', 'hex'),
+  parentHash: Buffer.from('e858292fd15a41e4', 'hex'),
+  edgeTags: ['service:service-name', 'env:env-name', 'topic:test-topic'],
+  edgeLatencyNs: 100000000,
+  pathwayLatencyNs: 100000000,
+  payloadSize: 100,
+}
+
+// `flushInterval: 0` is the "flush on write" sentinel the agent/agentless trace exporters already
+// honor. The processor must push each recorded checkpoint immediately, while the writer URL is known
+// live. The previous `setInterval(onInterval, 0)` fired on every event-loop tick instead, decoupled
+// from the recording, so a tick landing after the agent listener was torn down posted to a dead port
+// and lost the bucket (it is cleared on serialize) — dropping the single payload a producer-only DSM
+// test waits for and timing it out.
+describe('DataStreamsProcessor flush-on-write', () => {
+  let processor
+
+  afterEach(() => {
+    clearTimeout(processor?.timer)
+    writer.flush.resetHistory()
+  })
+
+  describe('with flushInterval 0', () => {
+    beforeEach(() => {
+      processor = new DataStreamsProcessor({ ...baseConfig, flushInterval: 0 })
+    })
+
+    it('does not arm an interval timer', () => {
+      assert.strictEqual(processor.timer, undefined)
+    })
+
+    it('flushes synchronously while recording a checkpoint', () => {
+      processor.recordCheckpoint(checkpoint)
+
+      sinon.assert.calledOnce(writer.flush)
+    })
+
+    it('flushes synchronously while recording an offset', () => {
+      processor.recordOffset({ timestamp: DEFAULT_TIMESTAMP, partition: 0, topic: 'test-topic' })
+
+      sinon.assert.calledOnce(writer.flush)
+    })
+
+    it('flushes synchronously while tracking a transaction', () => {
+      processor.trackTransaction('msg-id-001', 'ingested')
+
+      sinon.assert.calledOnce(writer.flush)
+    })
+  })
+
+  describe('with a non-zero flushInterval', () => {
+    beforeEach(() => {
+      processor = new DataStreamsProcessor({ ...baseConfig, flushInterval: 1000 })
+    })
+
+    it('arms an interval timer', () => {
+      assert.notStrictEqual(processor.timer, undefined)
+    })
+
+    it('does not flush while recording a checkpoint', () => {
+      processor.recordCheckpoint(checkpoint)
+
+      sinon.assert.notCalled(writer.flush)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The amqplib DSM spec (`Should emit DSM stats to the agent when sending a message on an unnamed exchange`) flakes with a timeout because the `DataStreamsProcessor` is the only `flushInterval` consumer that doesn't honor `flushInterval === 0` as a flush-on-write sentinel.

Under the test-agent config (`flushInterval: 0`, the same value the AWS Lambda path uses), the processor armed `setInterval(onInterval, 0)`. That timer fires on every event-loop tick, decoupled from when a checkpoint is recorded. A tick that lands in the window where the test agent has torn its HTTP listener down and not yet brought it back up posts to a dead port (`ECONNREFUSED`); buckets are cleared on serialize, so that single payload is gone. A producer-only DSM test waiting on exactly one payload then times out.

The fix aligns the processor with the agent and agentless trace exporters, which already branch on `flushInterval === 0`: skip the timer and flush each checkpoint, offset, and transaction the moment it is recorded, while the writer URL is known live.

## Test plan

- `packages/dd-trace/test/datastreams/flush_on_write.spec.js` is new: it pins both branches — `flushInterval: 0` arms no timer and flushes synchronously on `recordCheckpoint` / `recordOffset` / `trackTransaction`; a non-zero interval arms the timer and does not flush on record. It fails on master (the timer is armed, nothing flushes on write) and passes with the fix.
- All `packages/dd-trace/test/datastreams/*.spec.js` pass unchanged.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/28302648699/job/83853526808