### PR TITLE
fix(cypress): scope failure media uploads to screenshots

### DIFF
--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -24,12 +24,12 @@ async function runCypress () {
         specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
       },
       // Mirror the env-driven gating in cypress.config.js: off by default so most
-      // specs don't record video / capture screenshots; the failure-media upload
-      // test sets CYPRESS_ENABLE_FAILURE_MEDIA=true to turn both on for its run.
+      // specs do not capture screenshots; the failure-screenshot upload tests set
+      // CYPRESS_ENABLE_FAILURE_SCREENSHOTS=true for their runs.
       // The 'esm' module type runs Cypress through this programmatic config rather
       // than cypress.config.js, so the same gating has to live here too.
-      video: process.env.CYPRESS_ENABLE_FAILURE_MEDIA === 'true',
-      screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_MEDIA === 'true',
+      video: false,
+      screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_SCREENSHOTS === 'true',
     },
   })
 

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -60,9 +60,8 @@ module.exports = defineConfig({
     },
     specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
   },
-  // Off by default so most specs don't record video / capture screenshots; the
-  // failure-media upload test sets CYPRESS_ENABLE_FAILURE_MEDIA=true to turn both
-  // on for its run (a CLI --config override does not win over these file values).
-  video: process.env.CYPRESS_ENABLE_FAILURE_MEDIA === 'true',
-  screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_MEDIA === 'true',
+  // Off by default so most specs do not capture screenshots; the failure-screenshot
+  // upload tests set CYPRESS_ENABLE_FAILURE_SCREENSHOTS=true for their runs.
+  video: false,
+  screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_SCREENSHOTS === 'true',
 })

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -916,338 +916,190 @@ moduleTypes.forEach(({
       }
     })
 
