### PR TITLE
fix(opentelemetry): apply global/resource tags to OTel-bridged spans

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -152,6 +152,11 @@ class Span extends BridgeSpanBase {
       hostname: _tracer._hostname,
       integrationName: parentTracer?._isOtelLibrary ? 'otel.library' : 'otel',
       tags: {
+        // Apply global/resource tags (DD_TAGS, OTEL_RESOURCE_ATTRIBUTES) as
+        // defaults, mirroring the native path in opentracing/tracer.js. The
+        // explicit service/resource/span.kind below take precedence, and any
+        // user-set OTel attributes applied via setAttributes() still win.
+        ..._tracer._config.tags,
         [SERVICE_NAME]: _tracer._service,
         [RESOURCE_NAME]: spanName,
         [SPAN_KIND]: spanKindNames[kind],

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -48,6 +48,52 @@ describe('OTel Span', () => {
     assert.strictEqual(context._hostname, tracer._hostname)
   })
 
+  it('should apply global config tags (DD_TAGS / OTEL_RESOURCE_ATTRIBUTES) to bridged spans', () => {
+    // OTEL_RESOURCE_ATTRIBUTES and DD_TAGS are parsed into config.tags; the OTel
+    // bridge must apply them to bridged spans just like the native path does.
+    const { tags } = tracer._tracer._config
+    tags.dd_llmobs_enabled = 'false'
+    try {
+      const span = makeSpan('name')
+      assert.strictEqual(span._ddSpan.context().getTag('dd_llmobs_enabled'), 'false')
+    } finally {
+      delete tags.dd_llmobs_enabled
+    }
+  })
+
+  it('should let explicit span attributes take precedence over global config tags', () => {
+    const { tags } = tracer._tracer._config
+    tags.custom_tag = 'from-config'
+    try {
+      const span = makeSpan('name', { attributes: { custom_tag: 'from-span' } })
+      assert.strictEqual(span._ddSpan.context().getTag('custom_tag'), 'from-span')
+    } finally {
+      delete tags.custom_tag
+    }
+  })
+
+  it('should keep explicit service/resource/span.kind over colliding global config tags', () => {
+    // OTEL_RESOURCE_ATTRIBUTES commonly carries service.name (the reserved
+    // SERVICE_NAME key), so it lands in config.tags and collides with the value
+    // the bridge sets deliberately. The reserved value must win regardless of
+    // ordering, so the span's service/resource/span.kind stay correct.
+    const { tags } = tracer._tracer._config
+    tags[SERVICE_NAME] = 'from-config-tags'
+    tags[RESOURCE_NAME] = 'from-config-tags'
+    tags[SPAN_KIND] = 'from-config-tags'
+    try {
+      const span = makeSpan('name', { kind: api.SpanKind.CONSUMER })
+      const context = span._ddSpan.context()
+      assert.strictEqual(context.getTag(SERVICE_NAME), tracer._tracer._service)
+      assert.strictEqual(context.getTag(RESOURCE_NAME), 'name')
+      assert.strictEqual(context.getTag(SPAN_KIND), kinds.CONSUMER)
+    } finally {
+      delete tags[SERVICE_NAME]
+      delete tags[RESOURCE_NAME]
+      delete tags[SPAN_KIND]
+    }
+  })
+
   it('should expose parent span id', () => {
     tracer.trace('outer', (outer) => {
       const span = makeSpan('name', {})


### PR DESCRIPTION
## What does this PR do?

Applies global/resource tags (`DD_TAGS`, `OTEL_RESOURCE_ATTRIBUTES`) to spans created through the OpenTelemetry API bridge (`DD_TRACE_OTEL_ENABLED=true`).

## Motivation

`OTEL_RESOURCE_ATTRIBUTES` and `DD_TAGS` are parsed into `config.tags`, but they were only applied to spans created via the native tracer (`opentracing/tracer.js` → `span.addTags(this._config.tags)`). Spans created through the OTel API bridge (`opentelemetry/span.js`) were constructed directly with only `service`/`resource`/`span.kind`, so global/resource tags never reached them.

As a result, documented opt-outs that rely on a resource attribute reaching the span — e.g. `OTEL_RESOURCE_ATTRIBUTES=dd_llmobs_enabled=false` — had no effect on OTel-bridged spans, even though the value was correctly present in the tracer config.

## Change

Seed the bridge span's tags with `config.tags` as defaults, keeping the explicit `service`/`resource`/`span.kind` and any user-set OTel attributes as overrides — matching the precedence of the native path.

## Testing

Added unit tests in `packages/dd-trace/test/opentelemetry/span.spec.js`:
- global config tags (`DD_TAGS` / `OTEL_RESOURCE_ATTRIBUTES`) are applied to bridged spans (fails without this change)
- explicit span attributes take precedence over global config tags
- reserved `service.name`/`resource.name`/`span.kind` win over colliding config tags (fails if the spread order is reversed)

The full `packages/dd-trace/test/opentelemetry/` suite passes.

Internal reference: MLOB-7714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
