### PR TITLE
fix(child_process): avoid global Promise for promisified spans

### DIFF
--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -3,13 +3,13 @@
 const { errorMonitor } = require('events')
 const util = require('util')
 
-const dc = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
 const {
   addHook,
+  tracingChannel,
 } = require('./helpers/instrument')
 
-const childProcessChannel = dc.tracingChannel('datadog:child_process:execution')
+const childProcessChannel = tracingChannel('datadog:child_process:execution')
 const NativePromise = Promise
 
 // ignored exec method because it calls to execFile directly
@@ -130,13 +130,43 @@ function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
     const context = createContextFromChildProcessInfo(childProcessInfo)
     context.callArgs = callArgs
 
-    return childProcessChannel.tracePromise(function () {
-      if (context.abortController.signal.aborted) {
-        return NativePromise.reject(context.abortController.signal.reason || new Error('Aborted'))
-      }
+    // Keep this off tracePromise so promise normalization uses the cached
+    // native constructor instead of a process-wide Promise replacement.
+    const { start, end, asyncStart, asyncEnd, error: errorChannel } = childProcessChannel
 
-      return customPromisifyMethod.apply(this, context.callArgs)
-    }, context, this)
+    function reject (err) {
+      context.error = err
+      errorChannel.publish(context)
+      asyncStart.publish(context)
+
+      asyncEnd.publish(context)
+      return NativePromise.reject(err)
+    }
+
+    function resolve (result) {
+      context.result = result
+      asyncStart.publish(context)
+
+      asyncEnd.publish(context)
+      return result
+    }
+
+    return start.runStores(context, () => {
+      try {
+        const promise = context.abortController.signal.aborted
+          ? NativePromise.reject(context.abortController.signal.reason || new Error('Aborted'))
+          : customPromisifyMethod.apply(this, context.callArgs)
+
+        return NativePromise.resolve(promise).then(resolve, reject)
+      } catch (err) {
+        context.error = err
+        errorChannel.publish(context)
+
+        throw err
+      } finally {
+        end.publish(context)
+      }
+    })
   }
 }
 

--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -153,7 +153,7 @@ function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
       asyncStart.publish(context)
 
       asyncEnd.publish(context)
-      return Promise.reject(err)
+      throw err
     }
 
     function resolve (result) {
@@ -164,7 +164,7 @@ function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
       return result
     }
 
-    return Promise.resolve(result).then(resolve, reject)
+    return result.then(resolve, reject)
   }
 }
 

--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -10,6 +10,7 @@ const {
 } = require('./helpers/instrument')
 
 const childProcessChannel = dc.tracingChannel('datadog:child_process:execution')
+const NativePromise = Promise
 
 // ignored exec method because it calls to execFile directly
 const execAsyncMethods = ['execFile', 'spawn', 'fork']
@@ -129,42 +130,13 @@ function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
     const context = createContextFromChildProcessInfo(childProcessInfo)
     context.callArgs = callArgs
 
