### PR TITLE
feat(cypress): tag failure screenshot upload result

### DIFF
--- a/integration-tests/cypress-legacy-plugin.config.js
+++ b/integration-tests/cypress-legacy-plugin.config.js
@@ -1,11 +1,22 @@
 'use strict'
 
+const fs = require('node:fs')
+
 // Backwards compatibility config: uses defineConfig AND the old manual plugin.
 // When NODE_OPTIONS is set, the instrumentation wraps defineConfig and injects
 // setupNodeEvents. The manual plugin call sets cypressPlugin._isInit = true,
 // so the instrumentation skips its own registration to avoid double hooks.
 const { defineConfig } = require('cypress')
 const ddTracePlugin = require('dd-trace/ci/cypress/plugin')
+
+function renameScreenshot (details) {
+  const renamedPath = details.path.replace(/\.png$/, ' datadog-renamed.png')
+  try {
+    fs.unlinkSync(renamedPath)
+  } catch {}
+  fs.renameSync(details.path, renamedPath)
+  return { path: renamedPath }
+}
 
 module.exports = defineConfig({
   defaultCommandTimeout: 1000,
@@ -19,10 +30,14 @@ module.exports = defineConfig({
         const ddAfterSpec = require('dd-trace/ci/cypress/after-spec')
         on('after:spec', (...args) => ddAfterSpec(...args))
       }
-      return ddTracePlugin(on, config)
+      const resolvedConfig = ddTracePlugin(on, config)
+      if (process.env.CYPRESS_ENABLE_AFTER_SCREENSHOT_CUSTOM) {
+        on('after:screenshot', renameScreenshot)
+      }
+      return resolvedConfig
     },
     specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
   },
   video: false,
-  screenshotOnRunFailure: false,
+  screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_SCREENSHOTS === 'true',
 })

--- a/integration-tests/cypress-legacy-plugin.config.mjs
+++ b/integration-tests/cypress-legacy-plugin.config.mjs
@@ -1,5 +1,16 @@
+import fs from 'node:fs'
+
 import { defineConfig } from 'cypress'
 import ddTracePlugin from 'dd-trace/ci/cypress/plugin.js'
