### PR TITLE
fix(openfeature): create the flagging provider once, not on every reconfigure

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -290,11 +290,11 @@ class Tracer extends NoopProxy {
           this._modules.aiguard.enable(this._tracer, config)
           lazyProxy(this, 'aiguard', () => require('./aiguard/sdk'), this._tracer, config)
         }
+        if (config.experimental.flaggingProvider.enabled) {
+          this._modules.openfeature.enable(config)
+          lazyProxy(this, 'openfeature', () => require('./openfeature/flagging_provider'), this._tracer, config)
+        }
         this._tracingInitialized = true
-      }
-      if (config.experimental.flaggingProvider.enabled) {
-        this._modules.openfeature.enable(config)
-        lazyProxy(this, 'openfeature', () => require('./openfeature/flagging_provider'), this._tracer, config)
       }
       if (config.iast.enabled) {
         this._modules.iast.enable(config, this._tracer)

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -395,6 +395,16 @@ describe('TracerProxy', () => {
         sinon.assert.calledWith(openfeatureProvider._setConfiguration, flagConfig)
       })
 
+      it('should not recreate the openfeature provider when remote config reconfigures the tracer', () => {
+        config.experimental.flaggingProvider.enabled = true
+
+        proxy.init()
+
+        handlers.get('APM_TRACING')(createApmTracingTransaction('ffe-reconfig', { DD_TRACE_ENABLED: true }, 'modify'))
+
+        sinon.assert.calledOnce(OpenFeatureProvider)
+      })
+
       it('should support applying remote config', () => {
         const RemoteConfigProxy = proxyquire('../src/proxy', {
           './tracer': DatadogTracer,


### PR DESCRIPTION
### What does this PR do?

Creates the OpenFeature flagging provider exactly once, instead of re-creating it on every tracer reconfigure.

`Tracer#updateTracing` (in `packages/dd-trace/src/proxy.js`) runs on the initial `init()` and again on each `APM_TRACING` remote-config update, via the reconfigure callback registered in `init()`. The OpenFeature provider's `lazyProxy(this, 'openfeature', …)` was outside the `if (!this._tracingInitialized)` guard, so in the non-serverless path `defineEagerly` reassigned `this.openfeature = new FlaggingProvider(...)` on every reconfigure.

This moves that block inside the `_tracingInitialized` guard, next to the other tracing SDKs (appsec / llmobs / aiguard), so the provider is instantiated once.

### Motivation

Consumers register the provider a single time with the OpenFeature SDK:

```js
const { OpenFeature } = require('@openfeature/server-sdk')
const tracer = require('dd-trace').init()
OpenFeature.setProvider(tracer.openfeature)
```

When an `APM_TRACING` remote-config update later arrives, `updateTracing` re-runs and replaces `tracer.openfeature` with a new instance. Remote flag configuration is then delivered — through the `FFE_FLAGS` product handler's `() => this.openfeature` — to the **new** instance, while the OpenFeature SDK keeps evaluating against the **original** instance that `setProvider` captured. The original never receives configuration, stays not-ready / errored, and every evaluation falls back to the default value for the lifetime of the process.