### PR TITLE
perf(graphql): reuse filtered variables across resolve spans

### DIFF
--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -34,6 +34,11 @@ const patchedTypes = new WeakSet()
 // when depth=0 disables resolver instrumentation.
 let depthDisabled = false
 
+// Initial key for the per-operation variables-filter cache. A unique sentinel
+// so the first #filterVariables call never falsely matches, even when the
+// operation's variableValues is undefined.
+const NO_VARIABLES_CACHED = Symbol('noVariablesCached')
+
 class AbortError extends Error {
   constructor (message) {
     super(message)
@@ -179,6 +184,10 @@ class GraphQLExecutePlugin extends TracingPlugin {
       abortController,
       executeSpan: span,
       plugin: this,
+      // graphql.resolve variable tags: memoize the filtered result for the
+      // last-seen variableValues object (see #filterVariables).
+      filteredVariablesKey: NO_VARIABLES_CACHED,
+      filteredVariables: undefined,
     }
     ctx.ddRootCtx = rootCtx
     if (isWeakMapKey(contextValue)) {
@@ -291,7 +300,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
     field.span = span
 
     if (fieldNode && this.config.variables && fieldNode.arguments) {
-      const variables = this.config.variables(variableValues)
+      const variables = this.#filterVariables(rootCtx, variableValues)
       for (const arg of fieldNode.arguments) {
         if (arg.value?.name && arg.value.kind === 'Variable' && variables[arg.value.name.value]) {
           const name = arg.value.name.value
@@ -301,6 +310,27 @@ class GraphQLExecutePlugin extends TracingPlugin {
     }
 
     return span
+  }
+
+  // Memoize the user variables filter against the last-seen variableValues
+  // object. graphql hands every resolver in one execute the same coerced
+  // variableValues object, so all arg-bearing fields hit the identity fast
+  // path and the filter runs once per operation. A nested execute() sharing
+  // the same object contextValue reuses the outer rootCtx but carries its own
+  // variableValues; comparing by identity recomputes for it (and any later
+  // fields on that inner object reuse the slot), so each field's tags stay
+  // correct. A single slot beats a WeakMap here: no per-operation allocation,
+  // and the common single-object case is a bare `===` (see the microbenchmark
+  // numbers in the commit body).
+  #filterVariables (rootCtx, variableValues) {
+    if (rootCtx.filteredVariablesKey === variableValues) {
+      return rootCtx.filteredVariables
+    }
+
+    const filtered = this.config.variables(variableValues)
+    rootCtx.filteredVariablesKey = variableValues
+    rootCtx.filteredVariables = filtered
+    return filtered
   }
 
   // Public — called from wrapResolve. endTime reflects when the resolver

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2000,6 +2000,89 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with nested executions sharing a contextValue', () => {
+        before(() => {
+          tracer = require('../../dd-trace')
+
+          return agent.load('graphql', {
+            variables: variables => variables,
+          })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          graphql = require(`../../../versions/graphql@${version}`).get()
+        })
+
+        // A resolver that re-enters execute() with the same object contextValue
+        // (Apollo federation and stitching do this) is short-circuited by the
+        // plugin and its resolvers reuse the outer operation's context. The
+        // per-resolver variable tags must still come from each field's own
+        // variableValues, not the outer operation's.
+        it('tags each resolve span with its own operation variables', () => {
+          const outerDocument = graphql.parse('query Outer($x: String) { outer(x: $x) }')
+          const innerDocument = graphql.parse('query Inner($y: String) { inner(y: $y) }')
+
+          const nestedSchema = new graphql.GraphQLSchema({
+            query: new graphql.GraphQLObjectType({
+              name: 'NestedQuery',
+              fields: {
+                outer: {
+                  type: graphql.GraphQLString,
+                  args: { x: { type: graphql.GraphQLString } },
+                  resolve (source, args, contextValue) {
+                    return graphql.execute({
+                      schema: nestedSchema,
+                      document: innerDocument,
+                      contextValue,
+                      variableValues: { y: 'inner' },
+                    }).then(result => `outer:${result.data.inner}`)
+                  },
+                },
+                inner: {
+                  type: graphql.GraphQLString,
+                  args: { y: { type: graphql.GraphQLString } },
+                  resolve () {
+                    return 'inner-value'
+                  },
+                },
+              },
+            }),
+          })
+
+          const resolveSpans = new Map()
+          const assertion = agent.assertSomeTraces(traces => {
+            for (const trace of traces) {
+              for (const span of trace) {
+                if (span.name === 'graphql.resolve') resolveSpans.set(span.resource, span)
+              }
+            }
+
+            const outerSpan = resolveSpans.get('outer:String')
+            const innerSpan = resolveSpans.get('inner:String')
+            assert.ok(outerSpan, 'expected an outer graphql.resolve span')
+            assert.ok(innerSpan,
+              `expected an inner graphql.resolve span, got: ${[...resolveSpans.keys()].join(', ')}`)
+
+            assert.strictEqual(outerSpan.meta['graphql.variables.x'], 'outer')
+            assert.strictEqual(innerSpan.meta['graphql.variables.y'], 'inner')
+          }, { timeoutMs: 3000 })
+
+          const contextValue = {}
+          const execution = graphql.execute({
+            schema: nestedSchema,
+            document: outerDocument,
+            contextValue,
+            variableValues: { x: 'outer' },
+          })
+
+          return Promise.all([assertion, execution])
+        })
+      })
+
       describe('with an array of variable names', () => {
         before(() => {
           tracer = require('../../dd-trace')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2000,6 +2000,73 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with multiple argument-bearing fields in one operation', () => {
+        let variableFilterCalls
+
+        before(() => {
+          tracer = require('../../dd-trace')
+
+          return agent.load('graphql', {
+            variables: variables => {
+              variableFilterCalls += 1
+              return variables
+            },
+          })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          variableFilterCalls = 0
+          graphql = require(`../../../versions/graphql@${version}`).get()
+          buildSchema()
+        })
+
+        // graphql coerces variableValues once per execute and hands the same
+        // object to every resolver, so the plugin memoizes the user filter on
+        // the operation and reuses it across every argument-bearing field. The
+        // two sibling fields must each still be tagged only with their own
+        // arguments from that shared filtered object, and the filter must not
+        // re-run per field.
+        it('reuses the filtered variables across sibling resolve spans', () => {
+          const source = `
+            query TwoFields($name: String!, $title: String!) {
+              first: hello(name: $name)
+              second: hello(title: $title)
+            }
+          `
+          const variableValues = { name: 'world', title: 'planet' }
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const resolveSpans = sort(traces[0]).filter(span => span.name === 'graphql.resolve')
+
+            assert.strictEqual(resolveSpans.length, 2)
+
+            const nameSpan = resolveSpans.find(span => 'graphql.variables.name' in span.meta)
+            const titleSpan = resolveSpans.find(span => 'graphql.variables.title' in span.meta)
+
+            assert.ok(nameSpan, 'expected a resolve span tagged with the name variable')
+            assert.ok(titleSpan, 'expected a resolve span tagged with the title variable')
+            assert.strictEqual(nameSpan.meta['graphql.variables.name'], 'world')
+            assert.strictEqual(titleSpan.meta['graphql.variables.title'], 'planet')
+            assert.ok(!('graphql.variables.title' in nameSpan.meta))
+            assert.ok(!('graphql.variables.name' in titleSpan.meta))
+          }, { spanResourceMatch: /TwoFields/ })
+
+          return Promise.all([
+            assertion,
+            graphql.graphql({ schema, source, variableValues }).then(() => {
+              // One call tags the execute span; the second is the memoized
+              // resolve-path call shared by both fields. Without the cache the
+              // second field would trigger a third call.
+              assert.strictEqual(variableFilterCalls, 2)
+            }),
+          ])
+        })
+      })
+
       describe('with nested executions sharing a contextValue', () => {
         before(() => {
           tracer = require('../../dd-trace')


### PR DESCRIPTION
## Summary

The `graphql.resolve` variable tags run the user-supplied `config.variables` filter once for every instrumented field that carries arguments, even though graphql coerces `variableValues` once per execute and hands the same object to every resolver. Caching the filtered result on the execute context runs the filter once per operation instead.

## Why

The reduction (once-per-argument-bearing-field to once-per-execute) is structural and safe by inspection: the same filter runs against the same coerced `variableValues` object, so the produced tags are identical. Draft until I run a microbenchmark on a representative deep query to confirm the win is worth keeping.