### PR TITLE
chore(test): add in patch for failing orchestrion rewrites with nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "env": "bash ./plugin-env",
-    "prepare": "node scripts/patch-istanbul-lib-coverage.js && cd vendor && npm ci --include=dev",
+    "prepare": "node scripts/patch-istanbul-lib-coverage.js && node scripts/patch-append-transform.js && cd vendor && npm ci --include=dev",
     "prepack": "node scripts/release/swap-v5-types.js",
     "bench": "node benchmark/index.js",
     "bench:e2e:test-optimization": "node benchmark/e2e-test-optimization/benchmark-run.js",

--- a/scripts/patch-append-transform.js
+++ b/scripts/patch-append-transform.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+'use strict'
+
+/*
+ * Apply the missing arg-forwarding fix to the locked `append-transform`
+ * install (required by `istanbul-lib-hook`, which is required by `nyc`). The
+ * package's `replacementCompile` calls `module._compile(code, filename)` with
+ * just two arguments and drops anything else. Node 22+ passes a third
+ * `format` argument to `Module.prototype._compile` for ESM modules loaded
+ * synchronously via `require()`, and our rewriter relies on that arg to
+ * pick the ESM transformer. Under coverage, the strip reaches our rewriter
+ * as `format === undefined`, ESM-only packages (e.g. `ai@7`) get treated as
+ * CJS, and the CJS transformer splices `require()` into ESM source — the
+ * file then crashes at load with "require is not defined in ES module scope".
+ *
+ * Idempotent — no-ops while the current sentinel is present. When the patch
+ * body changes, the bumped sentinel makes it replace a stale dd-trace-js
+ * patch in place, so existing installs self-heal on the next `prepare`
+ * instead of keeping the old body. Fails loudly only if the upstream
+ * `replacementCompile` shape changes, so a future yarn upgrade can't
+ * silently leave it unapplied.
+ *
+ * Wired to the `prepare` lifecycle so the script never fires on consumer
+ * installs of the published tarball — the script itself is not in the
+ * `files` allowlist. `prepare` also fires under `npm pack`, whose stdout is
+ * captured by `FILENAME=$(npm pack --silent …)` in CI; all diagnostic output
+ * therefore goes to stderr so the tarball name on stdout stays clean.
+ *
+ * Upstream is effectively unmaintained (last release 2019, pre-dates Node's
+ * require-of-ESM support); no point chasing a PR there. See
+ * https://github.com/istanbuljs/append-transform/blob/v2.0.0/index.js#L57-L61
+ * for the upstream code being replaced.
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const SENTINEL = '// dd-trace-js patch v1: forward extra args (Node 22+ ESM format)'
+
+const PATCH_MARKER = '// dd-trace-js patch'
+
+// Upstream `append-transform/index.js` is tab-indented at 4 tabs for the
+// `replacementCompile` assignment / closing `};`, and 5 tabs for the body.
+const ORIGINAL = '\t\t\t\tmodule._compile = function replacementCompile(code, filename) {\n' +
+  '\t\t\t\t\tmodule._compile = originalCompile;\n' +
+  '\t\t\t\t\tcode = transform(code, filename);\n' +
+  '\t\t\t\t\tmodule._compile(code, filename);\n' +
+  '\t\t\t\t};'
+
+const REPLACEMENT = '\t\t\t\tmodule._compile = function replacementCompile(code, filename, ...rest) {\n' +
+  `\t\t\t\t\t${SENTINEL}\n` +
+  '\t\t\t\t\tmodule._compile = originalCompile;\n' +
+  '\t\t\t\t\tcode = transform(code, filename);\n' +
+  '\t\t\t\t\tmodule._compile(code, filename, ...rest);\n' +
+  '\t\t\t\t};'
+
+// Matches the whole `replacementCompile` assignment (pristine or already
+// patched) so a body change can be swapped in place. Upstream uses tabs at
+// 4 levels of indentation for the assignment and its closing `};`.
+const REPLACEMENT_COMPILE_RE = /\t{4}module\._compile = function replacementCompile\([\s\S]*?\n\t{4}\};/
+
+/**
+ * @param {string} message
+ */
+function log (message) {
+  process.stderr.write(`patch-append-transform: ${message}\n`)
+}
+
+/**
+ * @param {string} message
+ */
+function fail (message) {
+  process.stderr.write(`patch-append-transform: ${message}\n`)
+  process.exitCode = 1
+}
+
+const repoRoot = path.resolve(__dirname, '..')
+
+// Belt-and-braces guard against running from somewhere other than the
+// dd-trace-js source checkout, in case a future change moves the script
+// invocation off the `prepare` lifecycle.
+const requiredMarkers = [
+  path.join(repoRoot, 'eslint.config.mjs'),
+  path.join(repoRoot, 'packages', 'datadog-instrumentations'),
+]
+
+for (const marker of requiredMarkers) {
+  if (!fs.existsSync(marker)) {
+    log(`skipping: not running inside the dd-trace-js source checkout (missing ${path.relative(repoRoot, marker)})`)
+    return
+  }
+}
+
+// `append-transform` is a transitive dep of `nyc`, not a direct dependency,
+// so avoid `require.resolve` (which would trip `n/no-extraneous-require`) and
+// look up the file by its conventional location instead.
+const targetFile = path.join(repoRoot, 'node_modules', 'append-transform', 'index.js')
+if (!fs.existsSync(targetFile)) {
+  log('skipping: append-transform is not installed yet')
+  return
+}
+
+const source = fs.readFileSync(targetFile, 'utf8')
+const relativeTarget = path.relative(repoRoot, targetFile)
+
+if (source.includes(SENTINEL)) {
+  log(`already patched at ${relativeTarget}`)
+  return
+}
+
+const existing = source.match(REPLACEMENT_COMPILE_RE)
+if (existing === null) {
+  fail(
+    `refusing to patch ${relativeTarget}: could not locate replacementCompile. ` +
+    'Re-verify the patch against the new upstream code before bumping append-transform.'
+  )
+  return
+}
+
+// Pristine upstream must match (modulo whitespace) the captured ORIGINAL;
+// anything else without our marker means upstream shape changed and the
+// patch needs re-verifying. A body carrying the marker is an earlier patch
+// version and is replaced in place.
+const current = existing[0]
+const normalize = (str) => str.replaceAll(/\s+/g, ' ').trim()
+if (normalize(current) !== normalize(ORIGINAL) && !current.includes(PATCH_MARKER)) {
+  fail(
+    `refusing to patch ${relativeTarget}: upstream replacementCompile shape has changed. ` +
+    'Re-verify the patch against the new upstream code before bumping append-transform.'
+  )
+  return
+}
+
+fs.writeFileSync(targetFile, source.replace(current, REPLACEMENT))
+log(`patched ${relativeTarget}`)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds in a patch for one of the dependencies in `nyc` which is causing ESM-first packages to fail being orchestrion re-written in unit tests. This is because for `Module._compile`, it fails to pass in the `format` argument: https://github.com/istanbuljs/append-transform/blob/3e0547f68eacb10e85dbcbf1ac539df83afae751/index.js#L57-L61

Because of this, the orchestrion rewriter we have defaults to falling back to CJS, causing issues in tests. While there could be the fix of trying to actually identify the module kind / format if `format` is undefined, I believe this is an appropriate blanket fix for now. However, since I am not a domain expert, open to changing this!

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix ESM-first orchestrion rewrites in unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

AI generated. Related to issues in the following PRs:

1. https://github.com/DataDog/dd-trace-js/pull/8949 (this branch has the same fix)
2. https://github.com/DataDog/dd-trace-js/pull/7974 (has a different fix at a lower scope, but this one should apply as well).


