### PR TITLE
test(runtime-metrics): widen GC pause p95 bound to deflake

### DIFF
--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -326,7 +326,12 @@ function createGarbage (count = 50) {
             return value > 0 && Number.isInteger(value)
           })
           const isGC95Percentile = sinon.match((value) => {
-            return value >= 1e5 && value < 1e8 // In Nanoseconds. 0.1ms to 100ms.
+            // Nanoseconds, 1µs to 100ms. These bounds guard the unit conversion, not the timing:
+            // a sub-microsecond value means the ms→ns conversion (`entry.duration * 1e6`) was
+            // dropped, and a value over 100ms means it was left in milliseconds or seconds. The
+            // floor used to be 0.1ms, which flaked on fast/idle runners where a single scavenge
+            // pause is the only sample for a gc_type and its p95 sits below that.
+            return value >= 1e3 && value < 1e8
           })
           const isHeapSpace = sinon.match((metricName) => {
             return /^heap_space:[a-z_]+$/.test(metricName)


### PR DESCRIPTION
## Summary

The non-native runtime metrics test (`should start collecting runtimeMetrics every 10 seconds`) asserted that `runtime.node.gc.pause.by.type.95percentile` lands in `[0.1ms, 100ms)`. On a fast or idle runner a `gc_type` can have a single scavenge sample whose p95 sits below 0.1ms, so the matcher rejected a legitimate value and the test failed on Windows.

The bounds exist to catch a unit-conversion regression, not to assert a minimum pause length: a sub-microsecond value would mean the ms→ns conversion (`entry.duration * 1e6`) was dropped, a value over 100ms that it was left in ms or seconds. The floor drops to 1µs so it still trips on a dropped conversion while no longer assuming a GC pause takes at least 0.1ms. The aggregate `runtime.node.gc.pause.95percentile` already used the loose `isFiniteNumber` matcher — this brings the per-type bound in line.

Surfaced on an unrelated PR's Windows run: https://github.com/DataDog/dd-trace-js/actions/runs/28304714675/job/83858836956

## Test plan

- [ ] `node --expose-gc ./node_modules/mocha/bin/mocha.js --timeout 30000 packages/dd-trace/test/runtime_metrics.spec.js`