### PR TITLE
fix(cypress): handle missing beforeEach task result

### DIFF
--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -26,6 +26,34 @@ module.exports = defineConfig({
           return ddAfterSpec(...args)
         })
       }
+      if (process.env.CYPRESS_DD_BEFORE_EACH_NO_RESULT_ONCE) {
+        const ddTracePlugin = require('dd-trace/ci/cypress/plugin')
+        let ddBeforeEachCalls = 0
+
+        const wrappedOn = (event, handler) => {
+          if (event !== 'task' || !handler['dd:beforeEach']) {
+            on(event, handler)
+            return
+          }
+
+          const ddBeforeEach = handler['dd:beforeEach']
+          on('task', {
+            ...handler,
+            'dd:beforeEach': (test) => {
+              ddBeforeEachCalls++
+              // eslint-disable-next-line no-console
+              console.log(`[datadog:test] dd:beforeEach call ${ddBeforeEachCalls}`)
+              const result = ddBeforeEach(test)
+              if (ddBeforeEachCalls === 1) {
+                return null
+              }
+              return result
+            },
+          })
+        }
+
+        return ddTracePlugin(wrappedOn, config)
+      }
       if (process.env.CYPRESS_ENABLE_MANUAL_PLUGIN) {
         return require('dd-trace/ci/cypress/plugin')(on, config)
       }

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const { exec } = require('node:child_process')
 const { once } = require('node:events')
 
