### PR TITLE
fix(vitest): propagate no-worker request error tags

### DIFF
--- a/integration-tests/vitest/vitest.no-worker-init.spec.js
+++ b/integration-tests/vitest/vitest.no-worker-init.spec.js
@@ -27,6 +27,7 @@ const {
   DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
   DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE,
   DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE,
+  DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS,
   EARLY_FLAKE_DETECTION_RETRY_THRESHOLDS,
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_EARLY_FLAKE_ENABLED,
@@ -459,6 +460,51 @@ SUPPORTED_VERSIONS.forEach((version) => {
           EXPECT_NO_DD_TRACE_INIT: '1',
         }),
         metadataPromise,
+      ]).then(([exitCode]) => exitCode)
+
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
+    it('tags skipped no-worker events with request errors when settings fails', async () => {
+      receiver.setSettingsResponseCode(404)
+
+      const payloadsPromise = gatherCitestcyclePayloads(receiver, events => {
+        assertEventCounts(events, {
+          test_session_end: 1,
+          test_module_end: 1,
+          test_suite_end: 1,
+          test: 4,
+        })
+
+        for (const type of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const [event] = getEventContents(events, type)
+          assert.strictEqual(
+            event.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS],
+            'true',
+            `${type}: ${inspect(event.meta)}`
+          )
+        }
+
+        const skippedTest = getTestByName(
+          getEventContents(events, 'test'),
+          'early flake detection does not retry if the test is skipped'
+        )
+        assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
+        assert.strictEqual(
+          skippedTest.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS],
+          'true',
+          `test: ${inspect(skippedTest.meta)}`
+        )
+      })
+
+      const exitCode = await Promise.all([
+        runVitest({
+          TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection.mjs',
+          POOL_CONFIG: 'forks',
+          EXPECT_DD_TEST_OPT_VITEST_NO_WORKER_INIT_ACTIVE: '1',
+          EXPECT_NO_DD_TRACE_INIT: '1',
+        }, './node_modules/.bin/vitest run -t "does not retry if the test is skipped"'),
+        payloadsPromise,
       ]).then(([exitCode]) => exitCode)
 
       assert.strictEqual(exitCode, 0, testOutput)

