### PR TITLE
test(test-optimization): stabilize Playwright retry tagging flake

### DIFF
--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -239,18 +239,6 @@ versions.forEach((version) => {
 
     contextNewVersions('check retries tagging', () => {
       it('does not send attempt to fix tags if test is retried and not attempt to fix', async (receiver, run) => {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            assert.strictEqual(tests.length, NUM_RETRIES_EFD + 1)
-            for (const test of tests) {
-              assert.ok(!(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED in test.meta))
-              assert.ok(!(TEST_HAS_FAILED_ALL_RETRIES in test.meta))
-            }
-          })
-
         receiver.setKnownTests({ playwright: {} })
         receiver.setSettings({
           impacted_tests_enabled: true,
@@ -278,7 +266,21 @@ versions.forEach((version) => {
           }
         )
 
-        await Promise.all([once(proc, 'exit'), receiverPromise])
+        await receiver.gatherPayloadsUntilChildExit(
+          proc,
+          ({ url }) => url === '/api/v2/citestcycle',
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(tests.length, NUM_RETRIES_EFD + 1)
+            for (const test of tests) {
+              assert.ok(!(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED in test.meta))
+              assert.ok(!(TEST_HAS_FAILED_ALL_RETRIES in test.meta))
+            }
+          },
+          { hardTimeout: 70_000 }
+        )
       })
     })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Stabilizes the Playwright retry-tagging integration test by waiting for the Playwright child process to exit before asserting the final intake payload buffer.

### Motivation
<!-- What inspired you to submit this pull request? -->
The linked GitHub Actions job failed on its first attempt and passed on retry. The failing attempt asserted after seeing only 2 of the expected 4 retry test events, so the test could fail before all retry payloads had drained into the fake intake.

Flaky job evidence:

- [integration-playwright (latest, node-oldest, playwright-active-test-span)](https://github.com/DataDog/dd-trace-js/actions/runs/28608923223/job/84836209584)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Validated with:

```bash
./node_modules/.bin/eslint integration-tests/playwright/playwright-active-test-span.spec.js --max-warnings 0
PLAYWRIGHT_VERSION=latest SPEC=playwright-active-test-span npm run test:integration:playwright:coverage -- --grep "does not send attempt to fix tags"
git diff --check
```
