### PR TITLE
test(opentelemetry): deflake OTLP metrics HTTP export test with fake timers

### DIFF
--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -1175,7 +1175,7 @@ describe('OpenTelemetry Meter Provider', () => {
   })
 
   describe('HTTP Export Behavior', () => {
-    it('handles timeout and error without network', (done) => {
+    it('handles timeout and error without network', async () => {
       const results = { timeout: false, error: false }
       let requestCount = 0
 
@@ -1183,6 +1183,9 @@ describe('OpenTelemetry Meter Provider', () => {
         httpStub.restore()
         httpStub = null
       }
+
+      // Install fake timers before setupMetrics() so the reader's periodic export interval is faked.
+      const clock = sinon.useFakeTimers()
 
       httpStub = sinon.stub(http, 'request').callsFake((options, callback) => {
         requestCount++
@@ -1214,19 +1217,24 @@ describe('OpenTelemetry Meter Provider', () => {
         return mockReq
       })
 
-      setupMetrics()
-      const meter = metrics.getMeter('app')
-      meter.createCounter('test1').add(1)
+      try {
+        const { config } = setupMetrics()
+        const exportIntervalMs = Number(config.OTEL_METRIC_EXPORT_INTERVAL)
+        // One export interval plus a margin for the stub's 10ms socket-handler delay.
+        const exportRoundTripMs = exportIntervalMs + 20
+        const meter = metrics.getMeter('app')
 
-      setTimeout(() => {
+        meter.createCounter('test1').add(1)
+        await clock.tickAsync(exportRoundTripMs)
+        assert(results.timeout, 'first export should surface a socket timeout')
+
+        // Fresh data forces a second (delta) export.
         meter.createCounter('test2').add(2)
-      }, 120)
-
-      setTimeout(() => {
-        assert(results.timeout)
-        assert(results.error)
-        done()
-      }, 300)
+        await clock.tickAsync(exportRoundTripMs)
+        assert(results.error, 'second export should surface a socket error')
+      } finally {
+        clock.restore()
+      }
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Rewrites the OpenTelemetry metrics test `handles timeout and error without network` to use sinon fake timers instead of racing real wall-clock timeouts. No production code changes.

### Motivation

The test flaked on `master` (Node 24). It asserted `results.timeout` and `results.error` at a fixed 300ms deadline, but both flags depend on two real periodic-exporter ticks (100ms interval) plus each request's real +10ms timeout/error callback. The second export's error handler fires around ~251ms, leaving only ~50ms of slack, so a modest event-loop stall on a loaded runner (GC or CPU contention) pushed it past 300ms. With `results.error` still false, `assert(results.error)` threw inside `Timeout._onTimeout`.

The fix installs `useFakeTimers()` before `setupMetrics()` so the reader's export interval is faked, then advances the clock explicitly for each export round-trip. This matches the repo guidance to never rely on real time passing in unit tests. The HTTP stub is unchanged.

### Additional Notes

Verified: 25/25 clean runs and 8/8 under CPU contention. A 1.3s real event-loop stall injected into the window that broke the original still passes (the original flaked at ~150ms). Full `metrics.spec.js`: 58 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)