-    // 6.7.0 uses a flat JSON config that can't read env to enable media, so over10It skips it.
-    over10It('uploads failure screenshots and the spec video to the v2 media endpoint', async function () {
-      const envVars = getCiVisAgentlessConfig(receiver.port)
-      const specToRun = 'cypress/e2e/basic-fail.js'
-      // Failure media is off by default in cypress.config.js; CYPRESS_ENABLE_FAILURE_MEDIA
-      // (set below) turns the failure screenshot + per-spec video on for this run.
-      let testOutput = ''
+    const reportMethods = [
+      { name: 'evp proxy', getEnvVars: getCiVisEvpProxyConfig },
+      { name: 'agentless', getEnvVars: getCiVisAgentlessConfig },
+    ]
 
-      childProcess = exec(
-        testCommand,
-        {
-          cwd,
-          env: {
-            ...envVars,
-            CYPRESS_BASE_URL: webAppBaseUrl,
-            SPEC_PATTERN: specToRun,
-            CYPRESS_ENABLE_FAILURE_MEDIA: 'true',
-            DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
-            DD_TEST_FAILURE_VIDEO_ENABLED: 'true',
-          },
-        }
-      )
-      childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
-      childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
+    reportMethods.forEach(({ name: reportMethod, getEnvVars }) => {
+      context(`reporting with ${reportMethod}`, () => {
+        // 6.7.0 uses a flat JSON config that can't read env to enable screenshots, so over10It skips it.
+        // TODO: use over10It for evp proxy too once the Agent can forward the media endpoint.
+        const onlyAgentlessIt = reportMethod === 'agentless' ? over10It : it.skip
 
-      const receiverPromise = receiver
-        .gatherPayloadsUntilChildExit(
-          childProcess,
-          ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
-          (payloads) => {
-            const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
-            const failedTest = payloads
-              .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
-              .flatMap(({ payload }) => payload.events)
-              .filter(event => event.type === 'test')
-              .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
-
-            assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
-            const expectedTraceId = failedTest.content.trace_id.toString()
-
-            const expectedUrl = `/api/unstable/ci/test-runs/${expectedTraceId}/media`
-            const screenshotPayload = mediaPayloads.find(({ media }) => media.contentType === 'image/png')
-            const videoPayload = mediaPayloads.find(({ media }) => media.contentType === 'video/mp4')
-
-            assert.ok(screenshotPayload, `a screenshot should be uploaded to the v2 media endpoint\n${testOutput}`)
-            assert.ok(videoPayload, `the spec video should be uploaded to the v2 media endpoint\n${testOutput}`)
-
-            for (const mediaPayload of [screenshotPayload, videoPayload]) {
-              assert.strictEqual(mediaPayload.url, expectedUrl)
-              assert.strictEqual(mediaPayload.media.traceId, expectedTraceId)
-              assert.strictEqual(mediaPayload.headers['dd-api-key'], '1')
-
-              // v2 idempotency key is `<traceId>:<hex(filename)>` (filename hex-encoded so a
-              // non-ASCII title can't break the header), reused on retry so the media service
-              // overwrites instead of duplicating the stored object.
-              const idempotencyKey = mediaPayload.headers['x-dd-idempotency-key']
-              assert.ok(idempotencyKey, 'media upload should send an X-Dd-Idempotency-Key header')
-              assert.strictEqual(mediaPayload.media.idempotencyKey, idempotencyKey)
-              assert.match(
-                idempotencyKey,
-                new RegExp(`^${expectedTraceId}:`),
-                `idempotency key ${idempotencyKey} should start with the trace id`
-              )
-
-              // Capture time (epoch ms) is part of the stored object key and must be a positive integer.
-              const capturedAtHeader = mediaPayload.headers['x-dd-media-captured-at']
-              const capturedAt = Number(capturedAtHeader)
-              assert.ok(
-                Number.isInteger(capturedAt) && capturedAt > 0,
-                `X-Dd-Media-Captured-At should be a positive integer, got ${capturedAtHeader}`
-              )
-
-              // The v1 PoC sent this routing header; v2 must not.
-              assert.ok(
-                !('test-drive-test-failure-media-bucket' in mediaPayload.headers),
-                'v2 must not send the v1 test-drive-test-failure-media-bucket header'
-              )
+        function runCypressWithFailureScreenshots (specToRun) {
+          let testOutput = ''
+          childProcess = exec(
+            testCommand,
+            {
+              cwd,
+              env: {
+                ...getEnvVars(receiver.port),
+                CYPRESS_BASE_URL: webAppBaseUrl,
+                SPEC_PATTERN: specToRun,
+                CYPRESS_ENABLE_FAILURE_SCREENSHOTS: 'true',
+                DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
+              },
             }
-
-            // The screenshot body is a real PNG (magic bytes), not an empty/placeholder upload.
-            assert.deepStrictEqual(
-              [...screenshotPayload.media.content.subarray(0, 8)],
-              [137, 80, 78, 71, 13, 10, 26, 10]
-            )
-          }, { hardTimeout: 60000 })
-        .catch((error) => {
-          error.message += `\nCypress output:\n${testOutput}`
-          throw error
-        })
-
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
-    })
-
-    // 6.7.0 uses a flat JSON config that can't read env to enable media, so over10It skips it.
-    over10It('uploads only the auto failure frame, not a manual cy.screenshot()', async function () {
-      const envVars = getCiVisAgentlessConfig(receiver.port)
-      const specToRun = 'cypress/e2e/manual-screenshot-before-fail.js'
-      // The spec takes a manual cy.screenshot('before-failure') and then fails. Only the auto
-      // failure frame must reach the media endpoint; the manual capture is excluded for privacy.
-      let testOutput = ''
-
-      childProcess = exec(
-        testCommand,
-        {
-          cwd,
-          env: {
-            ...envVars,
-            CYPRESS_BASE_URL: webAppBaseUrl,
-            SPEC_PATTERN: specToRun,
-            CYPRESS_ENABLE_FAILURE_MEDIA: 'true',
-            DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
-            DD_TEST_FAILURE_VIDEO_ENABLED: 'true',
-          },
+          )
+          childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
+          childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
+          return () => testOutput
         }
-      )
-      childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
-      childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
 
-      const receiverPromise = receiver
-        .gatherPayloadsUntilChildExit(
-          childProcess,
-          ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
-          (payloads) => {
-            const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
-            const failedTest = payloads
-              .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
-              .flatMap(({ payload }) => payload.events)
-              .filter(event => event.type === 'test')
-              .find(event =>
-                event.content.resource ===
-                  'cypress/e2e/manual-screenshot-before-fail.js.manual screenshot before fail suite ' +
-                  'takes a manual screenshot then fails'
-              )
+        onlyAgentlessIt('uploads failure screenshots to the v2 media endpoint', async function () {
+          const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/basic-fail.js')
 
-            assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
-            const expectedTraceId = failedTest.content.trace_id.toString()
+          const receiverPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const testOutput = getTestOutput()
+                const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
+                const failedTest = payloads
+                  .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
+                  .flatMap(({ payload }) => payload.events)
+                  .filter(event => event.type === 'test')
+                  .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
 
-            const screenshotPayloads = mediaPayloads.filter(({ media }) => media.contentType === 'image/png')
+                assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+                const expectedTraceId = failedTest.content.trace_id.toString()
 
-            // Exactly the auto failure frame is uploaded; the manual 'before-failure' capture is not.
-            assert.strictEqual(
-              screenshotPayloads.length,
-              1,
-              `only the auto failure screenshot should be uploaded\n${testOutput}`
-            )
-            const [screenshotPayload] = screenshotPayloads
-            assert.strictEqual(screenshotPayload.media.traceId, expectedTraceId)
-            // The key is `<traceId>:<hex(filename)>` — the filename is hex-encoded so a non-ASCII
-            // test title can't break the X-Dd-Idempotency-Key header — so decode it to read the marker.
-            const decodeKeyFilename = (key) => {
-              const [, hexFilename] = (key || '').split(':')
-              return hexFilename ? Buffer.from(hexFilename, 'hex').toString('utf8') : ''
-            }
-            assert.match(
-              decodeKeyFilename(screenshotPayload.media.idempotencyKey),
-              /\(failed\)/,
-              `the uploaded screenshot should be the auto failure frame\n${testOutput}`
-            )
+                const screenshotPayload = mediaPayloads.find(({ media }) => media.contentType === 'image/png')
+                assert.ok(screenshotPayload, `a screenshot should be uploaded to the v2 media endpoint\n${testOutput}`)
+                assert.strictEqual(screenshotPayload.url, `/api/unstable/ci/test-runs/${expectedTraceId}/media`)
+                assert.strictEqual(screenshotPayload.media.traceId, expectedTraceId)
+                assert.strictEqual(screenshotPayload.headers['dd-api-key'], '1')
 
-            // The manual cy.screenshot('before-failure') must never reach the media endpoint.
-            const manualUpload = mediaPayloads.find(({ media }) =>
-              decodeKeyFilename(media.idempotencyKey).includes('before-failure')
-            )
-            assert.ok(
-              !manualUpload,
-              `the manual cy.screenshot() must not be uploaded to the media endpoint\n${testOutput}`
-            )
-          }, { hardTimeout: 60000 })
-        .catch((error) => {
-          error.message += `\nCypress output:\n${testOutput}`
-          throw error
+                // v2 idempotency key is `<traceId>:<hex(filename)>` (filename hex-encoded so a
+                // non-ASCII title can't break the header), reused on retry so the media service
+                // overwrites instead of duplicating the stored object.
+                const idempotencyKey = screenshotPayload.headers['x-dd-idempotency-key']
+                assert.ok(idempotencyKey, 'media upload should send an X-Dd-Idempotency-Key header')
+                assert.strictEqual(screenshotPayload.media.idempotencyKey, idempotencyKey)
+                assert.match(
+                  idempotencyKey,
+                  new RegExp(`^${expectedTraceId}:`),
+                  `idempotency key ${idempotencyKey} should start with the trace id`
+                )
+
+                const capturedAtHeader = screenshotPayload.headers['x-dd-media-captured-at']
+                const capturedAt = Number(capturedAtHeader)
+                assert.ok(
+                  Number.isInteger(capturedAt) && capturedAt > 0,
+                  `X-Dd-Media-Captured-At should be a positive integer, got ${capturedAtHeader}`
+                )
+                assert.ok(
+                  !('test-drive-test-failure-media-bucket' in screenshotPayload.headers),
+                  'v2 must not send the v1 test-drive-test-failure-media-bucket header'
+                )
+                assert.deepStrictEqual(
+                  [...screenshotPayload.media.content.subarray(0, 8)],
+                  [137, 80, 78, 71, 13, 10, 26, 10]
+                )
+              }, { hardTimeout: 60000 })
+            .catch((error) => {
+              error.message += `\nCypress output:\n${getTestOutput()}`
+              throw error
+            })
+
+          await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
         })
 
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
-    })
+        onlyAgentlessIt('uploads only the auto failure frame, not a manual cy.screenshot()', async function () {
+          const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/manual-screenshot-before-fail.js')
 
-    // Failure media upload only goes through the agentless transport for now; the evp proxy path
-    // is not wired up to the v2 media endpoint yet. These tests therefore always use the agentless
-    // config (getCiVisAgentlessConfig). The named helper documents that constraint so a future
-    // report-method param-loop can swap to a real gate.
-    // TODO: gate on the report method (agentless vs evp proxy) once evp proxy media upload is supported.
-    const onlyAgentlessIt = over10It
+          const receiverPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const testOutput = getTestOutput()
+                const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
+                const failedTest = payloads
+                  .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
+                  .flatMap(({ payload }) => payload.events)
+                  .filter(event => event.type === 'test')
+                  .find(event =>
+                    event.content.resource ===
+                      'cypress/e2e/manual-screenshot-before-fail.js.manual screenshot before fail suite ' +
+                      'takes a manual screenshot then fails'
+                  )
 
-    onlyAgentlessIt('uploads only screenshots when only screenshots are enabled', async function () {
-      const envVars = getCiVisAgentlessConfig(receiver.port)
-      const specToRun = 'cypress/e2e/basic-fail.js'
-      let testOutput = ''
+                assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+                const expectedTraceId = failedTest.content.trace_id.toString()
 
-      childProcess = exec(
-        testCommand,
-        {
-          cwd,
-          env: {
-            ...envVars,
-            CYPRESS_BASE_URL: webAppBaseUrl,
-            SPEC_PATTERN: specToRun,
-            CYPRESS_ENABLE_FAILURE_MEDIA: 'true',
-            DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
-            DD_TEST_FAILURE_VIDEO_ENABLED: 'false',
-          },
-        }
-      )
-      childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
-      childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
+                const screenshotPayloads = mediaPayloads.filter(({ media }) => media.contentType === 'image/png')
+                assert.strictEqual(
+                  screenshotPayloads.length,
+                  1,
+                  `only the auto failure screenshot should be uploaded\n${testOutput}`
+                )
+                const [screenshotPayload] = screenshotPayloads
+                assert.strictEqual(screenshotPayload.media.traceId, expectedTraceId)
 
-      const receiverPromise = receiver
-        .gatherPayloadsUntilChildExit(
-          childProcess,
-          ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
-          (payloads) => {
-            const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
+                const decodeKeyFilename = (key) => {
+                  const [, hexFilename] = (key || '').split(':')
+                  return hexFilename ? Buffer.from(hexFilename, 'hex').toString('utf8') : ''
+                }
+                assert.match(
+                  decodeKeyFilename(screenshotPayload.media.idempotencyKey),
+                  /\(failed\)/,
+                  `the uploaded screenshot should be the auto failure frame\n${testOutput}`
+                )
 
-            const screenshotPayload = mediaPayloads.find(({ media }) => media.contentType === 'image/png')
-            assert.ok(screenshotPayload, `a screenshot should be uploaded when screenshots are enabled\n${testOutput}`)
+                const manualUpload = mediaPayloads.find(({ media }) =>
+                  decodeKeyFilename(media.idempotencyKey).includes('before-failure')
+                )
+                assert.ok(
+                  !manualUpload,
+                  `the manual cy.screenshot() must not be uploaded to the media endpoint\n${testOutput}`
+                )
+              }, { hardTimeout: 60000 })
+            .catch((error) => {
+              error.message += `\nCypress output:\n${getTestOutput()}`
+              throw error
+            })
 
-            const videoPayload = mediaPayloads.find(({ media }) => media.contentType.startsWith('video/'))
-            assert.ok(!videoPayload, `no video should be uploaded when video is disabled\n${testOutput}`)
-          }, { hardTimeout: 60000 })
-        .catch((error) => {
-          error.message += `\nCypress output:\n${testOutput}`
-          throw error
+          await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
         })
 
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
-    })
+        onlyAgentlessIt('continues normally when the media upload endpoint fails', async function () {
+          receiver.setMediaResponseStatusCode(500)
+          const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/basic-fail.js')
 
-    onlyAgentlessIt('uploads only the video when only video is enabled', async function () {
-      const envVars = getCiVisAgentlessConfig(receiver.port)
-      const specToRun = 'cypress/e2e/basic-fail.js'
-      let testOutput = ''
+          const receiverPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const testOutput = getTestOutput()
+                const failedTest = payloads
+                  .flatMap(({ payload }) => payload.events)
+                  .filter(event => event.type === 'test')
+                  .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
 
-      childProcess = exec(
-        testCommand,
-        {
-          cwd,
-          env: {
-            ...envVars,
-            CYPRESS_BASE_URL: webAppBaseUrl,
-            SPEC_PATTERN: specToRun,
-            CYPRESS_ENABLE_FAILURE_MEDIA: 'true',
-            DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'false',
-            DD_TEST_FAILURE_VIDEO_ENABLED: 'true',
-          },
-        }
-      )
-      childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
-      childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
+                assert.ok(failedTest, `the failed test should still be reported when media upload fails\n${testOutput}`)
+                assert.strictEqual(failedTest.content.meta[TEST_STATUS], 'fail')
+              }, { hardTimeout: 60000 })
+            .catch((error) => {
+              error.message += `\nCypress output:\n${getTestOutput()}`
+              throw error
+            })
 
-      const receiverPromise = receiver
-        .gatherPayloadsUntilChildExit(
-          childProcess,
-          ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
-          (payloads) => {
-            const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
-
-            const videoPayload = mediaPayloads.find(({ media }) => media.contentType === 'video/mp4')
-            assert.ok(videoPayload, `the spec video should be uploaded when video is enabled\n${testOutput}`)
-
-            const screenshotPayload = mediaPayloads.find(({ media }) => media.contentType === 'image/png')
-            assert.ok(
-              !screenshotPayload,
-              `no screenshot should be uploaded when screenshots are disabled\n${testOutput}`
-            )
-          }, { hardTimeout: 60000 })
-        .catch((error) => {
-          error.message += `\nCypress output:\n${testOutput}`
-          throw error
+          await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
         })
-
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
-    })
-
-    onlyAgentlessIt('continues normally when the media upload endpoint fails', async function () {
-      // 500 is the backend's real "failed to store media" code; a failed upload must be swallowed
-      // so the cypress run still completes and the failed test is reported as usual.
-      receiver.setMediaResponseStatusCode(500)
-      const envVars = getCiVisAgentlessConfig(receiver.port)
-      const specToRun = 'cypress/e2e/basic-fail.js'
-      let testOutput = ''
-
-      childProcess = exec(
-        testCommand,
-        {
-          cwd,
-          env: {
-            ...envVars,
-            CYPRESS_BASE_URL: webAppBaseUrl,
-            SPEC_PATTERN: specToRun,
-            CYPRESS_ENABLE_FAILURE_MEDIA: 'true',
-            DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
-            DD_TEST_FAILURE_VIDEO_ENABLED: 'true',
-          },
-        }
-      )
-      childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
-      childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
-
-      const receiverPromise = receiver
-        .gatherPayloadsUntilChildExit(
-          childProcess,
-          ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
-          (payloads) => {
-            const failedTest = payloads
-              .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
-              .flatMap(({ payload }) => payload.events)
-              .filter(event => event.type === 'test')
-              .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
-
-            assert.ok(failedTest, `the failed test should still be reported when media upload fails\n${testOutput}`)
-            assert.strictEqual(failedTest.content.meta[TEST_STATUS], 'fail')
-          }, { hardTimeout: 60000 })
-        .catch((error) => {
-          error.message += `\nCypress output:\n${testOutput}`
-          throw error
-        })
-
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
+      })
     })
   })
 })

