### PR TITLE
fix(graphql): honor errorExtensions on the mercurius request span

### DIFF
--- a/packages/datadog-plugin-graphql/src/request.js
+++ b/packages/datadog-plugin-graphql/src/request.js
@@ -82,7 +82,7 @@ class GraphQLRequestPlugin extends TracingPlugin {
     if (result?.errors?.length) {
       span.setTag('error', result.errors[0])
       for (const error of result.errors) {
-        extractErrorIntoSpanEvent(this._tracerConfig, span, error)
+        extractErrorIntoSpanEvent(this.config, span, error)
       }
     }
 

--- a/packages/datadog-plugin-mercurius/test/index.spec.js
+++ b/packages/datadog-plugin-mercurius/test/index.spec.js
@@ -31,6 +31,7 @@ describe('Plugin', () => {
         type Query {
           hello(name: String): String
           fail: String
+          failWithExtensions: String
         }
       `
 
@@ -38,6 +39,10 @@ describe('Plugin', () => {
         Query: {
           hello: (_, { name }) => `Hello, ${name || 'world'}!`,
           fail: () => { throw new Error('resolver boom') },
+          failWithExtensions: () => {
+            const mercurius = require(`../../../versions/mercurius@${version}`).get()
+            throw new mercurius.ErrorWithProps('resolver boom', { code: 'BOOM', extra: 'ignored' })
+          },
         },
       }
 
@@ -370,6 +375,59 @@ describe('Plugin', () => {
           }, { spanResourceMatch: /NoSource/ })
 
           return Promise.all([assertion, axios.post(`http://localhost:${plainPort}/graphql`, { query })])
+        })
+      })
+
+      describe('with configured error extensions', () => {
+        let extApp
+        let extPort
+
+        before(async function () {
+          this.timeout(20000)
+
+          require('../../dd-trace')
+          await agent.load(['graphql', 'fastify', 'http'], [{ errorExtensions: ['code'] }, {}, { client: false }])
+
+          const resolvedMercurius = require(`../../../versions/mercurius@${version}`).version()
+          const fastifyKey = semver.satisfies(resolvedMercurius, '>=15') ? '5' : '4'
+          const Fastify = require(`../../../versions/fastify@${fastifyKey}`).get()
+          const mercurius = require(`../../../versions/mercurius@${version}`).get()
+
+          extApp = Fastify()
+          extApp.register(mercurius, { schema, resolvers })
+          await extApp.ready()
+          await extApp.listen({ port: 0 })
+          extPort = extApp.server.address().port
+        })
+
+        after(async () => {
+          await extApp?.close()
+          await agent.close({ ritmReset: false })
+        })
+
+        it('copies the configured error extension onto the request span error event', () => {
+          // The graphql.request span is the only top-level span mercurius always
+          // produces, so its error event has to honor the graphql plugin's
+          // `errorExtensions` config the same way the execute/validate spans do —
+          // it reads the plugin config, not the global tracer config.
+          const query = 'query ExtQuery { failWithExtensions }'
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const request = traces[0].find(span => span.name === expectedSchema.server.opName)
+            assert.ok(request, 'expected a graphql.request span')
+            assert.strictEqual(request.error, 1)
+
+            const spanEvents = agent.unformatSpanEvents(request)
+            assert.strictEqual(spanEvents.length, 1)
+            assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
+            assert.strictEqual(spanEvents[0].attributes['extensions.code'], 'BOOM')
+            assert.ok(
+              !Object.hasOwn(spanEvents[0].attributes, 'extensions.extra'),
+              'only configured extensions are copied'
+            )
+          }, { spanResourceMatch: /ExtQuery/ })
+
+          return Promise.all([assertion, axios.post(`http://localhost:${extPort}/graphql`, { query })])
         })
       })
 


### PR DESCRIPTION
## Summary

The top-level `graphql.request` span (mercurius) read the global tracer config when copying GraphQL error extensions onto its `dd.graphql.query.error` event, so a user's `tracer.use('graphql', { errorExtensions })` / `DD_TRACE_GRAPHQL_ERROR_EXTENSIONS` was silently dropped there — while the `graphql.execute` and `graphql.validate` spans honored it. It now reads the plugin config like its siblings do.

A mercurius regression test asserts a configured extension lands on the request span's error event and an unconfigured one does not; it fails on `master` and passes with the fix.