### PR TITLE
fix(core): release finished span from async context to prevent unbounded span retention

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -33,12 +33,17 @@ class RouterPlugin extends WebPlugin {
       const span = this.#getMiddlewareSpan(name, childOf)
       context = this.#updateContext(req, context, route, childOf)
 
+      context.storeStack.push(store)
+      const enteredStore = this.enter(span, store)
+
       if (childOf !== span) {
         context.middleware.push(span)
+        // Track the store this middleware span was entered into so its `span`
+        // reference can be released when the request finishes. Otherwise an
+        // async resource created inside the middleware body snapshots this store
+        // and pins the finished span (and its parent chain) forever.
+        context.middlewareStores.push(enteredStore)
       }
-
-      context.storeStack.push(store)
-      this.enter(span, store)
 
       web.patch(req)
       web.setRoute(req, context.route)
@@ -91,6 +96,22 @@ class RouterPlugin extends WebPlugin {
       while ((span = context.middleware.pop())) {
         span.finish()
       }
+
+      // The request/response is fully done, so no async continuation can still
+      // need these spans as the active span. Release every store a middleware
+      // span was entered into (whether the span finished during the request or
+      // just now above), dropping the `span` reference so any async resource
+      // that captured that store no longer retains the finished span or its
+      // parent chain. This is what prevents the unbounded span retention leak.
+      //
+      // Release only happens here (never at `middleware:finish`, which fires
+      // before `next.apply(...)`), so work a middleware schedules to run after
+      // `next()` still sees the correct active span for trace continuity.
+      let store
+
+      while ((store = context.middlewareStores.pop())) {
+        this.releaseSpan(store)
+      }
     })
   }
 
@@ -130,14 +151,17 @@ class RouterPlugin extends WebPlugin {
       return context
     }
 
-    // Five-property shape pinned at allocation so every request shares the
-    // same hidden class — no per-field transitions after construction.
+    // Fixed shape pinned at allocation so every request shares the same hidden
+    // class — no per-field transitions after construction.
     context = {
       span,
       stack: [route],
       route,
       middleware: [],
       storeStack: [],
+      // Parallel to `middleware`: the store each middleware span was entered
+      // into, released at request finish so captured frames stop retaining it.
+      middlewareStores: [],
     }
 
     this.#contexts.set(req, context)

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { AsyncResource } = require('node:async_hooks')
 const assert = require('node:assert/strict')
 const { once } = require('node:events')
 const http = require('node:http')
@@ -8,6 +9,7 @@ const axios = require('axios')
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 
 const agent = require('../../dd-trace/test/plugins/agent')
+const { storage } = require('../../datadog-core')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
@@ -149,6 +151,99 @@ describe('Plugin', () => {
               .get(`http://localhost:${port}/parent/child/123`)
               .catch(done)
           })
