### PR TITLE
fix(test-optimization): omit empty FTR capture containers

### DIFF
--- a/integration-tests/ci-visibility/dynamic-instrumentation/dependency.js
+++ b/integration-tests/ci-visibility/dynamic-instrumentation/dependency.js
@@ -1,9 +1,9 @@
 'use strict'
 
 module.exports = function (a, b) {
-  const localVariable = 2
+  const [localVariable, emptyObject, emptyArray, emptyMap] = [2, {}, [], new Map()]
   if (a > 10) {
     throw new Error('a is too big')
   }
-  return a + b + localVariable - localVariable
+  return a + b + localVariable - localVariable + Object.keys(emptyObject).length + emptyArray.length + emptyMap.size
 }

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -2425,6 +2425,8 @@ describe(`cucumber@${version} commonJS`, () => {
                 ddsource: 'dd_debugger',
                 level: 'error',
               })
+              assert.ok(diLog.ddtags.includes('git.repository_url:'), `Got: ${inspect(diLog.ddtags)}`)
+              assert.ok(diLog.ddtags.includes('git.commit.sha:'), `Got: ${inspect(diLog.ddtags)}`)
               assert.strictEqual(diLog.debugger.snapshot.language, 'javascript')
               assertObjectContains(diLog.debugger.snapshot.captures.lines['6'].locals, {
                 a: {

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -1329,7 +1329,17 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             ddsource: 'dd_debugger',
             level: 'error',
           })
+          assert.ok(diLog.ddtags.includes('git.repository_url:'), `Got: ${inspect(diLog.ddtags)}`)
+          assert.ok(diLog.ddtags.includes('git.commit.sha:'), `Got: ${inspect(diLog.ddtags)}`)
           assert.strictEqual(diLog.debugger.snapshot.language, 'javascript')
+          const locals = diLog.debugger.snapshot.captures.lines['6'].locals
+          assert.strictEqual(locals.emptyObject.type, 'Object')
+          assert.strictEqual('fields' in locals.emptyObject, false)
+          assert.strictEqual(locals.emptyArray.type, 'Array')
+          assert.strictEqual('elements' in locals.emptyArray, false)
+          assert.strictEqual(locals.emptyMap.type, 'Map')
+          assert.strictEqual('entries' in locals.emptyMap, false)
+          assert.doesNotMatch(JSON.stringify(diLog.debugger.snapshot.captures), /"(fields|elements|entries)":(?:\{\}|\[\]|null)/)
           spanIdByLog = diLog.dd.span_id
           traceIdByLog = diLog.dd.trace_id
           snapshotIdByLog = diLog.debugger.snapshot.id

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
@@ -51,12 +51,20 @@ const limits = {
 }
 
 /**
- * Remove empty collection arrays before sending snapshots through the Test Optimization logs path.
+ * @param {object} value - Snapshot object or sub-object.
+ * @returns {boolean}
+ */
+function isCapturedValue (value) {
+  return typeof value.type === 'string'
+}
+
+/**
+ * Remove empty capture containers before sending snapshots through the Test Optimization logs path.
  *
  * @param {object} value - Snapshot object or sub-object.
  * @returns {void}
  */
-function removeEmptyCollectionProperties (value) {
+function removeEmptyCaptureProperties (value) {
   const stack = [value]
 
   while (stack.length > 0) {
@@ -72,26 +80,25 @@ function removeEmptyCollectionProperties (value) {
       continue
     }
 
-    if (Array.isArray(current.elements)) {
-      if (current.elements.length === 0) {
+    if (isCapturedValue(current)) {
+      if (current.elements === null || (Array.isArray(current.elements) && current.elements.length === 0)) {
         delete current.elements
-      } else {
-        stack.push(current.elements)
       }
-    }
 
-    if (Array.isArray(current.entries)) {
-      if (current.entries.length === 0) {
+      if (current.entries === null || (Array.isArray(current.entries) && current.entries.length === 0)) {
         delete current.entries
-      } else {
-        stack.push(current.entries)
+      }
+
+      if (current.fields === null || (
+        current.fields &&
+        typeof current.fields === 'object' &&
+        Object.keys(current.fields).length === 0
+      )) {
+        delete current.fields
       }
     }
 
-    for (const key of Object.keys(current)) {
-      if (key === 'elements' || key === 'entries') continue
-
-      const child = current[key]
+    for (const child of Object.values(current)) {
       if (child && typeof child === 'object') {
         stack.push(child)
       }
@@ -129,7 +136,7 @@ session.on('Debugger.paused', async ({ params: { hitBreakpoints: [hitBreakpoint]
       language: 'javascript',
     }
 
-    removeEmptyCollectionProperties(snapshot.captures)
+    removeEmptyCaptureProperties(snapshot.captures)
 
     if (processTags) {
       snapshot[processTags.DYNAMIC_INSTRUMENTATION_FIELD_NAME] = processTags.tagsObject

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
@@ -46,6 +46,7 @@ describe('test visibility with dynamic instrumentation', () => {
               b: { type: 'number', value: '2' },
               localVar: { type: 'number', value: '1' },
               users: { type: 'Array' },
+              metadata: { type: 'Object' },
             },
           },
         },
@@ -55,7 +56,7 @@ describe('test visibility with dynamic instrumentation', () => {
     })
   })
 
-  it('omits empty collection payloads from captured values', (done) => {
+  it('omits empty capture containers from captured values', (done) => {
     childProcess = fork(path.join(__dirname, 'target-app', 'test-visibility-dynamic-instrumentation-script.js'))
 
     childProcess.on('message', ({ snapshot }) => {
@@ -64,9 +65,202 @@ describe('test visibility with dynamic instrumentation', () => {
       const users = snapshot.captures.lines[10].locals.users
       assert.strictEqual(users.type, 'Array')
       assert.strictEqual('elements' in users, false)
+      const metadata = snapshot.captures.lines[10].locals.metadata
+      assert.strictEqual(metadata.type, 'Object')
+      assert.strictEqual('fields' in metadata, false)
       assert.doesNotMatch(JSON.stringify(snapshot), /"elements":\[\]/)
+      assert.doesNotMatch(JSON.stringify(snapshot), /"elements":null/)
+      assert.doesNotMatch(JSON.stringify(snapshot), /"fields":\{\}/)
+      assert.doesNotMatch(JSON.stringify(snapshot), /"fields":null/)
 
       done()
+    })
+  })
+
+  it('recursively omits empty capture containers without skipping name collisions', async () => {
+    const breakpointSetChannel = new EventEmitter()
+    const breakpointHitChannel = new EventEmitter()
+    const breakpointRemoveChannel = new EventEmitter()
+    const postedBreakpointHits = []
+    const session = new EventEmitter()
+    const localState = {
+      emptyObject: { type: 'Object', fields: {} },
+      emptyArray: { type: 'Array', elements: [] },
+      emptySet: { type: 'Set', elements: [] },
+      emptyMap: { type: 'Map', entries: [] },
+      nullFields: { type: 'Object', fields: null },
+      nullElements: { type: 'Array', elements: null },
+      nullEntries: { type: 'Map', entries: null },
+      nestedObject: {
+        type: 'Object',
+        fields: {
+          child: { type: 'Object', fields: {} },
+          arrayChild: {
+            type: 'Array',
+            elements: [
+              { type: 'Object', fields: {} },
+            ],
+          },
+        },
+      },
+      elements: { type: 'Array', elements: [] },
+      entries: { type: 'Map', entries: [] },
+      fields: { type: 'Object', fields: {} },
+      propertyCollision: {
+        type: 'Object',
+        fields: {
+          elements: { type: 'Array', elements: [] },
+          entries: { type: 'Map', entries: [] },
+          fields: { type: 'Object', fields: {} },
+        },
+      },
+      nonEmptyObject: {
+        type: 'Object',
+        fields: {
+          value: { type: 'number', value: '1' },
+          emptyNested: { type: 'Object', fields: {} },
+        },
+      },
+      nonEmptyArray: {
+        type: 'Array',
+        elements: [
+          { type: 'number', value: '1' },
+          { type: 'Object', fields: {} },
+        ],
+      },
+      nonEmptyMap: {
+        type: 'Map',
+        entries: [
+          [
+            { type: 'string', value: 'key' },
+            { type: 'Object', fields: {} },
+          ],
+        ],
+      },
+      metadata: {
+        type: 'Object',
+        fields: {},
+        notCapturedReason: 'fieldCount',
+        size: 100,
+      },
+    }
+    session.post = sinon.stub()
+    session.post.withArgs('Debugger.enable').resolves()
+    session.post.withArgs('Debugger.setBreakpoint').resolves({ breakpointId: 'breakpoint-id' })
+    session.post.withArgs('Debugger.resume').resolves()
+    breakpointSetChannel.postMessage = sinon.stub()
+    breakpointHitChannel.postMessage = (message) => {
+      postedBreakpointHits.push(message)
+    }
+    breakpointRemoveChannel.postMessage = sinon.stub()
+
+    proxyquire('../../../src/ci-visibility/dynamic-instrumentation/worker', {
+      worker_threads: {
+        workerData: {
+          config: {},
+          breakpointSetChannel,
+          breakpointHitChannel,
+          breakpointRemoveChannel,
+        },
+      },
+      crypto: {
+        randomUUID: () => 'snapshot-id',
+      },
+      '../../../debugger/devtools_client/session': session,
+      '../../../debugger/devtools_client/source-maps': {
+        getGeneratedPosition: sinon.stub(),
+      },
+      '../../../debugger/devtools_client/snapshot': {
+        getLocalStateForCallFrame: () => ({
+          processLocalState: () => localState,
+        }),
+      },
+      '../../../debugger/devtools_client/snapshot/constants': {
+        DEFAULT_MAX_REFERENCE_DEPTH: 1,
+        DEFAULT_MAX_COLLECTION_SIZE: 1,
+        DEFAULT_MAX_FIELD_COUNT: 1,
+        DEFAULT_MAX_LENGTH: 1,
+      },
+      '../../../debugger/devtools_client/state': {
+        findScriptFromPartialPath: () => ({ url: 'file.js', scriptId: 'script-id' }),
+        getStackFromCallFrames: () => [{ fileName: 'file.js' }],
+      },
+      '../../../log': {
+        error: () => {},
+        warn: () => {},
+      },
+    })
+
+    breakpointSetChannel.emit('message', { id: 'probe-id', file: 'file.js', line: 10 })
+    await setImmediatePromise()
+
+    session.emit('Debugger.paused', {
+      params: {
+        hitBreakpoints: ['breakpoint-id'],
+        callFrames: [{ callFrameId: 'call-frame-id' }],
+      },
+    })
+    await setImmediatePromise()
+
+    assert.deepStrictEqual(postedBreakpointHits[0].snapshot.captures.lines[10].locals, {
+      emptyObject: { type: 'Object' },
+      emptyArray: { type: 'Array' },
+      emptySet: { type: 'Set' },
+      emptyMap: { type: 'Map' },
+      nullFields: { type: 'Object' },
+      nullElements: { type: 'Array' },
+      nullEntries: { type: 'Map' },
+      nestedObject: {
+        type: 'Object',
+        fields: {
+          child: { type: 'Object' },
+          arrayChild: {
+            type: 'Array',
+            elements: [
+              { type: 'Object' },
+            ],
+          },
+        },
+      },
+      elements: { type: 'Array' },
+      entries: { type: 'Map' },
+      fields: { type: 'Object' },
+      propertyCollision: {
+        type: 'Object',
+        fields: {
+          elements: { type: 'Array' },
+          entries: { type: 'Map' },
+          fields: { type: 'Object' },
+        },
+      },
+      nonEmptyObject: {
+        type: 'Object',
+        fields: {
+          value: { type: 'number', value: '1' },
+          emptyNested: { type: 'Object' },
+        },
+      },
+      nonEmptyArray: {
+        type: 'Array',
+        elements: [
+          { type: 'number', value: '1' },
+          { type: 'Object' },
+        ],
+      },
+      nonEmptyMap: {
+        type: 'Map',
+        entries: [
+          [
+            { type: 'string', value: 'key' },
+            { type: 'Object' },
+          ],
+        ],
+      },
+      metadata: {
+        type: 'Object',
+        notCapturedReason: 'fieldCount',
+        size: 100,
+      },
     })
   })
 

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/target-app/di-dependency.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/target-app/di-dependency.js
@@ -3,8 +3,9 @@
 module.exports = function (a, b) {
   const localVar = 1
   const users = []
+  const metadata = {}
   if (a > 10) {
     throw new Error('a is too big')
   }
-  return a + b + localVar + users.length // location of the breakpoint
+  return a + b + localVar + users.length + Object.keys(metadata).length // location of the breakpoint
 }


### PR DESCRIPTION
### What does this PR do?
Omits empty capture containers from Failed Test Replay DI snapshots before they are sent through the Test Optimization logs path. This keeps captured object and collection types while avoiding empty or null `fields`, `elements`, and `entries` payloads that can break debugger UI rendering.

The cleanup now only prunes recognized captured values and traverses all remaining object-valued children, so application variables or properties named `fields`, `elements`, or `entries` cannot block recursive cleanup.

This also adds coverage for the raw serialized FTR DI log body, verifying that captured empty objects, arrays, and maps preserve their `type` while omitting empty containers. The existing raw log assertions also confirm git `ddtags` are present for the covered FTR paths.

### Motivation
FTR snapshots can include empty captured objects and collections. In the Test Optimization logs flow, those empty containers may surface as `fields: null`, `elements: null`, or `entries: null` in the debugger UI, causing capture rendering failures.

### Additional Notes
Verification covers the worker snapshot cleanup matrix, recursive name-collision cases, metadata preservation, and a Jest FTR integration path that inspects the raw DI log body received by the fake intake.
