### PR TITLE
fix(vitest): route thread workers through main process

### DIFF
--- a/integration-tests/ci-visibility/run-tinypool-with-vitest-env.mjs
+++ b/integration-tests/ci-visibility/run-tinypool-with-vitest-env.mjs
@@ -1,0 +1,19 @@
+import Tinypool from 'tinypool'
+
+const pool = new Tinypool({
+  filename: new URL('./tinypool-app/worker.js', import.meta.url).href,
+  env: {
+    ...process.env,
+    VITEST: 'true',
+  },
+})
+
+const result = await pool.run({ a: 4, b: 6 })
+// eslint-disable-next-line no-console
+console.log('result', result.sum)
+// eslint-disable-next-line no-console
+console.log('dd vitest worker', result.ddVitestWorker)
+
+// Make sure to destroy pool once it's not needed anymore
+// This terminates all pool's idle workers
+await pool.destroy()

--- a/integration-tests/ci-visibility/tinypool-app/worker.js
+++ b/integration-tests/ci-visibility/tinypool-app/worker.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = ({ a, b }) => {
+  return {
+    sum: a + b,
+    ddVitestWorker: process.env.DD_VITEST_WORKER,
+  }
+}

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -315,6 +315,25 @@ versions.forEach((version) => {
       })
     })
 