+const semver = require('semver')
 const {
   sandboxCwd,
   useSandbox,
@@ -33,6 +34,7 @@ const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
 const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const CYPRESS_RUN_HARD_TIMEOUT = 70_000
+const over12It = (version === 'latest' || semver.gte(version, '12.0.0')) ? it : it.skip
 
 function assertItrSkippingEnabledTags (events, expected) {
   const testSuite = events.find(event => event.type === 'test_suite_end').content
@@ -270,6 +272,73 @@ moduleTypes.forEach(({
           skippableRequestPromise,
           coverageRequestPromise,
         ])
+      })
+
+      over12It('does not count ITR-skipped tests twice when retrying a missing dd:beforeEach result', async () => {
+        receiver.setSuitesToSkip([
+          {
+            type: 'test',
+            attributes: {
+              name: 'context passes',
+              suite: 'cypress/e2e/other.cy.js',
+            },
+          },
+          {
+            type: 'test',
+            attributes: {
+              name: 'basic pass suite can pass',
+              suite: 'cypress/e2e/basic-pass.js',
+            },
+          },
+        ])
+
+        const envVars = getCiVisAgentlessConfig(receiver.port)
+        let testOutput = ''
+
+        childProcess = exec(
+          testCommand,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: webAppBaseUrl,
+              CYPRESS_DD_BEFORE_EACH_NO_RESULT_ONCE: '1',
+              SPEC_PATTERN: 'cypress/e2e/{basic-pass,other.cy}.js',
+            },
+          }
+        )
+        childProcess.stdout?.on('data', (data) => { testOutput += data })
+        childProcess.stderr?.on('data', (data) => { testOutput += data })
+
+        const eventsPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const skippedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/other.cy.js.context passes'
+          ).content
+          assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(skippedTest.meta[TEST_SKIPPED_BY_ITR], 'true')
+
+          const skippedTestInOtherSpec = events.find(event =>
+            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+          ).content
+          assert.strictEqual(skippedTestInOtherSpec.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(skippedTestInOtherSpec.meta[TEST_SKIPPED_BY_ITR], 'true')
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 2)
+
+          const testModule = events.find(event => event.type === 'test_module_end').content
+          assert.strictEqual(testModule.metrics[TEST_ITR_SKIPPING_COUNT], 2)
+        })
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+
+        assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
+        assert.match(testOutput, /\[datadog:test\] dd:beforeEach call 1/)
+        assert.match(testOutput, /\[datadog:test\] dd:beforeEach call 2/)
       })
 
       it('does not skip tests if test skipping is disabled by the API', async () => {

--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -317,6 +317,54 @@ moduleTypes.forEach(({
       }
     })
 
+    over10It('retries when dd:beforeEach returns no result once', async () => {
+      const envVars = getCiVisAgentlessConfig(receiver.port)
+      let testOutput = ''
+
+      childProcess = exec(testCommand, {
+        cwd,
+        env: {
+          ...envVars,
+          CYPRESS_BASE_URL: webAppBaseUrl,
+          CYPRESS_DD_BEFORE_EACH_NO_RESULT_ONCE: '1',
+          SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
+        },
+      })
+      childProcess.stdout?.on('data', (data) => { testOutput += data })
+      childProcess.stderr?.on('data', (data) => { testOutput += data })
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads
+              .flatMap(({ payload }) => payload.events)
+              .filter(event => event.type === 'test')
+            const passedTest = events.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          },
+          { hardTimeout: 60000 }
+        )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        receiverPromise,
+      ])
+
+      assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
+      assert.match(testOutput, /\[datadog:test\] dd:beforeEach call 1/)
+      assert.match(testOutput, /\[datadog:test\] dd:beforeEach call 2/)
+    })
+
     over10It('preserves config returned from setupNodeEvents', async () => {
       const envVars = getCiVisAgentlessConfig(receiver.port)
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -390,6 +390,7 @@ class CypressPlugin {
   earlyFlakeDetectionFaultyThreshold = 0
   testsToSkip = []
   skippedTests = []
+  skippedTestIds = new Set()
   skippableTestsCoverage = {}
   testSessionCoverageMap = createCoverageMap()
   hasForcedToRunSuites = false
@@ -473,6 +474,7 @@ class CypressPlugin {
     this.earlyFlakeDetectionFaultyThreshold = 0
     this.testsToSkip = []
     this.skippedTests = []
+    this.skippedTestIds = new Set()
     this.skippableTestsCoverage = {}
     this.testSessionCoverageMap = createCoverageMap()
     this.hasForcedToRunSuites = false
@@ -1386,7 +1388,7 @@ class CypressPlugin {
         return suitePayload
       },
       'dd:beforeEach': (test) => {
-        const { testName, testSuite, isEfdRetry, efdRetryIndex } = test
+        const { testId, testName, testSuite, isEfdRetry, efdRetryIndex } = test
         if (isEfdRetry && this.shouldSkipEfdRetry(testSuite, testName, efdRetryIndex)) {
           return { shouldSkip: true, shouldDiscard: true }
         }
@@ -1398,7 +1400,11 @@ class CypressPlugin {
         const { isAttemptToFix, isDisabled, isQuarantined } = this.getTestProperties(testSuite, testName)
         // skip test
         if (shouldSkip && !isUnskippable) {
-          this.skippedTests.push(test)
+          const skippedTestId = `${testSuite}:${testId || testName}`
+          if (!this.skippedTestIds.has(skippedTestId)) {
+            this.skippedTestIds.add(skippedTestId)
+            this.skippedTests.push(test)
+          }
           this.isTestsSkipped = true
           return { shouldSkip: true }
         }

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -13,6 +13,8 @@ let testManagementTests = {}
 let isImpactedTestsEnabled = false
 let isModifiedTest = false
 let isTestIsolationEnabled = false
+let hasWarnedMissingBeforeEachTaskResult = false
+let hasWarnedMissingBeforeEachRetryResult = false
 // Array of test names that have been retried and the reason
 const retryReasonsByTestName = new Map()
 // Track test errors suppressed by test management so we can still report them to Datadog.
@@ -84,6 +86,47 @@ function getTestProperties (testName) {
   const { attempt_to_fix: isAttemptToFix, disabled: isDisabled, quarantined: isQuarantined } = properties
 
   return { isAttemptToFix, isDisabled, isQuarantined }
+}
+
+/**
+ * @param {string} message
+ * @returns {void}
+ */
+function warnMissingBeforeEachTaskResult (message) {
+  // eslint-disable-next-line no-console
+  console.warn(message)
+}
+
+/**
+ * @param {object} test
+ * @returns {Cypress.Chainable<{ traceId?: string, shouldSkip?: boolean, shouldDiscard?: boolean }>}
+ */
+function runBeforeEachTask (test) {
+  return cy.task('dd:beforeEach', test).then((taskResult) => {
+    if (taskResult !== undefined && taskResult !== null) {
+      return taskResult
+    }
+
+    if (!hasWarnedMissingBeforeEachTaskResult) {
+      hasWarnedMissingBeforeEachTaskResult = true
+      warnMissingBeforeEachTaskResult('Datadog Cypress dd:beforeEach task returned no result. Retrying once.')
+    }
+
+    return cy.task('dd:beforeEach', test).then((retryTaskResult) => {
+      if (retryTaskResult !== undefined && retryTaskResult !== null) {
+        return retryTaskResult
+      }
+
+      if (!hasWarnedMissingBeforeEachRetryResult) {
+        hasWarnedMissingBeforeEachRetryResult = true
+        warnMissingBeforeEachTaskResult(
+          'Datadog Cypress dd:beforeEach task returned no result after retry. Continuing with an empty task result.'
+        )
+      }
+
+      return {}
+    })
+  })
 }
 
 // Catch test failures for quarantined tests and suppress them
@@ -263,7 +306,8 @@ beforeEach(function () {
     originalWindow = win
   })
 
-  cy.task('dd:beforeEach', {
+  runBeforeEachTask({
+    testId: currentTest.id,
     testName,
     testSuite: Cypress.mocha.getRootSuite().file,
     isEfdRetry: Cypress.mocha.getRunner().suite.ctx.currentTest._ddIsEfdRetry,


### PR DESCRIPTION
### What does this PR do?
Adds a defensive retry around the Cypress `dd:beforeEach` task result before destructuring it. If Cypress yields `null` or `undefined`, the support hook now warns once and retries `dd:beforeEach`; if the retry also has no result, it warns once more and continues with an empty result instead of failing the run with a destructuring error.

Also makes the Node-side Cypress task handler idempotent for repeated ITR-skipped `dd:beforeEach` calls. When the missing-result edge happens after the task handler already ran, the retry no longer appends the same skipped test twice or inflates `test.itr.tests_skipping.count`. The de-dupe key is scoped by spec path so Cypress runnable ids reused across spec files do not under-count distinct skipped tests.

Integration coverage lives in the existing Cypress specs. The fixture now calls the real `dd:beforeEach` handler and then returns `null` on the first call, which simulates the sharper transport edge where task side effects already happened but Cypress yielded no result. The reporting test verifies the retry reaches the real task result, and the ITR test verifies two skipped specs are counted separately while the retried skipped test is counted once.

### Motivation
A user reported a rare Cypress failure where `cy.task("dd:beforeEach")` yielded `undefined`, causing the support hook to crash while destructuring the task result. The Datadog task handlers normally return an object, including noop fallback handlers, so this appears to be a rare Cypress/plugin task transport or lifecycle edge rather than an expected Datadog configuration path.

Fixes #9084.

