### PR TITLE
test(aap): select mongodb version by Node.js runtime in plugin tests

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -12,21 +12,12 @@ const satisfies = require('semifies')
 const agent = require('../../../plugins/agent')
 const { withVersions } = require('../../../setup/mocha')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { NODE_MAJOR } = require('../../../../../../version')
 
 describe('nosql injection detection in mongodb - whole feature', () => {
   // https://github.com/fiznool/express-mongo-sanitize/issues/200
   withVersions('express-mongo-sanitize', 'express', '>4.18.0 <5.0.0', expressVersion => {
     withVersions('express-mongo-sanitize', 'mongodb', mongodbVersion => {
       const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
-
-      // TODO: remove once Node.js 18 is no longer supported
-      if (satisfies(mongodb.version(), '>=7') && NODE_MAJOR < 20) {
-        describe.skip(
-          `Skipping the tests as mongodb@${mongodb.version()} requires Node.js >= 20 (current: ${NODE_MAJOR})`
-        )
-        return
-      }
 
       const vulnerableMethodFilename = 'mongodb-vulnerable-method.js'
       let collection, tmpFilePath

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js
@@ -7,26 +7,16 @@ const path = require('node:path')
 
 const axios = require('axios')
 const { after, before, describe } = require('mocha')
-const satisfies = require('semifies')
 
 const agent = require('../../../plugins/agent')
 const { withVersions } = require('../../../setup/mocha')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { NODE_MAJOR } = require('../../../../../../version')
 
 describe('nosql injection detection with mquery', () => {
   // https://github.com/fiznool/express-mongo-sanitize/issues/200
   withVersions('mquery', 'express', '>4.18.0 <5.0.0', expressVersion => {
     withVersions('mquery', 'mongodb', mongodbVersion => {
       const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
-
-      // TODO: remove once Node.js 18 is no longer supported
-      if (satisfies(mongodb.version(), '>=7') && NODE_MAJOR < 20) {
-        describe.skip(
-          `Skipping the tests as mongodb@${mongodb.version()} requires Node.js >= 20 (current: ${NODE_MAJOR})`
-        )
-        return
-      }
 
       const vulnerableMethodFilename = 'mquery-vulnerable-method.js'
       let client, testCollection, tmpFilePath, dbName

--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -163,7 +163,12 @@ module.exports = {
   'express-mongo-sanitize': [
     {
       name: 'mongodb',
-      versions: ['>=3.3 <5', '5', '6', '>=7'],
+      versions: ['>=3.3 <5', '5', '6'],
+    },
+    {
+      name: 'mongodb',
+      versions: ['>=7'],
+      node: '>=20',
     },
     {
       name: 'mongodb-core',
@@ -195,7 +200,12 @@ module.exports = {
     },
     {
       name: 'mongodb',
-      versions: ['5', '>=6'],
+      versions: ['5', '6'],
+    },
+    {
+      name: 'mongodb',
+      versions: ['>=7'],
+      node: '>=20',
     },
   ],
   mysql2: [

--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -163,12 +163,13 @@ module.exports = {
   'express-mongo-sanitize': [
     {
       name: 'mongodb',
-      versions: ['>=3.3 <5', '5', '6'],
+      versions: ['>=3.3 <5', '5', '6', '>=7'],
+      node: '>=20.19.0',
     },
     {
       name: 'mongodb',
-      versions: ['>=7'],
-      node: '>=20',
+      versions: ['>=3.3 <5', '5', '6'],
+      node: '<20.19.0',
     },
     {
       name: 'mongodb-core',
@@ -200,12 +201,13 @@ module.exports = {
     },
     {
       name: 'mongodb',
-      versions: ['5', '6'],
+      versions: ['5', '6', '>=7'],
+      node: '>=20.19.0',
     },
     {
       name: 'mongodb',
-      versions: ['>=7'],
-      node: '>=20',
+      versions: ['5', '6'],
+      node: '<20.19.0',
     },
   ],
   mysql2: [


### PR DESCRIPTION
### What does this PR do?
Adds a Node.js runtime gate (`node: '>=20'`) to the `mongodb >=7` version entries in t`est/plugins/externals.js` for the `express-mongo-sanitize` and `mquery` plugin tests, using the version-selection mechanism from #9306. Removes the now-redundant `NODE_MAJOR < 20` skip guards from the two NoSQL injection analyzer specs.

### Motivation
`mongodb@>=7` requires `Node.js >=20`; this was previously enforced with a manual `describe.skip` at test time.

### Additional Notes
`mongodb` here is a test-only dependency declared in `externals.js`, not the plugin's own `addHook`, so no production code changes were needed.


