### PR TITLE
fix(vitest): report typecheck tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -146,6 +146,9 @@
 /integration-tests/vitest/ @DataDog/ci-app-libraries
 /integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
 /integration-tests/vitest.second-project.config.mjs @DataDog/ci-app-libraries
+/integration-tests/vitest.typecheck.config.mjs @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck.json @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-fail.json @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.spec.js @DataDog/ci-app-libraries
 /integration-tests/CODEOWNERS @DataDog/ci-app-libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,6 +149,8 @@
 /integration-tests/vitest.typecheck.config.mjs @DataDog/ci-app-libraries
 /integration-tests/tsconfig.typecheck.json @DataDog/ci-app-libraries
 /integration-tests/tsconfig.typecheck-fail.json @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-test-management-fail.json @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-test-management-file-fail.json @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.spec.js @DataDog/ci-app-libraries
 /integration-tests/CODEOWNERS @DataDog/ci-app-libraries

--- a/integration-tests/ci-visibility/vitest-tests/typecheck-fail.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck-fail.test-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf, test } from 'vitest'
+
+test('typecheck can report failing assertion', () => {
+  expectTypeOf({ value: 'not ok' }).toEqualTypeOf<{ value: number }>()
+})

--- a/integration-tests/ci-visibility/vitest-tests/typecheck-test-management-fail.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck-test-management-fail.test-d.ts
@@ -1,0 +1,15 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+test('typecheck can report disabled failing assertion', () => {
+  expectTypeOf({ value: 'disabled fail' }).toEqualTypeOf<{ value: number }>()
+})
+
+test('typecheck can report quarantined failing assertion', () => {
+  expectTypeOf({ value: 'quarantined fail' }).toEqualTypeOf<{ value: number }>()
+})
+
+describe('typecheck nested failing suite', () => {
+  test('can report nested disabled failing assertion', () => {
+    expectTypeOf({ value: 'nested disabled fail' }).toEqualTypeOf<{ value: number }>()
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/typecheck-test-management-file-fail.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck-test-management-file-fail.test-d.ts
@@ -1,0 +1,13 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+const fileLevelTypeError: number = 'file-level typecheck error'
+
+describe('typecheck container failing suite', () => {
+  test('can report disabled assertion with file-level error', () => {
+    expectTypeOf({ value: 'disabled pass' }).toEqualTypeOf<{ value: string }>()
+  })
+
+  test('can report quarantined assertion with file-level error', () => {
+    expectTypeOf({ value: 'quarantined pass' }).toEqualTypeOf<{ value: string }>()
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
@@ -3,3 +3,7 @@ import { expectTypeOf, test } from 'vitest'
 test('typecheck can report type assertion', () => {
   expectTypeOf({ value: 'ok' }).toEqualTypeOf<{ value: string }>()
 })
+
+test.skip('typecheck can report skipped assertion', () => {
+  expectTypeOf({ value: 'skipped' }).toEqualTypeOf<{ value: string }>()
+})

--- a/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
@@ -4,6 +4,18 @@ test('typecheck can report type assertion', () => {
   expectTypeOf({ value: 'ok' }).toEqualTypeOf<{ value: string }>()
 })
 
+test('typecheck can report disabled assertion', () => {
+  expectTypeOf({ value: 'disabled' }).toEqualTypeOf<{ value: string }>()
+})
+
+test('typecheck can report quarantined assertion', () => {
+  expectTypeOf({ value: 'quarantined' }).toEqualTypeOf<{ value: string }>()
+})
+
+test('typecheck can report attempt-to-fix assertion', () => {
+  expectTypeOf({ value: 'attempt-to-fix' }).toEqualTypeOf<{ value: string }>()
+})
+
 test.skip('typecheck can report skipped assertion', () => {
   expectTypeOf({ value: 'skipped' }).toEqualTypeOf<{ value: string }>()
 })

--- a/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, test } from 'vitest'
+import { describe, expectTypeOf, test } from 'vitest'
 
 test('typecheck can report type assertion', () => {
   expectTypeOf({ value: 'ok' }).toEqualTypeOf<{ value: string }>()
@@ -18,4 +18,14 @@ test('typecheck can report attempt-to-fix assertion', () => {
 
 test.skip('typecheck can report skipped assertion', () => {
   expectTypeOf({ value: 'skipped' }).toEqualTypeOf<{ value: string }>()
+})
+
+describe('typecheck nested suite', () => {
+  test('can report nested assertion', () => {
+    expectTypeOf({ value: 'nested' }).toEqualTypeOf<{ value: string }>()
+  })
+
+  test('can report nested disabled assertion', () => {
+    expectTypeOf({ value: 'nested disabled' }).toEqualTypeOf<{ value: string }>()
+  })
 })

--- a/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
+++ b/integration-tests/ci-visibility/vitest-tests/typecheck.test-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf, test } from 'vitest'
+
+test('typecheck can report type assertion', () => {
+  expectTypeOf({ value: 'ok' }).toEqualTypeOf<{ value: string }>()
+})

--- a/integration-tests/tsconfig.typecheck-fail.json
+++ b/integration-tests/tsconfig.typecheck-fail.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.typecheck.json",
+  "include": [
+    "ci-visibility/vitest-tests/typecheck-fail.test-d.ts"
+  ]
+}

--- a/integration-tests/tsconfig.typecheck-test-management-fail.json
+++ b/integration-tests/tsconfig.typecheck-test-management-fail.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.typecheck.json",
+  "include": [
+    "ci-visibility/vitest-tests/typecheck-test-management-fail.test-d.ts"
+  ]
+}

--- a/integration-tests/tsconfig.typecheck-test-management-file-fail.json
+++ b/integration-tests/tsconfig.typecheck-test-management-file-fail.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.typecheck.json",
+  "include": [
+    "ci-visibility/vitest-tests/typecheck-test-management-file-fail.test-d.ts"
+  ]
+}

--- a/integration-tests/tsconfig.typecheck.json
+++ b/integration-tests/tsconfig.typecheck.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "target": "ES2022",
+    "types": [
+      "vitest"
+    ]
+  },
+  "include": [
+    "ci-visibility/vitest-tests/*.test-d.ts"
+  ]
+}

--- a/integration-tests/tsconfig.typecheck.json
+++ b/integration-tests/tsconfig.typecheck.json
@@ -9,6 +9,6 @@
     ]
   },
   "include": [
-    "ci-visibility/vitest-tests/*.test-d.ts"
+    "ci-visibility/vitest-tests/typecheck.test-d.ts"
   ]
 }

--- a/integration-tests/tsconfig.typecheck.json
+++ b/integration-tests/tsconfig.typecheck.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
     "types": [

--- a/integration-tests/vitest.typecheck.config.mjs
+++ b/integration-tests/vitest.typecheck.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: [],
+    typecheck: {
+      checker: 'tsc',
+      enabled: true,
+      include: ['ci-visibility/vitest-tests/*.test-d.ts'],
+      tsconfig: 'tsconfig.typecheck.json',
+    },
+  },
+})