--- a/integration-tests/cypress/e2e/manual-screenshot-before-fail.js
+++ b/integration-tests/cypress/e2e/manual-screenshot-before-fail.js
@@ -5,7 +5,7 @@ describe('manual screenshot before fail suite', () => {
   })
 
   it('takes a manual screenshot then fails', () => {
-    // Manual capture (not a failure frame): must NOT be uploaded to the failure-media endpoint.
+    // Manual capture (not a failure frame): must NOT be uploaded to the failure-screenshot endpoint.
     cy.screenshot('before-failure')
     cy.get('.hello-world')
       .should('have.text', 'Hello warld')

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -178,7 +178,7 @@ function isFailureScreenshot (screenshot) {
   const screenshotFilePath = getScreenshotFilePath(screenshot)
   // Require an explicit failure signal: prefer the `testFailure` metadata, and fall back to the
   // '(failed)' filename marker only when the RunResult omits `testFailure`. This keeps manual
-  // cy.screenshot() captures out of the failure-media upload (privacy).
+  // cy.screenshot() captures out of the failure-screenshot upload (privacy).
   return !!screenshotFilePath && (screenshot?.testFailure === true || screenshotFilePath.includes('(failed)'))
 }
 
@@ -718,6 +718,37 @@ class CypressPlugin {
     })
   }
 
