### PR TITLE
test: reject non-string version ranges in withVersions

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
@@ -35,7 +35,7 @@ function callViaPromise (client, method, params) {
 function withAwsSdkV2Versions (range, cb) {
   if (typeof range === 'function') {
     cb = range
-    range = undefined
+    range = '*'
   }
 
   withVersions('aws-sdk', ['aws-sdk'], range, cb)
@@ -49,7 +49,7 @@ function withAwsSdkV2Versions (range, cb) {
 function withAwsSdkV3Versions (range, cb) {
   if (typeof range === 'function') {
     cb = range
-    range = undefined
+    range = '*'
   }
 
   withVersions('aws-sdk', ['@aws-sdk/smithy-client'], getAwsSdkV3Range(range), cb)
@@ -63,7 +63,7 @@ function withAwsSdkV3Versions (range, cb) {
 function withAwsSdkVersions (range, cb) {
   if (typeof range === 'function') {
     cb = range
-    range = undefined
+    range = '*'
   }
 
   withAwsSdkV2Versions(range, cb)
@@ -71,11 +71,11 @@ function withAwsSdkVersions (range, cb) {
 }
 
 /**
- * @param {string|undefined} range
+ * @param {string} range
  * @returns {string}
  */
 function getAwsSdkV3Range (range) {
-  return range === undefined ? AWS_SDK_V3_RANGE : `${range} ${AWS_SDK_V3_RANGE}`
+  return range === '*' ? AWS_SDK_V3_RANGE : `${range} ${AWS_SDK_V3_RANGE}`
 }
 
 const helpers = {

--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -20,7 +20,7 @@ describe('esm', () => {
   let proc
   let variants
 
-  withVersions('grpc', '@grpc/grpc-js', NODE_MAJOR >= 25 && '>=1.3.0', version => {
+  withVersions('grpc', '@grpc/grpc-js', NODE_MAJOR >= 25 ? '>=1.3.0' : '*', version => {
     useSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader'], false, [
       './packages/datadog-plugin-grpc/test/integration-test/*',
       './packages/datadog-plugin-grpc/test/*'])

--- a/packages/dd-trace/test/plugins/with-versions.spec.js
+++ b/packages/dd-trace/test/plugins/with-versions.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { inspect } = require('node:util')
 
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
@@ -40,4 +41,27 @@ describe('withVersions', () => {
       { message: /no instrumentation declares the module "loopback"/ }
     )
   })
+
+  // A Node-version gate written as `NODE_MAJOR >= 25 && '>=1.3.0'` collapses to `false` on older Node; the old
+  // `!range` guard treated that as "run every version", so the intended restriction vanished without a trace.
+  for (const badRange of [false, '', null, undefined]) {
+    it(`throws when the range is ${inspect(badRange)} instead of a version string`, () => {
+      assert.throws(
+        () => withVersions('express', 'express', badRange, () => {}),
+        { name: 'TypeError', message: /version range must be a non-empty string/ }
+      )
+    })
+  }
+
+  // Both legitimate shapes reach the module resolver, so they fail with the module error rather than the range
+  // TypeError — proving range validation let them through: the omitted-range function form leaves range undefined,
+  // and an explicit '*' is a valid range.
+  for (const validCall of [
+    () => withVersions('express', 'not-a-real-module', () => {}),
+    () => withVersions('express', 'not-a-real-module', '*', () => {}),
+  ]) {
+    it('lets a valid range through to module resolution', () => {
+      assert.throws(validCall, { message: /no instrumentation declares the module "not-a-real-module"/ })
+    })
+  }
 })

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -259,6 +259,13 @@ function withVersions (plugin, modules, range, cb) {
   if (typeof range === 'function') {
     cb = range
     range = undefined
+  } else if (typeof range !== 'string' || range.length === 0) {
+    // A caller passed something in the range slot that is not a version range. The usual culprit is a Node-version
+    // gate written as `NODE_MAJOR >= 25 && '>=1.3.0'`, which evaluates to `false` on older Node and silently filtered
+    // every version through `!range`. Demand a real range string (use `'*'` for "all versions") so the misuse fails
+    // loudly instead of running zero tests.
+    throw new TypeError(`withVersions: the version range must be a non-empty string, got ${util.inspect(range)}. ` +
+      "Use '*' to match every installed version.")
   }
 
   if (!process.env.DD_INJECT_FORCE &&


### PR DESCRIPTION
## Summary

A Node-version gate written as `withVersions('grpc', pkg, NODE_MAJOR >= 25 && '>=1.3.0', cb)` collapses to `false` on older Node. The version filter's `!range` guard treated `false` (and every other nullish/empty value) identically to "no range", so the intended restriction silently vanished and the suite ran every installed version instead of the gated subset.

`withVersions` now throws a `TypeError` when a range argument is present but is not a non-empty string, so this class of misuse fails loudly at collection time instead of running the wrong set of versions. The `undefined` produced by the internal `typeof range === 'function'` reshuffle (the legitimate "no range" form) still passes through.

Callers that relied on the silent pass-through are updated to pass a real range:

1. The grpc ESM integration spec used the `&&` form; switched to a ternary yielding `'*'` on older Node, matching its sibling unit spec.
2. The aws-sdk version helpers forwarded an omitted range as `undefined` straight into `withVersions`; they now forward `'*'`. `semver.satisfies(v, '*')` selects the same set the `!range` short-circuit did, so the tested versions are unchanged.

## Test plan

- `packages/dd-trace/test/plugins/with-versions.spec.js` pins both sides: the helper throws on `false` / `''` / `null` / `undefined` explicit ranges, and lets the function form and an explicit `'*'` through to module resolution.