### PR TITLE
ci(test-optimization): make STS API key fetch non-fatal

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -153,6 +153,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.node-version }}
@@ -187,6 +188,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}
@@ -222,6 +224,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}
@@ -265,6 +268,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}
@@ -333,6 +337,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}
@@ -399,6 +404,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}
@@ -453,6 +459,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
+        continue-on-error: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}


### PR DESCRIPTION
## What does this PR do?

Adds `continue-on-error: true` to the `dd-sts-api-key` step in all 7 jobs of the Test Optimization workflow (playwright, mocha, jest, cucumber, selenium, cypress, vitest).

## Motivation

Each job independently exchanges a GitHub OIDC token for a Datadog API key via STS. If this exchange fails due to a transient infrastructure issue, the entire job fails before any tests run — producing false failures unrelated to the code under test.

`ci/init.js` already handles a missing `DD_API_KEY` gracefully: when `DD_CIVISIBILITY_AGENTLESS_ENABLED` is set but no key is present, it logs an error and skips initialization rather than crashing. So making the STS step non-fatal is safe — tests still run and results are still reported if the key is available.

## Alternative considered

A more robust long-term approach would be to intercept the agentless intake requests in each job and forward them to a single final job for batched submission. This is possible because `DD_CIVISIBILITY_AGENTLESS_URL` can redirect all intake traffic (`citestcycle`, `citestcov`, etc.) to an arbitrary URL. Each job would run a local proxy that saves payloads to disk, upload them as GitHub Actions artifacts, and a single final job would download all artifacts, fetch one STS key, and replay the payloads to the real Datadog intake. This would eliminate per-job STS exchanges entirely but requires building a proxy server and replayer. Left as a future improvement.

## Checklist

- [x] `continue-on-error: true` added to all 7 `dd-sts-api-key` steps

> Generated by Claude Code