### PR TITLE
fix(opentelemetry): wrap sdk-trace TracerProvider for sdk-node 0.220+

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -48,6 +48,7 @@ module.exports = {
   '@langchain/core': { esmFirst: true, fn: () => require('../langchain') },
   '@node-redis/client': () => require('../redis'),
   '@opensearch-project/opensearch': () => require('../opensearch'),
+  '@opentelemetry/sdk-trace': () => require('../otel-sdk-trace'),
   '@opentelemetry/sdk-trace-node': () => require('../otel-sdk-trace'),
   '@prisma/client': { esmFirst: true, fn: () => require('../prisma') },
   './runtime/library.js': () => require('../prisma'),

--- a/packages/datadog-instrumentations/src/otel-sdk-trace.js
+++ b/packages/datadog-instrumentations/src/otel-sdk-trace.js
@@ -16,6 +16,21 @@ if (isOtelSdkEnabled()) {
     })
     return mod
   })
+
+  // As of @opentelemetry/sdk-node 0.220.0, NodeSDK builds its provider from
+  // @opentelemetry/sdk-trace's TracerProvider instead of sdk-trace-node's
+  // NodeTracerProvider, so the hook above no longer intercepts it. Wrap this
+  // export too, otherwise DD_TRACE_OTEL_ENABLED spans never reach the tracer.
+  addHook({
+    name: '@opentelemetry/sdk-trace',
+    file: 'build/src/TracerProvider.js',
+    versions: ['*'],
+  }, (mod) => {
+    shimmer.wrap(mod, 'TracerProvider', () => {
+      return tracer.TracerProvider
+    })
+    return mod
+  })
 }
 
 function isOtelSdkEnabled () {

--- a/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
+++ b/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
@@ -72,11 +72,10 @@ describe('otel-sdk-trace', () => {
   })
 
   describe('hook registration', () => {
-    it('wraps NodeTracerProvider with the dd-trace TracerProvider', () => {
+    it('wraps sdk-trace-node NodeTracerProvider with the dd-trace TracerProvider', () => {
       const tracerProvider = function FakeTracerProvider () {}
       const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: true }, { TracerProvider: tracerProvider })
 
-      sinon.assert.calledOnce(addHook)
       const [hookOptions, transform] = addHook.firstCall.args
       assert.deepStrictEqual(hookOptions, {
         name: '@opentelemetry/sdk-trace-node',
@@ -87,8 +86,33 @@ describe('otel-sdk-trace', () => {
       const mod = { NodeTracerProvider: function OriginalProvider () {} }
       assert.equal(transform(mod), mod)
 
-      sinon.assert.calledOnceWithExactly(wrap, mod, 'NodeTracerProvider', sinon.match.func)
+      sinon.assert.calledWithExactly(wrap, mod, 'NodeTracerProvider', sinon.match.func)
       assert.equal(wrap.firstCall.args[2](), tracerProvider)
+    })
+
+    // sdk-node >= 0.220.0 builds its provider from sdk-trace's TracerProvider, so this second hook
+    // is what keeps DD_TRACE_OTEL_ENABLED spans flowing on the newer SDK.
+    it('wraps sdk-trace TracerProvider with the dd-trace TracerProvider', () => {
+      const tracerProvider = function FakeTracerProvider () {}
+      const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: true }, { TracerProvider: tracerProvider })
+
+      const [hookOptions, transform] = addHook.secondCall.args
+      assert.deepStrictEqual(hookOptions, {
+        name: '@opentelemetry/sdk-trace',
+        file: 'build/src/TracerProvider.js',
+        versions: ['*'],
+      })
+
+      const mod = { TracerProvider: function OriginalProvider () {} }
+      assert.equal(transform(mod), mod)
+
+      sinon.assert.calledWithExactly(wrap, mod, 'TracerProvider', sinon.match.func)
+      assert.equal(wrap.firstCall.args[2](), tracerProvider)
+    })
+
+    it('registers exactly the two provider hooks when enabled', () => {
+      const { addHook } = loadWithEnv({ ddTraceOtelEnabled: true })
+      sinon.assert.calledTwice(addHook)
     })
   })
 })

--- a/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
+++ b/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
@@ -4,115 +4,95 @@ const assert = require('node:assert/strict')
 
 const { describe, it } = require('mocha')
 const proxyquire = require('proxyquire').noPreserveCache()
-const sinon = require('sinon')
 
 describe('otel-sdk-trace', () => {
   /**
    * Re-load `otel-sdk-trace.js` with the supplied config values stubbed in via
-   * `getValueFromEnvSources` and report what `addHook` saw. `getValueFromEnvSources`
+   * `getValueFromEnvSources` and report whether it instrumented. `getValueFromEnvSources`
    * already parses these registered boolean options, so the gate sees `true`,
    * `false`, or `undefined` — never a raw string. Parsing tolerance ('1', 'maybe',
    * '') is exercised in the config helper's own spec.
    *
+   * The real `datadog-shimmer` and `addHook` transforms run so the load reflects
+   * production behavior; `capturedTransforms` collects the transforms so a test can
+   * apply them to a fake module and assert the observable swap.
+   *
    * @param {{ ddTraceOtelEnabled?: boolean, otelSdkDisabled?: boolean }} env
    * @param {{ TracerProvider?: unknown }} [tracerStub]
-   * @returns {{ addHook: sinon.SinonSpy, wrap: sinon.SinonSpy }}
+   * @returns {{ instrumented: boolean, capturedTransforms: Array<(mod: object) => object> }}
    */
   function loadWithEnv (env, tracerStub = {}) {
-    const addHook = sinon.spy()
-    const wrap = sinon.spy()
     const values = {
       DD_TRACE_OTEL_ENABLED: env.ddTraceOtelEnabled,
       OTEL_SDK_DISABLED: env.otelSdkDisabled,
     }
+    const capturedTransforms = []
     proxyquire('../src/otel-sdk-trace', {
-      '../../datadog-shimmer': { wrap },
       '../../dd-trace': tracerStub,
       '../../dd-trace/src/config/helper': {
         getValueFromEnvSources: (name) => values[name],
       },
-      './helpers/instrument': { addHook },
+      './helpers/instrument': {
+        addHook: (_options, transform) => capturedTransforms.push(transform),
+      },
     })
-    return { addHook, wrap }
+    return { instrumented: capturedTransforms.length > 0, capturedTransforms }
   }
 
   describe('gate precedence', () => {
     it('disables when DD_TRACE_OTEL_ENABLED is the explicit opt-out', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: false }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: false }).instrumented, false)
     })
 
     it('keeps DD opt-out winning even when OTEL_SDK_DISABLED=false opts in', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: false, otelSdkDisabled: false }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: false, otelSdkDisabled: false }).instrumented, false)
     })
 
     it('disables when OTEL_SDK_DISABLED is the explicit opt-out', () => {
-      assert.equal(loadWithEnv({ otelSdkDisabled: true }).addHook.called, false)
+      assert.equal(loadWithEnv({ otelSdkDisabled: true }).instrumented, false)
     })
 
     it('keeps OTel opt-out winning even when DD_TRACE_OTEL_ENABLED=true opts in', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true, otelSdkDisabled: true }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true, otelSdkDisabled: true }).instrumented, false)
     })
 
     it('enables when DD_TRACE_OTEL_ENABLED is the explicit opt-in', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true }).addHook.called, true)
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true, otelSdkDisabled: false }).addHook.called, true)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true }).instrumented, true)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true, otelSdkDisabled: false }).instrumented, true)
     })
 
     it('enables when OTEL_SDK_DISABLED=false is the OTel positive opt-in', () => {
-      assert.equal(loadWithEnv({ otelSdkDisabled: false }).addHook.called, true)
+      assert.equal(loadWithEnv({ otelSdkDisabled: false }).instrumented, true)
     })
 
     it('stays disabled by default when neither option is set', () => {
-      assert.equal(loadWithEnv({}).addHook.called, false)
+      assert.equal(loadWithEnv({}).instrumented, false)
     })
 
     it('treats a value the helper rejected (undefined) as unset', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: undefined, otelSdkDisabled: undefined }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: undefined, otelSdkDisabled: undefined }).instrumented, false)
     })
   })
 
