### PR TITLE
fix(azure): enable Web Crypto on Node 18

### DIFF
--- a/packages/datadog-plugin-azure-service-bus/test/integration-test/core-test/client.spec.js
+++ b/packages/datadog-plugin-azure-service-bus/test/integration-test/core-test/client.spec.js
@@ -14,7 +14,10 @@ const {
 } = require('../../../../../integration-tests/helpers')
 const { withVersions } = require('../../../../dd-trace/test/setup/mocha')
 
-const spawnEnv = { DD_TRACE_FLUSH_INTERVAL: '2000' }
+const spawnEnv = {
+  DD_TRACE_FLUSH_INTERVAL: '2000',
+  NODE_OPTIONS: '--experimental-global-webcrypto',
+}
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-azure-service-bus/test/integration-test/tryAddMessageRegressionTest/client.spec.js
+++ b/packages/datadog-plugin-azure-service-bus/test/integration-test/tryAddMessageRegressionTest/client.spec.js
@@ -11,7 +11,10 @@ const {
 } = require('../../../../../integration-tests/helpers')
 const { withVersions } = require('../../../../dd-trace/test/setup/mocha')
 
-const spawnEnv = { DD_TRACE_FLUSH_INTERVAL: '2000' }
+const spawnEnv = {
+  DD_TRACE_FLUSH_INTERVAL: '2000',
+  NODE_OPTIONS: '--experimental-global-webcrypto',
+}
 
 describe('esm', () => {
   let agent


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
 Enables the global Web Crypto API in the Azure Service Bus integration test processes on Node.js 18.
 
### Motivation
<!-- What inspired you to submit this pull request? -->

@azure/core-amqp 4.5.0 started using globalThis.crypto.subtle, which is not enabled by default for these Node.js 18 test processes. This caused all Azure Service Bus integration tests to fail after the dependency was published.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


