### PR TITLE
fix(appsec): Add runtime family tag to appsec lambda span

### DIFF
--- a/packages/dd-trace/src/appsec/lambda.js
+++ b/packages/dd-trace/src/appsec/lambda.js
@@ -33,7 +33,10 @@ function onLambdaStartInvocation (data) {
 
     activeInvocations.add(span)
 
-    span.setTag('_dd.appsec.enabled', 1)
+    span.addTags({
+      '_dd.appsec.enabled': 1,
+      '_dd.runtime_family': 'nodejs',
+    })
 
     const persistent = {}
 

--- a/packages/dd-trace/test/appsec/lambda.spec.js
+++ b/packages/dd-trace/test/appsec/lambda.spec.js
@@ -77,6 +77,7 @@ describe('AppSec Lambda handler', () => {
       })
 
       assert.equal(span.context().getTag('_dd.appsec.enabled'), 1)
+      assert.equal(span.context().getTag('_dd.runtime_family'), 'nodejs')
     })
 
     it('should set HTTP_CLIENT_IP tag when clientIp is provided', () => {


### PR DESCRIPTION
### What does this PR do?
Adds a missing tag to appsec lambda span

### Motivation
Align span tags with non-lambda appsec spans


