### PR TITLE
ci(chainguard): allow benchmark-health job to self-push branches

### DIFF
--- a/.github/chainguard/gitlab-benchmark-health-push.sts.yaml
+++ b/.github/chainguard/gitlab-benchmark-health-push.sts.yaml
@@ -1,0 +1,16 @@
+# Grants the benchmark-health fast-track job in GitLab a short-lived GitHub
+# token with 'contents: write' so it can self-push the stability-monitoring
+# patch to a dedicated 'external/benchmark-health/<run-id>' branch, which fires
+# the benchmark pipeline for flaky-benchmark detection.
+#
+# Scoped tightly: GitLab issuer, dd-trace-js project path only, and the
+# 'benchmark-health' job name. Contact: APM DCS Performance team.
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-js:ref_type:branch:ref:.*"
+
+claim_pattern:
+  job_name: benchmark-health
+
+permissions:
+  contents: write


### PR DESCRIPTION
### What does this PR do?

Adds a GitLab-issuer dd-octo-sts trust policy: `.github/chainguard/gitlab-benchmark-health-push.sts.yaml`. It grants the `benchmark-health` GitLab CI job a short-lived GitHub token with `contents: write`, scoped to dd-trace-js only.

### Motivation

The benchmark-health flow (flaky-benchmark detection) needs its fast-track job to self-push a patched branch (`external/benchmark-health/<run-id>`) that fires the benchmark pipeline. This policy authorizes that self-push. Split from the fast-track CI PR so the security-relevant grant is reviewed on its own.

### Additional Notes

Self-scoped (no cross-repo `repositories:` block). The fast-track job that consumes this lands in a separate PR.

---
## Review focus

- The grant is `contents: write` only, GitLab issuer, scoped to `project_path:DataDog/apm-reliability/dd-trace-js`.
- `claim_pattern.job_name: benchmark-health` is the intended pin. Confirm `job_name` is a valid claim for the GitLab issuer in this dd-octo-sts setup; if not, a tighter `subject_pattern` or `ci_config_ref_uri` pin is the fallback.
- `subject_pattern` currently allows any branch (`ref:.*`). Consider whether to pin to the fast-track config ref instead.
- No other repos are in scope; this cannot push anywhere but dd-trace-js.