### PR TITLE
fix(instrumentations): preserve asyncEnd wait with code-transformer 0.16

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -28,20 +28,29 @@ function waitForAsyncEnd (_state, node) {
     return
   }
 
-  const returnIndex = statements.findIndex(statement => (
-    statement.type === 'ReturnStatement' && statement.argument?.name === 'result'
-  ))
+  const returnStatement = statements.find(statement =>
+    statement.type === 'ReturnStatement' && statement.argument
+  )
 
-  if (returnIndex === -1) return
+  // The generated fulfillment handler always ends in a return; this only guards
+  // against a future template shape the transform can no longer splice into.
+  /* istanbul ignore next */
+  if (!returnStatement) return
 
   const waitStatements = parse(`
     function wrapper () {
       const __apm$asyncEndPromise = __apm$ctx.asyncEndPromise;
       if (__apm$asyncEndPromise && typeof __apm$asyncEndPromise.then === 'function') {
-        return __apm$asyncEndPromise.then(() => result, () => result);
+        return __apm$asyncEndPromise.then(() => __apm$result, () => __apm$result);
       }
     }
   `).body[0].body.body
 
-  statements.splice(returnIndex, 0, ...waitStatements)
+  // Resolve to whatever the fulfillment handler returns (its return argument),
+  // so a subscriber that reassigned `__apm$ctx.result` in `asyncEnd` still wins.
+  const { arguments: onSettled } = waitStatements[1].consequent.body[0].argument
+  onSettled[0].body = structuredClone(returnStatement.argument)
+  onSettled[1].body = structuredClone(returnStatement.argument)
+
+  statements.splice(statements.indexOf(returnStatement), 0, ...waitStatements)
 }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -8,6 +8,8 @@
 // the library, replace the custom registration with the built-in option and
 // remove the entry here.
 
+const clone = require('../../../../../vendor/dist/rfdc')({ proto: false, circles: false })
+
 const { parse, query } = require('./compiler')
 
 module.exports = { waitForAsyncEnd }
@@ -28,14 +30,14 @@ function waitForAsyncEnd (_state, node) {
     return
   }
 
-  const returnStatement = statements.find(statement =>
+  const returnIndex = statements.findIndex(statement =>
     statement.type === 'ReturnStatement' && statement.argument
   )
 
   // The generated fulfillment handler always ends in a return; this only guards
   // against a future template shape the transform can no longer splice into.
   /* istanbul ignore next */
-  if (!returnStatement) return
+  if (returnIndex === -1) return
 
   const waitStatements = parse(`
     function wrapper () {
@@ -48,9 +50,10 @@ function waitForAsyncEnd (_state, node) {
 
   // Resolve to whatever the fulfillment handler returns (its return argument),
   // so a subscriber that reassigned `__apm$ctx.result` in `asyncEnd` still wins.
+  const returnArgument = statements[returnIndex].argument
   const { arguments: onSettled } = waitStatements[1].consequent.body[0].argument
-  onSettled[0].body = structuredClone(returnStatement.argument)
-  onSettled[1].body = structuredClone(returnStatement.argument)
+  onSettled[0].body = clone(returnArgument)
+  onSettled[1].body = clone(returnArgument)
 
-  statements.splice(statements.indexOf(returnStatement), 0, ...waitStatements)
+  statements.splice(returnIndex, 0, ...waitStatements)
 }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -8,6 +8,8 @@
 // the library, replace the custom registration with the built-in option and
 // remove the entry here.
 
+const assert = require('node:assert')
+
 const clone = require('../../../../../vendor/dist/rfdc')({ proto: false, circles: false })
 
 const { parse, query } = require('./compiler')
@@ -34,10 +36,10 @@ function waitForAsyncEnd (_state, node) {
     statement.type === 'ReturnStatement' && statement.argument
   )
 
-  // The generated fulfillment handler always ends in a return; this only guards
-  // against a future template shape the transform can no longer splice into.
-  /* istanbul ignore next */
-  if (returnIndex === -1) return
+  // The generated fulfillment handler always ends in a return; a miss means the
+  // upstream template changed and the caller's try/catch falls back to the
+  // unwrapped source.
+  assert(returnIndex !== -1, 'waitForAsyncEnd: no return statement to wait on')
 
   const waitStatements = parse(`
     function wrapper () {

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.16.0",
         "@datadog/sketches-js": "2.1.1",
         "@datadog/source-map": "npm:source-map@^0.6.0",
         "@isaacs/ttlcache": "^2.1.5",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
-      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.16.0.tgz",
+      "integrity": "sha512-J3YRXRsxr/d48E7iDOAyVLrqQMCGU1iHWxXPKq7EeXQTRDDJ50piOfQNqxsM7u4XogJlirXvLHIznr0T33HTKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -4,7 +4,7 @@
     "postinstall": "node rspack"
   },
   "dependencies": {
-    "@apm-js-collab/code-transformer": "^0.15.0",
+    "@apm-js-collab/code-transformer": "^0.16.0",
     "@datadog/sketches-js": "2.1.1",
     "@datadog/source-map": "npm:source-map@^0.6.0",
     "@isaacs/ttlcache": "^2.1.5",


### PR DESCRIPTION
## Summary

Code-transformer 0.16 changes the generated native-Promise fulfillment handler to return `__apm$ctx.result` instead of the local `result`. `waitForAsyncEnd` located the return by matching an identifier named `result`, so on 0.16 it stops matching and silently skips injecting the `asyncEndPromise` wait — the Playwright RUM `Page.goto` tagging that depends on it then misses tags when a page closes immediately, and the `should wait for an asyncEnd promise when configured` rewriter spec fails.

1. `waitForAsyncEnd` now reuses the fulfillment handler's actual return argument instead of a hard-coded `result` identifier, so it keeps injecting across the shape change and resolves to the value a subscriber may reassign on `__apm$ctx.result` in `asyncEnd`.
2. Bump the vendored `@apm-js-collab/code-transformer` from 0.15.0 to 0.16.0.

Refs: https://github.com/nodejs/orchestrion-js/pull/85