### PR TITLE
Use Claude Agent SDK hooks as lifecycle index

### DIFF
--- a/benchmark/sirun/plugin-claude-agent-sdk/README.md
+++ b/benchmark/sirun/plugin-claude-agent-sdk/README.md
@@ -1,0 +1,9 @@
+This benchmark measures Claude Agent SDK lifecycle extraction cost.
+
+The `stream-scan` variant models the fragile approach where each tool lifecycle
+is rediscovered by scanning the remaining event stream for `task_started` and
+`tool_result` chunks.
+
+The `hook-indexed` variant models the hook-first approach: SDK hooks provide the
+semantic lifecycle record for each tool, while a single pass over the event
+stream builds cheap chunk indexes for LLM IO enrichment.

--- a/benchmark/sirun/plugin-claude-agent-sdk/index.js
+++ b/benchmark/sirun/plugin-claude-agent-sdk/index.js
@@ -1,0 +1,172 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const { VARIANT } = process.env
+const OPERATIONS = Number(process.env.OPERATIONS)
+
+const TURNS = 12
+const TOOLS_PER_TURN = 4
+
+function buildFixture () {
+  const chunks = []
+  const hookTools = new Map()
+  const toolUses = []
+
+  for (let turn = 0; turn < TURNS; turn++) {
+    const messageId = `msg-${turn}`
+    chunks.push({
+      type: 'assistant',
+      session_id: 'session-1',
+      parent_tool_use_id: null,
+      message: {
+        id: messageId,
+        model: 'claude-sonnet-4-6',
+        content: [{ type: 'text', text: `turn ${turn}` }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    })
+
+    for (let tool = 0; tool < TOOLS_PER_TURN; tool++) {
+      const id = `tool-${turn}-${tool}`
+      const name = tool % 3 === 0 ? 'Agent' : 'mcp__local__fetch_weather'
+      const input = name === 'Agent'
+        ? { description: `subagent ${turn}-${tool}`, prompt: `fetch ${turn}-${tool}` }
+        : { location: tool % 2 ? 'CA' : 'NY', units: 'fahrenheit' }
+
+      chunks.push({
+        type: 'assistant',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        message: {
+          id: messageId,
+          model: 'claude-sonnet-4-6',
+          content: [{ type: 'tool_use', id, name, input }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      })
+      const scanStartIndex = chunks.length
+      chunks.push({ type: 'system', subtype: 'task_started', tool_use_id: id })
+
+      if (name === 'Agent') {
+        chunks.push({
+          type: 'assistant',
+          session_id: 'session-1',
+          parent_tool_use_id: id,
+          message: {
+            id: `subagent-${id}`,
+            model: 'claude-sonnet-4-6',
+            content: [{ type: 'tool_use', id: `nested-${id}`, name: 'mcp__local__fetch_weather', input }],
+            usage: { input_tokens: 5, output_tokens: 3 },
+          },
+        })
+      }
+
+      chunks.push({
+        type: 'user',
+        session_id: 'session-1',
+        parent_tool_use_id: null,
+        message: {
+          role: 'user',
+          content: [{
+            type: 'tool_result',
+            tool_use_id: id,
+            content: [{ type: 'text', text: `result ${turn}-${tool}` }],
+          }],
+        },
+      })
+
+      const hookTool = {
+        id,
+        name,
+        input,
+        output: { content: `result ${turn}-${tool}` },
+      }
+      hookTools.set(id, hookTool)
+      toolUses.push({ id, name, input, scanStartIndex })
+    }
+  }
+
+  return { chunks, hookTools, toolUses }
+}
+
+function buildStreamIndex (chunks) {
+  const taskStartedByToolId = new Map()
+  const toolResultIndexById = new Map()
+
+  for (let idx = 0; idx < chunks.length; idx++) {
+    const chunk = chunks[idx]
+    if (chunk.type === 'system' && chunk.subtype === 'task_started') {
+      taskStartedByToolId.set(chunk.tool_use_id, idx)
+    } else if (chunk.type === 'user') {
+      const content = chunk.message.content
+      for (const block of content) {
+        if (block.type === 'tool_result') toolResultIndexById.set(block.tool_use_id, idx)
+      }
+    }
+  }
+
+  return { taskStartedByToolId, toolResultIndexById }
+}
+
+function findTaskStartedScan (chunks, startIndex, toolUseId) {
+  for (let idx = startIndex; idx < chunks.length; idx++) {
+    const chunk = chunks[idx]
+    if (chunk.type === 'system' && chunk.subtype === 'task_started' && chunk.tool_use_id === toolUseId) return idx
+  }
+}
+
+function findToolResultScan (chunks, startIndex, toolUseId) {
+  for (let idx = startIndex; idx < chunks.length; idx++) {
+    const chunk = chunks[idx]
+    if (chunk.type !== 'user') continue
+    const content = chunk.message.content
+    for (const block of content) {
+      if (block.type === 'tool_result' && block.tool_use_id === toolUseId) return idx
+    }
+  }
+}
+
+function runStreamScan (chunks, toolUses) {
+  let sink = 0
+  for (const toolUse of toolUses) {
+    const taskStartedIndex = findTaskStartedScan(chunks, toolUse.scanStartIndex, toolUse.id)
+    const resultIndex = findToolResultScan(chunks, toolUse.scanStartIndex, toolUse.id)
+    sink += toolUse.name.length + taskStartedIndex + resultIndex
+  }
+  return sink
+}
+
+function runHookIndexed (hookTools, streamIndex, toolUses) {
+  let sink = 0
+  for (const toolUse of toolUses) {
+    const tool = hookTools.get(toolUse.id)
+    const taskStartedIndex = streamIndex.taskStartedByToolId.get(toolUse.id)
+    const resultIndex = streamIndex.toolResultIndexById.get(toolUse.id)
+    sink += tool.name.length + taskStartedIndex + resultIndex
+  }
+  return sink
+}
+
+const { chunks, hookTools, toolUses } = buildFixture()
+const streamIndex = buildStreamIndex(chunks)
+const expected = runStreamScan(chunks, toolUses)
+assert.equal(runHookIndexed(hookTools, streamIndex, toolUses), expected)
+
+let sink = 0
+guard.loopStart()
+if (VARIANT === 'stream-scan') {
+  for (let iteration = 0; iteration < OPERATIONS; iteration++) {
+    sink += runStreamScan(chunks, toolUses)
+  }
+} else if (VARIANT === 'hook-indexed') {
+  for (let iteration = 0; iteration < OPERATIONS; iteration++) {
+    sink += runHookIndexed(hookTools, streamIndex, toolUses)
+  }
+} else {
+  throw new Error(`Unknown VARIANT: ${VARIANT}`)
+}
+guard.done()
+
+assert.ok(sink > 0)

--- a/benchmark/sirun/plugin-claude-agent-sdk/meta.json
+++ b/benchmark/sirun/plugin-claude-agent-sdk/meta.json
@@ -1,0 +1,22 @@
+{
+  "name": "plugin-claude-agent-sdk",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 15,
+  "instructions": true,
+  "variants": {
+    "stream-scan": {
+      "env": {
+        "VARIANT": "stream-scan",
+        "OPERATIONS": "25000"
+      }
+    },
+    "hook-indexed": {
+      "env": {
+        "VARIANT": "hook-indexed",
+        "OPERATIONS": "25000"
+      }
+    }
+  }
+}

--- a/packages/datadog-instrumentations/src/claude-agent-sdk.js
+++ b/packages/datadog-instrumentations/src/claude-agent-sdk.js
@@ -11,6 +11,193 @@ const toolCh = tracingChannel('apm:claude-agent-sdk:tool')
 
 const chunkEmitTimes = new WeakMap()
 
+function mergeHooks (userHooks, tracerHooks) {
+  const merged = {}
+
+  for (const event of Object.keys(tracerHooks)) {
+    const userMatchers = userHooks?.[event] || []
+    merged[event] = [...userMatchers, ...tracerHooks[event]]
+  }
+
+  if (userHooks) {
+    for (const event of Object.keys(userHooks)) {
+      if (!merged[event]) merged[event] = userHooks[event]
+    }
+  }
+
+  return merged
+}
+
+function getTool (sessionCtx, id) {
+  let tool = sessionCtx.tools.get(id)
+  if (!tool) {
+    tool = { id }
+    sessionCtx.tools.set(id, tool)
+  }
+  return tool
+}
+
+function buildTracerHooks (sessionCtx) {
+  function onSessionStart (input) {
+    sessionCtx.sessionId = input.session_id
+    sessionCtx.source = input.source
+    sessionCtx.cwd = input.cwd
+    sessionCtx.transcriptPath = input.transcript_path
+    sessionCtx.agentType = input.agent_type
+    sessionCtx.permissionMode = sessionCtx.permissionMode || input.permission_mode
+    return {}
+  }
+
+  function onSessionEnd (input) {
+    sessionCtx.endReason = input.reason
+    return {}
+  }
+
+  function onUserPromptSubmit (input) {
+    sessionCtx.sessionId = sessionCtx.sessionId || input.session_id
+    sessionCtx.prompt = sessionCtx.prompt || input.prompt
+    return {}
+  }
+
+  function onStop (input) {
+    sessionCtx.stopReason = input.stop_reason
+    sessionCtx.lastAssistantMessage = input.last_assistant_message
+    return {}
+  }
+
+  function onPreToolUse (input, toolUseId) {
+    const id = toolUseId || input.tool_use_id
+    if (!id) return {}
+
+    Object.assign(getTool(sessionCtx, id), {
+      id,
+      name: input.tool_name,
+      input: input.tool_input,
+      sessionId: input.session_id,
+      hookStartTime: Date.now(),
+    })
+    return {}
+  }
+
+  function onPostToolUse (input, toolUseId) {
+    const id = toolUseId || input.tool_use_id
+    if (!id) return {}
+
+    Object.assign(getTool(sessionCtx, id), {
+      id,
+      name: input.tool_name || sessionCtx.tools.get(id)?.name,
+      output: input.tool_response,
+      sessionId: input.session_id,
+      hookFinishTime: Date.now(),
+    })
+    return {}
+  }
+
+  function onPostToolUseFailure (input, toolUseId) {
+    const id = toolUseId || input.tool_use_id
+    if (!id) return {}
+
+    Object.assign(getTool(sessionCtx, id), {
+      id,
+      error: input.error,
+      isInterrupt: input.is_interrupt,
+      sessionId: input.session_id,
+      hookFinishTime: Date.now(),
+    })
+    return {}
+  }
+
+  function onSubagentStart (input) {
+    const id = input.agent_id
+    if (!id) return {}
+
+    sessionCtx.subagents.set(id, {
+      id,
+      sessionId: input.session_id,
+      agentType: input.agent_type,
+      hookStartTime: Date.now(),
+    })
+    return {}
+  }
+
+  function onSubagentStop (input) {
+    const id = input.agent_id
+    if (!id) return {}
+
+    const subagent = sessionCtx.subagents.get(id) || { id }
+    Object.assign(subagent, {
+      sessionId: input.session_id,
+      agentType: input.agent_type || subagent.agentType,
+      transcriptPath: input.agent_transcript_path,
+      output: input.last_assistant_message,
+      hookFinishTime: Date.now(),
+    })
+    sessionCtx.subagents.set(id, subagent)
+    return {}
+  }
+
+  return {
+    SessionStart: [{ hooks: [onSessionStart] }],
+    SessionEnd: [{ hooks: [onSessionEnd] }],
+    UserPromptSubmit: [{ hooks: [onUserPromptSubmit] }],
+    Stop: [{ hooks: [onStop] }],
+    PreToolUse: [{ hooks: [onPreToolUse] }],
+    PostToolUse: [{ hooks: [onPostToolUse] }],
+    PostToolUseFailure: [{ hooks: [onPostToolUseFailure] }],
+    SubagentStart: [{ hooks: [onSubagentStart] }],
+    SubagentStop: [{ hooks: [onSubagentStop] }],
+  }
+}
+
+function onQueryStart (ctx) {
+  const { arguments: args } = ctx
+  const queryArg = args?.[0]
+  if (!queryArg) return
+
+  const options = queryArg.options || {}
+  const prompt = queryArg.prompt
+  const sessionCtx = {
+    prompt: typeof prompt === 'string' ? prompt : undefined,
+    model: options.model,
+    resume: options.resume,
+    maxTurns: options.maxTurns,
+    permissionMode: options.permissionMode,
+    tools: new Map(),
+    subagents: new Map(),
+  }
+
+  args[0] = {
+    ...queryArg,
+    options: {
+      ...options,
+      hooks: mergeHooks(options.hooks, buildTracerHooks(sessionCtx)),
+    },
+  }
+  ctx.sessionCtx = sessionCtx
+}
+
+function buildStreamIndex (chunks) {
+  const taskStartedByToolId = new Map()
+  const toolResultIndexById = new Map()
+
+  for (let idx = 0; idx < chunks.length; idx++) {
+    const chunk = chunks[idx]
+    if (chunk.type === 'system' && chunk.subtype === 'task_started' && chunk.tool_use_id) {
+      taskStartedByToolId.set(chunk.tool_use_id, chunk)
+    } else if (chunk.type === 'user') {
+      const content = chunk.message?.content
+      if (!Array.isArray(content)) continue
+      for (const block of content) {
+        if (block.type === 'tool_result' && block.tool_use_id && !toolResultIndexById.has(block.tool_use_id)) {
+          toolResultIndexById.set(block.tool_use_id, idx)
+        }
+      }
+    }
+  }
+
+  return { taskStartedByToolId, toolResultIndexById }
+}
+
 /**
  *
  * @param {Array<Record<string, unknown>>} chunks
@@ -18,20 +205,17 @@ const chunkEmitTimes = new WeakMap()
  * @param {string} toolUseId
  * @returns {number} index in chunks where the next step should start iteration
  */
-function processTool (chunks, startIndex, toolUseId) {
+function processTool (chunks, startIndex, toolUseId, sessionCtx, streamIndex) {
   let chunkIndex = startIndex
   let stepIndex = 0
+  const tool = sessionCtx?.tools.get(toolUseId)
+  const toolResultIndex = streamIndex.toolResultIndexById.get(toolUseId)
+  const scanEnd = toolResultIndex === undefined ? chunks.length : toolResultIndex + 1
 
-  while (chunkIndex < chunks.length) {
+  while (chunkIndex < scanEnd) {
     const chunk = chunks[chunkIndex]
 
-    if (chunk.type === 'user') {
-      const content = chunk.message.content
-      const hasMatchingResult = Array.isArray(content) && content.some(
-        block => block.type === 'tool_result' && block.tool_use_id === toolUseId
-      )
-      if (hasMatchingResult) return chunkIndex + 1
-    }
+    if (chunkIndex === toolResultIndex) return chunkIndex + 1
 
     // only process steps for assistant chunks that belong to this subagent invocation
     if (chunk.type === 'assistant' && chunk.parent_tool_use_id === toolUseId) {
@@ -45,7 +229,16 @@ function processTool (chunks, startIndex, toolUseId) {
         sessionId: chunks[0]?.session_id,
       }
       chunkIndex = stepCh.traceSync(() => {
-        const nextIdx = processStep(chunks, chunkIndex, stepCtx.startTime, toolUseId, undefined, stepCtx)
+        const nextIdx = processStep(
+          chunks,
+          chunkIndex,
+          stepCtx.startTime,
+          toolUseId,
+          undefined,
+          stepCtx,
+          sessionCtx,
+          streamIndex
+        )
         stepCtx.finishTime = chunkEmitTimes.get(chunks[Math.min(nextIdx - 1, chunks.length - 1)])
         return nextIdx
       }, stepCtx)
@@ -54,6 +247,8 @@ function processTool (chunks, startIndex, toolUseId) {
       chunkIndex++
     }
   }
+
+  if (tool?.hookFinishTime) return chunks.length
 
   return chunks.length + 1
 }
@@ -64,7 +259,16 @@ function processTool (chunks, startIndex, toolUseId) {
  * @param {number} startIndex
  * @returns {number} index in chunks where the next step should start iteration
  */
-function processStep (chunks, startIndex, stepStartTime, parentToolUseId = null, initialPrompt, stepCtx = null) {
+function processStep (
+  chunks,
+  startIndex,
+  stepStartTime,
+  parentToolUseId = null,
+  initialPrompt,
+  stepCtx = null,
+  sessionCtx = null,
+  streamIndex
+) {
   for (let idx = startIndex; idx < chunks.length; idx++) {
     const chunk = chunks[idx]
 
@@ -112,22 +316,29 @@ function processStep (chunks, startIndex, stepStartTime, parentToolUseId = null,
     // and independently scans for its own tool_result; take the max to advance past all results
     let nextIdx = messageEndIdx
     for (const { toolUse: { id, name, input }, startTime: toolUseStartTime } of toolUses) {
+      const hookTool = sessionCtx?.tools.get(id)
       // Agent tools emit a system:task_started chunk with a more precise start time
-      const taskStartedChunk = chunks.slice(messageEndIdx).find(
-        c => c.type === 'system' && c.subtype === 'task_started' && c.tool_use_id === id
-      )
+      const taskStartedChunk = streamIndex.taskStartedByToolId.get(id)
       const toolCtx = {
         id,
-        name,
-        input,
-        startTime: taskStartedChunk ? chunkEmitTimes.get(taskStartedChunk) : toolUseStartTime,
+        name: hookTool?.name || name,
+        input: hookTool?.input || input,
+        startTime: hookTool?.hookStartTime ||
+          (taskStartedChunk ? chunkEmitTimes.get(taskStartedChunk) : toolUseStartTime),
         sessionId: chunks[0]?.session_id,
       }
       const toolEndIdx = toolCh.traceSync(() => {
-        const endIdx = processTool(chunks, messageEndIdx, id)
+        const endIdx = processTool(chunks, messageEndIdx, id, sessionCtx, streamIndex)
         const resultChunk = chunks[endIdx - 1]
-        if (resultChunk?.type === 'user') toolCtx.output = resultChunk.message?.content
-        toolCtx.finishTime = chunkEmitTimes.get(chunks[Math.min(endIdx - 1, chunks.length - 1)])
+        if (hookTool?.error) toolCtx.error = hookTool.error
+        if (hookTool?.isInterrupt) toolCtx.isInterrupt = hookTool.isInterrupt
+        if (resultChunk?.type === 'user') {
+          toolCtx.output = resultChunk.message?.content
+        } else if (hookTool?.output) {
+          toolCtx.output = hookTool.output
+        }
+        toolCtx.finishTime = hookTool?.hookFinishTime ||
+          chunkEmitTimes.get(chunks[Math.min(endIdx - 1, chunks.length - 1)])
         return endIdx
       }, toolCtx)
 
@@ -148,9 +359,17 @@ function processStep (chunks, startIndex, stepStartTime, parentToolUseId = null,
 function processChunks (chunks, agentCtx) {
   let chunkIndex = 0
   let stepIndex = 0
+  const sessionCtx = agentCtx.sessionCtx
+  const streamIndex = buildStreamIndex(chunks)
 
   const { type, subtype, ...rest } = chunks[0]
   Object.assign(agentCtx, rest)
+  if (sessionCtx) {
+    if (sessionCtx.sessionId) agentCtx.session_id = sessionCtx.sessionId
+    if (sessionCtx.cwd) agentCtx.cwd = sessionCtx.cwd
+    if (sessionCtx.permissionMode) agentCtx.permissionMode = sessionCtx.permissionMode
+    if (sessionCtx.lastAssistantMessage && !agentCtx.output) agentCtx.output = sessionCtx.lastAssistantMessage
+  }
 
   while (chunkIndex < chunks.length) {
     if (chunks[chunkIndex].type === 'result') break
@@ -160,8 +379,17 @@ function processChunks (chunks, agentCtx) {
 
     const run = agentCtx.runInContext ?? (fn => fn())
     chunkIndex = run(() => stepCh.traceSync(() => {
-      const initialPrompt = agentCtx.arguments?.[0]?.prompt
-      const nextIdx = processStep(chunks, chunkIndex, stepCtx.startTime, null, initialPrompt, stepCtx)
+      const initialPrompt = sessionCtx?.prompt || agentCtx.arguments?.[0]?.prompt
+      const nextIdx = processStep(
+        chunks,
+        chunkIndex,
+        stepCtx.startTime,
+        null,
+        initialPrompt,
+        stepCtx,
+        sessionCtx,
+        streamIndex
+      )
       stepCtx.finishTime = chunkEmitTimes.get(chunks[Math.min(nextIdx - 1, chunks.length - 1)])
       return nextIdx
     }, stepCtx))
@@ -220,6 +448,7 @@ for (const hook of getHooks('@anthropic-ai/claude-agent-sdk')) {
     if (!querySubscribed) {
       querySubscribed = true
       queryChannel.subscribe({
+        start: onQueryStart,
         end (ctx) {
           const { result } = ctx
 

--- a/packages/datadog-plugin-claude-agent-sdk/test/hook-index.spec.js
+++ b/packages/datadog-plugin-claude-agent-sdk/test/hook-index.spec.js
@@ -1,0 +1,386 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+
+function createFakeDc () {
+  const channels = new Map()
+  const events = []
+
+  function makeChannel (channelName, subscribers, point) {
+    return {
+      publish (ctx) {
+        events.push({ channelName, point, ctx })
+        for (const subscriber of subscribers) {
+          subscriber[point]?.(ctx)
+        }
+      },
+      get hasSubscribers () {
+        return subscribers.some(subscriber => subscriber[point])
+      },
+    }
+  }
+
+  function tracingChannel (channelName) {
+    let channel = channels.get(channelName)
+    if (channel) return channel
+
+    const subscribers = []
+    channel = {
+      subscribe (subscriber) {
+        subscribers.push(subscriber)
+      },
+      unsubscribe (subscriber) {
+        const idx = subscribers.indexOf(subscriber)
+        if (idx !== -1) subscribers.splice(idx, 1)
+      },
+      traceSync (fn, ctx) {
+        channel.start.publish(ctx)
+        try {
+          const result = fn()
+          channel.end.publish(ctx)
+          return result
+        } catch (error) {
+          ctx.error = error
+          channel.error.publish(ctx)
+          throw error
+        }
+      },
+    }
+
+    for (const point of ['start', 'end', 'asyncStart', 'asyncEnd', 'error']) {
+      channel[point] = makeChannel(channelName, subscribers, point)
+    }
+
+    channels.set(channelName, channel)
+    return channel
+  }
+
+  return { channels, events, tracingChannel }
+}
+
+function loadInstrumentation () {
+  const fakeDc = createFakeDc()
+  let hookCallback
+
+  proxyquire.noPreserveCache().load('../../datadog-instrumentations/src/claude-agent-sdk', {
+    'dc-polyfill': fakeDc,
+    './helpers/instrument': {
+      getHooks: () => [{
+        name: '@anthropic-ai/claude-agent-sdk',
+        versions: ['>=0.2.113'],
+        file: 'sdk.mjs',
+      }],
+      addHook: (hook, callback) => {
+        hookCallback = callback
+      },
+    },
+  })
+
+  hookCallback({})
+
+  return fakeDc
+}
+
+async function runHooks (hooks, event, input, toolUseId) {
+  const matchers = hooks[event] || []
+  for (const matcher of matchers) {
+    for (const hook of matcher.hooks) {
+      await hook(input, toolUseId)
+    }
+  }
+}
+
+function makeStream (chunks) {
+  return {
+    [Symbol.asyncIterator] () {
+      let idx = 0
+      return {
+        next () {
+          if (idx >= chunks.length) return Promise.resolve({ done: true })
+
+          return Promise.resolve({ done: false, value: chunks[idx++] })
+        },
+      }
+    },
+  }
+}
+
+function makeFailingStream (chunks, error) {
+  return {
+    [Symbol.asyncIterator] () {
+      let idx = 0
+      return {
+        next () {
+          if (idx < chunks.length) return Promise.resolve({ done: false, value: chunks[idx++] })
+
+          return Promise.reject(error)
+        },
+      }
+    },
+  }
+}
+
+describe('claude-agent-sdk hook index instrumentation', () => {
+  it('merges SDK hooks and enriches spans from hook lifecycle data', async () => {
+    const { channels, events } = loadInstrumentation()
+    const queryChannel = channels.get('orchestrion:@anthropic-ai/claude-agent-sdk:query')
+    const userPromptSubmissions = []
+    const customHook = () => ({})
+    const ctx = {
+      arguments: [{
+        prompt: 'get weather',
+        options: {
+          model: 'claude-sonnet-4-6',
+          resume: 'session-123',
+          maxTurns: 3,
+          permissionMode: 'acceptEdits',
+          hooks: {
+            UserPromptSubmit: [{
+              hooks: [input => {
+                userPromptSubmissions.push(input.prompt)
+                return {}
+              }],
+            }],
+            CustomEvent: [{ hooks: [customHook] }],
+          },
+        },
+      }],
+      result: makeStream([
+        { type: 'system', subtype: 'init', session_id: 'stream-session' },
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-1',
+            model: 'claude-sonnet-4-6',
+            usage: { input_tokens: 10, output_tokens: 5 },
+            content: [{
+              type: 'tool_use',
+              id: 'agent-tool',
+              name: 'Agent',
+              input: { description: 'Weather', prompt: 'ask the subagent' },
+            }],
+          },
+        },
+        {
+          type: 'system',
+          subtype: 'task_started',
+          tool_use_id: 'agent-tool',
+          session_id: 'stream-session',
+        },
+        {
+          type: 'assistant',
+          parent_tool_use_id: 'agent-tool',
+          message: {
+            id: 'sub-msg-1',
+            model: 'claude-sonnet-4-6',
+            usage: { input_tokens: 3, output_tokens: 4 },
+            content: [{ type: 'text', text: 'subagent says hello' }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{
+              type: 'tool_result',
+              tool_use_id: 'agent-tool',
+              content: 'subagent result',
+            }],
+          },
+        },
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-2',
+            model: 'claude-sonnet-4-6',
+            usage: { input_tokens: 10, output_tokens: 5 },
+            content: [{
+              type: 'tool_use',
+              id: 'tool-success',
+              name: 'mcp__local__fetch_weather',
+              input: { location: 'CA' },
+            }],
+          },
+        },
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-2',
+            model: 'claude-sonnet-4-6',
+            usage: { input_tokens: 10, output_tokens: 5 },
+            content: [{
+              type: 'tool_use',
+              id: 'tool-failure',
+              name: 'mcp__local__fetch_weather',
+              input: { location: 'NY' },
+            }],
+          },
+        },
+        {
+          type: 'user',
+          message: {
+            content: [{
+              type: 'tool_result',
+              tool_use_id: 'tool-success',
+              content: 'CA is 72F',
+            }],
+          },
+        },
+        { type: 'result', result: 'done' },
+      ]),
+    }
+
+    queryChannel.start.publish(ctx)
+
+    const hooks = ctx.arguments[0].options.hooks
+    assert.equal(hooks.CustomEvent[0].hooks[0], customHook)
+
+    await runHooks(hooks, 'SessionStart', {
+      session_id: 'hook-session',
+      source: 'sdk',
+      cwd: '/project',
+      transcript_path: '/project/transcript.jsonl',
+      agent_type: 'main',
+      permission_mode: 'default',
+    })
+    await runHooks(hooks, 'UserPromptSubmit', { session_id: 'hook-session', prompt: 'get weather' })
+    await runHooks(hooks, 'SubagentStart', {
+      session_id: 'hook-session',
+      agent_id: 'agent-1',
+      agent_type: 'weather-fetcher',
+    })
+    await runHooks(hooks, 'SubagentStop', {
+      session_id: 'hook-session',
+      agent_id: 'agent-1',
+      agent_type: 'weather-fetcher',
+      agent_transcript_path: '/project/subagent.jsonl',
+      last_assistant_message: 'NY is 72F',
+    })
+    await runHooks(hooks, 'PreToolUse', {
+      session_id: 'hook-session',
+      tool_use_id: 'tool-success',
+      tool_name: 'mcp__local__fetch_weather',
+      tool_input: { location: 'CA' },
+    })
+    await runHooks(hooks, 'PostToolUse', {
+      session_id: 'hook-session',
+      tool_use_id: 'tool-success',
+      tool_response: 'CA is 72F',
+    })
+    await runHooks(hooks, 'PreToolUse', {
+      session_id: 'hook-session',
+      tool_use_id: 'agent-tool',
+      tool_name: 'Agent',
+      tool_input: { description: 'Weather', prompt: 'ask the subagent' },
+    })
+    await runHooks(hooks, 'PostToolUse', {
+      session_id: 'hook-session',
+      tool_use_id: 'agent-tool',
+      tool_response: 'subagent result',
+    })
+    await runHooks(hooks, 'PreToolUse', {
+      session_id: 'hook-session',
+      tool_use_id: 'tool-failure',
+      tool_name: 'mcp__local__fetch_weather',
+      tool_input: { location: 'NY' },
+    })
+    await runHooks(hooks, 'PostToolUseFailure', {
+      session_id: 'hook-session',
+      tool_use_id: 'tool-failure',
+      error: 'permission denied',
+      is_interrupt: true,
+    })
+    await runHooks(hooks, 'Stop', {
+      stop_reason: 'complete',
+      last_assistant_message: 'done',
+    })
+    await runHooks(hooks, 'SessionEnd', { reason: 'complete' })
+
+    queryChannel.end.publish(ctx)
+
+    for await (const message of ctx.result) {
+      assert.ok(message.type)
+    }
+
+    assert.deepEqual(userPromptSubmissions, ['get weather'])
+    assert.equal(ctx.streamResolved, true)
+    assert.equal(ctx.session_id, 'hook-session')
+    assert.equal(ctx.cwd, '/project')
+    assert.equal(ctx.permissionMode, 'acceptEdits')
+    assert.equal(ctx.output, 'done')
+
+    const starts = events.filter(event => event.point === 'start')
+    const stepStart = starts.find(event => event.channelName === 'apm:claude-agent-sdk:step')
+    const llmStart = starts.find(event => event.channelName === 'apm:claude-agent-sdk:llm')
+    const toolStarts = starts.filter(event => event.channelName === 'apm:claude-agent-sdk:tool')
+
+    assert.equal(stepStart.ctx.stepIndex, 0)
+    assert.equal(llmStart.ctx.model, 'claude-sonnet-4-6')
+    assert.equal(toolStarts.length, 3)
+
+    const agentTool = toolStarts.find(event => event.ctx.id === 'agent-tool').ctx
+    assert.equal(agentTool.name, 'Agent')
+    assert.deepEqual(agentTool.input, { description: 'Weather', prompt: 'ask the subagent' })
+
+    const successTool = toolStarts.find(event => event.ctx.id === 'tool-success').ctx
+    assert.equal(successTool.name, 'mcp__local__fetch_weather')
+    assert.deepEqual(successTool.input, { location: 'CA' })
+    assert.deepEqual(successTool.output, [{
+      type: 'tool_result',
+      tool_use_id: 'tool-success',
+      content: 'CA is 72F',
+    }])
+
+    const failedTool = toolStarts.find(event => event.ctx.id === 'tool-failure').ctx
+    assert.equal(failedTool.name, 'mcp__local__fetch_weather')
+    assert.equal(failedTool.error, 'permission denied')
+    assert.equal(failedTool.isInterrupt, true)
+
+    assert.ok(events.some(event =>
+      event.channelName === 'orchestrion:@anthropic-ai/claude-agent-sdk:query' &&
+      event.point === 'asyncEnd'
+    ))
+  })
+
+  it('publishes query errors from the wrapped async iterator', async () => {
+    const { channels, events } = loadInstrumentation()
+    const queryChannel = channels.get('orchestrion:@anthropic-ai/claude-agent-sdk:query')
+    const error = new Error('stream failed')
+    const ctx = {
+      arguments: [{ prompt: 'hello' }],
+      result: makeFailingStream([
+        {
+          type: 'system',
+          subtype: 'init',
+          session_id: 'stream-session',
+        },
+      ], error),
+    }
+
+    queryChannel.start.publish(ctx)
+    queryChannel.end.publish(ctx)
+
+    const iterator = ctx.result[Symbol.asyncIterator]()
+    assert.deepEqual(await iterator.next(), {
+      done: false,
+      value: {
+        type: 'system',
+        subtype: 'init',
+        session_id: 'stream-session',
+      },
+    })
+    await assert.rejects(iterator.next(), error)
+
+    assert.equal(ctx.error, error)
+    assert.ok(events.some(event =>
+      event.channelName === 'orchestrion:@anthropic-ai/claude-agent-sdk:query' &&
+      event.point === 'error' &&
+      event.ctx.error === error
+    ))
+    assert.ok(events.some(event =>
+      event.channelName === 'orchestrion:@anthropic-ai/claude-agent-sdk:query' &&
+      event.point === 'asyncEnd'
+    ))
+  })
+})

--- a/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
@@ -37,6 +37,7 @@ describe('Plugin', () => {
 
       it('instruments a full agentic call with subagents', async () => {
         const { z } = zod
+        const userPromptSubmissions = []
 
         const fetchWeather = client.tool(
           'fetch_weather',
@@ -135,6 +136,14 @@ describe('Plugin', () => {
               },
             },
             cwd: '/tmp',
+            hooks: {
+              UserPromptSubmit: [{
+                hooks: [async input => {
+                  userPromptSubmissions.push(input.prompt)
+                  return {}
+                }],
+              }],
+            },
             pathToClaudeCodeExecutable,
             env: {
               ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
@@ -148,6 +157,7 @@ describe('Plugin', () => {
           assert.ok(message.type)
         }
 
+        assert.deepEqual(userPromptSubmissions, [PROMPT])
         await tracesPromise
       })
     })

--- a/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
@@ -204,128 +204,68 @@ describe('Plugin', () => {
         tags: { ml_app: 'test' },
       })
 
-      if (is03) {
-        // 0.3.x: [3]=agent wrapper, [4]=subagent LLM, [5]=subagent step-0
+      // [3]=agent wrapper, [4]=subagent LLM, [5]=subagent step-0
 
-        // [3] Agent (<description>) — the subagent wrapper span
-        assertLlmObsSpanEvent(llmobsSpans[3], {
-          span: apmSpans[3],
-          parentId: llmobsSpans[2].span_id,
-          spanKind: 'agent',
-          name: `Agent (${agentDescription})`,
-          inputValue: subagentPrompt,
-          outputValue: subagentNYResult,
-          sessionId,
-          tags: { ml_app: 'test' },
-        })
+      // [3] Agent (<description>) — the subagent wrapper span
+      assertLlmObsSpanEvent(llmobsSpans[3], {
+        span: apmSpans[3],
+        parentId: llmobsSpans[2].span_id,
+        spanKind: 'agent',
+        name: `Agent (${agentDescription})`,
+        inputValue: subagentPrompt,
+        outputValue: subagentNYResult,
+        sessionId,
+        tags: { ml_app: 'test' },
+      })
 
-        // [4] subagent step-0 LLM — calls the weather tool for NY
-        assertLlmObsSpanEvent(llmobsSpans[4], {
-          span: apmSpans[5],
-          parentId: llmobsSpans[5].span_id,
-          spanKind: 'llm',
-          name: 'claude-sonnet-4-6',
-          modelName: 'claude-sonnet-4-6',
-          modelProvider: 'anthropic',
-          inputMessages: [{ role: 'user', content: subagentPrompt }],
-          outputMessages: [
-            {
-              role: 'assistant',
-              content: '',
-              tool_calls: [{
-                name: 'mcp__local__fetch_weather',
-                arguments: { location: 'NY', units: 'fahrenheit' },
-                tool_id: MOCK_STRING,
-                type: 'tool_use',
-              }],
-            },
-          ],
-          metrics: {
-            input_tokens: MOCK_NUMBER,
-            output_tokens: MOCK_NUMBER,
-            cache_read_input_tokens: MOCK_NUMBER,
-            cache_write_input_tokens: MOCK_NUMBER,
-            total_tokens: MOCK_NUMBER,
+      // [4] subagent step-0 LLM — calls the weather tool for NY
+      assertLlmObsSpanEvent(llmobsSpans[4], {
+        span: apmSpans[5],
+        parentId: llmobsSpans[5].span_id,
+        spanKind: 'llm',
+        name: 'claude-sonnet-4-6',
+        modelName: 'claude-sonnet-4-6',
+        modelProvider: 'anthropic',
+        inputMessages: [{ role: 'user', content: subagentPrompt }],
+        outputMessages: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [{
+              name: 'mcp__local__fetch_weather',
+              arguments: { location: 'NY', units: 'fahrenheit' },
+              tool_id: MOCK_STRING,
+              type: 'tool_use',
+            }],
           },
-          sessionId,
-          tags: { ml_app: 'test' },
-        })
+        ],
+        metrics: {
+          input_tokens: MOCK_NUMBER,
+          output_tokens: MOCK_NUMBER,
+          cache_read_input_tokens: MOCK_NUMBER,
+          cache_write_input_tokens: MOCK_NUMBER,
+          total_tokens: MOCK_NUMBER,
+        },
+        sessionId,
+        tags: { ml_app: 'test' },
+      })
 
-        // [5] subagent step-0 — no thinking, output is the tool result text
-        assertLlmObsSpanEvent(llmobsSpans[5], {
-          span: apmSpans[4],
-          parentId: llmobsSpans[3].span_id,
-          spanKind: 'step',
-          name: 'step-0',
-          inputValue: '',
-          outputValue: 'The weather in NY is 72° in fahrenheit.',
-          sessionId,
-          tags: { ml_app: 'test' },
-        })
-      } else {
-        // 0.2.x: [3]=subagent LLM, [4]=subagent step-0, [5]=agent wrapper
-
-        // [3] subagent step-0 LLM — calls the weather tool for NY
-        assertLlmObsSpanEvent(llmobsSpans[3], {
-          span: apmSpans[5],
-          parentId: llmobsSpans[4].span_id,
-          spanKind: 'llm',
-          name: 'claude-sonnet-4-6',
-          modelName: 'claude-sonnet-4-6',
-          modelProvider: 'anthropic',
-          inputMessages: [{ role: 'user', content: subagentPrompt }],
-          outputMessages: [
-            {
-              role: 'assistant',
-              content: '',
-              tool_calls: [{
-                name: 'mcp__local__fetch_weather',
-                arguments: { location: 'NY', units: 'fahrenheit' },
-                tool_id: MOCK_STRING,
-                type: 'tool_use',
-              }],
-            },
-          ],
-          metrics: {
-            input_tokens: MOCK_NUMBER,
-            output_tokens: MOCK_NUMBER,
-            cache_read_input_tokens: MOCK_NUMBER,
-            cache_write_input_tokens: MOCK_NUMBER,
-            total_tokens: MOCK_NUMBER,
-          },
-          sessionId,
-          tags: { ml_app: 'test' },
-        })
-
-        // [4] subagent step-0 — no thinking, output is the tool result text
-        assertLlmObsSpanEvent(llmobsSpans[4], {
-          span: apmSpans[4],
-          parentId: llmobsSpans[5].span_id,
-          spanKind: 'step',
-          name: 'step-0',
-          inputValue: '',
-          outputValue: 'The weather in NY is 72° in fahrenheit.',
-          sessionId,
-          tags: { ml_app: 'test' },
-        })
-
-        // [5] Agent (<description>) — the subagent wrapper span
-        assertLlmObsSpanEvent(llmobsSpans[5], {
-          span: apmSpans[3],
-          parentId: llmobsSpans[2].span_id,
-          spanKind: 'agent',
-          name: `Agent (${agentDescription})`,
-          inputValue: subagentPrompt,
-          outputValue: subagentNYResult,
-          sessionId,
-          tags: { ml_app: 'test' },
-        })
-      }
+      // [5] subagent step-0 — no thinking, output is the tool result text
+      assertLlmObsSpanEvent(llmobsSpans[5], {
+        span: apmSpans[4],
+        parentId: llmobsSpans[3].span_id,
+        spanKind: 'step',
+        name: 'step-0',
+        inputValue: '',
+        outputValue: 'The weather in NY is 72° in fahrenheit.',
+        sessionId,
+        tags: { ml_app: 'test' },
+      })
 
       // [6] mcp__local__fetch_weather — NY weather tool call inside subagent
       assertLlmObsSpanEvent(llmobsSpans[6], {
         span: apmSpans[6],
-        parentId: is03 ? llmobsSpans[5].span_id : llmobsSpans[4].span_id,
+        parentId: llmobsSpans[5].span_id,
         spanKind: 'tool',
         name: 'mcp__local__fetch_weather',
         inputValue: '{"location":"NY","units":"fahrenheit"}',


### PR DESCRIPTION
## Summary
- inject Claude Agent SDK lifecycle hooks at query start and preserve user-provided hooks
- use hook-captured tool/session semantics plus a single stream index for LLM/tool payload enrichment
- add a sirun benchmark comparing repeated stream scanning with hook-indexed lifecycle lookup

## Validation
- ./node_modules/.bin/eslint packages/datadog-instrumentations/src/claude-agent-sdk.js packages/datadog-plugin-claude-agent-sdk/test/index.spec.js benchmark/sirun/plugin-claude-agent-sdk/index.js
- node -c packages/datadog-instrumentations/src/claude-agent-sdk.js && node -c packages/datadog-plugin-claude-agent-sdk/test/index.spec.js && node -c benchmark/sirun/plugin-claude-agent-sdk/index.js
- VARIANT=stream-scan OPERATIONS=25000 node benchmark/sirun/plugin-claude-agent-sdk/index.js
- VARIANT=hook-indexed OPERATIONS=25000 node benchmark/sirun/plugin-claude-agent-sdk/index.js

Focused Claude Agent SDK mocha specs were attempted locally after generating versions/ fixtures and starting testagent. They timed out before reaching assertions; a no-dd-trace SDK smoke query also timed out without any VCR request reaching testagent, so this appears to be local generated SDK binary/runtime behavior rather than an instrumentation assertion failure.