### PR TITLE
fix(jest): report tests from custom environments

### DIFF
--- a/integration-tests/ci-visibility/jestEnvironmentAsyncAddTest.js
+++ b/integration-tests/ci-visibility/jestEnvironmentAsyncAddTest.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const NodeEnvironment =
+  require('jest-environment-node').TestEnvironment ||
+  require('jest-environment-node')
+
+class CustomEnvironment extends NodeEnvironment {
+  handleTestEvent (event) {
+    if (event.name === 'add_test') {
+      return new Promise(() => {})
+    }
+  }
+}
+
+module.exports = CustomEnvironment

--- a/integration-tests/ci-visibility/jestEnvironmentNoSuper.js
+++ b/integration-tests/ci-visibility/jestEnvironmentNoSuper.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const NodeEnvironment =
+  require('jest-environment-node').TestEnvironment ||
+  require('jest-environment-node')
+
+class CustomEnvironment extends NodeEnvironment {
+  async handleTestEvent (event, state) {
+    if (!this.global.JEST_STATE_SYMBOL) {
+      this.global.JEST_STATE_SYMBOL = state
+    }
+  }
+}
+
+module.exports = CustomEnvironment

--- a/integration-tests/ci-visibility/jestEnvironmentNoSuperAfterSetup.js
+++ b/integration-tests/ci-visibility/jestEnvironmentNoSuperAfterSetup.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const NodeEnvironment =
+  require('jest-environment-node').TestEnvironment ||
+  require('jest-environment-node')
+
+class CustomEnvironment extends NodeEnvironment {
+  async setup () {
+    await super.setup()
+
+    this.handleTestEvent = async (event, state) => {
+      if (!this.global.JEST_STATE_SYMBOL) {
+        this.global.JEST_STATE_SYMBOL = state
+      }
+    }
+  }
+}
+
+module.exports = CustomEnvironment

--- a/integration-tests/ci-visibility/jestEnvironmentNoSuperInstanceField.js
+++ b/integration-tests/ci-visibility/jestEnvironmentNoSuperInstanceField.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const NodeEnvironment =
+  require('jest-environment-node').TestEnvironment ||
+  require('jest-environment-node')
+
+class CustomEnvironment extends NodeEnvironment {
+  handleTestEvent = async (event, state) => {
+    if (!this.global.JEST_STATE_SYMBOL) {
+      this.global.JEST_STATE_SYMBOL = state
+    }
+  }
+}
+
+module.exports = CustomEnvironment

--- a/integration-tests/ci-visibility/jestEnvironmentNoSuperSetupAndInstanceField.js
+++ b/integration-tests/ci-visibility/jestEnvironmentNoSuperSetupAndInstanceField.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const NodeEnvironment =
+  require('jest-environment-node').TestEnvironment ||
+  require('jest-environment-node')
+
+class CustomEnvironment extends NodeEnvironment {
+  handleTestEvent = async (event, state) => {
+    if (!this.global.JEST_STATE_SYMBOL) {
+      this.global.JEST_STATE_SYMBOL = state
+    }
+  }
+
+  async setup () {}
+}
+
+module.exports = CustomEnvironment

--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -78,6 +78,10 @@ if (process.env.ENABLE_HAPPY_DOM) {
   options.testEnvironment = '@happy-dom/jest-environment'
 }
 
+if (process.env.CUSTOM_TEST_ENVIRONMENT) {
+  options.testEnvironment = process.env.CUSTOM_TEST_ENVIRONMENT
+}
+
 if (process.env.COLLECT_COVERAGE_FROM) {
   options.collectCoverageFrom = process.env.COLLECT_COVERAGE_FROM.split(',')
 }

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -645,6 +645,10 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       it('reports test events when a custom environment defines handleTestEvent as an instance field', async () => {
         await assertCustomEnvironmentReportsTests('./ci-visibility/jestEnvironmentNoSuperInstanceField.js')
       })
+
+      it('reports test events when a custom environment assigns handleTestEvent after setup', async () => {
+        await assertCustomEnvironmentReportsTests('./ci-visibility/jestEnvironmentNoSuperAfterSetup.js')
+      })
     })
   })
 

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -600,7 +600,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         ])
       })
 
-      it('reports test events when a custom environment does not call super.handleTestEvent', async () => {
+      const assertCustomEnvironmentReportsTests = async (customTestEnvironment) => {
         const envVars = reportingOption === 'agentless'
           ? getCiVisAgentlessConfig(receiver.port)
           : getCiVisEvpProxyConfig(receiver.port)
@@ -625,7 +625,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             cwd,
             env: {
               ...envVars,
-              CUSTOM_TEST_ENVIRONMENT: './ci-visibility/jestEnvironmentNoSuper.js',
+              CUSTOM_TEST_ENVIRONMENT: customTestEnvironment,
               TESTS_TO_RUN: 'test/ci-visibility-test.js',
             },
           }
@@ -636,6 +636,14 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           eventsPromise,
         ])
         assert.strictEqual(exitCode, 0)