+  /**
+   * Warns when screenshot upload is enabled but Cypress cannot produce or send the screenshots.
+   *
+   * @param {object} cypressConfig - Cypress resolved config
+   * @param {object} tracer - dd-trace proxy tracer
+   * @param {object} testOptimizationConfig - Test Optimization config
+   * @returns {void}
+   */
+  warnIfMisconfiguredTestFailureScreenshots (cypressConfig, tracer, testOptimizationConfig) {
+    if (!testOptimizationConfig.DD_TEST_FAILURE_SCREENSHOTS_ENABLED) {
+      return
+    }
+
+    if (cypressConfig.screenshotOnRunFailure === false) {
+      log.warn(
+        '%s %s',
+        'DD_TEST_FAILURE_SCREENSHOTS_ENABLED is true, but Cypress screenshotOnRunFailure is false.',
+        'Datadog cannot upload failure screenshots unless Cypress is configured to capture them.'
+      )
+      return
+    }
+
+    if (!tracer?._tracer?._exporter?.canUploadTestScreenshots?.()) {
+      log.warn(
+        '%s %s',
+        'DD_TEST_FAILURE_SCREENSHOTS_ENABLED is true, but Cypress failure screenshot upload is only supported',
+        'in agentless mode. The Datadog Agent EVP proxy does not support this media endpoint yet.'
+      )
+    }
+  }
+
   // Init function returns a promise that resolves with the Cypress configuration
   // Depending on the received configuration, the Cypress configuration can be modified:
   // for example, to enable retries for failed tests.