+        })
+
+        it('should release finished middleware spans from the store captured in-request', async () => {
+          // Regression test for unbounded router.middleware span retention.
+          //
+          // dd-trace activates each middleware span with
+          // `AsyncLocalStorage.enterWith({ ...store, span })`. Any async resource
+          // created while that store is active snapshots the frame and keeps the
+          // store — and its `span` — reachable for the resource's whole lifetime,
+          // even after the span finishes. A never-released resource therefore
+          // pins the finished span (and its parent chain) forever. The fix nulls
+          // the store's `span` when the request finishes.
+          //
+          // Here we mimic a never-released resource by capturing, from inside a
+          // middleware, the exact store object the middleware span was entered
+          // into. After the request completes we assert that store no longer
+          // references the (now finished) span.
+          const router = Router()
+
+          let capturedStore
+
+          router.use((req, res, next) => {
+            // The store active here is the one the middleware span was entered
+            // into; a real async resource created now would capture it.
+            capturedStore = storage('legacy').getStore()
+            assert.ok(capturedStore)
+            assert.ok(capturedStore.span, 'middleware span should be active in-request')
+
+            // A concrete async resource that snapshots the same frame, standing
+            // in for the never-released handles seen in production.
+            const resource = new AsyncResource('test-resource')
+            resource.runInAsyncScope(() => {})
+
+            next()
+          })
+          router.get('/foo', (req, res) => {
+            res.end()
+          })
+
+          const httpd = server(router).listen(0, 'localhost')
+          await once(httpd, 'listening')
+          const port = httpd.address().port
+          await axios.get(`http://localhost:${port}/foo`)
+
+          // Once the request has finished, the span reference must have been
+          // released from the captured store so the finished span is collectable
+          // even though the captured store (and any resource holding it) lives on.
+          assert.strictEqual(capturedStore.span, null)
+        })
+
+        it('should keep the active span for async work scheduled after next() while in-flight', async () => {
+          // Continuity regression test. `middleware:finish` is published BEFORE
+          // `next.apply(...)`, so releasing the entered store at middleware finish
+          // would clobber the active span for any callback the middleware
+          // schedules to run after `next()` — orphaning its spans and breaking
+          // log correlation. Releasing only at request finish preserves it.
+          //
+          // Here a middleware schedules a `setImmediate` after calling `next()`;
+          // the route handler waits for that callback before ending the response,
+          // so the assertion runs while the request is still in-flight (after
+          // middleware finish, before request finish).
+          const tracer = require('../../dd-trace')
+          const router = Router()
+
+          let activeInDeferredWork = 'unset'
+          let deferredDone
+          const deferred = new Promise(resolve => { deferredDone = resolve })
+
+          router.use((req, res, next) => {
+            next()
+
+            // Runs after next() returns, i.e. after this middleware's
+            // `middleware:finish` has already fired, but while the request is
+            // still being handled.
+            setImmediate(() => {
+              activeInDeferredWork = tracer.scope().active()
+              deferredDone()
+            })
+          })
+          router.get('/foo', async (req, res) => {
+            await deferred
+            res.end()
+          })
+
+          const httpd = server(router).listen(0, 'localhost')
+          await once(httpd, 'listening')
+          const port = httpd.address().port
+          await axios.get(`http://localhost:${port}/foo`)
+
+          // The deferred callback must still have seen an active span (the
+          // request/middleware span), not null.
+          assert.notStrictEqual(activeInDeferredWork, 'unset', 'deferred work should have run')
+          assert.ok(activeInDeferredWork, 'deferred work after next() should still have an active span')
         })
 
         it('should not error a span when using next("route") with a string', async () => {

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -100,11 +100,47 @@ module.exports = class Plugin {
    *
    * @param {object} span The span to bind as current.
    * @param {object=} store Optional existing store to extend; if omitted, uses current store.
-   * @returns {void}
+   * @returns {object} The store object that was entered, so callers can later
+   * release its `span` reference via {@link Plugin#releaseSpan}.
    */
   enter (span, store) {
     store = store || legacyStorage.getStore()
-    legacyStorage.enterWith({ ...store, span })
+    // The entered store is a fresh object captured by the current async-context
+    // frame (and by any async resource created while this store is active).
+    // Return it so callers can later release its `span` reference once that span
+    // has finished, preventing finished spans from being retained for the life
+    // of any async resource that snapshotted the frame. See `releaseSpan`.
+    const enteredStore = { ...store, span }
+    legacyStorage.enterWith(enteredStore)
+    return enteredStore
+  }
+
+  /**
+   * Release the finished span from a store previously produced by `enter()`.
+   *
+   * `enter()` activates a span by writing a `{ ...store, span }` object into the
+   * current async-context frame. Any async resource created while that store is
+   * active snapshots the frame and therefore keeps the store — and its `span`
+   * property — reachable for the resource's entire lifetime, even after the span
+   * has finished. For never-released resources (subscriptions, un-removed
+   * listeners, queued callbacks) this pins finished spans forever, leaking the
+   * whole parent chain via each span's own captured store.
+   *
+   * Callers must only release a store once no further work can legitimately read
+   * its span as the active span — i.e. after the operation and any of its
+   * in-scope async continuation is done. Releasing too early (e.g. while a
+   * callback scheduled by the operation is still pending) would orphan that
+   * callback's spans and break log correlation. Once it is safe, nulling the
+   * reference lets the finished span (and its parent chain) be garbage collected
+   * while the capturing resource lives on.
+   *
+   * @param {object=} store A store object returned by `enter()`.
+   * @returns {void}
+   */
+  releaseSpan (store) {
+    if (store && store.span) {
+      store.span = null
+    }
   }
 
   /**

--- a/packages/dd-trace/test/plugins/plugin.spec.js
+++ b/packages/dd-trace/test/plugins/plugin.spec.js
@@ -77,6 +77,48 @@ describe('Plugin', () => {
     assert.strictEqual(plugin._enabled, true)
   })
 
+  describe('enter', () => {
+    it('should return the store it entered so callers can release it later', () => {
+      const parentSpan = { id: 'parent' }
+      const span = { id: 'child' }
+
+      plugin = new GoodPlugin()
+
+      const entered = plugin.enter(span, { span: parentSpan })
+
+      // The entered store is a fresh object carrying the new active span.
+      assert.strictEqual(typeof entered, 'object')
+      assert.strictEqual(entered.span, span)
+      // It is the same object written into storage, so mutating it later
+      // affects what any async resource captured off that frame retains.
+      assert.strictEqual(storage('legacy').getStore(), entered)
+    })
+  })
+
+  describe('releaseSpan', () => {
+    it('should null the span reference on the given store', () => {
+      const span = { id: 'child' }
+      const store = { span }
+
+      plugin = new GoodPlugin()
+      plugin.releaseSpan(store)
+
+      // Releasing lets a finished span be collected even while an async resource
+      // that captured this store lives on. This is the core of the fix for the
+      // unbounded router.middleware span retention leak.
+      assert.strictEqual(store.span, null)
+    })
+
+    it('should not throw for a missing store or a store without a span', () => {
+      plugin = new GoodPlugin()
+
+      // Executed directly: the test fails if any of these throw.
+      plugin.releaseSpan()
+      plugin.releaseSpan(undefined)
+      plugin.releaseSpan({})
+    })
+  })
+
   it('should run binding transforms with an undefined current store', () => {
     class TestPlugin extends Plugin {
       static id = 'test'


### PR DESCRIPTION
### What does this PR do?

Releases a finished span's reference from the async-context store it was entered into, so a finished span (and its parent chain) can be garbage-collected even when a long-lived async resource has captured the async-context frame.

- `Plugin#enter` now **returns** the `{ ...store, span }` object it writes into storage (previously discarded).
- A new `Plugin#releaseSpan(store)` nulls the `span` property on such a store.
- The **router plugin** (which backs express/connect/koa/restify/router middleware tracing) tracks the store each `router.middleware` span was entered into and releases all of them at **`http:server:request:finish`** — when the request/response is fully done.

Release deliberately happens **only at request finish, never at `middleware:finish`**: that channel is published *before* `next.apply(...)`, so releasing there would clobber the active span for any work a middleware schedules to run after `next()` (timers, promises, DB-client callbacks), orphaning their spans and breaking log correlation. (Thanks to the Codex review for catching this.) At request finish no in-request async continuation can still legitimately read the store as the current context, so nulling `span` is safe and still drops the reference any never-released resource captured.

The change is small (two src files), self-contained, and non-breaking. The one intended residual behavior change: work continuing *after the request has finished* no longer holds the request's spans as active — the correct lifecycle boundary, and what enables the leak fix.

### Motivation

Fixes #9227.

dd-trace activates each span via `AsyncLocalStorage.enterWith({ ...store, span })` (not `run()`), writing a fresh store object into the **current** async-context frame — see `packages/dd-trace/src/plugins/plugin.js` (`enter()`), `packages/dd-trace/src/plugins/tracing.js`, and the per-middleware activation in `packages/datadog-plugin-router/src/index.js`. Express runs the whole middleware chain synchronously on the frame established when the request began, so that frame ends up holding each `router.middleware` span (and, via each span's captured store, the entire ~20-deep parent chain).

Any async resource created during request handling that is **never released** (a subscription, an un-removed listener, a queued callback on a long-lived object) snapshots that frame at creation and pins the whole middleware span chain for the life of the process — **independent of the HTTP socket**. The span *is* finished correctly; the captured store snapshot still references it, so it is never collected. Retained spans then grow **linearly with request count, with no plateau**, until the heap is exhausted and the process OOMs (`FATAL ERROR: ... JavaScript heap out of memory`). A larger heap cap only delays the crash — the signature of a real leak, not an under-provisioned working set. In the affected production service ~93% of the leaked spans are `router.middleware`.

### Verification

Standalone reproducer (express + dd-trace, mock agent that 200s everything so flushing is not the cause): https://github.com/dwinrick-lever/dd-trace-express-middleware-span-leak

Post-GC retained heap **per request** (40 trivial middlewares, one never-released `AsyncResource` captured per request), measured on Node 18 and Node 24:

| | before (unpatched) | after (this PR) |
|---|---:|---:|
| dd-trace **ON** | ~36,740 B/req | ~335 B/req |
| dd-trace **OFF** (baseline) | ~92 B/req | ~92 B/req |
| amplification (ON/OFF) | ~400× | ~3.6× |

The per-request retention with dd-trace ON drops back to the same order of magnitude as with dd-trace disabled — the unbounded climb is gone.

Tests (run locally, scoped, green):
- `packages/dd-trace/test/plugins/plugin.spec.js` — new unit tests for `enter` returning its store and `releaseSpan`.
- `packages/datadog-plugin-router/test/index.spec.js` — two new integration regression tests:
  - **Leak fix**: captures the in-request store and asserts the finished middleware span is released after the response (fails without the fix).
  - **Continuity**: a middleware schedules async work after `next()`; while the request is still in-flight the deferred callback asserts `tracer.scope().active()` is non-null. This **fails** with a release-at-`middleware:finish` approach and **passes** with request-finish-only release — a guard against re-introducing the issue Codex flagged.
- `yarn lint` clean on all changed files.

### Additional Notes

- This is an **outside contribution**. Full CI won't run here; happy to have the team re-run under a full-CI user per CONTRIBUTING.
- Kept intentionally **minimal and backportable** per CONTRIBUTING — no `enterWith`→`run()` refactor, no config flag, no change to emitted spans. It targets the router plugin because that is where the overwhelming majority of retained spans originate; the same `enter`/`releaseSpan` primitive can be adopted incrementally by other plugins.
- Rebased onto current `master`.
- Very open to maintainer direction on the approach (e.g. whether you'd prefer the release entirely in the core plugin lifecycle rather than the router plugin, or a broader treatment of the `enterWith` capture pattern).
- Suggested semver label: **semver-patch** (bug fix, no behavior change to reported data).
