### PR TITLE
test(guardrails): skip node 24 initialize runtime checks

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -93,7 +93,8 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
 }
 
 function testRuntimeVersionChecks (arg, filename) {
-  const skipRuntimeVersionChecks = filename === 'initialize.mjs' && process.versions.node === '22.0.0'
+  const skipRuntimeVersionChecks = filename === 'initialize.mjs' &&
+    ['22.0.0', '24.0.0'].includes(process.versions.node)
   const runtimeVersionContext = skipRuntimeVersionChecks ? context.skip : context
 
   runtimeVersionContext('runtime version check', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Skips the `initialize.mjs` runtime-version guardrail checks on Node `24.0.0`, extending the existing Node `22.0.0` skip.

### Motivation
The v6 release proposal is failing `integration-guardrails (24.0.0)` in the same `initialize.mjs` runtime-version contexts that were already skipped for Node `22.0.0`. The sibling matrix jobs passed, so this keeps the workaround scoped to the exact first-release Node versions known to wedge these checks.

### Additional Notes
Validation:
- `./node_modules/.bin/eslint integration-tests/init.spec.js`
- `./node_modules/.bin/mocha --timeout 30000 integration-tests/init.spec.js --grep "runtime version check"` on local Node `24.14.1` (`48 passing`)