--- a/integration-tests/vitest/vitest.no-worker-init.spec.js
+++ b/integration-tests/vitest/vitest.no-worker-init.spec.js
@@ -27,7 +27,9 @@ const {
   DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
   DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE,
   DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE,
+  DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS,
   DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS,
+  DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS,
   EARLY_FLAKE_DETECTION_RETRY_THRESHOLDS,
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_EARLY_FLAKE_ENABLED,
@@ -110,6 +112,16 @@ function gatherCitestcyclePayloads (receiver, assertions) {
     ({ url }) => url === '/api/v2/citestcycle',
     payloads => assertions(getEvents(payloads))
   )
+}
+
+function assertRequestErrorTagOnEvents (events, tag) {
+  for (const type of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+    const [event] = getEventContents(events, type)
+    assert.strictEqual(event.meta[tag], 'true', `${type}: ${inspect(event.meta)}`)
+  }
+
+  const [test] = getEventContents(events, 'test')
+  assert.strictEqual(test.meta[tag], 'true', `test: ${inspect(test.meta)}`)
 }
 
 describe('vitest no-worker init instrumentation selection', () => {
@@ -476,14 +488,7 @@ SUPPORTED_VERSIONS.forEach((version) => {
           test: 4,
         })
 
-        for (const type of ['test_session_end', 'test_module_end', 'test_suite_end']) {
-          const [event] = getEventContents(events, type)
-          assert.strictEqual(
-            event.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS],
-            'true',
-            `${type}: ${inspect(event.meta)}`
-          )
-        }
+        assertRequestErrorTagOnEvents(events, DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS)
 
         const skippedTest = getTestByName(
           getEventContents(events, 'test'),
@@ -504,6 +509,66 @@ SUPPORTED_VERSIONS.forEach((version) => {
           EXPECT_DD_TEST_OPT_VITEST_NO_WORKER_INIT_ACTIVE: '1',
           EXPECT_NO_DD_TRACE_INIT: '1',
         }, './node_modules/.bin/vitest run -t "does not retry if the test is skipped"'),
+        payloadsPromise,
+      ]).then(([exitCode]) => exitCode)
+
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
+    it('tags no-worker events with request errors when known tests fails', async () => {
+      receiver.setSettings({ known_tests_enabled: true })
+      receiver.setKnownTestsResponseCode(404)
+
+      const payloadsPromise = gatherCitestcyclePayloads(receiver, events => {
+        assertEventCounts(events, {
+          test_session_end: 1,
+          test_module_end: 1,
+          test_suite_end: 1,
+          test: 1,
+        })
+
+        assertRequestErrorTagOnEvents(events, DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS)
+      })
+
+      const exitCode = await Promise.all([
+        runVitest({
+          TEST_DIR: 'ci-visibility/vitest-tests/vitest-worker-env.mjs',
+          POOL_CONFIG: 'forks',
+          EXPECT_DD_TEST_OPT_VITEST_NO_WORKER_INIT_ACTIVE: '1',
+          EXPECT_NO_DD_TRACE_INIT: '1',
+        }),
+        payloadsPromise,
+      ]).then(([exitCode]) => exitCode)
+
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
+    it('tags no-worker events with request errors when test management tests fails', async () => {
+      receiver.setSettings({
+        test_management: {
+          enabled: true,
+        },
+      })
+      receiver.setTestManagementTestsResponseCode(404)
+
+      const payloadsPromise = gatherCitestcyclePayloads(receiver, events => {
+        assertEventCounts(events, {
+          test_session_end: 1,
+          test_module_end: 1,
+          test_suite_end: 1,
+          test: 1,
+        })
+
+        assertRequestErrorTagOnEvents(events, DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS)
+      })
+
+      const exitCode = await Promise.all([
+        runVitest({
+          TEST_DIR: 'ci-visibility/vitest-tests/vitest-worker-env.mjs',
+          POOL_CONFIG: 'forks',
+          EXPECT_DD_TEST_OPT_VITEST_NO_WORKER_INIT_ACTIVE: '1',
+          EXPECT_NO_DD_TRACE_INIT: '1',
+        }),
         payloadsPromise,
       ]).then(([exitCode]) => exitCode)
 

--- a/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
+++ b/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
@@ -436,6 +436,7 @@ function createMainProcessReporter (reporterState) {
       testCommand: testSessionConfiguration.testCommand,
       repositoryRoot: testSessionConfiguration.repositoryRoot,
       codeOwnersEntries: testSessionConfiguration.codeOwnersEntries,
+      requestErrorTags: reporterState.state.requestErrorTags,
       isTestFrameworkWorker: true,
       isVitestNoWorkerInitActive: true,
     }
@@ -852,6 +853,7 @@ function getRepeatedTaskStatuses (task, status) {
 function reportFinalTestAttempt (testReport) {
   const {
     errors,
+    state,
     status,
     task,
     testName,
@@ -867,6 +869,7 @@ function reportFinalTestAttempt (testReport) {
       isNew: testProperties.isNew,
       isDisabled: testProperties.isDisabled,
       isTestFrameworkWorker: true,
+      requestErrorTags: state.requestErrorTags,
       ...testSuiteStore,
     })
     return
@@ -929,6 +932,7 @@ function reportTestAttempt (testReport, attempt) {
     isRetryReasonAtr: !testProperties.isAttemptToFix && !testProperties.isEarlyFlakeDetection &&
       testProperties.isFlakyTestRetries,
     isTestFrameworkWorker: true,
+    requestErrorTags: state.requestErrorTags,
   }
   if (testProperties.isAttemptToFix) {
     recordAttemptToFixExecution(state.attemptToFixExecutions, {

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -64,6 +64,7 @@ let testManagementAttemptToFixRetries = 0
 let isDiEnabled = false
 let testCodeCoverageLinesTotal
 let coverageRootDir
+let requestErrorTags = {}
 let isSessionStarted = false
 let isVitestNoWorkerInitActive = false
 let vitestPool = null
@@ -414,15 +415,21 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications, s
   }
 
   try {
-    const { err, libraryConfig } = await getChannelPromise(libraryConfigurationCh, frameworkVersion, {
+    const {
+      err,
+      libraryConfig,
+      requestErrorTags: receivedRequestErrorTags = {},
+    } = await getChannelPromise(libraryConfigurationCh, frameworkVersion, {
       isVitestNoWorkerInitActive: shouldInstallNoWorkerInit,
     })
+    requestErrorTags = receivedRequestErrorTags
     if (err) {
       resetLibraryConfig()
     } else {
       applyLibraryConfig(libraryConfig)
     }
   } catch {
+    requestErrorTags = {}
     resetLibraryConfig()
   }
 
@@ -597,6 +604,7 @@ function getNoWorkerInitState () {
     isFlakyTestRetriesEnabled,
     isKnownTestsEnabled,
     newTestsWithDynamicNames,
+    requestErrorTags,
     testManagementAttemptToFixRetries,
   }
 }
@@ -806,6 +814,7 @@ function getFinishWrapper (exitOrClose) {
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
+      requestErrorTags,
       vitestPool,
       isVitestNoWorkerInitActive,
       onFinish,

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -391,6 +391,20 @@ function resetMainProcessProvidedContext (ctx) {
   }, 'Could not reset Test Optimization context for workers.')
 }
 
+/**
+ * Merges request error tags from a Test Optimization request response into the tags propagated by no-worker mode.
+ *
+ * @param {{ requestErrorTags?: Record<string, string> }|undefined} requestResponse - Request response.
+ */
+function mergeRequestErrorTags (requestResponse) {
+  if (requestResponse?.requestErrorTags) {
+    requestErrorTags = {
+      ...requestErrorTags,
+      ...requestResponse.requestErrorTags,
+    }
+  }
+}
+
 async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications, shouldInstallNoWorkerInit) {
   if (!testSessionFinishCh.hasSubscribers) {
     return
@@ -465,6 +479,8 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications, s
     getKnownTests: () => getChannelPromise(knownTestsCh),
     getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
   })
+  mergeRequestErrorTags(knownTestsResponse)
+  mergeRequestErrorTags(testManagementTestsResponse)
 
   const flakyTestRetriesConfiguration = configureFlakyTestRetries(ctx, testSpecifications)
   if (flakyTestRetriesConfiguration) {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -164,10 +164,6 @@ module.exports = class CiPlugin extends Plugin {
           setItrSkippingEnabledTagFromLibraryConfig(this, frameworkVersion)
         }
 
-        const requestErrorTags = this.testSessionSpan
-          ? getSessionRequestErrorTags(this.testSessionSpan)
-          : Object.fromEntries(this._pendingRequestErrorTags.map(({ tag, value }) => [tag, value]))
-
         const libraryCapabilitiesTags = this.getLibraryCapabilitiesTags(frameworkVersion, ctx)
         const metadataTags = {
           test: {
@@ -175,7 +171,12 @@ module.exports = class CiPlugin extends Plugin {
           },
         }
         this.tracer._exporter.addMetadataTags(metadataTags)
-        onDone({ err, libraryConfig, repositoryRoot: this.repositoryRoot, requestErrorTags })
+        onDone({
+          err,
+          libraryConfig,
+          repositoryRoot: this.repositoryRoot,
+          requestErrorTags: this._getCurrentRequestErrorTags(),
+        })
       })
     })
 
@@ -307,7 +308,7 @@ module.exports = class CiPlugin extends Plugin {
             this.libraryConfig.isKnownTestsEnabled = false
           }
         }
-        onDone({ err, knownTests })
+        onDone({ err, knownTests, requestErrorTags: this._getCurrentRequestErrorTags() })
       })
     })
 
