### PR TITLE
test(undici): force proxy tunnel in CONNECT regression test

### DIFF
--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -851,7 +851,12 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              const dispatcher = new fetch.ProxyAgent(`http://localhost:${proxyPort}`)
+              // proxyTunnel forces a CONNECT tunnel for the plain-HTTP-over-HTTP-proxy case.
+              // undici 8.7.0 (nodejs/undici#5116) made that case forward an absolute-form
+              // request instead of tunneling by default, so without this the proxy never sees
+              // a CONNECT and there is no CONNECT span to assert on. The option is a no-op on
+              // undici < 6.22.0, where CONNECT was always used.
+              const dispatcher = new fetch.ProxyAgent({ uri: `http://localhost:${proxyPort}`, proxyTunnel: true })
               fetch.request(`http://localhost:${downstreamPort}/data`, { dispatcher })
                 .then(({ body }) => body.text())
                 .catch(done)


### PR DESCRIPTION
undici 8.7.0 (nodejs/undici#5116) changed the default so a plain HTTP request through an HTTP proxy forwards an absolute-form request instead of tunneling via CONNECT. The ProxyAgent CONNECT-span regression test then sees no CONNECT request at all and fails asserting a finished CONNECT span. Passing proxyTunnel: true restores the tunnel; the option is a no-op on undici < 6.22.0, where CONNECT was always used.

Refs: https://github.com/nodejs/undici/pull/5116