### PR TITLE
ci(benchmarks): add benchmark-health fast-track pipeline

### DIFF
--- a/.github/chainguard/gitlab-benchmark-health-push.sts.yaml
+++ b/.github/chainguard/gitlab-benchmark-health-push.sts.yaml
@@ -1,0 +1,16 @@
+# Grants the benchmark-health fast-track job in GitLab a short-lived GitHub
+# token with `contents: write` so it can self-push the stability-monitoring
+# patch to `external/benchmark-health/<run-id>` and trigger the benchmark
+# pipeline from bp-tools.
+#
+# Scoped tightly: GitLab issuer, dd-trace-js project path only, and the
+# `benchmark-health` job name. Contact: APM DCS Performance team.
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-js:ref_type:branch:ref:.*"
+
+claim_pattern:
+  job_name: benchmark-health
+
+permissions:
+  contents: write

--- a/.gitlab/benchmarks/benchmark-health.yml
+++ b/.gitlab/benchmarks/benchmark-health.yml
@@ -1,0 +1,88 @@
+# Fast-track CI shim for benchmark-health stability monitoring.
+#
+# bp-tools triggers this job via `trigger:project`, passing:
+#   EXTERNAL_BENCHMARK_RUN_ID  - unique run identifier (8-hex-char UUID prefix)
+#   STABILITY_N                - number of repetitions (N parallel indices)
+#   BENCHMARK_HEALTH           - set to "true" to activate this job
+#
+# The job applies `.gitlab/benchmarks/patches/stability-monitoring.patch` to
+# the working tree, which expands the `benchmark` parallel matrix with
+# STABILITY_MONITORING_INDEX 0..N-1, then self-pushes the patched tree to
+# `external/benchmark-health/${EXTERNAL_BENCHMARK_RUN_ID}`. The push fires
+# the normal benchmark pipeline on the patched branch via GitHub->GitLab mirror.
+
+benchmark-health:
+  stage: benchmarks
+  needs: []
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
+  rules:
+    - if: '$BENCHMARK_HEALTH != "true"'
+      when: never
+    - when: on_success
+  timeout: 15m
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  variables:
+    DDOCTOSTS_POLICY: "gitlab-benchmark-health-push"
+    TARGET_BRANCH: "external/benchmark-health/${EXTERNAL_BENCHMARK_RUN_ID}"
+    GIT_STRATEGY: clone
+  script:
+    - |
+      set -euo pipefail
+
+      # Validate required variables before doing any work.
+      for var in EXTERNAL_BENCHMARK_RUN_ID STABILITY_N; do
+        if [ -z "${!var:-}" ]; then
+          echo "ERROR: '$var' is required but not set."
+          exit 1
+        fi
+      done
+
+    - |
+      set -euo pipefail
+
+      # Mint a short-lived GitHub token via dd-octo-sts.
+      echo "Minting GitHub token with policy: $DDOCTOSTS_POLICY"
+      GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-js --policy "$DDOCTOSTS_POLICY")
+      if [ -z "$GITHUB_TOKEN" ]; then
+        echo "ERROR: dd-octo-sts returned an empty token. Check policy '$DDOCTOSTS_POLICY' in .github/chainguard/."
+        exit 1
+      fi
+
+    - |
+      set -euo pipefail
+
+      # Apply the stability-monitoring patch, which adds STABILITY_MONITORING_INDEX
+      # 0..2 to the benchmark parallel matrix. The patch is committed in-tree so
+      # its content is auditable alongside the CI config it targets.
+      PATCH=".gitlab/benchmarks/patches/stability-monitoring.patch"
+      echo "Applying patch: $PATCH"
+      git apply "$PATCH"
+      echo "Patch applied successfully."
+
+    - |
+      set -euo pipefail
+
+      # Configure git identity for the self-push commit.
+      git config user.email "benchmark-health-ci@datadoghq.com"
+      git config user.name "benchmark-health CI"
+
+      # Commit the patched tree on a new branch scoped to this run.
+      git checkout -b "$TARGET_BRANCH"
+      git add .gitlab/benchmarks/gitlab-ci.yml
+      git commit -m "ci(benchmarks): apply stability-monitoring patch for run ${EXTERNAL_BENCHMARK_RUN_ID}
+
+Stability run triggered by bp-tools with STABILITY_N=${STABILITY_N}.
+EXTERNAL_BENCHMARK_RUN_ID=${EXTERNAL_BENCHMARK_RUN_ID}"
+
+    - |
+      set -euo pipefail
+
+      # Push to GitHub over HTTPS using the minted token. The GitHub->GitLab
+      # mirror fires the benchmark pipeline on the pushed branch automatically.
+      REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/DataDog/dd-trace-js.git"
+      echo "Pushing to branch: $TARGET_BRANCH"
+      git push "$REMOTE_URL" "HEAD:refs/heads/${TARGET_BRANCH}"
+      echo "Push complete. Benchmark pipeline will fire on branch: $TARGET_BRANCH"

