### PR TITLE
fix(init): stabilize node 22 loader init tests

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -274,9 +274,9 @@ describe('init.js', () => {
 // or on 18.0.0 in particular.
 if (semver.satisfies(process.versions.node, '>=14.13.1')) {
   describe('initialize.mjs', () => {
-    // Node 20.0.0 can leave short-lived loader-based children alive after they
+    // Node 20.0.0 and 22.0.0 can leave short-lived loader-based children alive after they
     // print the expected output, so terminate them after a short grace period.
-    setShouldKill(process.versions.node === '20.0.0')
+    setShouldKill(process.versions.node === '20.0.0' || process.versions.node === '22.0.0')
     useSandbox()
     stubTracerIfNeeded()
 


### PR DESCRIPTION
## What does this PR do?

Extends the existing short-lived `--loader` child cleanup workaround from Node.js `20.0.0` to Node.js `22.0.0` in `integration-tests/init.spec.js`.

## Motivation

The `integration-guardrails (22.0.0)` job is flaky because Node.js `22.0.0` can leave short-lived loader-based child processes alive after they print the expected output. The test helper waits for the child `exit` event, so Mocha eventually fails with the 30s timeout.

Examples of observed failures:

- https://github.com/DataDog/dd-trace-js/actions/runs/28956036681/job/85927333665
- https://github.com/DataDog/dd-trace-js/actions/runs/28955955634/job/85915888709?pr=9262

## Additional Notes

Validated locally with Node.js `22.0.0`:

- `node node_modules/.bin/mocha --colors --timeout 30000 --grep "initialize\.mjs as --loader" integration-tests/init.spec.js`: `28 passing (9s)`
- `node node_modules/.bin/mocha --colors --timeout 30000 integration-tests/init.spec.js`: `84 passing (21s)`