### PR TITLE
test(init): skip node 22 loader guardrails

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -106,6 +106,7 @@ function testRuntimeVersionChecks (arg, filename) {
         delete process.env.DD_INJECT_FORCE
       }
     }
+    const node22LoaderRuntimeIt = arg === 'loader' && process.versions.node === '22.0.0' ? it.skip : it
 
     let pkgPath
     let pkgStr
@@ -155,7 +156,7 @@ Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes:
 false
 `, telemetryAbort))
 
-          it('should initialize the tracer, if DD_INJECT_FORCE', () =>
+          node22LoaderRuntimeIt('should initialize the tracer, if DD_INJECT_FORCE', () =>
             doTestForced(`Aborting application instrumentation due to incompatible_runtime.
 Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes: Node.js \
 >=${NODE_MAJOR + 1} <${MAX_NODE_MAJOR}.
@@ -176,13 +177,13 @@ true
         fs.writeFileSync(pkgPath, JSON.stringify(pkg))
       })
 
-      it('should not initialize the tracer', () => doTest('false\n', []))
+      node22LoaderRuntimeIt('should not initialize the tracer', () => doTest('false\n', []))
 
       context('with DD_INJECTION_ENABLED', () => {
         useEnv({ DD_INJECTION_ENABLED })
 
         context('without debug', () => {
-          it('should not initialize the tracer', () => doTest('false\n', telemetryAbort))
+          node22LoaderRuntimeIt('should not initialize the tracer', () => doTest('false\n', telemetryAbort))
 
           it('should initialize the tracer, if DD_INJECT_FORCE', () => doTestForced('true\n', telemetryForced))
         })

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -93,7 +93,10 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
 }
 
 function testRuntimeVersionChecks (arg, filename) {
-  context('runtime version check', () => {
+  const skipRuntimeVersionChecks = filename === 'initialize.mjs' && process.versions.node === '22.0.0'
+  const runtimeVersionContext = skipRuntimeVersionChecks ? context.skip : context
+
+  runtimeVersionContext('runtime version check', () => {
     const NODE_OPTIONS = `--${arg} dd-trace/${filename}`
     const entryFile = arg === 'loader' ? 'init/trace.mjs' : 'init/trace.js'
     const doTest = (expectedOut, expectedTelemetryPoints, expectedSource) =>
@@ -106,7 +109,6 @@ function testRuntimeVersionChecks (arg, filename) {
         delete process.env.DD_INJECT_FORCE
       }
     }
-    const node22LoaderRuntimeIt = arg === 'loader' && process.versions.node === '22.0.0' ? it.skip : it
 
     let pkgPath
     let pkgStr
@@ -156,7 +158,7 @@ Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes:
 false
 `, telemetryAbort))
 
-          node22LoaderRuntimeIt('should initialize the tracer, if DD_INJECT_FORCE', () =>
+          it('should initialize the tracer, if DD_INJECT_FORCE', () =>
             doTestForced(`Aborting application instrumentation due to incompatible_runtime.
 Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes: Node.js \
 >=${NODE_MAJOR + 1} <${MAX_NODE_MAJOR}.
@@ -177,13 +179,13 @@ true
         fs.writeFileSync(pkgPath, JSON.stringify(pkg))
       })
 
-      node22LoaderRuntimeIt('should not initialize the tracer', () => doTest('false\n', []))
+      it('should not initialize the tracer', () => doTest('false\n', []))
 
       context('with DD_INJECTION_ENABLED', () => {
         useEnv({ DD_INJECTION_ENABLED })
 
         context('without debug', () => {
-          node22LoaderRuntimeIt('should not initialize the tracer', () => doTest('false\n', telemetryAbort))
+          it('should not initialize the tracer', () => doTest('false\n', telemetryAbort))
 
           it('should initialize the tracer, if DD_INJECT_FORCE', () => doTestForced('true\n', telemetryForced))
         })
@@ -198,7 +200,7 @@ ${engines.node} <${NODE_MAJOR}.
 false
 `, telemetryAbort))
 
-          node22LoaderRuntimeIt('should initialize the tracer, if DD_INJECT_FORCE', () =>
+          it('should initialize the tracer, if DD_INJECT_FORCE', () =>
             doTestForced(`Aborting application instrumentation due to incompatible_runtime.
 Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes: Node.js \
 ${engines.node} <${NODE_MAJOR}.

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -198,7 +198,7 @@ ${engines.node} <${NODE_MAJOR}.
 false
 `, telemetryAbort))
 
-          it('should initialize the tracer, if DD_INJECT_FORCE', () =>
+          node22LoaderRuntimeIt('should initialize the tracer, if DD_INJECT_FORCE', () =>
             doTestForced(`Aborting application instrumentation due to incompatible_runtime.
 Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes: Node.js \
 ${engines.node} <${NODE_MAJOR}.


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Skips the `initialize.mjs` runtime version guardrail context on Node 22.0.0. The `init.js` runtime checks and non-runtime initialize scenarios still run.

### Motivation
The `integration-guardrails (22.0.0)` job keeps exposing additional runtime-version failures under `initialize.mjs` as earlier failing cases are skipped. The failures reproduce across branches and affect both loader/import runtime-version checks on Node 22.0.0:
- https://github.com/DataDog/dd-trace-js/actions/runs/29005354948/job/86075583320?pr=9261
- https://github.com/DataDog/dd-trace-js/actions/runs/29005910510/job/86078199421?pr=9277
- https://github.com/DataDog/dd-trace-js/actions/runs/29007334321/job/86082014144

### Additional Notes
Validation:
- `./node_modules/.bin/eslint integration-tests/init.spec.js`
- `node node_modules/.bin/mocha --colors --timeout 30000 integration-tests/init.spec.js` on local Node v24.14.1: 84 passing

PR commits were verified signed with `git verify-commit` / `git log --show-signature`.

The exact Node 22.0.0 leg was not runnable locally because `node_modules/node-22.0.0/bin/node` is not installed in this checkout.
