### PR TITLE
test(jest): pin Babel for unsupported test axes

### DIFF
--- a/integration-tests/jest/babel-dependencies.js
+++ b/integration-tests/jest/babel-dependencies.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { satisfies } = require('semver')
+
+const { NODE_VERSION } = require('../../version')
+
+const BABEL_7_CORE_VERSION = '7.29.0'
+const BABEL_7_PRESET_TYPESCRIPT_VERSION = '7.28.5'
+const BABEL_8_NODE_RANGE = '^22.18.0 || >=24.11.0'
+
+/**
+ * @param {string} jestVersion
+ * @param {string} [nodeVersion]
+ * @returns {string[]}
+ */
+function getBabelDependencies (jestVersion, nodeVersion = NODE_VERSION) {
+  if (jestVersion === 'latest' && satisfies(nodeVersion, BABEL_8_NODE_RANGE)) {
+    return [
+      '@babel/core',
+      '@babel/preset-typescript',
+    ]
+  }
+
+  return [
+    `@babel/core@${BABEL_7_CORE_VERSION}`,
+    `@babel/preset-typescript@${BABEL_7_PRESET_TYPESCRIPT_VERSION}`,
+  ]
+}
+
+module.exports = { getBabelDependencies }

--- a/integration-tests/jest/jest.babel-dependencies.spec.js
+++ b/integration-tests/jest/jest.babel-dependencies.spec.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const { getBabelDependencies } = require('./babel-dependencies')
+
+const babel7Dependencies = [
+  '@babel/core@7.29.0',
+  '@babel/preset-typescript@7.28.5',
+]
+
+describe('getBabelDependencies', () => {
+  it('uses Babel 7 pins when Node.js does not support Babel 8', () => {
+    assert.deepStrictEqual(getBabelDependencies('latest', '18.20.8'), babel7Dependencies)
+  })
+
+  it('uses Babel 7 pins when Jest is not latest', () => {
+    assert.deepStrictEqual(getBabelDependencies('28.0.0', '22.22.3'), babel7Dependencies)
+  })
+
+  it('uses Babel 7 pins before the Node.js 24 version supported by Babel 8', () => {
+    assert.deepStrictEqual(getBabelDependencies('latest', '24.10.0'), babel7Dependencies)
+  })
+
+  it('uses the unversioned Babel entries when Node.js and Jest support Babel 8', () => {
+    assert.deepStrictEqual(getBabelDependencies('latest', '22.22.3'), [
+      '@babel/core',
+      '@babel/preset-typescript',
+    ])
+  })
+})

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -55,6 +55,7 @@ const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/
 const { ERROR_MESSAGE, ERROR_TYPE, ORIGIN_KEY, COMPONENT } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR } = require('../../version')
 const { version: ddTraceVersion } = require('../../package.json')
+const { getBabelDependencies } = require('./babel-dependencies')
 
 const testFile = 'ci-visibility/run-jest.js'
 const expectedStdout = 'Test Suites: 2 passed'
@@ -82,8 +83,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     shouldInstallJestEnvironmentJsdom ? `jest-environment-jsdom@${JEST_VERSION}` : '',
     // jest-circus is not included in older versions of jest
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
-    '@babel/core',
-    '@babel/preset-typescript',
+    ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
     'office-addin-mock',
     'winston',

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -50,6 +50,7 @@ const {
 const { TELEMETRY_COVERAGE_UPLOAD } = require('../../packages/dd-trace/src/ci-visibility/telemetry')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR } = require('../../version')
+const { getBabelDependencies } = require('./babel-dependencies')
 
 const runTestsCommand = 'node ./ci-visibility/run-jest.js'
 
@@ -72,8 +73,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     shouldInstallJestEnvironmentJsdom ? `jest-environment-jsdom@${JEST_VERSION}` : '',
     // jest-circus is not included in older versions of jest
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
-    '@babel/core',
-    '@babel/preset-typescript',
+    ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
     'office-addin-mock',
     'winston',

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -51,6 +51,7 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getBabelDependencies } = require('./babel-dependencies')
 
 const testFile = 'ci-visibility/run-jest.js'
 const expectedCoverageFiles = [
@@ -98,8 +99,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     shouldInstallJestEnvironmentJsdom ? `jest-environment-jsdom@${JEST_VERSION}` : '',
     // jest-circus is not included in older versions of jest
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
-    '@babel/core',
-    '@babel/preset-typescript',
+    ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
     'office-addin-mock',
     'winston',


### PR DESCRIPTION
### What does this PR do?

Adds a shared Jest integration helper that keeps Babel dependencies on the existing Babel 7 pins whenever the local Node.js runtime is outside Babel 8 supported range or the suite is exercising an older Jest version. The latest Jest path on Babel 8-supported Node.js still uses the unversioned sandbox entries from `versions/package.json`.

### Motivation

#9125 updates `@babel/core` and `@babel/preset-typescript` to 8.0.1 in the sandbox latests file. Babel 8 requires Node.js `^22.18.0 || >=24.11.0`, but the `integration-jest` workflow still runs `oldest` Node, which currently resolves to Node 18.20.8. Without the pin, those jobs can fail during sandbox dependency installation before testing dd-trace.

### Additional Notes

Validation:
- `./node_modules/.bin/mocha integration-tests/jest/jest.babel-dependencies.spec.js`
- `./node_modules/.bin/eslint --concurrency=off integration-tests/jest/babel-dependencies.js integration-tests/jest/jest.babel-dependencies.spec.js integration-tests/jest/jest.core.spec.js integration-tests/jest/jest.tia-efd.spec.js integration-tests/jest/jest.test-management.spec.js`
- `git diff --check`
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER JEST_VERSION=latest ./node_modules/.bin/mocha --timeout 60000 integration-tests/jest/jest.core.spec.js --grep "does not crash when jest is badly initialized"`