+
+function renameScreenshot (details) {
+  const renamedPath = details.path.replace(/\.png$/, ' datadog-renamed.png')
+  try {
+    fs.unlinkSync(renamedPath)
+  } catch {}
+  fs.renameSync(details.path, renamedPath)
+  return { path: renamedPath }
+}
 
 export default defineConfig({
   defaultCommandTimeout: 1000,
@@ -13,10 +24,14 @@ export default defineConfig({
         const { default: ddAfterSpec } = await import('dd-trace/ci/cypress/after-spec.js')
         on('after:spec', (...args) => ddAfterSpec(...args))
       }
-      return ddTracePlugin(on, config)
+      const resolvedConfig = ddTracePlugin(on, config)
+      if (process.env.CYPRESS_ENABLE_AFTER_SCREENSHOT_CUSTOM) {
+        on('after:screenshot', renameScreenshot)
+      }
+      return resolvedConfig
     },
     specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
   },
   video: false,
-  screenshotOnRunFailure: false,
+  screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_SCREENSHOTS === 'true',
 })

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -951,6 +951,11 @@ moduleTypes.forEach(({
           return () => testOutput
         }
 
+        function decodeKeyFilename (key) {
+          const [, hexFilename] = (key || '').split(':')
+          return hexFilename ? Buffer.from(hexFilename, 'hex').toString('utf8') : ''
+        }
+
         onlyAgentlessIt('uploads failure screenshots to the v2 media endpoint', async function () {
           const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/basic-fail.js')
 
@@ -1055,10 +1060,6 @@ moduleTypes.forEach(({
                 const [screenshotPayload] = screenshotPayloads
                 assert.strictEqual(screenshotPayload.media.traceId, expectedTraceId)
 
-                const decodeKeyFilename = (key) => {
-                  const [, hexFilename] = (key || '').split(':')
-                  return hexFilename ? Buffer.from(hexFilename, 'hex').toString('utf8') : ''
-                }
                 assert.match(
                   decodeKeyFilename(screenshotPayload.media.idempotencyKey),
                   /\(failed\)/,
@@ -1083,6 +1084,70 @@ moduleTypes.forEach(({
             receiverPromise,
           ])
         })
+
+        onlyAgentlessIt(
+          'uploads after the user after:screenshot handler with auto-instrumentation and manual plugin',
+          async function () {
+            const legacyConfigFile = type === 'esm'
+              ? 'cypress-legacy-plugin.config.mjs'
+              : 'cypress-legacy-plugin.config.js'
+            let testOutput = ''
+            childProcess = exec(
+              `./node_modules/.bin/cypress run --config-file ${legacyConfigFile}`,
+              {
+                cwd,
+                env: {
+                  ...getEnvVars(receiver.port),
+                  CYPRESS_BASE_URL: webAppBaseUrl,
+                  SPEC_PATTERN: 'cypress/e2e/basic-fail.js',
+                  CYPRESS_ENABLE_FAILURE_SCREENSHOTS: 'true',
+                  CYPRESS_ENABLE_AFTER_SCREENSHOT_CUSTOM: 'true',
+                  DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
+                },
+              }
+            )
+            childProcess.stdout?.on('data', (d) => { testOutput += d.toString() })
+            childProcess.stderr?.on('data', (d) => { testOutput += d.toString() })
+
+            const receiverPromise = receiver
+              .gatherPayloadsUntilChildExit(
+                childProcess,
+                ({ url }) => url.startsWith('/api/v2/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
+                (payloads) => {
+                  const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/v2/ci/test-runs/'))
+                  const screenshotPayloads = mediaPayloads.filter(({ media }) => media.contentType === 'image/png')
+
+                  assert.strictEqual(
+                    screenshotPayloads.length,
+                    1,
+                    `Datadog should upload once, after the user after:screenshot handler\n${testOutput}`
+                  )
+                  assert.match(
+                    decodeKeyFilename(screenshotPayloads[0].media.idempotencyKey),
+                    / datadog-renamed\.png$/,
+                    `the uploaded screenshot should use the user handler's renamed path\n${testOutput}`
+                  )
+
+                  const failedTest = payloads
+                    .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
+                    .flatMap(({ payload }) => payload.events)
+                    .filter(event => event.type === 'test')
+                    .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
+
+                  assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+                  assert.strictEqual(failedTest.content.meta[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
+                }, { hardTimeout: 60000 })
+              .catch((error) => {
+                error.message += `\nCypress output:\n${testOutput}`
+                throw error
+              })
+
+            await Promise.all([
+              once(childProcess, 'exit'),
+              receiverPromise,
+            ])
+          }
+        )
 
         onlyAgentlessIt('continues normally when the media upload endpoint fails', async function () {
           receiver.setMediaResponseStatusCode(500)

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -28,6 +28,8 @@ const {
   TEST_SUITE,
   TEST_CODE_OWNERS,
   TEST_NAME,
+  TEST_FAILURE_SCREENSHOT_UPLOADED,
+  TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE, ERROR_TYPE, COMPONENT } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
@@ -284,6 +286,8 @@ moduleTypes.forEach(({
           )
           assert.ok(passTestEvent, 'passing cypress.test event exists')
           assert.ok(failTestEvent, 'failing cypress.test event exists')
+          assert.strictEqual(failTestEvent.content.meta[TEST_FAILURE_SCREENSHOT_UPLOADED], undefined)
+          assert.strictEqual(failTestEvent.content.meta[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], undefined)
 
           const stepEvents = events.filter(event => event.type === 'span' && event.content.name === 'cypress.step')
           assert.ok(stepEvents.length > 0, 'cypress.step spans exist')
@@ -964,6 +968,8 @@ moduleTypes.forEach(({
                   .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
 
                 assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+                assert.strictEqual(failedTest.content.meta[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
+                assert.strictEqual(failedTest.content.meta[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], undefined)
                 const expectedTraceId = failedTest.content.trace_id.toString()
 
                 const screenshotPayload = mediaPayloads.find(({ media }) => media.contentType === 'image/png')
@@ -1095,6 +1101,8 @@ moduleTypes.forEach(({
 
                 assert.ok(failedTest, `the failed test should still be reported when media upload fails\n${testOutput}`)
                 assert.strictEqual(failedTest.content.meta[TEST_STATUS], 'fail')
+                assert.strictEqual(failedTest.content.meta[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], 'true')
+                assert.strictEqual(failedTest.content.meta[TEST_FAILURE_SCREENSHOT_UPLOADED], undefined)
               }, { hardTimeout: 60000 })
             .catch((error) => {
               error.message += `\nCypress output:\n${getTestOutput()}`

--- a/integration-tests/cypress/e2e/manual-screenshot-before-fail.js
+++ b/integration-tests/cypress/e2e/manual-screenshot-before-fail.js
@@ -6,7 +6,7 @@ describe('manual screenshot before fail suite', () => {
 
   it('takes a manual screenshot then fails', () => {
     // Manual capture (not a failure frame): must NOT be uploaded to the failure-screenshot endpoint.
-    cy.screenshot('before-failure')
+    cy.screenshot('before-failure (failed)')
     cy.get('.hello-world')
       .should('have.text', 'Hello warld')
   })

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -1618,7 +1618,7 @@ class CypressPlugin {
       }
     }
 
-    const finishSpec = () => {
+    const finishSuite = () => {
       if (this.testSuiteSpan) {
         const status = getSuiteStatus(stats)
         this.testSuiteSpan.setTag(TEST_STATUS, status)
@@ -1630,7 +1630,9 @@ class CypressPlugin {
         this.testSuiteSpan = null
         this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       }
+    }
 
+    const waitForScreenshotUploads = () => {
       if (screenshotUploadPromises.length > 0 || this.pendingScreenshotUploads.length > 0) {
         const pendingScreenshotUploads = this.pendingScreenshotUploads
         this.pendingScreenshotUploads = []
@@ -1638,11 +1640,18 @@ class CypressPlugin {
       }
     }
 
+    finishSuite()
+
+    const screenshotUploadsPromise = waitForScreenshotUploads()
     if (testSpanFinishPromises.length > 0) {
-      return Promise.all(testSpanFinishPromises).then(finishSpec)
+      const testSpansPromise = Promise.all(testSpanFinishPromises).then(() => null)
+      if (screenshotUploadsPromise) {
+        return Promise.all([testSpansPromise, screenshotUploadsPromise]).then(() => null)
+      }
+      return testSpansPromise
     }
 
-    return finishSpec()
+    return screenshotUploadsPromise
   }
 
   /**

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -148,6 +148,13 @@ function getScreenshotFilePath (screenshot) {
   return typeof screenshot === 'string' ? screenshot : screenshot?.path
 }
 
+function isFailureScreenshotByMetadata (screenshot, screenshotFilePath) {
+  if (screenshot !== null && typeof screenshot === 'object' && screenshot.testFailure !== undefined) {
+    return screenshot.testFailure === true
+  }
+  return screenshotFilePath.includes('(failed)')
+}
+
 /**
  * Resolves a screenshot's capture time (epoch ms) for the media upload. Cypress
  * screenshot objects carry an ISO `takenAt`; falls back to the file's mtime, then
@@ -175,7 +182,13 @@ function getScreenshotCapturedAtMs (screenshot, filePath) {
 
 function isFailureScreenshotForUpload (screenshot) {
   const screenshotFilePath = getScreenshotFilePath(screenshot)
-  return !!screenshotFilePath && (screenshot?.testFailure === true || screenshotFilePath.includes('(failed)'))
+  if (!screenshotFilePath) {
+    return false
+  }
+  if (screenshot !== null && typeof screenshot === 'object') {
+    return screenshot.testFailure === true
+  }
+  return screenshotFilePath.includes('(failed)')
 }
 
 function isFailureScreenshot (screenshot) {
@@ -183,7 +196,7 @@ function isFailureScreenshot (screenshot) {
   // Require an explicit failure signal: prefer the `testFailure` metadata, and fall back to the
   // '(failed)' filename marker only when the RunResult omits `testFailure`. This keeps manual
   // cy.screenshot() captures out of the failure-screenshot upload (privacy).
-  return !!screenshotFilePath && (screenshot?.testFailure === true || screenshotFilePath.includes('(failed)'))
+  return !!screenshotFilePath && isFailureScreenshotByMetadata(screenshot, screenshotFilePath)
 }
 
 function getAttemptScreenshots (cypressTest, attemptIndex) {
@@ -516,6 +529,7 @@ class CypressPlugin {
   loggedAttemptToFixTests = new Set()
   uploadedScreenshotPaths = new Set()
   screenshotUploadPromisesByTraceId = new Map()
+  afterScreenshotHandler = undefined
   lastFinishedTest = null
   pendingScreenshotUploads = []
 
@@ -621,6 +635,19 @@ class CypressPlugin {
     this.libraryConfigurationPromise = undefined
     this._timeOrigin = 0
     this._perfOrigin = 0
+  }
+
+  /**
+   * Returns a stable after:screenshot handler so auto-instrumentation can recognize
+   * the handler registered by the manual plugin and avoid treating it as a user hook.
+   *
+   * @returns {Function} Datadog after:screenshot handler
+   */
+  getAfterScreenshotHandler () {
+    if (!this.afterScreenshotHandler) {
+      this.afterScreenshotHandler = this.afterScreenshot.bind(this)
+    }
+    return this.afterScreenshotHandler
   }
 
   /**

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -79,6 +79,8 @@ const {
   getMaxEfdRetryCount,
   getPullRequestBaseBranch,
   TEST_FINAL_STATUS,
+  TEST_FAILURE_SCREENSHOT_UPLOADED,
+  TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR,
   getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
@@ -139,6 +141,8 @@ const CYPRESS_STATUS_TO_TEST_STATUS = {
 }
 
 const SCREENSHOT_ATTEMPT_RE = /\(attempt \d+\)/
+const SCREENSHOT_UPLOAD_RESULT_UPLOADED = 'uploaded'
+const SCREENSHOT_UPLOAD_RESULT_ERROR = 'error'
 
 function getScreenshotFilePath (screenshot) {
   return typeof screenshot === 'string' ? screenshot : screenshot?.path
@@ -219,6 +223,27 @@ function getTestScreenshots (cypressTest, attemptIndex, specScreenshots) {
   }
   const titleParts = Array.isArray(cypressTest.title) ? cypressTest.title : []
   return specScreenshots.filter(screenshot => isScreenshotForTestAttempt(screenshot, titleParts, attemptIndex))
+}
+
+function getScreenshotUploadResult (uploadResults) {
+  let hasUploaded = false
+  for (const uploadResult of uploadResults) {
+    if (uploadResult === SCREENSHOT_UPLOAD_RESULT_ERROR) {
+      return SCREENSHOT_UPLOAD_RESULT_ERROR
+    }
+    if (uploadResult === SCREENSHOT_UPLOAD_RESULT_UPLOADED) {
+      hasUploaded = true
+    }
+  }
+  return hasUploaded ? SCREENSHOT_UPLOAD_RESULT_UPLOADED : undefined
+}
+
+function setScreenshotUploadTags (testSpan, uploadResult) {
+  if (uploadResult === SCREENSHOT_UPLOAD_RESULT_ERROR) {
+    testSpan.setTag(TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR, 'true')
+  } else if (uploadResult === SCREENSHOT_UPLOAD_RESULT_UPLOADED) {
+    testSpan.setTag(TEST_FAILURE_SCREENSHOT_UPLOADED, 'true')
+  }
 }
 
 function getSessionStatus (summary) {
@@ -490,6 +515,7 @@ class CypressPlugin {
   attemptToFixExecutions = new Map()
   loggedAttemptToFixTests = new Set()
   uploadedScreenshotPaths = new Set()
+  screenshotUploadPromisesByTraceId = new Map()
   lastFinishedTest = null
   pendingScreenshotUploads = []
 
@@ -578,6 +604,7 @@ class CypressPlugin {
     this.attemptToFixExecutions = new Map()
     this.loggedAttemptToFixTests = new Set()
     this.uploadedScreenshotPaths = new Set()
+    this.screenshotUploadPromisesByTraceId = new Map()
     this.lastFinishedTest = null
     this.pendingScreenshotUploads = []
     this.activeTestSpan = null
@@ -594,6 +621,37 @@ class CypressPlugin {
     this.libraryConfigurationPromise = undefined
     this._timeOrigin = 0
     this._perfOrigin = 0
+  }
+
+  /**
+   * Tracks a screenshot upload by its owning test trace id so the test event can be tagged
+   * before the span is finished.
+   *
+   * @param {string} traceId - Test trace id used for the upload
+   * @param {Promise<string|undefined>} uploadPromise - Promise resolving to the upload outcome
+   * @returns {void}
+   */
+  addScreenshotUploadPromise (traceId, uploadPromise) {
+    const uploadPromises = this.screenshotUploadPromisesByTraceId.get(traceId)
+    if (uploadPromises) {
+      uploadPromises.push(uploadPromise)
+    } else {
+      this.screenshotUploadPromisesByTraceId.set(traceId, [uploadPromise])
+    }
+  }
+
+  /**
+   * Returns the aggregate upload outcome for all screenshots associated with a test trace id.
+   *
+   * @param {string} traceId - Test trace id used for the upload
+   * @returns {Promise<string|undefined>|undefined} Promise resolving to the aggregate upload outcome
+   */
+  getScreenshotUploadResultPromise (traceId) {
+    const uploadPromises = this.screenshotUploadPromisesByTraceId.get(traceId)
+    if (!uploadPromises?.length) {
+      return
+    }
+    return Promise.all(uploadPromises).then(getScreenshotUploadResult)
   }
 
   /**
@@ -1341,6 +1399,7 @@ class CypressPlugin {
     const specScreenshots = screenshots || []
     const finishedTests = this.finishedTestsByFile[spec.relative] || []
     const screenshotUploadPromises = []
+    const testSpanFinishPromises = []
 
     if (!this.testSuiteSpan) {
       // dd:testSuiteStart hasn't been triggered for whatever reason
@@ -1448,8 +1507,9 @@ class CypressPlugin {
           latestError = new Error(cypressTest.displayError)
         }
 
+        let failedTestTraceId
         if (cypressTestStatus === 'fail' || finishedTest.testStatus === 'fail' || cypressTest.displayError) {
-          const failedTestTraceId = finishedTest.testSpan.context().toTraceId()
+          failedTestTraceId = finishedTest.testSpan.context().toTraceId()
           const testScreenshots = getTestScreenshots(cypressTest, attemptIndex, specScreenshots)
           const screenshotUploadPromise = this.uploadTestScreenshots({
             screenshots: testScreenshots,
@@ -1516,27 +1576,46 @@ class CypressPlugin {
           }
         }
 
-        finishedTest.testSpan.finish(finishedTest.finishTime)
+        const screenshotUploadResultPromise = failedTestTraceId
+          ? this.getScreenshotUploadResultPromise(failedTestTraceId)
+          : undefined
+        if (screenshotUploadResultPromise) {
+          testSpanFinishPromises.push(screenshotUploadResultPromise.then((uploadResult) => {
+            setScreenshotUploadTags(finishedTest.testSpan, uploadResult)
+            this.screenshotUploadPromisesByTraceId.delete(failedTestTraceId)
+            finishedTest.testSpan.finish(finishedTest.finishTime)
+          }))
+        } else {
+          finishedTest.testSpan.finish(finishedTest.finishTime)
+        }
       }
     }
 
-    if (this.testSuiteSpan) {
-      const status = getSuiteStatus(stats)
-      this.testSuiteSpan.setTag(TEST_STATUS, status)
+    const finishSpec = () => {
+      if (this.testSuiteSpan) {
+        const status = getSuiteStatus(stats)
+        this.testSuiteSpan.setTag(TEST_STATUS, status)
 
-      if (latestError) {
-        this.testSuiteSpan.setTag('error', latestError)
+        if (latestError) {
+          this.testSuiteSpan.setTag('error', latestError)
+        }
+        this.testSuiteSpan.finish()
+        this.testSuiteSpan = null
+        this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       }
-      this.testSuiteSpan.finish()
-      this.testSuiteSpan = null
-      this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
+
+      if (screenshotUploadPromises.length > 0 || this.pendingScreenshotUploads.length > 0) {
+        const pendingScreenshotUploads = this.pendingScreenshotUploads
+        this.pendingScreenshotUploads = []
+        return Promise.all([...pendingScreenshotUploads, ...screenshotUploadPromises]).then(() => null)
+      }
     }
 
-    if (screenshotUploadPromises.length > 0 || this.pendingScreenshotUploads.length > 0) {
-      const pendingScreenshotUploads = this.pendingScreenshotUploads
-      this.pendingScreenshotUploads = []
-      return Promise.all([...pendingScreenshotUploads, ...screenshotUploadPromises]).then(() => null)
+    if (testSpanFinishPromises.length > 0) {
+      return Promise.all(testSpanFinishPromises).then(finishSpec)
     }
+
+    return finishSpec()
   }
 
   /**
@@ -1545,7 +1624,7 @@ class CypressPlugin {
    * @param {object} options - Upload options
    * @param {Array<object|string>} options.screenshots - Cypress screenshot objects or screenshot paths
    * @param {string} options.traceId - Test trace id used as the screenshot key
-   * @returns {Promise<void>|undefined}
+   * @returns {Promise<string|undefined>|undefined}
    */
   uploadTestScreenshots ({ screenshots, traceId }) {
     const exporter = this.tracer?._tracer?._exporter
@@ -1574,14 +1653,16 @@ class CypressPlugin {
           traceId,
           idempotencyKey,
           capturedAtMs,
-        }, () => {
-          resolve()
+        }, (err) => {
+          resolve(err ? SCREENSHOT_UPLOAD_RESULT_ERROR : SCREENSHOT_UPLOAD_RESULT_UPLOADED)
         })
       }))
     }
 
     if (uploadPromises.length > 0) {
-      return Promise.all(uploadPromises).then(() => {})
+      const uploadPromise = Promise.all(uploadPromises).then(getScreenshotUploadResult)
+      this.addScreenshotUploadPromise(traceId, uploadPromise)
+      return uploadPromise
     }
   }
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -186,6 +186,8 @@ function isFailureScreenshotForUpload (screenshot) {
     return false
   }
   if (screenshot !== null && typeof screenshot === 'object') {
+    // after:screenshot details omit testFailure for manual cy.screenshot() captures, so this
+    // path cannot safely fall back to the '(failed)' filename marker.
     return screenshot.testFailure === true
   }
   return screenshotFilePath.includes('(failed)')

--- a/packages/datadog-plugin-cypress/src/index.js
+++ b/packages/datadog-plugin-cypress/src/index.js
@@ -41,6 +41,7 @@ class CypressPlugin extends Plugin {
       }
 
       const cypressPlugin = require('./cypress-plugin')
+      const datadogAfterScreenshotHandler = cypressPlugin.getAfterScreenshotHandler()
 
       // Cypress keeps a single after:screenshot handler, so registering the
       // plugin's would drop any user handler (e.g. one that moves/renames a
@@ -50,13 +51,16 @@ class CypressPlugin extends Plugin {
       // details and propagate the value back to Cypress. The user handler runs
       // regardless of whether screenshot upload is enabled.
       const registerAfterScreenshot = (afterScreenshotHandler) => {
-        if (userAfterScreenshotHandlers.length === 0) {
+        const filteredUserAfterScreenshotHandlers = userAfterScreenshotHandlers.filter(
+          handler => handler !== afterScreenshotHandler
+        )
+        if (filteredUserAfterScreenshotHandlers.length === 0) {
           if (afterScreenshotHandler) on('after:screenshot', afterScreenshotHandler)
           return
         }
 
         on('after:screenshot', (details) => {
-          const chain = userAfterScreenshotHandlers.reduce(
+          const chain = filteredUserAfterScreenshotHandlers.reduce(
             (p, h) => p.then((latestDetails) => Promise.resolve(h(latestDetails)).then(
               // Merge the user handler's (possibly partial) return into the running details
               // rather than replacing them, so Cypress metadata such as `testFailure` and
@@ -77,14 +81,14 @@ class CypressPlugin extends Plugin {
         // Pass the plugin's afterScreenshot so chaining a user handler doesn't drop the upload
         // (the chained registration replaces the one plugin.js set, so it must include it).
         for (const h of userAfterSpecHandlers) on('after:spec', h)
-        registerAfterScreenshot(cypressPlugin.afterScreenshot.bind(cypressPlugin))
+        registerAfterScreenshot(datadogAfterScreenshotHandler)
         registerAfterRunWithCleanup()
         payload.registered = true
         return
       }
 
       on('before:run', cypressPlugin.beforeRun.bind(cypressPlugin))
-      registerAfterScreenshot(cypressPlugin.afterScreenshot.bind(cypressPlugin))
+      registerAfterScreenshot(datadogAfterScreenshotHandler)
 
       on('after:spec', (spec, results) => {
         const chain = userAfterSpecHandlers.reduce(

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -40,7 +40,7 @@ module.exports = function CypressPlugin (on, config) {
   }
 
   on('before:run', cypressPlugin.beforeRun.bind(cypressPlugin))
-  on('after:screenshot', cypressPlugin.afterScreenshot.bind(cypressPlugin))
+  on('after:screenshot', cypressPlugin.getAfterScreenshotHandler())
   on('after:spec', cypressPlugin.afterSpec.bind(cypressPlugin))
   on('after:run', cypressPlugin.afterRun.bind(cypressPlugin))
   on('task', cypressPlugin.getTasks())

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -143,6 +143,11 @@ function uploadTestScreenshot (
       log.error('Error uploading test screenshot: %s', err.message)
       return callback(err)
     }
+    if (statusCode === undefined) {
+      const uploadError = new Error('Test screenshot upload request was dropped before it was sent')
+      log.error('Error uploading test screenshot: %s', uploadError.message)
+      return callback(uploadError)
+    }
     log.debug('Test screenshot uploaded successfully (status: %d)', statusCode)
     callback(null)
   })

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -95,6 +95,8 @@ const TEST_IS_RUM_ACTIVE = 'test.is_rum_active'
 const TEST_CODE_OWNERS = 'test.codeowners'
 const TEST_SOURCE_FILE = 'test.source.file'
 const TEST_SOURCE_START = 'test.source.start'
+const TEST_FAILURE_SCREENSHOT_UPLOADED = 'test.failure_screenshot.uploaded'
+const TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR = 'test.failure_screenshot.upload_error'
 const LIBRARY_VERSION = 'library_version'
 const TEST_COMMAND = 'test.command'
 const TEST_MODULE = 'test.module'
@@ -433,6 +435,8 @@ module.exports = {
   TEST_SKIP_REASON,
   TEST_IS_RUM_ACTIVE,
   TEST_SOURCE_FILE,
+  TEST_FAILURE_SCREENSHOT_UPLOADED,
+  TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR,
   CI_APP_ORIGIN,
   LIBRARY_VERSION,
   JEST_WORKER_TRACE_PAYLOAD_CODE,

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -80,6 +80,31 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       assert.strictEqual(headers['X-Datadog-EVP-Subdomain'], undefined)
     })
 
+    it('reports an error when the request helper drops the upload', () => {
+      const basename = 'screenshot.png'
+      const filePath = join(tmpDir, basename)
+      writeFileSync(filePath, 'not-empty')
+      requestStub.callsFake((_payload, _options, cb) => cb(null))
+
+      let callbackError
+      uploadTestScreenshot(
+        {
+          filePath,
+          traceId,
+          idempotencyKey: `${traceId}:${basename}`,
+          capturedAtMs: 1_700_000_000_000,
+          url: new URL('http://localhost:8126'),
+        },
+        (err) => {
+          callbackError = err
+        }
+      )
+
+      assert.ok(requestStub.calledOnce)
+      assert.ok(callbackError)
+      assert.match(callbackError.message, /dropped/)
+    })
+
     it('hex-encodes the filename in the idempotency key to the proxy-safe charset', () => {
       // A real failure screenshot name has spaces and parens (and here an em-dash, U+2014). The
       // Agent's evp_proxy validates the forwarded query against a restrictive charset and rejects


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds Cypress test-event tags for failure screenshot upload outcomes:

- `test.failure_screenshot.uploaded:true` when a failure screenshot upload succeeds.
- `test.failure_screenshot.upload_error:true` when upload is enabled but an attempted upload fails.
- No screenshot upload tag when `DD_TEST_FAILURE_SCREENSHOTS_ENABLED` is not enabled or no upload is possible.

The Cypress plugin now waits for the upload outcome before finishing the failed test span, so the upload result lands on the test event. It also keeps suite duration independent from media upload latency, preserves custom `after:screenshot` handling in the auto-instrumented path, and reports dropped media requests as upload errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

Follow-up to #8981 so users can distinguish disabled screenshot uploads from successful uploads and upload errors in Test Optimization events.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation covered syntax, lint, the screenshot upload request unit spec, and focused Cypress failure screenshot upload scenarios. The focused Cypress run passed the agentless cases; the EVP proxy variants remain pending as expected.

Semver: `semver-minor`.
