### PR TITLE
fix(profiling): abort profile upload on socket timeout

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -42,6 +42,19 @@ function sendRequest (options, form, callback) {
   storage('legacy').run({ noop: true }, () => {
     requestCounter.inc()
     const start = perf.now()
+
+    // Ensure the callback runs at most once per request. The 'timeout' handler
+    // below can fire after a response was already received (e.g. on a lingering
+    // keep-alive socket, once it goes idle); without this guard that would
+    // invoke the callback a second time and corrupt the retry accounting in
+    // AgentExporter.export.
+    let settled = false
+    const done = (err, res) => {
+      if (settled) return
+      settled = true
+      callback(err, res)
+    }
+
     const req = request(options, res => {
       durationDistribution.track(perf.now() - start)
       countStatusCode(res.statusCode)
@@ -49,16 +62,28 @@ function sendRequest (options, form, callback) {
         statusCodeErrorCounter.inc()
         const error = new Error(`HTTP Error ${res.statusCode}`)
         error.status = res.statusCode
-        callback(error)
+        done(error)
       } else {
-        callback(null, res)
+        done(null, res)
       }
     })
 
     req.on('error', (err) => {
       networkErrorCounter.inc()
-      callback(err)
+      done(err)
     })
+
+    // `options.timeout` sets the socket's idle timeout, which only emits a
+    // 'timeout' event — per the Node docs it does NOT abort the request. Without
+    // destroying the socket here, a stalled upload hangs indefinitely: no
+    // 'error' fires, so the retry/backoff in AgentExporter.export never runs and
+    // the export promise never settles. Destroying the request makes the
+    // 'error' handler above run, which drives the retry (see the trace exporter
+    // in ../common/request.js, which likewise aborts the request on timeout).
+    req.on('timeout', () => {
+      req.destroy(new Error(`Profiling agent export timed out after ${options.timeout}ms`))
+    })
+
     if (form) {
       sizeDistribution.track(form.size())
       form.pipe(req)

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -266,7 +266,12 @@ describe('exporters/agent', function () {
     })
 
     it('should backoff up to the uploadTimeout', async () => {
-      const uploadTimeout = 100
+      // The socket timeout is enforced now (see sendRequest), and the test
+      // agent runs in this same process, so the per-attempt timeout must be
+      // comfortably larger than the in-process request handling. Otherwise the
+      // timeout would fire before the handler's 500/destroy response and this
+      // test would assert on a timeout error instead of the intended HTTP 500.
+      const uploadTimeout = 2000
       const exporter = newAgentExporter({ url, uploadTimeout })
 
       const start = new Date()
@@ -318,6 +323,37 @@ describe('exporters/agent', function () {
         // Retry is 1-indexed so add 1 to i
         assert.strictEqual(call.args[0].timeout, initialTimeout * 2 ** (i + 1))
       }
+    })
+
+    it('should time out and reject instead of hanging when the agent never responds', async function () {
+      // Regression test: options.timeout only emits a 'timeout' event, it does
+      // not abort the socket. Without a handler that destroys the request, a
+      // stalled upload hangs forever — the export promise never settles and
+      // this test would time out. The mocha timeout below is the guard.
+      this.timeout(10000)
+
+      const uploadTimeout = 100
+      const exporter = newAgentExporter({ url, uploadTimeout })
+      const start = new Date()
+      const end = new Date()
+      const tags = { 'runtime-id': RUNTIME_ID }
+      const profiles = await createProfiles()
+
+      // Never respond: hold every request open so the client socket times out.
+      app.post('/profiling/v1/input', upload.any(), () => {})
+
+      let failed = false
+      try {
+        await exporter.export({ profiles, start, end, tags })
+      } catch {
+        failed = true
+      }
+
+      assert.strictEqual(failed, true, 'export should reject after exhausting timeout retries, not hang')
+      // computeRetries(100) => 1 initial attempt + retries, so the timeout must
+      // have been enforced repeatedly rather than the first attempt hanging.
+      assert.ok(http.request.getCalls().length > 1,
+        `expected multiple attempts (timeout enforced + retried), got ${http.request.getCalls().length}`)
     })
 
     it('should log exports and handle http errors gracefully', async function () {


### PR DESCRIPTION
## What does this PR do?

Makes the profiling agent exporter enforce its upload timeout by destroying the request on the socket `'timeout'` event, and guards the request callback so it runs at most once.

## Motivation

The exporter sets `options.timeout` on the upload request (`this.#backoffTime * 2 ** attempt`) but never registered a `'timeout'` handler. Per the [Node http docs](https://nodejs.org/api/http.html#event-timeout) the `'timeout'` event is informational only — it does **not** abort the socket. So a stalled upload (a connection that hangs on a loaded/shared host's network stack, even to a local agent) never emitted `'error'`: the retry/backoff in `AgentExporter.export` never ran and the returned promise never settled.

In practice this surfaced as a flaky/hung profile upload on shutdown: a worker's final `beforeExit` flush would block indefinitely on the stalled request, keeping the process alive until it was force-killed and losing that profile. The trace exporter (`exporters/common/request.js`) already aborts on timeout; only the profiling exporter was missing the equivalent.

This essentially brings the behavior in line with how the trace exporter behaves. 

NB: Node.js profiler is the only profiler that bothers with retries; other language profilers nonchalantly drop the profile if the first communication attempt with the agent fails. We could rethink if we want to go in that direction, but for now fixing the bug in existing retrying behavior feels like a good incremental fix.

## Changes

- `req.on('timeout', () => req.destroy(...))` in `sendRequest` — the destroy surfaces as an `'error'`, which drives the existing retry/backoff (and eventual rejection), instead of hanging forever.
- Guard the request callback so it runs at most once. The `'timeout'` can fire *after* a response was already received (e.g. on a lingering keep-alive socket once it goes idle); without the guard that invokes the callback a second time and corrupts the retry accounting.
- Regression test: asserts the export **rejects after retrying** rather than hanging when the agent never responds (guarded by the mocha timeout — it hangs without the fix).
- Adjusted the existing "should backoff up to the uploadTimeout" test: its `uploadTimeout` was unrealistically small (50ms first attempt), which — now that the timeout is actually enforced — raced the in-process test agent's response. Bumped it so the HTTP-error retries it means to exercise aren't pre-empted by a socket timeout.

## Testing

`packages/dd-trace/test/profiling/exporters/agent.spec.js`: 8 passing, ESLint clean; the new timeout test and the backoff test are stable across repeated runs.

Jira: [PROF-15326]

[PROF-15326]: https://datadoghq.atlassian.net/browse/PROF-15326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