-    const { start, end, asyncStart, asyncEnd, error: errorChannel } = childProcessChannel
-    start.publish(context)
-
-    let result
-    if (context.abortController.signal.aborted) {
-      result = Promise.reject(context.abortController.signal.reason || new Error('Aborted'))
-    } else {
-      try {
-        result = customPromisifyMethod.apply(this, context.callArgs)
-      } catch (error) {
-        context.error = error
-        errorChannel.publish(context)
-        throw error
-      } finally {
-        end.publish(context)
+    return childProcessChannel.tracePromise(function () {
+      if (context.abortController.signal.aborted) {
+        return NativePromise.reject(context.abortController.signal.reason || new Error('Aborted'))
       }
-    }
 
-    function reject (err) {
-      context.error = err
-      errorChannel.publish(context)
-      asyncStart.publish(context)
-
-      asyncEnd.publish(context)
-      throw err
-    }
-
-    function resolve (result) {
-      context.result = result
-      asyncStart.publish(context)
-
-      asyncEnd.publish(context)
-      return result
-    }
-
-    return result.then(resolve, reject)
+      return customPromisifyMethod.apply(this, context.callArgs)
+    }, context, this)
   }
 }
 

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -428,11 +428,10 @@ describe('Child process plugin', () => {
     let Bluebird
 
     // The regression only needs Bluebird to be the global `Promise` at the
-    // moment `util.promisify`/the wrapped child_process method runs, since that
-    // is when the instrumentation does `Promise.resolve(...).then(...)`. Holding
-    // the mutation across the awaited span round-trip leaks it into the shared
-    // mock agent and tracer, flip-flopping the process-wide `Promise` while the
-    // next test runs. Scope the mutation to the synchronous call and restore it
+    // moment `util.promisify`/the wrapped child_process method runs. Holding the
+    // mutation across the awaited span round-trip leaks it into the shared mock
+    // agent and tracer, flip-flopping the process-wide `Promise` while the next
+    // test runs. Scope the mutation to the synchronous call and restore it
     // before awaiting.
     function withBluebird (fn) {
       const original = global.Promise

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -479,19 +479,28 @@ describe('Child process plugin', () => {
     })
 
     it('should work with concurrent Bluebird promise calls', async () => {
-      const drained = []
+      const expectedCommands = new Set()
       for (let i = 0; i < 5; i++) {
-        drained.push(expectSomeSpan(agent, {
-          type: 'system',
-          name: 'command_execution',
-          error: 0,
-          meta: {
-            component: 'subprocess',
-            'cmd.exec': `["echo","concurrent-test-${i}"]`,
-            'cmd.exit_code': '0',
-          },
-        }))
+        expectedCommands.add(`["echo","concurrent-test-${i}"]`)
       }
+      const foundCommands = new Set()
+      const drained = agent.assertSomeTraces((traces) => {
+        for (const trace of traces) {
+          for (const span of trace) {
+            const command = span.meta?.['cmd.exec']
+
+            if (span.name !== 'command_execution' || !expectedCommands.has(command)) continue
+
+            assert.strictEqual(span.type, 'system')
+            assert.strictEqual(span.error, 0)
+            assert.strictEqual(span.meta.component, 'subprocess')
+            assert.strictEqual(span.meta['cmd.exit_code'], '0')
+            foundCommands.add(command)
+          }
+        }
+
+        assert.deepStrictEqual(foundCommands, expectedCommands)
+      }, { timeoutMs: 5000 })
 
       const promises = withBluebird(() => {
         const execFileAsync = util.promisify(childProcess.execFile)
@@ -513,7 +522,7 @@ describe('Child process plugin', () => {
 
       // Drain every concurrent span so a late flush does not leak into the next
       // test's matcher, and assert the promisify success exit code is 0.
-      await Promise.all(drained)
+      await drained
     })
 
     it('should handle Bluebird promise rejection properly', async () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Avoids routing promisified `child_process` completion through the mutable global `Promise`. The instrumentation now continues from the promise returned by Node's custom promisified method directly, and rethrows failures through that same chain.

### Motivation
The Bluebird compatibility tests can time out when `global.Promise` is temporarily replaced while `util.promisify(child_process.execFile)` runs. The wrapper used `Promise.resolve(result).then(...)`, so instrumentation completion depended on whichever constructor was installed on `global.Promise` at that moment. That could prevent the async end event from publishing and leave the expected `command_execution` span missing.

### Additional Notes
Validated locally:

- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha packages/datadog-plugin-child_process/test/index.spec.js --grep 'Bluebird Promise Compatibility'`
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER PLUGINS=child_process npm run test:plugins`

The investigated v5 failure appears to hit the same flaky path as master: the relevant child_process instrumentation, plugin, tests, and Bluebird version setup matched across the checked release/master lines.