### PR TITLE
test(electron): stabilize flaky CI (install/apt retries, IPC teardown)

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -445,10 +445,17 @@ jobs:
       # this to 0 re-enables them for the duration of the job.
       - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - run: |
-          sudo apt-get update
-          # Xvfb provides a virtual X display so Electron (a GUI app) can start
-          # on the headless CI runner without a physical screen.
-          sudo apt-get install -y xvfb x11-utils
+          # apt's package mirrors occasionally return transient 5xx/invalid-data errors; retry with backoff so a
+          # blip doesn't fail the job. `until` keeps `set -e` from aborting on an intermediate failure.
+          # Xvfb provides a virtual X display so Electron (a GUI app) can start on the headless CI runner
+          # without a physical screen.
+          n=0
+          until sudo apt-get update && sudo apt-get install -y xvfb x11-utils; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then echo "apt failed after $n attempts" >&2; exit 1; fi
+            echo "apt attempt $n failed; retrying in $((n * 10))s" >&2
+            sleep $((n * 10))
+          done
           # Launch the virtual display on screen :99 with a 24-bit 1024×768
           # framebuffer. Output is discarded; the & backgrounds it so the step
           # does not block.

--- a/integration-tests/electron/electron.spec.js
+++ b/integration-tests/electron/electron.spec.js
@@ -115,8 +115,11 @@ describe('Electron integration', function () {
   afterEach(done => {
     const proc = child
     child = null
-    proc.send({ name: 'quit' })
+    // Sending on a closed IPC channel emits an unhandled ERR_IPC_CHANNEL_CLOSED 'error' that masks the real
+    // failure, so only quit a still-connected child and let the send callback absorb a channel that races closed.
+    if (!proc?.connected) return done()
     proc.once('close', done)
+    proc.send({ name: 'quit' }, () => {})
   })
 
   it('should create an http.request span for net.fetch calls', done => {

--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -64,8 +64,14 @@ describe('Plugin', () => {
 
         afterEach(() => agent.close({ ritmReset: false }))
         afterEach(done => {
-          child.send({ name: 'quit' })
-          child.on('close', () => done())
+          const proc = child
+          child = undefined
+          // The child may have already exited (e.g. an app crash mid-test). Sending on a closed IPC channel emits
+          // an unhandled ERR_IPC_CHANNEL_CLOSED 'error' that masks the real failure and aborts the rest of the
+          // suite, so only quit a still-connected child and let the send callback absorb a channel that races closed.
+          if (!proc?.connected) return done()
+          proc.once('close', () => done())
+          proc.send({ name: 'quit' }, () => {})
         })
 
         it('should do automatic instrumentation for fetch', done => {

--- a/scripts/helpers/retry.js
+++ b/scripts/helpers/retry.js
@@ -1,0 +1,46 @@
+'use strict'
+
+/**
+ * Block the current thread for the given duration. Spacing out retries of a synchronous operation needs a synchronous
+ * sleep; `Atomics.wait` on a throwaway buffer provides one without spawning a process.
+ *
+ * @param {number} ms
+ */
+function sleepSync (ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+/**
+ * @typedef {object} RetryOptions
+ * @property {number} [attempts] Maximum number of attempts including the first (default 4).
+ * @property {number} [baseDelayMs] Delay before the first retry, doubled on each subsequent retry (default 5000).
+ * @property {(error: Error, attempt: number, delayMs: number) => void} [onRetry] Called before each backoff wait.
+ * @property {(ms: number) => void} [sleep] Synchronous sleep, injectable for testing (default blocks the thread).
+ */
+
+/**
+ * Run a synchronous function, retrying on any thrown error with exponential backoff.
+ *
+ * Install steps that download large prebuilt binaries (e.g. Electron fetches one archive per major from GitHub's
+ * release CDN) intermittently fail with 5xx gateway errors. Retrying immediately lands in the same outage window, so
+ * back off between attempts before giving up.
+ *
+ * @template T
+ * @param {() => T} fn The operation to attempt.
+ * @param {RetryOptions} [options]
+ * @returns {T} The result of the first successful attempt.
+ */
+function retry (fn, { attempts = 4, baseDelayMs = 5000, onRetry, sleep = sleepSync } = {}) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return fn()
+    } catch (error) {
+      if (attempt >= attempts) throw error
+      const delayMs = baseDelayMs * 2 ** (attempt - 1)
+      onRetry?.(error, attempt, delayMs)
+      sleep(delayMs)
+    }
+  }
+}
+
+module.exports = retry

--- a/scripts/helpers/retry.spec.js
+++ b/scripts/helpers/retry.spec.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const retry = require('./retry')
+
+const noSleep = () => {}
+
+describe('retry', () => {
+  it('returns the result without retrying when the first attempt succeeds', () => {
+    let calls = 0
+    const result = retry(() => {
+      calls++
+      return 'ok'
+    }, { sleep: noSleep })
+    assert.equal(result, 'ok')
+    assert.equal(calls, 1)
+  })
+
+  it('retries until an attempt succeeds', () => {
+    let calls = 0
+    const result = retry(() => {
+      calls++
+      if (calls < 3) throw new Error('boom')
+      return 'ok'
+    }, { sleep: noSleep })
+    assert.equal(result, 'ok')
+    assert.equal(calls, 3)
+  })
+
+  it('throws the last error after exhausting every attempt', () => {
+    let calls = 0
+    assert.throws(
+      () => retry(() => {
+        calls++
+        throw new Error(`boom ${calls}`)
+      }, { attempts: 4, sleep: noSleep }),
+      /boom 4/
+    )
+    assert.equal(calls, 4)
+  })
+
+  it('backs off exponentially from the base delay between attempts', () => {
+    const delays = []
+    assert.throws(() => retry(() => {
+      throw new Error('boom')
+    }, { attempts: 4, baseDelayMs: 5000, sleep: ms => delays.push(ms) }))
+    assert.deepEqual(delays, [5000, 10_000, 20_000])
+  })
+
+  it('reports each retry through onRetry before sleeping', () => {
+    const events = []
+    assert.throws(() => retry(() => {
+      throw new Error('boom')
+    }, {
+      attempts: 3,
+      baseDelayMs: 1000,
+      onRetry: (error, attempt, delayMs) => events.push({ message: error.message, attempt, delayMs }),
+      sleep: noSleep,
+    }))
+    assert.deepEqual(events, [
+      { message: 'boom', attempt: 1, delayMs: 1000 },
+      { message: 'boom', attempt: 2, delayMs: 2000 },
+    ])
+  })
+})

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -16,6 +16,7 @@ const latests = require('../packages/dd-trace/test/plugins/versions/package.json
 const { isRelativeRequire } = require('../packages/datadog-instrumentations/src/helpers/shared-utils')
 const exec = require('./helpers/exec')
 const mapWithConcurrency = require('./helpers/concurrency')
+const retry = require('./helpers/retry')
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 const requirePackageJson = require(requirePackageJsonPath)
 
@@ -352,18 +353,22 @@ async function assertWorkspaces () {
 }
 
 /**
- * @param {boolean} [retry]
+ * Install the generated versions/ workspaces.
+ *
+ * Some workspaces download large prebuilt binaries at postinstall time (e.g. Electron pulls one archive per major
+ * from GitHub's release CDN), which intermittently fail with 5xx gateway errors. Retry with backoff so a brief CDN
+ * outage doesn't fail the whole job.
  */
-function install (retry = true) {
+function install () {
   try {
-    exec('yarn --ignore-engines', { cwd: folder() })
+    retry(() => exec('yarn --ignore-engines', { cwd: folder() }), {
+      onRetry: (error, attempt, delayMs) => process.stderr.write(
+        `yarn install attempt ${attempt} failed, retrying in ${delayMs / 1000}s: ${error.message}\n`
+      ),
+    })
   } catch (error) {
-    if (retry) {
-      install(false) // retry in case of server error from registry
-      return
-    }
-    // A non-transient failure is most often an unresolvable version: a declared range spans a major version that was
-    // never published. Point at the fix instead of leaving a bare yarn error.
+    // A failure that outlasts the retries is most often an unresolvable version: a declared range spans a major
+    // version that was never published. Point at the fix instead of leaving a bare yarn error.
     throw new Error(
       'yarn failed to install the generated versions/ workspaces. If a plugin declares a version range that spans a ' +
       'major version that was never published (non-consecutive majors), add that package to ' +


### PR DESCRIPTION
### What does this PR do?

Fixes recurring flakiness in the `electron` CI job (surfaced by the weekly flakiness report) via three independent, root-caused changes:

1. **Retry the versions install on transient CDN errors** — the generated `versions/` workspaces download prebuilt binaries at postinstall time (Electron pulls one archive per major from GitHub's release CDN), which intermittently fail with 502/504 gateway errors. The previous single, immediate retry fired back-to-back, so both attempts landed in the same brief outage window. Now wrapped in a small backoff-retry helper (4 attempts, 5s/10s/20s). Benefits **every** plugin's version install, not just Electron.
2. **Retry `apt-get` in the electron job** — the `xvfb` install occasionally fails on transient apt-mirror errors; the update+install is now retried with backoff.
3. **Guard the IPC teardown against a closed channel** — `afterEach` sent `{ name: 'quit' }` unconditionally. If the Electron child had already exited (e.g. an app crash mid-test), sending on the closed IPC channel emitted an unhandled `ERR_IPC_CHANNEL_CLOSED` `'error'` that masked the real failure and, thrown inside the hook, aborted the rest of the suite. Now only quits a still-connected child and absorbs a raced-closed channel via the send callback.

### Motivation

The weekly flakiness report repeatedly flagged the `electron` job. Investigation showed the actual failures were HTTP 502/504 errors downloading Electron binaries **during install** — not the display/sandbox issues that prior fixes targeted, which is why it kept recurring. A separate, unguarded IPC teardown turned any early app-exit into a confusing, cascading `ERR_IPC_CHANNEL_CLOSED`.

### Additional Notes

- The install retry sleeps **only on failure**; successful installs are unaffected. A genuinely unresolvable version range fails ~35s slower (4 attempts) — acceptable, since that is a deterministic, self-inflicted error seen by the developer editing the range.
- `retry` ships with unit tests (`scripts/helpers/retry.spec.js`). The IPC teardown fix was reproduced and verified against Node's `ChildProcess` IPC (parent-side semantics are binary-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