-  describe('hook registration', () => {
-    it('wraps sdk-trace-node NodeTracerProvider with the dd-trace TracerProvider', () => {
-      const tracerProvider = function FakeTracerProvider () {}
-      const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: true }, { TracerProvider: tracerProvider })
+  describe('provider replacement', () => {
+    // Assert the observable swap through the real shimmer rather than the addHook metadata: whatever
+    // SDK provider export the transforms touch ends up as the dd-trace TracerProvider. This survives
+    // renames of the hooked file/version wiring and covers both the sdk-trace-node NodeTracerProvider
+    // and (for sdk-node >= 0.220.0) the sdk-trace TracerProvider export the newer SDK builds from.
+    it('replaces each SDK provider export with the dd-trace TracerProvider', () => {
+      class DatadogTracerProvider {}
+      const tracerStub = { TracerProvider: DatadogTracerProvider }
+      const { capturedTransforms } = loadWithEnv({ ddTraceOtelEnabled: true }, tracerStub)
 
-      const [hookOptions, transform] = addHook.firstCall.args
-      assert.deepStrictEqual(hookOptions, {
-        name: '@opentelemetry/sdk-trace-node',
-        file: 'build/src/NodeTracerProvider.js',
-        versions: ['*'],
-      })
+      assert.ok(capturedTransforms.length > 0, 'the instrumentation registered no hooks')
 
-      const mod = { NodeTracerProvider: function OriginalProvider () {} }
-      assert.equal(transform(mod), mod)
+      const mod = { NodeTracerProvider: class {}, TracerProvider: class {} }
+      for (const transform of capturedTransforms) {
+        assert.equal(transform(mod), mod)
+      }
 
-      sinon.assert.calledWithExactly(wrap, mod, 'NodeTracerProvider', sinon.match.func)
-      assert.equal(wrap.firstCall.args[2](), tracerProvider)
-    })
-
-    // sdk-node >= 0.220.0 builds its provider from sdk-trace's TracerProvider, so this second hook
-    // is what keeps DD_TRACE_OTEL_ENABLED spans flowing on the newer SDK.
-    it('wraps sdk-trace TracerProvider with the dd-trace TracerProvider', () => {
-      const tracerProvider = function FakeTracerProvider () {}
-      const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: true }, { TracerProvider: tracerProvider })
-
-      const [hookOptions, transform] = addHook.secondCall.args
-      assert.deepStrictEqual(hookOptions, {
-        name: '@opentelemetry/sdk-trace',
-        file: 'build/src/TracerProvider.js',
-        versions: ['*'],
-      })
-
-      const mod = { TracerProvider: function OriginalProvider () {} }
-      assert.equal(transform(mod), mod)
-
-      sinon.assert.calledWithExactly(wrap, mod, 'TracerProvider', sinon.match.func)
-      assert.equal(wrap.firstCall.args[2](), tracerProvider)
-    })
-
-    it('registers exactly the two provider hooks when enabled', () => {
-      const { addHook } = loadWithEnv({ ddTraceOtelEnabled: true })
-      sinon.assert.calledTwice(addHook)
+      assert.equal(mod.NodeTracerProvider, DatadogTracerProvider)
+      assert.equal(mod.TracerProvider, DatadogTracerProvider)
     })
   })
 })


### PR DESCRIPTION
## Summary

`@opentelemetry/sdk-node` 0.220.0 builds its provider from `@opentelemetry/sdk-trace`'s `TracerProvider` instead of `sdk-trace-node`'s `NodeTracerProvider`. The existing hook only wraps `NodeTracerProvider`, so under `DD_TRACE_OTEL_ENABLED` the OTel-bridged spans stop reaching the tracer on 0.220+. This wraps the `sdk-trace` `TracerProvider` export too, keeping the older hook for pre-0.220 and direct `NodeTracerProvider` users.

Surfaced by the version bump in #9247, whose integration jobs fail on `should auto-instrument @opentelemetry/sdk-node` with a fake-agent timeout (the `otel-sub` span never arrives).

## Why

master pins `@opentelemetry/sdk-node` at 0.219.0 in the test-versions folder, so this PR's own integration CI still installs 0.219 and won't exercise the new path. Verified locally against 0.220.0: the existing integration test times out without this change and passes with it. #9247 becomes the end-to-end guard once it rebases on top.