### PR TITLE
fix(opentelemetry): wire span processors passed to the provider constructor

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -433,6 +433,23 @@ describe('opentelemetry', function () {
       assert.ok(trace)
     })
   })
+
+  it('should deliver spans to a user span processor configured on @opentelemetry/sdk-node', async () => {
+    // Regression guard: sdk-node 0.220+ passes span processors through the
+    // provider constructor. The fixture exits non-zero if its own processor
+    // never saw the span, so the tracer producing the DD span while dropping
+    // the user's processor fails here rather than passing silently.
+    proc = fork(join(cwd, 'opentelemetry/sdk-node-span-processor.js'), {
+      cwd,
+      env: {
+        DD_TRACE_AGENT_PORT: agent?.port,
+      },
+    })
+    await check(agent, proc, timeout, ({ payload }) => {
+      const trace = payload.find(trace => trace.length === 1 && trace[0].name === 'otel-sub')
+      assert.ok(trace)
+    })
+  })
 })
 
 function isChildOf (childSpan, parentSpan) {

--- a/integration-tests/opentelemetry/sdk-node-span-processor.js
+++ b/integration-tests/opentelemetry/sdk-node-span-processor.js
@@ -1,0 +1,42 @@
+'use strict'
+
+process.env.DD_TRACE_OTEL_ENABLED = '1'
+
+require('dd-trace').init()
+
+const opentelemetry = require('@opentelemetry/sdk-node')
+
+// @opentelemetry/sdk-node 0.220+ hands span processors to the provider
+// constructor rather than calling addSpanProcessor, so a user processor only
+// receives onStart/onEnd if the dd-trace TracerProvider consumes
+// config.spanProcessors. Model a real user's exporter as a custom processor and
+// fail loudly if it never sees the span the tracer produced.
+let started = false
+let ended = false
+
+const userSpanProcessor = {
+  onStart () { started = true },
+  onEnd () { ended = true },
+  forceFlush () { return Promise.resolve() },
+  shutdown () { return Promise.resolve() },
+}
+
+const sdk = new opentelemetry.NodeSDK({
+  spanProcessors: [userSpanProcessor],
+})
+
+sdk.start()
+
+const otelTracer = opentelemetry.api.trace.getTracer('my-service-tracer')
+
+otelTracer.startActiveSpan('otel-sub', otelSpan => {
+  setImmediate(() => {
+    otelSpan.end()
+
+    if (!started || !ended) {
+      // eslint-disable-next-line no-console
+      console.error(`user span processor missed the span (onStart=${started}, onEnd=${ended})`)
+      process.exit(1)
+    }
+  })
+})

--- a/packages/dd-trace/src/opentelemetry/span_processor.js
+++ b/packages/dd-trace/src/opentelemetry/span_processor.js
@@ -14,32 +14,34 @@ class NoopSpanProcessor {
 }
 
 class MultiSpanProcessor extends NoopSpanProcessor {
+  #processors
+
   constructor (spanProcessors) {
     super()
-    this._processors = spanProcessors
+    this.#processors = spanProcessors
   }
 
   forceFlush () {
     return Promise.all(
-      this._processors.map(p => p.forceFlush())
+      this.#processors.map(p => p.forceFlush())
     )
   }
 
   onStart (span, context) {
-    for (const processor of this._processors) {
+    for (const processor of this.#processors) {
       processor.onStart(span, context)
     }
   }
 
   onEnd (span) {
-    for (const processor of this._processors) {
+    for (const processor of this.#processors) {
       processor.onEnd(span)
     }
   }
 
   shutdown () {
     return Promise.all(
-      this._processors.map(p => p.shutdown())
+      this.#processors.map(p => p.shutdown())
     )
   }
 }

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -43,7 +43,12 @@ class TracerProvider {
     return this._tracers.get(key)
   }
 
+  /**
+   * @param {NoopSpanProcessor} spanProcessor
+   */
   addSpanProcessor (spanProcessor) {
+    if (this._processors.includes(spanProcessor)) return
+
     if (!this._processors.length) {
       this._activeProcessor.shutdown()
     }

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -10,14 +10,14 @@ const { MultiSpanProcessor, NoopSpanProcessor } = require('./span_processor')
 const Tracer = require('./tracer')
 
 class TracerProvider {
+  #activeProcessor = new NoopSpanProcessor()
+  #contextManager = new ContextManager()
+  #processors = []
+  #tracers = new Map()
+
   constructor (config = {}) {
     this.config = config
     this.resource = config.resource
-
-    this._processors = []
-    this._tracers = new Map()
-    this._activeProcessor = new NoopSpanProcessor()
-    this._contextManager = new ContextManager()
 
     // @opentelemetry/sdk-trace 2.x (used by @opentelemetry/sdk-node 0.220+)
     // dropped `addSpanProcessor` and hands the processors to the provider
@@ -33,39 +33,39 @@ class TracerProvider {
 
   getTracer (name = 'opentelemetry', version = '0.0.0', options) {
     const key = `${name}@${version}`
-    if (!this._tracers.has(key)) {
-      this._tracers.set(key, new Tracer(
+    if (!this.#tracers.has(key)) {
+      this.#tracers.set(key, new Tracer(
         { ...options, name, version },
         this.config,
         this
       ))
     }
-    return this._tracers.get(key)
+    return this.#tracers.get(key)
   }
 
   /**
    * @param {NoopSpanProcessor} spanProcessor
    */
   addSpanProcessor (spanProcessor) {
-    if (this._processors.includes(spanProcessor)) return
+    if (this.#processors.includes(spanProcessor)) return
 
-    if (!this._processors.length) {
-      this._activeProcessor.shutdown()
+    if (!this.#processors.length) {
+      this.#activeProcessor.shutdown()
     }
-    this._processors.push(spanProcessor)
-    this._activeProcessor = new MultiSpanProcessor(
-      this._processors
+    this.#processors.push(spanProcessor)
+    this.#activeProcessor = new MultiSpanProcessor(
+      this.#processors
     )
   }
 
   getActiveSpanProcessor () {
-    return this._activeProcessor
+    return this.#activeProcessor
   }
 
   // Not actually required by the SDK spec, but the official Node.js SDK does
   // this and the docs reflect that so we should do this too for familiarity.
   register (config = {}) {
-    context.setGlobalContextManager(this._contextManager)
+    context.setGlobalContextManager(this.#contextManager)
     if (!trace.setGlobalTracerProvider(this)) {
       trace.getTracerProvider().setDelegate(this)
     }
@@ -85,11 +85,11 @@ class TracerProvider {
     }
 
     exporter._writer?.flush()
-    return this._activeProcessor.forceFlush()
+    return this.#activeProcessor.forceFlush()
   }
 
   shutdown () {
-    return this._activeProcessor.shutdown()
+    return this.#activeProcessor.shutdown()
   }
 }
 

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -18,6 +18,17 @@ class TracerProvider {
     this._tracers = new Map()
     this._activeProcessor = new NoopSpanProcessor()
     this._contextManager = new ContextManager()
+
+    // @opentelemetry/sdk-trace 2.x (used by @opentelemetry/sdk-node 0.220+)
+    // dropped `addSpanProcessor` and hands the processors to the provider
+    // constructor instead. Wire them the same way the 1.x `addSpanProcessor`
+    // path does, so a NodeSDK configured with a trace exporter or custom
+    // processors still delivers onStart/onEnd to them.
+    if (Array.isArray(config.spanProcessors)) {
+      for (const spanProcessor of config.spanProcessors) {
+        this.addSpanProcessor(spanProcessor)
+      }
+    }
   }
 
   getTracer (name = 'opentelemetry', version = '0.0.0', options) {

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -55,6 +55,41 @@ describe('OTel TracerProvider', () => {
     assert.ok(provider.getActiveSpanProcessor() instanceof MultiSpanProcessor)
   })
 
+  it('should wire span processors passed through the constructor', () => {
+    // @opentelemetry/sdk-node 0.220+ builds the provider from
+    // @opentelemetry/sdk-trace 2.x, which hands processors to the constructor
+    // instead of `addSpanProcessor`. A processor supplied that way has to reach
+    // the active fan-out so a user's exporter still sees onStart/onEnd.
+    const first = new NoopSpanProcessor()
+    const second = new NoopSpanProcessor()
+    first.onStart = sinon.stub()
+    first.onEnd = sinon.stub()
+    second.onStart = sinon.stub()
+    second.onEnd = sinon.stub()
+
+    const provider = new TracerProvider({ spanProcessors: [first, second] })
+
+    assert.strictEqual(provider._processors.length, 2)
+    const active = provider.getActiveSpanProcessor()
+    assert.ok(active instanceof MultiSpanProcessor)
+
+    const span = {}
+    const context = {}
+    active.onStart(span, context)
+    active.onEnd(span)
+
+    sinon.assert.calledOnceWithExactly(first.onStart, span, context)
+    sinon.assert.calledOnceWithExactly(first.onEnd, span)
+    sinon.assert.calledOnceWithExactly(second.onStart, span, context)
+    sinon.assert.calledOnceWithExactly(second.onEnd, span)
+  })
+
+  it('should keep the noop processor when the constructor gets no processors', () => {
+    assert.ok(new TracerProvider().getActiveSpanProcessor() instanceof NoopSpanProcessor)
+    assert.ok(new TracerProvider({ spanProcessors: [] }).getActiveSpanProcessor() instanceof NoopSpanProcessor)
+    assert.strictEqual(new TracerProvider({ spanProcessors: [] })._processors.length, 0)
+  })
+
   it('should delegate shutdown to active span processor', () => {
     const provider = new TracerProvider()
     const processor = new NoopSpanProcessor()

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -84,6 +84,24 @@ describe('OTel TracerProvider', () => {
     sinon.assert.calledOnceWithExactly(second.onEnd, span)
   })
 
+  it('should not register a constructor span processor twice', () => {
+    const processor = new NoopSpanProcessor()
+    processor.onStart = sinon.stub()
+    processor.onEnd = sinon.stub()
+
+    const provider = new TracerProvider({ spanProcessors: [processor] })
+    provider.addSpanProcessor(processor)
+
+    const span = {}
+    const context = {}
+    provider.getActiveSpanProcessor().onStart(span, context)
+    provider.getActiveSpanProcessor().onEnd(span)
+
+    assert.strictEqual(provider._processors.length, 1)
+    sinon.assert.calledOnceWithExactly(processor.onStart, span, context)
+    sinon.assert.calledOnceWithExactly(processor.onEnd, span)
+  })
+
   it('should keep the noop processor when the constructor gets no processors', () => {
     assert.ok(new TracerProvider().getActiveSpanProcessor() instanceof NoopSpanProcessor)
     assert.ok(new TracerProvider({ spanProcessors: [] }).getActiveSpanProcessor() instanceof NoopSpanProcessor)

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -41,7 +41,6 @@ describe('OTel TracerProvider', () => {
     const provider = new TracerProvider()
 
     // Initially is a NoopSpanProcessor
-    assert.strictEqual(provider._processors.length, 0)
     assert.ok(provider.getActiveSpanProcessor() instanceof NoopSpanProcessor)
 
     // Swap out shutdown function to check if it's called
@@ -51,7 +50,6 @@ describe('OTel TracerProvider', () => {
     // After adding a span processor it should be a MultiSpanProcessor
     provider.addSpanProcessor(new NoopSpanProcessor())
     sinon.assert.calledOnce(shutdown)
-    assert.strictEqual(provider._processors.length, 1)
     assert.ok(provider.getActiveSpanProcessor() instanceof MultiSpanProcessor)
   })
 
@@ -69,7 +67,6 @@ describe('OTel TracerProvider', () => {
 
     const provider = new TracerProvider({ spanProcessors: [first, second] })
 
-    assert.strictEqual(provider._processors.length, 2)
     const active = provider.getActiveSpanProcessor()
     assert.ok(active instanceof MultiSpanProcessor)
 
@@ -97,7 +94,6 @@ describe('OTel TracerProvider', () => {
     provider.getActiveSpanProcessor().onStart(span, context)
     provider.getActiveSpanProcessor().onEnd(span)
 
-    assert.strictEqual(provider._processors.length, 1)
     sinon.assert.calledOnceWithExactly(processor.onStart, span, context)
     sinon.assert.calledOnceWithExactly(processor.onEnd, span)
   })
@@ -105,7 +101,6 @@ describe('OTel TracerProvider', () => {
   it('should keep the noop processor when the constructor gets no processors', () => {
     assert.ok(new TracerProvider().getActiveSpanProcessor() instanceof NoopSpanProcessor)
     assert.ok(new TracerProvider({ spanProcessors: [] }).getActiveSpanProcessor() instanceof NoopSpanProcessor)
-    assert.strictEqual(new TracerProvider({ spanProcessors: [] })._processors.length, 0)
   })
 
   it('should delegate shutdown to active span processor', () => {


### PR DESCRIPTION
## Summary

`@opentelemetry/sdk-node` 0.220+ builds on `@opentelemetry/sdk-trace` 2.x, which dropped `addSpanProcessor` and hands span processors to the provider constructor instead. The dd-trace `TracerProvider` only consumed processors through `addSpanProcessor`, so a `NodeSDK` configured with a `traceExporter` or custom `spanProcessors` produced Datadog spans while the user's OTel processors never received `onStart`/`onEnd`. It now consumes `config.spanProcessors` through the same wiring.

## Why

The hook targets `versions: ['*']` for both `@opentelemetry/sdk-trace-node` and `@opentelemetry/sdk-trace`, so the replacement provider has to satisfy both configuration contracts at once: the 1.x `addSpanProcessor` call and the 2.x constructor `spanProcessors`. Routing the constructor wiring through `addSpanProcessor` keeps the two paths from drifting apart.