### PR TITLE
docs(agents): clarify internal import ordering rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ Separate groups with empty line, sort alphabetically within each:
 
 1. Node.js core modules (with `node:` prefix)
 2. Third-party modules
-3. Internal imports (by path proximity, then alpha)
+3. Internal imports (by path proximity, furthest first, then alpha)
 
 ### ECMAScript and Node.js API Standards
 


### PR DESCRIPTION
### What does this PR do?
Clarifies the internal import ordering rule in `AGENTS.md`. The previous wording ("by path proximity, then alpha") was ambiguous, it didn't specify whether proximity meant closer-first or furthest-first, which is the opposite of what the `import/order` ESLint rule enforces.

### Motivation
The ambiguity caused a lint failure in a separate PR: imports were written closer-first following an intuitive reading of "proximity", but the linter requires furthest-first. The updated wording makes the direction explicit and aligns with the actual ESLint configuration.

### Additional Notes
The authoritative source remains ESLint configuration: the `import/order` rule groups parent paths (`../`) before sibling paths (`./`) by default, which is what "furthest first" reflects in practice.


