### PR TITLE
fix(esm): skip loader hook registration when instrumentation bails out

### DIFF
--- a/initialize.mjs
+++ b/initialize.mjs
@@ -75,8 +75,10 @@ export const resolve = brokenLoaders ? undefined : hookResolve
 
 if (isMainThread) {
   const require = Module.createRequire(import.meta.url)
-  require('./init.js')
-  if (Module.register) {
+  const initialized = require('./init.js')
+  // Only register the loader hook when instrumentation initialized. On a bailout the
+  // loader has nothing to instrument and can keep a short-lived process from exiting.
+  if (Module.register && initialized) {
     // The loader builds its own include/exclude matcher in `initialize`, so no
     // options need to cross the registration boundary.
     Module.register('./loader-hook.mjs', import.meta.url)

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -288,6 +288,9 @@ if (semver.satisfies(process.versions.node, '>=14.13.1')) {
 
     if (semver.satisfies(process.versions.node, '>=20.6.0')) {
       context('as --import', () => {
+        // The loader hook is skipped on bailout, so --import children exit on their
+        // own; killing them would mask a regression that keeps the process alive.
+        setShouldKill(false)
         testInjectionScenarios('import', 'initialize.mjs', true)
         testRuntimeVersionChecks('import', 'initialize.mjs')
       })


### PR DESCRIPTION
## Summary

`--import dd-trace/initialize.mjs` on an unsupported runtime, or as a single-step install that defers to a manually-installed copy, still registered the async ESM loader even though the tracer never initialized. With nothing to instrument, that loader can keep a short-lived process from exiting — the hanging `--import` guardrail children seen on Node 24.

`init.js` returns the tracer on success and `undefined` on a bailout, so the registration is now gated on that result. The `--import` guardrail cases drop the kill timer so a child that fails to exit fails the suite instead of being masked.