### PR TITLE
test(express): narrow loopback phase-sorting setup

### DIFF
--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1493,22 +1493,20 @@ describe('Plugin', () => {
         })
 
         withVersions('express', 'loopback', loopbackVersion => {
-          let createLoopbackExpressApp
+          let loopback
 
-          before(() => {
-            // Load the module that owns phase sorting; the public entry also loads unrelated models and connectors.
-            createLoopbackExpressApp = require(`../../../versions/loopback@${loopbackVersion}`)
-              .get('loopback/lib/server-app')
-          })
+          before(function () {
+            // The public entry synchronously initializes LoopBack's model, connector, and remoting stack.
+            this.timeout(10000)
 
-          beforeEach(() => {
-            // Legacy loopback invokes the deprecated `util._extend` while creating an app;
-            // allow it so the harness deprecation guard does not throw.
+            // Legacy loopback emits the deprecated `util._extend` at module
+            // load; allow it so the harness deprecation guard does not throw.
             temporaryWarningExceptions.add('The `util._extend` API is deprecated. Please use Object.assign() instead.')
+            loopback = require(`../../../versions/loopback@${loopbackVersion}`).get()
           })
 
           it('should handle loopback with express middleware', done => {
-            const app = createLoopbackExpressApp()
+            const app = loopback()
 
             app.get('/dd', (req, res) => {
               res.status(200).send()
@@ -1543,7 +1541,7 @@ describe('Plugin', () => {
           })
 
           it('should handle loopback re-sorting', done => {
-            const app = createLoopbackExpressApp()
+            const app = loopback()
 
             app.middleware('final', [], function throwError (req, res) {
               throw new Error('should not reach')

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1493,19 +1493,22 @@ describe('Plugin', () => {
         })
 
         withVersions('express', 'loopback', loopbackVersion => {
-          let loopback
+          let createLoopbackExpressApp
 
-          beforeEach(function () {
-            this.timeout(5000)
+          before(() => {
+            // Load the module that owns phase sorting; the public entry also loads unrelated models and connectors.
+            createLoopbackExpressApp = require(`../../../versions/loopback@${loopbackVersion}`)
+              .get('loopback/lib/server-app')
+          })
 
-            // Legacy loopback emits the deprecated `util._extend` at module
-            // load; allow it so the harness deprecation guard does not throw.
+          beforeEach(() => {
+            // Legacy loopback invokes the deprecated `util._extend` while creating an app;
+            // allow it so the harness deprecation guard does not throw.
             temporaryWarningExceptions.add('The `util._extend` API is deprecated. Please use Object.assign() instead.')
-            loopback = require(`../../../versions/loopback@${loopbackVersion}`).get()
           })
 
           it('should handle loopback with express middleware', done => {
-            const app = loopback()
+            const app = createLoopbackExpressApp()
 
             app.get('/dd', (req, res) => {
               res.status(200).send()
@@ -1540,7 +1543,7 @@ describe('Plugin', () => {
           })
 
           it('should handle loopback re-sorting', done => {
-            const app = loopback()
+            const app = createLoopbackExpressApp()
 
             app.middleware('final', [], function throwError (req, res) {
               throw new Error('should not reach')


### PR DESCRIPTION
## Summary

The Express/LoopBack compatibility test loaded LoopBack's public entry even though it only exercises the Express phase sorter. That entry eagerly initializes the model, connector, and remoting stack, so cold module loading could push synchronous setup past Mocha's five-second limit. Load the owning server-app module directly while keeping the real LoopBack sorting and HTTP assertions.