### PR TITLE
ci(plugin-env): read apm-integrations.yml after workflow rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -445,6 +445,8 @@ You can also run the tests for multiple plugins at once by separating them with 
 PLUGINS="amqplib|bluebird" yarn test:plugins
 ```
 
+The necessary shell commands for the setup can also be executed at once by the `yarn env` script.
+
 ### Other Unit Tests
 
 There are several types of unit tests, for various types of components. The

--- a/plugin-env
+++ b/plugin-env
@@ -13,7 +13,7 @@ if [ -z "$plugin_name" ]; then
   node - << EOF
     const fs=require('fs');
     const yaml = require('yaml');
-    const pluginsData = fs.readFileSync('.github/workflows/plugins.yml', 'utf8');
+    const pluginsData = fs.readFileSync('.github/workflows/apm-integrations.yml', 'utf8');
     const env=Object.keys(yaml.parse(pluginsData).jobs);
     console.log(...env);
 EOF
@@ -36,7 +36,7 @@ fi
 read -r PLUGINS SERVICES <<<$(node - << EOF
 const fs=require('fs');
 const yaml = require('yaml');
-const pluginsData = fs.readFileSync('.github/workflows/plugins.yml', 'utf8');
+const pluginsData = fs.readFileSync('.github/workflows/apm-integrations.yml', 'utf8');
 const { PLUGINS, SERVICES } = yaml.parse(pluginsData).jobs['$plugin_name'].env;
 console.log(PLUGINS || '', SERVICES || '')
 EOF


### PR DESCRIPTION
## Summary

`npm run env` / `yarn env` reads `.github/workflows/plugins.yml` to list the plugin jobs and their `PLUGINS` / `SERVICES` values, but that workflow was renamed to `apm-integrations.yml`, so the script fails with ENOENT before it can open a plugin dev shell.

## Drive-by

Mention the `yarn env` script in CONTRIBUTING.md.