### PR TITLE
fix(playwright): ignore intermediate retry failures in aggregate status

### DIFF
--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -20,6 +20,7 @@ const {
   TEST_MANAGEMENT_IS_DISABLED,
   TEST_MANAGEMENT_IS_QUARANTINED,
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
@@ -128,6 +129,9 @@ versions.forEach((version) => {
           .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            const testModule = events.find(event => event.type === 'test_module_end').content
+            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
 
             const eventuallyPassingTests = tests.filter(
               test => test.meta[TEST_NAME] === 'playwright should eventually pass after retrying'
@@ -145,6 +149,21 @@ versions.forEach((version) => {
             const nonFinalRuns = eventuallyPassingTests.filter(t => !(TEST_FINAL_STATUS in t.meta))
             assert.strictEqual(nonFinalRuns.length, eventuallyPassingTests.length - 1,
               'All other ATR runs should not have TEST_FINAL_STATUS')
+
+            if (version === latest) {
+              assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(testSession.error, 0)
+              assert.strictEqual(testSession.meta[ERROR_MESSAGE], undefined)
+              assert.strictEqual(testModule.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(testModule.error, 0)
+              assert.strictEqual(testModule.meta[ERROR_MESSAGE], undefined)
+              assert.ok(testSuites.length > 0, 'Expected test suite events')
+              for (const testSuite of testSuites) {
+                assert.strictEqual(testSuite.meta[TEST_STATUS], 'pass')
+                assert.strictEqual(testSuite.error, 0)
+                assert.strictEqual(testSuite.meta[ERROR_MESSAGE], undefined)
+              }
+            }
           }, RETRY_FINAL_STATUS_TIMEOUT)
 
         // --retries=2 is passed via CLI so test.info().retry increments correctly across all playwright versions.

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -840,6 +840,8 @@ function testEndHandler ({
     test._ddHasFailedAllRetries = true
   }
 
+  const willRetry = testWillRetry(test, testStatus)
+
   // this handles tests that do not go through the worker process (because they're skipped)
   if (shouldCreateTestSpan) {
     const testResult = results.at(-1)
@@ -850,7 +852,7 @@ function testEndHandler ({
       !test._ddIsEfdRetry
 
     const finalStatus = getFinalStatus({
-      isFinalExecution: !testWillRetry(test, testStatus),
+      isFinalExecution: !willRetry,
       isDisabled: test._ddIsDisabled,
       isQuarantined: test._ddIsQuarantined,
       isAtrRetry,
@@ -888,17 +890,19 @@ function testEndHandler ({
     }
   }
 
-  if (testSuiteToTestStatuses.has(testSuiteAbsolutePath)) {
-    testSuiteToTestStatuses.get(testSuiteAbsolutePath).push(testStatus)
-  } else {
-    testSuiteToTestStatuses.set(testSuiteAbsolutePath, [testStatus])
+  if (!willRetry) {
+    if (testSuiteToTestStatuses.has(testSuiteAbsolutePath)) {
+      testSuiteToTestStatuses.get(testSuiteAbsolutePath).push(testStatus)
+    } else {
+      testSuiteToTestStatuses.set(testSuiteAbsolutePath, [testStatus])
+    }
+
+    if (error) {
+      addErrorToTestSuite(testSuiteAbsolutePath, error)
+    }
   }
 
-  if (error) {
-    addErrorToTestSuite(testSuiteAbsolutePath, error)
-  }
-
-  if (!testWillRetry(test, testStatus)) {
+  if (!willRetry) {
     remainingTestsByFile[testSuiteAbsolutePath] = remainingTestsByFile[testSuiteAbsolutePath]
       .filter(currentTest => currentTest !== test)
   }

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -87,7 +87,7 @@ class PlaywrightPlugin extends CiPlugin {
       if (isEarlyFlakeDetectionFaulty) {
         this.testSessionSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'faulty')
       }
-      if (this.numFailedSuites > 0) {
+      if (status === 'fail' && this.numFailedSuites > 0) {
         let errorMessage = `Test suites failed: ${this.numFailedSuites}.`
         if (this.numFailedTests > 0) {
           errorMessage += ` Tests failed: ${this.numFailedTests}`
@@ -113,6 +113,7 @@ class PlaywrightPlugin extends CiPlugin {
       appClosingTelemetry()
       this.tracer._exporter.flush(onDone)
       this.numFailedTests = 0
+      this.numFailedSuites = 0
     })
 
     this.addBind('ci:playwright:test-suite:start', (ctx) => {
@@ -408,7 +409,7 @@ class PlaywrightPlugin extends CiPlugin {
         }
         stepSpan.finish(stepStartTime + stepDuration)
       }
-      if (testStatus === 'fail') {
+      if (finalStatus === 'fail') {
         this.numFailedTests++
       }
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Fixes Playwright Test Optimization aggregate reporting for flaky tests that pass after retry.

Failed retry attempts are still reported as failed test events, but they no longer make the final suite, module, or session events look failed when Playwright eventually passes the test.

### Motivation
For example, consider a Playwright test that fails on the first attempt and passes on retry. The test-level events are expected to show both attempts:

- first attempt: `test.status=fail`
- retry attempt: `test.status=pass`, `test.is_retry=true`, `test.retry_reason=auto_test_retry`, `test.final_status=pass`

Before this fix, the aggregate events could still reflect the intermediate failed attempt:

- `test_suite_end` was reported as failed
- `test_module_end` and `test_session_end` could report `test.status=pass` while also carrying `error=1` and `Test suites failed: 1.`

That made a flaky-successful Playwright run look contradictory: the test retry passed, but the suite/session payload still looked failed. The root cause was that failed intermediate retry attempts were recorded into aggregate suite status and error state before Playwright had finished retrying the test.

This change only records suite status and suite errors once Playwright is done retrying that test, and only attaches session/module aggregate errors when the final session status failed.

### Additional Notes
Added integration coverage for the flaky-success case so the final suite, module, and session events are passing and error-free when the final Playwright retry passes. Existing coverage still verifies that tests which exhaust all ATR attempts continue to report failure.