--- a/.gitlab/benchmarks/gitlab-ci.yml
+++ b/.gitlab/benchmarks/gitlab-ci.yml
@@ -4,6 +4,7 @@
 include:
   - project: 'DataDog/benchmarking-platform-tools'
     file: 'images/templates/gitlab/build-ci-images.template.yml'
+  - local: '.gitlab/benchmarks/benchmark-health.yml'
 
 variables:
   # Consumed by the benchmark jobs below. Repin after a `build-benchmark-ci-images`

--- a/.gitlab/benchmarks/patches/stability-monitoring.patch
+++ b/.gitlab/benchmarks/patches/stability-monitoring.patch
@@ -1,0 +1,197 @@
+From 6137f886efefa485ea65014722a6d190e4c6142c Mon Sep 17 00:00:00 2001
+From: Augusto de Oliveira <augusto.deoliveira@datadoghq.com>
+Date: Tue, 30 Jun 2026 19:15:32 +0200
+Subject: [PATCH] feat(benchmarks): add STABILITY_MONITORING_INDEX dimension
+ for flaky detection
+
+---
+ .gitlab/benchmarks/gitlab-ci.yml | 133 ++++++++++++++++++++++++++++++-
+ 1 file changed, 131 insertions(+), 2 deletions(-)
+
+diff --git a/.gitlab/benchmarks/gitlab-ci.yml b/.gitlab/benchmarks/gitlab-ci.yml
+index c9e30a6..10dcbc3 100644
+--- a/.gitlab/benchmarks/gitlab-ci.yml
++++ b/.gitlab/benchmarks/gitlab-ci.yml
+@@ -86,48 +86,177 @@ check-big-regressions:
+ 
+ benchmark:
+   extends: .benchmarks
+-  # The number of GROUP rows per MAJOR_VERSION must equal SPLITS. If you change
+-  # one, change the other — otherwise variants get silently skipped.
++  # The number of GROUP rows per (MAJOR_VERSION, STABILITY_MONITORING_INDEX) pair
++  # must equal SPLITS. If you change one, change the other — otherwise variants get
++  # silently skipped. STABILITY_MONITORING_INDEX repeats the full suite N times to
++  # measure run-to-run variance for flaky benchmark detection.
+   parallel:
+     matrix:
+       - MAJOR_VERSION: 20
+         GROUP: 1
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 20
+         GROUP: 2
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 20
+         GROUP: 3
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 20
+         GROUP: 4
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 20
+         GROUP: 5
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 20
+         GROUP: 6
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 24
+         GROUP: 1
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 24
+         GROUP: 2
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 24
+         GROUP: 3
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 24
+         GROUP: 4
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 24
+         GROUP: 5
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 24
+         GROUP: 6
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 26
+         GROUP: 1
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 26
+         GROUP: 2
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 26
+         GROUP: 3
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 26
+         GROUP: 4
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 26
+         GROUP: 5
++        STABILITY_MONITORING_INDEX: 0
+       - MAJOR_VERSION: 26
+         GROUP: 6
++        STABILITY_MONITORING_INDEX: 0
++      - MAJOR_VERSION: 20
++        GROUP: 1
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 20
++        GROUP: 2
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 20
++        GROUP: 3
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 20
++        GROUP: 4
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 20
++        GROUP: 5
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 20
++        GROUP: 6
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 24
++        GROUP: 1
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 24
++        GROUP: 2
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 24
++        GROUP: 3
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 24
++        GROUP: 4
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 24
++        GROUP: 5
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 24
++        GROUP: 6
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 26
++        GROUP: 1
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 26
++        GROUP: 2
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 26
++        GROUP: 3
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 26
++        GROUP: 4
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 26
++        GROUP: 5
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 26
++        GROUP: 6
++        STABILITY_MONITORING_INDEX: 1
++      - MAJOR_VERSION: 20
++        GROUP: 1
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 20
++        GROUP: 2
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 20
++        GROUP: 3
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 20
++        GROUP: 4
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 20
++        GROUP: 5
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 20
++        GROUP: 6
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 24
++        GROUP: 1
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 24
++        GROUP: 2
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 24
++        GROUP: 3
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 24
++        GROUP: 4
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 24
++        GROUP: 5
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 24
++        GROUP: 6
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 26
++        GROUP: 1
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 26
++        GROUP: 2
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 26
++        GROUP: 3
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 26
++        GROUP: 4
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 26
++        GROUP: 5
++        STABILITY_MONITORING_INDEX: 2
++      - MAJOR_VERSION: 26
++        GROUP: 6
++        STABILITY_MONITORING_INDEX: 2
+   variables:
+     SPLITS: 6
++    STABILITY_MONITORING_INDEX: 0
+ 
+ benchmark-serverless:
+   stage: benchmarks
+-- 
+2.50.1
+

