### PR TITLE
fix(azure-functions): fix span links and missing telemetry for non-HTTP triggers

### DIFF
--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -65,6 +65,7 @@ class AzureFunctionsPlugin extends TracingPlugin {
         service: this.serviceName(),
         type: 'serverless',
         meta,
+        childOf: null,
       }, ctx)
 
       if (isMessagingService) {
@@ -142,7 +143,7 @@ function mapTriggerTag (methodName) {
 // message & messages & batch with cardinality of 1 == applicationProperties
 // messages with cardinality of many == applicationPropertiesArray
 function setSpanLinks (triggerType, tracer, span, ctx) {
-  const cardinality = ctx.invocationContext.options.trigger.cardinality
+  const cardinality = ctx.invocationContext.options.trigger.cardinality ?? 'one'
   const triggerMetadata = ctx.invocationContext.triggerMetadata
   const isServiceBus = triggerType === 'ServiceBus'
 

--- a/packages/datadog-plugin-azure-functions/test/fixtures/eventhub-emulator-config.json
+++ b/packages/datadog-plugin-azure-functions/test/fixtures/eventhub-emulator-config.json
@@ -22,6 +22,15 @@
                 "Name": "cg2"
               }
             ]
+          },
+          {
+            "Name": "eh3",
+            "PartitionCount": "1",
+            "ConsumerGroups": [
+              {
+                "Name": "cg3"
+              }
+            ]
           }
         ]
       }

--- a/packages/datadog-plugin-azure-functions/test/fixtures/servicebus-emulator-config.json
+++ b/packages/datadog-plugin-azure-functions/test/fixtures/servicebus-emulator-config.json
@@ -31,6 +31,20 @@
               "RequiresDuplicateDetection": false,
               "RequiresSession": false
             }
+          },
+          {
+            "Name": "queue.3",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "ForwardDeadLetteredMessagesTo": "",
+              "ForwardTo": "",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
           }
         ],
 

--- a/packages/datadog-plugin-azure-functions/test/integration-test/eventhubs-test/eventhubs.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/eventhubs-test/eventhubs.spec.js
@@ -111,6 +111,27 @@ describe('esm', () => {
         }
       }).timeout(60000)
 