@@ -327,7 +328,7 @@ module.exports = class CiPlugin extends Plugin {
             this.libraryConfig.isTestManagementEnabled = false
           }
         }
-        onDone({ err, testManagementTests })
+        onDone({ err, testManagementTests, requestErrorTags: this._getCurrentRequestErrorTags() })
       })
     })
 
@@ -457,6 +458,18 @@ module.exports = class CiPlugin extends Plugin {
     } else {
       this._pendingRequestErrorTags.push({ tag, value })
     }
+  }
+
+  /**
+   * Returns the current request error tags, including tags queued before session creation.
+   *
+   * @returns {Record<string, string>}
+   */
+  _getCurrentRequestErrorTags () {
+    if (this.testSessionSpan) {
+      return getSessionRequestErrorTags(this.testSessionSpan)
+    }
+    return Object.fromEntries(this._pendingRequestErrorTags.map(({ tag, value }) => [tag, value]))
   }
 
   /**


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Propagates Test Optimization request error tags through Vitest no-worker-init reporting.

Specifically, this returns the current request error tags from settings, known-tests, and test-management requests, stores them in Vitest main no-worker state, and forwards them to no-worker session, suite, and test events, including skipped tests.

### Motivation

When a Test Optimization request fails, normal worker instrumentation tags emitted events with the request error. No-worker-init reporting should keep that diagnostic signal on the same event types even when worker instrumentation is skipped.

