### PR TITLE
fix(config): handle invalid programmatic option values

### DIFF
--- a/packages/dd-trace/src/config/config-types.d.ts
+++ b/packages/dd-trace/src/config/config-types.d.ts
@@ -70,3 +70,11 @@ export type ConfigKey = KnownStringKeys<ConfigProperties>
 export type ConfigPath = ConfigPathFor<ConfigProperties>
 export type ConfigPathValue<TPath extends ConfigPath> = ConfigPathValueFor<ConfigProperties, TPath>
 export type ConfigDefaults = Partial<{ [TPath in ConfigPath]: ConfigPathValue<TPath> }>
+export type ConfigurationOption = {
+  property?: string
+  parser?: (value: unknown, optionName: string, source: string) => unknown
+  type?: string
+  canonicalName?: string
+  transformer?: (value: unknown, optionName: string, source: string) => unknown
+  telemetryTransformer?: (value: unknown) => unknown
+}

--- a/packages/dd-trace/src/config/config-types.d.ts
+++ b/packages/dd-trace/src/config/config-types.d.ts
@@ -73,7 +73,7 @@ export type ConfigDefaults = Partial<{ [TPath in ConfigPath]: ConfigPathValue<TP
 export type ConfigurationOption = {
   property?: string
   parser?: (value: unknown, optionName: string, source: string) => unknown
-  type?: string
+  type: string
   canonicalName?: string
   transformer?: (value: unknown, optionName: string, source: string) => unknown
   telemetryTransformer?: (value: unknown) => unknown

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -3,7 +3,13 @@
 const util = require('util')
 
 const { DD_MAJOR } = require('../../../../version')
-const { parsers, transformers, telemetryTransformers, setWarnInvalidValue } = require('./parsers')
+const {
+  parsers,
+  programmaticTypeTransformers,
+  transformers,
+  telemetryTransformers,
+  setWarnInvalidValue,
+} = require('./parsers')
 const applyMajorOverrides = require('./major-overrides')
 const {
   supportedConfigurations,
@@ -184,16 +190,52 @@ const parser = (value, optionName, source) => {
 }
 
 /**
- * @template {import('./config-types').ConfigPath} TPath
- * @type {Partial<Record<TPath, {
+ * @typedef {{
  *   property?: string,
- *   parser: (value: unknown, optionName: string, source: string) => unknown,
+ *   parser?: (value: unknown, optionName: string, source: string) => unknown,
+ *   type?: string,
  *   canonicalName?: string,
  *   transformer?: (value: unknown, optionName: string, source: string) => unknown,
  *   telemetryTransformer?: (value: unknown) => unknown
- * }>>} ConfigurationsTable
+ * }} ConfigurationOption
+ */
+
+/**
+ * @template {import('./config-types').ConfigPath} TPath
+ * @type {Partial<Record<TPath, ConfigurationOption>>} ConfigurationsTable
  */
 const configurationsTable = {}
+
+/**
+ * @param {ConfigurationOption} entry
+ * @param {unknown} value
+ * @param {string} optionName
+ * @param {string} source
+ */
+function transformProgrammaticOption (entry, value, optionName, source) {
+  let transformed = value
+  if (entry.type) {
+    try {
+      transformed = programmaticTypeTransformers[entry.type](value, entry.canonicalName ?? optionName)
+    } catch (error) {
+      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`, error)
+      return
+    }
+    if (transformed === undefined) {
+      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`)
+      return
+    }
+  }
+  if (entry.transformer) {
+    try {
+      transformed = entry.transformer(transformed, optionName, source)
+    } catch (error) {
+      warnInvalidValue(value, optionName, source, 'Invalid value', error)
+      return
+    }
+  }
+  return transformed
+}
 
 // One way aliases. Must be applied in apply calculated entries.
 const fallbackConfigurations = new Map()
@@ -231,6 +273,10 @@ for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) 
       ? `${entry.namespace}.${canonicalName}`
       : (entry.internalPropertyName ?? entry.configurationNames?.[0] ?? canonicalName)
     const type = entry.type.toUpperCase()
+    /* istanbul ignore if -- supported configuration types are static metadata */
+    if (!programmaticTypeTransformers[type]) {
+      throw new Error(`Missing programmatic transformer for configuration type: ${type}`)
+    }
 
     let transformer = transformers[entry.transform]
     if (entry.allowed) {
@@ -353,6 +399,8 @@ module.exports = {
   parseErrors,
 
   generateTelemetry,
+
+  transformProgrammaticOption,
 }
 
 // `dns` is instrumented, so requiring it pulls in the dns plugin, which loads

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -1,11 +1,12 @@
 'use strict'
 
+const assert = require('node:assert')
 const util = require('util')
 
 const { DD_MAJOR } = require('../../../../version')
 const {
   parsers,
-  programmaticTypeTransformers,
+  programmaticTypeCoercions,
   transformers,
   telemetryTransformers,
   setWarnInvalidValue,
@@ -76,6 +77,7 @@ for (const [name, value] of Object.entries(defaults)) {
 function generateTelemetry (value = null, origin, optionName) {
   const tableEntry = configurationsTable[optionName]
   const { type, canonicalName = optionName } = tableEntry ?? { type: typeof value }
+  const error = parseErrors.get(`${canonicalName}${origin}`)
   // Sensitive configurations are excluded from configuration telemetry: their
   // entry is never added to `configWithOrigin`, the single source for every
   // telemetry path (app-started and app-client-configuration-change).
@@ -87,7 +89,9 @@ function generateTelemetry (value = null, origin, optionName) {
   // TODO: Validate that space separated tags are parsed by the backend. Optimizations would be possible with that.
   // TODO: How to handle telemetry reporting for aliases?
   if (value !== null) {
-    if (telemetryTransformers[type]) {
+    if (error && typeof value === 'object') {
+      value = util.inspect(value, { customInspect: false, getters: false })
+    } else if (telemetryTransformers[type]) {
       value = telemetryTransformers[type](value)
     } else if (typeof value === 'object' && value !== null) {
       // Custom optionsTable entries (no `configurationsTable` row, e.g. `logger`)
@@ -106,7 +110,6 @@ function generateTelemetry (value = null, origin, optionName) {
     origin,
     seq_id: seqId++,
   }
-  const error = parseErrors.get(`${canonicalName}${origin}`)
   if (error) {
     parseErrors.delete(`${canonicalName}${origin}`)
     telemetryEntry.error = error
@@ -190,52 +193,10 @@ const parser = (value, optionName, source) => {
 }
 
 /**
- * @typedef {{
- *   property?: string,
- *   parser?: (value: unknown, optionName: string, source: string) => unknown,
- *   type?: string,
- *   canonicalName?: string,
- *   transformer?: (value: unknown, optionName: string, source: string) => unknown,
- *   telemetryTransformer?: (value: unknown) => unknown
- * }} ConfigurationOption
- */
-
-/**
  * @template {import('./config-types').ConfigPath} TPath
- * @type {Partial<Record<TPath, ConfigurationOption>>} ConfigurationsTable
+ * @type {Partial<Record<TPath, import('./config-types').ConfigurationOption>>} ConfigurationsTable
  */
 const configurationsTable = {}
-
-/**
- * @param {ConfigurationOption} entry
- * @param {unknown} value
- * @param {string} optionName
- * @param {string} source
- */
-function transformProgrammaticOption (entry, value, optionName, source) {
-  let transformed = value
-  if (entry.type) {
-    try {
-      transformed = programmaticTypeTransformers[entry.type](value, entry.canonicalName ?? optionName)
-    } catch (error) {
-      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`, error)
-      return
-    }
-    if (transformed === undefined) {
-      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`)
-      return
-    }
-  }
-  if (entry.transformer) {
-    try {
-      transformed = entry.transformer(transformed, optionName, source)
-    } catch (error) {
-      warnInvalidValue(value, optionName, source, 'Invalid value', error)
-      return
-    }
-  }
-  return transformed
-}
 
 // One way aliases. Must be applied in apply calculated entries.
 const fallbackConfigurations = new Map()
@@ -273,10 +234,7 @@ for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) 
       ? `${entry.namespace}.${canonicalName}`
       : (entry.internalPropertyName ?? entry.configurationNames?.[0] ?? canonicalName)
     const type = entry.type.toUpperCase()
-    /* istanbul ignore if -- supported configuration types are static metadata */
-    if (!programmaticTypeTransformers[type]) {
-      throw new Error(`Missing programmatic transformer for configuration type: ${type}`)
-    }
+    assert.ok(programmaticTypeCoercions[type])
 
     let transformer = transformers[entry.transform]
     if (entry.allowed) {
@@ -400,7 +358,7 @@ module.exports = {
 
   generateTelemetry,
 
-  transformProgrammaticOption,
+  warnInvalidValue,
 }
 
 // `dns` is instrumented, so requiring it pulls in the dns plugin, which loads

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -144,12 +144,8 @@ function generateTelemetry (value = null, origin, optionName) {
 const optionsTable = {
   // Additional properties that are not supported by the supported-configurations.json file.
   lookup: {
-    transformer (value) {
-      if (typeof value === 'function') {
-        return value
-      }
-    },
     property: 'lookup',
+    type: 'FUNCTION',
   },
   logger: {
     transformer (object) {
@@ -174,12 +170,15 @@ const optionsTable = {
       }
     },
     property: 'logger',
+    type: 'MAP',
   },
   isCiVisibility: {
     property: 'isCiVisibility',
+    type: 'BOOLEAN',
   },
   plugins: {
     property: 'plugins',
+    type: 'BOOLEAN',
   },
 }
 

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -3,7 +3,6 @@
 const fs = require('node:fs')
 const os = require('node:os')
 const { URL, format } = require('node:url')
-const { inspect } = require('node:util')
 
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
 const uuid = require('../../../../vendor/dist/crypto-randomuuid') // we need to keep the old uuid dep because of cypress
@@ -36,10 +35,10 @@ const {
   configWithOrigin,
   parseErrors,
   generateTelemetry,
-  transformProgrammaticOption,
+  warnInvalidValue,
 } = require('./defaults')
 const { normalizeService } = require('./normalize-service')
-const { transformers } = require('./parsers')
+const { programmaticTypeCoercions, transformers } = require('./parsers')
 
 const RUNTIME_ID = uuid()
 
@@ -57,6 +56,7 @@ const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
  * @typedef {import('../../../../index').TracerOptions} TracerOptions
  * @typedef {import('./config-types').ConfigKey} ConfigKey
  * @typedef {import('./config-types').ConfigPath} ConfigPath
+ * @typedef {import('./config-types').ConfigurationOption} ConfigurationOption
  * @typedef {{
  *   value: import('./config-types').ConfigPathValue<ConfigPath>,
  *   source: TelemetrySource
@@ -124,14 +124,7 @@ function setAndTrack (config, name, value, rawValue = value, source = 'calculate
     // TODO: This works as before while ignoring undefined programmatic options is not ideal.
     if (source !== 'default') {
       if (rawValue !== value) {
-        const rawType = typeof rawValue
-        const telemetryValue = rawValue === null ||
-          rawType === 'string' ||
-          rawType === 'number' ||
-          rawType === 'boolean'
-          ? rawValue
-          : inspect(rawValue, { customInspect: false, getters: false })
-        generateTelemetry(telemetryValue, source, name)
+        generateTelemetry(rawValue, source, name)
       }
       return
     }
@@ -158,6 +151,37 @@ function setAndTrack (config, name, value, rawValue = value, source = 'calculate
   } else {
     trackedConfigOrigins.set(name, source)
   }
+}
+
+/**
+ * @param {ConfigurationOption} entry
+ * @param {unknown} value
+ * @param {string} optionName
+ * @param {TelemetrySource} source
+ */
+function coerceType (entry, value, optionName, source) {
+  let coerced = value
+  if (entry.type) {
+    try {
+      coerced = programmaticTypeCoercions[entry.type](value, entry.canonicalName ?? optionName)
+    } catch (error) {
+      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`, error)
+      return
+    }
+    if (coerced === undefined) {
+      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`)
+      return
+    }
+  }
+  if (entry.transformer) {
+    try {
+      coerced = entry.transformer(coerced, optionName, source)
+    } catch (error) {
+      warnInvalidValue(value, optionName, source, 'Invalid value', error)
+      return
+    }
+  }
+  return coerced
 }
 
 module.exports = getConfig
@@ -299,7 +323,7 @@ class Config extends ConfigBase {
       }
       const transformed = value === undefined
         ? value
-        : transformProgrammaticOption(entry, value, fullName, source)
+        : coerceType(entry, value, fullName, source)
       setAndTrack(this, entry.property ?? name, transformed, value, source)
     }
   }

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -156,32 +156,9 @@ function setAndTrack (config, name, value, rawValue = value, source = 'calculate
 /**
  * @param {ConfigurationOption} entry
  * @param {unknown} value
- * @param {string} optionName
- * @param {TelemetrySource} source
  */
-function coerceType (entry, value, optionName, source) {
-  let coerced = value
-  if (entry.type) {
-    try {
-      coerced = programmaticTypeCoercions[entry.type](value, entry.canonicalName ?? optionName)
-    } catch (error) {
-      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`, error)
-      return
-    }
-    if (coerced === undefined) {
-      warnInvalidValue(value, optionName, source, `Invalid ${entry.type} input`)
-      return
-    }
-  }
-  if (entry.transformer) {
-    try {
-      coerced = entry.transformer(coerced, optionName, source)
-    } catch (error) {
-      warnInvalidValue(value, optionName, source, 'Invalid value', error)
-      return
-    }
-  }
-  return coerced
+function coerceType (entry, value) {
+  return programmaticTypeCoercions[entry.type](value)
 }
 
 module.exports = getConfig
@@ -321,9 +298,13 @@ class Config extends ConfigBase {
           continue
         }
       }
-      const transformed = value === undefined
-        ? value
-        : coerceType(entry, value, fullName, source)
+      const coerced = value === undefined ? value : coerceType(entry, value)
+      if (coerced === undefined && value !== undefined) {
+        warnInvalidValue(value, fullName, source, `Invalid ${entry.type} input`)
+      }
+      const transformed = coerced !== undefined && entry.transformer
+        ? entry.transformer(coerced, fullName, source)
+        : coerced
       setAndTrack(this, entry.property ?? name, transformed, value, source)
     }
   }

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs')
 const os = require('node:os')
 const { URL, format } = require('node:url')
+const { inspect } = require('node:util')
 
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
 const uuid = require('../../../../vendor/dist/crypto-randomuuid') // we need to keep the old uuid dep because of cypress
@@ -35,6 +36,7 @@ const {
   configWithOrigin,
   parseErrors,
   generateTelemetry,
+  transformProgrammaticOption,
 } = require('./defaults')
 const { normalizeService } = require('./normalize-service')
 const { transformers } = require('./parsers')
@@ -121,6 +123,16 @@ function setAndTrack (config, name, value, rawValue = value, source = 'calculate
   if (value == null) {
     // TODO: This works as before while ignoring undefined programmatic options is not ideal.
     if (source !== 'default') {
+      if (rawValue !== value) {
+        const rawType = typeof rawValue
+        const telemetryValue = rawValue === null ||
+          rawType === 'string' ||
+          rawType === 'number' ||
+          rawType === 'boolean'
+          ? rawValue
+          : inspect(rawValue, { customInspect: false, getters: false })
+        generateTelemetry(telemetryValue, source, name)
+      }
       return
     }
   } else if (source === 'calculated' || source === 'remote_config') {
@@ -285,8 +297,9 @@ class Config extends ConfigBase {
           continue
         }
       }
-      // TODO: Coerce mismatched types to the expected type, if possible. E.g., strings <> numbers
-      const transformed = value !== undefined && entry.transformer ? entry.transformer(value, fullName, source) : value
+      const transformed = value === undefined
+        ? value
+        : transformProgrammaticOption(entry, value, fullName, source)
       setAndTrack(this, entry.property ?? name, transformed, value, source)
     }
   }

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -153,14 +153,6 @@ function setAndTrack (config, name, value, rawValue = value, source = 'calculate
   }
 }
 
-/**
- * @param {ConfigurationOption} entry
- * @param {unknown} value
- */
-function coerceType (entry, value) {
-  return programmaticTypeCoercions[entry.type](value)
-}
-
 module.exports = getConfig
 
 // We extend from ConfigBase to make our types work
@@ -298,7 +290,7 @@ class Config extends ConfigBase {
           continue
         }
       }
-      const coerced = value === undefined ? value : coerceType(entry, value)
+      const coerced = programmaticTypeCoercions[entry.type](value)
       if (coerced === undefined && value !== undefined) {
         warnInvalidValue(value, fullName, source, `Invalid ${entry.type} input`)
       }

--- a/packages/dd-trace/src/config/parsers.js
+++ b/packages/dd-trace/src/config/parsers.js
@@ -297,7 +297,7 @@ const parsers = {
   },
 }
 
-const programmaticTypeTransformers = {
+const programmaticTypeCoercions = {
   /**
    * @param {unknown} value
    */
@@ -313,7 +313,7 @@ const programmaticTypeTransformers = {
    * @param {unknown} value
    */
   INT (value) {
-    if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) {
+    if (typeof value === 'number' || typeof value === 'string' && value.trim() !== '') {
       return parsers.INT(value)
     }
   },
@@ -321,7 +321,7 @@ const programmaticTypeTransformers = {
    * @param {unknown} value
    */
   DECIMAL (value) {
-    if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) {
+    if (typeof value === 'number' || typeof value === 'string' && value.trim() !== '') {
       return parsers.DECIMAL(value)
     }
   },
@@ -332,7 +332,7 @@ const programmaticTypeTransformers = {
     if (typeof value === 'string') {
       return value
     }
-    if (typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))) {
+    if (typeof value === 'boolean' || typeof value === 'number' && Number.isFinite(value)) {
       return String(value)
     }
   },
@@ -342,7 +342,7 @@ const programmaticTypeTransformers = {
   ARRAY (value) {
     if (Array.isArray(value)) {
       for (const item of value) {
-        if (typeof item !== 'string') {
+        if (typeof item !== 'string' && typeof item !== 'number' && typeof item !== 'boolean') {
           return
         }
       }
@@ -369,7 +369,7 @@ const programmaticTypeTransformers = {
 
 module.exports = {
   parsers,
-  programmaticTypeTransformers,
+  programmaticTypeCoercions,
   transformers,
   telemetryTransformers,
   setWarnInvalidValue,

--- a/packages/dd-trace/src/config/parsers.js
+++ b/packages/dd-trace/src/config/parsers.js
@@ -297,8 +297,79 @@ const parsers = {
   },
 }
 
+const programmaticTypeTransformers = {
+  /**
+   * @param {unknown} value
+   */
+  BOOLEAN (value) {
+    if (typeof value === 'boolean') {
+      return value
+    }
+    if (typeof value === 'string') {
+      return parsers.BOOLEAN(value)
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
+  INT (value) {
+    if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) {
+      return parsers.INT(value)
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
+  DECIMAL (value) {
+    if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) {
+      return parsers.DECIMAL(value)
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
+  STRING (value) {
+    if (typeof value === 'string') {
+      return value
+    }
+    if (typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))) {
+      return String(value)
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
+  ARRAY (value) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item !== 'string') {
+          return
+        }
+      }
+      return value
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
+  MAP (value) {
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      return value
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
+  JSON (value) {
+    if (typeof value === 'object' && value !== null) {
+      return value
+    }
+  },
+}
+
 module.exports = {
   parsers,
+  programmaticTypeTransformers,
   transformers,
   telemetryTransformers,
   setWarnInvalidValue,

--- a/packages/dd-trace/src/config/parsers.js
+++ b/packages/dd-trace/src/config/parsers.js
@@ -339,6 +339,14 @@ const programmaticTypeCoercions = {
   /**
    * @param {unknown} value
    */
+  FUNCTION (value) {
+    if (typeof value === 'function') {
+      return value
+    }
+  },
+  /**
+   * @param {unknown} value
+   */
   ARRAY (value) {
     if (Array.isArray(value)) {
       for (const item of value) {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1737,26 +1737,6 @@ describe('Config', () => {
     assert.strictEqual(config.service, 'node')
   })
 
-  it('should ignore programmatic options when their transformations throw', () => {
-    const headerTags = new Proxy([], {
-      get () {
-        throw new Error('array transformation failed')
-      },
-    })
-    const samplingRules = new Proxy({}, {
-      ownKeys () {
-        throw new Error('option transformation failed')
-      },
-    })
-
-    const config = getConfig({ headerTags, samplingRules })
-
-    assert.deepStrictEqual(config.headerTags, defaults.headerTags)
-    assert.deepStrictEqual(config.samplingRules, defaults.samplingRules)
-    sinon.assert.calledWithMatch(log.error, /^Invalid ARRAY input:/)
-    sinon.assert.calledWithMatch(log.error, /^Invalid value:/)
-  })
-
   it('should initialize from environment variables with url taking precedence', () => {
     process.env.DD_TRACE_AGENT_URL = 'https://agent2:7777'
     process.env.DD_SITE = 'datadoghq.eu'

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1642,6 +1642,7 @@ describe('Config', () => {
       },
       profiling: true,
       service: 1234,
+      baggageTagKeys: ['valid', 1, true],
     })
 
     assert.strictEqual(config.startupLogs, false)
@@ -1649,6 +1650,7 @@ describe('Config', () => {
     assert.strictEqual(config.remoteConfig.pollInterval, 2.5)
     assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'true')
     assert.strictEqual(config.service, '1234')
+    assert.deepStrictEqual(config.baggageTagKeys, ['valid', 1, true])
   })
 
   it('should accept infinite numeric programmatic option values', () => {
@@ -1691,7 +1693,7 @@ describe('Config', () => {
         pollInterval: [],
       },
       service: {},
-      baggageTagKeys: ['valid', 1],
+      baggageTagKeys: [null],
       headerTags: 'valid:value',
       serviceMapping: 'mysql:database',
       samplingRules,

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1633,6 +1633,128 @@ describe('Config', () => {
     })
   })
 
+  it('should transform safe programmatic option types', () => {
+    const config = getConfig({
+      startupLogs: 'False',
+      flushInterval: '1234.9',
+      remoteConfig: {
+        pollInterval: '2.5',
+      },
+      profiling: true,
+      service: 1234,
+    })
+
+    assert.strictEqual(config.startupLogs, false)
+    assert.strictEqual(config.flushInterval, 1234)
+    assert.strictEqual(config.remoteConfig.pollInterval, 2.5)
+    assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'true')
+    assert.strictEqual(config.service, '1234')
+  })
+
+  it('should accept infinite numeric programmatic option values', () => {
+    const config = getConfig({
+      flushInterval: Infinity,
+      remoteConfig: {
+        pollInterval: '-Infinity',
+      },
+    })
+
+    assert.strictEqual(config.flushInterval, Infinity)
+    assert.strictEqual(config.remoteConfig.pollInterval, -Infinity)
+  })
+
+  it('should ignore undefined programmatic option values', () => {
+    const config = getConfig({ startupLogs: undefined })
+
+    assert.strictEqual(config.startupLogs, defaults.startupLogs)
+    sinon.assert.notCalled(log.warn)
+  })
+
+  it('should preserve environment tags when the programmatic tags type is invalid', () => {
+    process.env.DD_TRACE_GLOBAL_TAGS = 'team:checkout,tier:backend'
+
+    const config = getConfig({ tags: process.env.DD_TRACE_GLOBAL_TAGS })
+
+    assertObjectContains(config.tags, { team: 'checkout', tier: 'backend' })
+    sinon.assert.calledWithExactly(
+      log.warn,
+      "Invalid MAP input: 'team:checkout,tier:backend' for tags (source: code), picked default",
+    )
+  })
+
+  it('should ignore invalid programmatic option types and report them to telemetry', () => {
+    const samplingRules = JSON.stringify([{ service: 'web', sample_rate: 1 }])
+    const config = getConfig({
+      startupLogs: 'yes',
+      flushInterval: {},
+      remoteConfig: {
+        pollInterval: [],
+      },
+      service: {},
+      baggageTagKeys: ['valid', 1],
+      headerTags: 'valid:value',
+      serviceMapping: 'mysql:database',
+      samplingRules,
+    })
+
+    assert.strictEqual(config.startupLogs, defaults.startupLogs)
+    assert.strictEqual(config.flushInterval, defaults.flushInterval)
+    assert.strictEqual(config.remoteConfig.pollInterval, defaults['remoteConfig.pollInterval'])
+    assert.strictEqual(config.service, 'node')
+    assert.deepStrictEqual(config.baggageTagKeys, defaults.baggageTagKeys)
+    assert.deepStrictEqual(config.headerTags, defaults.headerTags)
+    assert.deepStrictEqual(config.serviceMapping, defaults.serviceMapping)
+    assert.deepStrictEqual(config.samplingRules, defaults.samplingRules)
+    sinon.assert.calledWithExactly(
+      log.warn,
+      "Invalid BOOLEAN input: 'yes' for startupLogs (source: code), picked default",
+    )
+    assertConfigUpdateContains(updateConfig.getCall(0).args[0], [{
+      name: 'DD_TRACE_STARTUP_LOGS',
+      value: 'yes',
+      origin: 'code',
+      error: {
+        message: "Invalid BOOLEAN input: 'yes' for startupLogs (source: code), picked default",
+      },
+    }])
+  })
+
+  it('should ignore invalid primitive programmatic option values', () => {
+    const config = getConfig({
+      startupLogs: 1,
+      flushInterval: ' ',
+      remoteConfig: {
+        pollInterval: NaN,
+      },
+      service: null,
+    })
+
+    assert.strictEqual(config.startupLogs, defaults.startupLogs)
+    assert.strictEqual(config.flushInterval, defaults.flushInterval)
+    assert.strictEqual(config.remoteConfig.pollInterval, defaults['remoteConfig.pollInterval'])
+    assert.strictEqual(config.service, 'node')
+  })
+
+  it('should ignore programmatic options when their transformations throw', () => {
+    const headerTags = new Proxy([], {
+      get () {
+        throw new Error('array transformation failed')
+      },
+    })
+    const samplingRules = new Proxy({}, {
+      ownKeys () {
+        throw new Error('option transformation failed')
+      },
+    })
+
+    const config = getConfig({ headerTags, samplingRules })
+
+    assert.deepStrictEqual(config.headerTags, defaults.headerTags)
+    assert.deepStrictEqual(config.samplingRules, defaults.samplingRules)
+    sinon.assert.calledWithMatch(log.error, /^Invalid ARRAY input:/)
+    sinon.assert.calledWithMatch(log.error, /^Invalid value:/)
+  })
+
   it('should initialize from environment variables with url taking precedence', () => {
     process.env.DD_TRACE_AGENT_URL = 'https://agent2:7777'
     process.env.DD_SITE = 'datadoghq.eu'
@@ -1847,7 +1969,7 @@ describe('Config', () => {
       },
       dogstatsd: {
         hostname: 'agent-dsd',
-        port: '5218',
+        port: 5218,
       },
       dynamicInstrumentation: {
         enabled: true,


### PR DESCRIPTION
## Summary
Invalid programmatic configuration values could reach option-specific transforms and abort tracer startup. This adds safe per-type coercion and ignores invalid inputs so lower-priority environment or default values remain active.

Refs: https://github.com/DataDog/dd-trace-js/pull/9226