### PR TITLE
test(mocha): stabilize atf final status assertion

### DIFF
--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6522,23 +6522,27 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
 
     const assertAttemptToFixFailThenPass = (tests) => {
       assert.strictEqual(tests.length, 3)
-      assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
-      assert.strictEqual(tests[0].meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
-      assert.strictEqual(tests[0].meta[TEST_IS_MODIFIED], 'true')
-      assert.ok(!(TEST_IS_RETRY in tests[0].meta))
-      assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
 
-      const retriedTests = tests.slice(1)
-      retriedTests.forEach(test => {
+      const originalAttempts = tests.filter(test => !(TEST_IS_RETRY in test.meta))
+      assert.strictEqual(originalAttempts.length, 1)
+      assert.strictEqual(originalAttempts[0].meta[TEST_STATUS], 'fail')
+      assert.strictEqual(originalAttempts[0].meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+      assert.strictEqual(originalAttempts[0].meta[TEST_IS_MODIFIED], 'true')
+      assert.ok(!(TEST_RETRY_REASON in originalAttempts[0].meta))
+
+      const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+      assert.strictEqual(retriedTests.length, 2)
+      for (const test of retriedTests) {
         assert.strictEqual(test.meta[TEST_STATUS], 'pass')
         assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
         assert.strictEqual(test.meta[TEST_IS_MODIFIED], 'true')
-        assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
         assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atf)
-      })
+      }
 
-      assert.strictEqual(tests[tests.length - 1].meta[TEST_FINAL_STATUS], 'fail')
-      assert.strictEqual(tests[tests.length - 1].meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+      const finalStatusTests = tests.filter(test => TEST_FINAL_STATUS in test.meta)
+      assert.strictEqual(finalStatusTests.length, 1)
+      assert.strictEqual(finalStatusTests[0].meta[TEST_FINAL_STATUS], 'fail')
+      assert.strictEqual(finalStatusTests[0].meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
     }
 
     context('test is not new', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Stabilizes the Mocha Test Optimization attempt-to-fix integration assertion by identifying original attempts, retry attempts, and the final-status attempt from their tags instead of relying on retry span timestamp ordering.

### Motivation
<!-- What inspired you to submit this pull request? -->
The `integration-mocha (latest, latest)` GitHub Actions job flaked because the parallel-mode test sorted retry spans by `start` and expected the final attempt to be last. In parallel mode, equivalent or close timestamps can make that ordering unstable, so the assertion could inspect a span without `test.final_status` even though the final-status span was present.

