### PR TITLE
test(metrics): deflake CPU percentage runtime metrics test

### DIFF
--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -150,6 +150,39 @@ function createGarbage (count = 50) {
       let client
       let Client
 
+      // Builds an isolated runtime_metrics module instance (own module-level state, own
+      // DogStatsD client) so a test can drive it without interference from the shared
+      // `runtimeMetrics`/`client` fixture above. Used wherever a test needs to inject a mock
+      // `@datadog/native-metrics` module, since its `stats` accessor is non-configurable and
+      // can't be sinon.stub()-ed directly on the real module.
+      function createLocalRuntimeMetrics (nativeMetricsModule) {
+        const localClient = {
+          gauge: sinon.spy(),
+          increment: sinon.spy(),
+          histogram: sinon.spy(),
+          flush: sinon.spy(),
+        }
+
+        const LocalClient = sinon.spy(function () {
+          return {
+            gauge: localClient.gauge,
+            increment: localClient.increment,
+            histogram: localClient.histogram,
+            flush: localClient.flush,
+          }
+        })
+        LocalClient.generateClientConfig = DogStatsDClient.generateClientConfig
+
+        const localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
+          './client': proxyquire('../src/runtime_metrics/client', {
+            '../dogstatsd': { DogStatsDClient: LocalClient },
+          }),
+          '@datadog/native-metrics': nativeMetricsModule,
+        })
+
+        return { localRuntimeMetrics, localClient }
+      }
+
       beforeEach(() => {
         // This is needed because sinon spies keep references to arguments which
         // breaks tests because the tags parameter is now mutated right after the
@@ -492,46 +525,26 @@ function createGarbage (count = 50) {
             stats: sinon.stub().returns({ cpu: { user: 0, system: 0 }, heap: { spaces: [] }, eventLoop: {}, gc: {} }),
           }
 
-          const localClient = {
-            gauge: sinon.spy(),
-            increment: sinon.spy(),
-            histogram: sinon.spy(),
-            flush: sinon.spy(),
-          }
-
-          const LocalClient = sinon.spy(function () {
-            return {
-              gauge: localClient.gauge,
-              increment: localClient.increment,
-              histogram: localClient.histogram,
-              flush: localClient.flush,
-            }
-          })
-          LocalClient.generateClientConfig = DogStatsDClient.generateClientConfig
-
-          const localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
-            './client': proxyquire('../src/runtime_metrics/client', {
-              '../dogstatsd': { DogStatsDClient: LocalClient },
-            }),
-            '@datadog/native-metrics': nativeMetricsModule,
-          })
+          const { localRuntimeMetrics, localClient } = createLocalRuntimeMetrics(nativeMetricsModule)
 
           const configNativeDisabled = {
             ...config,
             runtimeMetrics: { ...config.runtimeMetrics, eventLoop: true, gc: true, native: false },
           }
 
-          localRuntimeMetrics.start(configNativeDisabled)
+          try {
+            localRuntimeMetrics.start(configNativeDisabled)
 
-          // Native metrics should not have been started despite eventLoop and gc being enabled
-          sinon.assert.notCalled(nativeMetricsStart)
+            // Native metrics should not have been started despite eventLoop and gc being enabled
+            sinon.assert.notCalled(nativeMetricsStart)
 
-          // Should still collect basic metrics via the JS fallback path
-          clock.tick(10000)
-          sinon.assert.calledWith(localClient.gauge, 'runtime.node.mem.rss')
-          sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.user')
-
-          localRuntimeMetrics.stop()
+            // Should still collect basic metrics via the JS fallback path
+            clock.tick(10000)
+            sinon.assert.calledWith(localClient.gauge, 'runtime.node.mem.rss')
+            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.user')
+          } finally {
+            localRuntimeMetrics.stop()
+          }
         })
       })
 