--- a/.gitlab/benchmarks/upload-results-to-s3.sh
+++ b/.gitlab/benchmarks/upload-results-to-s3.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 # EXTERNAL_S3_URL overrides the default destination prefix (must stay within
-# relenv-benchmarking-data). A _READY marker is written last to signal upload
-# completion for this sample.
+# relenv-benchmarking-data) so an external orchestrator can collect results
+# under a prefix it controls.
 DEST="${EXTERNAL_S3_URL:-s3://relenv-benchmarking-data/dd-trace-js/${CI_COMMIT_SHA}/node-${MAJOR_VERSION}/}"
 [[ "$DEST" == s3://relenv-benchmarking-data/* ]] || { echo "EXTERNAL_S3_URL must stay within relenv-benchmarking-data" >&2; exit 1; }
 
 aws s3 cp --recursive --acl bucket-owner-full-control "$ARTIFACTS_DIR/" "$DEST"
-aws s3 cp --acl bucket-owner-full-control /dev/null "${DEST}_READY"

--- a/.gitlab/benchmarks/upload-results-to-s3.sh
+++ b/.gitlab/benchmarks/upload-results-to-s3.sh
@@ -1,3 +1,25 @@
 #!/usr/bin/env bash
 
-aws s3 cp --recursive --acl bucket-owner-full-control $ARTIFACTS_DIR/ s3://relenv-benchmarking-data/dd-trace-js/${CI_COMMIT_SHA}/node-${MAJOR_VERSION}/
+# EXTERNAL_S3_URL: optional override for the upload destination prefix.
+# When unset, results go to the default relenv-benchmarking-data path.
+# When set, must start with 's3://relenv-benchmarking-data/' to prevent
+# exfiltration to an arbitrary bucket.
+#
+# After upload, a '_READY' marker object is written to the destination prefix
+# to signal to downstream pollers that the upload for this sample is complete.
+
+DEFAULT_S3_URL="s3://relenv-benchmarking-data/dd-trace-js/${CI_COMMIT_SHA}/node-${MAJOR_VERSION}/"
+
+if [ -n "${EXTERNAL_S3_URL}" ]; then
+  if [[ "${EXTERNAL_S3_URL}" != s3://relenv-benchmarking-data/* ]]; then
+    echo "ERROR: EXTERNAL_S3_URL must start with 's3://relenv-benchmarking-data/'" >&2
+    exit 1
+  fi
+  DESTINATION="${EXTERNAL_S3_URL}"
+else
+  DESTINATION="${DEFAULT_S3_URL}"
+fi
+
+aws s3 cp --recursive --acl bucket-owner-full-control "$ARTIFACTS_DIR/" "${DESTINATION}"
+
+aws s3 cp --acl bucket-owner-full-control /dev/null "${DESTINATION}_READY"

--- a/.gitlab/benchmarks/upload-results-to-s3.sh
+++ b/.gitlab/benchmarks/upload-results-to-s3.sh
@@ -1,25 +1,10 @@
 #!/usr/bin/env bash
 
-# EXTERNAL_S3_URL: optional override for the upload destination prefix.
-# When unset, results go to the default relenv-benchmarking-data path.
-# When set, must start with 's3://relenv-benchmarking-data/' to prevent
-# exfiltration to an arbitrary bucket.
-#
-# After upload, a '_READY' marker object is written to the destination prefix
-# to signal to downstream pollers that the upload for this sample is complete.
+# EXTERNAL_S3_URL overrides the default destination prefix (must stay within
+# relenv-benchmarking-data). A _READY marker is written last to signal upload
+# completion for this sample.
+DEST="${EXTERNAL_S3_URL:-s3://relenv-benchmarking-data/dd-trace-js/${CI_COMMIT_SHA}/node-${MAJOR_VERSION}/}"
+[[ "$DEST" == s3://relenv-benchmarking-data/* ]] || { echo "EXTERNAL_S3_URL must stay within relenv-benchmarking-data" >&2; exit 1; }
 
-DEFAULT_S3_URL="s3://relenv-benchmarking-data/dd-trace-js/${CI_COMMIT_SHA}/node-${MAJOR_VERSION}/"
-
-if [ -n "${EXTERNAL_S3_URL}" ]; then
-  if [[ "${EXTERNAL_S3_URL}" != s3://relenv-benchmarking-data/* ]]; then
-    echo "ERROR: EXTERNAL_S3_URL must start with 's3://relenv-benchmarking-data/'" >&2
-    exit 1
-  fi
-  DESTINATION="${EXTERNAL_S3_URL}"
-else
-  DESTINATION="${DEFAULT_S3_URL}"
-fi
-
-aws s3 cp --recursive --acl bucket-owner-full-control "$ARTIFACTS_DIR/" "${DESTINATION}"
-
-aws s3 cp --acl bucket-owner-full-control /dev/null "${DESTINATION}_READY"
+aws s3 cp --recursive --acl bucket-owner-full-control "$ARTIFACTS_DIR/" "$DEST"
+aws s3 cp --acl bucket-owner-full-control /dev/null "${DEST}_READY"


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Adds a `benchmark-health` GitLab CI job that bp-tools can trigger via `trigger:project` to run the benchmark suite N times from a single ref. The job applies a patch that expands the `benchmark` parallel matrix with a `STABILITY_MONITORING_INDEX` dimension, then self-pushes the patched tree to `external/benchmark-health/<run-id>`. The GitHub->GitLab mirror fires the full benchmark pipeline on that branch, yielding N independent runs for flaky-benchmark detection.

Three files added:
- `.gitlab/benchmarks/benchmark-health.yml`: the fast-track CI job (guarded by `BENCHMARK_HEALTH="true"`)
- `.gitlab/benchmarks/patches/stability-monitoring.patch`: the matrix expansion patch (STABILITY_MONITORING_INDEX 0..2, preserving SPLITS=6)
- `.github/chainguard/gitlab-benchmark-health-push.sts.yaml`: dd-octo-sts trust policy granting `contents: write` to the benchmark-health job

### Motivation

Part of the benchmark-health stability monitoring initiative. bp-tools needs a way to trigger N identical benchmark pipelines from a single ref without N separate push events. The fast-track shim is the mechanism: bp-tools triggers it once, the job patches and pushes, and the mirror fires the expanded pipeline.

### Additional Notes

The `benchmark-health` job is completely inert on normal pipelines (no `BENCHMARK_HEALTH` variable set). The patched branch lives under `external/benchmark-health/` and does not affect `master` or PR branches.

---
## Review focus

- **Rules guard**: the job only runs when `BENCHMARK_HEALTH="true"`, so every normal push, PR pipeline, and schedule run is unaffected; the variable is only injected by bp-tools via `trigger:project`.
- **Self-push + chainguard policy**: the token is minted per-job with `dd-octo-sts` using `gitlab-benchmark-health-push` policy, which is scoped to the GitLab `dd-trace-js` project path and pinned to the `benchmark-health` job name via `claim_pattern.job_name`; the policy grants only `contents: write` with no `repositories:` block.
- **SPLITS invariant**: the patch adds `STABILITY_MONITORING_INDEX` as a third dimension with values 0, 1, 2; each (MAJOR_VERSION, STABILITY_MONITORING_INDEX) pair still has exactly 6 GROUP rows, so SPLITS=6 holds; total legs = 3 majors x 6 groups x 3 indices = 54.
- **Per-run branch name**: branches land at `external/benchmark-health/<EXTERNAL_BENCHMARK_RUN_ID>` where the run ID is an 8-hex-char UUID prefix generated by bp-tools; this keeps runs isolated and makes cleanup trivial.
- **Trigger flow**: bp-tools fires `trigger:project: DataDog/apm-reliability/dd-trace-js` with `BENCHMARK_HEALTH=true`, `EXTERNAL_BENCHMARK_RUN_ID`, and `STABILITY_N`; this job runs, patches, and pushes; the mirror fires the normal pipeline on the patched branch.
- **Unknowns flagged**: (1) I assumed `claim_pattern.job_name` is a supported claim field for the GitLab issuer in dd-octo-sts; if not, the policy needs loosening to match on `sub` regex alone. (2) The image `registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest` is used in bp-infra CI and includes `dd-octo-sts` and `git`; confirm it is accessible from the `runner:apm-k8s-m7i-metal` tag or change to `arch:amd64`.