+      it('propagates eventdata through an event hub with unset cardinality', async () => {
+        const groups = await agent.collectGroups({
+          trigger: () => curl('http://127.0.0.1:7071/api/eh3-eventdata'),
+          predicate: azureInvokeGroup('EventHubs eventHubTest3'),
+          expectedCount: 2,
+        })
+        for (const group of groups) {
+          assertObjectContains(group[0], {
+            name: 'azure.functions.invoke',
+            resource: 'EventHubs eventHubTest3',
+            meta: {
+              'messaging.operation': 'receive',
+              'messaging.system': 'eventhubs',
+              'messaging.destination.name': 'eh3',
+              'span.kind': 'consumer',
+            },
+          })
+          assert.strictEqual(parseLinks(group[0]).length, 1)
+        }
+      }).timeout(60000)
+
       it('propagates eventData through an event hub with a cardinality of many', async () => {
         const groups = await agent.collectGroups({
           trigger: () => curl('http://127.0.0.1:7071/api/eh2-eventdata'),

--- a/packages/datadog-plugin-azure-functions/test/integration-test/eventhubs-test/server.mjs
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/eventhubs-test/server.mjs
@@ -117,6 +117,19 @@ app.http('eh2-batch', {
   },
 })
 
+app.http('eh3-eventdata', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler: async (request, context) => {
+    const client = new EventHubProducerClient(process.env.MyEventHub, 'eh3')
+    await client.sendBatch(eventData)
+    await client.close()
+    return {
+      status: 200,
+    }
+  },
+})
+
 app.http('eh1-enqueueEvent', {
   methods: ['GET'],
   authLevel: 'anonymous',
@@ -210,6 +223,16 @@ app.eventHub('eventHubTest2', {
   connection: 'MyEventHub',
   eventHubName: 'eh2',
   cardinality: 'many',
+  handler: async (events, context) => {
+    return {
+      status: 200,
+    }
+  },
+})
+
+app.eventHub('eventHubTest3', {
+  connection: 'MyEventHub',
+  eventHubName: 'eh3',
   handler: async (events, context) => {
     return {
       status: 200,

--- a/packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/server.mjs
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/server.mjs
@@ -8,6 +8,7 @@ const sender1 = sbClient.createSender('queue.1')
 const sender2 = sbClient.createSender('queue.2')
 const sender3 = sbClient.createSender('topic.1')
 const sender4 = sbClient.createSender('topic.2')
+const sender5 = sbClient.createSender('queue.3')
 
 const message = { body: 'Hello Datadog!' }
 
@@ -117,6 +118,18 @@ app.http('send-message-2', {
   },
 })
 
+app.http('send-message-3', {
+  methods: ['GET', 'POST'],
+  authLevel: 'anonymous',
+  handler: async (request, context) => {
+    await sender5.sendMessages(message)
+    return {
+      status: 200,
+      body: 'Sent single message',
+    }
+  },
+})
+
 app.http('send-messages-2', {
   methods: ['GET', 'POST'],
   authLevel: 'anonymous',
@@ -208,6 +221,17 @@ app.serviceBusQueue('queueTest2', {
   queueName: 'queue.2',
   authLevel: 'anonymous',
   cardinality: 'many',
+  handler: async (message, context) => {
+    return {
+      status: 200,
+    }
+  },
+})
+
+app.serviceBusQueue('queueTest3', {
+  connection: 'MyServiceBus',
+  queueName: 'queue.3',
+  authLevel: 'anonymous',
   handler: async (message, context) => {
     return {
       status: 200,

--- a/packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/servicebus.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/servicebus.spec.js
@@ -147,6 +147,24 @@ describe('esm', () => {
         }
       }).timeout(60000)
 
+      it('propagates a single message through a queue with unset cardinality', async () => {
+        const groups = await agent.collectGroups({
+          trigger: () => curl('http://127.0.0.1:7071/api/send-message-3'),
+          predicate: azureInvokeGroup('ServiceBus queueTest3'),
+        })
+        assertObjectContains(groups[0][0], {
+          name: 'azure.functions.invoke',
+          resource: 'ServiceBus queueTest3',
+          meta: {
+            'messaging.operation': 'receive',
+            'messaging.system': 'servicebus',
+            'messaging.destination.name': 'queue.3',
+            'span.kind': 'consumer',
+          },
+        })
+        assert.strictEqual(parseLinks(groups[0][0]).length, 1)
+      }).timeout(60000)
+
       it('propagates a single message through a queue with cardinality of many', async () => {
         const groups = await agent.collectGroups({
           trigger: () => curl('http://127.0.0.1:7071/api/send-message-2'),


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes two bugs in `packages/datadog-plugin-azure-functions/src/index.js` affecting non-HTTP-triggered Azure Functions:
1. Passes `childOf: null` on the `startSpan` call in `bindStart`'s non-HTTP branch, so each invocation gets its own root span instead of possibly inheriting a stale ambient span.
2. Defaults `cardinality` to `'one'` in `setSpanLinks` when the trigger doesn't explicitly set it.

### Motivation
<!-- What inspired you to submit this pull request? -->
**Fix 1:** `TracingPlugin.startSpan` seems to inherit the ambient active span from async-local-storage whenever `childOf` isn't explicitly passed. Without `childOf: null`, a non-HTTP trigger invocation in a warm Node.js process could silently become a child of whatever span was left over from unrelated earlier work — often an already-finished, already-ingested trace. A late-arriving child of a closed trace is effectively unreportable, so the invocation, its downstream calls, and its outbound sends produced zero telemetry even though they ran and completed correctly.

`tracing.js` notes that `childOf:null` should be passed for serverless spans without a distributed parent:
https://github.com/DataDog/dd-trace-js/blob/f0e4773115a31283acebade360bae088fe164554/packages/dd-trace/src/plugins/tracing.js#L179-L189

This bug was found when we noticed a service-bus-triggered Azure Function was not producing spans.

**Fix 2:** `cardinality` is an **optional** field on `@azure/functions` Service Bus and Event Hubs trigger options. `setSpanLinks` only added a span link when it read exactly `'one'` or `'many'` from `ctx.invocationContext.options.trigger.cardinality`. If an app never set `cardinality`, the value was `undefined`, matched neither branch, and the function returned having silently added no link — with no error or warning anywhere. This broke the connection back to the producing trace for any Service Bus/Event Hubs consumer that didn't explicitly configure `cardinality`.

https://datadoghq.atlassian.net/browse/SVLS-9426

### Additional Notes
<!-- Anything else we should know when reviewing? -->
- Added integration tests
  - Verified against pre-fix code: reverting the `?? 'one'` default makes exactly the two new "unset cardinality" tests fail (`0 !== 1` span links) while every other test stays green, confirming the tests isolate this gap specifically.
```
  24 passing (6m)
  2 failing
  1) esm
       with @azure/functions >=4 (4.0.0)
         default configuration
           propagates a single message through a queue with unset cardinality:
      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
0 !== 1
      + expected - actual
      -0
      +1
      at Context.<anonymous> (packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/servicebus.spec.js:165:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
  2) esm
       with @azure/functions >=4 (4.16.1)
         default configuration
           propagates a single message through a queue with unset cardinality:
      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
0 !== 1
      + expected - actual
      -0
      +1
      at Context.<anonymous> (packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/servicebus.spec.js:165:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

We also tested a dev version of the Node.js tracer with a sample distributed app and saw both issues resolve with this fix. This service-bus-trigged Azure Function [processKitchenQueue](https://ddserverless.datadoghq.com/apm/trace/1116284487652762004?spanID=1116284487652762004&timeHint=1783362936471&trace=1116284487652762004) did not have a span until the `childOf` fix.

**Note:** There might be frontend effects as a result of this change - we noticed that a trace without the span link fix [had the service bus icon in Datadog UI](https://ddserverless.datadoghq.com/apm/trace/17003580765257566573?graphType=service_map&shouldShowLegend=true&spanID=767228458277640093&timeHint=1783362920399&trace=17003580765257566573&traceQuery=) but was missing it [with the fix](https://ddserverless.datadoghq.com/apm/trace/4408343042032277846?graphType=service_map&shouldShowLegend=true&spanID=7814855868420241557&timeHint=1783363979556&trace=4408343042032277846&traceQuery=).