### PR TITLE
fix(dogstatsd): send metrics over UDP when DogStatsD host differs from the agent

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -197,8 +197,17 @@ class DogStatsDClient {
       lookup: config.lookup,
     }
 
+    // The trace agent's /dogstatsd/v2/proxy endpoint only exists on the real Datadog Agent. Route
+    // metrics through it while DogStatsD still targets the agent: either the host was left to the
+    // agent-derived default or it matches the resolved agent URL host. An explicit host pointing
+    // elsewhere must reach it over UDP, otherwise its metrics are silently dropped (e.g. the
+    // OpenTelemetry Collector answers the unknown proxy path with HTTP 200, masking the loss).
     if (config.url) {
-      clientConfig.metricsProxyUrl = config.url
+      const dogstatsdHostOrigin = config.getOrigin('dogstatsd.hostname')
+      const dogstatsdHostExplicit = dogstatsdHostOrigin !== 'default' && dogstatsdHostOrigin !== 'calculated'
+      if (!dogstatsdHostExplicit || config.dogstatsd.hostname === config.url.hostname) {
+        clientConfig.metricsProxyUrl = config.url
+      }
     }
 
     return clientConfig

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -458,6 +458,94 @@ describe('dogstatsd', () => {
     client.flush()
   })
 
+  describe('generateClientConfig', () => {
+    // `origin` mirrors what Config.getOrigin('dogstatsd.hostname') returns: 'calculated'/'default'
+    // when the host was derived from the agent, and a user source ('env_var', 'code', ...) when set.
+    function generateClientConfig ({ hostname, url, origin }) {
+      return DogStatsDClient.generateClientConfig({
+        lookup: dns.lookup,
+        tags: {},
+        url: url === undefined ? undefined : new URL(url),
+        dogstatsd: { hostname, port: 8125 },
+        getOrigin: () => origin,
+      })
+    }
+
+    it('routes through the agent proxy when the host is agent-derived (calculated)', () => {
+      const clientConfig = generateClientConfig({
+        hostname: '127.0.0.1', url: 'http://127.0.0.1:8126', origin: 'calculated',
+      })
+
+      assert.deepStrictEqual(clientConfig.metricsProxyUrl, new URL('http://127.0.0.1:8126'))
+      assert.strictEqual(clientConfig.host, '127.0.0.1')
+    })
+
+    it('routes through the agent proxy when the host is agent-derived (default)', () => {
+      const clientConfig = generateClientConfig({
+        hostname: 'localhost', url: 'http://localhost:8126', origin: 'default',
+      })
+
+      assert.deepStrictEqual(clientConfig.metricsProxyUrl, new URL('http://localhost:8126'))
+    })
+
+    it('routes through the agent proxy when the derived host differs from a remote agent URL host', () => {
+      // DD_TRACE_AGENT_URL resolves the agent to a different host than the 127.0.0.1 default, but the
+      // DogStatsD host was never configured (origin 'calculated'), so metrics still belong on the proxy.
+      const clientConfig = generateClientConfig({
+        hostname: '127.0.0.1', url: 'http://agent:8126', origin: 'calculated',
+      })
+
+      assert.deepStrictEqual(clientConfig.metricsProxyUrl, new URL('http://agent:8126'))
+    })
+
+    it('routes through the agent proxy when an explicit host matches the agent URL host', () => {
+      const clientConfig = generateClientConfig({
+        hostname: 'agent', url: 'http://agent:8126', origin: 'env_var',
+      })
+
+      assert.deepStrictEqual(clientConfig.metricsProxyUrl, new URL('http://agent:8126'))
+    })
+
+    it('sends metrics over UDP when an explicit host diverges from the agent host', () => {
+      const clientConfig = generateClientConfig({
+        hostname: '10.0.0.5', url: 'http://127.0.0.1:8126', origin: 'env_var',
+      })
+
+      assert.strictEqual(clientConfig.metricsProxyUrl, undefined)
+      assert.strictEqual(clientConfig.host, '10.0.0.5')
+    })
+
+    it('sends metrics over UDP when an explicit host diverges from a remote agent URL host', () => {
+      const clientConfig = generateClientConfig({
+        hostname: '10.0.0.5', url: 'http://agent:8126', origin: 'env_var',
+      })
+
+      assert.strictEqual(clientConfig.metricsProxyUrl, undefined)
+    })
+
+    it('routes through the socket proxy when the host is agent-derived for a unix-socket agent', () => {
+      const clientConfig = generateClientConfig({
+        hostname: '127.0.0.1', url: 'unix:///var/run/datadog/apm.socket', origin: 'calculated',
+      })
+
+      assert.deepStrictEqual(clientConfig.metricsProxyUrl, new URL('unix:///var/run/datadog/apm.socket'))
+    })
+
+    it('sends metrics over UDP when an explicit host is set alongside a unix-socket agent', () => {
+      const clientConfig = generateClientConfig({
+        hostname: '10.0.0.5', url: 'unix:///var/run/datadog/apm.socket', origin: 'env_var',
+      })
+
+      assert.strictEqual(clientConfig.metricsProxyUrl, undefined)
+    })
+
+    it('sends metrics over UDP when there is no agent URL', () => {
+      const clientConfig = generateClientConfig({ hostname: '10.0.0.5', url: undefined, origin: 'env_var' })
+
+      assert.strictEqual(clientConfig.metricsProxyUrl, undefined)
+    })
+  })
+
   describe('CustomMetrics', () => {
     it('.gauge()', () => {
       client = createCustomMetrics()


### PR DESCRIPTION
## Summary

DogStatsD metrics were routed through the trace agent's `/dogstatsd/v2/proxy`
whenever an agent URL was present, so an explicit `DD_DOGSTATSD_HOST` pointing
elsewhere never received them. The OpenTelemetry Collector's Datadog receiver
answers the unknown proxy path with HTTP 200, so the POST looked successful and
delivery never fell back to the configured UDP host.

The proxy is now used only when the DogStatsD host was left agent-derived or
matches the resolved agent URL host. The decision reads the `dogstatsd.hostname`
config origin, so an unset host still routes to the agent even when the resolved
agent URL host differs from the `127.0.0.1` default (e.g. `DD_TRACE_AGENT_URL`).

Fixes: https://github.com/DataDog/dd-trace-js/issues/9191