### PR TITLE
fix(appsec): suppress informational responses after blocking requests

### DIFF
--- a/integration-tests/appsec/iast-stack-traces-ts-with-sourcemaps/tsconfig.json
+++ b/integration-tests/appsec/iast-stack-traces-ts-with-sourcemaps/tsconfig.json
@@ -12,6 +12,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "types": ["node"],
     "resolveJsonModule": true
   },
   "include": [

--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -24,9 +24,18 @@ addHook({ name: 'http' }, http => {
   shimmer.wrap(http.ServerResponse.prototype, 'end', wrapEnd)
   shimmer.wrap(http.ServerResponse.prototype, 'setHeader', wrapSetHeader)
   shimmer.wrap(http.ServerResponse.prototype, 'removeHeader', wrapAppendOrRemoveHeader)
+  if (http.ServerResponse.prototype.writeContinue) {
+    shimmer.wrap(http.ServerResponse.prototype, 'writeContinue', wrapInformationalResponse)
+  }
+  if (http.ServerResponse.prototype.writeProcessing) {
+    shimmer.wrap(http.ServerResponse.prototype, 'writeProcessing', wrapInformationalResponse)
+  }
   // Added in node v16.17.0
   if (http.ServerResponse.prototype.appendHeader) {
     shimmer.wrap(http.ServerResponse.prototype, 'appendHeader', wrapAppendOrRemoveHeader)
+  }
+  if (http.ServerResponse.prototype.writeEarlyHints) {
+    shimmer.wrap(http.ServerResponse.prototype, 'writeEarlyHints', wrapInformationalResponse)
   }
   return http
 })
@@ -209,6 +218,23 @@ function wrapAppendOrRemoveHeader (originalMethod) {
     }
 
     return originalMethod.apply(this, args)
+  }
+}
+
+function wrapInformationalResponse (originalMethod) {
+  return function wrappedInformationalResponse (...args) {
+    if (!startSetHeaderCh.hasSubscribers) {
+      return Reflect.apply(originalMethod, this, args)
+    }
+
+    const abortController = new AbortController()
+    startSetHeaderCh.publish({ res: this, abortController })
+
+    if (abortController.signal.aborted) {
+      return
+    }
+
+    return Reflect.apply(originalMethod, this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -13,6 +13,7 @@ const finishServerCh = channel('apm:http:server:request:finish')
 const startWriteHeadCh = channel('apm:http:server:response:writeHead:start')
 const finishSetHeaderCh = channel('datadog:http:server:response:set-header:finish')
 const startSetHeaderCh = channel('datadog:http:server:response:set-header:start')
+const startInformationalResponseCh = channel('datadog:http:server:informational-response:start')
 
 const requestFinishedSet = new WeakSet()
 
@@ -223,12 +224,12 @@ function wrapAppendOrRemoveHeader (originalMethod) {
 
 function wrapInformationalResponse (originalMethod) {
   return function wrappedInformationalResponse (...args) {
-    if (!startSetHeaderCh.hasSubscribers) {
+    if (!startInformationalResponseCh.hasSubscribers) {
       return Reflect.apply(originalMethod, this, args)
     }
 
     const abortController = new AbortController()
-    startSetHeaderCh.publish({ res: this, abortController })
+    startInformationalResponseCh.publish({ res: this, abortController })
 
     if (abortController.signal.aborted) {
       return

--- a/packages/dd-trace/src/appsec/channels.js
+++ b/packages/dd-trace/src/appsec/channels.js
@@ -25,6 +25,7 @@ module.exports = {
   httpClientRequestStart: dc.channel('apm:http:client:request:start'),
   httpClientResponseStart: dc.channel('apm:http:client:response:start'),
   httpClientResponseFinish: dc.channel('apm:http:client:response:finish'),
+  informationalResponse: dc.channel('datadog:http:server:informational-response:start'),
   incomingHttpRequestEnd: dc.channel('dd-trace:incomingHttpRequestEnd'),
   incomingHttpRequestStart: dc.channel('dd-trace:incomingHttpRequestStart'),
   lambdaStartInvocation: dc.channel('datadog:lambda:start-invocation'),

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -29,6 +29,7 @@ const {
   responseBody,
   responseWriteHead,
   responseSetHeader,
+  informationalResponse,
   routerParam,
   fastifyResponseChannel,
   fastifyPathParams,
@@ -98,7 +99,8 @@ function enable (_config) {
     responseBody.subscribe(onResponseBody)
     fastifyResponseChannel.subscribe(onResponseBody)
     responseWriteHead.subscribe(onResponseWriteHead)
-    responseSetHeader.subscribe(onResponseSetHeader)
+    responseSetHeader.subscribe(onResponseOperation)
+    informationalResponse.subscribe(onResponseOperation)
     stripeCheckoutSessionCreate.subscribe(onStripeCheckoutSessionCreate)
     stripePaymentIntentCreate.subscribe(onStripePaymentIntentCreate)
     stripeConstructEvent.subscribe(onStripeConstructEvent)
@@ -403,7 +405,7 @@ function onResponseWriteHead ({ req, res, abortController, statusCode, responseH
   handleResults(results?.actions, req, res, rootSpan, abortController)
 }
 
-function onResponseSetHeader ({ res, abortController }) {
+function onResponseOperation ({ res, abortController }) {
   if (isBlocked(res)) {
     abortController?.abort()
   }
@@ -547,7 +549,8 @@ function disable () {
   if (responseBody.hasSubscribers) responseBody.unsubscribe(onResponseBody)
   if (fastifyResponseChannel.hasSubscribers) fastifyResponseChannel.unsubscribe(onResponseBody)
   if (responseWriteHead.hasSubscribers) responseWriteHead.unsubscribe(onResponseWriteHead)
-  if (responseSetHeader.hasSubscribers) responseSetHeader.unsubscribe(onResponseSetHeader)
+  if (responseSetHeader.hasSubscribers) responseSetHeader.unsubscribe(onResponseOperation)
+  if (informationalResponse.hasSubscribers) informationalResponse.unsubscribe(onResponseOperation)
   if (stripeCheckoutSessionCreate.hasSubscribers) stripeCheckoutSessionCreate.unsubscribe(onStripeCheckoutSessionCreate)
   if (stripePaymentIntentCreate.hasSubscribers) stripePaymentIntentCreate.unsubscribe(onStripePaymentIntentCreate)
   if (stripeConstructEvent.hasSubscribers) stripeConstructEvent.unsubscribe(onStripeConstructEvent)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -28,6 +28,7 @@ const {
   responseBody,
   responseWriteHead,
   responseSetHeader,
+  informationalResponse,
 } = require('../../src/appsec/channels')
 const Reporter = require('../../src/appsec/reporter')
 const agent = require('../plugins/agent')
@@ -219,6 +220,7 @@ describe('AppSec Index', function () {
       assert.strictEqual(routerParam.hasSubscribers, false)
       assert.strictEqual(responseWriteHead.hasSubscribers, false)
       assert.strictEqual(responseSetHeader.hasSubscribers, false)
+      assert.strictEqual(informationalResponse.hasSubscribers, false)
 
       AppSec.enable(config)
 
@@ -234,6 +236,7 @@ describe('AppSec Index', function () {
       assert.strictEqual(routerParam.hasSubscribers, true)
       assert.strictEqual(responseWriteHead.hasSubscribers, true)
       assert.strictEqual(responseSetHeader.hasSubscribers, true)
+      assert.strictEqual(informationalResponse.hasSubscribers, true)
     })
 
     it('should still subscribe to passportVerify if eventTracking is disabled', () => {
@@ -317,6 +320,7 @@ describe('AppSec Index', function () {
       assert.strictEqual(routerParam.hasSubscribers, false)
       assert.strictEqual(responseWriteHead.hasSubscribers, false)
       assert.strictEqual(responseSetHeader.hasSubscribers, false)
+      assert.strictEqual(informationalResponse.hasSubscribers, false)
     })
 
     it('should call appsec telemetry disable', () => {
@@ -1474,7 +1478,7 @@ describe('AppSec Index', function () {
       })
     })
 
-    describe('onResponseSetHeader', () => {
+    describe('onResponseOperation', () => {
       it('should call abortController if response was already blocked', () => {
         // First block the request
         waf.run.returns(resultActions)
@@ -1493,10 +1497,17 @@ describe('AppSec Index', function () {
         responseSetHeader.publish({ res, abortController })
 
         sinon.assert.calledOnce(abortController.abort)
+
+        abortController.abort.reset()
+
+        informationalResponse.publish({ res, abortController })
+
+        sinon.assert.calledOnce(abortController.abort)
       })
 
       it('should not call abortController if response was not blocked', () => {
         responseSetHeader.publish({ res, abortController })
+        informationalResponse.publish({ res, abortController })
 
         sinon.assert.notCalled(abortController.abort)
       })

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -261,6 +261,40 @@ describe('mocha hooks setup', () => {
     assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
   })
 
+  it('reports before all errors after async before all hooks with allow uncaught enabled', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        before(async () => {})
+
+        before(() => {
+          throw new Error('setup failed')
+        })
+
+        it('does something', () => {})
+      })
+    `, ['--allow-uncaught'])
+
+    assert.deepStrictEqual(getFailureMessages(result), ['setup failed'])
+  })
+
+  it('suppresses after all errors with allow uncaught enabled', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        before(() => {
+          throw new Error('setup failed')
+        })
+
+        after(() => {
+          throw new Error('cleanup failed')
+        })
+
+        it('does something', () => {})
+      })
+    `, ['--allow-uncaught'])
+
+    assert.deepStrictEqual(getFailureMessages(result), ['setup failed'])
+  })
+
   it('does not let a suppressed after each error change bail behavior', async () => {
     const result = await runFixture(`
       describe('suite', () => {

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -7,6 +7,8 @@ const os = require('node:os')
 const path = require('node:path')
 const util = require('node:util')
 
+const { Hook } = require('mocha')
+
 const execFileAsync = util.promisify(execFile)
 const mochaBin = path.join(__dirname, '../../../node_modules/mocha/bin/mocha.js')
 const coreSetupPath = path.join(__dirname, 'setup/core.js')
@@ -293,6 +295,34 @@ describe('mocha hooks setup', () => {
     `, ['--allow-uncaught'])
 
     assert.deepStrictEqual(getFailureMessages(result), ['setup failed'])
+  })
+
+  it('clears the timeout when a callback hook throws with allow uncaught enabled', () => {
+    const failure = new Error('setup failed')
+    const hook = new Hook('before all', (done) => {
+      assert.strictEqual(typeof done, 'function')
+      throw failure
+    })
+    const clearTimeout = hook.clearTimeout
+    let clearTimeoutCalls = 0
+    let hookError
+
+    hook.allowUncaught = true
+    hook.clearTimeout = function () {
+      clearTimeoutCalls++
+      return clearTimeout.call(this)
+    }
+
+    try {
+      hook.run((err) => {
+        hookError = err
+      })
+    } finally {
+      clearTimeout.call(hook)
+    }
+
+    assert.strictEqual(hookError, failure)
+    assert.strictEqual(clearTimeoutCalls, 2)
   })
 
   it('does not let a suppressed after each error change bail behavior', async () => {

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -325,6 +325,26 @@ describe('mocha hooks setup', () => {
     assert.strictEqual(clearTimeoutCalls, 2)
   })
 
+  it('reports falsy callback hook errors with allow uncaught enabled', () => {
+    const hook = new Hook('before all', (done) => {
+      assert.strictEqual(typeof done, 'function')
+      // eslint-disable-next-line no-throw-literal
+      throw undefined
+    })
+    let hookError
+
+    hook.allowUncaught = true
+    hook.run((err) => {
+      hookError = err
+    })
+
+    assert.ok(hookError instanceof Error)
+    assert.strictEqual(
+      hookError.message,
+      'Runnable failed with falsy or undefined exception. Please throw an Error instead.'
+    )
+  })
+
   it('does not let a suppressed after each error change bail behavior', async () => {
     const result = await runFixture(`
       describe('suite', () => {

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -5,7 +5,7 @@
 
 /** @typedef {import('mocha')} Mocha */
 
-const { Hook, Runner } = require('mocha')
+const { Hook, Runnable, Runner } = require('mocha')
 
 const patched = new WeakSet()
 const failedSuites = new WeakSet()
@@ -51,7 +51,7 @@ if (!patched.has(Runner.prototype)) {
         return fn(err && shouldSuppress(this) ? undefined : err)
       })
     } catch (err) {
-      return this.callback(shouldSuppress(this) ? undefined : err)
+      return this.callback(shouldSuppress(this) ? undefined : Runnable.toValueOrError(err))
     }
   }
 }

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -52,7 +52,7 @@ if (!patched.has(Runner.prototype)) {
       })
     } catch (err) {
       if (shouldSuppress(this)) return fn()
-      throw err
+      return fn(err)
     }
   }
 }

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -51,8 +51,7 @@ if (!patched.has(Runner.prototype)) {
         return fn(err && shouldSuppress(this) ? undefined : err)
       })
     } catch (err) {
-      if (shouldSuppress(this)) return fn()
-      return fn(err)
+      return this.callback(shouldSuppress(this) ? undefined : err)
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes AppSec request blocking so applications cannot emit an HTTP informational response after AppSec has already blocked the request.

The HTTP server instrumentation now wraps `ServerResponse.writeContinue()`, `writeProcessing()`, and `writeEarlyHints()` and publishes a dedicated informational-response diagnostic channel. AppSec subscribes to that channel and aborts the operation when the response is already blocked; otherwise, the original Node.js method runs unchanged.

This PR also includes test-infrastructure fixes needed for these tests to fail correctly if necessary:

- Route synchronous Mocha hook errors through the runnable callback under `allowUncaught`, preserving timeout cleanup and normalizing falsy thrown values.
- Update the IAST source-map TypeScript fixture for TypeScript 6 resolution behavior.

### Motivation

Once AppSec has produced a blocking response, later calls to Node.js informational-response APIs must not write additional status lines to the socket. These methods were not covered by the existing response-operation guard, so application code could still call them after a request had been blocked.

When `allowUncaught` enabled, synchronous hook failures could escape through Mocha's uncaught-exception path, terminate a fixture before its reporter output was complete, and make later AppSec tests appear skipped or successful. Routing those failures through Mocha's runnable callback makes the suite report the original failure deterministically.

### Additional Notes

- AppSec tests cover channel subscription lifecycle and both blocked and non-blocked informational-response operations.
- Mocha-hook tests cover asynchronous hook ordering, teardown suppression, callback timeout cleanup, and falsy thrown values under `--allow-uncaught`.
- This is a `semver-patch` production fix.
