### PR TITLE
fix(playwright): do not mark unchanged tests as impacted

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-impacted-tests/unimpacted-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-impacted-tests/unimpacted-test.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { test } = require('@playwright/test')
+
+test.describe('unimpacted test', () => {
+  test('should not be impacted', () => {})
+})

--- a/integration-tests/playwright/playwright-impacted-tests.spec.js
+++ b/integration-tests/playwright/playwright-impacted-tests.spec.js
@@ -36,8 +36,10 @@ const versions = [oldest, latest]
 
 const DEFAULT_IMPACTED_KNOWN_TESTS = {
   playwright: {
-    'ci-visibility/playwright-tests-impacted-tests/impacted-test.js':
+    'impacted-test.js':
       ['impacted test should be impacted', 'impacted test 2 should be impacted 2'],
+    'unimpacted-test.js':
+      ['unimpacted test should not be impacted'],
   },
 }
 
@@ -137,12 +139,9 @@ versions.forEach((version) => {
 
             const resourceNames = tests.map(span => span.resource)
 
-            assertObjectContains(resourceNames,
-              [
-                'impacted-test.js.impacted test should be impacted',
-                'impacted-test.js.impacted test 2 should be impacted 2',
-              ]
-            )
+            assert.ok(resourceNames.includes('unimpacted-test.js.unimpacted test should not be impacted'))
+            assert.ok(resourceNames.includes('impacted-test.js.impacted test should be impacted'))
+            assert.ok(resourceNames.includes('impacted-test.js.impacted test 2 should be impacted 2'))
 
             const impactedTests = tests.filter(test =>
               test.meta[TEST_SOURCE_FILE] === 'ci-visibility/playwright-tests-impacted-tests/impacted-test.js')
@@ -169,6 +168,15 @@ versions.forEach((version) => {
                 assert.ok(!(TEST_IS_NEW in impactedTest.meta))
               }
             }
+
+            const unmodifiedTests = tests.filter(test =>
+              test.meta[TEST_SOURCE_FILE] ===
+                'ci-visibility/playwright-tests-impacted-tests/unimpacted-test.js')
+
+            assert.strictEqual(unmodifiedTests.length, 1)
+            assert.ok(!(TEST_IS_MODIFIED in unmodifiedTests[0].meta))
+            assert.ok(!(TEST_IS_NEW in unmodifiedTests[0].meta))
+            assert.ok(!(TEST_IS_RETRY in unmodifiedTests[0].meta))
 
             if (isEfd) {
               const retriedTests = tests.filter(
@@ -225,6 +233,25 @@ versions.forEach((version) => {
           await runImpactedTest(receiver, { isModified: true })
         })
 
+        it('does not mark or retry tests in unmodified files', async (receiver) => {
+          receiver.setKnownTests(DEFAULT_IMPACTED_KNOWN_TESTS)
+          receiver.setSettings({
+            impacted_tests_enabled: true,
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': NUM_RETRIES_EFD,
+                '10s': NUM_RETRIES_EFD,
+              },
+            },
+            known_tests_enabled: true,
+          })
+          await runImpactedTest(
+            receiver,
+            { isModified: true, isEfd: true }
+          )
+        })
+
         it('should not be detected as impacted if disabled', async (receiver) => {
           receiver.setKnownTests(DEFAULT_IMPACTED_KNOWN_TESTS)
           receiver.setSettings({ impacted_tests_enabled: false })
@@ -246,7 +273,10 @@ versions.forEach((version) => {
       context('test is new', () => {
         it('should be retried and marked both as new and modified', async (receiver) => {
           receiver.setKnownTests({
-            playwright: {},
+            playwright: {
+              'unimpacted-test.js':
+                ['unimpacted test should not be impacted'],
+            },
           })
           receiver.setSettings({
             impacted_tests_enabled: true,

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -68,7 +68,7 @@ class PlaywrightPlugin extends CiPlugin {
     }) => {
       const testSuite = getTestSuitePath(filePath, this.repositoryRoot)
       const isModified = isModifiedTest(testSuite, 0, 0, modifiedFiles, this.constructor.id)
-      onDone({ isModified })
+      onDone(isModified)
     })
 
     this.addSub('ci:playwright:session:finish', ({


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Returns the Playwright impacted-test result as a boolean instead of wrapping it in an object.

Adds an unchanged Playwright fixture and integration coverage proving that Impacted Tests does not mark or retry tests from files outside the git diff when Early Flake Detection is enabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

The Playwright instrumentation expects its `onDone` callback to receive a boolean. The plugin returned `{ isModified }`, so `{ isModified: false }` was truthy and every Playwright test was treated as modified. When Early Flake Detection was enabled, unchanged tests were repeated unnecessarily.