+      }
+
+      it('reports test events when a custom environment does not call super.handleTestEvent', async () => {
+        await assertCustomEnvironmentReportsTests('./ci-visibility/jestEnvironmentNoSuper.js')
+      })
+
+      it('reports test events when a custom environment defines handleTestEvent as an instance field', async () => {
+        await assertCustomEnvironmentReportsTests('./ci-visibility/jestEnvironmentNoSuperInstanceField.js')
       })
     })
   })

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -599,6 +599,44 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           eventsPromise,
         ])
       })
+
+      it('reports test events when a custom environment does not call super.handleTestEvent', async () => {
+        const envVars = reportingOption === 'agentless'
+          ? getCiVisAgentlessConfig(receiver.port)
+          : getCiVisEvpProxyConfig(receiver.port)
+        if (reportingOption === 'evp proxy') {
+          receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+        }
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const resourceNames = tests.map(test => test.resource)
+
+            assertObjectContains(resourceNames, [
+              'ci-visibility/test/ci-visibility-test.js.ci visibility can report tests',
+            ])
+          })
+
+        childProcess = exec(
+          runTestsCommand,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CUSTOM_TEST_ENVIRONMENT: './ci-visibility/jestEnvironmentNoSuper.js',
+              TESTS_TO_RUN: 'test/ci-visibility-test.js',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 0)
+      })
     })
   })
 

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -649,6 +649,10 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       it('reports test events when a custom environment assigns handleTestEvent after setup', async () => {
         await assertCustomEnvironmentReportsTests('./ci-visibility/jestEnvironmentNoSuperAfterSetup.js')
       })
+
+      it('reports test events when a custom environment has an instance field and setup without super', async () => {
+        await assertCustomEnvironmentReportsTests('./ci-visibility/jestEnvironmentNoSuperSetupAndInstanceField.js')
+      })
     })
   })
 

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -437,6 +437,17 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         runAttemptToFixTest(done, { isAttemptToFix: true })
       })
 
