### PR TITLE
fix(iast): instrument cookie parseCookie for cookie >=1.1

### DIFF
--- a/packages/datadog-instrumentations/src/cookie.js
+++ b/packages/datadog-instrumentations/src/cookie.js
@@ -15,13 +15,12 @@ function wrapParse (originalParse) {
   }
 }
 
-// cookie <1 exports only `parse`. 1.x exports `parse` plus a `parseCookie` alias. 2.x is ESM-only and exports only
-// `parseCookie`. Wrap whichever parse entry points the installed version exposes so the caller's chosen name is
-// instrumented; a single call hits exactly one export, so wrapping both when present does not double-publish.
+/** @param {typeof import('cookie')} cookie */
 addHook({ name: 'cookie', versions: ['>=0.4'] }, cookie => {
   for (const name of ['parse', 'parseCookie']) {
     if (typeof cookie[name] === 'function') {
-      shimmer.wrap(cookie, name, wrapParse)
+      // shimmer returns a mutable replacement when an ESM namespace export is non-configurable.
+      cookie = shimmer.wrap(cookie, name, wrapParse)
     }
   }
   return cookie

--- a/packages/datadog-instrumentations/src/cookie.js
+++ b/packages/datadog-instrumentations/src/cookie.js
@@ -15,7 +15,14 @@ function wrapParse (originalParse) {
   }
 }
 
+// cookie <1 exports only `parse`. 1.x exports `parse` plus a `parseCookie` alias. 2.x is ESM-only and exports only
+// `parseCookie`. Wrap whichever parse entry points the installed version exposes so the caller's chosen name is
+// instrumented; a single call hits exactly one export, so wrapping both when present does not double-publish.
 addHook({ name: 'cookie', versions: ['>=0.4'] }, cookie => {
-  shimmer.wrap(cookie, 'parse', wrapParse)
+  for (const name of ['parse', 'parseCookie']) {
+    if (typeof cookie[name] === 'function') {
+      shimmer.wrap(cookie, name, wrapParse)
+    }
+  }
   return cookie
 })

--- a/packages/datadog-plugin-cookie/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cookie/test/integration-test/client.spec.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+
+const semver = require('semver')
+
 const {
   sandboxCwd,
   useSandbox,
@@ -11,16 +14,24 @@ const {
   stopProc,
 } = require('../../../../integration-tests/helpers')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
+const { NODE_MAJOR } = require('../../../../version')
 
-withVersions('cookie', 'cookie', version => {
+withVersions('cookie', 'cookie', (version, _moduleName, resolvedVersion) => {
+  // cookie >=2 is ESM-only with named exports (no default), renames `parse` to `parseCookie`, and requires Node >=22.
+  const isEsmOnly = semver.satisfies(resolvedVersion, '>=2')
+
   describe('ESM', () => {
+    if (isEsmOnly && NODE_MAJOR < 22) return
+
     let variants, proc, agent
 
     useSandbox([`'cookie@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-cookie/test/integration-test/*'])
 
     before(function () {
-      variants = varySandbox('server.mjs', 'cookie')
+      variants = isEsmOnly
+        ? varySandbox('server-v2.mjs', 'parseCookie', 'parseCookie', 'cookie', true)
+        : varySandbox('server.mjs', 'cookie')
     })
 
     beforeEach(async () => {
@@ -32,7 +43,8 @@ withVersions('cookie', 'cookie', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    const variantNames = isEsmOnly ? ['star', 'destructure'] : varySandbox.VARIANTS
+    for (const variant of variantNames) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-cookie/test/integration-test/server-v2.mjs
+++ b/packages/datadog-plugin-cookie/test/integration-test/server-v2.mjs
@@ -1,0 +1,23 @@
+import 'dd-trace/init.js'
+import express from 'express'
+import { parseCookie } from 'cookie'
+import dc from 'dc-polyfill'
+
+const cookieParseCh = dc.channel('datadog:cookie:parse:finish')
+let counter = 0
+cookieParseCh.subscribe(() => {
+  counter += 1
+})
+
+const app = express()
+
+app.get('/', (req, res) => {
+  parseCookie('hello=world')
+  res.setHeader('X-Counter', counter)
+  res.end('ok')
+})
+
+const server = app.listen(0, () => {
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
+  process.send({ port })
+})

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { isModuleNamespaceObject } = require('node:util').types
+
 /**
  * @type {Set<string | symbol>}
  */
@@ -168,14 +170,19 @@ function wrap (target, name, wrapper, options) {
 
   copyProperties(original, wrapped)
 
-  if (descriptor.writable) {
+  const immutableModuleNamespace = descriptor.configurable === false &&
+    descriptor.writable && isModuleNamespaceObject(target)
+
+  if (descriptor.writable && !immutableModuleNamespace) {
     if (descriptor.configurable && descriptor.enumerable) {
       target[name] = wrapped
       return target
     }
     descriptor.value = wrapped
   } else {
-    if (descriptor.set && options?.replaceGetter) {
+    if (immutableModuleNamespace) {
+      descriptor.value = wrapped
+    } else if (descriptor.set && options?.replaceGetter) {
       // A lazy accessor pair (e.g. Node 20's `fs.opendir`). `original` already
       // resolved the value through the getter. Keep the property an accessor pair
       // so the shape stays observationally identical — a downstream consumer may

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -373,6 +373,18 @@ describe('shimmer', () => {
       })
     })
 
+    it('should wrap writable non-configurable module namespace exports', async () => {
+      const namespace = await import('data:text/javascript,export function count() { return 1 }')
+
+      /** @param {Function} count */
+      const increment = count => () => count() + 1
+      const wrapped = shimmer.wrap(namespace, 'count', increment)
+
+      assert.strictEqual(namespace.count(), 1)
+      assert.strictEqual(wrapped.count(), 2)
+      assert.notStrictEqual(wrapped, namespace)
+    })
+
     it('should skip non-configurable/writable string keyed methods', () => {
       const obj = {
         configurable () {},

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 
 const axios = require('axios')
 const { afterEach, beforeEach, describe, it } = require('mocha')
+const semver = require('semver')
 
 const { storage } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
@@ -11,6 +12,7 @@ const iastContextFunctions = require('../../../../../src/appsec/iast/iast-contex
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
 const { getConfigFresh } = require('../../../../helpers/config')
 const { withVersions } = require('../../../../setup/mocha')
+const { NODE_MAJOR } = require('../../../../../../../version')
 const {
   HTTP_REQUEST_COOKIE_NAME,
   HTTP_REQUEST_COOKIE_VALUE,
@@ -19,13 +21,20 @@ const { testInRequest } = require('../../utils')
 
 describe('Cookies sourcing with cookies', () => {
   let cookie
-  withVersions('cookie', 'cookie', version => {
+  withVersions('cookie', 'cookie', (version, _moduleName, resolvedVersion) => {
+    // cookie >=2 requires Node >=22.
+    if (semver.satisfies(resolvedVersion, '>=2') && NODE_MAJOR < 22) {
+      it.skip(`skipped — cookie ${resolvedVersion} requires Node >=22`, () => {})
+      return
+    }
+
     function app () {
       const store = storage('legacy').getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const rawCookies = 'cookie=value'
-      const parsedCookies = cookie.parse(rawCookies)
+      const parse = cookie.parseCookie ?? cookie.parse
+      const parsedCookies = parse(rawCookies)
       Object.getOwnPropertySymbols(parsedCookies).forEach(cookieName => {
         const cookieValue = parsedCookies[cookieName]
         const isCookieValueTainted = isTainted(iastContext, cookieValue)

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
@@ -13,10 +13,7 @@ const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-t
 const { getConfigFresh } = require('../../../../helpers/config')
 const { withVersions } = require('../../../../setup/mocha')
 const { NODE_MAJOR } = require('../../../../../../../version')
-const {
-  HTTP_REQUEST_COOKIE_NAME,
-  HTTP_REQUEST_COOKIE_VALUE,
-} = require('../../../../../src/appsec/iast/taint-tracking/source-types')
+const { HTTP_REQUEST_COOKIE_VALUE } = require('../../../../../src/appsec/iast/taint-tracking/source-types')
 const { testInRequest } = require('../../utils')
 
 describe('Cookies sourcing with cookies', () => {
@@ -35,17 +32,10 @@ describe('Cookies sourcing with cookies', () => {
       const rawCookies = 'cookie=value'
       const parse = cookie.parseCookie ?? cookie.parse
       const parsedCookies = parse(rawCookies)
-      Object.getOwnPropertySymbols(parsedCookies).forEach(cookieName => {
-        const cookieValue = parsedCookies[cookieName]
-        const isCookieValueTainted = isTainted(iastContext, cookieValue)
-        assert.strictEqual(isCookieValueTainted, true)
-        const taintedCookieValueRanges = getRanges(iastContext, cookieValue)
-        assert.strictEqual(taintedCookieValueRanges[0].iinfo.type, HTTP_REQUEST_COOKIE_VALUE)
-        const isCookieNameTainted = isTainted(iastContext, cookieName)
-        assert.strictEqual(isCookieNameTainted, true)
-        const taintedCookieNameRanges = getRanges(iastContext, cookieName)
-        assert.strictEqual(taintedCookieNameRanges[0].iinfo.type, HTTP_REQUEST_COOKIE_NAME)
-      })
+      const cookieValue = parsedCookies.cookie
+      assert.strictEqual(isTainted(iastContext, cookieValue), true)
+      const taintedCookieValueRanges = getRanges(iastContext, cookieValue)
+      assert.strictEqual(taintedCookieValueRanges[0].iinfo.type, HTTP_REQUEST_COOKIE_VALUE)
     }
 
     function tests (config) {

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -111,7 +111,7 @@
     "cassandra-driver": "4.9.0",
     "collections": "5.1.13",
     "connect": "3.7.0",
-    "cookie": "1.1.1",
+    "cookie": "2.0.1",
     "cookie-parser": "1.4.7",
     "couchbase": "4.7.0",
     "cypress": "15.16.0",


### PR DESCRIPTION
cookie 1.1 added a parseCookie alias next to parse, and cookie 2.0 dropped parse entirely in an ESM-only rewrite that exports only parseCookie. The hook only wrapped parse, so the datadog:cookie:parse:finish channel never fired for callers using parseCookie (all of cookie 2.x, and 1.x code that adopted the new name) and IAST stopped tainting those cookies.

Wrap every parse entry the installed version exposes; a single call hits one export, so wrapping both names when present does not double-publish.

The plugin ESM integration test gains a parseCookie fixture for the named-export 2.x shape, and both it and the IAST source test skip cookie 2.x on Node <22, which the package's engines field requires.


