### PR TITLE
fix(child_process): stabilize preloaded builtin instrumentation

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -238,6 +238,34 @@ jobs:
         with:
           id: ${{ github.job }}
 
+  child_process_stress:
+    name: child_process stress (${{ matrix.runner }})
+    runs-on: ubuntu-latest
+    needs: child_process
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [1, 2, 3, 4]
+    env:
+      PLUGINS: child_process
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/node/active-lts
+      - uses: ./.github/actions/install
+      - name: Run child_process suite repeatedly
+        run: |
+          for iteration in 1 2 3 4 5; do
+            echo "::group::child_process stress runner ${{ matrix.runner }} iteration ${iteration}"
+            npm run test:plugins:ci
+            echo "::endgroup::"
+          done
+      - uses: ./.github/actions/upload-junit-artifacts
+        if: "!cancelled()"
+        with:
+          id: ${{ github.job }}-${{ strategy.job-index }}
+
   crypto:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -46,6 +46,13 @@ function Hook (modules, hookOptions, onrequire) {
     hookOptions = {}
   }
 
+  const ritmOptions = {}
+  if (hookOptions.patchLoadedBuiltins) {
+    ritmOptions.patchLoadedBuiltins = true
+    hookOptions = { ...hookOptions }
+    delete hookOptions.patchLoadedBuiltins
+  }
+
   this._patched = Object.create(null)
   const patched = new WeakMap()
 
@@ -94,7 +101,7 @@ function Hook (modules, hookOptions, onrequire) {
     return newExports
   }
 
-  this._ritmHook = ritm(modules, {}, safeHook)
+  this._ritmHook = ritm(modules, ritmOptions, safeHook)
   this._iitmHook = iitm(modules, hookOptions, (moduleExports, moduleName, moduleBaseDir) => {
     return safeHook(moduleExports, moduleName, moduleBaseDir, null, true)
   })

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   // Only list unprefixed node modules. They will automatically be instrumented as prefixed and unprefixed.
-  child_process: () => require('../child_process'),
+  child_process: { patchLoadedBuiltins: true, fn: () => require('../child_process') },
   crypto: () => require('../crypto'),
   dns: () => require('../dns'),
   'dns/promises': () => require('../dns'),

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -84,6 +84,9 @@ for (const name of names) {
     if (hook.serverless === false && IS_SERVERLESS) continue
 
     hookOptions.internals = hook.esmFirst
+    if (hook.patchLoadedBuiltins) {
+      hookOptions.patchLoadedBuiltins = true
+    }
     hook = hook.fn
   }
 

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -2,15 +2,19 @@
 
 const assert = require('node:assert/strict')
 const events = require('node:events')
+const { inspect } = require('node:util')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const { storage } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
-const ChildProcessPlugin = require('../src')
+const { compare } = require('../../dd-trace/test/plugins/helpers')
 const { temporaryWarningExceptions } = require('../../dd-trace/test/setup/core')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
+const ChildProcessPlugin = require('../src')
+
+const COMMAND_SPAN_TIMEOUT = 4000
 
 function noop () {}
 
