### PR TITLE
test(plugins): select version targets by Node.js runtime

### DIFF
--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -219,7 +219,13 @@ module.exports = {
     },
     {
       name: '@fastify/cookie',
+      versions: ['>=6 <11.1.0'],
+      node: '<22',
+    },
+    {
+      name: '@fastify/cookie',
       versions: ['>=6'],
+      node: '>=22',
     },
     {
       name: '@fastify/multipart',

--- a/packages/dd-trace/test/plugins/versions.spec.js
+++ b/packages/dd-trace/test/plugins/versions.spec.js
@@ -88,6 +88,45 @@ describe('resolvePluginVersions', () => {
     assert.equal(result.unversioned, '4')
   })
 
+  it('includes declarations at the Node.js range boundary', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <5'],
+      nodeRange: '>=22',
+      nodeVersion: '22.0.0',
+      env: {},
+    })
+
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
+  })
+
+  it('excludes declarations outside the Node.js range before applying package range overrides', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <5'],
+      nodeRange: '>=22',
+      nodeVersion: '21.999.999',
+      env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
+    })
+
+    assert.deepEqual(result.versionList, [])
+    assert.equal(result.unversioned, undefined)
+  })
+
+  it('throws on an invalid Node.js range', () => {
+    assert.throws(
+      () => resolvePluginVersions({
+        name: 'mongodb',
+        declaredVersions: ['>=2 <5'],
+        nodeRange: 'not-a-version',
+        nodeVersion: '22.0.0',
+        env: {},
+      }),
+      /Invalid Node.js version range/
+    )
+  })
+
   it('filters the installed keys by RANGE and follows the filtered tail', () => {
     const result = resolvePluginVersions({
       name: 'mongodb',

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { clean, coerce, intersects, satisfies, subset } = require('semver')
+const { clean, coerce, intersects, satisfies, subset, validRange } = require('semver')
 
 const latests = require('./package.json').dependencies
 
@@ -219,6 +219,8 @@ function highestMajor (name, range, floorMajor) {
  * @param {object} options
  * @param {string} options.name The module name, e.g. `fastify`.
  * @param {string[]} options.declaredVersions The declared version entries to expand.
+ * @param {string} [options.nodeRange] The Node.js versions where these declarations apply.
+ * @param {string} [options.nodeVersion] The current Node.js version; injectable for testing.
  * @param {boolean} [options.honourEnvRange] Whether `PACKAGE_VERSION_RANGE` applies to this module. False for sibling
  *   externals that must stay on their declared versions while the matrix shards a different package.
  * @param {NodeJS.ProcessEnv} [options.env] Injectable for testing.
@@ -226,7 +228,19 @@ function highestMajor (name, range, floorMajor) {
  *   `RANGE`-filtered key set, and the key the default `versions/<name>` folder resolves to (the newest in-scope entry,
  *   or `undefined` when nothing is in scope).
  */
-function resolvePluginVersions ({ name, declaredVersions, honourEnvRange = true, env = process.env }) {
+function resolvePluginVersions ({
+  name,
+  declaredVersions,
+  nodeRange,
+  nodeVersion = process.versions.node,
+  honourEnvRange = true,
+  env = process.env,
+}) {
+  if (nodeRange !== undefined) {
+    if (!validRange(nodeRange)) throw new Error(`Invalid Node.js version range for '${name}': ${nodeRange}`)
+    if (!satisfies(nodeVersion, nodeRange)) return { versionList: [], unversioned: undefined }
+  }
+
   const useEnvRange = Boolean(env.PACKAGE_VERSION_RANGE) && honourEnvRange
   const versions = useEnvRange ? [env.PACKAGE_VERSION_RANGE] : declaredVersions
 

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -37,7 +37,7 @@
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/transport": "9.3.5",
     "@electron/packager": "20.0.0",
-    "@fastify/cookie": "11.0.2",
+    "@fastify/cookie": "11.1.1",
     "@fastify/multipart": "10.0.0",
     "@google-cloud/pubsub": "5.3.1",
     "@google-cloud/vertexai": "1.12.0",

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -303,6 +303,7 @@ function withVersions (plugin, modules, range, cb) {
       const { versionList } = resolvePluginVersions({
         name: moduleName,
         declaredVersions: normalizeVersions(instrumentation.versions),
+        nodeRange: instrumentation.node,
       })
 
       for (const { versionKey, range: declaredRange } of versionList) {

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -92,7 +92,7 @@ function collectPackages (moduleNames) {
   }
 
   /**
-   * @param {{ name: string, versions?: string[] }} instrumentation
+   * @param {{ name: string, versions?: string[], node?: string }} instrumentation
    * @param {boolean} external
    * @param {string} [pluginName] The plugin key an external entry belongs to. Same-name externals (e.g. the aerospike
    *   entry mirroring the addHook versions) honour `PACKAGE_VERSION_RANGE` so per-major CI matrices do not force every
@@ -102,6 +102,7 @@ function collectPackages (moduleNames) {
     const { versionList, unversioned } = resolvePluginVersions({
       name: instrumentation.name,
       declaredVersions: instrumentation.versions || [],
+      nodeRange: instrumentation.node,
       honourEnvRange: !external || instrumentation.name === pluginName,
     })
 


### PR DESCRIPTION
## Summary
The latest `@fastify/cookie` release depends on an ESM-only `cookie` package and fails to load in the Node.js 18/20 AppSec matrix. Keep the latest dependency in the version manifest while selecting Node-compatible package ranges for installation and `withVersions()`.

## Why
The shared resolver now applies the same Node.js range filter to both generated install targets and tested versions, preventing the two sets from drifting.