### PR TITLE
feat(llmobs): resolve and propagate agent attribution

### DIFF
--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -24,8 +24,8 @@ module.exports = {
   // and must pass `agentNameWireSafe` before being written to the `x-datadog-tags` tagset.
   PARENT_AGENT_NAME: '_ml_obs.parent_agent_name',
   PARENT_AGENT_SPAN_ID: '_ml_obs.parent_agent_span_id',
-  PROPAGATED_PARENT_AGENT_ID_KEY: '_dd.p.llmobs_parent_agent_id',
-  PROPAGATED_PARENT_AGENT_NAME_KEY: '_dd.p.llmobs_parent_agent_name',
+  PROPAGATED_PARENT_AGENT_ID_KEY: '_dd.p.llmobs_pagent_span_id',
+  PROPAGATED_PARENT_AGENT_NAME_KEY: '_dd.p.llmobs_pagent_name',
   PROPAGATED_SAMPLE_RATE_KEY: '_dd.p.llmobs_sr',
   PROPAGATED_SAMPLING_DECISION_KEY: '_dd.p.llmobs_sd',
   SAMPLE_RATE: '_ml_obs.sample_rate',

--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -16,6 +16,16 @@ module.exports = {
   PROPAGATED_ML_APP_KEY: '_dd.p.llmobs_ml_app',
   PROPAGATED_SESSION_ID_KEY: '_dd.p.llmobs_sid',
   PARENT_ID_KEY: '_ml_obs.llmobs_parent_id',
+
+  // Agent attribution: the nearest agent ancestor a span is attributed to. Resolved once at
+  // span registration and stored on the registry entry; surfaced on the wire as
+  // `meta.agent_attribution`. The propagated keys carry the same identity across process
+  // boundaries. The id is always `str(span_id)` (digit-safe); the name is arbitrary user text
+  // and must pass `agentNameWireSafe` before being written to the `x-datadog-tags` tagset.
+  PARENT_AGENT_NAME: '_ml_obs.parent_agent_name',
+  PARENT_AGENT_SPAN_ID: '_ml_obs.parent_agent_span_id',
+  PROPAGATED_PARENT_AGENT_ID_KEY: '_dd.p.llmobs_parent_agent_id',
+  PROPAGATED_PARENT_AGENT_NAME_KEY: '_dd.p.llmobs_parent_agent_name',
   PROPAGATED_SAMPLE_RATE_KEY: '_dd.p.llmobs_sr',
   PROPAGATED_SAMPLING_DECISION_KEY: '_dd.p.llmobs_sd',
   SAMPLE_RATE: '_ml_obs.sample_rate',

--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -17,11 +17,6 @@ module.exports = {
   PROPAGATED_SESSION_ID_KEY: '_dd.p.llmobs_sid',
   PARENT_ID_KEY: '_ml_obs.llmobs_parent_id',
 
-  // Agent attribution: the nearest agent ancestor a span is attributed to. Resolved once at
-  // span registration and stored on the registry entry; surfaced on the wire as
-  // `meta.agent_attribution`. The propagated keys carry the same identity across process
-  // boundaries. The id is always `str(span_id)` (digit-safe); the name is arbitrary user text
-  // and must pass `agentNameWireSafe` before being written to the `x-datadog-tags` tagset.
   PARENT_AGENT_NAME: '_ml_obs.parent_agent_name',
   PARENT_AGENT_SPAN_ID: '_ml_obs.parent_agent_span_id',
   PROPAGATED_PARENT_AGENT_ID_KEY: '_dd.p.llmobs_pagent_span_id',

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -171,7 +171,10 @@ function handleLLMObsInjection ({ carrier }) {
   // encoder drop the whole header. The backend resolves the name from the id in that case.
   if (parentAgentSpanId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_ID_KEY}=${parentAgentSpanId}`
   if (parentAgentName && agentNameWireSafe(parentAgentName)) {
-    tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_NAME_KEY}=${parentAgentName}`
+    const nameEntry = `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_NAME_KEY}=${parentAgentName}`
+    if (tags.length + nameEntry.length <= globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH) {
+      tags += nameEntry
+    }
   }
   if (tags !== existing) writeDatadogTags(carrier, tags)
 }

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -13,6 +13,8 @@ const {
   PROPAGATED_ML_APP_KEY,
   PROPAGATED_PARENT_ID_KEY,
   PROPAGATED_SESSION_ID_KEY,
+  PROPAGATED_PARENT_AGENT_ID_KEY,
+  PROPAGATED_PARENT_AGENT_NAME_KEY,
   SAMPLE_RATE,
   SAMPLING_DECISION,
   PROPAGATED_SAMPLE_RATE_KEY,
@@ -21,6 +23,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
+const { agentNameWireSafe } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
 const LLMObsEvalMetricsWriter = require('./writers/evaluations')
@@ -148,6 +151,12 @@ function handleLLMObsInjection ({ carrier }) {
 
   if (!parentId && !mlApp && samplingDecision == null && !sessionId && !propagatedTraceId) return
 
+  // Propagate the nearest agent so spans in the downstream process attribute correctly. When the
+  // active span sits under a distributed agent, `resolveAgentAttribution` inherits the propagated
+  // id/name already on the parent's registry entry, so the chain survives multiple hops. Resolved
+  // after the bail-out above so we don't allocate when there is nothing to inject.
+  const { name: parentAgentName, spanId: parentAgentSpanId } = LLMObsTagger.resolveAgentAttribution(parent)
+
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.
   const existing = readDatadogTags(carrier)
@@ -158,6 +167,12 @@ function handleLLMObsInjection ({ carrier }) {
   if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
   if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
   if (propagatedTraceId != null) tags += `${tags ? ',' : ''}${PROPAGATED_TRACE_ID_KEY}=${propagatedTraceId}`
+  // The id is always digit-safe; skip an unsafe name (id-only) rather than letting the tagset
+  // encoder drop the whole header. The backend resolves the name from the id in that case.
+  if (parentAgentSpanId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_ID_KEY}=${parentAgentSpanId}`
+  if (parentAgentName && agentNameWireSafe(parentAgentName)) {
+    tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_NAME_KEY}=${parentAgentName}`
+  }
   if (tags !== existing) writeDatadogTags(carrier, tags)
 }
 

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -155,7 +155,9 @@ function handleLLMObsInjection ({ carrier }) {
   // active span sits under a distributed agent, `resolveAgentAttribution` inherits the propagated
   // id/name already on the parent's registry entry, so the chain survives multiple hops. Resolved
   // after the bail-out above so we don't allocate when there is nothing to inject.
-  const { name: parentAgentName, spanId: parentAgentSpanId } = resolveAgentAttribution(LLMObsTagger.tagMap.get(parent), parent)
+  const { name: parentAgentName, spanId: parentAgentSpanId } = resolveAgentAttribution(
+    LLMObsTagger.tagMap.get(parent), parent
+  )
 
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -23,7 +23,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { agentNameWireSafe } = require('./util')
+const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
 const LLMObsEvalMetricsWriter = require('./writers/evaluations')
@@ -155,7 +155,7 @@ function handleLLMObsInjection ({ carrier }) {
   // active span sits under a distributed agent, `resolveAgentAttribution` inherits the propagated
   // id/name already on the parent's registry entry, so the chain survives multiple hops. Resolved
   // after the bail-out above so we don't allocate when there is nothing to inject.
-  const { name: parentAgentName, spanId: parentAgentSpanId } = LLMObsTagger.resolveAgentAttribution(parent)
+  const { name: parentAgentName, spanId: parentAgentSpanId } = resolveAgentAttribution(LLMObsTagger.tagMap.get(parent), parent)
 
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.
@@ -167,15 +167,10 @@ function handleLLMObsInjection ({ carrier }) {
   if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
   if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
   if (propagatedTraceId != null) tags += `${tags ? ',' : ''}${PROPAGATED_TRACE_ID_KEY}=${propagatedTraceId}`
-  // The id is always digit-safe; skip an unsafe name (id-only) rather than letting the tagset
-  // encoder drop the whole header. The backend resolves the name from the id in that case.
-  if (parentAgentSpanId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_ID_KEY}=${parentAgentSpanId}`
-  if (parentAgentName && agentNameWireSafe(parentAgentName)) {
-    const nameEntry = `${tags ? ',' : ''}${PROPAGATED_PARENT_AGENT_NAME_KEY}=${parentAgentName}`
-    if (tags.length + nameEntry.length <= globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH) {
-      tags += nameEntry
-    }
-  }
+  // The id is always digit-safe; skip an unsafe name rather than letting the tagset encoder drop
+  // the whole header. Budget overflow (like ml_app) is a known limitation tracked separately.
+  tags = appendOptionalPropagatedTag(tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId)
+  tags = appendOptionalPropagatedTag(tags, PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName, agentNameWireSafe)
   if (tags !== existing) writeDatadogTags(carrier, tags)
 }
 

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -178,10 +178,17 @@ function handleLLMObsInjection ({ carrier }) {
     tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_NAME_KEY)
   }
   const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
-  tags = appendOptionalPropagatedTag(tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId, null, maxLength)
-  tags = appendOptionalPropagatedTag(
-    tags, PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName, agentNameWireSafe, maxLength
+  const tagsWithId = appendOptionalPropagatedTag(
+    tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId, null, maxLength
   )
+  // Only append the name when the id fit: a name without an id is unresolvable by the backend.
+  if (tagsWithId === tags) {
+    tags = tagsWithId
+  } else {
+    tags = appendOptionalPropagatedTag(
+      tagsWithId, PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName, agentNameWireSafe, maxLength
+    )
+  }
   if (tags !== existing) writeDatadogTags(carrier, tags)
 }
 

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -23,7 +23,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution } = require('./util')
+const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution, stripTagsetEntry } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
 const LLMObsEvalMetricsWriter = require('./writers/evaluations')
@@ -156,7 +156,7 @@ function handleLLMObsInjection ({ carrier }) {
   // id/name already on the parent's registry entry, so the chain survives multiple hops. Resolved
   // after the bail-out above so we don't allocate when there is nothing to inject.
   const { name: parentAgentName, spanId: parentAgentSpanId } = resolveAgentAttribution(
-    LLMObsTagger.tagMap.get(parent), parent
+    mlObsSpanTags, parent
   )
 
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
@@ -169,10 +169,19 @@ function handleLLMObsInjection ({ carrier }) {
   if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
   if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
   if (propagatedTraceId != null) tags += `${tags ? ',' : ''}${PROPAGATED_TRACE_ID_KEY}=${propagatedTraceId}`
-  // The id is always digit-safe; skip an unsafe name rather than letting the tagset encoder drop
-  // the whole header. Budget overflow (like ml_app) is a known limitation tracked separately.
-  tags = appendOptionalPropagatedTag(tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId)
-  tags = appendOptionalPropagatedTag(tags, PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName, agentNameWireSafe)
+  // When a local agent attribution is resolved, strip any stale upstream pagent entries that
+  // `_injectTags` may have already written into the carrier (it propagates all `_dd.p.*` from
+  // `_trace.tags`). This ensures the downstream sees a consistent id-only or id+name pair
+  // rather than a mix from different hops. The id is always digit-safe; an unsafe name is wiped.
+  if (parentAgentSpanId) {
+    tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_ID_KEY)
+    tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_NAME_KEY)
+  }
+  const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
+  tags = appendOptionalPropagatedTag(tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId, null, maxLength)
+  tags = appendOptionalPropagatedTag(
+    tags, PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName, agentNameWireSafe, maxLength
+  )
   if (tags !== existing) writeDatadogTags(carrier, tags)
 }
 

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -27,6 +27,8 @@ const {
   ML_APP,
   TAGS,
   PARENT_ID_KEY,
+  PARENT_AGENT_NAME,
+  PARENT_AGENT_SPAN_ID,
   SESSION_ID,
   NAME,
   INPUT_PROMPT,
@@ -155,6 +157,20 @@ class LLMObsSpanProcessor {
     if (mlObsTags[TOOL_DEFINITIONS]) {
       meta.tool_definitions = []
       this.#addObject(mlObsTags[TOOL_DEFINITIONS], meta.tool_definitions)
+    }
+
+    // Surface the agent attribution resolved at registration, but only on spans that actually
+    // have an agent ancestor. The id is always present in that case; the name may be missing when
+    // it arrived id-only over distributed propagation (older/unsafe upstream). Emit the name as
+    // explicit `null` then, matching the cross-language wire shape (dd-trace-py sends null, not an
+    // absent key) so the shared backend and system-tests see the same payload.
+    const parentAgentName = mlObsTags[PARENT_AGENT_NAME]
+    const parentAgentSpanId = mlObsTags[PARENT_AGENT_SPAN_ID]
+    if (parentAgentName != null || parentAgentSpanId != null) {
+      meta.agent_attribution = {
+        parent_agent_name: parentAgentName ?? null,
+        parent_agent_span_id: parentAgentSpanId,
+      }
     }
 
     const llmObsSpan = new LLMObservabilitySpan(spanKind)

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -168,8 +168,8 @@ class LLMObsSpanProcessor {
     const parentAgentSpanId = mlObsTags[PARENT_AGENT_SPAN_ID]
     if (parentAgentName != null || parentAgentSpanId != null) {
       meta.agent_attribution = {
-        parent_agent_name: parentAgentName ?? null,
-        parent_agent_span_id: parentAgentSpanId,
+        pagent_name: parentAgentName ?? null,
+        pagent_span_id: parentAgentSpanId,
       }
     }
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -23,7 +23,11 @@ const {
   OUTPUT_MESSAGES,
   TAGS,
   NAME,
+  PARENT_AGENT_NAME,
+  PARENT_AGENT_SPAN_ID,
   PROPAGATED_PARENT_ID_KEY,
+  PROPAGATED_PARENT_AGENT_ID_KEY,
+  PROPAGATED_PARENT_AGENT_NAME_KEY,
   ROOT_PARENT_ID,
   CACHE_READ_INPUT_TOKENS_METRIC_KEY,
   CACHE_WRITE_INPUT_TOKENS_METRIC_KEY,
@@ -105,6 +109,27 @@ class LLMObsTagger {
     return registry.get(span)?.[SPAN_KIND]
   }
 
+  /**
+   * Resolve the nearest agent that a *child* of `span` should be attributed to.
+   *
+   * If `span` is itself an agent, the child attributes directly to `span`. Otherwise `span`
+   * already resolved its own nearest agent when it was registered, so the child inherits that
+   * (one-level lookup, no ancestor walk). An agent never attributes itself: resolution always
+   * looks at the passed span as the prospective parent. Returns `undefined` values when there
+   * is no agent ancestor (or when `span` is not a registered LLMObs span).
+   *
+   * @param {import('../opentracing/span')} [span]
+   * @returns {{ name: string | undefined, spanId: string | undefined }}
+   */
+  static resolveAgentAttribution (span) {
+    const tags = registry.get(span)
+    if (!tags) return { name: undefined, spanId: undefined }
+    if (tags[SPAN_KIND] === 'agent') {
+      return { name: tags[NAME] || span._name, spanId: span.context().toSpanId() }
+    }
+    return { name: tags[PARENT_AGENT_NAME], spanId: tags[PARENT_AGENT_SPAN_ID] }
+  }
+
   registerLLMObsSpan (span, {
     modelName,
     modelProvider,
@@ -173,6 +198,7 @@ class LLMObsTagger {
     this._setTag(span, PARENT_ID_KEY, parentId)
 
     this.#tagSamplingDecision(span, parent)
+    this.#tagAgentAttribution(span, parent)
 
     // apply annotation context
     const annotationContext = storage.getStore()?.annotationContext
@@ -227,6 +253,32 @@ class LLMObsTagger {
 
     if (sampleRate != null) this._setTag(span, SAMPLE_RATE, sampleRate)
     if (samplingDecision != null) this._setTag(span, SAMPLING_DECISION, samplingDecision)
+  }
+
+  /**
+   * Store the nearest agent ancestor on the span so it can be surfaced as
+   * `meta.agent_attribution` at finish. Resolved once here, at registration, so downstream
+   * children inherit it with a single lookup rather than walking the ancestor chain.
+   *
+   * @param {import('../opentracing/span')} span
+   * @param {import('../opentracing/span')} [parent] the LLMObs parent span, if any
+   */
+  #tagAgentAttribution (span, parent) {
+    let name, spanId
+    if (registry.has(parent)) {
+      // Local LLMObs parent: attribute to it if it is an agent, else inherit its resolution.
+      ({ name, spanId } = LLMObsTagger.resolveAgentAttribution(parent))
+    } else if (span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY]) {
+      // Distributed LLMObs parent: inherit the nearest agent propagated from upstream. The
+      // name may be absent when the upstream hop ran an older SDK or its name was not
+      // wire-safe; the id-only case is expected and the backend resolves the name by span id.
+      const traceTags = span.context()._trace.tags
+      name = traceTags[PROPAGATED_PARENT_AGENT_NAME_KEY]
+      spanId = traceTags[PROPAGATED_PARENT_AGENT_ID_KEY]
+    }
+
+    if (name != null) this._setTag(span, PARENT_AGENT_NAME, name)
+    if (spanId != null) this._setTag(span, PARENT_AGENT_SPAN_ID, spanId)
   }
 
   // TODO: similarly for the following `tag` methods,

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -61,6 +61,7 @@ const {
 const { storage } = require('./storage')
 const {
   findGenAIAncestorSpanId,
+  resolveAgentAttribution,
   validateCostTags,
   writeBridgeTags,
   validateToolDefinitions,
@@ -107,27 +108,6 @@ class LLMObsTagger {
 
   static getSpanKind (span) {
     return registry.get(span)?.[SPAN_KIND]
-  }
-
-  /**
-   * Resolve the nearest agent that a *child* of `span` should be attributed to.
-   *
-   * If `span` is itself an agent, the child attributes directly to `span`. Otherwise `span`
-   * already resolved its own nearest agent when it was registered, so the child inherits that
-   * (one-level lookup, no ancestor walk). An agent never attributes itself: resolution always
-   * looks at the passed span as the prospective parent. Returns `undefined` values when there
-   * is no agent ancestor (or when `span` is not a registered LLMObs span).
-   *
-   * @param {import('../opentracing/span')} [span]
-   * @returns {{ name: string | undefined, spanId: string | undefined }}
-   */
-  static resolveAgentAttribution (span) {
-    const tags = registry.get(span)
-    if (!tags) return { name: undefined, spanId: undefined }
-    if (tags[SPAN_KIND] === 'agent') {
-      return { name: tags[NAME] || span._name, spanId: span.context().toSpanId() }
-    }
-    return { name: tags[PARENT_AGENT_NAME], spanId: tags[PARENT_AGENT_SPAN_ID] }
   }
 
   registerLLMObsSpan (span, {
@@ -263,11 +243,13 @@ class LLMObsTagger {
    * @param {import('../opentracing/span')} span
    * @param {import('../opentracing/span')} [parent] the LLMObs parent span, if any
    */
+  // TODO: spans whose kind changes after registration (e.g. claude-agent-sdk tools promoted to
+  // sub-agents) will not retroactively update already-finished children's attribution. Follow up.
   #tagAgentAttribution (span, parent) {
     let name, spanId
     if (registry.has(parent)) {
       // Local LLMObs parent: attribute to it if it is an agent, else inherit its resolution.
-      ({ name, spanId } = LLMObsTagger.resolveAgentAttribution(parent))
+      ({ name, spanId } = resolveAgentAttribution(registry.get(parent), parent))
     } else if (span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY]) {
       // Distributed LLMObs parent: inherit the nearest agent propagated from upstream. The
       // name may be absent when the upstream hop ran an older SDK or its name was not

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -294,6 +294,26 @@ function getFunctionArguments (fn, args = []) {
   }
 }
 
+// The `x-datadog-tags` tagset encoder rejects commas (the entry delimiter) and any byte
+// outside 0x20-0x7E, and a raise there drops the ENTIRE header (taking ml_app,
+// llmobs_trace_id, parent_id, sampling with it). An agent name is arbitrary user text, so it
+// must be skipped rather than sanitized when unsafe: only the digit-safe id then propagates and
+// the backend resolves the real name by span id. `=` is legal in tagset values (illegal only in
+// keys), so a name containing `=` is safe and must not be dropped.
+/**
+ * @param {string} name
+ * @returns {boolean}
+ */
+function agentNameWireSafe (name) {
+  // Conservative slice of the 512B shared tagset budget, mirroring dd-trace-py.
+  if (Buffer.byteLength(name, 'utf8') > 256) return false
+  for (let index = 0; index < name.length; index++) {
+    const code = name.charCodeAt(index)
+    if (code < 0x20 || code > 0x7E || code === 0x2C /* comma */) return false
+  }
+  return true
+}
+
 function spanHasError (span) {
   const spanContext = span.context()
   return !!(spanContext.getTag('error') || spanContext.getTag('error.type'))
@@ -443,6 +463,7 @@ function formatAudioPart (data, mimeType) {
 }
 
 module.exports = {
+  agentNameWireSafe,
   audioMimeTypeFromFormat,
   encodeUnicode,
   findGenAIAncestorSpanId,

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -325,7 +325,7 @@ function agentNameWireSafe (name) {
  * already resolved its own nearest agent at registration, so the child inherits that with a
  * single lookup rather than walking the ancestor chain. An agent never attributes itself.
  *
- * @param {Record<string, any> | undefined} tags - Registry entry for the parent span.
+ * @param {Record<string, unknown> | undefined} tags - Registry entry for the parent span.
  * @param {import('../opentracing/span')} [span] - The parent span itself (needed for span id / name).
  * @returns {{ name: string | undefined, spanId: string | undefined }}
  */

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -6,6 +6,10 @@ const {
   LLMOBS_PARENT_ID_BRIDGE_KEY,
   LLMOBS_TRACE_ID_BRIDGE_KEY,
   SPAN_KINDS,
+  SPAN_KIND,
+  NAME,
+  PARENT_AGENT_NAME,
+  PARENT_AGENT_SPAN_ID,
 } = require('./constants/tags')
 
 const DECIMAL_TRACE_ID_REGEX = /^\d+$/
@@ -314,6 +318,42 @@ function agentNameWireSafe (name) {
   return true
 }
 
+/**
+ * Resolve the nearest agent that a *child* of `span` should be attributed to.
+ *
+ * If `span` is itself an agent, the child attributes directly to `span`. Otherwise `span`
+ * already resolved its own nearest agent at registration, so the child inherits that with a
+ * single lookup rather than walking the ancestor chain. An agent never attributes itself.
+ *
+ * @param {Record<string, any> | undefined} tags - Registry entry for the parent span.
+ * @param {import('../opentracing/span')} [span] - The parent span itself (needed for span id / name).
+ * @returns {{ name: string | undefined, spanId: string | undefined }}
+ */
+function resolveAgentAttribution (tags, span) {
+  if (!tags) return { name: undefined, spanId: undefined }
+  if (tags[SPAN_KIND] === 'agent') {
+    return { name: tags[NAME] || span._name, spanId: span.context().toSpanId() }
+  }
+  return { name: tags[PARENT_AGENT_NAME], spanId: tags[PARENT_AGENT_SPAN_ID] }
+}
+
+/**
+ * Appends `key=value` to the tagset string with a comma separator, but only when `value` is
+ * truthy and passes the optional `safeguard` predicate. Returns the original `tags` unchanged
+ * when the value is absent or unsafe, so the caller can chain calls without branching.
+ *
+ * @param {string} tags - Existing tagset string (may be empty).
+ * @param {string} key
+ * @param {string | undefined} value
+ * @param {(v: string) => boolean} [safeguard]
+ * @returns {string}
+ */
+function appendOptionalPropagatedTag (tags, key, value, safeguard) {
+  if (!value) return tags
+  if (safeguard && !safeguard(value)) return tags
+  return `${tags}${tags ? ',' : ''}${key}=${value}`
+}
+
 function spanHasError (span) {
   const spanContext = span.context()
   return !!(spanContext.getTag('error') || spanContext.getTag('error.type'))
@@ -464,6 +504,7 @@ function formatAudioPart (data, mimeType) {
 
 module.exports = {
   agentNameWireSafe,
+  appendOptionalPropagatedTag,
   audioMimeTypeFromFormat,
   encodeUnicode,
   findGenAIAncestorSpanId,
@@ -471,6 +512,7 @@ module.exports = {
   llmObsTraceIdToWire,
   normalizeLlmObsTraceId,
   formatAudioPart,
+  resolveAgentAttribution,
   validateCostTags,
   validateKind,
   getFunctionArguments,

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -338,20 +338,34 @@ function resolveAgentAttribution (tags, span) {
 }
 
 /**
+ * Removes all `key=value` entries for the given key from a comma-separated tagset string.
+ *
+ * @param {string} tags - Existing tagset string (may be empty).
+ * @param {string} key
+ * @returns {string}
+ */
+function stripTagsetEntry (tags, key) {
+  if (!tags.includes(key)) return tags
+  return tags.split(',').filter(entry => !entry.startsWith(`${key}=`)).join(',')
+}
+
+/**
  * Appends `key=value` to the tagset string with a comma separator, but only when `value` is
- * truthy and passes the optional `safeguard` predicate. Returns the original `tags` unchanged
- * when the value is absent or unsafe, so the caller can chain calls without branching.
+ * truthy, passes the optional `safeguard` predicate, and fits within `maxTagSetLength`. Returns
+ * the original `tags` unchanged when the value is absent, unsafe, or would overflow the budget.
  *
  * @param {string} tags - Existing tagset string (may be empty).
  * @param {string} key
  * @param {string | undefined} value
- * @param {(v: string) => boolean} [safeguard]
+ * @param {((v: string) => boolean) | null} [safeguard]
+ * @param {number} [maxTagSetLength]
  * @returns {string}
  */
-function appendOptionalPropagatedTag (tags, key, value, safeguard) {
-  if (!value) return tags
-  if (safeguard && !safeguard(value)) return tags
-  return `${tags}${tags ? ',' : ''}${key}=${value}`
+function appendOptionalPropagatedTag (tags, key, value, safeguard, maxTagSetLength) {
+  if (!value || (safeguard && !safeguard(value))) return tags
+  const entry = `${tags ? ',' : ''}${key}=${value}`
+  if (maxTagSetLength != null && tags.length + entry.length > maxTagSetLength) return tags
+  return `${tags}${entry}`
 }
 
 function spanHasError (span) {
@@ -513,6 +527,7 @@ module.exports = {
   normalizeLlmObsTraceId,
   formatAudioPart,
   resolveAgentAttribution,
+  stripTagsetEntry,
   validateCostTags,
   validateKind,
   getFunctionArguments,

--- a/packages/dd-trace/test/llmobs/sdk/agent_attribution.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/agent_attribution.spec.js
@@ -1,0 +1,122 @@
+'use strict'
+
+const assert = require('node:assert')
+
+const { describe, it } = require('mocha')
+
+const { useLlmObs } = require('../util')
+
+// The SDK resolves the nearest agent ancestor at span registration (a one-level lookup that
+// inherits the parent's already-resolved attribution) and surfaces it as `meta.agent_attribution`
+// only on spans that have an agent ancestor. Spans with no agent ancestor omit the block entirely.
+// This mirrors dd-trace-py's tests/llmobs/test_llmobs_agent_attribution.py case for case.
+describe('llmobs agent attribution', () => {
+  const { getEvents } = useLlmObs()
+
+  let tracer, llmobs
+  before(() => {
+    tracer = global._ddtrace
+    llmobs = tracer.llmobs
+  })
+
+  function eventByName (llmobsSpans, name) {
+    const matches = llmobsSpans.filter(event => event.name === name)
+    assert.strictEqual(matches.length, 1, `expected exactly one event named ${name}, got ${matches.length}`)
+    return matches[0]
+  }
+
+  it('attributes a tool under an agent to the agent', async () => {
+    llmobs.trace({ kind: 'agent', name: 'my_agent' }, () => {
+      llmobs.trace({ kind: 'tool', name: 'my_tool' }, () => {})
+    })
+
+    const { llmobsSpans } = await getEvents(2)
+    const agentEvent = eventByName(llmobsSpans, 'my_agent')
+    const toolEvent = eventByName(llmobsSpans, 'my_tool')
+
+    assert.deepStrictEqual(toolEvent.meta.agent_attribution, {
+      parent_agent_name: 'my_agent',
+      parent_agent_span_id: agentEvent.span_id,
+    })
+  })
+
+  it('attributes indirectly nested spans to the nearest agent', async () => {
+    // agent -> workflow -> tool: the workflow and the tool both attribute to the agent.
+    llmobs.trace({ kind: 'agent', name: 'my_agent' }, () => {
+      llmobs.trace({ kind: 'workflow', name: 'my_workflow' }, () => {
+        llmobs.trace({ kind: 'tool', name: 'my_tool' }, () => {})
+      })
+    })
+
+    const { llmobsSpans } = await getEvents(3)
+    const expected = {
+      parent_agent_name: 'my_agent',
+      parent_agent_span_id: eventByName(llmobsSpans, 'my_agent').span_id,
+    }
+
+    assert.deepStrictEqual(eventByName(llmobsSpans, 'my_workflow').meta.agent_attribution, expected)
+    assert.deepStrictEqual(eventByName(llmobsSpans, 'my_tool').meta.agent_attribution, expected)
+  })
+
+  it('attributes a sub-agent and its children to the enclosing agent', async () => {
+    // An agent nested under an agent attributes to the enclosing agent, never itself.
+    llmobs.trace({ kind: 'agent', name: 'outer_agent' }, () => {
+      llmobs.trace({ kind: 'agent', name: 'inner_agent' }, () => {
+        llmobs.trace({ kind: 'tool', name: 'inner_tool' }, () => {})
+      })
+    })
+
+    const { llmobsSpans } = await getEvents(3)
+    const outerId = eventByName(llmobsSpans, 'outer_agent').span_id
+    const innerId = eventByName(llmobsSpans, 'inner_agent').span_id
+
+    assert.deepStrictEqual(eventByName(llmobsSpans, 'inner_agent').meta.agent_attribution, {
+      parent_agent_name: 'outer_agent',
+      parent_agent_span_id: outerId,
+    })
+    // The tool's nearest agent ancestor is the inner agent.
+    assert.deepStrictEqual(eventByName(llmobsSpans, 'inner_tool').meta.agent_attribution, {
+      parent_agent_name: 'inner_agent',
+      parent_agent_span_id: innerId,
+    })
+  })
+
+  it('omits the block on a top-level agent', async () => {
+    llmobs.trace({ kind: 'agent', name: 'root_agent' }, () => {})
+
+    const { llmobsSpans } = await getEvents(1)
+    assert.ok(!('agent_attribution' in eventByName(llmobsSpans, 'root_agent').meta))
+  })
+
+  it('omits the block on a top-level llm', async () => {
+    llmobs.trace({ kind: 'llm', name: 'root_llm' }, () => {})
+
+    const { llmobsSpans } = await getEvents(1)
+    assert.ok(!('agent_attribution' in eventByName(llmobsSpans, 'root_llm').meta))
+  })
+
+  it('omits the block when there is no agent in the chain', async () => {
+    // A workflow with a tool but no agent anywhere: neither gets the block.
+    llmobs.trace({ kind: 'workflow', name: 'lonely_workflow' }, () => {
+      llmobs.trace({ kind: 'tool', name: 'lonely_tool' }, () => {})
+    })
+
+    const { llmobsSpans } = await getEvents(2)
+    assert.ok(!('agent_attribution' in eventByName(llmobsSpans, 'lonely_workflow').meta))
+    assert.ok(!('agent_attribution' in eventByName(llmobsSpans, 'lonely_tool').meta))
+  })
+
+  it('stringifies the parent agent span id', async () => {
+    let agentSpanId
+    llmobs.trace({ kind: 'agent', name: 'my_agent' }, span => {
+      agentSpanId = span.context().toSpanId()
+      llmobs.trace({ kind: 'tool', name: 'my_tool' }, () => {})
+    })
+
+    const { llmobsSpans } = await getEvents(2)
+    const attribution = eventByName(llmobsSpans, 'my_tool').meta.agent_attribution
+
+    assert.strictEqual(typeof attribution.parent_agent_span_id, 'string')
+    assert.strictEqual(attribution.parent_agent_span_id, agentSpanId)
+  })
+})

--- a/packages/dd-trace/test/llmobs/sdk/agent_attribution.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/agent_attribution.spec.js
@@ -35,8 +35,8 @@ describe('llmobs agent attribution', () => {
     const toolEvent = eventByName(llmobsSpans, 'my_tool')
 
     assert.deepStrictEqual(toolEvent.meta.agent_attribution, {
-      parent_agent_name: 'my_agent',
-      parent_agent_span_id: agentEvent.span_id,
+      pagent_name: 'my_agent',
+      pagent_span_id: agentEvent.span_id,
     })
   })
 
@@ -50,8 +50,8 @@ describe('llmobs agent attribution', () => {
 
     const { llmobsSpans } = await getEvents(3)
     const expected = {
-      parent_agent_name: 'my_agent',
-      parent_agent_span_id: eventByName(llmobsSpans, 'my_agent').span_id,
+      pagent_name: 'my_agent',
+      pagent_span_id: eventByName(llmobsSpans, 'my_agent').span_id,
     }
 
     assert.deepStrictEqual(eventByName(llmobsSpans, 'my_workflow').meta.agent_attribution, expected)
@@ -71,13 +71,13 @@ describe('llmobs agent attribution', () => {
     const innerId = eventByName(llmobsSpans, 'inner_agent').span_id
 
     assert.deepStrictEqual(eventByName(llmobsSpans, 'inner_agent').meta.agent_attribution, {
-      parent_agent_name: 'outer_agent',
-      parent_agent_span_id: outerId,
+      pagent_name: 'outer_agent',
+      pagent_span_id: outerId,
     })
     // The tool's nearest agent ancestor is the inner agent.
     assert.deepStrictEqual(eventByName(llmobsSpans, 'inner_tool').meta.agent_attribution, {
-      parent_agent_name: 'inner_agent',
-      parent_agent_span_id: innerId,
+      pagent_name: 'inner_agent',
+      pagent_span_id: innerId,
     })
   })
 
@@ -116,7 +116,7 @@ describe('llmobs agent attribution', () => {
     const { llmobsSpans } = await getEvents(2)
     const attribution = eventByName(llmobsSpans, 'my_tool').meta.agent_attribution
 
-    assert.strictEqual(typeof attribution.parent_agent_span_id, 'string')
-    assert.strictEqual(attribution.parent_agent_span_id, agentSpanId)
+    assert.strictEqual(typeof attribution.pagent_span_id, 'string')
+    assert.strictEqual(attribution.pagent_span_id, agentSpanId)
   })
 })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -2526,5 +2526,27 @@ describe('sdk', () => {
       assert.ok(tags.includes(`_dd.p.llmobs_pagent_span_id=${agentId}`), tags)
       assert.ok(!tags.includes('_dd.p.llmobs_pagent_name'), tags)
     })
+
+    it('drops the name when the budget is too tight for the id entry', () => {
+      const originalMax = tracer._tracer._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
+      const carrier = { 'x-datadog-tags': '' }
+
+      llmobs.trace({ kind: 'agent', name: 'my_agent' }, () => {
+        // First injection: measure the tags string length WITHOUT pagent entries.
+        injectCh.publish({ carrier })
+        const baseLength = carrier['x-datadog-tags']
+          .split(',').filter(e => !e.startsWith('_dd.p.llmobs_pagent')).join(',').length
+
+        // Second injection: budget allows the base tags but not the id entry (so name is also dropped).
+        carrier['x-datadog-tags'] = ''
+        tracer._tracer._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH = baseLength
+        injectCh.publish({ carrier })
+      })
+      tracer._tracer._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH = originalMax
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(!tags.includes('_dd.p.llmobs_pagent_span_id'), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_pagent_name'), tags)
+    })
   })
 })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -2439,8 +2439,8 @@ describe('sdk', () => {
       })
 
       const tags = carrier['x-datadog-tags']
-      assert.ok(tags.includes(`_dd.p.llmobs_parent_agent_id=${agentId}`), tags)
-      assert.ok(tags.includes('_dd.p.llmobs_parent_agent_name=my_agent'), tags)
+      assert.ok(tags.includes(`_dd.p.llmobs_pagent_span_id=${agentId}`), tags)
+      assert.ok(tags.includes('_dd.p.llmobs_pagent_name=my_agent'), tags)
     })
 
     it('inherits the agent attribution when injecting from a tool under an agent', () => {
@@ -2454,8 +2454,8 @@ describe('sdk', () => {
       })
 
       const tags = carrier['x-datadog-tags']
-      assert.ok(tags.includes(`_dd.p.llmobs_parent_agent_id=${agentId}`), tags)
-      assert.ok(tags.includes('_dd.p.llmobs_parent_agent_name=my_agent'), tags)
+      assert.ok(tags.includes(`_dd.p.llmobs_pagent_span_id=${agentId}`), tags)
+      assert.ok(tags.includes('_dd.p.llmobs_pagent_name=my_agent'), tags)
     })
 
     it('does not propagate agent attribution when there is no agent in the chain', () => {
@@ -2465,8 +2465,8 @@ describe('sdk', () => {
       })
 
       const tags = carrier['x-datadog-tags']
-      assert.ok(!tags.includes('_dd.p.llmobs_parent_agent_id'), tags)
-      assert.ok(!tags.includes('_dd.p.llmobs_parent_agent_name'), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_pagent_span_id'), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_pagent_name'), tags)
     })
 
     it('skips an unsafe agent name but still propagates the id', () => {
@@ -2478,8 +2478,8 @@ describe('sdk', () => {
       })
 
       const tags = carrier['x-datadog-tags']
-      assert.ok(tags.includes(`_dd.p.llmobs_parent_agent_id=${agentId}`), tags)
-      assert.ok(!tags.includes('_dd.p.llmobs_parent_agent_name'), tags)
+      assert.ok(tags.includes(`_dd.p.llmobs_pagent_span_id=${agentId}`), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_pagent_name'), tags)
     })
 
     it('propagates an agent name containing "=" (legal in tagset values)', () => {
@@ -2489,7 +2489,7 @@ describe('sdk', () => {
       })
 
       const tags = carrier['x-datadog-tags']
-      assert.ok(tags.includes('_dd.p.llmobs_parent_agent_name=model=gpt4'), tags)
+      assert.ok(tags.includes('_dd.p.llmobs_pagent_name=model=gpt4'), tags)
     })
   })
 })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -2429,5 +2429,67 @@ describe('sdk', () => {
         `_dd.p.llmobs_parent_id=${parentId},_dd.p.llmobs_ml_app=mlApp,_dd.p.llmobs_sr=1,_dd.p.llmobs_sd=1,_dd.p.llmobs_trace_id=${wireTraceId}`
       )
     })
+
+    it('propagates the agent attribution when injecting from within an agent', () => {
+      const carrier = { 'x-datadog-tags': '' }
+      let agentId
+      llmobs.trace({ kind: 'agent', name: 'my_agent' }, span => {
+        agentId = span.context().toSpanId()
+        injectCh.publish({ carrier })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(tags.includes(`_dd.p.llmobs_parent_agent_id=${agentId}`), tags)
+      assert.ok(tags.includes('_dd.p.llmobs_parent_agent_name=my_agent'), tags)
+    })
+
+    it('inherits the agent attribution when injecting from a tool under an agent', () => {
+      const carrier = { 'x-datadog-tags': '' }
+      let agentId
+      llmobs.trace({ kind: 'agent', name: 'my_agent' }, span => {
+        agentId = span.context().toSpanId()
+        llmobs.trace({ kind: 'tool', name: 'my_tool' }, () => {
+          injectCh.publish({ carrier })
+        })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(tags.includes(`_dd.p.llmobs_parent_agent_id=${agentId}`), tags)
+      assert.ok(tags.includes('_dd.p.llmobs_parent_agent_name=my_agent'), tags)
+    })
+
+    it('does not propagate agent attribution when there is no agent in the chain', () => {
+      const carrier = { 'x-datadog-tags': '' }
+      llmobs.trace({ kind: 'workflow', name: 'my_workflow' }, () => {
+        injectCh.publish({ carrier })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(!tags.includes('_dd.p.llmobs_parent_agent_id'), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_parent_agent_name'), tags)
+    })
+
+    it('skips an unsafe agent name but still propagates the id', () => {
+      const carrier = { 'x-datadog-tags': '' }
+      let agentId
+      llmobs.trace({ kind: 'agent', name: 'Researcher, v2' }, span => {
+        agentId = span.context().toSpanId()
+        injectCh.publish({ carrier })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(tags.includes(`_dd.p.llmobs_parent_agent_id=${agentId}`), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_parent_agent_name'), tags)
+    })
+
+    it('propagates an agent name containing "=" (legal in tagset values)', () => {
+      const carrier = { 'x-datadog-tags': '' }
+      llmobs.trace({ kind: 'agent', name: 'model=gpt4' }, () => {
+        injectCh.publish({ carrier })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(tags.includes('_dd.p.llmobs_parent_agent_name=model=gpt4'), tags)
+    })
   })
 })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -2491,5 +2491,40 @@ describe('sdk', () => {
       const tags = carrier['x-datadog-tags']
       assert.ok(tags.includes('_dd.p.llmobs_pagent_name=model=gpt4'), tags)
     })
+
+    it('strips stale upstream pagent entries when a local agent overrides them', () => {
+      // Simulate `_injectTags` having already written upstream attribution into the carrier.
+      let agentId
+      const carrier = {
+        'x-datadog-tags': '_dd.p.llmobs_pagent_span_id=upstream_id,_dd.p.llmobs_pagent_name=upstream_agent',
+      }
+      llmobs.trace({ kind: 'agent', name: 'local_agent' }, span => {
+        agentId = span.context().toSpanId()
+        injectCh.publish({ carrier })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(tags.includes(`_dd.p.llmobs_pagent_span_id=${agentId}`), tags)
+      assert.ok(tags.includes('_dd.p.llmobs_pagent_name=local_agent'), tags)
+      assert.ok(!tags.includes('upstream_id'), tags)
+      assert.ok(!tags.includes('upstream_agent'), tags)
+    })
+
+    it('strips stale upstream pagent_name when local agent name is unsafe', () => {
+      // Even though the upstream name was safe, the downstream should see id-only when the
+      // local agent name is not wire-safe (decision: keep just the id, wipe the name).
+      let agentId
+      const carrier = {
+        'x-datadog-tags': '_dd.p.llmobs_pagent_span_id=upstream_id,_dd.p.llmobs_pagent_name=upstream_agent',
+      }
+      llmobs.trace({ kind: 'agent', name: 'Researcher, v2' }, span => {
+        agentId = span.context().toSpanId()
+        injectCh.publish({ carrier })
+      })
+
+      const tags = carrier['x-datadog-tags']
+      assert.ok(tags.includes(`_dd.p.llmobs_pagent_span_id=${agentId}`), tags)
+      assert.ok(!tags.includes('_dd.p.llmobs_pagent_name'), tags)
+    })
   })
 })

--- a/packages/dd-trace/test/llmobs/sdk/integration.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/integration.spec.js
@@ -62,7 +62,7 @@ describe('end to end sdk integration tests', () => {
       inputValue: 'world',
       outputValue: 'hello',
       // The workflow sits under the agent, so it is attributed to it.
-      agentAttribution: { parent_agent_name: 'agent', parent_agent_span_id: llmobsSpans[0].span_id },
+      agentAttribution: { pagent_name: 'agent', pagent_span_id: llmobsSpans[0].span_id },
     })
   })
 
@@ -244,8 +244,8 @@ describe('end to end sdk integration tests', () => {
       const { llmobsSpans } = await getEvents(2)
       const toolEvent = llmobsSpans.find(event => event.name === 'downstream_tool')
       assert.deepStrictEqual(toolEvent.meta.agent_attribution, {
-        parent_agent_name: 'upstream_agent',
-        parent_agent_span_id: agentId,
+        pagent_name: 'upstream_agent',
+        pagent_span_id: agentId,
       })
     })
 
@@ -267,8 +267,8 @@ describe('end to end sdk integration tests', () => {
       // The comma-bearing name was skipped on the wire, so only the id survives; the name is
       // emitted as explicit null (matching dd-trace-py) and the backend resolves it from the id.
       assert.deepStrictEqual(toolEvent.meta.agent_attribution, {
-        parent_agent_name: null,
-        parent_agent_span_id: agentId,
+        pagent_name: null,
+        pagent_span_id: agentId,
       })
     })
 

--- a/packages/dd-trace/test/llmobs/sdk/integration.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/integration.spec.js
@@ -61,6 +61,8 @@ describe('end to end sdk integration tests', () => {
       name: 'myWorkflow',
       inputValue: 'world',
       outputValue: 'hello',
+      // The workflow sits under the agent, so it is attributed to it.
+      agentAttribution: { parent_agent_name: 'agent', parent_agent_span_id: llmobsSpans[0].span_id },
     })
   })
 
@@ -224,6 +226,50 @@ describe('end to end sdk integration tests', () => {
       assert.equal(getTag(llmobsSpans[1], 'ml_app'), 'test')
       assert.equal(llmobsSpans[0].trace_id, llmobsSpans[1].trace_id)
       assert.match(llmobsSpans[0].trace_id, /^[0-9a-f]{32}$/)
+    })
+
+    it('propagates agent attribution across a distributed boundary', async () => {
+      const carrier = {}
+      let agentId
+      llmobs.trace({ kind: 'agent', name: 'upstream_agent' }, agentSpan => {
+        agentId = agentSpan.context().toSpanId()
+        tracer.inject(agentSpan, 'text_map', carrier)
+      })
+
+      const spanContext = tracer.extract('text_map', carrier)
+      tracer.trace('new-service-root', { childOf: spanContext }, () => {
+        llmobs.trace({ kind: 'tool', name: 'downstream_tool' }, () => {})
+      })
+
+      const { llmobsSpans } = await getEvents(2)
+      const toolEvent = llmobsSpans.find(event => event.name === 'downstream_tool')
+      assert.deepStrictEqual(toolEvent.meta.agent_attribution, {
+        parent_agent_name: 'upstream_agent',
+        parent_agent_span_id: agentId,
+      })
+    })
+
+    it('propagates only the id across a boundary when the upstream agent name is unsafe', async () => {
+      const carrier = {}
+      let agentId
+      llmobs.trace({ kind: 'agent', name: 'Researcher, v2' }, agentSpan => {
+        agentId = agentSpan.context().toSpanId()
+        tracer.inject(agentSpan, 'text_map', carrier)
+      })
+
+      const spanContext = tracer.extract('text_map', carrier)
+      tracer.trace('new-service-root', { childOf: spanContext }, () => {
+        llmobs.trace({ kind: 'tool', name: 'downstream_tool' }, () => {})
+      })
+
+      const { llmobsSpans } = await getEvents(2)
+      const toolEvent = llmobsSpans.find(event => event.name === 'downstream_tool')
+      // The comma-bearing name was skipped on the wire, so only the id survives; the name is
+      // emitted as explicit null (matching dd-trace-py) and the backend resolves it from the id.
+      assert.deepStrictEqual(toolEvent.meta.agent_attribution, {
+        parent_agent_name: null,
+        parent_agent_span_id: agentId,
+      })
     })
 
     it('injects the local mlApp', async () => {

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -33,7 +33,7 @@ const MOCK_NOT_NULLISH = Symbol('not-nullish')
  *   metrics?: Record<string, number | MockValue> | MockValue,
  *   metadata?: Record<string, unknown> | MockValue,
  *   toolDefinitions?: Array<Record<string, unknown> | MockValue> | MockValue,
- *   agentAttribution?: { parent_agent_name?: string, parent_agent_span_id?: string },
+ *   agentAttribution?: { pagent_name?: string, pagent_span_id?: string },
  *   modelName?: string,
  *   modelProvider?: string,
  *   parentId?: string,

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -33,6 +33,7 @@ const MOCK_NOT_NULLISH = Symbol('not-nullish')
  *   metrics?: Record<string, number | MockValue> | MockValue,
  *   metadata?: Record<string, unknown> | MockValue,
  *   toolDefinitions?: Array<Record<string, unknown> | MockValue> | MockValue,
+ *   agentAttribution?: { parent_agent_name?: string, parent_agent_span_id?: string },
  *   modelName?: string,
  *   modelProvider?: string,
  *   parentId?: string,
@@ -139,6 +140,7 @@ function assertLlmObsSpanEvent (actual, expected) {
     traceId = MOCK_STRING, // used for future custom LLMObs trace IDs,
     metrics,
     metadata,
+    agentAttribution,
     inputMessages,
     inputValue,
     inputDocuments,
@@ -211,10 +213,15 @@ function assertLlmObsSpanEvent (actual, expected) {
   const actualOutputDocuments = actual.meta.output.documents
   const actualTraceId = actual.trace_id
   const actualTags = actual.tags
+  // agent_attribution is present on every span that has an agent ancestor, which most callers
+  // don't restate. Pull it out and assert it only when a test opts in via `agentAttribution`;
+  // otherwise ignore it so unrelated nested-span assertions keep passing.
+  const actualAgentAttribution = actual.meta.agent_attribution
 
   delete actual.metrics
   delete actual.meta.metadata
   delete actual.meta.output
+  delete actual.meta.agent_attribution
   delete actual.trace_id
   delete actual.tags
   delete actual._dd // we do not care about asserting on the private dd fields
@@ -222,6 +229,7 @@ function assertLlmObsSpanEvent (actual, expected) {
   assertWithMockValues(actualTraceId, traceId, 'traceId')
   assertWithMockValues(actualMetrics, metrics ?? {}, 'metrics')
   assertWithMockValues(actualMetadata, metadata, 'metadata')
+  if (agentAttribution) assertWithMockValues(actualAgentAttribution, agentAttribution, 'agentAttribution')
 
   // 1a. sort tags since they might be unordered
   const expectedTags = expectedLLMObsTags({ span, tags, error, sessionId })

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -6,6 +6,7 @@ const { before, describe, it } = require('mocha')
 
 const getConfig = require('../../src/config')
 const {
+  agentNameWireSafe,
   audioMimeTypeFromFormat,
   encodeUnicode,
   findGenAIAncestorSpanId,
@@ -71,6 +72,30 @@ describe('util', () => {
 
     it('should encode only unicode characters in a string', () => {
       assert.strictEqual(encodeUnicode('test 😀'), 'test \\ud83d\\ude00')
+    })
+  })
+
+  describe('agentNameWireSafe', () => {
+    it('accepts a plain ascii name', () => {
+      assert.strictEqual(agentNameWireSafe('my_agent'), true)
+    })
+
+    it('accepts a name containing "=" (legal in tagset values)', () => {
+      assert.strictEqual(agentNameWireSafe('model=gpt4'), true)
+    })
+
+    it('rejects a name containing a comma (the tagset entry delimiter)', () => {
+      assert.strictEqual(agentNameWireSafe('Researcher, v2'), false)
+    })
+
+    it('rejects a name with a byte outside 0x20-0x7E', () => {
+      assert.strictEqual(agentNameWireSafe('café'), false)
+      assert.strictEqual(agentNameWireSafe('tab\tname'), false)
+    })
+
+    it('accepts a name at the 256 byte cap and rejects the first byte over', () => {
+      assert.strictEqual(agentNameWireSafe('a'.repeat(256)), true)
+      assert.strictEqual(agentNameWireSafe('a'.repeat(257)), false)
     })
   })
 

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -7,6 +7,7 @@ const { before, describe, it } = require('mocha')
 const getConfig = require('../../src/config')
 const {
   agentNameWireSafe,
+  appendOptionalPropagatedTag,
   audioMimeTypeFromFormat,
   encodeUnicode,
   findGenAIAncestorSpanId,
@@ -15,6 +16,7 @@ const {
   formatAudioPart,
   getFunctionArguments,
   normalizeLlmObsTraceId,
+  stripTagsetEntry,
   validateCostTags,
   safeJsonParse,
   validateKind,
@@ -96,6 +98,65 @@ describe('util', () => {
     it('accepts a name at the 256 byte cap and rejects the first byte over', () => {
       assert.strictEqual(agentNameWireSafe('a'.repeat(256)), true)
       assert.strictEqual(agentNameWireSafe('a'.repeat(257)), false)
+    })
+  })
+
+  describe('appendOptionalPropagatedTag', () => {
+    it('appends key=value to an empty tagset', () => {
+      assert.strictEqual(appendOptionalPropagatedTag('', 'k', 'v'), 'k=v')
+    })
+
+    it('appends with a comma separator to a non-empty tagset', () => {
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v'), 'a=1,k=v')
+    })
+
+    it('returns the original tagset when value is falsy', () => {
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', undefined), 'a=1')
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', ''), 'a=1')
+    })
+
+    it('returns the original tagset when the safeguard rejects the value', () => {
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'bad', () => false), 'a=1')
+    })
+
+    it('appends when the safeguard accepts the value', () => {
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'good', () => true), 'a=1,k=good')
+    })
+
+    it('skips the entry when it would exceed maxTagSetLength', () => {
+      // 'a=1' is 3 chars; ',k=v' is 4 chars; total 7. Cap at 6 → skip.
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v', null, 6), 'a=1')
+    })
+
+    it('appends when the entry fits exactly within maxTagSetLength', () => {
+      // 'a=1' (3) + ',k=v' (4) = 7. Cap at 7 → fits.
+      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v', null, 7), 'a=1,k=v')
+    })
+  })
+
+  describe('stripTagsetEntry', () => {
+    it('removes a key=value entry from the middle of the tagset', () => {
+      assert.strictEqual(stripTagsetEntry('a=1,b=2,c=3', 'b'), 'a=1,c=3')
+    })
+
+    it('removes a key=value entry from the start of the tagset', () => {
+      assert.strictEqual(stripTagsetEntry('b=2,c=3', 'b'), 'c=3')
+    })
+
+    it('removes a key=value entry from the end of the tagset', () => {
+      assert.strictEqual(stripTagsetEntry('a=1,b=2', 'b'), 'a=1')
+    })
+
+    it('removes all occurrences of a duplicate key', () => {
+      assert.strictEqual(stripTagsetEntry('k=old,a=1,k=new', 'k'), 'a=1')
+    })
+
+    it('returns the original tagset unchanged when the key is absent', () => {
+      assert.strictEqual(stripTagsetEntry('a=1,c=3', 'b'), 'a=1,c=3')
+    })
+
+    it('returns empty string when stripping the only entry', () => {
+      assert.strictEqual(stripTagsetEntry('k=v', 'k'), '')
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Ports the LLM Observability **agent attribution** feature to the Node.js tracer, on par with the Python implementation ([DataDog/dd-trace-py#18788](https://github.com/DataDog/dd-trace-py/pull/18788)).

Every LLMObs span that has an agent ancestor now carries:

```
meta.agent_attribution = {
  pagent_name:    "<nearest agent ancestor's name>",  // string (null id-only)
  pagent_span_id: "<that agent span's id>",           // stringified span id
}
```

Spans with no agent ancestor omit the block entirely.

Layers implemented (matching Python):
- **Resolve + store** (`tagger.js`): the nearest agent is resolved once at span registration via a one-level lookup that inherits the parent's already-resolved attribution (no ancestor walk). An agent never attributes itself; a sub-agent attributes to the enclosing agent.
- **Emit** (`span_processor.js`): surfaced as `meta.agent_attribution`, gated on presence, no sentinel.
- **Distributed propagation** (`index.js`): `_dd.p.llmobs_pagent_id` (always, digit-safe) and `_dd.p.llmobs_pagent_name` (only when tagset-safe) so attribution survives across service boundaries. An unsafe agent name is skipped rather than sanitized so it cannot drop the whole `x-datadog-tags` header; the backend then resolves the name from the id.

### Motivation

The backend pass-through for this field already ships ([ddoghq/dd-source#5177](https://github.com/ddoghq/dd-source/pull/5177), [DataDog/dd-go#244115](https://github.com/DataDog/dd-go/pull/244115)) and the Python producer is in review. This makes the Node.js tracer emit the identical wire field so JS customers get per-agent attribution too. Producer-only: no additional backend work, the wire contract is identical across languages.

### Additional Notes

- New in-process SDK tests (`sdk/agent_attribution.spec.js`), distributed inject tests (`sdk/index.spec.js`), a real inject→extract→childOf round-trip (`sdk/integration.spec.js`), and `agentNameWireSafe` unit cases including the 256-byte boundary.
- `pagent_name` is emitted as explicit `null` in the id-only distributed case to match the Python wire shape exactly.
- Please label `semver-minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)