### PR TITLE
chore(engines): allow lower min node version in CI

### DIFF
--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -27,7 +27,7 @@ runs:
         }
         case "$VERSION" in
           eol)         version=16 ;;
-          oldest)      oldest_major=$(awk '/"node"/{match($0,/[0-9]+/);print substr($0,RSTART,RLENGTH);exit}' package.json)
+          oldest)      version=$(node_version 18) ;;
                       version=$(node_version "$oldest_major") ;;
           maintenance) version=$(node_version 20) ;;
           active)      version=$(node_version 24) ;;

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -28,7 +28,6 @@ runs:
         case "$VERSION" in
           eol)         version=16 ;;
           oldest)      version=$(node_version 18) ;;
-                      version=$(node_version "$oldest_major") ;;
           maintenance) version=$(node_version 20) ;;
           active)      version=$(node_version 24) ;;
           latest)      version=${LATEST_VERSION:-$(node_version 26)}

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    env:
+      DD_INJECT_FORCE: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -45,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    env:
+      DD_INJECT_FORCE: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/node/oldest-maintenance-lts

--- a/.gitlab/benchmarks/gitlab-ci.yml
+++ b/.gitlab/benchmarks/gitlab-ci.yml
@@ -178,3 +178,4 @@ benchmark-serverless-trigger:
     # only available on Merge Requests
     UPSTREAM_MERGE_TARGET_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     DD_TAGS: "SLS_CI_BRANCH:$SLS_CI_BRANCH"
+    DD_INJECT_FORCE: true

--- a/integration-tests/code-origin.spec.js
+++ b/integration-tests/code-origin.spec.js
@@ -24,6 +24,7 @@ describe('Code Origin for Spans', function () {
         _DD_TRACE_INTEGRATION_COVERAGE_DISABLE: '1',
         NODE_OPTIONS: '--enable-source-maps',
         DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
+        DD_INJECT_FORCE: true,
       },
       stdio: 'pipe',
     })

--- a/integration-tests/debugger/re-evaluation.spec.js
+++ b/integration-tests/debugger/re-evaluation.spec.js
@@ -115,6 +115,7 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
               DD_TRACE_AGENT_PORT: agent.port,
               DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
               DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
+              DD_INJECT_FORCE: 'true',
             },
           }).then(_proc => {
             assert(_proc, 'proc must be spawned successfully')

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -213,6 +213,7 @@ function setup ({ env, testApp, testAppSource, dependencies, silent, stdioHandle
         DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS: '0',
         DD_TRACE_AGENT_PORT: t.agent.port,
         DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
+        DD_INJECT_FORCE: 'true',
         DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: pollInterval,
         ...env,
       },

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -956,6 +956,7 @@ function preparePluginIntegrationTestSpawnOptions (
         NODE_OPTIONS,
         DD_TRACE_AGENT_PORT: String(agentPort),
         DD_TRACE_FLUSH_INTERVAL: '0',
+        DD_INJECT_FORCE: true,
         ...additionalEnvArgs,
       },
       execArgv,

--- a/integration-tests/package-guardrails.spec.js
+++ b/integration-tests/package-guardrails.spec.js
@@ -23,13 +23,39 @@ const FASTIFY_DEP = NODE_MAJOR < 20 ? 'fastify@4' : 'fastify'
 delete process.env.DD_INJECTION_ENABLED
 delete process.env.DD_INJECT_FORCE
 
+/**
+ * Creates a sandbox with runtime guardrails disabled so this spec only tests package guardrails.
+ *
+ * @param {string[]} dependencies
+ * @param {boolean} isGitRepo
+ * @param {string[]} integrationTestsPaths
+ * @param {string} [followUpCommand]
+ * @returns {void}
+ */
+function useRuntimeSupportedSandbox (
+  dependencies = [],
+  isGitRepo = false,
+  integrationTestsPaths = ['./integration-tests/*'],
+  followUpCommand
+) {
+  useSandbox(dependencies, isGitRepo, integrationTestsPaths, followUpCommand)
+
+  before(() => {
+    const packagePath = path.join(sandboxCwd(), 'node_modules/dd-trace/package.json')
+    const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'))
+    pkg.engines.node = '>=0'
+    pkg.nodeMaxMajor = 1000
+    fs.writeFileSync(packagePath, JSON.stringify(pkg))
+  })
+}
+
 describe('package guardrails', () => {
   useEnv({ NODE_OPTIONS })
   const runTest = (expectedOut, expectedTelemetryPoints, expectedSource = '') =>
     testFile('package-guardrails/index.js', expectedOut, expectedTelemetryPoints, expectedSource)
 
   context('when package is out of range', () => {
-    useSandbox(['bluebird@1.0.0'])
+    useRuntimeSupportedSandbox(['bluebird@1.0.0'])
 
     context('with DD_INJECTION_ENABLED', () => {
       useEnv({ DD_INJECTION_ENABLED })
@@ -71,13 +97,13 @@ Found incompatible integration version: bluebird@1.0.0
 
   context('when package is in range', () => {
     context('when bluebird is 2.9.0', () => {
-      useSandbox(['bluebird@2.9.0'])
+      useRuntimeSupportedSandbox(['bluebird@2.9.0'])
 
       it('should instrument the package', () => runTest('true\n', [], 'manual'))
     })
 
     context('when bluebird is 3.7.2', () => {
-      useSandbox(['bluebird@3.7.2'])
+      useRuntimeSupportedSandbox(['bluebird@3.7.2'])
 
       it('should instrument the package', () => runTest('true\n', [], 'manual'))
     })
@@ -85,13 +111,13 @@ Found incompatible integration version: bluebird@1.0.0
 
   context('when package is in range (fastify)', () => {
     context('when fastify is latest', () => {
-      useSandbox([FASTIFY_DEP])
+      useRuntimeSupportedSandbox([FASTIFY_DEP])
 
       it('should instrument the package', () => runTest('true\n', [], 'manual'))
     })
 
     context('when fastify is latest and logging enabled', () => {
-      useSandbox([FASTIFY_DEP])
+      useRuntimeSupportedSandbox([FASTIFY_DEP])
       useEnv({ DD_TRACE_DEBUG })
 
       it('should instrument the package', () =>
@@ -100,7 +126,7 @@ Found incompatible integration version: bluebird@1.0.0
   })
 
   context('when package errors out', () => {
-    useSandbox(['bluebird'])
+    useRuntimeSupportedSandbox(['bluebird'])
 
     before(() => {
       const file = path.join(sandboxCwd(), 'node_modules/dd-trace/packages/datadog-instrumentations/src/bluebird.js')

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "nodeMaxMajor": 27,
   "files": [


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds DD_INJECT_FORCE into CI workflows that run CI in lower node version than the one established in the engines field. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