@@ -600,17 +613,34 @@ function createGarbage (count = 50) {
 
           const totalDiff = Math.abs(totalPercent - userPercent - systemPercent)
           assert(totalDiff <= 0.03, `Total CPU percentage sanity check failed: ${totalDiff} > 0.03`)
+
+          // Physically-motivated ceiling (not a timing assumption): a process cannot consume more
+          // than cpuCount * 100% averaged over a wall-clock window. Catches a systematic
+          // unit-conversion bug (e.g. a dropped *10 in elapsedUsDividedBy100) that a
+          // self-consistency check alone (total == user + system) can't, since such a bug would
+          // scale user/system/total proportionally and still pass that check.
+          const cpuCeiling = os.cpus().length * 100
+          assert(totalPercent <= cpuCeiling, `total CPU usage should not exceed ${cpuCeiling}%, got ${totalPercent}`)
         })
 
         it('should calculate CPU percentages correctly from a known usage delta', () => {
           // Deterministic companion to the busy-loop test above: pins the percent-conversion
           // math with hand-derived values instead of real (and therefore noisy) OS measurements.
-          // process.cpuUsage()/native stats report microseconds; over a 10s (10_000ms) flush
-          // interval, elapsedUsDividedBy100 = 10_000 * 10 = 100_000, so:
-          //   userPercent   = 1_030_000us / 100_000 = 10.30
-          //   systemPercent =    52_000us / 100_000 =  0.52
-          //   totalPercent  = 10.30 + 0.52           = 10.82
+          // process.cpuUsage()/native stats report microseconds.
+          const flushIntervalMs = 10000
           const cpuUsage = { user: 1_030_000, system: 52_000 }
+          const elapsedUsDividedBy100 = flushIntervalMs * 10
+          const userPercentRaw = cpuUsage.user / elapsedUsDividedBy100
+          const systemPercentRaw = cpuUsage.system / elapsedUsDividedBy100
+          const userPercent = userPercentRaw.toFixed(2)
+          const systemPercent = systemPercentRaw.toFixed(2)
+          const totalPercent = (userPercentRaw + systemPercentRaw).toFixed(2)
+
+          const assertCpuGauges = (gauge) => {
+            sinon.assert.calledWith(gauge, 'runtime.node.cpu.user', userPercent)
+            sinon.assert.calledWith(gauge, 'runtime.node.cpu.system', systemPercent)
+            sinon.assert.calledWith(gauge, 'runtime.node.cpu.total', totalPercent)
+          }
 
           // Stop the outer instance from beforeEach: its interval is still registered on the fake
           // clock, and its own captureCpuUsage/captureNativeMetrics call would otherwise consume a
@@ -619,68 +649,45 @@ function createGarbage (count = 50) {
 
           const nowStub = sinon.stub(performance, 'now')
           nowStub.onFirstCall().returns(0) // captured as lastTime on start()
-          nowStub.onSecondCall().returns(10000) // captured as currentTime inside the flush
+          nowStub.onSecondCall().returns(flushIntervalMs) // captured as currentTime inside the flush
 
-          if (nativeMetrics) {
-            // The native module's `stats` accessor is non-configurable, so it can't be sinon.stub()-ed
-            // directly. Inject a mock module instead, the same way the "should not load native metrics"
-            // test above does. The native path also reports a delta directly, unlike
-            // process.cpuUsage()'s cumulative total, so a single stubbed return is enough.
-            const nativeMetricsModule = {
-              start: sinon.spy(),
-              stop: sinon.spy(),
-              stats: sinon.stub().returns({ cpu: cpuUsage, heap: { spaces: [] }, eventLoop: {}, gc: {} }),
-            }
+          let cleanup = () => {}
 
-            const localClient = {
-              gauge: sinon.spy(),
-              increment: sinon.spy(),
-              histogram: sinon.spy(),
-              flush: sinon.spy(),
-            }
-
-            const LocalClient = sinon.spy(function () {
-              return {
-                gauge: localClient.gauge,
-                increment: localClient.increment,
-                histogram: localClient.histogram,
-                flush: localClient.flush,
+          try {
+            if (nativeMetrics) {
+              // The native module's `stats` accessor is non-configurable, so it can't be
+              // sinon.stub()-ed directly. Inject a mock module instead, the same way the "should not
+              // load native metrics" test above does. The native path also reports a delta directly,
+              // unlike process.cpuUsage()'s cumulative total, so a single stubbed return is enough.
+              const nativeMetricsModule = {
+                start: sinon.spy(),
+                stop: sinon.spy(),
+                stats: sinon.stub().returns({ cpu: cpuUsage, heap: { spaces: [] }, eventLoop: {}, gc: {} }),
               }
-            })
-            LocalClient.generateClientConfig = DogStatsDClient.generateClientConfig
 
-            const localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
-              './client': proxyquire('../src/runtime_metrics/client', {
-                '../dogstatsd': { DogStatsDClient: LocalClient },
-              }),
-              '@datadog/native-metrics': nativeMetricsModule,
-            })
+              const { localRuntimeMetrics, localClient } = createLocalRuntimeMetrics(nativeMetricsModule)
+              cleanup = () => localRuntimeMetrics.stop()
 
-            localRuntimeMetrics.start(config)
-            clock.tick(10000)
-            localRuntimeMetrics.stop()
+              localRuntimeMetrics.start(config)
+              clock.tick(flushIntervalMs)
 
+              assertCpuGauges(localClient.gauge)
+            } else {
+              const cpuStub = sinon.stub(process, 'cpuUsage')
+              cpuStub.onFirstCall().returns({ user: 0, system: 0 }) // captured as lastCpuUsage on start()
+              cpuStub.onSecondCall().returns(cpuUsage)
+              cleanup = () => cpuStub.restore()
+
+              runtimeMetrics.start(config)
+              client.gauge.resetHistory()
+
+              clock.tick(flushIntervalMs)
+
+              assertCpuGauges(client.gauge)
+            }
+          } finally {
+            cleanup()
             nowStub.restore()
-
-            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.user', '10.30')
-            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.system', '0.52')
-            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.total', '10.82')
-          } else {
-            const cpuStub = sinon.stub(process, 'cpuUsage')
-            cpuStub.onFirstCall().returns({ user: 0, system: 0 }) // captured as lastCpuUsage on start()
-            cpuStub.onSecondCall().returns(cpuUsage)
-
-            runtimeMetrics.start(config)
-            client.gauge.resetHistory()
-
-            clock.tick(10000)
-
-            nowStub.restore()
-            cpuStub.restore()
-
-            sinon.assert.calledWith(client.gauge, 'runtime.node.cpu.user', '10.30')
-            sinon.assert.calledWith(client.gauge, 'runtime.node.cpu.system', '0.52')
-            sinon.assert.calledWith(client.gauge, 'runtime.node.cpu.total', '10.82')
           }
         })
       })

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -568,10 +568,11 @@ function createGarbage (count = 50) {
       })
 
       describe('CPU Usage Calculations', () => {
-        it('should report CPU percentages within valid ranges', () => {
-          const startCpuUsage = process.cpuUsage()
+        it('should report positive CPU usage after a real busy loop', () => {
+          // Exercises the real OS/native measurement path end-to-end. Assertions stay loose:
+          // "system" CPU time is dominated by kernel/scheduler noise (context switches, page
+          // faults) that scales with CI runner contention, not with anything this code controls.
           const startTime = Date.now()
-          const startPerformanceNow = performance.now()
           let iterations = 0
           let ticks = 0
           while (Date.now() - startTime < 100) {
@@ -581,68 +582,106 @@ function createGarbage (count = 50) {
               ticks++
             }
           }
-          const cpuUsage = process.cpuUsage()
-          const cpuUsageStub = sinon.stub(process, 'cpuUsage').returns(cpuUsage)
-          const performanceNowStub = sinon.stub(performance, 'now').returns(startPerformanceNow + 10000)
           clock.tick(10000 - ticks)
-          performanceNowStub.restore()
-          cpuUsageStub.restore()
 
-          const timeDivisor = 100_000 // Microseconds * 100 for percent
-
-          const cpuMetrics = new Map([[
-            'runtime.node.cpu.user',
-            Number(((cpuUsage.user - startCpuUsage.user) / timeDivisor).toFixed(2)),
-          ], [
-            'runtime.node.cpu.system',
-            Number(((cpuUsage.system - startCpuUsage.system) / timeDivisor).toFixed(2)),
-          ], [
-            'runtime.node.cpu.total',
-            Number((
-              ((cpuUsage.user - startCpuUsage.user) + (cpuUsage.system - startCpuUsage.system)) / timeDivisor
-            ).toFixed(2)),
-          ]])
-
-          let userPercent = 0
-          let systemPercent = 0
-          let totalPercent = 0
-
+          const cpuMetrics = new Map()
           for (const call of client.gauge.getCalls()) {
-            const metric = call.args[0]
-            const expected = cpuMetrics.get(metric)
-            cpuMetrics.delete(metric)
-            if (expected !== undefined) {
-              const stringValue = call.args[1]
-              assert.match(stringValue, /^\d+(\.\d{1,2})?$/)
-              const number = Number(stringValue)
-              if (metric === 'runtime.node.cpu.user') {
-                assert(
-                  number >= 1,
-                  `${metric} sanity check failed (increase CPU load above with more ticks): ${number}`
-                )
-                userPercent = number
-              }
-              if (metric === 'runtime.node.cpu.system') {
-                assert(number >= 0 && number <= 5, `${metric} sanity check failed: ${number}`)
-                systemPercent = number
-              }
-              if (metric === 'runtime.node.cpu.total') {
-                assert(
-                  // Subtracting 0.1 for time-window/baseline alignment numbers and due to rounding issues.
-                  number >= expected - 0.1 && number <= expected + 1,
-                  `${metric} sanity check failed (increase CPU load above with more ticks): ${number} ${expected}`
-                )
-                totalPercent = number
-              }
-              const epsilon = os.platform() === 'win32' ? 1.5 : 0.5
-              assert(number - expected < epsilon, `${metric} sanity check failed: ${number} ${expected}`)
+            if (call.args[0].startsWith('runtime.node.cpu.')) {
+              cpuMetrics.set(call.args[0], Number(call.args[1]))
             }
           }
 
-          assert.strictEqual(cpuMetrics.size, 0, `All CPU metrics should be matched, missing ${[...cpuMetrics.keys()]}`)
+          const userPercent = cpuMetrics.get('runtime.node.cpu.user')
+          const systemPercent = cpuMetrics.get('runtime.node.cpu.system')
+          const totalPercent = cpuMetrics.get('runtime.node.cpu.total')
+
+          assert(userPercent > 0, `expected user CPU usage after a real busy loop, got ${userPercent}`)
+          assert(systemPercent >= 0, `system CPU usage should never be negative, got ${systemPercent}`)
 
           const totalDiff = Math.abs(totalPercent - userPercent - systemPercent)
           assert(totalDiff <= 0.03, `Total CPU percentage sanity check failed: ${totalDiff} > 0.03`)
+        })
+
+        it('should calculate CPU percentages correctly from a known usage delta', () => {
+          // Deterministic companion to the busy-loop test above: pins the percent-conversion
+          // math with hand-derived values instead of real (and therefore noisy) OS measurements.
+          // process.cpuUsage()/native stats report microseconds; over a 10s (10_000ms) flush
+          // interval, elapsedUsDividedBy100 = 10_000 * 10 = 100_000, so:
+          //   userPercent   = 1_030_000us / 100_000 = 10.30
+          //   systemPercent =    52_000us / 100_000 =  0.52
+          //   totalPercent  = 10.30 + 0.52           = 10.82
+          const cpuUsage = { user: 1_030_000, system: 52_000 }
+
+          // Stop the outer instance from beforeEach: its interval is still registered on the fake
+          // clock, and its own captureCpuUsage/captureNativeMetrics call would otherwise consume a
+          // performance.now() stub slot meant for the local/mocked instance below.
+          runtimeMetrics.stop()
+
+          const nowStub = sinon.stub(performance, 'now')
+          nowStub.onFirstCall().returns(0) // captured as lastTime on start()
+          nowStub.onSecondCall().returns(10000) // captured as currentTime inside the flush
+
+          if (nativeMetrics) {
+            // The native module's `stats` accessor is non-configurable, so it can't be sinon.stub()-ed
+            // directly. Inject a mock module instead, the same way the "should not load native metrics"
+            // test above does. The native path also reports a delta directly, unlike
+            // process.cpuUsage()'s cumulative total, so a single stubbed return is enough.
+            const nativeMetricsModule = {
+              start: sinon.spy(),
+              stop: sinon.spy(),
+              stats: sinon.stub().returns({ cpu: cpuUsage, heap: { spaces: [] }, eventLoop: {}, gc: {} }),
+            }
+
+            const localClient = {
+              gauge: sinon.spy(),
+              increment: sinon.spy(),
+              histogram: sinon.spy(),
+              flush: sinon.spy(),
+            }
+
+            const LocalClient = sinon.spy(function () {
+              return {
+                gauge: localClient.gauge,
+                increment: localClient.increment,
+                histogram: localClient.histogram,
+                flush: localClient.flush,
+              }
+            })
+            LocalClient.generateClientConfig = DogStatsDClient.generateClientConfig
+
+            const localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
+              './client': proxyquire('../src/runtime_metrics/client', {
+                '../dogstatsd': { DogStatsDClient: LocalClient },
+              }),
+              '@datadog/native-metrics': nativeMetricsModule,
+            })
+
+            localRuntimeMetrics.start(config)
+            clock.tick(10000)
+            localRuntimeMetrics.stop()
+
+            nowStub.restore()
+
+            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.user', '10.30')
+            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.system', '0.52')
+            sinon.assert.calledWith(localClient.gauge, 'runtime.node.cpu.total', '10.82')
+          } else {
+            const cpuStub = sinon.stub(process, 'cpuUsage')
+            cpuStub.onFirstCall().returns({ user: 0, system: 0 }) // captured as lastCpuUsage on start()
+            cpuStub.onSecondCall().returns(cpuUsage)
+
+            runtimeMetrics.start(config)
+            client.gauge.resetHistory()
+
+            clock.tick(10000)
+
+            nowStub.restore()
+            cpuStub.restore()
+
+            sinon.assert.calledWith(client.gauge, 'runtime.node.cpu.user', '10.30')
+            sinon.assert.calledWith(client.gauge, 'runtime.node.cpu.system', '0.52')
+            sinon.assert.calledWith(client.gauge, 'runtime.node.cpu.total', '10.82')
+          }
         })
       })
 

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -150,11 +150,8 @@ function createGarbage (count = 50) {
       let client
       let Client
 
-      // Builds an isolated runtime_metrics module instance (own module-level state, own
-      // DogStatsD client) so a test can drive it without interference from the shared
-      // `runtimeMetrics`/`client` fixture above. Used wherever a test needs to inject a mock
-      // `@datadog/native-metrics` module, since its `stats` accessor is non-configurable and
-      // can't be sinon.stub()-ed directly on the real module.
+      // Isolated runtime_metrics instance with its own spy client, for tests that inject a mock
+      // `@datadog/native-metrics` (its `stats` accessor is non-configurable and can't be stubbed).
       function createLocalRuntimeMetrics (nativeMetricsModule) {
         const localClient = {
           gauge: sinon.spy(),
@@ -582,9 +579,8 @@ function createGarbage (count = 50) {
 
       describe('CPU Usage Calculations', () => {
         it('should report positive CPU usage after a real busy loop', () => {
-          // Exercises the real OS/native measurement path end-to-end. Assertions stay loose:
-          // "system" CPU time is dominated by kernel/scheduler noise (context switches, page
-          // faults) that scales with CI runner contention, not with anything this code controls.
+          // Exercises the real measurement path, so assertions check invariants rather than values:
+          // system CPU is dominated by scheduler noise that scales with CI contention, not this code.
           const startTime = Date.now()
           let iterations = 0
           let ticks = 0
@@ -614,19 +610,15 @@ function createGarbage (count = 50) {
           const totalDiff = Math.abs(totalPercent - userPercent - systemPercent)
           assert(totalDiff <= 0.03, `Total CPU percentage sanity check failed: ${totalDiff} > 0.03`)
 
-          // Physically-motivated ceiling (not a timing assumption): a process cannot consume more
-          // than cpuCount * 100% averaged over a wall-clock window. Catches a systematic
-          // unit-conversion bug (e.g. a dropped *10 in elapsedUsDividedBy100) that a
-          // self-consistency check alone (total == user + system) can't, since such a bug would
-          // scale user/system/total proportionally and still pass that check.
+          // Physical ceiling: a process can't exceed cpuCount * 100% over a wall-clock window.
+          // Catches gross unit-conversion regressions the self-consistency check above can't.
           const cpuCeiling = os.cpus().length * 100
           assert(totalPercent <= cpuCeiling, `total CPU usage should not exceed ${cpuCeiling}%, got ${totalPercent}`)
         })
 
         it('should calculate CPU percentages correctly from a known usage delta', () => {
-          // Deterministic companion to the busy-loop test above: pins the percent-conversion
-          // math with hand-derived values instead of real (and therefore noisy) OS measurements.
-          // process.cpuUsage()/native stats report microseconds.
+          // Deterministic companion: pins the percent conversion with fixed values instead of
+          // noisy real measurements. cpuUsage is in microseconds, elapsed in milliseconds.
           const flushIntervalMs = 10000
           const cpuUsage = { user: 1_030_000, system: 52_000 }
           const elapsedUsDividedBy100 = flushIntervalMs * 10
@@ -642,9 +634,8 @@ function createGarbage (count = 50) {
             sinon.assert.calledWith(gauge, 'runtime.node.cpu.total', totalPercent)
           }
 
-          // Stop the outer instance from beforeEach: its interval is still registered on the fake
-          // clock, and its own captureCpuUsage/captureNativeMetrics call would otherwise consume a
-          // performance.now() stub slot meant for the local/mocked instance below.
+          // Stop the beforeEach instance first: its live interval would otherwise fire on the fake
+          // clock and consume a performance.now() stub slot meant for the instance under test.
           runtimeMetrics.stop()
 
           const nowStub = sinon.stub(performance, 'now')
@@ -655,10 +646,8 @@ function createGarbage (count = 50) {
 
           try {
             if (nativeMetrics) {
-              // The native module's `stats` accessor is non-configurable, so it can't be
-              // sinon.stub()-ed directly. Inject a mock module instead, the same way the "should not
-              // load native metrics" test above does. The native path also reports a delta directly,
-              // unlike process.cpuUsage()'s cumulative total, so a single stubbed return is enough.
+              // The native path reports a delta directly (unlike process.cpuUsage()'s cumulative
+              // total), so a single stubbed return is enough.
               const nativeMetricsModule = {
                 start: sinon.spy(),
                 stop: sinon.spy(),


### PR DESCRIPTION
### What does this PR do?
Replaces the flaky `should report CPU percentages within valid ranges` test in `packages/dd-trace/test/runtime_metrics.spec.js` with two tests:
- `should report positive CPU usage after a real busy loop` — a smoke test that exercises the real OS/native measurement path end-to-end, asserting only invariants (user > 0, system >= 0, self-consistency of the total, and a physical `cpuCount * 100` ceiling) rather than tight numeric windows.
- `should calculate CPU percentages correctly from a known usage delta` — a deterministic test that pins the percent-conversion math with fixed stubbed inputs, covering both the JS-fallback (`process.cpuUsage()`) and native-addon (`@datadog/native-metrics`) code paths.

It also extracts a shared `createLocalRuntimeMetrics()` helper (reused by the existing "should not load native metrics" test) and guards stub restoration with try/finally so a failed assertion can't leak a stubbed `performance.now`/`process.cpuUsage` into later tests.

### Motivation
The original test measured real OS CPU from a real busy loop and checked it against tight hardcoded bounds (e.g. `systemPercent <= 5`), which made it sensitive to CI runner contention — system CPU time is dominated by scheduler noise. It also only stubbed `process.cpuUsage()`, silently skipping the native-addon path, so a regression in `captureNativeMetrics()`'s conversion math would go uncaught.

### Additional Notes
No production code changed — this is test-only.

**Why this removes the flake class rather than widening the bounds**

The deterministic test has no non-deterministic inputs: `performance.now()` and the CPU source are stubbed to fixed values, so production reduces to pure arithmetic (`1_030_000 / ((10000 - 0) * 10) = 10.30`). Its result is the same every run, and the only thing that can change it is the production math.

The smoke test still reads real CPU, but every assertion is an invariant that holds for all possible values rather than a window around a noisy one:
- `systemPercent >= 0` — delta of a monotonic counter, so non-negative by definition
- `|total - user - system| <= 0.03` — three `.toFixed(2)` roundings, max discrepancy 0.015 regardless of value
- `total <= cpuCount * 100` — physical ceiling, since the CPU-sample window is nested inside the wall-clock window
- `userPercent > 0` — a real 100M-iteration loop consumes more than 0 measurable µs of user CPU

**Verification**
- Ran the CPU tests 120× under full 16-core saturation (to reproduce CI contention): 120 passed, 0 failed.
- Sampled the measured values over 80 runs under that load: `system` reached 6.13, which exceeds the old test's `<= 5` bound — the old test would have failed under this load, while the new `>= 0` invariant absorbs it.
- Mutation check: breaking the production conversion (`* 10` → `* 1`) makes the deterministic test fail, confirming it is not vacuously green.

**Known limitation:** the `cpuCount * 100` ceiling is coarse — on a 16-core host it won't catch a 10× conversion bug, so the deterministic test is the precise guard there. On smaller CI runners the ceiling does catch it.
