### PR TITLE
ci(scripts): disable V8 Maglev for Windows test children

### DIFF
--- a/scripts/mocha-parallel-files.js
+++ b/scripts/mocha-parallel-files.js
@@ -10,6 +10,12 @@ const { globSync } = require('glob')
 
 const multiMochaRc = require('../.mochamultireporterrc')
 
+// V8's top-level `--maglev`/`--no-maglev` toggle landed in V8 11 (Node 20). On
+// V8 10 (Node 18) the flag does not exist, so passing it aborts the child with
+// `bad option: --no-maglev` (exit 9) before mocha runs. Children reuse this
+// process's binary, so our own V8 major decides whether the flag is safe.
+const SUPPORTS_NO_MAGLEV = Number.parseInt(process.versions.v8, 10) >= 11
+
 /**
  * @param {string} openTag
  * @param {string} name
@@ -553,7 +559,7 @@ async function main () {
         // (0xC0000409) when mocha-run-file's process.exit() races V8's Maglev teardown
         // on Windows. Maglev can only be disabled via a CLI flag, not NODE_OPTIONS.
         // TODO(BridgeAR): drop once https://github.com/nodejs/node/issues/62260 is fixed.
-        if (process.platform === 'win32') nodeArgs.push('--no-maglev')
+        if (process.platform === 'win32' && SUPPORTS_NO_MAGLEV) nodeArgs.push('--no-maglev')
         nodeArgs.push(runFileScript, file)
 
         entry.started = true

--- a/scripts/mocha-parallel-files.js
+++ b/scripts/mocha-parallel-files.js
@@ -549,6 +549,11 @@ async function main () {
 
         const nodeArgs = []
         if (opts.exposeGc) nodeArgs.push('--expose-gc')
+        // Network-heavy specs intermittently abort with STATUS_STACK_BUFFER_OVERRUN
+        // (0xC0000409) when mocha-run-file's process.exit() races V8's Maglev teardown
+        // on Windows. Maglev can only be disabled via a CLI flag, not NODE_OPTIONS.
+        // TODO(BridgeAR): drop once https://github.com/nodejs/node/issues/62260 is fixed.
+        if (process.platform === 'win32') nodeArgs.push('--no-maglev')
         nodeArgs.push(runFileScript, file)
 
         entry.started = true


### PR DESCRIPTION
## Summary

Windows test jobs intermittently fail with a crashed spec file and exit code
`3221226505` (`0xC0000409` / `STATUS_STACK_BUFFER_OVERRUN`) — no stderr, no
crash report, no mocha failure. `scripts/mocha-run-file.js` forces
`process.exit()` as soon as mocha finishes, and on Windows that races V8's
Maglev teardown while libuv still has in-flight sockets from a spec's real HTTP
traffic. The runner only sees a non-zero child exit and reports the file as
crashed. The file in the originating run was `inferred_proxy.spec.js`, but it is
just whichever network-heavy spec lost the race — its plugin logic is sound.

`scripts/mocha-parallel-files.js` now injects `--no-maglev` into the spawned
per-file `node` processes on `win32` only, sidestepping the faulty tier.

## Why

`--no-maglev` is a V8 flag that cannot be set through `NODE_OPTIONS`, so it has
to be a direct CLI argument on each spawned child — the parent runner can't
forward it any other way. The crash is upstream (nodejs/node#62260, still open);
this is a stop-gap until that lands, gated to Windows where the abort occurs.

## Test plan

- [ ] Windows test jobs (`tracing-windows`, and other Windows suites routed
      through `mocha-parallel-files.js`) stay green across reruns.
- [x] Non-Windows path unchanged: `node scripts/mocha-parallel-files.js --timeout 30000 -- "packages/dd-trace/test/plugins/util/inferred_proxy.spec.js"` passes locally with no flag added.

Refs: https://github.com/nodejs/node/issues/62260