@@ -25,6 +29,76 @@ function normalizeArgs (methodName, command, options) {
   args.push(options)
 
   return args
+}
+
+function getTestMarker (...parts) {
+  return ['dd-child-process', ...parts].join('-')
+}
+
+function isCommandExecutionSpan (span) {
+  return span.name === 'command_execution' && span.meta?.component === 'subprocess'
+}
+
+function matchesExpectedCommand (span, expected) {
+  const expectedMeta = expected.meta
+  if (expectedMeta === undefined || expectedMeta === null || typeof expectedMeta !== 'object') {
+    return true
+  }
+
+  if (Object.hasOwn(expectedMeta, 'cmd.exec') && span.meta?.['cmd.exec'] !== expectedMeta['cmd.exec']) {
+    return false
+  }
+
+  if (Object.hasOwn(expectedMeta, 'cmd.shell') && span.meta?.['cmd.shell'] !== expectedMeta['cmd.shell']) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Waits for the child_process span under test instead of letting parent/manual
+ * spans from shared agent payloads become assertion candidates.
+ *
+ * @param {Record<string, unknown>} expected expected span fields
+ * @param {number} [timeout] timeout in milliseconds
+ * @returns {Promise<void>}
+ */
+function expectCommandSpan (expected, timeout = COMMAND_SPAN_TIMEOUT) {
+  return agent.assertSomeTraces(traces => {
+    const commandSpans = []
+    const matchingCommandSpans = []
+    const scoredErrors = []
+
+    for (const trace of traces) {
+      for (const span of trace) {
+        if (!isCommandExecutionSpan(span)) continue
+
+        commandSpans.push(span)
+        if (!matchesExpectedCommand(span, expected)) continue
+
+        matchingCommandSpans.push(span)
+
+        try {
+          assertObjectContains(span, expected)
+          return
+        } catch (err) {
+          scoredErrors.push({ err, score: compare(expected, span) })
+        }
+      }
+    }
+
+    if (scoredErrors.length > 0) {
+      const error = scoredErrors.sort((a, b) => a.score - b.score)[0].err
+      error.message += '\n\nCandidate Child Process Spans:\n' + inspect(matchingCommandSpans)
+      throw error
+    }
+
+    throw new assert.AssertionError({
+      message: 'No matching child_process command_execution span found\n\nCandidate Child Process Spans:\n' +
+        inspect(commandSpans),
+    })
+  }, { timeoutMs: timeout })
 }
 
 describe('Child process plugin', () => {
@@ -415,7 +489,7 @@ describe('Child process plugin', () => {
       assert.strictEqual(global.Promise, Bluebird)
       assert.ok(global.Promise.version)
 
-      const expectedPromise = expectSomeSpan(agent, {
+      const expectedPromise = expectCommandSpan({
         type: 'system',
         name: 'command_execution',
         error: 0,
@@ -455,7 +529,7 @@ describe('Child process plugin', () => {
 
       const execFileAsync = util.promisify(childProcess.execFile)
 
-      const expectedPromise = expectSomeSpan(agent, {
+      const expectedPromise = expectCommandSpan({
         type: 'system',
         name: 'command_execution',
         error: 1,
@@ -529,30 +603,36 @@ describe('Child process plugin', () => {
 
           methods.forEach(({ methodName, async }) => {
             describe(methodName, () => {
-              const lsExpected = {
-                type: 'system',
-                name: 'command_execution',
-                error: 0,
-                meta: {
-                  component: 'subprocess',
-                  'cmd.shell': 'ls',
-                  'cmd.exit_code': '0',
-                },
+              const markerPrefix = getTestMarker('shell', hasParentSpan ? 'parent' : 'root', methodName)
+
+              function getExpectedShellSpan (command) {
+                return {
+                  type: 'system',
+                  name: 'command_execution',
+                  error: 0,
+                  meta: {
+                    component: 'subprocess',
+                    'cmd.shell': command,
+                    'cmd.exit_code': '0',
+                  },
+                }
               }
 
               it('should be instrumented', (done) => {
-                expectSomeSpan(agent, lsExpected).then(done, done)
+                const command = `echo ${markerPrefix}-instrumented`
+                expectCommandSpan(getExpectedShellSpan(command)).then(done, done)
 
-                const res = childProcess[methodName]('ls')
+                const res = childProcess[methodName](command)
                 if (async) {
                   res.on('close', noop)
                 }
               })
 
               it('should maintain previous span after the execution', async () => {
-                const drained = expectSomeSpan(agent, lsExpected)
+                const command = `echo ${markerPrefix}-maintain`
+                const drained = expectCommandSpan(getExpectedShellSpan(command))
 
-                const res = childProcess[methodName]('ls')
+                const res = childProcess[methodName](command)
                 assert.strictEqual(storage('legacy').getStore()?.span, parentSpan)
                 if (async) {
                   await Promise.all([drained, (async () => {
@@ -566,8 +646,9 @@ describe('Child process plugin', () => {
 
               if (async) {
                 it('should maintain previous span in the callback', async () => {
-                  await Promise.all([expectSomeSpan(agent, lsExpected), new Promise(resolve => {
-                    childProcess[methodName]('ls', () => {
+                  const command = `echo ${markerPrefix}-callback`
+                  await Promise.all([expectCommandSpan(getExpectedShellSpan(command)), new Promise(resolve => {
+                    childProcess[methodName](command, () => {
                       assert.strictEqual(storage('legacy').getStore()?.span, parentSpan)
                       resolve()
                     })
@@ -576,24 +657,25 @@ describe('Child process plugin', () => {
               }
 
               it('command should be scrubbed', (done) => {
+                const marker = `${markerPrefix}-scrubbed`
                 const expected = {
                   type: 'system',
                   name: 'command_execution',
                   error: 0,
                   meta: {
                     component: 'subprocess',
-                    'cmd.shell': 'echo password ?',
+                    'cmd.shell': `echo password ? ${marker}`,
                     'cmd.exit_code': '0',
                   },
                 }
-                expectSomeSpan(agent, expected).then(done, done)
+                expectCommandSpan(expected).then(done, done)
 
                 const args = []
                 if (methodName === 'exec' || methodName === 'execSync') {
-                  args.push('echo password 123')
+                  args.push(`echo password 123 ${marker}`)
                 } else {
                   args.push('echo')
-                  args.push(['password', '123'])
+                  args.push(['password', '123', marker])
                 }
 
                 const res = childProcess[methodName](...args)
@@ -603,7 +685,7 @@ describe('Child process plugin', () => {
               })
 
               it('should be instrumented with error code', (done) => {
-                const command = ['node', '-badOption']
+                const command = ['node', `-badOption-${markerPrefix}-error`]
                 const options = {
                   stdio: 'pipe',
                 }
@@ -613,12 +695,12 @@ describe('Child process plugin', () => {
                   error: 1,
                   meta: {
                     component: 'subprocess',
-                    'cmd.shell': 'node -badOption',
+                    'cmd.shell': command.join(' '),
                     'cmd.exit_code': '9',
                   },
                 }
 
-                expectSomeSpan(agent, expected).then(done, done)
+                expectCommandSpan(expected).then(done, done)
 
                 const args = normalizeArgs(methodName, command, options)
 
@@ -669,44 +751,48 @@ describe('Child process plugin', () => {
 
           methods.forEach(({ methodName, async }) => {
             describe(methodName, () => {
+              const markerPrefix = getTestMarker('exec', parentSpan ? 'parent' : 'root', methodName)
+
               it('should be instrumented', (done) => {
+                const marker = `${markerPrefix}-instrumented`
                 const expected = {
                   type: 'system',
                   name: 'command_execution',
                   error: 0,
                   meta: {
                     component: 'subprocess',
-                    'cmd.exec': '["ls"]',
+                    'cmd.exec': JSON.stringify(['echo', marker]),
                     'cmd.exit_code': '0',
                   },
                 }
-                expectSomeSpan(agent, expected).then(done, done)
+                expectCommandSpan(expected).then(done, done)
 
-                const res = childProcess[methodName]('ls')
+                const res = childProcess[methodName]('echo', [marker])
                 if (async) {
                   res.on('close', noop)
                 }
               })
 
               it('command should be scrubbed', (done) => {
+                const marker = `${markerPrefix}-scrubbed`
                 const expected = {
                   type: 'system',
                   name: 'command_execution',
                   error: 0,
                   meta: {
                     component: 'subprocess',
-                    'cmd.exec': '["echo","password","?"]',
+                    'cmd.exec': JSON.stringify(['echo', 'password', '?', marker]),
                     'cmd.exit_code': '0',
                   },
                 }
-                expectSomeSpan(agent, expected).then(done, done)
+                expectCommandSpan(expected).then(done, done)
 
                 const args = []
                 if (methodName === 'exec' || methodName === 'execSync') {
-                  args.push('echo password 123')
+                  args.push(`echo password 123 ${marker}`)
                 } else {
                   args.push('echo')
-                  args.push(['password', '123'])
+                  args.push(['password', '123', marker])
                 }
 
                 const res = childProcess[methodName](...args)
@@ -716,7 +802,7 @@ describe('Child process plugin', () => {
               })
 
               it('should be instrumented with error code', (done) => {
-                const command = ['node', '-badOption']
+                const command = ['node', `-badOption-${markerPrefix}-error`]
                 const options = {
                   stdio: 'pipe',
                 }
@@ -727,7 +813,7 @@ describe('Child process plugin', () => {
                   error: 1,
                   meta: {
                     component: 'subprocess',
-                    'cmd.exec': '["node","-badOption"]',
+                    'cmd.exec': JSON.stringify(command),
                     'cmd.exit_code': '9',
                   },
                 }
@@ -738,7 +824,7 @@ describe('Child process plugin', () => {
                   error: 0,
                   meta: {
                     component: 'subprocess',
-                    'cmd.exec': '["node","-badOption"]',
+                    'cmd.exec': JSON.stringify(command),
                     'cmd.exit_code': '9',
                   },
                 }
@@ -746,15 +832,15 @@ describe('Child process plugin', () => {
                 const args = normalizeArgs(methodName, command, options)
 
                 if (async) {
-                  expectSomeSpan(agent, errorExpected).then(done, done)
+                  expectCommandSpan(errorExpected).then(done, done)
                   const res = childProcess[methodName].apply(null, args)
                   res.on('close', noop)
                 } else {
                   try {
                     if (methodName === 'spawnSync') {
-                      expectSomeSpan(agent, noErrorExpected).then(done, done)
+                      expectCommandSpan(noErrorExpected).then(done, done)
                     } else {
-                      expectSomeSpan(agent, errorExpected).then(done, done)
+                      expectCommandSpan(errorExpected).then(done, done)
                     }
                     childProcess[methodName].apply(null, args)
                   } catch {
@@ -764,7 +850,7 @@ describe('Child process plugin', () => {
               })
 
               it('should be instrumented with error code (override shell default behavior)', (done) => {
-                const command = ['node', '-badOption']
+                const command = ['node', `-badOption-${markerPrefix}-shell-error`]
                 const options = {
                   stdio: 'pipe',
                   shell: true,
@@ -776,7 +862,7 @@ describe('Child process plugin', () => {
                   error: 1,
                   meta: {
                     component: 'subprocess',
-                    'cmd.shell': 'node -badOption',
+                    'cmd.shell': command.join(' '),
                     'cmd.exit_code': '9',
                   },
                 }
@@ -787,7 +873,7 @@ describe('Child process plugin', () => {
                   error: 0,
                   meta: {
                     component: 'subprocess',
-                    'cmd.shell': 'node -badOption',
+                    'cmd.shell': command.join(' '),
                     'cmd.exit_code': '9',
                   },
                 }
@@ -800,15 +886,15 @@ describe('Child process plugin', () => {
                 )
 
                 if (async) {
-                  expectSomeSpan(agent, errorExpected).then(done, done)
+                  expectCommandSpan(errorExpected).then(done, done)
                   const res = childProcess[methodName].apply(null, args)
                   res.on('close', noop)
                 } else {
                   try {
                     if (methodName === 'spawnSync') {
-                      expectSomeSpan(agent, noErrorExpected).then(done, done)
+                      expectCommandSpan(noErrorExpected).then(done, done)
                     } else {
-                      expectSomeSpan(agent, errorExpected).then(done, done)
+                      expectCommandSpan(errorExpected).then(done, done)
                     }
                     childProcess[methodName].apply(null, args)
                   } catch {

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -11,6 +11,7 @@ const { isRelativeRequire } = require('../../datadog-instrumentations/src/helper
 const { getConfiguredEnvName, getEnvironmentVariable } = require('./config/helper')
 
 const origRequire = Module.prototype.require
+const runtimeRequire = Module.createRequire(__filename)
 // derived from require-in-the-middle@3 with tweaks
 
 module.exports = Hook
@@ -78,7 +79,12 @@ function Hook (modules, options, onrequire) {
     }
   }
 
-  if (patchedRequire) return
+  if (patchedRequire) {
+    if (options.patchLoadedBuiltins) {
+      patchLoadedBuiltins(modules)
+    }
+    return
+  }
 
   const _origRequire = Module.prototype.require
   patchedRequire = Module.prototype.require = function (request) {
@@ -203,6 +209,45 @@ function Hook (modules, options, onrequire) {
 
     return cache[moduleId].exports
   }
+
+  if (options.patchLoadedBuiltins) {
+    patchLoadedBuiltins(modules)
+  }
+}
+
+/**
+ * @param {string[]|undefined} modules
+ */
+function patchLoadedBuiltins (modules) {
+  if (!Array.isArray(modules)) return
+
+  for (const moduleName of modules) {
+    if (!isLoadedBuiltinModule(moduleName)) continue
+
+    const moduleId = normalizeModuleName(moduleName)
+    if (cache[moduleId]) continue
+
+    const hooks = moduleHooks[moduleId]
+    if (!hooks) continue
+
+    const exports = runtimeRequire(moduleId)
+    cache[moduleId] = { exports, original: exports }
+
+    for (const hook of hooks) {
+      cache[moduleId].exports = hook(cache[moduleId].exports, moduleId)
+    }
+  }
+}
+
+/**
+ * @param {string} moduleName
+ * @returns {boolean}
+ */
+function isLoadedBuiltinModule (moduleName) {
+  const moduleId = normalizeModuleName(moduleName)
+
+  return isBuiltinModuleName(moduleId) &&
+    process.moduleLoadList.includes(`NativeModule ${moduleId}`)
 }
 
 /**

--- a/packages/dd-trace/test/plugins/agent.spec.js
+++ b/packages/dd-trace/test/plugins/agent.spec.js
@@ -13,6 +13,32 @@ describe('test agent helper', () => {
   describe('agent.load contract', () => {
     afterEach(() => agent.close())
 
+    it('patches a builtin that was loaded before the tracer', async () => {
+      const childProcess = require('child_process')
+      const marker = 'agent-preloaded-child-process'
+
+      await agent.load(['child_process'])
+
+      const expected = agent.assertSomeTraces(traces => {
+        for (const trace of traces) {
+          for (const span of trace) {
+            if (span.name !== 'command_execution' || span.meta?.component !== 'subprocess') continue
+            if (span.meta['cmd.exec'] !== JSON.stringify(['echo', marker])) continue
+
+            assert.strictEqual(span.error, 0)
+            assert.strictEqual(span.type, 'system')
+            return
+          }
+        }
+
+        throw new assert.AssertionError({ message: 'No child_process command span found' })
+      }, { timeoutMs: 4000 })
+
+      childProcess.execFile('echo', [marker])
+
+      await expected
+    })
+
     it('resolves with the live TracerProxy', async () => {
       const tracer = await agent.load([])
       assert.strictEqual(tracer, global._ddtrace)

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -149,4 +149,21 @@ describe('Ritm', () => {
       }
     }
   })
+
+  it('should patch an already loaded builtin when requested', () => {
+    const childProcess = require('child_process')
+    const marker = Symbol('dd-ritm-loaded-builtin')
+    const hook = Hook(['child_process'], { patchLoadedBuiltins: true }, exports => {
+      exports[marker] = true
+      return exports
+    })
+
+    try {
+      assert.equal(childProcess[marker], true)
+      assert.equal(require('child_process')[marker], true)
+    } finally {
+      delete childProcess[marker]
+      hook.unhook()
+    }
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Adds opt-in support for patching already-loaded builtin modules through RITM, and enables that path for the `child_process` instrumentation.

This also hardens the `child_process` plugin tests so each command assertion matches the span emitted by that test case, then adds a repeated `child_process` stress job to the APM integrations workflow.

### Motivation

The `child_process` suite was flaky when the builtin module had already been loaded before tracer/plugin setup. In that state, the instrumentation could miss the already-cached builtin export, and the old span assertions could also match stale command spans from shared payloads.

### Additional Notes

Validation:

- `packages/dd-trace/test/ritm.spec.js`: 7 passing
- `packages/dd-trace/test/plugins/agent.spec.js`: 13 passing
- `PLUGINS=child_process npm run test:plugins:ci`: 87 passing
- Local stress loop: 5 repeated `PLUGINS=child_process npm run test:plugins:ci` runs, each 87 passing
- Commit checks for `0940f8e49`: 412/412 successful

Remote stress results:

- `child_process stress (1)`: success - https://github.com/DataDog/dd-trace-js/actions/runs/28534510143/job/84592589148
- `child_process stress (2)`: success - https://github.com/DataDog/dd-trace-js/actions/runs/28534510143/job/84592589194
- `child_process stress (3)`: success - https://github.com/DataDog/dd-trace-js/actions/runs/28534510143/job/84592589306
- `child_process stress (4)`: success - https://github.com/DataDog/dd-trace-js/actions/runs/28534510143/job/84592589196
