### PR TITLE
[prototype] collect test suite coverage without code coverage 

### DIFF
--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage.spec.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage.spec.js
@@ -1,0 +1,220 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { exec } = require('node:child_process')
+const { once } = require('node:events')
+
+const {
+  getCiVisAgentlessConfig,
+  sandboxCwd,
+  useSandbox,
+} = require('../helpers')
+const { FakeCiVisIntake } = require('../ci-visibility-intake')
+
+const FIXTURE_ROOT = 'ci-visibility/jest-tia-runtime-coverage'
+const MINIMUM_JEST_VERSION = '28.0.0'
+
+const JEST_VERSION_CONFIGS = [
+  {
+    version: 'latest',
+    dependencies: ['jest', 'typescript'],
+  },
+  {
+    version: MINIMUM_JEST_VERSION,
+    dependencies: [`jest@${MINIMUM_JEST_VERSION}`, `jest-circus@${MINIMUM_JEST_VERSION}`, 'typescript'],
+  },
+]
+
+const EXPECTED_SUITE_COVERAGE = {
+  [`${FIXTURE_ROOT}/__tests__/alpha.spec.js`]: [
+    `${FIXTURE_ROOT}/__tests__/alpha.spec.js`,
+    `${FIXTURE_ROOT}/src/branch.js`,
+    `${FIXTURE_ROOT}/src/lazy.js`,
+    `${FIXTURE_ROOT}/src/math.js`,
+    `${FIXTURE_ROOT}/src/passive.js`,
+    `${FIXTURE_ROOT}/src/shared.js`,
+    `${FIXTURE_ROOT}/src/side-effect.js`,
+    `${FIXTURE_ROOT}/src/throws-on-import.js`,
+  ],
+  [`${FIXTURE_ROOT}/__tests__/beta.spec.js`]: [
+    `${FIXTURE_ROOT}/__tests__/beta.spec.js`,
+    `${FIXTURE_ROOT}/src/branch.js`,
+    `${FIXTURE_ROOT}/src/manual-target.js`,
+  ],
+  [`${FIXTURE_ROOT}/__tests__/gamma.spec.js`]: [
+    `${FIXTURE_ROOT}/__tests__/gamma.spec.js`,
+    `${FIXTURE_ROOT}/src/aggregator.js`,
+    `${FIXTURE_ROOT}/src/math.js`,
+    `${FIXTURE_ROOT}/src/shared.js`,
+  ],
+  [`${FIXTURE_ROOT}/__tests__/delta-esm.spec.mjs`]: [
+    `${FIXTURE_ROOT}/__tests__/delta-esm.spec.mjs`,
+    `${FIXTURE_ROOT}/esm/entry.mjs`,
+    `${FIXTURE_ROOT}/esm/lazy-esm.mjs`,
+    `${FIXTURE_ROOT}/esm/nested-esm.mjs`,
+    `${FIXTURE_ROOT}/esm/shared-esm.mjs`,
+    `${FIXTURE_ROOT}/src/math.js`,
+  ],
+  [`${FIXTURE_ROOT}/__tests__/theta-typescript.spec.ts`]: [
+    `${FIXTURE_ROOT}/__tests__/theta-typescript.spec.ts`,
+    `${FIXTURE_ROOT}/ts/ts-branch.ts`,
+    `${FIXTURE_ROOT}/ts/ts-entry.ts`,
+    `${FIXTURE_ROOT}/ts/ts-shared.ts`,
+  ],
+}
+
+for (const suiteCoverage of Object.values(EXPECTED_SUITE_COVERAGE)) {
+  suiteCoverage.sort()
+}
+
+function getCoverageEvents (payloads) {
+  return payloads
+    .flatMap(({ payload }) => payload)
+    .flatMap(({ content }) => content.coverages)
+}
+
+function getFilename (file) {
+  return file.filename
+}
+
+function getSuiteCoverageBySuiteFile (coverages) {
+  const coverageBySuite = {}
+
+  for (const coverage of coverages) {
+    if (!coverage.test_suite_id) continue
+
+    const filenames = coverage.files.map(getFilename).sort()
+    const suiteFile = filenames.find(filename =>
+      filename.startsWith(`${FIXTURE_ROOT}/__tests__/`) &&
+      filename.includes('.spec.')
+    )
+
+    assert.ok(suiteFile, `suite coverage should include its test file: ${filenames.join(', ')}`)
+    coverageBySuite[suiteFile] = filenames
+  }
+
+  return coverageBySuite
+}
+
+function getBitmapFilenames (coverages) {
+  return coverages
+    .flatMap(coverage => coverage.files)
+    .filter(file => file.bitmap)
+    .map(getFilename)
+    .sort()
+}
+
+function describeJestVersion ({ version, dependencies }) {
+  describe(`Jest TIA runtime coverage engine jest@${version}`, function () {
+    let cwd
+    let childProcess
+
+    this.timeout(180_000)
+
+    useSandbox(dependencies, true)
+
+    before(() => {
+      cwd = sandboxCwd()
+    })
+
+    afterEach(() => {
+      if (childProcess?.exitCode === null) {
+        childProcess.kill()
+      }
+    })
+
+    async function runFixture ({ enableUserCoverage = false } = {}) {
+      const receiver = await new FakeCiVisIntake().start()
+      receiver.setSettings({
+        itr_enabled: true,
+        code_coverage: true,
+        coverage_report_upload_enabled: false,
+        tests_skipping: false,
+      })
+
+      let output = ''
+      let coverages
+      const coveragePromise = receiver.gatherPayloadsMaxTimeout(
+        ({ url }) => url.endsWith('/api/v2/citestcov'),
+        payloads => {
+          coverages = getCoverageEvents(payloads)
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsMaxTimeout(
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          assert.ok(events.find(event => event.type === 'test_session_end'), `missing session event:\n${output}`)
+        }
+      )
+
+      const startTime = Date.now()
+      childProcess = exec(
+        'node ./ci-visibility/run-jest.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--experimental-vm-modules -r dd-trace/ci/init',
+            USE_JEST_RUN: '1',
+            USE_CONFIG_FILE: '1',
+            CONFIG_TEST_MATCH: `**/${FIXTURE_ROOT}/__tests__/*.spec.*`,
+            CONFIG_TRANSFORM: JSON.stringify({
+              '^.+\\.tsx?$': `<rootDir>/${FIXTURE_ROOT}/ts-transformer.cjs`,
+            }),
+            SHOULD_CHECK_RESULTS: '1',
+            OTEL_TRACES_EXPORTER: '',
+            OTEL_LOGS_EXPORTER: '',
+            OTEL_METRICS_EXPORTER: '',
+            ...(enableUserCoverage ? { ENABLE_CODE_COVERAGE: '1', COVERAGE_REPORTERS: 'none' } : {}),
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => {
+        output += chunk.toString()
+      })
+      childProcess.stderr?.on('data', chunk => {
+        output += chunk.toString()
+      })
+
+      try {
+        const [, , [exitCode]] = await Promise.all([
+          coveragePromise,
+          eventsPromise,
+          once(childProcess, 'exit'),
+        ])
+        assert.strictEqual(exitCode, 0, output)
+
+        return {
+          coverages,
+          durationMs: Date.now() - startTime,
+          suiteCoverage: getSuiteCoverageBySuiteFile(coverages),
+        }
+      } finally {
+        await receiver.stop()
+      }
+    }
+
+    it('matches legacy Istanbul per-suite touched files without forcing Jest coverage', async () => {
+      const legacy = await runFixture({ enableUserCoverage: true })
+      const runtime = await runFixture()
+
+      assert.deepStrictEqual(legacy.suiteCoverage, EXPECTED_SUITE_COVERAGE)
+      assert.deepStrictEqual(runtime.suiteCoverage, EXPECTED_SUITE_COVERAGE)
+      assert.deepStrictEqual(runtime.suiteCoverage, legacy.suiteCoverage)
+      assert.ok(
+        getBitmapFilenames(legacy.coverages).includes(`${FIXTURE_ROOT}/src/math.js`),
+        'legacy Istanbul coverage should include line bitmaps for covered source files'
+      )
+      assert.deepStrictEqual(getBitmapFilenames(runtime.coverages), [])
+      assert.ok(
+        runtime.durationMs < legacy.durationMs * 2,
+        `runtime coverage took ${runtime.durationMs}ms and legacy took ${legacy.durationMs}ms`
+      )
+    })
+  })
+}
+
+for (const jestVersionConfig of JEST_VERSION_CONFIGS) {
+  describeJestVersion(jestVersionConfig)
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/alpha.spec.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/alpha.spec.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+require('../src/side-effect')
+
+const { chooseBranch } = require('../src/branch')
+const { sharedLabel } = require('../src/shared')
+require('../src/passive')
+
+describe('alpha suite', () => {
+  it('touches direct, side-effect, lazy, passive, and throwing modules', () => {
+    const lazyMessage = require('../src/lazy')
+
+    assert.strictEqual(sharedLabel('alpha'), 'alpha:3')
+    assert.strictEqual(chooseBranch('alpha'), 'first')
+    assert.strictEqual(lazyMessage('alpha'), 'lazy:alpha')
+    assert.strictEqual(global.__ddTiaRuntimeCoverageSideEffect, 1)
+    assert.throws(() => require('../src/throws-on-import'), /expected import failure/)
+  })
+})

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/beta.spec.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/beta.spec.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+jest.mock('../src/manual-target.js', () => {
+  return function manualTarget () {
+    return 'mocked manual target'
+  }
+})
+
+const { chooseBranch } = require('../src/branch')
+const manualTarget = require('../src/manual-target.js')
+
+describe('beta suite', () => {
+  it('touches a mocked dependency without executing the real module', () => {
+    assert.strictEqual(chooseBranch('beta'), 'fallback')
+    assert.strictEqual(manualTarget(), 'mocked manual target')
+  })
+})

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/delta-esm.spec.mjs
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/delta-esm.spec.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+
+import { describe, it } from '@jest/globals'
+
+import { esmAggregate } from '../esm/entry.mjs'
+
+describe('delta esm suite', () => {
+  it('touches static esm, dynamic esm, and cjs imported from esm', async () => {
+    const lazyModule = await import('../esm/lazy-esm.mjs')
+
+    assert.strictEqual(esmAggregate('delta'), 'delta:esm:6:6')
+    assert.strictEqual(lazyModule.lazyEsm('delta'), 'lazy-esm:delta')
+  })
+})

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/gamma.spec.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/gamma.spec.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { aggregate } = require('../src/aggregator')
+
+describe('gamma suite', () => {
+  it('touches a transitive dependency graph', () => {
+    assert.strictEqual(aggregate('gamma'), 'gamma:3:8')
+  })
+})

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/theta-typescript.spec.ts
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/__tests__/theta-typescript.spec.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+
+import { describe, it } from '@jest/globals'
+
+import { buildTypedLabel } from '../ts/ts-entry'
+
+describe('theta typescript suite', () => {
+  it('touches transformed typescript imports and type-only imports', () => {
+    assert.strictEqual(buildTypedLabel({ name: 'theta', count: 4 }), 'theta:typed:10')
+  })
+})

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/entry.mjs
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/entry.mjs
@@ -1,0 +1,7 @@
+import math from '../src/math.js'
+
+import { esmLabel } from './shared-esm.mjs'
+
+export function esmAggregate (name) {
+  return `${name}:${esmLabel()}:${math.multiply(2, 3)}`
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/lazy-esm.mjs
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/lazy-esm.mjs
@@ -1,0 +1,3 @@
+export function lazyEsm (name) {
+  return `lazy-esm:${name}`
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/nested-esm.mjs
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/nested-esm.mjs
@@ -1,0 +1,3 @@
+export function nestedEsmValue () {
+  return 6
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/shared-esm.mjs
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/esm/shared-esm.mjs
@@ -1,0 +1,5 @@
+import { nestedEsmValue } from './nested-esm.mjs'
+
+export function esmLabel () {
+  return `esm:${nestedEsmValue()}`
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/aggregator.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/aggregator.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const { multiply } = require('./math')
+const { sharedLabel } = require('./shared')
+
+function aggregate (name) {
+  return `${sharedLabel(name)}:${multiply(2, 4)}`
+}
+
+module.exports = { aggregate }

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/branch.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/branch.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function chooseBranch (value) {
+  if (value === 'alpha') {
+    return 'first'
+  }
+
+  return 'fallback'
+}
+
+module.exports = { chooseBranch }

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/lazy.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/lazy.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function lazyMessage (name) {
+  return `lazy:${name}`
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/manual-target.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/manual-target.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function manualTarget () {
+  return 'real manual target'
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/math.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/math.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function add (left, right) {
+  return left + right
+}
+
+function multiply (left, right) {
+  return left * right
+}
+
+module.exports = { add, multiply }

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/passive.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/passive.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function declaredButNotCalled () {
+  return 'passive'
+}
+
+module.exports = { declaredButNotCalled }

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/shared.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/shared.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { add } = require('./math')
+
+function sharedLabel (name) {
+  return `${name}:${add(1, 2)}`
+}
+
+module.exports = { sharedLabel }

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/side-effect.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/side-effect.js
@@ -1,0 +1,3 @@
+'use strict'
+
+global.__ddTiaRuntimeCoverageSideEffect = (global.__ddTiaRuntimeCoverageSideEffect || 0) + 1

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/throws-on-import.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/throws-on-import.js
@@ -1,0 +1,3 @@
+'use strict'
+
+throw new Error('expected import failure')

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/uncovered.js
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/src/uncovered.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function uncovered () {
+  return 'not touched'
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts-transformer.cjs
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts-transformer.cjs
@@ -1,0 +1,18 @@
+'use strict'
+
+const ts = require('typescript')
+
+module.exports = {
+  process (sourceText, sourcePath) {
+    const output = ts.transpileModule(sourceText, {
+      compilerOptions: {
+        esModuleInterop: true,
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2019,
+      },
+      fileName: sourcePath,
+    })
+
+    return { code: output.outputText }
+  },
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/ts-branch.ts
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/ts-branch.ts
@@ -1,0 +1,7 @@
+export function typedBranch (value: number): number {
+  if (value > 3) {
+    return value + 6
+  }
+
+  return value
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/ts-entry.ts
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/ts-entry.ts
@@ -1,0 +1,8 @@
+import type { TypedInput } from './types'
+
+import { typedBranch } from './ts-branch'
+import { typedShared } from './ts-shared'
+
+export function buildTypedLabel (input: TypedInput): string {
+  return `${input.name}:${typedShared()}:${typedBranch(input.count)}`
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/ts-shared.ts
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/ts-shared.ts
@@ -1,0 +1,3 @@
+export function typedShared (): string {
+  return 'typed'
+}

--- a/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/types.ts
+++ b/integration-tests/ci-visibility/jest-tia-runtime-coverage/ts/types.ts
@@ -1,0 +1,4 @@
+export interface TypedInput {
+  name: string
+  count: number
+}

--- a/integration-tests/ci-visibility/tia-code-coverage.spec.js
+++ b/integration-tests/ci-visibility/tia-code-coverage.spec.js
@@ -145,6 +145,7 @@ function describeJestVersion (jestVersion, dependencies) {
       expectSessionCoverage = true,
       expectCoveragePayloads = true,
       expectCoverageOutput = true,
+      expectCoverageBitmaps = true,
     }) {
       const receiver = await new FakeCiVisIntake().start()
       receiver.setSettings(settings)
@@ -210,7 +211,15 @@ function describeJestVersion (jestVersion, dependencies) {
             `session executable-line coverage should not be reported:\n${output}`
             )
           }
-          assert.ok(coveredFile?.bitmap, `covered files should report line coverage bitmaps:\n${output}`)
+          if (expectCoverageBitmaps) {
+            assert.ok(coveredFile?.bitmap, `covered files should report line coverage bitmaps:\n${output}`)
+          } else {
+            assert.strictEqual(
+              coveredFile,
+              undefined,
+              `covered files should not report line coverage bitmaps:\n${output}`
+            )
+          }
 
           coverageResult = coverages
         })
@@ -465,9 +474,8 @@ function describeJestVersion (jestVersion, dependencies) {
       assert.ok(result.stdoutCodeCoverageLinesPct > 0)
     })
 
-    // The same suite-only upload behavior applies when TIA has to force Jest coverage because the user did not
-    // configure it. coverage_report_upload_enabled=false still means no backfill, no session executable coverage,
-    // and no Datadog lines_pct.
+    // The same suite-only upload behavior applies without user Jest coverage. Because Datadog Code Coverage is not
+    // enabled, TIA can report filename-only suite coverage without forcing Istanbul.
     it('only uploads suite coverage without report upload or user jest coverage', async () => {
       const framework = {
         ...FRAMEWORKS[0],
@@ -492,6 +500,7 @@ function describeJestVersion (jestVersion, dependencies) {
         },
         expectSessionCoverage: false,
         expectCoverageOutput: false,
+        expectCoverageBitmaps: false,
       })
 
       assert.strictEqual(result.isTiaSkipped, 'true')

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -142,6 +142,7 @@ const newTestsWithDynamicNames = new Set()
 const loggedAttemptToFixTests = new Set()
 const testSuiteMockedFiles = new Map()
 const testsToBeRetried = new Set()
+const testSuiteTouchedFiles = new Map()
 // Per-test: how many EFD retries were determined after the first execution.
 const efdDeterminedRetries = new Map()
 // Tests whose first run exceeded the 5-min threshold — tagged "slow".
@@ -152,6 +153,7 @@ const efdNewTestCandidates = new Set()
 const newTests = new Set()
 const testSuiteJestObjects = new Map()
 const wrappedJestGlobals = new WeakSet()
+const wrappedJestEsmLoaders = new WeakSet()
 const wrappedJestObjects = new WeakSet()
 const wrappedWorkerInitializers = new WeakSet()
 const publishedRuntimeReferenceErrors = new WeakMap()
@@ -166,9 +168,13 @@ const MINIMUM_JEST_WORKER_VERSION_BEFORE_30 = DD_MAJOR >= 6 ? '>=28.0.0 <30.0.0'
 const MINIMUM_JEST_CONFIG_ASYNC_VERSION = DD_MAJOR >= 6 ? '>=28.0.0' : '>=25.1.0'
 const MINIMUM_JEST_TEST_SCHEDULER_VERSION = DD_MAJOR >= 6 ? '>=28.0.0' : '>=27.0.0'
 const MINIMUM_JEST_COVERAGE_BACKFILL_VERSION = '>=28.0.0'
+const JEST_RUNTIME_COVERAGE_VERSION_RANGE = '>=28.0.0'
+const JEST_TIA_COVERAGE_ENGINE_RUNTIME = 'runtime'
+const JEST_TIA_COVERAGE_ENGINE_ISTANBUL = 'istanbul'
 const atrSuppressedErrors = new Map()
 let hasWarnedDeprecatedJestVersion = false
 let isJestCoverageBackfillSupported = false
+let isJestRuntimeCoverageEngineSupported = false
 let hasFinishedTestSession = false
 
 // Track quarantined tests whose errors were suppressed, keyed by "suite › testName"
@@ -1175,12 +1181,33 @@ function hasSkippableSuitesCoverage () {
 }
 
 function shouldCollectJestCoverageForTia () {
-  return shouldReportJestSuiteCoverageForTia() ||
+  return shouldReportJestSuiteCoverageWithIstanbulForTia() ||
     (isJestCoverageBackfillSupported && isItrEnabled && isCoverageReportUploadEnabled)
 }
 
 function shouldReportJestSuiteCoverageForTia () {
   return isItrEnabled && isCodeCoverageEnabled
+}
+
+/**
+ * Checks whether Jest's Istanbul coverage should be enabled for TIA suite coverage.
+ *
+ * @returns {boolean}
+ */
+function shouldReportJestSuiteCoverageWithIstanbulForTia () {
+  return shouldReportJestSuiteCoverageForTia() && !shouldUseJestRuntimeCoverageForTia()
+}
+
+/**
+ * Checks whether the Jest runtime coverage engine should collect TIA suite coverage.
+ *
+ * @returns {boolean}
+ */
+function shouldUseJestRuntimeCoverageForTia () {
+  return isJestRuntimeCoverageEngineSupported &&
+    shouldReportJestSuiteCoverageForTia() &&
+    !isCoverageReportUploadEnabled &&
+    !isUserCodeCoverageEnabled
 }
 
 function hasJestCoverageMap () {
@@ -1588,6 +1615,8 @@ function getCliWrapper (isNewJestVersion) {
     warnDeprecatedJestVersion(jestVersion)
     isJestCoverageBackfillSupported = !!jestVersion &&
       satisfies(jestVersion, MINIMUM_JEST_COVERAGE_BACKFILL_VERSION)
+    isJestRuntimeCoverageEngineSupported = !!jestVersion &&
+      satisfies(jestVersion, JEST_RUNTIME_COVERAGE_VERSION_RANGE)
 
     if (isNewJestVersion) {
       cli = shimmer.wrap(
@@ -1925,6 +1954,135 @@ function publishTestSuiteFinish (payload, waitForFinish) {
 function cleanupTestSuiteState (testSuiteAbsolutePath) {
   testSuiteMockedFiles.delete(testSuiteAbsolutePath)
   testSuiteJestObjects.delete(testSuiteAbsolutePath)
+  testSuiteTouchedFiles.delete(testSuiteAbsolutePath)
+}
+
+/**
+ * @typedef {object} JestRuntimeCoverageResolver
+ * @property {(moduleName: string) => boolean} [isCoreModule]
+ * @property {(from: string|undefined, moduleName: string) => string} [resolveCjs]
+ */
+
+/**
+ * @typedef {object} JestRuntimeCoverageRuntime
+ * @property {string} [_testPath]
+ * @property {{ testEnvironmentOptions?: { _ddTestCodeCoverageEngine?: string } }} [_config]
+ * @property {JestRuntimeCoverageResolver} [_resolver]
+ * @property {(from: string|undefined, moduleName: string, options: { conditions?: string[] }) => string}
+ *   [_resolveCjsModule]
+ * @property {string[]} [cjsConditions]
+ * @property {{ resolution?: JestRuntimeCoverageResolver }} [cjsLoader]
+ * @property {{ loadEsmModule?: (modulePath: string, query?: string) => unknown }} [esmLoader]
+ */
+
+/**
+ * Records a file executed by Jest's runtime for its active test suite.
+ *
+ * @param {JestRuntimeCoverageRuntime} runtime
+ * @param {string|undefined} filename
+ * @returns {void}
+ */
+function recordJestRuntimeTouchedFile (runtime, filename) {
+  const testSuiteAbsolutePath = runtime?._testPath
+  if (!testSuiteAbsolutePath || typeof filename !== 'string' || !path.isAbsolute(filename)) return
+
+  let touchedFiles = testSuiteTouchedFiles.get(testSuiteAbsolutePath)
+  if (!touchedFiles) {
+    touchedFiles = new Set()
+    testSuiteTouchedFiles.set(testSuiteAbsolutePath, touchedFiles)
+  }
+  touchedFiles.add(filename)
+}
+
+/**
+ * Checks whether the parent Jest process selected runtime TIA coverage for this suite.
+ *
+ * @param {JestRuntimeCoverageRuntime} runtime
+ * @returns {boolean}
+ */
+function shouldRecordJestRuntimeCoverage (runtime) {
+  return runtime?._config?.testEnvironmentOptions?._ddTestCodeCoverageEngine === JEST_TIA_COVERAGE_ENGINE_RUNTIME
+}
+
+/**
+ * Resolves a Jest runtime require call to the file path that will be executed.
+ *
+ * @param {JestRuntimeCoverageRuntime} runtime
+ * @param {string|undefined} from
+ * @param {string|undefined} moduleName
+ * @returns {string|undefined}
+ */
+function resolveJestRuntimeRequiredFile (runtime, from, moduleName) {
+  if (typeof moduleName !== 'string') return
+  if (path.isAbsolute(moduleName)) return moduleName
+
+  try {
+    if (
+      runtime?._resolver?.isCoreModule?.(moduleName) ||
+      runtime?.cjsLoader?.resolution?.isCoreModule?.(moduleName)
+    ) {
+      return
+    }
+
+    if (typeof runtime?._resolveCjsModule === 'function') {
+      return runtime._resolveCjsModule(from, moduleName, { conditions: runtime.cjsConditions })
+    }
+
+    const resolveCjs = runtime?.cjsLoader?.resolution?.resolveCjs
+    if (typeof resolveCjs === 'function') {
+      return resolveCjs.call(runtime.cjsLoader.resolution, from, moduleName)
+    }
+  } catch {
+    // If Jest cannot resolve this module, preserve Jest's original error path.
+  }
+}
+
+/**
+ * Checks whether a file is inside a directory without treating sibling prefixes as matches.
+ *
+ * @param {string} filename
+ * @param {string|undefined} directory
+ * @returns {boolean}
+ */
+function isPathInsideDirectory (filename, directory) {
+  if (!directory) return false
+
+  const relativePath = path.relative(directory, filename)
+  return relativePath === '' || (
+    !!relativePath &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  )
+}
+
+/**
+ * Converts runtime-touched files into the coverage-file shape used by the CITESTCOV encoder.
+ *
+ * @param {string} testSuiteAbsolutePath
+ * @param {string} rootDir
+ * @param {string[]} mockedFiles
+ * @returns {{ filename: string }[]}
+ */
+function getJestRuntimeTouchedCoverageFiles (testSuiteAbsolutePath, rootDir, mockedFiles) {
+  const touchedFiles = testSuiteTouchedFiles.get(testSuiteAbsolutePath)
+  if (!touchedFiles?.size) return []
+
+  const mockedFileSet = mockedFiles.length ? new Set(mockedFiles) : undefined
+  const coverageFiles = []
+  for (const filename of touchedFiles) {
+    if (
+      filename === testSuiteAbsolutePath ||
+      mockedFileSet?.has(filename) ||
+      filename.includes(`${path.sep}node_modules${path.sep}`) ||
+      !isPathInsideDirectory(filename, rootDir)
+    ) {
+      continue
+    }
+
+    coverageFiles.push({ filename: getTestSuitePath(filename, rootDir) })
+  }
+
+  return coverageFiles
 }
 
 addHook({
@@ -2045,19 +2203,21 @@ function jestAdapterWrapper (jestAdapter, jestVersion) {
        */
       if (environment.testEnvironmentOptions?._ddTestCodeCoverageEnabled) {
         const root = environment.repositoryRoot || environment.rootDir
-
-        const coverageFiles = getCoveredFilesFromCoverage(environment.global.__coverage__)
-          .map(file => ({
-            ...file,
-            filename: getTestSuitePath(file.filename, root),
-          }))
+        const coverageEngine = environment.testEnvironmentOptions._ddTestCodeCoverageEngine
         const mockedFiles = getMockedFiles(environment.testSuiteAbsolutePath)
-          .map(file => getTestSuitePath(file, root))
+        const coverageFiles = coverageEngine === JEST_TIA_COVERAGE_ENGINE_RUNTIME
+          ? getJestRuntimeTouchedCoverageFiles(environment.testSuiteAbsolutePath, root, mockedFiles)
+          : getCoveredFilesFromCoverage(environment.global.__coverage__)
+            .map(file => ({
+              ...file,
+              filename: getTestSuitePath(file.filename, root),
+            }))
 
         testSuiteCodeCoverageCh.publish({
           coverageFiles,
           testSuite: environment.testSourceFile,
-          mockedFiles,
+          mockedFiles: mockedFiles.map(file => getTestSuitePath(file, root)),
+          coverageLibrary: coverageEngine || JEST_TIA_COVERAGE_ENGINE_ISTANBUL,
           testSuiteAbsolutePath: environment.testSuiteAbsolutePath,
         })
       }
@@ -2154,6 +2314,9 @@ function configureTestEnvironment (readConfigsResult) {
     const testEnvironmentOptions = config.testEnvironmentOptions || {}
     testEnvironmentOptions._ddRepositoryRoot = repositoryRoot
     testEnvironmentOptions._ddTestCodeCoverageEnabled = shouldReportJestSuiteCoverageForTia()
+    testEnvironmentOptions._ddTestCodeCoverageEngine = shouldUseJestRuntimeCoverageForTia()
+      ? JEST_TIA_COVERAGE_ENGINE_RUNTIME
+      : JEST_TIA_COVERAGE_ENGINE_ISTANBUL
 
     return {
       ...config,
@@ -2211,6 +2374,7 @@ const DD_TEST_ENVIRONMENT_OPTION_KEYS = [
   '_ddEarlyFlakeDetectionSlowTestRetries',
   '_ddRepositoryRoot',
   '_ddTestCodeCoverageEnabled',
+  '_ddTestCodeCoverageEngine',
   '_ddIsFlakyTestRetriesEnabled',
   '_ddFlakyTestRetriesCount',
   '_ddItrSkippingEnabledTags',
@@ -2394,6 +2558,28 @@ function wrapJestGlobalsForRuntime (runtime) {
   })
 }
 
+/**
+ * Wraps Jest's modern per-runtime ESM loader so native ESM static and dynamic imports
+ * are visible to the runtime TIA coverage collector.
+ *
+ * @param {JestRuntimeCoverageRuntime} runtime
+ * @returns {void}
+ */
+function wrapJestRuntimeEsmLoader (runtime) {
+  const esmLoader = runtime?.esmLoader
+  if (!esmLoader || wrappedJestEsmLoaders.has(esmLoader) || typeof esmLoader.loadEsmModule !== 'function') {
+    return
+  }
+
+  wrappedJestEsmLoaders.add(esmLoader)
+  shimmer.wrap(esmLoader, 'loadEsmModule', loadEsmModule => function (modulePath) {
+    if (shouldRecordJestRuntimeCoverage(runtime)) {
+      recordJestRuntimeTouchedFile(runtime, modulePath)
+    }
+    return loadEsmModule.apply(this, arguments)
+  })
+}
+
 function getLastLoggedReferenceError (runtime) {
   const loggedReferenceErrors = runtime?.loggedReferenceErrors
   if (!loggedReferenceErrors?.size) return
@@ -2469,8 +2655,40 @@ addHook({
     })
   }
 
+  // Jest runtime loaders are version-dependent internals created at runtime, so keep this in the existing
+  // shimmer hook rather than trying to express it with Orchestrion's static rewrites.
+  if (typeof Runtime.prototype._execModule === 'function') {
+    shimmer.wrap(Runtime.prototype, '_execModule', _execModule => function (localModule) {
+      if (shouldRecordJestRuntimeCoverage(this)) {
+        recordJestRuntimeTouchedFile(this, localModule?.filename)
+      }
+      return _execModule.apply(this, arguments)
+    })
+  }
+
+  if (typeof Runtime.prototype.loadEsmModule === 'function') {
+    shimmer.wrap(Runtime.prototype, 'loadEsmModule', loadEsmModule => function (modulePath) {
+      if (shouldRecordJestRuntimeCoverage(this)) {
+        recordJestRuntimeTouchedFile(this, modulePath)
+      }
+      return loadEsmModule.apply(this, arguments)
+    })
+  }
+
+  if (typeof Runtime.prototype.unstable_importModule === 'function') {
+    shimmer.wrap(Runtime.prototype, 'unstable_importModule', unstableImportModule => function () {
+      wrapJestGlobalsForRuntime(this)
+      wrapJestRuntimeEsmLoader(this)
+      return unstableImportModule.apply(this, arguments)
+    })
+  }
+
   shimmer.wrap(Runtime.prototype, 'requireModule', requireModule => function (from, moduleName) {
     wrapJestGlobalsForRuntime(this)
+    wrapJestRuntimeEsmLoader(this)
+    if (shouldRecordJestRuntimeCoverage(this)) {
+      recordJestRuntimeTouchedFile(this, resolveJestRuntimeRequiredFile(this, from, moduleName))
+    }
     try {
       return requireModule.apply(this, arguments)
     } catch (error) {
@@ -2483,6 +2701,7 @@ addHook({
 
   shimmer.wrap(Runtime.prototype, 'requireModuleOrMock', requireModuleOrMock => function (from, moduleName) {
     wrapJestGlobalsForRuntime(this)
+    wrapJestRuntimeEsmLoader(this)
     // `requireModuleOrMock` may log errors to the console. If we don't remove ourselves
     // from the stack trace, the user might see a useless stack trace rather than the error
     // that `jest` tries to show.

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -293,7 +293,9 @@ class JestPlugin extends CiPlugin {
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
       if (_ddTestCodeCoverageEnabled) {
-        this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_STARTED, 'suite', { library: 'istanbul' })
+        this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_STARTED, 'suite', {
+          library: testEnvironmentOptions._ddTestCodeCoverageEngine || 'istanbul',
+        })
       }
       this.testSuiteSpanPerTestSuiteAbsolutePath.set(testSuiteAbsolutePath, this.testSuiteSpan)
     })
@@ -401,7 +403,12 @@ class JestPlugin extends CiPlugin {
      * because this subscription happens in a different process from the one
      * fetching the ITR config.
      */
-    this.addSub('ci:jest:test-suite:code-coverage', ({ coverageFiles, testSuite, mockedFiles }) => {
+    this.addSub('ci:jest:test-suite:code-coverage', ({
+      coverageFiles,
+      testSuite,
+      mockedFiles,
+      coverageLibrary = 'istanbul',
+    }) => {
       if (!coverageFiles.length) {
         this.telemetry.count(TELEMETRY_CODE_COVERAGE_EMPTY)
       }
@@ -415,7 +422,7 @@ class JestPlugin extends CiPlugin {
       }
 
       this.tracer._exporter.exportCoverage(formattedCoverage)
-      this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: 'istanbul' })
+      this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: coverageLibrary })
       this.telemetry.distribution(TELEMETRY_CODE_COVERAGE_NUM_FILES, {}, files.length)
     })
 


### PR DESCRIPTION
Add a runtime touched-file coverage engine for TIA-only Jest suite coverage while preserving Istanbul for user coverage and Datadog Code Coverage upload paths that need bitmaps.\n\nBenchmark with 240 modules, 24 suites, 7 alternating trials:\n- Istanbul median: 5681ms\n- Runtime median: 4130ms\n- Improvement: 27.3%

<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


