### PR TITLE
feat(span-stats): encode SpanKind and GRPCStatusCode in v0.6 stats payload

### DIFF
--- a/ext/tags.d.ts
+++ b/ext/tags.d.ts
@@ -20,6 +20,7 @@ declare const tags: {
   HTTP_RESPONSE_HEADERS: 'http.response.headers'
   HTTP_USERAGENT: 'http.useragent',
   HTTP_CLIENT_IP: 'http.client_ip',
+  GRPC_STATUS_CODE: 'grpc.status.code'
   PATHWAY_HASH: 'pathway.hash'
 }
 

--- a/packages/dd-trace/src/encode/span-stats.js
+++ b/packages/dd-trace/src/encode/span-stats.js
@@ -31,7 +31,7 @@ class SpanStatsEncoder extends AgentEncoder {
   }
 
   _encodeStat (bytes, stat) {
-    bytes.writeMapPrefix(15)
+    this._encodeMapPrefix(bytes, 17)
 
     this._encodeString(bytes, 'Service')
     const service = stat.Service || DEFAULT_SERVICE_NAME
@@ -79,6 +79,12 @@ class SpanStatsEncoder extends AgentEncoder {
 
     this._encodeString(bytes, 'srv_src')
     this._encodeString(bytes, stat.srv_src || '')
+
+    this._encodeString(bytes, 'SpanKind')
+    this._encodeString(bytes, stat.SpanKind || '')
+
+    this._encodeString(bytes, 'GRPCStatusCode')
+    this._encodeString(bytes, stat.GRPCStatusCode || '')
   }
 
   _encodeBucket (bytes, bucket) {

--- a/packages/dd-trace/src/encode/span-stats.js
+++ b/packages/dd-trace/src/encode/span-stats.js
@@ -31,7 +31,7 @@ class SpanStatsEncoder extends AgentEncoder {
   }
 
   _encodeStat (bytes, stat) {
-    this._encodeMapPrefix(bytes, 17)
+    bytes.writeMapPrefix(17)
 
     this._encodeString(bytes, 'Service')
     const service = stat.Service || DEFAULT_SERVICE_NAME

--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_span_stats_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_span_stats_transformer.js
@@ -3,6 +3,7 @@
 const { LogCollapsingLowestDenseDDSketch } = require('../../../../../vendor/dist/@datadog/sketches-js')
 const OtlpTransformerBase = require('../otlp/otlp_transformer_base')
 const { getProtobufTypes } = require('../otlp/protobuf_loader')
+const { GRPC_STATUS_NAMES } = require('../../constants')
 
 const NS_PER_S = 1e9
 
@@ -152,7 +153,10 @@ class OtlpStatsTransformer extends OtlpTransformerBase {
     if (aggKey.method) raw['http.request.method'] = aggKey.method
     if (aggKey.endpoint) raw['http.route'] = aggKey.endpoint
     if (aggKey.rpcStatusCode !== '') {
-      raw['rpc.response.status_code'] = String(aggKey.rpcStatusCode).toUpperCase()
+      const n = Number(aggKey.rpcStatusCode)
+      raw['rpc.response.status_code'] = Number.isInteger(n) && n >= 0 && n < GRPC_STATUS_NAMES.length
+        ? GRPC_STATUS_NAMES[n]
+        : String(aggKey.rpcStatusCode).toUpperCase()
     }
 
     if (!this.#otelSemanticsEnabled) {

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -14,6 +14,8 @@ const {
   GRPC_STATUS_CODE,
 } = require('../../../ext/tags')
 const { ORIGIN_KEY, TOP_LEVEL_KEY, SVC_SRC_KEY, GRPC_STATUS_NAMES } = require('./constants')
+
+const GRPC_STATUS_CODE_MAP = Object.fromEntries(GRPC_STATUS_NAMES.map((name, i) => [name, String(i)]))
 const { version } = require('./pkg')
 const processTags = require('./process-tags')
 
@@ -108,10 +110,22 @@ class SpanAggKey {
     this.srvSrc = span.meta[SVC_SRC_KEY] || ''
     this.spanKind = span.meta[SPAN_KIND] || ''
     // dd gRPC plugin sets a numeric code via setTag; OTel/manual sets a string name via meta.
+    // Normalize to numeric string to match the Agent's parseGRPCStatusString convention.
     const grpcCode = span.meta[GRPC_STATUS_CODE] ?? span.metrics?.[GRPC_STATUS_CODE]
-    this.rpcStatusCode = typeof grpcCode === 'number'
-      ? (GRPC_STATUS_NAMES[grpcCode] ?? String(grpcCode))
-      : (grpcCode ?? '')
+    if (typeof grpcCode === 'number') {
+      this.rpcStatusCode = String(grpcCode)
+    } else if (grpcCode) {
+      const upper = String(grpcCode).toUpperCase()
+      const numeric = GRPC_STATUS_CODE_MAP[upper]
+      if (numeric === undefined) {
+        const n = Number(grpcCode)
+        this.rpcStatusCode = Number.isInteger(n) && n >= 0 ? String(n) : ''
+      } else {
+        this.rpcStatusCode = numeric
+      }
+    } else {
+      this.rpcStatusCode = ''
+    }
   }
 
   toString () {

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -111,7 +111,11 @@ class SpanAggKey {
     this.spanKind = span.meta[SPAN_KIND] || ''
     // dd gRPC plugin sets a numeric code via setTag; OTel/manual sets a string name via meta.
     // Normalize to numeric string to match the Agent's parseGRPCStatusString convention.
-    const grpcCode = span.meta[GRPC_STATUS_CODE] ?? span.metrics?.[GRPC_STATUS_CODE]
+    // Also check OTel semantic aliases (rpc.grpc.status_code, rpc.response.status_code) as
+    // the OTel bridge stores attributes under their original key without remapping.
+    const grpcCode = span.meta[GRPC_STATUS_CODE] ?? span.metrics?.[GRPC_STATUS_CODE] ??
+      span.meta['rpc.grpc.status_code'] ?? span.metrics?.['rpc.grpc.status_code'] ??
+      span.meta['rpc.response.status_code'] ?? span.metrics?.['rpc.response.status_code']
     if (typeof grpcCode === 'number') {
       this.rpcStatusCode = String(grpcCode)
     } else if (grpcCode) {

--- a/packages/dd-trace/test/encode/span-stats.spec.js
+++ b/packages/dd-trace/test/encode/span-stats.spec.js
@@ -50,7 +50,7 @@ describe('span-stats-encode', () => {
       HTTPEndpoint: '/users/:id',
       srv_src: 'kafka',
       SpanKind: 'server',
-      GRPCStatusCode: 'OK',
+      GRPCStatusCode: '0',
       Hits: 30799,
       TopLevelHits: 30799,
       Duration: 1230,
@@ -215,7 +215,7 @@ describe('span-stats-encode', () => {
 
     const decodedStat = decoded.Stats[0].Stats[0]
     assert.strictEqual(decodedStat.SpanKind, 'server')
-    assert.strictEqual(decodedStat.GRPCStatusCode, 'OK')
+    assert.strictEqual(decodedStat.GRPCStatusCode, '0')
   })
 
   it('should encode SpanKind and GRPCStatusCode as empty strings when not present', () => {

--- a/packages/dd-trace/test/encode/span-stats.spec.js
+++ b/packages/dd-trace/test/encode/span-stats.spec.js
@@ -49,6 +49,8 @@ describe('span-stats-encode', () => {
       HTTPMethod: 'GET',
       HTTPEndpoint: '/users/:id',
       srv_src: 'kafka',
+      SpanKind: 'server',
+      GRPCStatusCode: 'OK',
       Hits: 30799,
       TopLevelHits: 30799,
       Duration: 1230,
@@ -203,5 +205,31 @@ describe('span-stats-encode', () => {
 
     const decodedStat = decoded.Stats[0].Stats[0]
     assert.strictEqual(decodedStat.srv_src, '')
+  })
+
+  it('should encode SpanKind and GRPCStatusCode', () => {
+    encoder.encode(stats)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer)
+
+    const decodedStat = decoded.Stats[0].Stats[0]
+    assert.strictEqual(decodedStat.SpanKind, 'server')
+    assert.strictEqual(decodedStat.GRPCStatusCode, 'OK')
+  })
+
+  it('should encode SpanKind and GRPCStatusCode as empty strings when not present', () => {
+    const statsWithout = {
+      ...stats,
+      Stats: [{ ...bucket, Stats: [{ ...stat, SpanKind: undefined, GRPCStatusCode: undefined }] }],
+    }
+    encoder.encode(statsWithout)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer)
+
+    const decodedStat = decoded.Stats[0].Stats[0]
+    assert.strictEqual(decodedStat.SpanKind, '')
+    assert.strictEqual(decodedStat.GRPCStatusCode, '')
   })
 })

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -202,6 +202,19 @@ describe('SpanAggKey', () => {
     assert.strictEqual(
       key.toString(), 'basic-span,service-name,resource-name,span-type,0,false,,,,,14')
   })
+
+  it('should use rpc.grpc.status_code OTel alias when grpc.status.code is absent', () => {
+    const span = { ...basicSpan, meta: { ...basicSpan.meta, 'rpc.grpc.status_code': '2' }, metrics: {} }
+    const key = new SpanAggKey(span)
+    assert.strictEqual(key.rpcStatusCode, '2')
+  })
+
+  it('should use rpc.response.status_code OTel alias as last resort', () => {
+    const meta = { ...basicSpan.meta, 'rpc.response.status_code': 'INVALID_ARGUMENT' }
+    const span = { ...basicSpan, meta, metrics: {} }
+    const key = new SpanAggKey(span)
+    assert.strictEqual(key.rpcStatusCode, '3')
+  })
 })
 
 describe('SpanAggStats', () => {

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -19,6 +19,8 @@ const {
   HTTP_ENDPOINT,
   HTTP_ROUTE,
   HTTP_METHOD,
+  SPAN_KIND,
+  GRPC_STATUS_CODE,
 } = require('../../../ext/tags')
 const {
   DEFAULT_SPAN_NAME,
@@ -178,6 +180,27 @@ describe('SpanAggKey', () => {
     const key = new SpanAggKey(span)
     assert.strictEqual(
       key.toString(), 'basic-span,service-name,resource-name,span-type,200,false,,,opt.plugin,,')
+  })
+
+  it('should include span kind in aggregation key', () => {
+    const span = { ...basicSpan, meta: { ...basicSpan.meta, [SPAN_KIND]: 'server' } }
+    const key = new SpanAggKey(span)
+    assert.strictEqual(
+      key.toString(), 'basic-span,service-name,resource-name,span-type,200,false,,,integration,server,')
+  })
+
+  it('should include gRPC status code string in aggregation key', () => {
+    const span = { ...basicSpan, meta: { ...basicSpan.meta, [GRPC_STATUS_CODE]: 'NOT_FOUND' } }
+    const key = new SpanAggKey(span)
+    assert.strictEqual(
+      key.toString(), 'basic-span,service-name,resource-name,span-type,200,false,,,integration,,NOT_FOUND')
+  })
+
+  it('should translate numeric gRPC status code to canonical name in aggregation key', () => {
+    const span = { ...basicSpan, meta: {}, metrics: { [GRPC_STATUS_CODE]: 14 } }
+    const key = new SpanAggKey(span)
+    assert.strictEqual(
+      key.toString(), 'basic-span,service-name,resource-name,span-type,0,false,,,,,UNAVAILABLE')
   })
 })
 

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -189,18 +189,18 @@ describe('SpanAggKey', () => {
       key.toString(), 'basic-span,service-name,resource-name,span-type,200,false,,,integration,server,')
   })
 
-  it('should include gRPC status code string in aggregation key', () => {
+  it('should normalize gRPC status name to numeric string in aggregation key', () => {
     const span = { ...basicSpan, meta: { ...basicSpan.meta, [GRPC_STATUS_CODE]: 'NOT_FOUND' } }
     const key = new SpanAggKey(span)
     assert.strictEqual(
-      key.toString(), 'basic-span,service-name,resource-name,span-type,200,false,,,integration,,NOT_FOUND')
+      key.toString(), 'basic-span,service-name,resource-name,span-type,200,false,,,integration,,5')
   })
 
-  it('should translate numeric gRPC status code to canonical name in aggregation key', () => {
+  it('should keep numeric gRPC status code as numeric string in aggregation key', () => {
     const span = { ...basicSpan, meta: {}, metrics: { [GRPC_STATUS_CODE]: 14 } }
     const key = new SpanAggKey(span)
     assert.strictEqual(
-      key.toString(), 'basic-span,service-name,resource-name,span-type,0,false,,,,,UNAVAILABLE')
+      key.toString(), 'basic-span,service-name,resource-name,span-type,0,false,,,,,14')
   })
 })
 


### PR DESCRIPTION
## Summary

- `SpanKind` and `GRPCStatusCode` are supported by the Agent's msgpack decoder (`stats_gen.go`) but were never sent by the tracer — spans differing only by span kind or gRPC status code were silently merged at the client side
- Adds both fields to `SpanAggKey` (bucketing key) and `toJSON()` output, with numeric gRPC codes translated to canonical name strings via `GRPC_STATUS_NAMES`
- Updates `SpanStatsEncoder._encodeStat` to write them (map prefix 15 → 17)
- Exports `GRPC_STATUS_CODE` from `ext/tags.js` and moves `GRPC_STATUS_NAMES` to `constants.js`

## Agent deserialization references

These fields are consumed by the Agent's `ClientStatsPayload` (`/v0.6/stats`) receiver. Links pinned to `datadog-agent@f86c193`:

- **Receiver entrypoint** — `/v0.6/stats` decodes the msgpack body into `pb.ClientStatsPayload`: [`handleStats` in `pkg/trace/api/api.go`](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/trace/api/api.go#L793-L805)
- **msgpack field decoder** — `ClientGroupedStats.DecodeMsg` switches on the map keys the tracer writes: [decoder](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/proto/pbgo/trace/stats_gen.go#L16), [`SpanKind` (string)](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/proto/pbgo/trace/stats_gen.go#L121-L126), [`GRPCStatusCode` (string)](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/proto/pbgo/trace/stats_gen.go#L160-L165)
- **`GRPCStatusCode` numeric-string convention** — the Agent computes its own value as a numeric string, so client-side stats must match this form to aggregate into the same bucket: [`parseGRPCStatusString`](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/trace/stats/aggregation.go#L194-L209), [`getGRPCStatusCode`](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/trace/stats/aggregation.go#L211-L218)
- **Aggregation key** — the deserialized `SpanKind` / `GRPCStatusCode` values become part of the bucketing key (string equality): [`NewAggregationFromGroup`](https://github.com/DataDog/datadog-agent/blob/f86c193331a7a727cf5eceddd5fbe3c4f61c71d9/pkg/trace/stats/aggregation.go#L152-L171)

## Test plan

- [ ] `packages/dd-trace/test/span_stats.spec.js` — updated `toString()` / `toJSON()` assertions; new tests for `SpanKind` and numeric/string gRPC status code in aggregation key
- [ ] `packages/dd-trace/test/encode/span-stats.spec.js` — updated fixture; new tests for encoding present and absent `SpanKind`/`GRPCStatusCode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
