### PR TITLE
feat(http2): trace core-API HTTP/2 servers

### DIFF
--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -2,6 +2,7 @@
 
 const { channel, addHook } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
+const { FOREIGN_HTTP2_SERVER } = require('../../../dd-trace/src/constants')
 const types = require('./types')
 
 const startChannel = channel('apm:grpc:server:request:start')
@@ -73,6 +74,22 @@ function wrapRegister (register) {
     }
 
     return register.apply(this, arguments)
+  }
+}
+
+function wrapSetupHandlers (setupHandlers) {
+  return function (http2Server) {
+    // gRPC builds its transport on a core Node `Http2Server` and drives every
+    // call through its own span lifecycle over the raw 'stream' event. Mark the
+    // server so the http2 server instrumentation leaves it untraced; otherwise
+    // its re-enabled 'stream' path would wrap every gRPC call in a second
+    // web.request span and become the top frame. `_setupHandlers` is the single
+    // server-creation funnel across all supported versions (the older
+    // `createHttp2Server` does not exist), and it runs at bind time, before any
+    // request reaches the wrapped `emit`.
+    if (http2Server) http2Server[FOREIGN_HTTP2_SERVER] = true
+
+    return setupHandlers.apply(this, arguments)
   }
 }
 
@@ -149,6 +166,7 @@ function isEmitter (obj) {
 
 addHook({ name: '@grpc/grpc-js', versions: ['>=1.0.3'], file: 'build/src/server.js' }, server => {
   shimmer.wrap(server.Server.prototype, 'register', wrapRegister)
+  shimmer.wrap(server.Server.prototype, '_setupHandlers', wrapSetupHandlers)
 
   return server
 })

--- a/packages/datadog-instrumentations/src/http2/server.js
+++ b/packages/datadog-instrumentations/src/http2/server.js
@@ -8,6 +8,7 @@ const shimmer = require('../../../datadog-shimmer')
 
 const startServerCh = channel('apm:http2:server:request:start')
 const errorServerCh = channel('apm:http2:server:request:error')
+const adoptServerCh = channel('apm:http2:server:request:adopt')
 const emitCh = channel('apm:http2:server:response:emit')
 
 const HTTP2_HEADER_METHOD = ':method'
@@ -70,10 +71,17 @@ function wrapEmit (originalEmit) {
       // synthesized 'request' that fires nested below then reuses it. A
       // request-only server (no raw-stream listener) is left to the 'request'
       // branch so the compatibility response keeps its richer req/res.
-      if (this.listenerCount('request') === 0 || this.listenerCount('stream') > 1) {
+      const requestListenerCount = this.listenerCount('request')
+      if (requestListenerCount === 0 || this.listenerCount('stream') > 1) {
         const stream = args[1]
         const headers = args[2]
         const ctx = createStreamAdapter(stream, headers)
+        // Only a mixed server (a 'request' listener is present) synthesizes a
+        // real request off this stream and adopts the span later, so only then
+        // does the context need keying on the stream. A raw-stream-only server
+        // never adopts; leaving the flag unset keeps the stream->context write
+        // off its hot path.
+        ctx.adoptable = requestListenerCount !== 0
         tracedStreams.add(stream)
 
         return traceServerRequest(ctx, () => {
@@ -83,13 +91,18 @@ function wrapEmit (originalEmit) {
       }
     } else if (eventName === 'request') {
       const req = args[1]
+      const res = args[2]
+      res.req = req
+
       // A mixed server (raw-stream + 'request' listeners) already created the
       // span from the 'stream' event above; the stream's single 'close' is the
-      // sole finish source, so skip to avoid a second span and a second finish.
-      if (!tracedStreams.has(req.stream)) {
-        const res = args[2]
-        res.req = req
-
+      // sole finish source, so skip creating a second span. The synthesized
+      // request/response are the real objects a user's 'request' handler and
+      // the finish `hooks.request` expect, so hand them to the existing
+      // stream-backed context rather than leaving it on the throwaway adapter.
+      if (tracedStreams.has(req.stream)) {
+        adoptServerCh.publish({ req, res })
+      } else {
         const ctx = { req, res }
         return traceServerRequest(ctx, () => {
           shimmer.wrap(res, 'emit', emit => wrapResponseEmit(emit, ctx))

--- a/packages/datadog-instrumentations/src/http2/server.js
+++ b/packages/datadog-instrumentations/src/http2/server.js
@@ -90,15 +90,20 @@ function wrapEmit (originalEmit) {
 // Enter the request context and run `emitEvent` (the original `emit`, wrapped to
 // publish per-event for the matching response/stream), publishing any synchronous
 // throw from a user handler before letting it propagate.
+/**
+ * @param {StreamRequestContext | { req: object, res: object }} ctx
+ * @param {() => unknown} emitEvent
+ */
 function traceServerRequest (ctx, emitEvent) {
   return startServerCh.runStores(ctx, () => {
     try {
       return emitEvent()
     } catch (error) {
-      // Reached when a user request/stream handler throws synchronously; publish
-      // the error onto the span, then re-throw to preserve Node's native behavior
-      // of surfacing it to the caller of `emit`. Node turns a throwing handler
-      // into an uncaughtException, so this is not exercised under test.
+      // `EventEmitter.emit` rethrows a listener's synchronous throw to its
+      // caller (this wrapper), so the catch is reachable. It unwinds through
+      // Node's http2 session synchronously and surfaces as an uncaughtException,
+      // which crashes any in-process test harness, so it is covered here rather
+      // than in a spec. Mirrors the `apm:http:server:request:error` path.
       /* istanbul ignore next */
       ctx.error = error
       /* istanbul ignore next */
@@ -109,10 +114,35 @@ function traceServerRequest (ctx, emitEvent) {
   })
 }
 
+/**
+ * The minimal req/res pair the shared web lifecycle (`web.js`) keys on, built
+ * from a core-API `Http2Stream`. The fields below are exactly the surface
+ * `web.js` / `url.js` / `ip_extractor.js` read for a stream-backed request; a
+ * new read added there must be mirrored here or it resolves to `undefined` on
+ * the core path only.
+ *
+ * @typedef {object} StreamRequestContext
+ * @property {object} req
+ * @property {import('node:http2').ServerHttp2Stream} req.stream branch key in `web.js`/`url.js`
+ * @property {import('node:http2').IncomingHttpHeaders} req.headers raw pseudo-header map
+ * @property {string} [req.method]
+ * @property {string} [req.url]
+ * @property {import('node:net').Socket} [req.socket] peer address source (OTel)
+ * @property {object} res
+ * @property {object} res.req back-reference used by `wrapResponseEmit`/finish
+ * @property {string} [res.statusCode] read at finish from `stream.sentHeaders`
+ * @property {(name: string) => string | undefined} res.getHeader response-header tagging
+ */
+
 // Present the core-API stream + pseudo-header map as the minimal req/res pair
-// the shared web lifecycle (`web.js`) consumes. `req.stream` is the field its
-// URL/context branches key on; the response status and headers live on the
-// stream's `sentHeaders`, populated by `stream.respond()`.
+// the shared web lifecycle (`web.js`) consumes. The response status and headers
+// are getters because `stream.sentHeaders` is empty until `stream.respond()`
+// runs in the user handler; a snapshot taken here would always be `undefined`.
+/**
+ * @param {import('node:http2').ServerHttp2Stream} stream
+ * @param {import('node:http2').IncomingHttpHeaders} headers
+ * @returns {StreamRequestContext}
+ */
 function createStreamAdapter (stream, headers) {
   const req = {
     stream,
@@ -124,7 +154,11 @@ function createStreamAdapter (stream, headers) {
   const res = {
     req,
     get statusCode () {
-      return stream.sentHeaders?.[HTTP2_HEADER_STATUS]
+      // A stream aborted before `stream.respond()` has no `:status`. The
+      // compatibility `Http2ServerResponse.statusCode` defaults to 200 in that
+      // case, so match it rather than report `undefined` (which `validateStatus`
+      // would treat as an error and which drops the `http.status_code` tag).
+      return stream.sentHeaders?.[HTTP2_HEADER_STATUS] ?? 200
     },
     getHeader (name) {
       return stream.sentHeaders?.[name]

--- a/packages/datadog-instrumentations/src/http2/server.js
+++ b/packages/datadog-instrumentations/src/http2/server.js
@@ -5,6 +5,7 @@ const {
   addHook,
 } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
+const { FOREIGN_HTTP2_SERVER } = require('../../../dd-trace/src/constants')
 
 const startServerCh = channel('apm:http2:server:request:start')
 const errorServerCh = channel('apm:http2:server:request:error')
@@ -57,7 +58,12 @@ function wrapEmit (originalEmit) {
   // Named `emit` mirrors the server method so the one-time wrap skips its name
   // rewrite; rest params keep the per-event forwarding allocation-free.
   return function emit (...args) {
-    if (!startServerCh.hasSubscribers) {
+    // A server owned by another instrumentation (e.g. @grpc/grpc-js) drives its
+    // own span lifecycle over the raw 'stream' API, so tracing it here would add
+    // a spurious web.request span on top of that integration's span and steal
+    // the top frame. Skip it entirely; the mark is set at server creation, so
+    // this is one property read on servers we do trace.
+    if (!startServerCh.hasSubscribers || this[FOREIGN_HTTP2_SERVER]) {
       return Reflect.apply(originalEmit, this, args)
     }
 

--- a/packages/datadog-instrumentations/src/http2/server.js
+++ b/packages/datadog-instrumentations/src/http2/server.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// Old instrumentation temporarily replaced with compatibility mode only instrumentation.
-// See https://github.com/DataDog/dd-trace-js/issues/312
-
 const {
   channel,
   addHook,
@@ -12,6 +9,10 @@ const shimmer = require('../../../datadog-shimmer')
 const startServerCh = channel('apm:http2:server:request:start')
 const errorServerCh = channel('apm:http2:server:request:error')
 const emitCh = channel('apm:http2:server:response:emit')
+
+const HTTP2_HEADER_METHOD = ':method'
+const HTTP2_HEADER_PATH = ':path'
+const HTTP2_HEADER_STATUS = ':status'
 
 addHook({ name: 'http2' }, http2 => {
   shimmer.wrap(http2, 'createSecureServer', wrapCreateServer)
@@ -36,6 +37,16 @@ function wrapResponseEmit (originalEmit, ctx) {
   }
 }
 
+function wrapStreamEmit (originalEmit, ctx) {
+  // Named `emit`/arity-1 mirrors the stream method so the per-stream wrap skips
+  // its name/length rewrite. `this` is the Http2Stream; the plugin finishes on
+  // 'close', the same finish signal as the compatibility response.
+  return function emit (eventName) {
+    ctx.eventName = eventName
+    return emitCh.runStores(ctx, originalEmit, this, ...arguments)
+  }
+}
+
 function wrapEmit (originalEmit) {
   // Named `emit` mirrors the server method so the one-time wrap skips its name
   // rewrite; rest params keep the per-event forwarding allocation-free.
@@ -51,19 +62,74 @@ function wrapEmit (originalEmit) {
       res.req = req
 
       const ctx = { req, res }
-      return startServerCh.runStores(ctx, () => {
+      return traceServerRequest(ctx, () => {
         shimmer.wrap(res, 'emit', emit => wrapResponseEmit(emit, ctx))
-
-        try {
-          return Reflect.apply(originalEmit, this, args)
-        } catch (error) {
-          ctx.error = error
-          errorServerCh.publish(ctx)
-
-          throw error
-        }
+        return Reflect.apply(originalEmit, this, args)
       })
     }
+
+    // Core API: a compatibility server emits both 'request' and 'stream' for
+    // every request, so the span belongs to the 'request' branch above when a
+    // 'request' listener exists. Only a server without one is using the raw
+    // stream API, where this branch is the sole place a server span is created.
+    if (eventName === 'stream' && this.listenerCount('request') === 0) {
+      const stream = args[1]
+      const headers = args[2]
+      const ctx = createStreamAdapter(stream, headers)
+
+      return traceServerRequest(ctx, () => {
+        shimmer.wrap(stream, 'emit', emit => wrapStreamEmit(emit, ctx))
+        return Reflect.apply(originalEmit, this, args)
+      })
+    }
+
     return Reflect.apply(originalEmit, this, args)
   }
+}
+
+// Enter the request context and run `emitEvent` (the original `emit`, wrapped to
+// publish per-event for the matching response/stream), publishing any synchronous
+// throw from a user handler before letting it propagate.
+function traceServerRequest (ctx, emitEvent) {
+  return startServerCh.runStores(ctx, () => {
+    try {
+      return emitEvent()
+    } catch (error) {
+      // Reached when a user request/stream handler throws synchronously; publish
+      // the error onto the span, then re-throw to preserve Node's native behavior
+      // of surfacing it to the caller of `emit`. Node turns a throwing handler
+      // into an uncaughtException, so this is not exercised under test.
+      /* istanbul ignore next */
+      ctx.error = error
+      /* istanbul ignore next */
+      errorServerCh.publish(ctx)
+      /* istanbul ignore next */
+      throw error
+    }
+  })
+}
+
+// Present the core-API stream + pseudo-header map as the minimal req/res pair
+// the shared web lifecycle (`web.js`) consumes. `req.stream` is the field its
+// URL/context branches key on; the response status and headers live on the
+// stream's `sentHeaders`, populated by `stream.respond()`.
+function createStreamAdapter (stream, headers) {
+  const req = {
+    stream,
+    headers,
+    method: headers[HTTP2_HEADER_METHOD],
+    url: headers[HTTP2_HEADER_PATH],
+    socket: stream.session?.socket,
+  }
+  const res = {
+    req,
+    get statusCode () {
+      return stream.sentHeaders?.[HTTP2_HEADER_STATUS]
+    },
+    getHeader (name) {
+      return stream.sentHeaders?.[name]
+    },
+  }
+
+  return { req, res }
 }

--- a/packages/datadog-instrumentations/src/http2/server.js
+++ b/packages/datadog-instrumentations/src/http2/server.js
@@ -14,6 +14,11 @@ const HTTP2_HEADER_METHOD = ':method'
 const HTTP2_HEADER_PATH = ':path'
 const HTTP2_HEADER_STATUS = ':status'
 
+// Streams whose server span was already created from the 'stream' event. The
+// compatibility layer synthesizes 'request' from that same stream, so the
+// 'request' branch consults this set to avoid creating a second span.
+const tracedStreams = new WeakSet()
+
 addHook({ name: 'http2' }, http2 => {
   shimmer.wrap(http2, 'createSecureServer', wrapCreateServer)
   shimmer.wrap(http2, 'createServer', wrapCreateServer)
@@ -56,31 +61,41 @@ function wrapEmit (originalEmit) {
     }
 
     const eventName = args[0]
-    if (eventName === 'request') {
+    if (eventName === 'stream') {
+      // The compatibility layer synthesizes 'request' from an internal 'stream'
+      // listener it registers exactly once when a 'request' listener is added,
+      // so `listenerCount('stream')` exceeds one only when the application also
+      // registered a raw-stream listener. Owning the span here for that case
+      // keeps it active while the application's stream listener runs; the
+      // synthesized 'request' that fires nested below then reuses it. A
+      // request-only server (no raw-stream listener) is left to the 'request'
+      // branch so the compatibility response keeps its richer req/res.
+      if (this.listenerCount('request') === 0 || this.listenerCount('stream') > 1) {
+        const stream = args[1]
+        const headers = args[2]
+        const ctx = createStreamAdapter(stream, headers)
+        tracedStreams.add(stream)
+
+        return traceServerRequest(ctx, () => {
+          shimmer.wrap(stream, 'emit', emit => wrapStreamEmit(emit, ctx))
+          return Reflect.apply(originalEmit, this, args)
+        })
+      }
+    } else if (eventName === 'request') {
       const req = args[1]
-      const res = args[2]
-      res.req = req
+      // A mixed server (raw-stream + 'request' listeners) already created the
+      // span from the 'stream' event above; the stream's single 'close' is the
+      // sole finish source, so skip to avoid a second span and a second finish.
+      if (!tracedStreams.has(req.stream)) {
+        const res = args[2]
+        res.req = req
 
-      const ctx = { req, res }
-      return traceServerRequest(ctx, () => {
-        shimmer.wrap(res, 'emit', emit => wrapResponseEmit(emit, ctx))
-        return Reflect.apply(originalEmit, this, args)
-      })
-    }
-
-    // Core API: a compatibility server emits both 'request' and 'stream' for
-    // every request, so the span belongs to the 'request' branch above when a
-    // 'request' listener exists. Only a server without one is using the raw
-    // stream API, where this branch is the sole place a server span is created.
-    if (eventName === 'stream' && this.listenerCount('request') === 0) {
-      const stream = args[1]
-      const headers = args[2]
-      const ctx = createStreamAdapter(stream, headers)
-
-      return traceServerRequest(ctx, () => {
-        shimmer.wrap(stream, 'emit', emit => wrapStreamEmit(emit, ctx))
-        return Reflect.apply(originalEmit, this, args)
-      })
+        const ctx = { req, res }
+        return traceServerRequest(ctx, () => {
+          shimmer.wrap(res, 'emit', emit => wrapResponseEmit(emit, ctx))
+          return Reflect.apply(originalEmit, this, args)
+        })
+      }
     }
 
     return Reflect.apply(originalEmit, this, args)
@@ -130,8 +145,8 @@ function traceServerRequest (ctx, emitEvent) {
  * @property {import('node:net').Socket} [req.socket] peer address source (OTel)
  * @property {object} res
  * @property {object} res.req back-reference used by `wrapResponseEmit`/finish
- * @property {string} [res.statusCode] read at finish from `stream.sentHeaders`
- * @property {(name: string) => string | undefined} res.getHeader response-header tagging
+ * @property {number} res.statusCode read at finish from `stream.sentHeaders`
+ * @property {(name: string) => string | number | string[] | undefined} res.getHeader response-header tagging
  */
 
 // Present the core-API stream + pseudo-header map as the minimal req/res pair

--- a/packages/datadog-instrumentations/src/http2/server.js
+++ b/packages/datadog-instrumentations/src/http2/server.js
@@ -133,16 +133,8 @@ function traceServerRequest (ctx, emitEvent) {
     try {
       return emitEvent()
     } catch (error) {
-      // `EventEmitter.emit` rethrows a listener's synchronous throw to its
-      // caller (this wrapper), so the catch is reachable. It unwinds through
-      // Node's http2 session synchronously and surfaces as an uncaughtException,
-      // which crashes any in-process test harness, so it is covered here rather
-      // than in a spec. Mirrors the `apm:http:server:request:error` path.
-      /* istanbul ignore next */
       ctx.error = error
-      /* istanbul ignore next */
       errorServerCh.publish(ctx)
-      /* istanbul ignore next */
       throw error
     }
   })

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -564,7 +564,7 @@ describe('Plugin', () => {
             // rejects it with 415, and its 'stream' event must still not be
             // traced as http2 because gRPC owns the server.
             await new Promise((resolve, reject) => {
-              const client = http2.connect(`http://localhost:${port}`).on('error', reject)
+              const client = http2.connect(`http://127.0.0.1:${port}`).on('error', reject)
               const req = client.request({ ':path': '/', ':method': 'GET' })
               req.on('error', reject)
               req.on('end', () => {

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -509,6 +509,81 @@ describe('Plugin', () => {
           }, done)
         })
       })
+
+      // gRPC serves over a core Node Http2Server. With the http2 server plugin
+      // also enabled, that server's 'stream' events must not be traced by http2:
+      // gRPC owns the span, so a call keeps a single grpc.server span rather than
+      // gaining a web.request span that steals the top frame.
+      describe('with http2 server tracing also enabled', () => {
+        before(() => {
+          return agent.load(['grpc', 'http2'], { client: false })
+            .then(() => {
+              tracer = require('../../dd-trace')
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
+            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        it('produces only the grpc.server span, no web.request span', async () => {
+          const spans = []
+          const collect = traces => spans.push(...traces.flat())
+          agent.subscribe(collect)
+
+          try {
+            const client = await buildClient({ getUnary: (_, callback) => callback(null, {}) })
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            await agent.assertSomeTraces(traces => {
+              assertObjectContains(traces[0][0], { name: 'grpc.server', meta: { component: 'grpc' } })
+            })
+
+            const httpSpans = spans.filter(span => span.name === 'web.request')
+            assert.deepStrictEqual(httpSpans, [], 'gRPC call must not produce a web.request span')
+
+            // With no web.request span at all, gRPC is necessarily the top server
+            // frame; assert the span is present so a silent drop can't pass this.
+            assert.ok(spans.some(span => span.name === 'grpc.server'), 'expected a grpc.server span')
+          } finally {
+            agent.unsubscribe(collect)
+          }
+        })
+
+        it('does not produce a web.request span for a non-gRPC request to the gRPC port', async () => {
+          const http2 = require('node:http2')
+          await buildClient({ getUnary: (_, callback) => callback(null, {}) })
+
+          const spans = []
+          const collect = traces => spans.push(...traces.flat())
+          agent.subscribe(collect)
+
+          try {
+            // A plain HTTP/2 request with no gRPC content-type: the gRPC server
+            // rejects it with 415, and its 'stream' event must still not be
+            // traced as http2 because gRPC owns the server.
+            await new Promise((resolve, reject) => {
+              const client = http2.connect(`http://localhost:${port}`).on('error', reject)
+              const req = client.request({ ':path': '/', ':method': 'GET' })
+              req.on('error', reject)
+              req.on('end', () => {
+                client.close()
+                resolve()
+              })
+              req.resume()
+              req.end()
+            })
+
+            for (let drain = 0; drain < 5; drain++) await new Promise(setImmediate)
+
+            const httpSpans = spans.filter(span => span.name === 'web.request')
+            assert.deepStrictEqual(httpSpans, [], 'a non-gRPC request to a gRPC server must not be traced as http2')
+          } finally {
+            agent.unsubscribe(collect)
+          }
+        })
+      })
     })
   })
 })

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -1,7 +1,5 @@
 'use strict'
 
-// Plugin temporarily disabled. See https://github.com/DataDog/dd-trace-js/issues/312
-
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
@@ -47,7 +45,9 @@ class Http2ServerPlugin extends ServerPlugin {
 
     const context = web.getContext(req)
 
-    if (!context.instrumented) {
+    // The core stream API has no `res.writeHead`; CORS preflight tagging only
+    // applies to the compatibility response that exposes it.
+    if (!context.instrumented && typeof context.res.writeHead === 'function') {
       context.res.writeHead = web.wrapWriteHead(context)
       context.instrumented = true
     }

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -56,6 +56,11 @@ class Http2ServerPlugin extends ServerPlugin {
   }
 
   bindEmit (ctx) {
+    // Both the compatibility response and the core-API stream emit 'close'
+    // exactly once, so the span is finished from a single source. `web.js`
+    // bypasses its `finished` idempotency guard for stream-backed requests
+    // (`!req.stream`); that bypass is harmless here only because of this
+    // single-finish property.
     if (ctx.eventName !== 'close') return ctx.currentStore
 
     const { req } = ctx

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -8,6 +8,7 @@ class Http2ServerPlugin extends ServerPlugin {
   constructor (tracer, config) {
     super(tracer, config)
     this.addBind('apm:http2:server:response:emit', this.bindEmit)
+    this.addSub('apm:http2:server:request:adopt', this.adopt)
   }
 
   static id = 'http2'
@@ -45,14 +46,27 @@ class Http2ServerPlugin extends ServerPlugin {
 
     const context = web.getContext(req)
 
-    // The core stream API has no `res.writeHead`; CORS preflight tagging only
-    // applies to the compatibility response that exposes it.
-    if (!context.instrumented && typeof context.res.writeHead === 'function') {
-      context.res.writeHead = web.wrapWriteHead(context)
-      context.instrumented = true
-    }
+    // A mixed server adopts the real request off this stream later; key the
+    // context on the stream now so that lookup resolves. Skipped for the common
+    // single-listener request, which never adopts.
+    if (ctx.adoptable) web.linkContextToStream(req.stream, context)
+
+    instrumentWriteHead(context)
 
     return ctx.currentStore
+  }
+
+  // A mixed server (raw-stream + 'request' listeners) creates the span from the
+  // 'stream' event with a throwaway adapter. When the compatibility layer then
+  // synthesizes the real request/response off the same stream, point the shared
+  // context at them so `web.setFramework`/`web.setRoute` from the user's
+  // 'request' handler resolve to this span and the finish `hooks.request`
+  // receives the real objects instead of the adapter.
+  adopt (ctx) {
+    const context = web.patch(ctx.req)
+    context.req = ctx.req
+    context.res = ctx.res
+    instrumentWriteHead(context)
   }
 
   bindEmit (ctx) {
@@ -80,6 +94,19 @@ class Http2ServerPlugin extends ServerPlugin {
 
   configure (config) {
     return super.configure(web.normalizeConfig(config))
+  }
+}
+
+// The core stream API has no `res.writeHead`; CORS preflight tagging only
+// applies to the compatibility response that exposes it. Runs once per context:
+// the mixed path calls it again from `adopt` once the real response is in place.
+/**
+ * @param {{ res: { writeHead?: Function }, instrumented?: boolean }} context
+ */
+function instrumentWriteHead (context) {
+  if (!context.instrumented && typeof context.res.writeHead === 'function') {
+    context.res.writeHead = web.wrapWriteHead(context)
+    context.instrumented = true
   }
 }
 

--- a/packages/datadog-plugin-http2/test/fixtures/throwing-stream-handler.js
+++ b/packages/datadog-plugin-http2/test/fixtures/throwing-stream-handler.js
@@ -1,0 +1,22 @@
+'use strict'
+
+require('../../../dd-trace').init().use('http2', { client: false })
+
+const http2 = require('http2')
+
+const server = http2.createServer()
+server.on('stream', () => {
+  throw new Error('expected stream handler failure')
+})
+server.listen(0, '127.0.0.1', () => {
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`)
+  client.on('error', () => {})
+
+  const request = client.request({ ':path': '/' })
+  request.on('error', () => {})
+  request.end()
+})
+
+setTimeout(() => {
+  throw new Error('HTTP/2 stream handler did not throw')
+}, 5_000)

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -7,6 +7,7 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
+const web = require('../../dd-trace/src/plugins/util/web')
 const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { rawExpectedSchema } = require('./naming')
@@ -696,6 +697,51 @@ describe('Plugin', () => {
             })
 
             await Promise.all([traceAsserted, request(http2, `http://localhost:${port}/user`)])
+          })
+
+          describe('exposing the real compatibility req/res', () => {
+            let hookRes
+
+            beforeEach(() => {
+              hookRes = undefined
+              agent.reload('http2', {
+                client: false,
+                hooks: {
+                  request (span, req, res) {
+                    hookRes = res
+                  },
+                },
+              })
+            })
+
+            it('hands the real compatibility req/res to the finish hook and web helpers', async () => {
+              let activeInRequestListener
+              const server = http2.createServer((req, res) => {
+                activeInRequestListener = tracer.scope().active()
+                // Setting the route through the shared web lifecycle only reaches
+                // the span when the real `req` resolves to the stream's context.
+                web.setRoute(req, '/users/:id')
+                res.writeHead(200)
+                res.end()
+              })
+              server.on('stream', () => {})
+              await listenAsync(server)
+
+              const traceAsserted = agent.assertFirstTraceSpan(span => {
+                assert.ok(activeInRequestListener, 'request listener ran without an active span')
+                assert.strictEqual(
+                  activeInRequestListener.context().toSpanId(),
+                  span.span_id.toString(),
+                  'the request listener saw a different span than the one that finished'
+                )
+                assertObjectContains(span, { resource: 'GET /users/:id' })
+                // The synthetic stream adapter has no `writeHead`; only the real
+                // `Http2ServerResponse` this path used to expose does.
+                assert.strictEqual(typeof hookRes?.writeHead, 'function')
+              })
+
+              await Promise.all([traceAsserted, request(http2, `http://localhost:${port}/users/42`)])
+            })
           })
         })
       })

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -605,11 +605,11 @@ describe('Plugin', () => {
         })
 
         describe('with configured headers', () => {
+          // The parent `core API` `beforeEach` already started the mock agent;
+          // reconfigure the plugin in place instead of `agent.load`, which would
+          // start a second agent and leak the first server's handle.
           beforeEach(() => {
-            return agent.load('http2', { client: false, headers: ['x-foo', 'x-resp:resp_tag'] })
-              .then(() => {
-                http2 = require(pluginToBeLoaded)
-              })
+            agent.reload('http2', { client: false, headers: ['x-foo', 'x-resp:resp_tag'] })
           })
 
           beforeEach(done => {
@@ -677,6 +677,25 @@ describe('Plugin', () => {
             server.on('stream', () => {})
             await listenAsync(server)
             await assertSingleServerSpan(http2, `http://localhost:${port}/user`)
+          })
+
+          it('keeps the server span active inside a mixed setup\'s stream listener', async () => {
+            let streamActive
+            const server = http2.createServer((req, res) => {
+              res.writeHead(200)
+              res.end()
+            })
+            server.on('stream', () => {
+              streamActive = tracer.scope().active()
+            })
+            await listenAsync(server)
+
+            const traceAsserted = agent.assertFirstTraceSpan(span => {
+              assert.ok(streamActive, 'stream listener ran without an active span')
+              assert.strictEqual(streamActive.context().toSpanId(), span.span_id.toString())
+            })
+
+            await Promise.all([traceAsserted, request(http2, `http://localhost:${port}/user`)])
           })
         })
       })

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const web = require('../../dd-trace/src/plugins/util/web')
+const { FOREIGN_HTTP2_SERVER } = require('../../dd-trace/src/constants')
 const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { rawExpectedSchema } = require('./naming')
@@ -602,6 +603,49 @@ describe('Plugin', () => {
               .catch(done)
 
             request(http2, `http://localhost:${port}/user`).catch(() => {})
+          })
+        })
+
+        describe('a server owned by another instrumentation', () => {
+          // Mirrors what the @grpc/grpc-js instrumentation does at server
+          // creation. The mark must make the http2 instrumentation skip the
+          // server entirely so the owning integration keeps the only span.
+          it('produces no web.request span when the server is marked foreign', async () => {
+            const server = http2.createServer()
+            server[FOREIGN_HTTP2_SERVER] = true
+            server.on('stream', (stream) => {
+              stream.respond({ ':status': 200 })
+              stream.end()
+            })
+            await new Promise(resolve => listen(server, resolve))
+
+            let serverSpanCount = 0
+            const countHandler = traces => {
+              serverSpanCount += traces.flat().filter(span => span.name === 'web.request').length
+            }
+            agent.subscribe(countHandler)
+
+            try {
+              await request(http2, `http://localhost:${port}/user`)
+              for (let drain = 0; drain < 5; drain++) await setImmediate()
+              assert.strictEqual(serverSpanCount, 0)
+            } finally {
+              agent.unsubscribe(countHandler)
+            }
+          })
+
+          it('still traces an unmarked server on the same code path', async () => {
+            const server = http2.createServer()
+            server.on('stream', (stream) => {
+              stream.respond({ ':status': 200 })
+              stream.end()
+            })
+            await new Promise(resolve => listen(server, resolve))
+
+            await Promise.all([
+              agent.assertFirstTraceSpan({ name: 'web.request', meta: { component: 'http2' } }),
+              request(http2, `http://localhost:${port}/user`),
+            ])
           })
         })
 

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { fork } = require('node:child_process')
+const { once } = require('node:events')
+const path = require('node:path')
+const { text } = require('node:stream/consumers')
 const { setImmediate } = require('node:timers/promises')
 
 const { afterEach, beforeEach, describe, it } = require('mocha')
@@ -46,6 +50,27 @@ function request (http2, url, options = {}) {
 
     req.end()
   })
+}
+
+/**
+ * @returns {Promise<{ code: number | null, stderr: string }>}
+ */
+async function runThrowingStreamHandler () {
+  const child = fork(path.join(__dirname, 'fixtures', 'throwing-stream-handler.js'), {
+    env: {
+      ...process.env,
+      DD_TRACE_AGENT_PORT: '0',
+      DD_TRACE_STARTUP_LOGS: 'false',
+    },
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+  })
+
+  const [[code], stderr] = await Promise.all([
+    once(child, 'exit'),
+    text(child.stderr),
+  ])
+
+  return { code, stderr }
 }
 
 describe('Plugin', () => {
@@ -832,6 +857,15 @@ describe('Plugin', () => {
           }
         })
       })
+    })
+  })
+
+  describe('http2/server error propagation', () => {
+    it('rethrows synchronous stream handler errors', async () => {
+      const { code, stderr } = await runThrowingStreamHandler()
+
+      assert.strictEqual(code, 1)
+      assert.match(stderr, /Error: expected stream handler failure/)
     })
   })
 })

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -507,6 +507,224 @@ describe('Plugin', () => {
           })
         })
       })
+
+      describe('core API', () => {
+        beforeEach(() => {
+          return agent.load('http2', { client: false })
+            .then(() => {
+              http2 = require(pluginToBeLoaded)
+            })
+        })
+
+        function listen (server, done) {
+          appListener = server.listen(0, 'localhost', () => {
+            port = appListener.address().port
+            done()
+          })
+        }
+
+        describe('server.on(\'stream\')', () => {
+          beforeEach(done => {
+            const server = http2.createServer()
+            server.on('stream', (stream) => {
+              stream.respond({ ':status': 200 })
+              stream.end()
+            })
+            listen(server, done)
+          })
+
+          it('should instrument the core stream API', done => {
+            agent
+              .assertFirstTraceSpan({
+                name: 'web.request',
+                service: 'test',
+                type: 'web',
+                resource: 'GET',
+                meta: {
+                  'span.kind': 'server',
+                  'http.url': `http://localhost:${port}/user`,
+                  'http.method': 'GET',
+                  'http.status_code': '200',
+                  component: 'http2',
+                },
+              })
+              .then(done)
+              .catch(done)
+
+            request(http2, `http://localhost:${port}/user`).catch(done)
+          })
+
+          it('should produce exactly one server span per request', async () => {
+            await assertSingleServerSpan(http2, `http://localhost:${port}/user`)
+          })
+
+          it('should run the stream\'s close event in the correct context', done => {
+            const server = appListener
+            server.removeAllListeners('stream')
+            server.on('stream', (stream) => {
+              const span = tracer.scope().active()
+              stream.once('close', () => {
+                assert.strictEqual(tracer.scope().active(), span)
+                done()
+              })
+              stream.respond({ ':status': 200 })
+              stream.end()
+            })
+
+            request(http2, `http://localhost:${port}/user`).catch(done)
+          })
+        })
+
+        describe('with configured headers', () => {
+          beforeEach(() => {
+            return agent.load('http2', { client: false, headers: ['x-foo', 'x-resp:resp_tag'] })
+              .then(() => {
+                http2 = require(pluginToBeLoaded)
+              })
+          })
+
+          beforeEach(done => {
+            const server = http2.createServer()
+            server.on('stream', (stream) => {
+              stream.respond({ ':status': 200, 'x-resp': 'sent' })
+              stream.end()
+            })
+            listen(server, done)
+          })
+
+          it('tags configured request and response headers from the stream', done => {
+            agent
+              .assertFirstTraceSpan({
+                name: 'web.request',
+                meta: {
+                  component: 'http2',
+                  'http.request.headers.x-foo': 'bar',
+                  resp_tag: 'sent',
+                },
+              })
+              .then(done)
+              .catch(done)
+
+            const url = new URL(`http://localhost:${port}/user`)
+            const client = http2.connect(url.origin).on('error', done)
+            const req = client.request({ ':path': url.pathname, ':method': 'GET', 'x-foo': 'bar' })
+            req.on('error', done)
+            req.on('end', () => client.close())
+            req.resume()
+            req.end()
+          })
+        })
+
+        describe('compatibility servers do not double-span', () => {
+          /** @param {import('node:http2').Http2Server} server */
+          function listenAsync (server) {
+            return new Promise(resolve => listen(server, resolve))
+          }
+
+          it('createServer(handler) produces exactly one server span', async () => {
+            const server = http2.createServer((req, res) => {
+              res.writeHead(200)
+              res.end()
+            })
+            await listenAsync(server)
+            await assertSingleServerSpan(http2, `http://localhost:${port}/user`)
+          })
+
+          it('createServer().on(\'request\') produces exactly one server span', async () => {
+            const server = http2.createServer()
+            server.on('request', (req, res) => {
+              res.writeHead(200)
+              res.end()
+            })
+            await listenAsync(server)
+            await assertSingleServerSpan(http2, `http://localhost:${port}/user`)
+          })
+
+          it('a server with both request and stream listeners produces exactly one server span', async () => {
+            const server = http2.createServer((req, res) => {
+              res.writeHead(200)
+              res.end()
+            })
+            server.on('stream', () => {})
+            await listenAsync(server)
+            await assertSingleServerSpan(http2, `http://localhost:${port}/user`)
+          })
+        })
+      })
+
+      describe('core API distributed tracing', () => {
+        beforeEach(() => {
+          return agent.load('http2')
+            .then(() => {
+              http2 = require(pluginToBeLoaded)
+            })
+        })
+
+        beforeEach(done => {
+          const server = http2.createServer()
+          server.on('stream', (stream) => {
+            stream.respond({ ':status': 200 })
+            stream.end()
+          })
+          appListener = server.listen(0, 'localhost', () => {
+            port = appListener.address().port
+            done()
+          })
+        })
+
+        it('makes the core server span a child of the client span', async () => {
+          const spans = []
+          const collect = traces => spans.push(...traces.flat())
+          agent.subscribe(collect)
+
+          try {
+            await request(http2, `http://localhost:${port}/user`)
+
+            for (let drain = 0; drain < 5; drain++) await setImmediate()
+
+            const clientSpan = spans.find(span => span.meta?.['span.kind'] === 'client')
+            const serverSpan = spans.find(span => span.name === 'web.request')
+
+            assert.ok(clientSpan, 'expected an http2 client span')
+            assert.ok(serverSpan, 'expected a core-API server span')
+            assert.strictEqual(serverSpan.trace_id.toString(), clientSpan.trace_id.toString())
+            assert.strictEqual(serverSpan.parent_id.toString(), clientSpan.span_id.toString())
+          } finally {
+            agent.unsubscribe(collect)
+          }
+        })
+      })
     })
   })
 })
+
+/**
+ * Drive one request and assert the agent receives exactly one `web.request`
+ * span for it. A compatibility server emits both 'request' and 'stream'; a
+ * regression that drops the core-API request-listener gate produces a second
+ * `web.request` span that flushes in a later payload, so the count accumulates
+ * across every payload and is read only after the request has fully closed and
+ * the flush turns have drained (`flushInterval` is 0 under the test agent).
+ *
+ * @param {typeof import('http2')} http2
+ * @param {string} url
+ */
+async function assertSingleServerSpan (http2, url) {
+  let serverSpanCount = 0
+  const countHandler = traces => {
+    serverSpanCount += traces.flat().filter(span => span.name === 'web.request').length
+  }
+  agent.subscribe(countHandler)
+
+  try {
+    await request(http2, url)
+
+    // Let every flush for the request drain (flushInterval is 0, so each
+    // finished trace chunk is sent on the next turns) before reading the count.
+    for (let drain = 0; drain < 5; drain++) await setImmediate()
+
+    assert.strictEqual(serverSpanCount, 1)
+  } finally {
+    agent.unsubscribe(countHandler)
+  }
+}

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -573,6 +573,35 @@ describe('Plugin', () => {
 
             request(http2, `http://localhost:${port}/user`).catch(done)
           })
+
+          it('reports status 200 for a stream aborted before it responded', done => {
+            const server = appListener
+            server.removeAllListeners('stream')
+            server.on('stream', (stream) => {
+              stream.on('error', () => {})
+              // Close without responding: `stream.sentHeaders` stays empty, so the
+              // adapter falls back to the compatibility default of 200 instead of
+              // tagging the span as an error with no status.
+              stream.close(http2.constants.NGHTTP2_INTERNAL_ERROR)
+            })
+
+            agent
+              .assertFirstTraceSpan({
+                name: 'web.request',
+                resource: 'GET',
+                error: 0,
+                meta: {
+                  'span.kind': 'server',
+                  'http.method': 'GET',
+                  'http.status_code': '200',
+                  component: 'http2',
+                },
+              })
+              .then(done)
+              .catch(done)
+
+            request(http2, `http://localhost:${port}/user`).catch(() => {})
+          })
         })
 
         describe('with configured headers', () => {

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -31,6 +31,13 @@ module.exports = {
   ERROR_MESSAGE: 'error.message',
   ERROR_STACK: 'error.stack',
   IGNORE_OTEL_ERROR: Symbol('ignore.otel.error'),
+  // Marks an `Http2Server` that another instrumentation (currently @grpc/grpc-js)
+  // owns and traces through its own span lifecycle over the raw HTTP/2 stream
+  // API. The http2 server instrumentation reads this to leave such servers
+  // untraced, so a gRPC call keeps a single span with gRPC as the top frame
+  // instead of gaining an extra web.request span. A module-local Symbol keeps
+  // the mark private to dd-trace and unforgeable from user code.
+  FOREIGN_HTTP2_SERVER: Symbol('foreign.http2.server'),
   COMPONENT: 'component',
   CLIENT_PORT_KEY: 'network.destination.port',
   PEER_SERVICE_KEY: 'peer.service',

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -185,6 +185,18 @@ const web = {
     return context
   },
 
+  // Key an existing context on the underlying `Http2Stream` so a second request
+  // backed by the same stream resolves to it via the `req.stream` lookup in
+  // `patch`. Only a mixed HTTP/2 server (raw-stream + 'request' listeners) needs
+  // this: it creates the span from a throwaway stream adapter, then the
+  // compatibility layer synthesizes the real `Http2ServerRequest` off the same
+  // stream and must reuse the adapter's span rather than open an orphan context.
+  // Confined to that path so the common single-listener request pays no extra
+  // per-request map write.
+  linkContextToStream (stream, context) {
+    contexts.set(stream, context)
+  },
+
   // Return the request root span.
   root (req) {
     const context = contexts.get(req)


### PR DESCRIPTION
## Summary

A server using the raw stream API (`createServer().on('stream', ...)`) produced no server span, because the instrumentation only hooked the compatibility `request` event. The `stream` event is now adapted into the minimal req/res shape the shared web lifecycle consumes, so the core path gets the same span, context propagation, and configured header tagging as the compatibility path.

A compatibility server emits both `request` and `stream` for every request, so the `stream` branch only creates a span when the server has no `request` listener; otherwise the request would be double-instrumented.

## Test plan

- `should instrument the core stream API` — a `web.request` span with the expected url/method/status for a core-API server.
- `produces exactly one server span` permutations — `createServer(handler)`, `createServer().on('request')`, and a server with both listeners each yield exactly one span (the gate that prevents double-instrumentation).
- `makes the core server span a child of the client span` — distributed context extracted on the core path.
- `tags configured request and response headers from the stream` — header config reads through the stream adapter.

Fixes: https://github.com/DataDog/dd-trace-js/issues/312