### PR TITLE
chore(skills): add orchestrion patterns skill

### DIFF
--- a/.agents/skills/orchestrion-patterns/SKILL.md
+++ b/.agents/skills/orchestrion-patterns/SKILL.md
@@ -37,30 +37,30 @@ rewriter schema and edge-case patterns.
 ## Migration Workflow
 
 1. **Inventory the existing hook surface.** Read
-   `packages/datadog-instrumentations/src/<package>.js` before the plugin. List
-   every `addHook`, version range, file path, wrapped class/function/method,
-   `channel(...)` name, channel event method, and `ctx` field produced by the
-   instrumentation.
+  `packages/datadog-instrumentations/src/<package>.js` before the plugin. List
+  every `addHook`, version range, file path, wrapped class/function/method,
+  `channel(...)` name, channel event method, and `ctx` field produced by the
+  instrumentation.
 2. **Extract the behavioral contract.** Read the plugin tests and span
-   assertions. Preserve span names, resources, tags, metrics, services, error
-   behavior, skip/no-span behavior, and parent/child relationships.
+  assertions. Preserve span names, resources, tags, metrics, services, error
+  behavior, skip/no-span behavior, and parent/child relationships.
 3. **Check downstream subscribers.** Grep every old channel name. IAST, AppSec,
-   DSM, or other non-tracing subscribers may need per-call cardinality even when
-   tracing only needs one publish per span. Preserve those channels or migrate
-   all subscribers deliberately with tests.
+  DSM, or other non-tracing subscribers may need per-call cardinality even when
+  tracing only needs one publish per span. Preserve those channels or migrate
+  all subscribers deliberately with tests.
 4. **Map each old wrapping point to a static Orchestrion target.** Verify the
-   actual installed package source under the supported version fixture before
-   choosing `functionQuery` fields. Do not infer kind or file path from the old
-   wrapper shape alone.
+  actual installed package source under the supported version fixture before
+  choosing `functionQuery` fields. Do not infer kind or file path from the old
+  wrapper shape alone.
 5. **Bridge instrumentation with `getHooks`.** After registering the rewriter
-   config, the package instrumentation entrypoint should normally be only the
-   standard `getHooks('<package>')` bridge.
+  config, the package instrumentation entrypoint should normally be only the
+  standard `getHooks('<package>')` bridge.
 6. **Rewrite the plugin around Orchestrion ctx.** Subscribe with
-   `static prefix = 'tracing:orchestrion:<npm-package>:<channelName>'`, read
-   data from `ctx.arguments`, `ctx.self`, `ctx.result`, and `ctx.error`, and
-   pass `ctx` to `startSpan`.
+  `static prefix = 'tracing:orchestrion:<npm-package>:<channelName>'`, read
+  data from `ctx.arguments`, `ctx.self`, `ctx.result`, and `ctx.error`, and
+  pass `ctx` to `startSpan`.
 7. **Verify by contract.** Run the focused plugin tests plus any dependent
-   integration checks discovered from channel subscribers or subclassed plugins.
+  integration checks discovered from channel subscribers or subclassed plugins.
 
 ## Halt Instead of Guessing
 

