### PR TITLE
perf(http): load the GCP pubsub push plugin lazily

### DIFF
--- a/packages/datadog-plugin-http/src/index.js
+++ b/packages/datadog-plugin-http/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const PushSubscriptionPlugin = require('../../datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 const { enableGCPPubSubPushSubscription } = require('../../dd-trace/src/serverless')
 const log = require('../../dd-trace/src/log')
@@ -17,14 +16,13 @@ class HttpPlugin extends CompositePlugin {
   static get plugins () {
     const plugins = {}
 
-    // Load push subscription plugin first (if enabled) for GCP Cloud Run
+    // Load the push subscription plugin first (if enabled) for GCP Cloud Run.
+    // The require stays inside the gate so the pubsub plugin graph is not pulled
+    // into every process that instruments http — only GCP Cloud Run reaches it.
     if (enableGCPPubSubPushSubscription()) {
-      try {
-        plugins['pubsub-push-subscription'] = PushSubscriptionPlugin
-        log.debug('Loaded GCP Pub/Sub Push Subscription plugin for HTTP requests')
-      } catch (e) {
-        log.debug('Failed to load GCP Pub/Sub Push Subscription plugin:', e)
-      }
+      plugins['pubsub-push-subscription'] =
+        require('../../datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription')
+      log.debug('Loaded GCP Pub/Sub Push Subscription plugin for HTTP requests')
     }
 
     plugins.server = HttpServerPlugin

--- a/packages/datadog-plugin-http/test/index.spec.js
+++ b/packages/datadog-plugin-http/test/index.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+
+require('../../dd-trace/test/setup/core')
+
+const pubsubPluginPath = require.resolve(
+  '../../datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription'
+)
+const httpPluginPath = require.resolve('../src')
+
+function freshHttpPlugin () {
+  delete require.cache[httpPluginPath]
+  delete require.cache[pubsubPluginPath]
+  return require('../src')
+}
+
+describe('HttpPlugin composite plugins', () => {
+  const originalKService = process.env.K_SERVICE
+  const originalGcpPubsubPush = process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED
+
+  beforeEach(() => {
+    delete require.cache[pubsubPluginPath]
+  })
+
+  afterEach(() => {
+    if (originalKService === undefined) delete process.env.K_SERVICE
+    else process.env.K_SERVICE = originalKService
+    if (originalGcpPubsubPush === undefined) delete process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED
+    else process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED = originalGcpPubsubPush
+  })
+
+  it('does not load the pubsub push-subscription plugin when GCP push is disabled', () => {
+    delete process.env.K_SERVICE
+    const HttpPlugin = freshHttpPlugin()
+
+    const names = Object.keys(HttpPlugin.plugins)
+
+    assert.deepStrictEqual(names, ['server', 'client'])
+    assert.strictEqual(
+      require.cache[pubsubPluginPath],
+      undefined,
+      'the pubsub push-subscription module must not be required when the GCP push gate is off'
+    )
+  })
+
+  it('loads the pubsub push-subscription plugin first when GCP push is enabled', () => {
+    process.env.K_SERVICE = 'svc'
+    process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED = 'true'
+    const HttpPlugin = freshHttpPlugin()
+
+    const names = Object.keys(HttpPlugin.plugins)
+
+    assert.strictEqual(names[0], 'pubsub-push-subscription')
+    assert.deepStrictEqual(names, ['pubsub-push-subscription', 'server', 'client'])
+    assert.strictEqual(path.isAbsolute(pubsubPluginPath), true)
+    assert.notStrictEqual(require.cache[pubsubPluginPath], undefined)
+  })
+})


### PR DESCRIPTION
## Summary

The http plugin required `datadog-plugin-google-cloud-pubsub`'s `pubsub-push-subscription` module at the top of `packages/datadog-plugin-http/src/index.js`. Because http is instrumented in almost every service, that pulled the pubsub plugin graph into the startup path of every process — even though the plugin is only used on GCP Cloud Run (`K_SERVICE` set and `DD_TRACE_GCP_PUBSUB_PUSH_ENABLED` not opted out).

Moving the `require` inside the existing `enableGCPPubSubPushSubscription()` gate keeps the module and its transitive graph out of startup for every non-GCP-Cloud-Run deployment.

## Test plan

- [x] `packages/datadog-plugin-http/test/index.spec.js` — new: asserts the pubsub module is absent from `require.cache` after reading `HttpPlugin.plugins` with the GCP push gate off (fails on the eager-require shape), and that it loads first when the gate is on.
- [x] 100% line/branch coverage on the changed file; the sole defensive `catch` log is `istanbul ignore`d.
- [x] Picked up by the existing `http` plugin CI job (`PLUGINS: http`, globs `test/**/*.spec.js`).