+    it('does not mark application tinypool workers as Vitest workers', (done) => {
+      childProcess = exec('node ./ci-visibility/run-tinypool-with-vitest-env.mjs', {
+        cwd,
+        env: getCiVisAgentlessConfig(receiver.port),
+      })
+      childProcess.stdout?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.on('exit', (code) => {
+        assert.match(testOutput, /result 10/)
+        assert.match(testOutput, /dd vitest worker undefined/)
+        assert.strictEqual(code, 0)
+        done()
+      })
+    })
+
     context('programmatic api', () => {
       it('can report data using the vitest programmatic api', async () => {
         const eventsPromise = receiver

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -231,19 +231,13 @@ versions.forEach((version) => {
             )
 
             testEvents.forEach(test => {
-              // `threads` config will report directly. TODO: update this once we're testing vitest@>=4
-              if (poolConfig === 'forks') {
-                assert.strictEqual(test.content.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
-              }
+              assert.strictEqual(test.content.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
               assert.ok(test.content.metrics[DD_HOST_CPU_COUNT])
               assert.strictEqual(test.content.meta[DD_TEST_IS_USER_PROVIDED_SERVICE], 'false')
             })
 
             testSuiteEvents.forEach(testSuite => {
-              // `threads` config will report directly. TODO: update this once we're testing vitest@>=4
-              if (poolConfig === 'forks') {
-                assert.strictEqual(testSuite.content.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
-              }
+              assert.strictEqual(testSuite.content.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
               assert.strictEqual(
                 testSuite.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/vitest-tests/test-visibility'),
                 true
@@ -256,38 +250,40 @@ versions.forEach((version) => {
       })
     })
 
-    newerVitestIt('sets DD_VITEST_WORKER in workers with pool=forks', async () => {
-      const eventsPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-          const test = events.find(event => event.type === 'test').content
+    for (const workerPoolConfig of poolConfig) {
+      it(`sets DD_VITEST_WORKER in workers with pool=${workerPoolConfig}`, async () => {
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const test = events.find(event => event.type === 'test').content
 
-          assert.ok(test)
-          assert.strictEqual(test.meta[TEST_NAME], 'vitest worker env sets DD_VITEST_WORKER')
-          assert.strictEqual(test.meta[TEST_STATUS], 'pass')
-        }, 25000)
+            assert.ok(test)
+            assert.strictEqual(test.meta[TEST_NAME], 'vitest worker env sets DD_VITEST_WORKER')
+            assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+          }, 25000)
 
-      childProcess = exec(
-        './node_modules/.bin/vitest run',
-        {
-          cwd,
-          env: {
-            ...getCiVisAgentlessConfig(receiver.port),
-            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
-            TEST_DIR: 'ci-visibility/vitest-tests/vitest-worker-env.mjs',
-            POOL_CONFIG: 'forks',
-            DD_SERVICE: undefined,
-          },
-        }
-      )
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              TEST_DIR: 'ci-visibility/vitest-tests/vitest-worker-env.mjs',
+              POOL_CONFIG: workerPoolConfig,
+              DD_SERVICE: undefined,
+            },
+          }
+        )
 
-      const [[code]] = await Promise.all([
-        once(childProcess, 'exit'),
-        eventsPromise,
-      ])
+        const [[code]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
 
-      assert.strictEqual(code, 0)
-    })
+        assert.strictEqual(code, 0)
+      })
+    }
 
     newerVitestIt('sets DD_VITEST_WORKER in workers when a fork project has a threads root pool', async () => {
       const eventsPromise = receiver

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -5,6 +5,7 @@ const realSetTimeout = setTimeout
 
 const path = require('node:path')
 const { performance } = require('node:perf_hooks')
+const { MessagePort } = require('node:worker_threads')
 
 const shimmer = require('../../datadog-shimmer')
 const log = require('../../dd-trace/src/log')
@@ -98,6 +99,8 @@ let testCodeCoverageLinesTotal
 let coverageRootDir
 let isSessionStarted = false
 let vitestPool = null
+let isMessagePortWrapped = false
+const tinyPoolClassWrappers = new WeakMap()
 
 const BREAKPOINT_HIT_GRACE_PERIOD_MS = 400
 
@@ -913,6 +916,10 @@ function isThreadPool (pool) {
   return pool === 'threads' || pool === 'vmThreads'
 }
 
+function isVitestWorkerPool (pool) {
+  return isForkPool(pool) || isThreadPool(pool)
+}
+
 /**
  * Return the project object attached to a Vitest test specification.
  *
@@ -931,13 +938,13 @@ function getTestSpecificationPool (testSpecification) {
   return project?.config?.pool || project?.serializedConfig?.pool || project?.pool || testSpecification?.pool
 }
 
-function hasForkPoolTestSpecification (testSpecifications) {
+function hasVitestWorkerPoolTestSpecification (testSpecifications) {
   if (!Array.isArray(testSpecifications)) {
     return false
   }
 
   for (const testSpecification of testSpecifications) {
-    if (isForkPool(getTestSpecificationPool(testSpecification))) {
+    if (isVitestWorkerPool(getTestSpecificationPool(testSpecification))) {
       return true
     }
   }
@@ -946,8 +953,8 @@ function hasForkPoolTestSpecification (testSpecifications) {
 }
 
 function shouldMarkVitestWorkerEnv (pool, testSpecifications) {
-  return isForkPool(pool) || hasForkPoolTestSpecification(testSpecifications) ||
-    (!testSpecifications && !isThreadPool(pool))
+  return isVitestWorkerPool(pool) || hasVitestWorkerPoolTestSpecification(testSpecifications) ||
+    (!testSpecifications && pool === undefined)
 }
 
 function markVitestWorkerEnv (ctx, testSpecifications) {
@@ -1011,20 +1018,25 @@ function threadHandler (thread) {
   workerProcesses.add(workerProcess)
   workerProcess.on('message', (message) => {
     if (message.__tinypool_worker_message__ && message.data) {
-      if (message.interprocessCode === VITEST_WORKER_TRACE_PAYLOAD_CODE) {
-        collectTestOptimizationSummariesFromTraces(message.data, {
-          newTestsWithDynamicNames,
-          attemptToFixExecutions,
-        })
-        workerReportTraceCh.publish(message.data)
-      } else if (message.interprocessCode === VITEST_WORKER_LOGS_PAYLOAD_CODE) {
-        workerReportLogsCh.publish(message.data)
-      }
+      handleWorkerReport(message.interprocessCode, message.data)
     }
   })
 }
 
+function isVitestTinypoolOptions (options) {
+  return options?.env?.VITEST === 'true' &&
+    (options.filename?.endsWith(`${path.sep}worker.js`) || options.filename?.endsWith('/worker.js'))
+}
+
+function markVitestTinypoolOptions (options) {
+  if (!isVitestTinypoolOptions(options)) return
+
+  options.env.DD_VITEST_WORKER = '1'
+}
+
 function wrapTinyPoolRun (TinyPool) {
+  if (!TinyPool?.prototype?.run) return
+
   shimmer.wrap(TinyPool.prototype, 'run', run => async function () {
     // We have to do this before and after because the threads list gets recycled, that is, the processes are re-created
     // eslint-disable-next-line unicorn/no-array-for-each
@@ -1036,13 +1048,51 @@ function wrapTinyPoolRun (TinyPool) {
   })
 }
 
+function wrapTinyPoolClass (TinyPool) {
+  if (typeof TinyPool !== 'function') return TinyPool
+
+  const wrappedTinyPool = tinyPoolClassWrappers.get(TinyPool)
+  if (wrappedTinyPool) return wrappedTinyPool
+
+  class DatadogTinyPool extends TinyPool {
+    constructor (options) {
+      markVitestTinypoolOptions(options)
+      super(options)
+    }
+  }
+
+  tinyPoolClassWrappers.set(TinyPool, DatadogTinyPool)
+  wrapTinyPoolRun(DatadogTinyPool)
+
+  return DatadogTinyPool
+}
+
+function wrapTinyPool (TinyPool) {
+  if (typeof TinyPool === 'function') {
+    return wrapTinyPoolClass(TinyPool)
+  }
+
+  const defaultTinyPool = wrapTinyPoolClass(TinyPool?.default)
+  if (defaultTinyPool) {
+    TinyPool.default = defaultTinyPool
+  }
+
+  const namedTinyPool = TinyPool?.Tinypool === TinyPool?.default
+    ? defaultTinyPool
+    : wrapTinyPoolClass(TinyPool?.Tinypool)
+  if (namedTinyPool) {
+    TinyPool.Tinypool = namedTinyPool
+  }
+
+  return TinyPool
+}
+
 addHook({
   name: 'tinypool',
   // version from tinypool@0.8 was used in vitest@1.6.0
   versions: ['>=0.8.0'],
 }, (TinyPool) => {
-  wrapTinyPoolRun(TinyPool)
-  return TinyPool
+  return wrapTinyPool(TinyPool)
 })
 
 function getWrappedOn (on) {
@@ -1056,22 +1106,41 @@ function getWrappedOn (on) {
     arguments[1] = shimmer.wrapFunction(callback, callback => function (message) {
       if (message.type !== 'Buffer' && Array.isArray(message)) {
         const [interprocessCode, data] = message
-        if (interprocessCode === VITEST_WORKER_TRACE_PAYLOAD_CODE) {
-          collectTestOptimizationSummariesFromTraces(data, {
-            newTestsWithDynamicNames,
-            attemptToFixExecutions,
-          })
-          workerReportTraceCh.publish(data)
-        } else if (interprocessCode === VITEST_WORKER_LOGS_PAYLOAD_CODE) {
-          workerReportLogsCh.publish(data)
+        if (handleWorkerReport(interprocessCode, data)) {
+          // If we execute the callback vitest crashes, as the message is not supported
+          return
         }
-        // If we execute the callback vitest crashes, as the message is not supported
-        return
       }
       return callback.apply(this, arguments)
     })
     return on.apply(this, arguments)
   }
+}
+
+function handleWorkerReport (interprocessCode, data) {
+  if (interprocessCode === VITEST_WORKER_TRACE_PAYLOAD_CODE) {
+    collectTestOptimizationSummariesFromTraces(data, {
+      newTestsWithDynamicNames,
+      attemptToFixExecutions,
+    })
+    workerReportTraceCh.publish(data)
+    return true
+  }
+
+  if (interprocessCode === VITEST_WORKER_LOGS_PAYLOAD_CODE) {
+    workerReportLogsCh.publish(data)
+    return true
+  }
+
+  return false
+}
+
+function wrapMessagePortOn () {
+  if (isMessagePortWrapped) return
+
+  isMessagePortWrapped = true
+  shimmer.wrap(MessagePort.prototype, 'on', getWrappedOn)
+  shimmer.wrap(MessagePort.prototype, 'addListener', getWrappedOn)
 }
 
 function getStartVitestWrapper (cliApiPackage, frameworkVersion) {
@@ -1080,6 +1149,7 @@ function getStartVitestWrapper (cliApiPackage, frameworkVersion) {
   }
   const startVitestExport = findExportByName(cliApiPackage, 'startVitest')
   shimmer.wrap(cliApiPackage, startVitestExport.key, getCliOrStartVitestWrapper(frameworkVersion))
+  wrapMessagePortOn()
 
   const vitest = getVitestExport(cliApiPackage)
   if (vitest) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -5,6 +5,7 @@ const realSetTimeout = setTimeout
 
 const path = require('node:path')
 const { performance } = require('node:perf_hooks')
+const { fileURLToPath } = require('node:url')
 const { MessagePort } = require('node:worker_threads')
 
 const shimmer = require('../../datadog-shimmer')
@@ -1024,8 +1025,24 @@ function threadHandler (thread) {
 }
 
 function isVitestTinypoolOptions (options) {
-  return options?.env?.VITEST === 'true' &&
-    (options.filename?.endsWith(`${path.sep}worker.js`) || options.filename?.endsWith('/worker.js'))
+  if (options?.env?.VITEST !== 'true' || typeof options.filename !== 'string') return false
+
+  let filename = options.filename
+  if (filename.startsWith('file:')) {
+    try {
+      filename = fileURLToPath(filename)
+    } catch {
+      return false
+    }
+  }
+
+  const workerPath = path.normalize(filename)
+  const workerDir = path.dirname(workerPath)
+  const packageDir = path.dirname(workerDir)
+
+  return path.basename(workerPath) === 'worker.js' &&
+    path.basename(workerDir) === 'dist' &&
+    path.basename(packageDir) === 'vitest'
 }
 
 function markVitestTinypoolOptions (options) {

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
@@ -3,6 +3,11 @@ const { JSONEncoder } = require('../../encode/json-encoder')
 const { getEnvironmentVariable } = require('../../../config/helper')
 const log = require('../../../log')
 
+function getVitestWorkerPort () {
+  const port = globalThis.__vitest_worker__?.ctx?.port
+  return typeof port?.postMessage === 'function' ? port : undefined
+}
+
 class Writer {
   constructor (interprocessCode) {
     this._encoder = new JSONEncoder()
@@ -36,6 +41,18 @@ class Writer {
     const payload = isVitestWorkerOld
       ? { __tinypool_worker_message__: true, interprocessCode: this._interprocessCode, data }
       : [this._interprocessCode, data]
+
+    const vitestWorkerPort = getVitestWorkerPort()
+    if (vitestWorkerPort) {
+      try {
+        vitestWorkerPort.postMessage(payload)
+      } catch (error) {
+        log.error('Error posting message to vitest worker port', error)
+      } finally {
+        onDone()
+      }
+      return
+    }
 
     // child_process workers (jest default, cucumber)
     if (process.send) {

--- a/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
@@ -160,6 +160,7 @@ describe('CI Visibility Test Worker Exporter', () => {
     afterEach(() => {
       delete process.env.DD_VITEST_WORKER
       delete process.env.TINYPOOL_WORKER_ID
+      delete globalThis.__vitest_worker__
     })
 
     it('can export traces (vitest >=4)', () => {
@@ -184,6 +185,25 @@ describe('CI Visibility Test Worker Exporter', () => {
         interprocessCode: VITEST_WORKER_TRACE_PAYLOAD_CODE,
         data: JSON.stringify([trace]),
       })
+    })
+
+    it('can export traces through the worker port in legacy thread workers (vitest <4)', () => {
+      process.env.DD_VITEST_WORKER = '1'
+      delete process.send
+      const postMessage = sinon.spy()
+      const trace = [{ type: 'test' }]
+      globalThis.__vitest_worker__ = {
+        ctx: {
+          port: {
+            postMessage,
+          },
+        },
+      }
+      const vitestWorkerExporter = new TestWorkerCiVisibilityExporter()
+      vitestWorkerExporter.export(trace)
+      vitestWorkerExporter.flush()
+      sinon.assert.calledWith(postMessage, [VITEST_WORKER_TRACE_PAYLOAD_CODE, JSON.stringify([trace])])
+      sinon.assert.notCalled(send)
     })
 
     it('does not break if process.send is undefined', () => {


### PR DESCRIPTION
### What does this PR do?

Routes Vitest thread-pool workers through the Test Optimization test-worker exporter so they report back to the Vitest main process instead of reporting directly to the intake or Datadog Agent.

This updates the legacy Tinypool instrumentation to mark Vitest worker environments before eager workers are spawned, adds a Vitest worker MessagePort path for legacy thread workers, and tightens Vitest integration coverage so both `forks` and `threads` must be reported as framework worker events.

### Motivation

Vitest `forks` workers already used `ci-visibility/exporters/test-worker`, and Vitest 4 thread workers behaved correctly. Older Vitest thread workers did not get a worker-identifying environment marker, so `dd-trace/ci/init` selected the normal exporter and those workers reported directly.

The root cause is that legacy Tinypool thread workers do not expose `TINYPOOL_WORKER_ID` in `process.env`, and Vitest 1.x/2.x do not export the `Vitest` class from the CLI chunk where our `runFiles` wrapper attaches. Marking the Tinypool worker options before construction gives all supported Vitest worker pools the same reporting behavior.