+      it('can attempt to fix when a custom environment returns an async add_test result', (done) => {
+        receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+
+        runAttemptToFixTest(done, {
+          isAttemptToFix: true,
+          extraEnvVars: {
+            CUSTOM_TEST_ENVIRONMENT: './ci-visibility/jestEnvironmentAsyncAddTest.js',
+          },
+        })
+      })
+
       it('can attempt to fix and mark last attempt as passed if every attempt passes', (done) => {
         receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -462,6 +462,27 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
     }
 
     /**
+     * Rechecks custom `handleTestEvent` implementations after subclass instance fields
+     * and constructors have run.
+     *
+     * @returns {Promise<void>|void}
+     */
+    setup () {
+      this.wrapCustomHandleTestEvent(DatadogEnvironment.prototype.handleTestEvent)
+
+      if (super.setup) {
+        const result = super.setup()
+        if (typeof result?.then === 'function') {
+          return result.then(() => {
+            this.wrapCustomHandleTestEvent(DatadogEnvironment.prototype.handleTestEvent)
+          })
+        }
+        this.wrapCustomHandleTestEvent(DatadogEnvironment.prototype.handleTestEvent)
+        return result
+      }
+    }
+
+    /**
      * Ensures Datadog handles Jest circus events even when a custom environment overrides
      * `handleTestEvent` without calling `super.handleTestEvent`.
      *
@@ -488,6 +509,11 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             return datadogResult.then(() => value)
           }
           return value
+        }
+
+        if (event.name === 'add_test') {
+          runDatadogHandler(result)
+          return result
         }
 
         if (typeof result?.then === 'function') {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -89,6 +89,7 @@ const FLUSH_TIMEOUT = 10_000
 const JEST_SESSION_STATE = Symbol.for('dd-trace:jest:session')
 const JEST_BAIL_REPORTER_PATH = require.resolve('./jest/bail-reporter')
 const DD_JEST_HANDLE_TEST_EVENT_WRAPPED = Symbol('dd-trace:jest:handle-test-event-wrapped')
+const DD_JEST_HANDLE_TEST_EVENT_DATADOG = Symbol('dd-trace:jest:handle-test-event-datadog')
 const isJestWorker = !!getEnvironmentVariable('JEST_WORKER_ID')
 const jestSessionState = globalThis[JEST_SESSION_STATE] || (globalThis[JEST_SESSION_STATE] = {})
 
@@ -501,6 +502,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         }
       }
 
+      this[DD_JEST_HANDLE_TEST_EVENT_DATADOG] = DatadogEnvironment.prototype.handleTestEvent
       this.wrapCustomHandleTestEvent(DatadogEnvironment.prototype.handleTestEvent)
     }
 
@@ -2031,6 +2033,19 @@ function cleanupTestSuiteState (testSuiteAbsolutePath) {
   testSuiteJestObjects.delete(testSuiteAbsolutePath)
 }
 
+/**
+ * Rechecks custom handlers after Jest has finished constructing the environment.
+ *
+ * @param {object} environment
+ * @returns {void}
+ */
+function wrapEnvironmentCustomHandleTestEvent (environment) {
+  const datadogHandleTestEvent = environment[DD_JEST_HANDLE_TEST_EVENT_DATADOG]
+  if (typeof environment.wrapCustomHandleTestEvent === 'function' && datadogHandleTestEvent) {
+    environment.wrapCustomHandleTestEvent(datadogHandleTestEvent)
+  }
+}
+
 addHook({
   name: '@jest/core',
   file: 'build/TestScheduler.js',
@@ -2125,6 +2140,9 @@ function jestAdapterWrapper (jestAdapter, jestVersion) {
     if (!environment || !environment.testEnvironmentOptions) {
       return adapter.apply(this, args)
     }
+
+    wrapEnvironmentCustomHandleTestEvent(environment)
+
     testSuiteStartCh.publish({
       testSuite: environment.testSuite,
       testEnvironmentOptions: environment.testEnvironmentOptions,

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -376,6 +376,49 @@ function markDatadogJestEventHandled (event) {
   }
 }
 
+/**
+ * Wraps a custom Jest environment handler so Datadog still observes events even
+ * when the custom environment does not call `super.handleTestEvent`.
+ *
+ * @param {(event: object, state: object) => Promise<void>|void} handleTestEvent
+ * @param {(event: object, state: object) => Promise<void>|void} datadogHandleTestEvent
+ * @returns {(event: object, state: object) => Promise<void>|void}
+ */
+function getWrappedCustomHandleTestEvent (handleTestEvent, datadogHandleTestEvent) {
+  if (
+    !handleTestEvent ||
+    handleTestEvent === datadogHandleTestEvent ||
+    handleTestEvent[DD_JEST_HANDLE_TEST_EVENT_WRAPPED]
+  ) {
+    return handleTestEvent || datadogHandleTestEvent
+  }
+
+  const wrappedHandleTestEvent = function (event, state) {
+    const result = handleTestEvent.call(this, event, state)
+    const runDatadogHandler = value => {
+      if (isDatadogJestEventHandled(event)) return value
+
+      const datadogResult = datadogHandleTestEvent.call(this, event, state)
+      if (typeof datadogResult?.then === 'function') {
+        return datadogResult.then(() => value)
+      }
+      return value
+    }
+
+    if (event.name === 'add_test') {
+      runDatadogHandler(result)
+      return result
+    }
+
+    if (typeof result?.then === 'function') {
+      return result.then(runDatadogHandler)
+    }
+    return runDatadogHandler(result)
+  }
+  wrappedHandleTestEvent[DD_JEST_HANDLE_TEST_EVENT_WRAPPED] = true
+  return wrappedHandleTestEvent
+}
+
 function getWrappedEnvironment (BaseEnvironment, jestVersion) {
   return class DatadogEnvironment extends BaseEnvironment {
     constructor (config, context) {
@@ -490,38 +533,19 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
      * @returns {void}
      */
     wrapCustomHandleTestEvent (datadogHandleTestEvent) {
-      const handleTestEvent = this.handleTestEvent
-      if (
-        !handleTestEvent ||
-        handleTestEvent === datadogHandleTestEvent ||
-        handleTestEvent[DD_JEST_HANDLE_TEST_EVENT_WRAPPED]
-      ) {
-        return
-      }
+      const descriptor = Object.getOwnPropertyDescriptor(this, 'handleTestEvent')
+      let handleTestEvent = getWrappedCustomHandleTestEvent(this.handleTestEvent, datadogHandleTestEvent)
 
-      this.handleTestEvent = function (event, state) {
-        const result = handleTestEvent.call(this, event, state)
-        const runDatadogHandler = value => {
-          if (isDatadogJestEventHandled(event)) return value
-
-          const datadogResult = datadogHandleTestEvent.call(this, event, state)
-          if (typeof datadogResult?.then === 'function') {
-            return datadogResult.then(() => value)
-          }
-          return value
-        }
-
-        if (event.name === 'add_test') {
-          runDatadogHandler(result)
-          return result
-        }
-
-        if (typeof result?.then === 'function') {
-          return result.then(runDatadogHandler)
-        }
-        return runDatadogHandler(result)
-      }
-      this.handleTestEvent[DD_JEST_HANDLE_TEST_EVENT_WRAPPED] = true
+      Object.defineProperty(this, 'handleTestEvent', {
+        configurable: true,
+        enumerable: descriptor?.enumerable ?? false,
+        get () {
+          return handleTestEvent
+        },
+        set (value) {
+          handleTestEvent = getWrappedCustomHandleTestEvent(value, datadogHandleTestEvent)
+        },
+      })
     }
 
     /**

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -88,6 +88,7 @@ const CHILD_MESSAGE_CALL = 1
 const FLUSH_TIMEOUT = 10_000
 const JEST_SESSION_STATE = Symbol.for('dd-trace:jest:session')
 const JEST_BAIL_REPORTER_PATH = require.resolve('./jest/bail-reporter')
+const DD_JEST_HANDLE_TEST_EVENT_WRAPPED = Symbol('dd-trace:jest:handle-test-event-wrapped')
 const isJestWorker = !!getEnvironmentVariable('JEST_WORKER_ID')
 const jestSessionState = globalThis[JEST_SESSION_STATE] || (globalThis[JEST_SESSION_STATE] = {})
 
@@ -157,6 +158,7 @@ const wrappedWorkerInitializers = new WeakSet()
 const publishedRuntimeReferenceErrors = new WeakMap()
 const wrappedCoverageReporters = new WeakSet()
 const coverageReporterRequires = new WeakMap()
+const handledJestEvents = new WeakSet()
 
 const BREAKPOINT_HIT_GRACE_PERIOD_MS = 200
 const ATR_RETRY_SUPPRESSION_FLAG = '_ddDisableAtrRetry'
@@ -364,6 +366,16 @@ function wrapConsoleErrorForJestReferenceErrors () {
   }
 }
 
+function isDatadogJestEventHandled (event) {
+  return event && typeof event === 'object' && handledJestEvents.has(event)
+}
+
+function markDatadogJestEventHandled (event) {
+  if (event && typeof event === 'object') {
+    handledJestEvents.add(event)
+  }
+}
+
 function getWrappedEnvironment (BaseEnvironment, jestVersion) {
   return class DatadogEnvironment extends BaseEnvironment {
     constructor (config, context) {
@@ -445,6 +457,45 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           this.isImpactedTestsEnabled = false
         }
       }
+
+      this.wrapCustomHandleTestEvent(DatadogEnvironment.prototype.handleTestEvent)
+    }
+
+    /**
+     * Ensures Datadog handles Jest circus events even when a custom environment overrides
+     * `handleTestEvent` without calling `super.handleTestEvent`.
+     *
+     * @param {(event: object, state: object) => Promise<void>|void} datadogHandleTestEvent
+     * @returns {void}
+     */
+    wrapCustomHandleTestEvent (datadogHandleTestEvent) {
+      const handleTestEvent = this.handleTestEvent
+      if (
+        !handleTestEvent ||
+        handleTestEvent === datadogHandleTestEvent ||
+        handleTestEvent[DD_JEST_HANDLE_TEST_EVENT_WRAPPED]
+      ) {
+        return
+      }
+
+      this.handleTestEvent = function (event, state) {
+        const result = handleTestEvent.call(this, event, state)
+        const runDatadogHandler = value => {
+          if (isDatadogJestEventHandled(event)) return value
+
+          const datadogResult = datadogHandleTestEvent.call(this, event, state)
+          if (typeof datadogResult?.then === 'function') {
+            return datadogResult.then(() => value)
+          }
+          return value
+        }
+
+        if (typeof result?.then === 'function') {
+          return result.then(runDatadogHandler)
+        }
+        return runDatadogHandler(result)
+      }
+      this.handleTestEvent[DD_JEST_HANDLE_TEST_EVENT_WRAPPED] = true
     }
 
     /**
@@ -579,6 +630,9 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
     }
 
     async handleTestEvent (event, state) {
+      if (isDatadogJestEventHandled(event)) return
+      markDatadogJestEventHandled(event)
+
       if (super.handleTestEvent) {
         await super.handleTestEvent(event, state)
       }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Ensures dd-trace still reports Jest test events when a project uses a custom Jest environment that overrides `handleTestEvent` without calling `super.handleTestEvent`.

The Jest environment wrapper now detects custom `handleTestEvent` overrides and runs Datadog's event handler after the custom handler when the event has not already been handled.

### Motivation
<!-- What inspired you to submit this pull request? -->

While validating Test Optimization against `webpack/webpack`, the runbook reported session, module, and suite events, but zero test events. The project uses a custom Jest environment, and that environment shadows Datadog's Jest circus `handleTestEvent` hook. As a result, per-test events never reached the intake even though the broader Jest lifecycle was instrumented.