--- a/.agents/skills/orchestrion-patterns/SKILL.md
+++ b/.agents/skills/orchestrion-patterns/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: orchestrion-patterns
+description: |
+  Migrate or review dd-trace-js integrations that use Orchestrion rewriter
+  instrumentation. Use when mapping shimmer/addHook wrappers to
+  packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/*.js,
+  choosing functionQuery targets or Sync/Async/Callback/AsyncIterator kinds,
+  preserving diagnostic channel behavior, wiring plugins to
+  tracing:orchestrion package channel prefixes, handling CJS/ESM file paths, or
+  debugging Orchestrion channel/plugin mismatches. Triggers: "Orchestrion",
+  "rewriter", "functionQuery", "channelName", "getHooks", "migrate shimmer",
+  "migrate addHook", "Sync kind", "Async kind", "Callback kind", and
+  "AsyncIterator kind".
+---
+
+# Orchestrion Patterns
+
+Use Orchestrion as the hook mechanism while preserving the old integration's
+observable behavior. Treat the current shimmer/addHook instrumentation, plugin,
+tests, and downstream channel subscribers as the compatibility contract.
+
+## Coordinate With Other Skills
+
+Use this skill together with:
+
+- `apm-integrations` for general dd-trace-js instrumentation architecture,
+  plugin base-class choice, and test commands.
+- `integration-internals` for repository layout, generated files, and local
+  workflow details.
+- `observability-patterns` when span tags, semantic conventions, or service
+  naming are part of the migration.
+
+If `apm-integrations/references/orchestrion.md` is available in the target repo,
+read it before writing rewriter config. It is the low-level source of truth for
+rewriter schema and edge-case patterns.
+
+## Migration Workflow
+
+1. **Inventory the existing hook surface.** Read
+   `packages/datadog-instrumentations/src/<package>.js` before the plugin. List
+   every `addHook`, version range, file path, wrapped class/function/method,
+   `channel(...)` name, channel event method, and `ctx` field produced by the
+   instrumentation.
+2. **Extract the behavioral contract.** Read the plugin tests and span
+   assertions. Preserve span names, resources, tags, metrics, services, error
+   behavior, skip/no-span behavior, and parent/child relationships.
+3. **Check downstream subscribers.** Grep every old channel name. IAST, AppSec,
+   DSM, or other non-tracing subscribers may need per-call cardinality even when
+   tracing only needs one publish per span. Preserve those channels or migrate
+   all subscribers deliberately with tests.
+4. **Map each old wrapping point to a static Orchestrion target.** Verify the
+   actual installed package source under the supported version fixture before
+   choosing `functionQuery` fields. Do not infer kind or file path from the old
+   wrapper shape alone.
+5. **Bridge instrumentation with `getHooks`.** After registering the rewriter
+   config, the package instrumentation entrypoint should normally be only the
+   standard `getHooks('<package>')` bridge.
+6. **Rewrite the plugin around Orchestrion ctx.** Subscribe with
+   `static prefix = 'tracing:orchestrion:<npm-package>:<channelName>'`, read
+   data from `ctx.arguments`, `ctx.self`, `ctx.result`, and `ctx.error`, and
+   pass `ctx` to `startSpan`.
+7. **Verify by contract.** Run the focused plugin tests plus any dependent
+   integration checks discovered from channel subscribers or subclassed plugins.
+
+## Halt Instead of Guessing
+
+Stop and explain the blocker if Orchestrion cannot safely express the old
+wrapping point. Common blockers include:
+
+- the old wrapper mutates arguments before the original call and no equivalent
+  Orchestrion-safe pattern is established;
+- the old wrapper instruments a factory return value or runtime-created method
+  with no stable static dispatch function;
+- the old channel is published from a wrapper passed into the library and no
+  source-verified dispatch target exists;
+- the target file path, class, or function differs across supported versions and
+  the split cannot be verified locally.
+
+Do not silently drop an old channel, loosen a test, or keep both shimmer and
+Orchestrion wrapping the same operation.
+
+## Reference
+
+Read [rewriter-and-plugin.md](references/rewriter-and-plugin.md) when writing or
+reviewing the rewriter config, plugin subscriptions, finish method selection,
+CJS/ESM path coverage, or dependent channel compatibility.

--- a/.agents/skills/orchestrion-patterns/references/rewriter-and-plugin.md
+++ b/.agents/skills/orchestrion-patterns/references/rewriter-and-plugin.md
@@ -1,0 +1,106 @@
+# Rewriter and Plugin Checklist
+
+Use this reference while editing or reviewing an Orchestrion migration.
+
+## Rewriter Entries
+
+Create entries in:
+
+`packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/<package>.js`
+
+Register them in the rewriter instrumentations index if the package is not
+already registered.
+
+Each migrated operation needs a source-verified entry:
+
+```js
+{
+  module: {
+    name: '<npm package>',
+    versionRange: '<version range from old addHook unless verified otherwise>',
+    filePath: '<path inside the package>'
+  },
+  functionQuery: {
+    kind: 'Sync',
+    methodName: '<method>',
+    className: '<class>'
+  },
+  channelName: '<operation_channel>'
+}
+```
+
+Use `functionName` for top-level declarations and `expressionName` for function
+or arrow expressions assigned to a name. Use raw `astQuery` only when
+`functionQuery` cannot express a verified target.
+
+## Kind Selection
+
+Choose the kind from the package source, not from the old wrapper:
+
+| Source behavior | Orchestrion kind | Plugin finish path |
+| --- | --- | --- |
+| synchronous return or throw | `Sync` | `end(ctx)` |
+| returns a Promise or is `async` | `Async` | `asyncEnd(ctx)` |
+| callback completes operation | `Callback` | `asyncEnd(ctx)` |
+| async generator or async iterable lifecycle | `AsyncIterator` | base channel plus `_next` channel |
+
+For callbacks, use `functionQuery.index` when the callback is not always the
+last argument. If an `Async` target can return non-Promise values on early
+branches, handle both `end(ctx)` and `asyncEnd(ctx)` in the plugin.
+
+## File Paths and Module Formats
+
+Read the installed package source for the supported version range. Check
+`package.json` `main`, `module`, `exports`, and any CJS/ESM build directories.
+Add separate entries for distinct CJS and ESM files that define the same target.
+
+Do not add an ESM path from naming convention alone. Verify the file exists and
+contains the target function/class/method.
+
+## Plugin Subscription Rules
+
+Use the Orchestrion channel prefix:
+
+```js
+static prefix = 'tracing:orchestrion:<npm-package>:<channelName>'
+```
+
+`<channelName>` must exactly match the rewriter config. Use the old plugin only
+as a behavior source. It may read old shimmer-created `ctx` fields that no
+longer exist. In Orchestrion plugins, prefer:
+
+- `ctx.arguments` for call arguments;
+- `ctx.self` for the receiver instance;
+- `ctx.result` for return or resolved values;
+- `ctx.error` for thrown or rejected errors;
+- `ctx.currentStore` for the span store created by `startSpan`.
+
+Always call `this.startSpan(..., ctx)` so the span is stored in the Orchestrion
+context.
+
+## Dependent Channels and Compatibility
+
+Before removing old channel publishes, run `rg` for each old channel name.
+Classify subscribers by required cardinality:
+
+- tracing span lifecycle: usually one event per span;
+- IAST or AppSec analysis: often one event per library call or argument object;
+- DSM or propagation: may require exact position relative to user callbacks.
+
+If a non-tracing subscriber depends on old channels, either preserve a
+legacy-compatible publish path or migrate that subscriber and add focused
+coverage. For subclassed integrations such as `mysql2` or `mariadb` reusing
+`datadog-plugin-mysql`, verify the dependent plugin still receives the data it
+expects even if the primary package now uses Orchestrion.
+
+## Cleanup
+
+Before finishing, verify:
+
+- no stale `shimmer.wrap`, `shimmer.unwrap`, `shimmer.massWrap`, or unused
+  shimmer imports remain for the migrated operation;
+- the instrumentation entrypoint is the `getHooks` bridge unless a documented
+  non-Orchestrion hook is still required;
+- rewriter config is registered once;
+- plugin prefixes match the rewriter `channelName` values;
+- tests still assert the old behavior rather than weaker new behavior.

--- a/.agents/skills/orchestrion-patterns/references/rewriter-and-plugin.md
+++ b/.agents/skills/orchestrion-patterns/references/rewriter-and-plugin.md
@@ -42,7 +42,7 @@ Choose the kind from the package source, not from the old wrapper:
 | synchronous return or throw | `Sync` | `end(ctx)` |
 | returns a Promise or is `async` | `Async` | `asyncEnd(ctx)` |
 | callback completes operation | `Callback` | `asyncEnd(ctx)` |
-| async generator or async iterable lifecycle | `AsyncIterator` | base channel plus `_next` channel |
+| async generator or async iterable lifecycle | `AsyncIterator` | base channel plus generated `:next` channel |
 
 For callbacks, use `functionQuery.index` when the callback is not always the
 last argument. If an `Async` target can return non-Promise values on early


### PR DESCRIPTION
### What does this PR do?
Adds a repo-local `orchestrion-patterns` agent skill under `.agents/skills/` for dd-trace-js Orchestrion migration and review work. The skill captures the migration workflow from shimmer/addHook instrumentation to Orchestrion rewriter config, including downstream channel compatibility, plugin subscription rules, and cleanup checks.

### Motivation
The APM migration workflow expects an `orchestrion-patterns` skill, but dd-trace-js did not provide one. Keeping it in the repo makes the migration guidance available to toolkit runs and future Codex sessions working directly in dd-trace-js.

### Additional Notes
Validated with:

```
/Users/crystal.magloire/apm-instrumentation-toolkit/.venv/bin/python3 /Users/crystal.magloire/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/orchestrion-patterns
```

Also ran `git diff --check` and `git diff --cached --check` before committing.