### PR TITLE
ci(engines): widen engines.node to >=18 in CI to keep Node 18/20 jobs running

### DIFF
--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -27,8 +27,10 @@ runs:
         }
         case "$VERSION" in
           eol)         version=16 ;;
-          oldest)      oldest_major=$(awk '/"node"/{match($0,/[0-9]+/);print substr($0,RSTART,RLENGTH);exit}' package.json)
-                      version=$(node_version "$oldest_major") ;;
+          # Pinned to 18 rather than derived from package.json engines.node: CI keeps testing the
+          # oldest version we still exercise (18) even though the shipped engines floor is now >=22.
+          # See the Widen engines.node for CI step below, which restores >=18 on the 18/20 legs.
+          oldest)      version=$(node_version 18) ;;
           maintenance) version=$(node_version 20) ;;
           active)      version=$(node_version 24) ;;
           latest)      version=${LATEST_VERSION:-$(node_version 26)}

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -47,9 +47,18 @@ runs:
     # The shipped package.json pins engines.node to the supported runtime range, but CI keeps
     # running the full suite on Node 18/20. Widen the field to >=18 for this checkout so the
     # runtime guard and the withVersions test helper don't bail and silently skip those jobs.
+    # Gate on the major so this never runs on the ancient runtimes the guardrails-unsupported
+    # job installs (those must keep seeing the shipped >=22 so the guard aborts), and so the
+    # script is only ever parsed by a Node version new enough to run it.
     - name: Widen engines.node for CI
       shell: bash
-      run: node scripts/ci/widen-engines-for-ci.js
+      run: |
+        MAJOR=$(node -e "process.stdout.write(String(parseInt(process.versions.node)))")
+        if [ "$MAJOR" = "18" ] || [ "$MAJOR" = "20" ]; then
+          node scripts/ci/widen-engines-for-ci.js
+        else
+          echo "Leaving engines.node unchanged on Node $(node -v) (only widened on Node 18/20)."
+        fi
 
     # Persist the resolved version so subsequent runs within this 60-minute window can reuse it.
     - name: Save resolved version

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -44,6 +44,13 @@ runs:
         node-version: ${{ steps.node-version.outputs.version }}
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}
 
