### PR TITLE
test(init): guard fixture source logging

### DIFF
--- a/integration-tests/init/instrument.js
+++ b/integration-tests/init/instrument.js
@@ -17,8 +17,10 @@ const server = http.createServer((req, res) => {
       server.close()
       // eslint-disable-next-line no-console
       console.log(gotEvent)
-      // eslint-disable-next-line no-console
-      console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+      if (global._ddtrace?._tracer) {
+        // eslint-disable-next-line no-console
+        console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+      }
       process.exit()
     })
   })

--- a/integration-tests/init/instrument.mjs
+++ b/integration-tests/init/instrument.mjs
@@ -15,8 +15,10 @@ const server = http.createServer((req, res) => {
       server.close()
       // eslint-disable-next-line no-console
       console.log(gotEvent)
-      // eslint-disable-next-line no-console
-      console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+      if (global._ddtrace?._tracer) {
+        // eslint-disable-next-line no-console
+        console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+      }
       process.exit()
     })
   })

--- a/integration-tests/init/trace.js
+++ b/integration-tests/init/trace.js
@@ -2,6 +2,8 @@
 
 // eslint-disable-next-line no-console
 console.log(!!global._ddtrace)
-// eslint-disable-next-line no-console
-console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+if (global._ddtrace?._tracer) {
+  // eslint-disable-next-line no-console
+  console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+}
 process.exit()

--- a/integration-tests/init/trace.mjs
+++ b/integration-tests/init/trace.mjs
@@ -1,5 +1,7 @@
 // eslint-disable-next-line no-console
 console.log(!!global._ddtrace)
-// eslint-disable-next-line no-console
-console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+if (global._ddtrace?._tracer) {
+  // eslint-disable-next-line no-console
+  console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
+}
 process.exit()


### PR DESCRIPTION
### What does this PR do?

Guards the init integration fixtures before printing `global._ddtrace._tracer._config.instrumentationSource`.

The negative `DD_INJECTION_ENABLED` scenarios intentionally do not initialize the tracer, so the fixtures should print
the expected `false` result and exit instead of dereferencing `_tracer`.

### Motivation

The integration guardrails job was failing in `DD_INJECTION_ENABLED` cases with:

```text
TypeError: Cannot read properties of undefined (reading '_tracer')
```

Depending on child-process exit timing, the same fixture crash can also surface as a Mocha timeout.

### Additional Notes

Focused verification:

- `nvm exec 22.10.0 node /private/tmp/probe-init-dd-injection.js`
- `PROBE_FILE=init/trace.mjs nvm exec 22.10.0 node /private/tmp/probe-init-dd-injection.js`
- `PROBE_FILE=init/trace.js nvm exec 22.10.0 node /private/tmp/probe-init-dd-injection.js`
- `PROBE_FILE=init/instrument.js nvm exec 22.10.0 node /private/tmp/probe-init-dd-injection.js`
- `nvm exec 22.10.0 node --check integration-tests/init/{trace.js,trace.mjs,instrument.js,instrument.mjs}`
