### PR TITLE
fix(ci): strip NODE_V8_COVERAGE from plugin integration test subprocesses

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -944,12 +944,21 @@ function preparePluginIntegrationTestSpawnOptions (
 
   const scriptPath = path.join(cwd, serverFile)
 
+  // When running under c8-ci.js (NODE_V8_COVERAGE set, integration coverage harness inactive),
+  // strip NODE_V8_COVERAGE from the fixture subprocess. These short-lived fixture processes can
+  // hang during V8 coverage flush on exit — especially oracledb 6.x ESM, which loads many more
+  // modules than 5.x and triggers a coverage serialisation that outlasts the 20s test timeout.
+  // The integration coverage harness (when active) handles V8 coverage propagation itself via its
+  // child_process patch; stripping here only applies to the c8-ci.js path where that harness is off.
+  const { NODE_V8_COVERAGE: _v8Coverage, ...parentEnv } = process.env
+  const baseEnv = (!isCoverageActive() && 'NODE_V8_COVERAGE' in process.env) ? parentEnv : process.env
+
   return {
     filename: scriptPath,
     options: {
       cwd,
       env: {
-        ...process.env,
+        ...baseEnv,
         NODE_OPTIONS,
         DD_TRACE_AGENT_PORT: String(agentPort),
         DD_TRACE_FLUSH_INTERVAL: '0',


### PR DESCRIPTION
## Problem

`c8-ci.js` sets `NODE_V8_COVERAGE` in the environment it passes to mocha, which propagates via `...process.env` to every fixture subprocess spawned by integration tests. For oracledb 6.x ESM (which loads significantly more ES modules than 5.x), these short-lived subprocesses hang during V8 coverage data serialization on exit, exceeding the 20-second test timeout.

This manifested as 9 oracledb test failures across APM integrations CI runs, reported in the flakiness report at https://github.com/DataDog/dd-trace-js/actions/runs/29230837991.

## Fix

In `preparePluginIntegrationTestSpawnOptions` (`integration-tests/helpers/index.js`), strip `NODE_V8_COVERAGE` from the fixture subprocess env when:
- `NODE_V8_COVERAGE` is set (c8-ci.js is active), AND
- `_DD_TRACE_INTEGRATION_COVERAGE_ROOT` is NOT set (integration coverage harness is inactive)

The integration coverage harness, when active, handles `NODE_V8_COVERAGE` propagation itself via its child_process patch — stripping here only applies to the c8-ci.js path where that harness is off.

## Testing

The fix is targeted at CI behaviour; the condition it changes (`NODE_V8_COVERAGE` present, integration harness absent) only occurs when running `test:plugins:ci`. Manual local testing of this specific path is not straightforward, but the logic is simple and the root cause is well-understood.

---
_This PR was generated by [Claude Code](https://claude.ai/claude-code)_