### PR TITLE
fix(appsec): skip @fastify/cookie 11.1.1 on Node.js < 22 due to ESM-only cookie dependency

### DIFF
--- a/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
@@ -10,6 +10,7 @@ const Axios = require('axios')
 const semver = require('semver')
 const sinon = require('sinon')
 
+const { NODE_MAJOR } = require('../../../../version')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
 const { withVersions } = require('../setup/mocha')
@@ -447,7 +448,17 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
   })
 
   describe('Suspicious request blocking - cookie', () => {
-    withVersions('fastify', '@fastify/cookie', cookieVersion => {
+    withVersions('fastify', '@fastify/cookie', (cookieVersion, _, cookieLoadedVersion) => {
+      // @fastify/cookie@11.1.1 bumped its own `cookie` dependency to ^2.0.0, which ships ESM-only
+      // with no CJS entry point. Requiring it throws ERR_REQUIRE_ESM on any Node.js version without
+      // synchronous require(esm) support.
+      if (semver.gte(cookieLoadedVersion, '11.1.1') && NODE_MAJOR < 22) {
+        // eslint-disable-next-line mocha/no-pending-tests
+        describe.skip(`refusing to run tests as @fastify/cookie@${cookieLoadedVersion} depends on an ESM-only ` +
+          `cookie package incompatible with Node.js ${NODE_MAJOR}`)
+        return
+      }
+
       const hookConfigurations = [
         'onRequest',
         'preParsing',

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -37,7 +37,7 @@
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/transport": "9.3.5",
     "@electron/packager": "20.0.0",
-    "@fastify/cookie": "11.0.2",
+    "@fastify/cookie": "11.1.1",
     "@fastify/multipart": "10.0.0",
     "@google-cloud/pubsub": "5.3.1",
     "@google-cloud/vertexai": "1.12.0",


### PR DESCRIPTION
### What does this PR do?
Bumps `@fastify/cookie` to `11.1.1` and skips its cookie-blocking tests on `Node.js < 22`, since that version pulls in an ESM-only `cookie@2.x` (requires `Node >=22`) that a CommonJS require() can't load on older runtimes.

### Motivation
This dependency bump broke the Appsec/fastify [CI job on Node 18 with ERR_REQUIRE_ESM](https://github.com/DataDog/dd-trace-js/actions/runs/29217755237/job/86717371407?pr=9293). It's an upstream incompatibility, not fixable in dd-trace, the same `NODE_MAJOR` skip pattern is already used elsewhere (`index.express.plugin.spec.js`, #9272) for this exact class of issue.

### Additional Notes
`fastify` core was not bumped, unrelated to this failure, no peer dependency ties it to `@fastify/cookie`.