+    # The shipped package.json pins engines.node to the supported runtime range, but CI keeps
+    # running the full suite on Node 18/20. Widen the field to >=18 for this checkout so the
+    # runtime guard and the withVersions test helper don't bail and silently skip those jobs.
+    - name: Widen engines.node for CI
+      shell: bash
+      run: node scripts/ci/widen-engines-for-ci.js
+
     # Persist the resolved version so subsequent runs within this 60-minute window can reuse it.
     - name: Save resolved version
       if: steps.node-version-cache.outputs.cache-hit != 'true'

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=22"
+    "node": ">=18"
   },
   "nodeMaxMajor": 27,
   "files": [

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "nodeMaxMajor": 27,
   "files": [

--- a/scripts/ci/widen-engines-for-ci.js
+++ b/scripts/ci/widen-engines-for-ci.js
@@ -24,6 +24,8 @@ const packageJsonPath = path.join(__dirname, '..', '..', 'package.json')
 const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
 
 const before = pkg.engines.node
+if (before === CI_MIN_NODE) return
+
 pkg.engines.node = CI_MIN_NODE
 const after = pkg.engines.node
 

--- a/scripts/ci/widen-engines-for-ci.js
+++ b/scripts/ci/widen-engines-for-ci.js
@@ -3,12 +3,17 @@
 'use strict'
 
 // CI-only helper. The shipped package.json pins `engines.node` to the supported
-// runtime range (`>=22`), but CI still runs the full suite on Node 18/20 to keep
-// those jobs exercising real tests. The runtime guard
+// runtime range (`>=22`), but CI still runs the full suite on Node 18 and 20 to
+// keep those jobs exercising real tests. The runtime guard
 // (packages/dd-trace/src/guardrails/index.js) and the `withVersions` test helper
 // both read `engines.node` and bail when the running major is below it, which would
-// silently skip every suite on the older majors. Widening the field to `>=18` for
-// the CI checkout keeps those jobs honest without touching what we publish.
+// silently skip every suite on those majors. Widening the field to `>=18` for the
+// CI checkout keeps those jobs honest without touching what we publish.
+//
+// The node/setup action gates this step so it only runs on the supported majors the
+// `>=22` bump newly excludes (18 and 20); it is never invoked on the ancient runtimes
+// the `integration-guardrails-unsupported` job installs, which must keep seeing the
+// shipped `>=22` so the guard aborts.
 
 const fs = require('node:fs')
 const path = require('node:path')

--- a/scripts/ci/widen-engines-for-ci.js
+++ b/scripts/ci/widen-engines-for-ci.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+'use strict'
+
+// CI-only helper. The shipped package.json pins `engines.node` to the supported
+// runtime range (`>=22`), but CI still runs the full suite on Node 18/20 to keep
+// those jobs exercising real tests. The runtime guard
+// (packages/dd-trace/src/guardrails/index.js) and the `withVersions` test helper
+// both read `engines.node` and bail when the running major is below it, which would
+// silently skip every suite on the older majors. Widening the field to `>=18` for
+// the CI checkout keeps those jobs honest without touching what we publish.
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const CI_MIN_NODE = '>=18'
+
+const packageJsonPath = path.join(__dirname, '..', '..', 'package.json')
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+const before = pkg.engines.node
+pkg.engines.node = CI_MIN_NODE
+const after = pkg.engines.node
+
+fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n')
+
+// eslint-disable-next-line no-console
+console.log(`Widened engines.node for CI: ${before} -> ${after}`)


### PR DESCRIPTION
### What does this PR do?

Bumps the shipped `package.json#engines.node` from `>=18` to `>=22`, while keeping CI exercising real tests on Node 18 and 20 (rather than letting them silently skip). Concretely:

- Bumps `package.json#engines.node` to `>=22` (`nodeMaxMajor` unchanged at `27`). This is the value that ships.
- Adds `scripts/ci/widen-engines-for-ci.js`, which reads `package.json`, sets `engines.node` to `>=18`, writes it back, and logs the before/after.
- Wires that script into `.github/actions/node/setup/action.yml` as a new step right after `actions/setup-node`. The step is **gated to Node majors 18 and 20**: on those legs it widens `engines.node` to `>=18`; on every other version it leaves the shipped `>=22` untouched and never even invokes the script.
- Pins the `oldest` version alias in the same action back to a literal Node 18, instead of deriving the minimum major from `engines.node`.

### Motivation

With `engines.node` bumped to `>=22`, the runtime guard in `packages/dd-trace/src/guardrails/index.js` and the `withVersions` test helper both read `engines.node` and bail when the running major is below it. On Node 18/20 that means every suite would **silently skip**: `withVersions` returns early, the `init.js` guard short-circuits, and mocha reports 0 passing — green CI that exercised nothing.

Widening `engines.node` to `>=18` at the action level keeps the Node 18/20 jobs exercising real tests. The widen step is the only new CI logic — there are no per-spec or per-helper workarounds. The on-disk `package.json` that ships is unchanged: `engines.node` stays `>=22`; the widening only happens in the CI checkout at runtime.

Two follow-up fixes were needed so the rest of CI keeps working with the bumped floor:

- **Gate the widen step to Node 18/20.** The step lives in the shared `node/setup` action, so it ran on every job — including `integration-guardrails-unsupported`, which installs ancient Node (0.8–14) on purpose to verify the guard aborts. The script used a `node:`-prefixed require (unsupported before Node 14.18) and crashed there; even without the crash, rewriting `engines.node` on those runtimes would undermine that job. Gating to majors 18/20 fixes both, and means the script is only ever parsed by a runtime new enough to run it. The unsupported matrix keeps seeing the shipped `>=22`.

- **Pin the `oldest` alias to Node 18.** A prior commit (`prepare infrastructure for dropping Node 18/20 in v6`, #9033) had changed the `oldest` alias to derive the minimum major from `engines.node`. Once `engines.node` became `>=22`, `oldest` resolved to Node 22, which dropped Node 18 from the matrix and shifted the `child_process` job's legs to `{22, 20, 24, 26}`. That leg order (Node 22 first, then 20) destabilized the Bluebird global-`Promise` tests on the Node 20 leg, which pass on master's `{18, 20, 24, 26}`. Pinning `oldest` back to a literal 18 restores the matrix and leg order to match master; the widen step still restores `>=18` on the 18/20 legs.

### Additional Notes

CI on the latest commit: the previously red `child_process`, `instrumentation-child_process`, and all `integration-guardrails` / `integration-guardrails-unsupported` / `unit-guardrails` jobs are green. (The `Performance and correctness tests` failure is unrelated to this change and is being handled separately.)

Verified locally with engines widened to `>=18`:

- `./node_modules/.bin/mocha --timeout 30000 packages/dd-trace/test/plugins/with-versions.spec.js` → 2 passing
- `./node_modules/.bin/mocha --timeout 60000 packages/dd-trace/test/profiling/exporters/agent.spec.js` → 7 passing

No production code (`packages/*/src/`) is touched.

Made with [Cursor](https://cursor.com)