### PR TITLE
fix(ssi): run ssi in current proposal branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ configure_system_tests:
       when: never
     - if: $DANGEROUSLY_SKIP_SHARED_PIPELINE_TESTS == "true"
       when: never
-    - if: $CI_COMMIT_BRANCH == "master" || $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME =~ /^v\d+\.\d+\.\d+-proposal$/ || $CI_MERGE_REQUEST_LABELS =~ /run-ssi-tests/
+    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH =~ /^v6\.\d+\.\d+-proposal$/
       when: on_success
     - when: never
 
@@ -71,7 +71,7 @@ system_tests:
       when: never
     - if: $DANGEROUSLY_SKIP_SHARED_PIPELINE_TESTS == "true"
       when: never
-    - if: $CI_COMMIT_BRANCH == "master" || $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME =~ /^v\d+\.\d+\.\d+-proposal$/ || $CI_MERGE_REQUEST_LABELS =~ /run-ssi-tests/
+    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH =~ /^v6\.\d+\.\d+-proposal$/
       when: on_success
     - when: never
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR fixes the SSI test guard. Previously, SSI tests only ran on master because CI_MERGE_REQUEST_LABELS and CI_MERGE_REQUEST_SOURCE_BRANCH_NAME are only available during GitLab merge requests. Since this is a GitHub merge, those variables are not available, causing the condition to always evaluate to false.

Because labels are not currently accessible by gitlab in GitHub merges, running SSI tests using the run-ssi-tests label is not supported at the moment.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


