### PR TITLE
fix(aws-durable-execution-sdk-js): [SVLS-9168] handle FAILED checkpoints properly

### DIFF
--- a/packages/datadog-plugin-aws-durable-execution-sdk-js/src/util.js
+++ b/packages/datadog-plugin-aws-durable-execution-sdk-js/src/util.js
@@ -2,6 +2,12 @@
 
 const { createHash } = require('node:crypto')
 
+// A checkpoint in one of these terminal states means the operation is served from the checkpoint
+// on a replay rather than executed: the SDK reloads a SUCCEEDED result or re-raises a FAILED error
+// without running the user function. Both also carry the 1-indexed attempt that reached the terminal
+// state, so both need the same normalization to agree with the 0-indexed live run.
+const REPLAYED_STATUSES = new Set(['SUCCEEDED', 'FAILED'])
+
 /**
  * Resolves the SDK's next stepId and its checkpoint entry in a single pass, so one span start can
  * feed both addOpMeta and getOperationAttempt without traversing the SDK internals twice. `stepData`
@@ -18,9 +24,9 @@ function getStepDataForNext (ctxImpl) {
 /**
  * Populates the replay and operation_id tags from a pre-resolved step lookup (see
  * getStepDataForNext). `aws.durable.replayed` is always set ('true' when the next stepId already
- * has a SUCCEEDED checkpoint entry, i.e. the op will be served from the SDK's checkpoint).
- * `aws.durable.operation_id` — the 16-hex-char MD5 of the stepId, mirroring the SDK's internal
- * calculation — is only added when a stepId exists.
+ * has a terminal checkpoint entry — SUCCEEDED or FAILED — i.e. the op will be served from the SDK's
+ * checkpoint rather than executed). `aws.durable.operation_id` — the 16-hex-char MD5 of the stepId,
+ * mirroring the SDK's internal calculation — is only added when a stepId exists.
  * @param {Record<string, string>} meta - The span meta/tags object to populate.
  * @param {{ stepId?: string, stepData?: object }} stepInfo - Resolved next stepId and checkpoint entry.
  * @returns {void}
@@ -30,7 +36,7 @@ function addOpMeta (meta, { stepId, stepData }) {
     meta['aws.durable.replayed'] = 'false'
     return
   }
-  meta['aws.durable.replayed'] = String(stepData?.Status === 'SUCCEEDED')
+  meta['aws.durable.replayed'] = String(REPLAYED_STATUSES.has(stepData?.Status))
   meta['aws.durable.operation_id'] = createHash('md5').update(stepId).digest('hex').slice(0, 16)
 }
 
@@ -39,10 +45,10 @@ function addOpMeta (meta, { stepId, stepData }) {
  * checkpoint entry (see getStepDataForNext), defaulting to 0 before any checkpoint exists.
  *
  * StepDetails.Attempt is indexed differently depending on checkpoint status: on a pending/retry
- * checkpoint it's the count of prior failed attempts (already 0-indexed), but on a SUCCEEDED
- * checkpoint (a replay) it's the 1-indexed attempt that succeeded. We subtract 1 in the latter
- * case so a replay agrees with the original run, flooring at 0 since the 1-indexing is observed
- * server behavior, not an SDK guarantee.
+ * checkpoint it's the count of prior failed attempts (already 0-indexed), but on a terminal
+ * checkpoint read on replay (SUCCEEDED or FAILED) it's the 1-indexed attempt that reached that
+ * state. We subtract 1 in the terminal case so a replay agrees with the original run, flooring at
+ * 0 since the 1-indexing is observed server behavior, not an SDK guarantee.
  *
  * @param {object} [stepData] - The checkpoint entry for the next stepId.
  * @returns {number}
@@ -50,7 +56,7 @@ function addOpMeta (meta, { stepId, stepData }) {
 function getOperationAttempt (stepData) {
   const attempt = stepData?.StepDetails?.Attempt
   if (!Number.isFinite(attempt)) return 0
-  return stepData.Status === 'SUCCEEDED' ? Math.max(0, attempt - 1) : attempt
+  return REPLAYED_STATUSES.has(stepData.Status) ? Math.max(0, attempt - 1) : attempt
 }
 
 /**

--- a/packages/datadog-plugin-aws-durable-execution-sdk-js/test/index.spec.js
+++ b/packages/datadog-plugin-aws-durable-execution-sdk-js/test/index.spec.js
@@ -419,6 +419,39 @@ createIntegrationTestSuite('aws-durable-execution-sdk-js', '@aws/durable-executi
     return replayedStep
   })
 
+  it('checkpoint plugin: replayed step that failed permanently reports normalized operation_attempt', async () => {
+    const replayedFailedStep = agent.assertSomeTraces(traces => {
+      const span = traces.flat().find(s =>
+        s.name === 'aws.durable.step' &&
+        s.resource === 'always-fails' &&
+        s.meta?.['aws.durable.replayed'] === 'true'
+      )
+      assert.ok(span, 'expected a replayed FAILED step span')
+      // The step exhausts its retries and fails on its 2nd attempt. On replay the SDK reloads the
+      // FAILED checkpoint (re-raising without running the body), whose StepDetails.Attempt is the
+      // 1-indexed attempt that failed (2). A FAILED checkpoint is a replay just like a SUCCEEDED
+      // one, so it is tagged replayed=true and normalized back to the live 0-indexed final attempt.
+      assert.equal(span.metrics?.['aws.durable.operation_attempt'], 1,
+        'replayed FAILED step should carry the normalized operation_attempt=1')
+    }, { timeoutMs: 8000 })
+
+    await invokeHandler(async (event, ctx) => {
+      try {
+        await ctx.step(
+          'always-fails',
+          async () => { throw new Error('permanent failure') },
+          { retryStrategy: (error, attempt) => ({ shouldRetry: attempt < 2, delay: { seconds: 1 } }) }
+        )
+      } catch {
+        // The durable step surfaces the permanent failure; swallow it so the execution continues
+        // to the wait below, whose replay re-reads the now-FAILED checkpoint.
+      }
+      await ctx.wait('suspend-trigger', { seconds: 1 })
+    })
+
+    return replayedFailedStep
+  })
+
   // waitForCondition is the other retryable op. Its StepDetails.Attempt follows the
   // same convention as step (live: prior-attempt count; SUCCEEDED replay: 1-indexed
   // attempt that succeeded), so it must get the same replay normalization. This guards


### PR DESCRIPTION
## What does this PR do?

Treats a **FAILED** durable checkpoint the same as a SUCCEEDED one, for two span attributes on durable operation spans:

- `aws.durable.replayed` — now `true` when the operation is served from a terminal checkpoint (FAILED or SUCCEEDED)
- `aws.durable.operation_attempt` — the 0-indexing normalization (i.e. subtracting attempt value by 1) now applies to FAILED checkpoints too. Right now we only do this for SUCCEEDED checkpoints.

## Testing
### Context
The `always-fails` operation runs/replays three times:
- original attempt: fails
- 2nd and final attempt (1st retry): fails
- replay of the 2nd attempt

### Result
#### Before
The last span for the `always-fails` operation has `replay == false` and `operation_attempt` span tag of `2`, both of which are wrong.
<img width="772" height="300" alt="image" src="https://github.com/user-attachments/assets/190ea200-7d91-475f-8017-24eefd7667b6" />
<img width="344" height="230" alt="image" src="https://github.com/user-attachments/assets/6373ff32-620d-4863-9d09-7bd0b6305efc" />

#### After
The replay span shows as a separate row in the operations table, and is hidden by default (when "Show replays" is off)
<img width="846" height="501" alt="image" src="https://github.com/user-attachments/assets/07c68877-d1a7-470c-8940-ae6cb9337240" />

## Related PR
The same fix for Python: https://github.com/DataDog/dd-trace-js/pull/9160