### PR TITLE
feat(llmobs): propagate session_id to following spans and across services [MLOB-7756]

### DIFF
--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -13,7 +13,7 @@ module.exports = {
   ML_APP: '_ml_obs.meta.ml_app',
   PROPAGATED_PARENT_ID_KEY: '_dd.p.llmobs_parent_id',
   PROPAGATED_ML_APP_KEY: '_dd.p.llmobs_ml_app',
-  PROPAGATED_SESSION_ID_KEY: '_dd.p.llmobs_session_id',
+  PROPAGATED_SESSION_ID_KEY: '_dd.p.llmobs_sid',
   PARENT_ID_KEY: '_ml_obs.llmobs_parent_id',
   PROPAGATED_SAMPLE_RATE_KEY: '_dd.p.llmobs_sr',
   PROPAGATED_SAMPLING_DECISION_KEY: '_dd.p.llmobs_sd',

--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -13,6 +13,7 @@ module.exports = {
   ML_APP: '_ml_obs.meta.ml_app',
   PROPAGATED_PARENT_ID_KEY: '_dd.p.llmobs_parent_id',
   PROPAGATED_ML_APP_KEY: '_dd.p.llmobs_ml_app',
+  PROPAGATED_SESSION_ID_KEY: '_dd.p.llmobs_session_id',
   PARENT_ID_KEY: '_ml_obs.llmobs_parent_id',
   PROPAGATED_SAMPLE_RATE_KEY: '_dd.p.llmobs_sr',
   PROPAGATED_SAMPLING_DECISION_KEY: '_dd.p.llmobs_sd',

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -35,6 +35,7 @@ const {
   INTEGRATION,
   DECORATOR,
   PROPAGATED_ML_APP_KEY,
+  PROPAGATED_SESSION_ID_KEY,
   DEFAULT_PROMPT_NAME,
   INTERNAL_CONTEXT_VARIABLE_KEYS,
   INTERNAL_QUERY_VARIABLE_KEYS,
@@ -139,8 +140,17 @@ class LLMObsTagger {
     if (modelName) this.tagModelName(span, modelName)
     if (modelProvider) this._setTag(span, MODEL_PROVIDER, modelProvider)
 
-    sessionId = sessionId || registry.get(parent)?.[SESSION_ID]
-    if (sessionId) this._setTag(span, SESSION_ID, sessionId)
+    const traceTags = span.context()._trace.tags
+    sessionId = sessionId || registry.get(parent)?.[SESSION_ID] || traceTags[PROPAGATED_SESSION_ID_KEY]
+    if (sessionId) {
+      this._setTag(span, SESSION_ID, sessionId)
+      // The first session set in a trace becomes the trace-level default, stored on the trace-shared
+      // propagating tags. Later spans (including those under a session-less parent) inherit it, and it
+      // rides `x-datadog-tags` across service boundaries. An explicit sessionId still overrides locally.
+      if (traceTags[PROPAGATED_SESSION_ID_KEY] === undefined) {
+        traceTags[PROPAGATED_SESSION_ID_KEY] = sessionId
+      }
+    }
     if (integration) this._setTag(span, INTEGRATION, integration)
     if (_decorator) this._setTag(span, DECORATOR, _decorator)
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -142,15 +142,7 @@ class LLMObsTagger {
 
     const traceTags = span.context()._trace.tags
     sessionId = sessionId || registry.get(parent)?.[SESSION_ID] || traceTags[PROPAGATED_SESSION_ID_KEY]
-    if (sessionId) {
-      this._setTag(span, SESSION_ID, sessionId)
-      // The first session set in a trace becomes the trace-level default, stored on the trace-shared
-      // propagating tags. Later spans (including those under a session-less parent) inherit it, and it
-      // rides `x-datadog-tags` across service boundaries. An explicit sessionId still overrides locally.
-      if (traceTags[PROPAGATED_SESSION_ID_KEY] === undefined) {
-        traceTags[PROPAGATED_SESSION_ID_KEY] = sessionId
-      }
-    }
+    if (sessionId) this._setTag(span, SESSION_ID, sessionId)
     if (integration) this._setTag(span, INTEGRATION, integration)
     if (_decorator) this._setTag(span, DECORATOR, _decorator)
 
@@ -762,6 +754,18 @@ class LLMObsTagger {
 
     const tagsCarrier = registry.get(span)
     tagsCarrier[key] = value
+
+    // The first session set in a trace becomes the trace-level default, stored on the trace-shared
+    // propagating tags so later spans (incl. those under a session-less parent) inherit it and it
+    // rides `x-datadog-tags` across service boundaries. Established here, the single choke point for
+    // session writes, so sessions post-populated by integrations after span start also seed it.
+    // First-writer wins, so an explicit session still overrides locally.
+    if (key === SESSION_ID && value) {
+      const traceTags = span.context()._trace.tags
+      if (traceTags[PROPAGATED_SESSION_ID_KEY] === undefined) {
+        traceTags[PROPAGATED_SESSION_ID_KEY] = value
+      }
+    }
   }
 }
 

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -104,6 +104,30 @@ describe('tagger', () => {
         })
       })
 
+      it('establishes the trace-level default session when a session is set', () => {
+        tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'my-session' })
+
+        assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'my-session')
+        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_session_id'], 'my-session')
+      })
+
+      it('inherits the trace-level default session when the span sets none', () => {
+        spanContext._trace.tags['_dd.p.llmobs_session_id'] = 'trace-session'
+
+        tagger.registerLLMObsSpan(span, { kind: 'llm' })
+
+        assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'trace-session')
+      })
+
+      it('lets an explicit session override without changing the established trace default', () => {
+        spanContext._trace.tags['_dd.p.llmobs_session_id'] = 'trace-session'
+
+        tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'other-session' })
+
+        assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'other-session')
+        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_session_id'], 'trace-session')
+      })
+
       it('uses the name if provided', () => {
         tagger.registerLLMObsSpan(span, { kind: 'llm', name: 'my-span-name' })
 

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -108,11 +108,11 @@ describe('tagger', () => {
         tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'my-session' })
 
         assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'my-session')
-        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_session_id'], 'my-session')
+        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'my-session')
       })
 
       it('inherits the trace-level default session when the span sets none', () => {
-        spanContext._trace.tags['_dd.p.llmobs_session_id'] = 'trace-session'
+        spanContext._trace.tags['_dd.p.llmobs_sid'] = 'trace-session'
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -120,12 +120,12 @@ describe('tagger', () => {
       })
 
       it('lets an explicit session override without changing the established trace default', () => {
-        spanContext._trace.tags['_dd.p.llmobs_session_id'] = 'trace-session'
+        spanContext._trace.tags['_dd.p.llmobs_sid'] = 'trace-session'
 
         tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'other-session' })
 
         assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'other-session')
-        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_session_id'], 'trace-session')
+        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'trace-session')
       })
 
       it('uses the name if provided', () => {

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -128,6 +128,16 @@ describe('tagger', () => {
         assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'trace-session')
       })
 
+      it('establishes the trace-level default when a session is post-populated via _setTag', () => {
+        tagger.registerLLMObsSpan(span, { kind: 'llm' }) // no session at registration
+        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], undefined)
+
+        tagger._setTag(span, '_ml_obs.session_id', 'late-session') // integration sets it after start
+
+        assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'late-session')
+        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'late-session')
+      })
+
       it('uses the name if provided', () => {
         tagger.registerLLMObsSpan(span, { kind: 'llm', name: 'my-span-name' })
 


### PR DESCRIPTION
## What

Propagates LLMObs `session_id` so it reaches the spans that follow it in a trace — including spans under a session-less parent and spans in downstream services.

The first `session_id` set in a trace is stored on the trace-shared propagating tags as `_dd.p.llmobs_sid`. Later spans inherit it (via the tagger's resolution fallback), and it rides `x-datadog-tags` across service boundaries via the standard propagator's `_dd.p.*` inject/extract. An explicit `session_id` on a span still overrides locally, so multiple sessions can still coexist in one trace.

Mirrors the dd-trace-py change in [dd-trace-py#18952](https://github.com/DataDog/dd-trace-py/pull/18952) and the same `_dd.p.llmobs_*` propagation pattern already used for `ml_app`.

## Changes

- `packages/dd-trace/src/llmobs/constants/tags.js` — add `PROPAGATED_SESSION_ID_KEY` (`_dd.p.llmobs_sid`).
- `packages/dd-trace/src/llmobs/tagger.js` — resolve `session_id` from explicit arg → parent → trace default; establish the trace default on `_trace.tags` (first-writer). No `index.js` inject change needed: `_injectTags` already propagates any `_dd.p.*` trace tag.
- `packages/dd-trace/test/llmobs/tagger.spec.js` — tests for establishing the default, sibling-gap inheritance, and explicit override not clobbering the default.

## Test plan

[Simulating a distributed session](https://github.com/ncybul/sdk-manual-testing/blob/master/node/cross_service.js) ([trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Asdk-manual-testing%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ9NXzyGWql71AAAABhBWjlOWHp5R0FBRDZjZUFYUVpaR0FBQUEAAAAkMDE5ZjRkNWYtNDJiYy00MDcwLThjMzgtNTVjNzFhZDFhZmI1AAABGg%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=8919455883608056772&start=1783708623356&end=1783709523356&paused=false))

- session_id:my-session set in service A which calls service B and inherits the same session ID

[Simulating default session being applied to subsequent spans in a trace unless explicitly annotated](https://github.com/ncybul/sdk-manual-testing/blob/master/node/in_process.js) ([trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Asdk-manual-testing%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ9NXLXUF1aE9gAAABhBWjlOWExYVUFBQlBvaXJuQ1NDVUFBQUEAAAAkMDE5ZjRkNWMtYzNiZS00OGU2LWE5MTktOWJkOGZhMmMyOTQwAAAi8A%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=5542716077113562671&start=1783705765556&end=1783709365556&paused=false))
- first span sets `session_id:my-session` which is inherited by subsequent spans except those explicitly annotated with `session_id:other-session`

MLOB-7756