--- a/integration-tests/vitest.typecheck.config.mjs
+++ b/integration-tests/vitest.typecheck.config.mjs
@@ -1,11 +1,33 @@
 import { defineConfig } from 'vite'
 
-const typecheckFile = process.env.TYPECHECK_FAIL === 'true'
-  ? 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts'
-  : 'ci-visibility/vitest-tests/typecheck.test-d.ts'
-const tsconfig = process.env.TYPECHECK_FAIL === 'true'
-  ? 'tsconfig.typecheck-fail.json'
-  : 'tsconfig.typecheck.json'
+const typecheckFixture = process.env.TYPECHECK_FAIL === 'true'
+  ? 'fail'
+  : process.env.TYPECHECK_TEST_MANAGEMENT_FAIL === 'true'
+    ? 'testManagementFail'
+    : process.env.TYPECHECK_TEST_MANAGEMENT_FILE_FAIL === 'true'
+      ? 'testManagementFileFail'
+      : 'default'
+
+const typecheckFixtures = {
+  default: {
+    typecheckFile: 'ci-visibility/vitest-tests/typecheck.test-d.ts',
+    tsconfig: 'tsconfig.typecheck.json',
+  },
+  fail: {
+    typecheckFile: 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts',
+    tsconfig: 'tsconfig.typecheck-fail.json',
+  },
+  testManagementFail: {
+    typecheckFile: 'ci-visibility/vitest-tests/typecheck-test-management-fail.test-d.ts',
+    tsconfig: 'tsconfig.typecheck-test-management-fail.json',
+  },
+  testManagementFileFail: {
+    typecheckFile: 'ci-visibility/vitest-tests/typecheck-test-management-file-fail.test-d.ts',
+    tsconfig: 'tsconfig.typecheck-test-management-file-fail.json',
+  },
+}
+
+const { typecheckFile, tsconfig } = typecheckFixtures[typecheckFixture]
 
 export default defineConfig({
   test: {

--- a/integration-tests/vitest.typecheck.config.mjs
+++ b/integration-tests/vitest.typecheck.config.mjs
@@ -1,13 +1,20 @@
 import { defineConfig } from 'vite'
 
+const typecheckFile = process.env.TYPECHECK_FAIL === 'true'
+  ? 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts'
+  : 'ci-visibility/vitest-tests/typecheck.test-d.ts'
+const tsconfig = process.env.TYPECHECK_FAIL === 'true'
+  ? 'tsconfig.typecheck-fail.json'
+  : 'tsconfig.typecheck.json'
+
 export default defineConfig({
   test: {
     include: [],
     typecheck: {
       checker: 'tsc',
       enabled: true,
-      include: ['ci-visibility/vitest-tests/*.test-d.ts'],
-      tsconfig: 'tsconfig.typecheck.json',
+      include: [typecheckFile],
+      tsconfig,
     },
   },
 })

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -43,6 +43,10 @@ const {
   TEST_HAS_FAILED_ALL_RETRIES,
   TEST_RETRY_REASON_TYPES,
   TEST_HAS_DYNAMIC_NAME,
+  TEST_FINAL_STATUS,
+  TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
+  TEST_MANAGEMENT_IS_DISABLED,
+  TEST_MANAGEMENT_IS_QUARANTINED,
   VITEST_POOL,
   TEST_IS_TEST_FRAMEWORK_WORKER,
   DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS,
@@ -356,6 +360,87 @@ versions.forEach((version) => {
           assert.strictEqual(passedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
           assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
           assert.strictEqual(skippedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck.test-d.ts --reporter=verbose',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            DD_SERVICE: undefined,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 0, testOutput)
+    })
+
+    typecheckIt('honors Test Management metadata for typecheck tests', async () => {
+      receiver.setSettings({ test_management: { enabled: true } })
+      receiver.setTestManagementTests({
+        vitest: {
+          suites: {
+            'ci-visibility/vitest-tests/typecheck.test-d.ts': {
+              tests: {
+                'typecheck can report disabled assertion': {
+                  properties: {
+                    disabled: true,
+                  },
+                },
+                'typecheck can report quarantined assertion': {
+                  properties: {
+                    quarantined: true,
+                  },
+                },
+                'typecheck can report attempt-to-fix assertion': {
+                  properties: {
+                    attempt_to_fix: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const disabledTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report disabled assertion'
+          )
+          const quarantinedTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report quarantined assertion'
+          )
+          const attemptToFixTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report attempt-to-fix assertion'
+          )
+
+          assert.ok(disabledTest, testOutput)
+          assert.ok(quarantinedTest, testOutput)
+          assert.ok(attemptToFixTest, testOutput)
+
+          assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+
+          assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+
+          assert.strictEqual(attemptToFixTest.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(attemptToFixTest.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
         }, 25000)
 
       childProcess = exec(

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -328,25 +328,34 @@ versions.forEach((version) => {
           const testSessionEvent = events.find(event => event.type === 'test_session_end')
           const testModuleEvent = events.find(event => event.type === 'test_module_end')
           const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-          const testEvent = events.find(event => event.type === 'test')
+          const testEvents = events.filter(event => event.type === 'test')
+          const passedTestEvent = testEvents.find(event =>
+            event.content.meta[TEST_NAME] === 'typecheck can report type assertion'
+          )
+          const skippedTestEvent = testEvents.find(event =>
+            event.content.meta[TEST_NAME] === 'typecheck can report skipped assertion'
+          )
 
           assert.ok(testSessionEvent, testOutput)
           assert.ok(testModuleEvent, testOutput)
           assert.ok(testSuiteEvent, testOutput)
-          assert.ok(testEvent, testOutput)
+          assert.ok(passedTestEvent, testOutput)
+          assert.ok(skippedTestEvent, testOutput)
 
           const testSession = testSessionEvent.content
           const testModule = testModuleEvent.content
           const testSuite = testSuiteEvent.content
-          const test = testEvent.content
+          const passedTest = passedTestEvent.content
+          const skippedTest = skippedTestEvent.content
 
           assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
           assert.strictEqual(testModule.meta[TEST_STATUS], 'pass')
           assert.strictEqual(testSuite.meta[TEST_STATUS], 'pass')
           assert.strictEqual(testSuite.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
-          assert.strictEqual(test.meta[TEST_STATUS], 'pass')
-          assert.strictEqual(test.meta[TEST_NAME], 'typecheck can report type assertion')
-          assert.strictEqual(test.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
+          assert.strictEqual(passedTest.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(passedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
+          assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(skippedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
         }, 25000)
 
       childProcess = exec(
@@ -370,6 +379,60 @@ versions.forEach((version) => {
       ])
 
       assert.strictEqual(code, 0, testOutput)
+    })
+
+    typecheckIt('can report failed typecheck tests', async () => {
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSessionEvent = events.find(event => event.type === 'test_session_end')
+          const testModuleEvent = events.find(event => event.type === 'test_module_end')
+          const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+          const testEvent = events.find(event => event.type === 'test')
+
+          assert.ok(testSessionEvent, testOutput)
+          assert.ok(testModuleEvent, testOutput)
+          assert.ok(testSuiteEvent, testOutput)
+          assert.ok(testEvent, testOutput)
+
+          const testSession = testSessionEvent.content
+          const testModule = testModuleEvent.content
+          const testSuite = testSuiteEvent.content
+          const test = testEvent.content
+
+          assert.strictEqual(testSession.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(testModule.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(testSuite.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(testSuite.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts')
+          assert.strictEqual(test.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(test.meta[TEST_NAME], 'typecheck can report failing assertion')
+          assert.strictEqual(test.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts')
+          assert.strictEqual(test.meta[ERROR_TYPE], 'TypeCheckError')
+          assert.ok(test.meta[ERROR_MESSAGE])
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck-fail.test-d.ts --reporter=verbose',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            DD_SERVICE: undefined,
+            TYPECHECK_FAIL: 'true',
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 1, testOutput)
     })
 
     it('propagates test span context to HTTP requests and hooks during test execution', async () => {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -69,12 +69,14 @@ versions.forEach((version) => {
   describe(`vitest@${version}`, () => {
     let cwd, receiver, childProcess, testOutput
     const newerVitestIt = version === '1.6.0' ? it.skip : it
+    const typecheckIt = version === 'latest' && NODE_MAJOR >= 20 ? it : it.skip
 
     useSandbox([
       `vitest@${version}`,
       `@vitest/coverage-istanbul@${version}`,
       `@vitest/coverage-v8@${version}`,
       'tinypool',
+      'typescript',
     ], true)
 
     before(function () {
@@ -317,6 +319,57 @@ versions.forEach((version) => {
       ])
 
       assert.strictEqual(code, 0)
+    })
+
+    typecheckIt('can report typecheck tests', async () => {
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSessionEvent = events.find(event => event.type === 'test_session_end')
+          const testModuleEvent = events.find(event => event.type === 'test_module_end')
+          const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+          const testEvent = events.find(event => event.type === 'test')
+
+          assert.ok(testSessionEvent, testOutput)
+          assert.ok(testModuleEvent, testOutput)
+          assert.ok(testSuiteEvent, testOutput)
+          assert.ok(testEvent, testOutput)
+
+          const testSession = testSessionEvent.content
+          const testModule = testModuleEvent.content
+          const testSuite = testSuiteEvent.content
+          const test = testEvent.content
+
+          assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(testModule.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(testSuite.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(testSuite.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
+          assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(test.meta[TEST_NAME], 'typecheck can report type assertion')
+          assert.strictEqual(test.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck.test-d.ts --reporter=verbose',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            DD_SERVICE: undefined,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 0, testOutput)
     })
 
     it('propagates test span context to HTTP requests and hooks during test execution', async () => {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { exec, execSync } = require('node:child_process')
 const { once } = require('node:events')
-const { exec } = require('child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 const { inspect } = require('node:util')
 const { assertObjectContains } = require('../helpers')
 
@@ -28,6 +30,7 @@ const {
   TEST_COMMAND,
   TEST_SOURCE_FILE,
   TEST_SOURCE_START,
+  TEST_IS_MODIFIED,
   TEST_IS_NEW,
   TEST_NAME,
   TEST_EARLY_FLAKE_ENABLED,
@@ -66,6 +69,43 @@ const FLAKY_UNNECESSARY_RETRY_RESOURCE =
   'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 
+function assertCompleteEventHierarchy (events, testOutput) {
+  const testSessionEvent = events.find(event => event.type === 'test_session_end')
+  const testModuleEvent = events.find(event => event.type === 'test_module_end')
+  const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+  const testEvents = events.filter(event => event.type === 'test')
+
+  assert.ok(testSessionEvent, testOutput)
+  assert.ok(testModuleEvent, testOutput)
+  assert.ok(testSuiteEvent, testOutput)
+  assert.ok(testEvents.length, testOutput)
+
+  const testSession = testSessionEvent.content
+  const testModule = testModuleEvent.content
+  const testSuite = testSuiteEvent.content
+  const tests = testEvents.map(event => event.content)
+  const testSessionId = testSession.test_session_id.toString()
+  const testModuleId = testModule.test_module_id.toString()
+  const testSuiteId = testSuite.test_suite_id.toString()
+
+  assert.strictEqual(testModule.test_session_id.toString(), testSessionId)
+  assert.strictEqual(testSuite.test_session_id.toString(), testSessionId)
+  assert.strictEqual(testSuite.test_module_id.toString(), testModuleId)
+
+  for (const test of tests) {
+    assert.strictEqual(test.test_session_id.toString(), testSessionId)
+    assert.strictEqual(test.test_module_id.toString(), testModuleId)
+    assert.strictEqual(test.test_suite_id.toString(), testSuiteId)
+  }
+
+  return {
+    testSession,
+    testModule,
+    testSuite,
+    tests,
+  }
+}
+
 // vitest@4.x requires Node.js >= 20
 const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 
@@ -73,12 +113,13 @@ versions.forEach((version) => {
   describe(`vitest@${version}`, () => {
     let cwd, receiver, childProcess, testOutput
     const newerVitestIt = version === '1.6.0' ? it.skip : it
-    const typecheckIt = version === 'latest' && NODE_MAJOR >= 20 ? it : it.skip
+    const typecheckIt = version === '1.6.0' ? it.skip : it
 
     useSandbox([
       `vitest@${version}`,
       `@vitest/coverage-istanbul@${version}`,
       `@vitest/coverage-v8@${version}`,
+      '@types/node',
       'tinypool',
       'typescript',
     ], true)
@@ -329,28 +370,25 @@ versions.forEach((version) => {
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
-          const testSessionEvent = events.find(event => event.type === 'test_session_end')
-          const testModuleEvent = events.find(event => event.type === 'test_module_end')
-          const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-          const testEvents = events.filter(event => event.type === 'test')
-          const passedTestEvent = testEvents.find(event =>
-            event.content.meta[TEST_NAME] === 'typecheck can report type assertion'
+          const {
+            testSession,
+            testModule,
+            testSuite,
+            tests,
+          } = assertCompleteEventHierarchy(events, testOutput)
+          const passedTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report type assertion'
           )
-          const skippedTestEvent = testEvents.find(event =>
-            event.content.meta[TEST_NAME] === 'typecheck can report skipped assertion'
+          const skippedTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report skipped assertion'
+          )
+          const nestedTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck nested suite can report nested assertion'
           )
 
-          assert.ok(testSessionEvent, testOutput)
-          assert.ok(testModuleEvent, testOutput)
-          assert.ok(testSuiteEvent, testOutput)
-          assert.ok(passedTestEvent, testOutput)
-          assert.ok(skippedTestEvent, testOutput)
-
-          const testSession = testSessionEvent.content
-          const testModule = testModuleEvent.content
-          const testSuite = testSuiteEvent.content
-          const passedTest = passedTestEvent.content
-          const skippedTest = skippedTestEvent.content
+          assert.ok(passedTest, testOutput)
+          assert.ok(skippedTest, testOutput)
+          assert.ok(nestedTest, testOutput)
 
           assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
           assert.strictEqual(testModule.meta[TEST_STATUS], 'pass')
@@ -360,6 +398,8 @@ versions.forEach((version) => {
           assert.strictEqual(passedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
           assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
           assert.strictEqual(skippedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
+          assert.strictEqual(nestedTest.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(nestedTest.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck.test-d.ts')
         }, 25000)
 
       childProcess = exec(
@@ -383,6 +423,116 @@ versions.forEach((version) => {
       ])
 
       assert.strictEqual(code, 0, testOutput)
+    })
+
+    typecheckIt('honors Known Tests metadata for typecheck tests', async () => {
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': NUM_RETRIES_EFD,
+          },
+        },
+        known_tests_enabled: true,
+      })
+      receiver.setKnownTests({
+        vitest: {
+          'ci-visibility/vitest-tests/typecheck.test-d.ts': [
+            'typecheck can report type assertion',
+          ],
+        },
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const knownTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report type assertion'
+          )
+          const newTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report disabled assertion'
+          )
+
+          assert.ok(knownTest, testOutput)
+          assert.ok(newTest, testOutput)
+          assert.ok(!(TEST_IS_NEW in knownTest.meta))
+          assert.strictEqual(newTest.meta[TEST_IS_NEW], 'true')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck.test-d.ts --reporter=verbose',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            DD_SERVICE: undefined,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 0, testOutput)
+    })
+
+    typecheckIt('honors Impacted Tests metadata for typecheck tests', async () => {
+      receiver.setSettings({ impacted_tests_enabled: true })
+
+      const branchName = `typecheck-impacted-${process.pid}`
+      execSync(`git checkout -b ${branchName}`, { cwd, stdio: 'ignore' })
+
+      try {
+        const typecheckFile = 'ci-visibility/vitest-tests/typecheck.test-d.ts'
+        fs.appendFileSync(path.join(cwd, typecheckFile), '\n// impacted typecheck test\n')
+        execSync(`git add ${typecheckFile}`, { cwd, stdio: 'ignore' })
+        execSync('git commit -m "modify typecheck test"', { cwd, stdio: 'ignore' })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const impactedTest = tests.find(test =>
+              test.meta[TEST_NAME] === 'typecheck can report type assertion'
+            )
+
+            assert.ok(impactedTest, testOutput)
+            assert.strictEqual(impactedTest.meta[TEST_IS_MODIFIED], 'true')
+          }, 25000)
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+            'ci-visibility/vitest-tests/typecheck.test-d.ts --reporter=verbose',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              DD_SERVICE: undefined,
+              GITHUB_BASE_REF: '',
+            },
+          }
+        )
+        childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+        childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+        const [[code]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+
+        assert.strictEqual(code, 0, testOutput)
+      } finally {
+        execSync('git checkout -', { cwd, stdio: 'ignore' })
+        execSync(`git branch -D ${branchName}`, { cwd, stdio: 'ignore' })
+      }
     })
 
     typecheckIt('honors Test Management metadata for typecheck tests', async () => {
@@ -407,6 +557,11 @@ versions.forEach((version) => {
                     attempt_to_fix: true,
                   },
                 },
+                'typecheck nested suite can report nested disabled assertion': {
+                  properties: {
+                    disabled: true,
+                  },
+                },
               },
             },
           },
@@ -426,10 +581,14 @@ versions.forEach((version) => {
           const attemptToFixTest = tests.find(test =>
             test.meta[TEST_NAME] === 'typecheck can report attempt-to-fix assertion'
           )
+          const nestedDisabledTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck nested suite can report nested disabled assertion'
+          )
 
           assert.ok(disabledTest, testOutput)
           assert.ok(quarantinedTest, testOutput)
           assert.ok(attemptToFixTest, testOutput)
+          assert.ok(nestedDisabledTest, testOutput)
 
           assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
           assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
@@ -441,6 +600,10 @@ versions.forEach((version) => {
 
           assert.strictEqual(attemptToFixTest.meta[TEST_STATUS], 'pass')
           assert.strictEqual(attemptToFixTest.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+
+          assert.strictEqual(nestedDisabledTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(nestedDisabledTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(nestedDisabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
         }, 25000)
 
       childProcess = exec(
@@ -466,31 +629,196 @@ versions.forEach((version) => {
       assert.strictEqual(code, 0, testOutput)
     })
 
+    typecheckIt('does not fail the typecheck run for Test Management managed failures', async () => {
+      receiver.setSettings({ test_management: { enabled: true } })
+      receiver.setTestManagementTests({
+        vitest: {
+          suites: {
+            'ci-visibility/vitest-tests/typecheck-test-management-fail.test-d.ts': {
+              tests: {
+                'typecheck can report disabled failing assertion': {
+                  properties: {
+                    disabled: true,
+                  },
+                },
+                'typecheck can report quarantined failing assertion': {
+                  properties: {
+                    quarantined: true,
+                  },
+                },
+                'typecheck nested failing suite can report nested disabled failing assertion': {
+                  properties: {
+                    disabled: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          const testModule = events.find(event => event.type === 'test_module_end').content
+          const testSuite = events.find(event => event.type === 'test_suite_end').content
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const disabledTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report disabled failing assertion'
+          )
+          const quarantinedTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report quarantined failing assertion'
+          )
+          const nestedDisabledTest = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck nested failing suite can report nested disabled failing assertion'
+          )
+
+          assert.ok(disabledTest, testOutput)
+          assert.ok(quarantinedTest, testOutput)
+          assert.ok(nestedDisabledTest, testOutput)
+          assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(testModule.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(testSuite.meta[TEST_STATUS], 'pass')
+
+          assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+
+          assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+
+          assert.strictEqual(nestedDisabledTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(nestedDisabledTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(nestedDisabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck-test-management-fail.test-d.ts --reporter=verbose',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            DD_SERVICE: undefined,
+            TYPECHECK_TEST_MANAGEMENT_FAIL: 'true',
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 0, testOutput)
+    })
+
+    typecheckIt('preserves file-level typecheck failures with Test Management managed tests', async () => {
+      receiver.setSettings({ test_management: { enabled: true } })
+      receiver.setTestManagementTests({
+        vitest: {
+          suites: {
+            'ci-visibility/vitest-tests/typecheck-test-management-file-fail.test-d.ts': {
+              tests: {
+                'typecheck container failing suite can report disabled assertion with file-level error': {
+                  properties: {
+                    disabled: true,
+                  },
+                },
+                'typecheck container failing suite can report quarantined assertion with file-level error': {
+                  properties: {
+                    quarantined: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          const testModule = events.find(event => event.type === 'test_module_end').content
+          const testSuite = events.find(event => event.type === 'test_suite_end').content
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const disabledTest = tests.find(test =>
+            test.meta[TEST_NAME] ===
+              'typecheck container failing suite can report disabled assertion with file-level error'
+          )
+          const quarantinedTest = tests.find(test =>
+            test.meta[TEST_NAME] ===
+              'typecheck container failing suite can report quarantined assertion with file-level error'
+          )
+
+          assert.ok(disabledTest, testOutput)
+          assert.ok(quarantinedTest, testOutput)
+          assert.strictEqual(testSession.meta[TEST_STATUS], 'fail', testOutput)
+          assert.strictEqual(testModule.meta[TEST_STATUS], 'fail', testOutput)
+          assert.strictEqual(testSuite.meta[TEST_STATUS], 'fail', testOutput)
+          assert.strictEqual(testSuite.meta[ERROR_TYPE], 'TypeCheckError')
+          assert.ok(testSuite.meta[ERROR_MESSAGE])
+
+          assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+
+          assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck-test-management-file-fail.test-d.ts --reporter=verbose',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            DD_SERVICE: undefined,
+            TYPECHECK_TEST_MANAGEMENT_FILE_FAIL: 'true',
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 1, testOutput)
+    })
+
     typecheckIt('can report failed typecheck tests', async () => {
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
-          const testSessionEvent = events.find(event => event.type === 'test_session_end')
-          const testModuleEvent = events.find(event => event.type === 'test_module_end')
-          const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-          const testEvent = events.find(event => event.type === 'test')
+          const {
+            testSession,
+            testModule,
+            testSuite,
+            tests,
+          } = assertCompleteEventHierarchy(events, testOutput)
+          const test = tests.find(test =>
+            test.meta[TEST_NAME] === 'typecheck can report failing assertion'
+          )
 
-          assert.ok(testSessionEvent, testOutput)
-          assert.ok(testModuleEvent, testOutput)
-          assert.ok(testSuiteEvent, testOutput)
-          assert.ok(testEvent, testOutput)
-
-          const testSession = testSessionEvent.content
-          const testModule = testModuleEvent.content
-          const testSuite = testSuiteEvent.content
-          const test = testEvent.content
+          assert.ok(test, testOutput)
 
           assert.strictEqual(testSession.meta[TEST_STATUS], 'fail')
           assert.strictEqual(testModule.meta[TEST_STATUS], 'fail')
           assert.strictEqual(testSuite.meta[TEST_STATUS], 'fail')
           assert.strictEqual(testSuite.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts')
           assert.strictEqual(test.meta[TEST_STATUS], 'fail')
-          assert.strictEqual(test.meta[TEST_NAME], 'typecheck can report failing assertion')
           assert.strictEqual(test.meta[TEST_SOURCE_FILE], 'ci-visibility/vitest-tests/typecheck-fail.test-d.ts')
           assert.strictEqual(test.meta[ERROR_TYPE], 'TypeCheckError')
           assert.ok(test.meta[ERROR_MESSAGE])

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -40,6 +40,7 @@ const {
   getTypeTasks,
   getWorkspaceProject,
   setProvidedContext,
+  getVitestTestProperties,
 } = require('./vitest-util')
 
 const newTestsWithDynamicNames = new Set()
@@ -845,14 +846,53 @@ function getTypecheckTestName (task) {
   return task.fullTestName || task.name
 }
 
-function reportTypecheckTest (task, testSuiteAbsolutePath) {
+/**
+ * Return Test Optimization metadata prepared in Vitest's main process setup.
+ *
+ * @param {object|undefined} ctx
+ * @returns {{ testPropertiesByFilepath: object }}
+ */
+function getMainProcessProvidedContext (ctx) {
+  try {
+    const workspaceProject = getWorkspaceProject(ctx)
+    const providedContext = workspaceProject.getProvidedContext?.() || workspaceProject._provided || {}
+
+    return {
+      testPropertiesByFilepath: providedContext._ddTestPropertiesByFilepath || {},
+    }
+  } catch {
+    return {
+      testPropertiesByFilepath: {},
+    }
+  }
+}
+
+/**
+ * Return the Vitest context that owns a Typechecker instance.
+ *
+ * @param {object} typechecker
+ * @returns {object|undefined}
+ */
+function getTypecheckerVitestContext (typechecker) {
+  return typechecker.ctx || typechecker.project?.vitest
+}
+
+function reportTypecheckTest (task, testSuiteAbsolutePath, providedContext) {
   const testName = getTypecheckTestName(task)
-  if (getTypecheckTaskStatus(task) === 'skip') {
+  const testProperties = getVitestTestProperties(providedContext, testSuiteAbsolutePath, testName)
+  const isAttemptToFix = testProperties.isAttemptToFix === true
+  const isDisabled = testProperties.isDisabled === true
+  const isQuarantined = testProperties.isQuarantined === true
+  const isModified = testProperties.isModified === true
+  const isSkippedByTestManagement = !isAttemptToFix && isDisabled
+  const status = getTypecheckTaskStatus(task)
+
+  if (status === 'skip' || isSkippedByTestManagement) {
     testSkipCh.publish({
       testName,
       testSuiteAbsolutePath,
-      isNew: false,
-      isDisabled: false,
+      isNew: testProperties.isNew,
+      isDisabled,
     })
     return
   }
@@ -861,30 +901,33 @@ function reportTypecheckTest (task, testSuiteAbsolutePath) {
     testName,
     testSuiteAbsolutePath,
     isRetry: false,
-    isNew: false,
+    isNew: testProperties.isNew,
     hasDynamicName: false,
     mightHitProbe: false,
-    isAttemptToFix: false,
-    isDisabled: false,
-    isQuarantined: false,
-    isModified: false,
+    isAttemptToFix,
+    isDisabled,
+    isQuarantined,
+    isModified,
   }
   testStartCh.runStores(ctx, () => {})
 
-  if (getTypecheckTaskStatus(task) === 'fail') {
+  const finalStatus = !isAttemptToFix && isQuarantined ? 'skip' : undefined
+  if (status === 'fail') {
     testErrorCh.publish({
       error: task.result?.errors?.[0],
+      finalStatus,
       ...ctx.currentStore,
     })
   } else {
     testPassCh.publish({
       task,
+      finalStatus,
       ...ctx.currentStore,
     })
   }
 }
 
-async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion) {
+async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion, providedContext) {
   const testSuiteAbsolutePath = file.filepath
   const testSuiteCtx = {
     testSuiteAbsolutePath,
@@ -898,7 +941,7 @@ async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion
   testSuiteStartCh.runStores(testSuiteCtx, () => {})
 
   for (const task of getTypeTasks(file.tasks)) {
-    reportTypecheckTest(task, testSuiteAbsolutePath)
+    reportTypecheckTest(task, testSuiteAbsolutePath, providedContext)
   }
 
   let onFinish
@@ -913,15 +956,24 @@ async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion
   await onFinishPromise
 }
 
-async function reportTypecheckResults (result, frameworkVersion) {
+async function reportTypecheckResults (result, frameworkVersion, ctx) {
   if (!testSuiteFinishCh.hasSubscribers) return
   if (!Array.isArray(result?.files)) return
 
+  if (ctx) {
+    await ensureMainProcessSetup(ctx, frameworkVersion)
+  }
+  const providedContext = getMainProcessProvidedContext(ctx)
   const sessionConfiguration = testSessionConfigurationCh.hasSubscribers
     ? await getChannelPromise(testSessionConfigurationCh, frameworkVersion)
     : {}
 
-  await Promise.all(result.files.map(file => reportTypecheckFile(file, sessionConfiguration, frameworkVersion)))
+  await Promise.all(result.files.map(file => reportTypecheckFile(
+    file,
+    sessionConfiguration,
+    frameworkVersion,
+    providedContext
+  )))
 }
 
 function wrapTypechecker (Typechecker, frameworkVersion) {
@@ -929,7 +981,7 @@ function wrapTypechecker (Typechecker, frameworkVersion) {
 
   shimmer.wrap(Typechecker.prototype, 'prepareResults', prepareResults => async function () {
     const result = await prepareResults.apply(this, arguments)
-    await reportTypecheckResults(result, frameworkVersion)
+    await reportTypecheckResults(result, frameworkVersion, getTypecheckerVitestContext(this))
     return result
   })
 }

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -18,6 +18,12 @@ const {
 } = require('../../dd-trace/src/plugins/util/test')
 const { addHook } = require('./helpers/instrument')
 const {
+  testStartCh,
+  testPassCh,
+  testErrorCh,
+  testSkipCh,
+  testSuiteStartCh,
+  testSuiteFinishCh,
   testSessionStartCh,
   testSessionFinishCh,
   testSessionConfigurationCh,
@@ -31,6 +37,7 @@ const {
   codeCoverageReportCh,
   findExportByName,
   getChannelPromise,
+  getTypeTasks,
   getWorkspaceProject,
   setProvidedContext,
 } = require('./vitest-util')
@@ -96,6 +103,10 @@ function isCliApiPackage (vitestPackage) {
 
 function getVitestExport (vitestPackage) {
   return findExportByName(vitestPackage, 'Vitest')
+}
+
+function getTypecheckerExport (vitestPackage) {
+  return findExportByName(vitestPackage, 'Typechecker')
 }
 
 function getForksPoolWorkerExport (vitestPackage) {
@@ -823,6 +834,108 @@ function wrapVitestRunFiles (Vitest, frameworkVersion) {
   }
 }
 
+function getTypecheckTaskStatus (task) {
+  const state = task.result?.state
+  if (state === 'fail') return 'fail'
+  if (state === 'skip' || task.mode === 'skip' || task.mode === 'todo') return 'skip'
+  return 'pass'
+}
+
+function getTypecheckTestName (task) {
+  return task.fullTestName || task.name
+}
+
+function reportTypecheckTest (task, testSuiteAbsolutePath) {
+  const testName = getTypecheckTestName(task)
+  if (getTypecheckTaskStatus(task) === 'skip') {
+    testSkipCh.publish({
+      testName,
+      testSuiteAbsolutePath,
+      isNew: false,
+      isDisabled: false,
+    })
+    return
+  }
+
+  const ctx = {
+    testName,
+    testSuiteAbsolutePath,
+    isRetry: false,
+    isNew: false,
+    hasDynamicName: false,
+    mightHitProbe: false,
+    isAttemptToFix: false,
+    isDisabled: false,
+    isQuarantined: false,
+    isModified: false,
+  }
+  testStartCh.runStores(ctx, () => {})
+
+  if (getTypecheckTaskStatus(task) === 'fail') {
+    testErrorCh.publish({
+      error: task.result?.errors?.[0],
+      ...ctx.currentStore,
+    })
+  } else {
+    testPassCh.publish({
+      task,
+      ...ctx.currentStore,
+    })
+  }
+}
+
+async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion) {
+  const testSuiteAbsolutePath = file.filepath
+  const testSuiteCtx = {
+    testSuiteAbsolutePath,
+    frameworkVersion,
+    testSessionId: sessionConfiguration.testSessionId,
+    testModuleId: sessionConfiguration.testModuleId,
+    testCommand: sessionConfiguration.testCommand,
+    repositoryRoot: sessionConfiguration.repositoryRoot,
+    codeOwnersEntries: sessionConfiguration.codeOwnersEntries,
+  }
+  testSuiteStartCh.runStores(testSuiteCtx, () => {})
+
+  for (const task of getTypeTasks(file.tasks)) {
+    reportTypecheckTest(task, testSuiteAbsolutePath)
+  }
+
+  let onFinish
+  const onFinishPromise = new Promise(resolve => {
+    onFinish = resolve
+  })
+  testSuiteFinishCh.publish({
+    status: getTypecheckTaskStatus(file),
+    onFinish,
+    ...testSuiteCtx.currentStore,
+  })
+  await onFinishPromise
+}
+
+async function reportTypecheckResults (result, frameworkVersion) {
+  if (!testSuiteFinishCh.hasSubscribers) return
+  if (!Array.isArray(result?.files)) return
+
+  const sessionConfiguration = testSessionConfigurationCh.hasSubscribers
+    ? await getChannelPromise(testSessionConfigurationCh, frameworkVersion)
+    : {}
+
+  for (const file of result.files) {
+    await reportTypecheckFile(file, sessionConfiguration, frameworkVersion)
+  }
+}
+
+function wrapTypechecker (Typechecker, frameworkVersion) {
+  if (!Typechecker?.prototype?.prepareResults) return
+
+  shimmer.wrap(Typechecker.prototype, 'prepareResults', prepareResults => async function () {
+    const result = await prepareResults.apply(this, arguments)
+    await reportTypecheckResults(result, frameworkVersion)
+    return result
+  })
+}
+
 function getCreateCliWrapper (vitestPackage, frameworkVersion) {
   const createCliExport = findExportByName(vitestPackage, 'createCLI')
   if (!createCliExport) {
@@ -1077,6 +1190,18 @@ addHook({
     shimmer.wrap(vitestPackage.h.prototype, 'sort', getSortWrapper)
   }
 
+  return vitestPackage
+})
+
+addHook({
+  name: 'vitest',
+  versions: ['>=4.0.0'],
+  filePattern: 'dist/chunks/index.*',
+}, (vitestPackage, frameworkVersion) => {
+  const typechecker = getTypecheckerExport(vitestPackage)
+  if (typechecker) {
+    wrapTypechecker(typechecker.value, frameworkVersion)
+  }
   return vitestPackage
 })
 

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -24,6 +24,7 @@ const {
   testSkipCh,
   testSuiteStartCh,
   testSuiteFinishCh,
+  testSuiteErrorCh,
   testSessionStartCh,
   testSessionFinishCh,
   testSessionConfigurationCh,
@@ -842,8 +843,41 @@ function getTypecheckTaskStatus (task) {
   return 'pass'
 }
 
-function getTypecheckTestName (task) {
-  return task.fullTestName || task.name
+/**
+ * Return whether a typecheck suite name represents the synthetic file-level suite.
+ *
+ * @param {string|undefined} suiteName
+ * @param {string} testSuiteAbsolutePath
+ * @returns {boolean}
+ */
+function isTypecheckFileSuiteName (suiteName, testSuiteAbsolutePath) {
+  if (!suiteName || !testSuiteAbsolutePath) return false
+
+  const normalizedSuiteName = path.normalize(suiteName).replaceAll('\\', '/')
+  const normalizedSuitePath = path.normalize(testSuiteAbsolutePath).replaceAll('\\', '/')
+
+  return normalizedSuitePath === normalizedSuiteName || normalizedSuitePath.endsWith(`/${normalizedSuiteName}`)
+}
+
+/**
+ * Return a typecheck test name with describe/suite prefixes and without the file-level suite prefix.
+ *
+ * @param {object} task
+ * @param {string} testSuiteAbsolutePath
+ * @returns {string}
+ */
+function getTypecheckTestName (task, testSuiteAbsolutePath) {
+  let testName = task.name || task.fullTestName
+  let currentTask = task.suite
+
+  while (currentTask) {
+    if (currentTask.name && !isTypecheckFileSuiteName(currentTask.name, testSuiteAbsolutePath)) {
+      testName = `${currentTask.name} ${testName}`
+    }
+    currentTask = currentTask.suite
+  }
+
+  return testName
 }
 
 /**
@@ -877,8 +911,121 @@ function getTypecheckerVitestContext (typechecker) {
   return typechecker.ctx || typechecker.project?.vitest
 }
 
+/**
+ * Apply Test Management result semantics to Vitest's returned typecheck task result.
+ *
+ * @param {object} task
+ * @param {string} status
+ * @param {{
+ *   isAttemptToFix: boolean,
+ *   isDisabled: boolean,
+ *   isQuarantined: boolean
+ * }} testManagement
+ */
+function updateTypecheckTaskResultForTestManagement (task, status, testManagement) {
+  const { isAttemptToFix, isDisabled, isQuarantined } = testManagement
+  if (isAttemptToFix || !task.result) return
+
+  if (isDisabled) {
+    task.mode = 'skip'
+    task.result.state = 'skip'
+    task.result.errors = []
+    return
+  }
+
+  if (isQuarantined && status === 'fail') {
+    task.result.state = 'pass'
+    task.result.errors = []
+  }
+}
+
+/**
+ * Recompute suite/file typecheck results after Test Management rewrites child test results.
+ *
+ * @param {object} task
+ * @returns {string}
+ */
+function updateTypecheckTaskTreeResult (task) {
+  if (!Array.isArray(task.tasks)) return getTypecheckTaskStatus(task)
+
+  let hasPassedTest = false
+  let hasSkippedTest = false
+  for (const childTask of task.tasks) {
+    const status = updateTypecheckTaskTreeResult(childTask)
+    if (status === 'fail') {
+      task.result = {
+        ...task.result,
+        state: 'fail',
+      }
+      return 'fail'
+    }
+    if (status === 'skip') {
+      hasSkippedTest = true
+    } else {
+      hasPassedTest = true
+    }
+  }
+
+  if (task.result?.errors?.length) return 'fail'
+  if (!hasPassedTest && !hasSkippedTest) return getTypecheckTaskStatus(task)
+
+  task.result = {
+    ...task.result,
+    state: hasPassedTest ? 'pass' : 'skip',
+    errors: [],
+  }
+  return task.result.state
+}
+
+/**
+ * Recompute the aggregate typecheck result after Test Management rewrites file results.
+ *
+ * @param {{
+ *   files?: object[],
+ *   errors?: object[],
+ *   diagnostics?: object[],
+ *   sourceErrors?: object[],
+ *   state?: string
+ * }} result
+ * @returns {boolean}
+ */
+function updateTypecheckResult (result) {
+  if (result.sourceErrors?.length) return false
+
+  let hasPassedFile = false
+  let hasSkippedFile = false
+  for (const file of result.files) {
+    const status = getTypecheckTaskStatus(file)
+    if (status === 'fail') return false
+    if (status === 'skip') {
+      hasSkippedFile = true
+    } else {
+      hasPassedFile = true
+    }
+  }
+
+  if (!hasPassedFile && !hasSkippedFile) return false
+
+  result.state = hasPassedFile ? 'pass' : 'skip'
+  result.errors = []
+  result.diagnostics = []
+  result.sourceErrors = []
+  return true
+}
+
+/**
+ * Clear Vitest's typechecker exit code after all typecheck failures were handled by Test Management.
+ *
+ * @param {{ process?: { exitCode?: number|null } }} typechecker
+ */
+function clearTypecheckerExitCode (typechecker) {
+  if (typechecker?.process?.exitCode == null) return
+
+  typechecker.process.exitCode = 0
+}
+
 function reportTypecheckTest (task, testSuiteAbsolutePath, providedContext) {
-  const testName = getTypecheckTestName(task)
+  const testName = getTypecheckTestName(task, testSuiteAbsolutePath)
   const testProperties = getVitestTestProperties(providedContext, testSuiteAbsolutePath, testName)
   const isAttemptToFix = testProperties.isAttemptToFix === true
   const isDisabled = testProperties.isDisabled === true
@@ -894,6 +1041,7 @@ function reportTypecheckTest (task, testSuiteAbsolutePath, providedContext) {
       isNew: testProperties.isNew,
       isDisabled,
     })
+    updateTypecheckTaskResultForTestManagement(task, status, { isAttemptToFix, isDisabled, isQuarantined })
     return
   }
 
@@ -925,6 +1073,7 @@ function reportTypecheckTest (task, testSuiteAbsolutePath, providedContext) {
       ...ctx.currentStore,
     })
   }
+  updateTypecheckTaskResultForTestManagement(task, status, { isAttemptToFix, isDisabled, isQuarantined })
 }
 
 async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion, providedContext) {
@@ -943,6 +1092,13 @@ async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion
   for (const task of getTypeTasks(file.tasks)) {
     reportTypecheckTest(task, testSuiteAbsolutePath, providedContext)
   }
+  updateTypecheckTaskTreeResult(file)
+
+  const testSuiteError = file.result?.errors?.[0]
+  if (testSuiteError) {
+    testSuiteCtx.error = testSuiteError
+    testSuiteErrorCh.runStores(testSuiteCtx, () => {})
+  }
 
   let onFinish
   const onFinishPromise = new Promise(resolve => {
@@ -956,12 +1112,12 @@ async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion
   await onFinishPromise
 }
 
-async function reportTypecheckResults (result, frameworkVersion, ctx) {
+async function reportTypecheckResults (result, frameworkVersion, ctx, typechecker) {
   if (!testSuiteFinishCh.hasSubscribers) return
   if (!Array.isArray(result?.files)) return
 
   if (ctx) {
-    await ensureMainProcessSetup(ctx, frameworkVersion)
+    await ensureMainProcessSetup(ctx, frameworkVersion, result.files)
   }
   const providedContext = getMainProcessProvidedContext(ctx)
   const sessionConfiguration = testSessionConfigurationCh.hasSubscribers
@@ -974,6 +1130,9 @@ async function reportTypecheckResults (result, frameworkVersion, ctx) {
     frameworkVersion,
     providedContext
   )))
+  if (updateTypecheckResult(result)) {
+    clearTypecheckerExitCode(typechecker)
+  }
 }
 
 function wrapTypechecker (Typechecker, frameworkVersion) {
@@ -981,9 +1140,17 @@ function wrapTypechecker (Typechecker, frameworkVersion) {
 
   shimmer.wrap(Typechecker.prototype, 'prepareResults', prepareResults => async function () {
     const result = await prepareResults.apply(this, arguments)
-    await reportTypecheckResults(result, frameworkVersion, getTypecheckerVitestContext(this))
+    await reportTypecheckResults(result, frameworkVersion, getTypecheckerVitestContext(this), this)
     return result
   })
+}
+
+function getTypecheckerWrapper (vitestPackage, frameworkVersion) {
+  const typechecker = getTypecheckerExport(vitestPackage)
+  if (typechecker) {
+    wrapTypechecker(typechecker.value, frameworkVersion)
+  }
+  return vitestPackage
 }
 
 function getCreateCliWrapper (vitestPackage, frameworkVersion) {
@@ -1245,15 +1412,15 @@ addHook({
 
 addHook({
   name: 'vitest',
+  versions: ['>=3.2.0 <4.0.0'],
+  filePattern: 'dist/chunks/typechecker.*',
+}, getTypecheckerWrapper)
+
+addHook({
+  name: 'vitest',
   versions: ['>=4.0.0'],
   filePattern: 'dist/chunks/index.*',
-}, (vitestPackage, frameworkVersion) => {
-  const typechecker = getTypecheckerExport(vitestPackage)
-  if (typechecker) {
-    wrapTypechecker(typechecker.value, frameworkVersion)
-  }
-  return vitestPackage
-})
+}, getTypecheckerWrapper)
 
 addHook({
   name: 'vitest',

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -921,9 +921,7 @@ async function reportTypecheckResults (result, frameworkVersion) {
     ? await getChannelPromise(testSessionConfigurationCh, frameworkVersion)
     : {}
 
-  for (const file of result.files) {
-    await reportTypecheckFile(file, sessionConfiguration, frameworkVersion)
-  }
+  await Promise.all(result.files.map(file => reportTypecheckFile(file, sessionConfiguration, frameworkVersion)))
 }
 
 function wrapTypechecker (Typechecker, frameworkVersion) {


### PR DESCRIPTION
### What does this PR do?

Adds Vitest typecheck reporting for Test Optimization by wrapping `Typechecker.prepareResults` in the main Vitest instrumentation and emitting suite/test events for `.test-d.ts` tasks.

The reporting path supports Vitest 3.2.x and 4.x typecheck flows, preserves nested test names, reports typecheck failures with `TypeCheckError` metadata, and applies Known Tests, Impacted Tests, and Test Management metadata to typecheck tasks.

### Motivation

Vitest typecheck-only runs do not execute through the normal `@vitest/runner` worker path. They can report session/module events while missing per-suite and per-test events, which makes typecheck commands look unsupported in Test Optimization.