@@ -730,7 +761,9 @@ class CypressPlugin {
 
     this.isTestIsolationEnabled = getIsTestIsolationEnabled(cypressConfig)
 
-    this.rumFlushWaitMillis = getConfig().testOptimization.DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS
+    const testOptimizationConfig = getConfig().testOptimization
+    this.rumFlushWaitMillis = testOptimizationConfig.DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS
+    this.warnIfMisconfiguredTestFailureScreenshots(cypressConfig, tracer, testOptimizationConfig)
 
     if (!this.isTestIsolationEnabled) {
       log.warn('Test isolation is disabled, retries will not be enabled')
@@ -1303,14 +1336,11 @@ class CypressPlugin {
   }
 
   afterSpec (spec, results) {
-    const { tests, stats, screenshots, video } = results || {}
+    const { tests, stats, screenshots } = results || {}
     const cypressTests = tests || []
     const specScreenshots = screenshots || []
     const finishedTests = this.finishedTestsByFile[spec.relative] || []
     const screenshotUploadPromises = []
-    // Cypress records one video per spec; collect the failed tests' trace ids so the
-    // spec video can be attached to each failed test run's media after the loop.
-    const failedTestTraceIds = []
 
     if (!this.testSuiteSpan) {
       // dd:testSuiteStart hasn't been triggered for whatever reason
@@ -1420,7 +1450,6 @@ class CypressPlugin {
 
         if (cypressTestStatus === 'fail' || finishedTest.testStatus === 'fail' || cypressTest.displayError) {
           const failedTestTraceId = finishedTest.testSpan.context().toTraceId()
-          failedTestTraceIds.push(failedTestTraceId)
           const testScreenshots = getTestScreenshots(cypressTest, attemptIndex, specScreenshots)
           const screenshotUploadPromise = this.uploadTestScreenshots({
             screenshots: testScreenshots,
@@ -1491,14 +1520,6 @@ class CypressPlugin {
       }
     }
 
-    // Attach the per-spec Cypress video to each failed test run's media.
-    if (video && failedTestTraceIds.length > 0) {
-      const videoUploadPromise = this.uploadTestVideo({ videoPath: video, traceIds: failedTestTraceIds })
-      if (videoUploadPromise) {
-        screenshotUploadPromises.push(videoUploadPromise)
-      }
-    }
-
     if (this.testSuiteSpan) {
       const status = getSuiteStatus(stats)
       this.testSuiteSpan.setTag(TEST_STATUS, status)
@@ -1552,47 +1573,6 @@ class CypressPlugin {
           filePath,
           traceId,
           idempotencyKey,
-          capturedAtMs,
-        }, () => {
-          resolve()
-        })
-      }))
-    }
-
-    if (uploadPromises.length > 0) {
-      return Promise.all(uploadPromises).then(() => {})
-    }
-  }
-
-  /**
-   * Uploads the per-spec Cypress video to each given failed test run's media.
-   * Cypress records one video per spec, so the same recording is attached to every
-   * failed test in that spec. The capture time falls back to the file mtime since
-   * the spec video has no per-test timestamp.
-   *
-   * @param {object} options - Upload options
-   * @param {string} options.videoPath - Path to the spec video file
-   * @param {Array<string>} options.traceIds - Failed test trace ids to attach the video to
-   * @returns {Promise<void>|undefined}
-   */
-  uploadTestVideo ({ videoPath, traceIds }) {
-    const exporter = this.tracer?._tracer?._exporter
-    if (!videoPath || !traceIds.length ||
-      !exporter?.canUploadTestVideo?.() ||
-      !exporter.uploadTestScreenshot) {
-      return
-    }
-
-    const capturedAtMs = getScreenshotCapturedAtMs(videoPath, videoPath)
-    const videoFileName = basename(videoPath)
-    const uploadPromises = []
-
-    for (const traceId of new Set(traceIds)) {
-      uploadPromises.push(new Promise(resolve => {
-        exporter.uploadTestScreenshot({
-          filePath: videoPath,
-          traceId,
-          idempotencyKey: `${traceId}:${videoFileName}`,
           capturedAtMs,
         }, () => {
           resolve()

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -33,10 +33,9 @@ function getCanForwardDebuggerLogs (err, agentInfo) {
 class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
     super(config)
-    // Agent-mode media upload is not wired yet: the Datadog Agent's evp_proxy must
-    // allow-list POST /api/unstable/ci/test-runs/<trace_id>/media before screenshots
-    // can be forwarded through it. Until then, upload is enabled only in agentless
-    // mode (canUploadTestScreenshots() returns false while this stays undefined).
+    // Screenshot media upload is agentless-only for now. The Datadog Agent's
+    // evp_proxy does not forward POST /api/unstable/ci/test-runs/<trace_id>/media
+    // yet, so canUploadTestScreenshots() returns false while this stays undefined.
     this._testScreenshotUploadUrl = undefined
 
     const {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -50,9 +50,8 @@ class CiVisibilityExporter extends BufferingExporter {
     // AKA CI Vis Protocol
     this._canUseCiVisProtocol = false
 
-    // Screenshot and video uploads on test failure are independent opt-in toggles.
-    this._isTestFailureScreenshotsEnabled = Boolean(config && config.isTestFailureScreenshotsEnabled)
-    this._isTestFailureVideoEnabled = Boolean(config && config.isTestFailureVideoEnabled)
+    this._isTestFailureScreenshotsEnabled =
+      Boolean(config?.testOptimization?.DD_TEST_FAILURE_SCREENSHOTS_ENABLED)
 
     const gitUploadTimeoutId = setTimeout(() => {
       this._resolveGit(new Error('Timeout while uploading git metadata'))
@@ -471,15 +470,6 @@ class CiVisibilityExporter extends BufferingExporter {
    */
   canUploadTestScreenshots () {
     return Boolean(this._testScreenshotUploadUrl) && this._isTestFailureScreenshotsEnabled
-  }
-
-  /**
-   * Returns whether the exporter can upload test failure video.
-   *
-   * @returns {boolean}
-   */
-  canUploadTestVideo () {
-    return Boolean(this._testScreenshotUploadUrl) && this._isTestFailureVideoEnabled
   }
 
   /**

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -23,12 +23,6 @@ function getContentType (filePath) {
   if (extension === '.webp') {
     return 'image/webp'
   }
-  if (extension === '.mp4') {
-    return 'video/mp4'
-  }
-  if (extension === '.webm') {
-    return 'video/webm'
-  }
   return 'image/png'
 }
 
@@ -82,12 +76,12 @@ function uploadTestScreenshot (
   { filePath, traceId, idempotencyKey, capturedAtMs, url },
   callback
 ) {
-  const apiKey = getConfig().apiKey
+  const { DD_API_KEY } = getConfig()
 
   if (!isValidTraceId(traceId)) {
     return callback(new Error('A non-zero decimal uint64 trace_id is required for test screenshot upload'))
   }
-  if (!apiKey) {
+  if (!DD_API_KEY) {
     return callback(new Error('DD_API_KEY is required for test screenshot upload'))
   }
   if (!idempotencyKey) {
@@ -112,7 +106,7 @@ function uploadTestScreenshot (
     method: 'POST',
     headers: {
       'Content-Type': contentType,
-      'DD-API-KEY': apiKey,
+      'DD-API-KEY': DD_API_KEY,
       // Stable per-artifact key (reused on retry) → the service overwrites instead of duplicating.
       // Rendered header-safe so a non-ASCII filename can't throw ERR_INVALID_CHAR in http.request.
       'X-Dd-Idempotency-Key': toIdempotencyHeaderValue(idempotencyKey),

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -446,8 +446,6 @@ export interface GeneratedConfig {
     telemetryVerbosity: string;
   };
   inferredProxyServicesEnabled: boolean;
-  isTestFailureScreenshotsEnabled: boolean;
-  isTestFailureVideoEnabled: boolean;
   langchain: {
     DD_LANGCHAIN_SPAN_CHAR_LIMIT: number;
     DD_LANGCHAIN_SPAN_PROMPT_COMPLETION_SAMPLE_RATE: number;
@@ -557,6 +555,7 @@ export interface GeneratedConfig {
     DD_CIVISIBILITY_TEST_MODULE_ID: string | undefined;
     DD_CIVISIBILITY_TEST_SESSION_ID: string | undefined;
     DD_TEST_FAILED_TEST_REPLAY_ENABLED: boolean;
+    DD_TEST_FAILURE_SCREENSHOTS_ENABLED: boolean;
     DD_TEST_FLEET_CONFIG_PATH: string | undefined;
     DD_TEST_LOCAL_CONFIG_PATH: string | undefined;
     DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES: number;
@@ -788,7 +787,6 @@ export interface GeneratedEnvVarConfig {
   DD_TELEMETRY_METRICS_ENABLED: boolean;
   DD_TEST_FAILED_TEST_REPLAY_ENABLED: boolean;
   DD_TEST_FAILURE_SCREENSHOTS_ENABLED: boolean;
-  DD_TEST_FAILURE_VIDEO_ENABLED: boolean;
   DD_TEST_FLEET_CONFIG_PATH: string | undefined;
   DD_TEST_LOCAL_CONFIG_PATH: string | undefined;
   DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES: number;

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1817,15 +1817,7 @@
         "implementation": "A",
         "type": "boolean",
         "default": "false",
-        "configurationNames": ["isTestFailureScreenshotsEnabled"]
-      }
-    ],
-    "DD_TEST_FAILURE_VIDEO_ENABLED": [
-      {
-        "implementation": "A",
-        "type": "boolean",
-        "default": "false",
-        "configurationNames": ["isTestFailureVideoEnabled"]
+        "namespace": "testOptimization"
       }
     ],
     "DD_TEST_FLEET_CONFIG_PATH": [

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1167,12 +1167,18 @@ describe('CI Visibility Exporter', () => {
 
   describe('canUploadTestScreenshots', () => {
     it('should return false when there is no upload URL', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url, isTestFailureScreenshotsEnabled: true })
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+      })
       assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), false)
     })
 
     it('should return false when the URL is set but screenshots are disabled', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url, isTestFailureScreenshotsEnabled: false })
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: false },
+      })
       ciVisibilityExporter._testScreenshotUploadUrl = url
       assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), false)
     })
@@ -1184,58 +1190,12 @@ describe('CI Visibility Exporter', () => {
     })
 
     it('should return true when the URL is set and screenshots are enabled', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url, isTestFailureScreenshotsEnabled: true })
-      ciVisibilityExporter._testScreenshotUploadUrl = url
-      assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), true)
-    })
-  })
-
-  describe('canUploadTestVideo', () => {
-    it('should return false when there is no upload URL', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url, isTestFailureVideoEnabled: true })
-      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
-    })
-
-    it('should return false when the URL is set but video is disabled', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url, isTestFailureVideoEnabled: false })
-      ciVisibilityExporter._testScreenshotUploadUrl = url
-      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
-    })
-
-    it('should return false when the URL is set but the video flag is absent (default off)', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url })
-      ciVisibilityExporter._testScreenshotUploadUrl = url
-      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
-    })
-
-    it('should return true when the URL is set and video is enabled', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({ url, isTestFailureVideoEnabled: true })
-      ciVisibilityExporter._testScreenshotUploadUrl = url
-      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), true)
-    })
-  })
-
-  describe('media upload gate independence', () => {
-    it('should allow screenshots but not video when only screenshots are enabled', () => {
       const ciVisibilityExporter = new CiVisibilityExporter({
         url,
-        isTestFailureScreenshotsEnabled: true,
-        isTestFailureVideoEnabled: false,
+        testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
       })
       ciVisibilityExporter._testScreenshotUploadUrl = url
       assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), true)
-      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
-    })
-
-    it('should allow video but not screenshots when only video is enabled', () => {
-      const ciVisibilityExporter = new CiVisibilityExporter({
-        url,
-        isTestFailureScreenshotsEnabled: false,
-        isTestFailureVideoEnabled: true,
-      })
-      ciVisibilityExporter._testScreenshotUploadUrl = url
-      assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), false)
-      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), true)
     })
   })
 })

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -36,7 +36,9 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
     )
 
     assert.ok(requestStub.calledOnce)
-    return requestStub.getCall(0).args[1].headers['X-Dd-Idempotency-Key']
+    const headers = requestStub.getCall(0).args[1].headers
+    assert.strictEqual(headers['DD-API-KEY'], 'test-api-key')
+    return headers['X-Dd-Idempotency-Key']
   }
 
   before(() => {
@@ -48,7 +50,7 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
     const { uploadTestScreenshot: upload } = proxyquire(
       '../../../src/ci-visibility/requests/upload-test-screenshot',
       {
-        '../../config': () => ({ apiKey: 'test-api-key' }),
+        '../../config': () => ({ DD_API_KEY: 'test-api-key' }),
         '../../exporters/common/request': requestStub,
       }
     )

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -3347,7 +3347,6 @@ describe('Config', () => {
       delete process.env.DD_CIVISIBILITY_FLAKY_RETRY_ENABLED
       delete process.env.DD_CIVISIBILITY_FLAKY_RETRY_COUNT
       delete process.env.DD_TEST_FAILURE_SCREENSHOTS_ENABLED
-      delete process.env.DD_TEST_FAILURE_VIDEO_ENABLED
       delete process.env.DD_TEST_SESSION_NAME
       delete process.env.JEST_WORKER_ID
       delete process.env.DD_TEST_FAILED_TEST_REPLAY_ENABLED
@@ -3418,31 +3417,17 @@ describe('Config', () => {
       })
       it('should disable test failure screenshots by default', () => {
         const config = getConfig(options)
-        assert.strictEqual(config.isTestFailureScreenshotsEnabled, false)
+        assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_SCREENSHOTS_ENABLED, false)
       })
       it('should enable test failure screenshots if DD_TEST_FAILURE_SCREENSHOTS_ENABLED is true', () => {
         process.env.DD_TEST_FAILURE_SCREENSHOTS_ENABLED = 'true'
         const config = getConfig(options)
-        assert.strictEqual(config.isTestFailureScreenshotsEnabled, true)
+        assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_SCREENSHOTS_ENABLED, true)
       })
       it('should disable test failure screenshots if DD_TEST_FAILURE_SCREENSHOTS_ENABLED is false', () => {
         process.env.DD_TEST_FAILURE_SCREENSHOTS_ENABLED = 'false'
         const config = getConfig(options)
-        assert.strictEqual(config.isTestFailureScreenshotsEnabled, false)
-      })
-      it('should disable test failure video by default', () => {
-        const config = getConfig(options)
-        assert.strictEqual(config.isTestFailureVideoEnabled, false)
-      })
-      it('should enable test failure video if DD_TEST_FAILURE_VIDEO_ENABLED is true', () => {
-        process.env.DD_TEST_FAILURE_VIDEO_ENABLED = 'true'
-        const config = getConfig(options)
-        assert.strictEqual(config.isTestFailureVideoEnabled, true)
-      })
-      it('should disable test failure video if DD_TEST_FAILURE_VIDEO_ENABLED is false', () => {
-        process.env.DD_TEST_FAILURE_VIDEO_ENABLED = 'false'
-        const config = getConfig(options)
-        assert.strictEqual(config.isTestFailureVideoEnabled, false)
+        assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_SCREENSHOTS_ENABLED, false)
       })
       it('should read DD_CIVISIBILITY_FLAKY_RETRY_COUNT if present', () => {
         process.env.DD_CIVISIBILITY_FLAKY_RETRY_COUNT = '4'


### PR DESCRIPTION
## Summary

- keep the Cypress failure media work focused on screenshots by removing video upload config, code, and tests
- move `DD_TEST_FAILURE_SCREENSHOTS_ENABLED` under the Test Optimization supported config namespace
- make EVP proxy unsupported behavior explicit in Cypress tests and user warnings
- use `DD_API_KEY` for screenshot media uploads

## Testing

- `./node_modules/.bin/mocha packages/dd-trace/test/config/generated-config-types.spec.js packages/dd-trace/test/config/index.spec.js --grep "internalPropertyName|test failure screenshots|generated config types|unsupported config|property surface"`
- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js --grep "canUploadTestScreenshots"`
- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js`
- `./node_modules/.bin/eslint integration-tests/cypress-esm-config.mjs integration-tests/cypress.config.js integration-tests/cypress/cypress-reporting.spec.js integration-tests/cypress/e2e/manual-screenshot-before-fail.js packages/datadog-plugin-cypress/src/cypress-plugin.js packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js packages/dd-trace/test/config/index.spec.js`
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER CYPRESS_VERSION=12.0.0 CYPRESS_MODULE_TYPE=commonJS ./node_modules/.bin/mocha --timeout 180000 integration-tests/cypress/cypress-reporting.spec.js --grep "reporting with"`