### PR TITLE
fix(proxy): retain feature modules across tracing reconfiguration

### DIFF
--- a/packages/dd-trace/src/openfeature/register.js
+++ b/packages/dd-trace/src/openfeature/register.js
@@ -2,9 +2,21 @@
 
 const { registerFeature } = require('../feature-registry')
 
+const noop = new (require('./noop'))()
+
+/**
+ * @param {import('../proxy')} proxy
+ * @returns {boolean}
+ */
+function hasFlaggingProvider (proxy) {
+  const descriptor = Reflect.getOwnPropertyDescriptor(proxy, 'openfeature')
+
+  return descriptor?.value !== undefined && descriptor.value !== noop
+}
+
 registerFeature({
   name: 'openfeature',
-  noop: new (require('./noop'))(),
+  noop,
   factory: () => require('./index'),
 
   /**
@@ -25,12 +37,8 @@ registerFeature({
    */
   enable (config, tracer, proxy, lazyProxy) {
     if (config.experimental.flaggingProvider.enabled) {
-      const openfeature = proxy._modules.openfeature
-      const shouldCreateProvider = openfeature.module === undefined
-
-      openfeature.enable(config)
-
-      if (shouldCreateProvider) {
+      proxy._modules.openfeature.enable(config)
+      if (!hasFlaggingProvider(proxy)) {
         lazyProxy(proxy, 'openfeature', () => require('./flagging_provider'), tracer, config)
       }
     }

--- a/packages/dd-trace/src/openfeature/register.js
+++ b/packages/dd-trace/src/openfeature/register.js
@@ -25,8 +25,14 @@ registerFeature({
    */
   enable (config, tracer, proxy, lazyProxy) {
     if (config.experimental.flaggingProvider.enabled) {
-      proxy._modules.openfeature.enable(config)
-      lazyProxy(proxy, 'openfeature', () => require('./flagging_provider'), tracer, config)
+      const openfeature = proxy._modules.openfeature
+      const shouldCreateProvider = openfeature.module === undefined
+
+      openfeature.enable(config)
+
+      if (shouldCreateProvider) {
+        lazyProxy(proxy, 'openfeature', () => require('./flagging_provider'), tracer, config)
+      }
     }
   },
 })

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -306,6 +306,9 @@ class Tracer extends NoopProxy {
       for (const feature of Object.values(features)) {
         feature.enable?.(config, this._tracer, this, lazyProxy)
       }
+      if (config.experimental?.aiguard?.enabled) {
+        this._modules.aiguard.enable(this._tracer, config)
+      }
       if (config.iast.enabled) {
         this._modules.iast.enable(config, this._tracer)
       }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -296,11 +296,9 @@ class Tracer extends NoopProxy {
         lazyProxy(this, 'llmobs', () => require('./llmobs/sdk'), this._tracer, this._modules.llmobs, config)
 
         if (config.experimental?.aiguard?.enabled) {
-          this._modules.aiguard.enable(this._tracer, config)
           lazyProxy(this, 'aiguard', () => require('./aiguard/sdk'), this._tracer, config)
         }
         if (config.experimental.flaggingProvider.enabled) {
-          this._modules.openfeature.enable(config)
           lazyProxy(this, 'openfeature', () => require('./openfeature/flagging_provider'), this._tracer, config)
         }
         this._tracingInitialized = true

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -298,9 +298,6 @@ class Tracer extends NoopProxy {
         if (config.experimental?.aiguard?.enabled) {
           lazyProxy(this, 'aiguard', () => require('./aiguard/sdk'), this._tracer, config)
         }
-        if (config.experimental.flaggingProvider.enabled) {
-          lazyProxy(this, 'openfeature', () => require('./openfeature/flagging_provider'), this._tracer, config)
-        }
         this._tracingInitialized = true
       }
       for (const feature of Object.values(features)) {

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -299,6 +299,10 @@ class Tracer extends NoopProxy {
           this._modules.aiguard.enable(this._tracer, config)
           lazyProxy(this, 'aiguard', () => require('./aiguard/sdk'), this._tracer, config)
         }
+        if (config.experimental.flaggingProvider.enabled) {
+          this._modules.openfeature.enable(config)
+          lazyProxy(this, 'openfeature', () => require('./openfeature/flagging_provider'), this._tracer, config)
+        }
         this._tracingInitialized = true
       }
       for (const feature of Object.values(features)) {

--- a/packages/dd-trace/test/aiguard/integrations/index.spec.js
+++ b/packages/dd-trace/test/aiguard/integrations/index.spec.js
@@ -11,19 +11,17 @@ const chatCompletionsBeforeChannel = channel('dd-trace:openai:chat.completions:b
 
 describe('AIGuard integration wiring', () => {
   const config = { experimental: { aiguard: { block: true } } }
+  let AIGuard
   let evaluate
   let aiguard
 
   beforeEach(() => {
     evaluate = sinon.stub().resolves()
-
-    function MockAIGuard () {
-      return { evaluate }
-    }
+    AIGuard = sinon.stub().returns({ evaluate })
 
     aiguard = proxyquire('../../../src/aiguard/index', {
       '../log': { error: sinon.stub() },
-      './sdk': MockAIGuard,
+      './sdk': AIGuard,
     })
   })
 
@@ -43,7 +41,7 @@ describe('AIGuard integration wiring', () => {
     return ctx
   }
 
-  it('subscribes and unsubscribes AI Guard integrations from enable and disable', async () => {
+  it('subscribes, unsubscribes, and resubscribes AI Guard integrations', async () => {
     aiguard.enable({}, config)
 
     const enabledCtx = publishChatBefore()
@@ -55,6 +53,14 @@ describe('AIGuard integration wiring', () => {
 
     const disabledCtx = publishChatBefore()
     assert.strictEqual(disabledCtx.pending.length, 0)
+
+    aiguard.enable({}, config)
+
+    const reenabledCtx = publishChatBefore()
+    assert.strictEqual(reenabledCtx.pending.length, 1)
+    await Promise.all(reenabledCtx.pending)
+    sinon.assert.calledTwice(AIGuard)
+    sinon.assert.calledTwice(evaluate)
   })
 
   it('enables and disables providers through the integrations index', () => {

--- a/packages/dd-trace/test/openfeature/register.spec.js
+++ b/packages/dd-trace/test/openfeature/register.spec.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+describe('OpenFeature register', () => {
+  let config
+  let feature
+  let lazyProxy
+  let openfeatureModule
+  let proxy
+  let registerFeature
+  let tracer
+
+  function NoopFlaggingProvider () {}
+
+  function FlaggingProvider (...args) {
+    this.args = args
+  }
+
+  beforeEach(() => {
+    registerFeature = sinon.spy(registeredFeature => {
+      feature = registeredFeature
+    })
+    openfeatureModule = {
+      enable: sinon.spy(),
+      disable: sinon.spy(),
+    }
+
+    delete require.cache[require.resolve('../../src/openfeature/register')]
+    proxyquire('../../src/openfeature/register', {
+      '../feature-registry': { registerFeature },
+      './flagging_provider': FlaggingProvider,
+      './index': openfeatureModule,
+      './noop': NoopFlaggingProvider,
+    })
+
+    config = {
+      experimental: {
+        flaggingProvider: {
+          enabled: true,
+        },
+      },
+    }
+    tracer = {}
+    proxy = {
+      openfeature: feature.noop,
+      _modules: {
+        openfeature: {
+          enable: sinon.spy(),
+        },
+      },
+    }
+    lazyProxy = sinon.spy((target, property, getClass, ...args) => {
+      const RealClass = getClass()
+      target[property] = new RealClass(...args)
+    })
+  })
+
+  it('registers the OpenFeature feature', () => {
+    sinon.assert.calledOnce(registerFeature)
+
+    assert.strictEqual(feature.name, 'openfeature')
+    assert.ok(feature.noop instanceof NoopFlaggingProvider)
+    assert.strictEqual(feature.factory(), openfeatureModule)
+  })
+
+  it('defines the flagging provider when enabled', () => {
+    feature.enable(config, tracer, proxy, lazyProxy)
+
+    sinon.assert.calledOnceWithExactly(proxy._modules.openfeature.enable, config)
+    sinon.assert.calledOnce(lazyProxy)
+    assert.ok(proxy.openfeature instanceof FlaggingProvider)
+    assert.deepStrictEqual(proxy.openfeature.args, [tracer, config])
+  })
+
+  it('keeps an existing flagging provider on repeated enable calls', () => {
+    feature.enable(config, tracer, proxy, lazyProxy)
+    const provider = proxy.openfeature
+
+    feature.enable(config, tracer, proxy, lazyProxy)
+
+    sinon.assert.calledTwice(proxy._modules.openfeature.enable)
+    sinon.assert.calledOnce(lazyProxy)
+    assert.strictEqual(proxy.openfeature, provider)
+  })
+
+  it('does not define the flagging provider when disabled', () => {
+    config.experimental.flaggingProvider.enabled = false
+
+    feature.enable(config, tracer, proxy, lazyProxy)
+
+    sinon.assert.notCalled(proxy._modules.openfeature.enable)
+    sinon.assert.notCalled(lazyProxy)
+    assert.strictEqual(proxy.openfeature, feature.noop)
+  })
+})

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -32,6 +32,7 @@ describe('TracerProxy', () => {
   let log
   let profiler
   let appsec
+  let aiguard
   let telemetry
   let iast
   let openfeature
@@ -186,6 +187,11 @@ describe('TracerProxy', () => {
       disable: sinon.spy(),
     }
 
+    aiguard = {
+      enable: sinon.spy(),
+      disable: sinon.spy(),
+    }
+
     telemetry = {
       start: sinon.spy(),
     }
@@ -248,6 +254,7 @@ describe('TracerProxy', () => {
       './profiler': profiler,
       './appsec': appsec,
       './appsec/iast': iast,
+      './aiguard': aiguard,
       './telemetry': telemetry,
       './remote_config': RemoteConfig,
       './aiguard/sdk': AIGuardSdk,
@@ -267,8 +274,14 @@ describe('TracerProxy', () => {
       },
       enable (config, tracer, proxy, lazyProxy) {
         if (config.experimental.flaggingProvider.enabled) {
-          proxy._modules.openfeature.enable(config)
-          lazyProxy(proxy, 'openfeature', () => OpenFeatureProvider, tracer, config)
+          const openfeatureModule = proxy._modules.openfeature
+          const shouldCreateProvider = openfeatureModule.module === undefined
+
+          openfeatureModule.enable(config)
+
+          if (shouldCreateProvider) {
+            lazyProxy(proxy, 'openfeature', () => OpenFeatureProvider, tracer, config)
+          }
         }
       },
     })
@@ -418,6 +431,41 @@ describe('TracerProxy', () => {
         handlers.get('APM_TRACING')(createApmTracingTransaction('ffe-reconfig', { DD_TRACE_ENABLED: true }, 'modify'))
 
         sinon.assert.calledOnce(OpenFeatureProvider)
+      })
+
+      it('should re-enable OpenFeature without replacing its provider when remote config re-enables tracing', () => {
+        config.experimental.flaggingProvider.enabled = true
+        /** @param {{ DD_TRACE_ENABLED: boolean }} remoteConfig */
+        config.setRemoteConfig = remoteConfig => {
+          config.DD_TRACE_ENABLED = remoteConfig.DD_TRACE_ENABLED
+        }
+
+        proxy.init()
+
+        const provider = proxy.openfeature
+        handlers.get('APM_TRACING')(createApmTracingTransaction('ffe-disable', { DD_TRACE_ENABLED: false }))
+        handlers.get('APM_TRACING')(createApmTracingTransaction('ffe-enable', { DD_TRACE_ENABLED: true }, 'modify'))
+
+        assert.strictEqual(proxy.openfeature, provider)
+        sinon.assert.calledOnce(OpenFeatureProvider)
+        sinon.assert.calledTwice(openfeature.enable)
+        sinon.assert.calledOnce(openfeature.disable)
+      })
+
+      it('should re-enable AI Guard when remote config re-enables tracing', () => {
+        /** @param {{ DD_TRACE_ENABLED: boolean }} remoteConfig */
+        config.setRemoteConfig = remoteConfig => {
+          config.DD_TRACE_ENABLED = remoteConfig.DD_TRACE_ENABLED
+        }
+
+        proxy.init()
+
+        handlers.get('APM_TRACING')(createApmTracingTransaction('aiguard-disable', { DD_TRACE_ENABLED: false }))
+        handlers.get('APM_TRACING')(createApmTracingTransaction('aiguard-enable', { DD_TRACE_ENABLED: true }, 'modify'))
+
+        sinon.assert.calledOnce(AIGuardSdk)
+        sinon.assert.calledTwice(aiguard.enable)
+        sinon.assert.calledOnce(aiguard.disable)
       })
 
       it('should support applying remote config', () => {

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -206,11 +206,12 @@ describe('TracerProxy', () => {
       disable: sinon.spy(),
     }
 
-    openfeatureProvider = {
-      _setConfiguration: sinon.spy(),
-    }
-
-    OpenFeatureProvider = sinon.stub().returns(openfeatureProvider)
+    OpenFeatureProvider = sinon.stub().callsFake(function () {
+      openfeatureProvider = {
+        _setConfiguration: sinon.spy(),
+      }
+      return openfeatureProvider
+    })
 
     flare = {
       enable: sinon.spy(),
@@ -265,21 +266,29 @@ describe('TracerProxy', () => {
     })
 
     const { enable: openfeatureRcEnable } = require('../src/openfeature/remote_config')
+    const noopOpenfeature = {}
+
+    /**
+     * @param {object} proxy
+     * @returns {boolean}
+     */
+    function hasOpenfeatureProvider (proxy) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(proxy, 'openfeature')
+
+      return descriptor?.value !== undefined && descriptor.value !== noopOpenfeature
+    }
+
     featureRegistry.registerFeature({
       name: 'openfeature',
-      noop: {},
+      noop: noopOpenfeature,
       factory: () => openfeature,
       remoteConfig (rc, config, proxy) {
         openfeatureRcEnable(rc, config, () => proxy.openfeature)
       },
       enable (config, tracer, proxy, lazyProxy) {
         if (config.experimental.flaggingProvider.enabled) {
-          const openfeatureModule = proxy._modules.openfeature
-          const shouldCreateProvider = openfeatureModule.module === undefined
-
-          openfeatureModule.enable(config)
-
-          if (shouldCreateProvider) {
+          proxy._modules.openfeature.enable(config)
+          if (!hasOpenfeatureProvider(proxy)) {
             lazyProxy(proxy, 'openfeature', () => OpenFeatureProvider, tracer, config)
           }
         }
@@ -423,14 +432,20 @@ describe('TracerProxy', () => {
         sinon.assert.calledWith(openfeatureProvider._setConfiguration, flagConfig)
       })
 
-      it('should not recreate the openfeature provider when remote config reconfigures the tracer', () => {
+      it('keeps OpenFeature bound to the provider receiving FFE_FLAGS after tracing reconfigures', () => {
         config.experimental.flaggingProvider.enabled = true
 
         proxy.init()
+        const boundProvider = proxy.openfeature
 
         handlers.get('APM_TRACING')(createApmTracingTransaction('ffe-reconfig', { DD_TRACE_ENABLED: true }, 'modify'))
 
+        const flagConfig = { flags: { 'test-flag': {} } }
+        handlers.get('FFE_FLAGS')('apply', flagConfig)
+
         sinon.assert.calledOnce(OpenFeatureProvider)
+        assert.strictEqual(proxy.openfeature, boundProvider)
+        sinon.assert.calledOnceWithExactly(boundProvider._setConfiguration, flagConfig)
       })
 
       it('should re-enable OpenFeature without replacing its provider when remote config re-enables tracing', () => {
@@ -459,10 +474,12 @@ describe('TracerProxy', () => {
         }
 
         proxy.init()
+        const sdk = proxy.aiguard
 
         handlers.get('APM_TRACING')(createApmTracingTransaction('aiguard-disable', { DD_TRACE_ENABLED: false }))
         handlers.get('APM_TRACING')(createApmTracingTransaction('aiguard-enable', { DD_TRACE_ENABLED: true }, 'modify'))
 
+        assert.strictEqual(proxy.aiguard, sdk)
         sinon.assert.calledOnce(AIGuardSdk)
         sinon.assert.calledTwice(aiguard.enable)
         sinon.assert.calledOnce(aiguard.disable)

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -410,6 +410,16 @@ describe('TracerProxy', () => {
         sinon.assert.calledWith(openfeatureProvider._setConfiguration, flagConfig)
       })
 
+      it('should not recreate the openfeature provider when remote config reconfigures the tracer', () => {
+        config.experimental.flaggingProvider.enabled = true
+
+        proxy.init()
+
+        handlers.get('APM_TRACING')(createApmTracingTransaction('ffe-reconfig', { DD_TRACE_ENABLED: true }, 'modify'))
+
+        sinon.assert.calledOnce(OpenFeatureProvider)
+      })
+
       it('should support applying remote config', () => {
         const RemoteConfigProxy = proxyquire('../src/proxy', {
           './tracer': DatadogTracer,


### PR DESCRIPTION
## Summary
Remote configuration can disable and later re-enable tracing in one process. This retains the OpenFeature provider registered by callers, then restores OpenFeature exposure reporting and AI Guard integrations when tracing returns.