### PR TITLE
fix(test-optimization): reject symlinked coverage reports

### DIFF
--- a/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
+++ b/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
@@ -52,17 +52,15 @@ function discoverCoverageReports (rootDir) {
     const fullPath = path.join(rootDir, pattern.path)
 
     try {
-      if (fs.existsSync(fullPath)) {
-        const stats = fs.statSync(fullPath)
+      const stats = fs.lstatSync(fullPath, { throwIfNoEntry: false })
 
-        // Only include regular files, not directories or symlinks
-        if (stats.isFile()) {
-          discoveredReports.push({
-            filePath: fullPath,
-            format: pattern.format,
-          })
-          log.debug('Found coverage report: %s (format: %s)', fullPath, pattern.format)
-        }
+      // Only include regular files, not directories or symlinks
+      if (stats?.isFile()) {
+        discoveredReports.push({
+          filePath: fullPath,
+          format: pattern.format,
+        })
+        log.debug('Found coverage report: %s (format: %s)', fullPath, pattern.format)
       }
     } catch (err) {
       // Log but don't fail if we can't access a file

--- a/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
+++ b/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
@@ -52,7 +52,13 @@ function discoverCoverageReports (rootDir) {
     const fullPath = path.join(rootDir, pattern.path)
 
     try {
-      const stats = fs.lstatSync(fullPath, { throwIfNoEntry: false })
+      let currentPath = rootDir
+      let stats
+      for (const pathSegment of pattern.path.split('/')) {
+        currentPath = path.join(currentPath, pathSegment)
+        stats = fs.lstatSync(currentPath, { throwIfNoEntry: false })
+        if (!stats || stats.isSymbolicLink()) break
+      }
 
       // Only include regular files, not directories or symlinks
       if (stats?.isFile()) {

--- a/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
+++ b/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
@@ -46,13 +46,26 @@ function discoverCoverageReports (rootDir) {
     return []
   }
 
+  let resolvedRoot
+  try {
+    resolvedRoot = path.resolve(rootDir)
+    const rootStats = fs.lstatSync(resolvedRoot, { throwIfNoEntry: false })
+    if (rootStats?.isSymbolicLink() || !rootStats?.isDirectory()) {
+      log.debug('Coverage report root is not a regular directory: %s', resolvedRoot)
+      return []
+    }
+  } catch (error) {
+    log.debug('Error checking coverage report root %s: %s', rootDir, error.message)
+    return []
+  }
+
   const discoveredReports = []
 
   for (const pattern of COVERAGE_REPORT_PATTERNS) {
     const fullPath = path.join(rootDir, pattern.path)
 
     try {
-      let currentPath = rootDir
+      let currentPath = resolvedRoot
       let stats
       for (const pathSegment of pattern.path.split('/')) {
         currentPath = path.join(currentPath, pathSegment)

--- a/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
+++ b/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
@@ -5,6 +5,8 @@ const path = require('node:path')
 
 const log = require('../log')
 
+const BIGINT_LSTAT_OPTIONS = { bigint: true, throwIfNoEntry: false }
+
 /**
  * Coverage report file patterns to search for
  * Each entry contains the relative path from root and the format identifier
@@ -38,7 +40,7 @@ const COVERAGE_REPORT_PATTERNS = [
 /**
  * Discovers code coverage report files in the given root directory
  * @param {string} rootDir - The root directory to search for coverage reports
- * @returns {Array<{filePath: string, fileDevice: number, fileInode: number, format: string}>}
+ * @returns {Array<{filePath: string, fileDevice: bigint, fileInode: bigint, format: string}>}
  */
 function discoverCoverageReports (rootDir) {
   if (!rootDir) {
@@ -49,14 +51,14 @@ function discoverCoverageReports (rootDir) {
   let resolvedRoot
   try {
     const unresolvedRoot = path.resolve(rootDir)
-    const rootStats = fs.lstatSync(unresolvedRoot, { throwIfNoEntry: false })
+    const rootStats = fs.lstatSync(unresolvedRoot, BIGINT_LSTAT_OPTIONS)
     if (rootStats?.isSymbolicLink() || !rootStats?.isDirectory()) {
       log.debug('Coverage report root is not a regular directory: %s', unresolvedRoot)
       return []
     }
     resolvedRoot = fs.realpathSync(unresolvedRoot)
-    const resolvedRootStats = fs.lstatSync(resolvedRoot)
-    if (resolvedRootStats.dev !== rootStats.dev || resolvedRootStats.ino !== rootStats.ino) {
+    const resolvedRootStats = fs.lstatSync(resolvedRoot, BIGINT_LSTAT_OPTIONS)
+    if (!resolvedRootStats || resolvedRootStats.dev !== rootStats.dev || resolvedRootStats.ino !== rootStats.ino) {
       log.debug('Coverage report root changed while resolving it: %s', unresolvedRoot)
       return []
     }
@@ -74,19 +76,25 @@ function discoverCoverageReports (rootDir) {
       let stats
       for (const pathSegment of pattern.path.split('/')) {
         currentPath = path.join(currentPath, pathSegment)
-        stats = fs.lstatSync(currentPath, { throwIfNoEntry: false })
+        stats = fs.lstatSync(currentPath, BIGINT_LSTAT_OPTIONS)
         if (!stats || stats.isSymbolicLink()) break
       }
 
-      // Only include regular files, not directories or symlinks
-      if (stats?.isFile()) {
+      // A hard link can name a file outside the root without changing its real path.
+      if (stats?.isFile() && stats.nlink === 1n) {
+        const resolvedPath = fs.realpathSync(currentPath)
+        const pathFromRoot = path.relative(resolvedRoot, resolvedPath)
+        if (pathFromRoot === '..' || pathFromRoot.startsWith(`..${path.sep}`) || path.isAbsolute(pathFromRoot)) {
+          log.debug('Coverage report resolved outside the root directory: %s', currentPath)
+          continue
+        }
         discoveredReports.push({
-          filePath: currentPath,
+          filePath: resolvedPath,
           fileDevice: stats.dev,
           fileInode: stats.ino,
           format: pattern.format,
         })
-        log.debug('Found coverage report: %s (format: %s)', currentPath, pattern.format)
+        log.debug('Found coverage report: %s (format: %s)', resolvedPath, pattern.format)
       }
     } catch (error) {
       // Log but don't fail if we can't access a file

--- a/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
+++ b/packages/dd-trace/src/ci-visibility/coverage-report-discovery.js
@@ -38,7 +38,7 @@ const COVERAGE_REPORT_PATTERNS = [
 /**
  * Discovers code coverage report files in the given root directory
  * @param {string} rootDir - The root directory to search for coverage reports
- * @returns {Array<{filePath: string, format: string}>} Array of discovered coverage reports
+ * @returns {Array<{filePath: string, fileDevice: number, fileInode: number, format: string}>}
  */
 function discoverCoverageReports (rootDir) {
   if (!rootDir) {
@@ -48,10 +48,16 @@ function discoverCoverageReports (rootDir) {
 
   let resolvedRoot
   try {
-    resolvedRoot = path.resolve(rootDir)
-    const rootStats = fs.lstatSync(resolvedRoot, { throwIfNoEntry: false })
+    const unresolvedRoot = path.resolve(rootDir)
+    const rootStats = fs.lstatSync(unresolvedRoot, { throwIfNoEntry: false })
     if (rootStats?.isSymbolicLink() || !rootStats?.isDirectory()) {
-      log.debug('Coverage report root is not a regular directory: %s', resolvedRoot)
+      log.debug('Coverage report root is not a regular directory: %s', unresolvedRoot)
+      return []
+    }
+    resolvedRoot = fs.realpathSync(unresolvedRoot)
+    const resolvedRootStats = fs.lstatSync(resolvedRoot)
+    if (resolvedRootStats.dev !== rootStats.dev || resolvedRootStats.ino !== rootStats.ino) {
+      log.debug('Coverage report root changed while resolving it: %s', unresolvedRoot)
       return []
     }
   } catch (error) {
@@ -62,10 +68,9 @@ function discoverCoverageReports (rootDir) {
   const discoveredReports = []
 
   for (const pattern of COVERAGE_REPORT_PATTERNS) {
-    const fullPath = path.join(rootDir, pattern.path)
+    let currentPath = resolvedRoot
 
     try {
-      let currentPath = resolvedRoot
       let stats
       for (const pathSegment of pattern.path.split('/')) {
         currentPath = path.join(currentPath, pathSegment)
@@ -76,14 +81,16 @@ function discoverCoverageReports (rootDir) {
       // Only include regular files, not directories or symlinks
       if (stats?.isFile()) {
         discoveredReports.push({
-          filePath: fullPath,
+          filePath: currentPath,
+          fileDevice: stats.dev,
+          fileInode: stats.ino,
           format: pattern.format,
         })
-        log.debug('Found coverage report: %s (format: %s)', fullPath, pattern.format)
+        log.debug('Found coverage report: %s (format: %s)', currentPath, pattern.format)
       }
-    } catch (err) {
+    } catch (error) {
       // Log but don't fail if we can't access a file
-      log.debug('Error checking coverage report path %s: %s', fullPath, err.message)
+      log.debug('Error checking coverage report path %s: %s', currentPath, error.message)
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -521,17 +521,21 @@ class CiVisibilityExporter extends BufferingExporter {
    * Uploads a single coverage report to the CI intake.
    * @param {object} options - Upload options
    * @param {string} options.filePath - Path to the coverage report file
+   * @param {number} options.fileDevice - Device containing the discovered report
+   * @param {number} options.fileInode - Inode of the discovered report
    * @param {string} options.format - Format of the coverage report
    * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
    * @param {(error: Error|null) => void} callback - Callback function
    */
-  uploadCoverageReport ({ filePath, format, testEnvironmentMetadata }, callback) {
+  uploadCoverageReport ({ filePath, fileDevice, fileInode, format, testEnvironmentMetadata }, callback) {
     if (!this._codeCoverageReportUrl) {
       return callback(new Error('Coverage report upload URL not configured'))
     }
 
     uploadCoverageReportRequest({
       filePath,
+      fileDevice,
+      fileInode,
       format,
       flags: this._coverageReportFlags,
       testEnvironmentMetadata,

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -521,8 +521,8 @@ class CiVisibilityExporter extends BufferingExporter {
    * Uploads a single coverage report to the CI intake.
    * @param {object} options - Upload options
    * @param {string} options.filePath - Path to the coverage report file
-   * @param {number} options.fileDevice - Device containing the discovered report
-   * @param {number} options.fileInode - Inode of the discovered report
+   * @param {bigint} options.fileDevice - Device containing the discovered report
+   * @param {bigint} options.fileInode - Inode of the discovered report
    * @param {string} options.format - Format of the coverage report
    * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
    * @param {(error: Error|null) => void} callback - Callback function

--- a/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
@@ -18,16 +18,17 @@ const {
 
 const UPLOAD_TIMEOUT_MS = 30_000
 const COVERAGE_FILE_OPEN_FLAGS = constants.O_RDONLY |
-  constants.O_NOFOLLOW |
+  (constants.O_NOFOLLOW || 0) |
   constants.O_NONBLOCK
+const BIGINT_STAT_OPTIONS = { bigint: true }
 
 /**
  * Uploads a single coverage report to the Datadog CI intake.
  * One file per request with field names 'coverage' and 'event'.
  * @param {object} options - Upload options
  * @param {string} options.filePath - Path to the coverage report file
- * @param {number} options.fileDevice - Device containing the discovered report
- * @param {number} options.fileInode - Inode of the discovered report
+ * @param {bigint} options.fileDevice - Device containing the discovered report
+ * @param {bigint} options.fileInode - Inode of the discovered report
  * @param {string} options.format - Format of the coverage report (e.g., 'lcov', 'cobertura')
  * @param {string[]} [options.flags] - Optional coverage report grouping flags
  * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
@@ -51,7 +52,7 @@ function uploadCoverageReport (
     const fileDescriptor = openSync(filePath, COVERAGE_FILE_OPEN_FLAGS)
     let coverageContent
     try {
-      const fileStats = fstatSync(fileDescriptor)
+      const fileStats = fstatSync(fileDescriptor, BIGINT_STAT_OPTIONS)
       if (!fileStats.isFile() || fileStats.dev !== fileDevice || fileStats.ino !== fileInode) {
         throw new Error('Coverage report changed after discovery')
       }

--- a/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { readFileSync } = require('node:fs')
+const { closeSync, constants, fstatSync, openSync, readFileSync } = require('node:fs')
 const { gzipSync } = require('node:zlib')
 
 const getConfig = require('../../config')
@@ -17,12 +17,17 @@ const {
 } = require('../telemetry')
 
 const UPLOAD_TIMEOUT_MS = 30_000
+const COVERAGE_FILE_OPEN_FLAGS = constants.O_RDONLY |
+  constants.O_NOFOLLOW |
+  constants.O_NONBLOCK
 
 /**
  * Uploads a single coverage report to the Datadog CI intake.
  * One file per request with field names 'coverage' and 'event'.
  * @param {object} options - Upload options
  * @param {string} options.filePath - Path to the coverage report file
+ * @param {number} options.fileDevice - Device containing the discovered report
+ * @param {number} options.fileInode - Inode of the discovered report
  * @param {string} options.format - Format of the coverage report (e.g., 'lcov', 'cobertura')
  * @param {string[]} [options.flags] - Optional coverage report grouping flags
  * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
@@ -32,7 +37,7 @@ const UPLOAD_TIMEOUT_MS = 30_000
  * @param {(error: Error|null) => void} callback - Callback function
  */
 function uploadCoverageReport (
-  { filePath, format, flags, testEnvironmentMetadata, url, isEvpProxy, evpProxyPrefix },
+  { filePath, fileDevice, fileInode, format, flags, testEnvironmentMetadata, url, isEvpProxy, evpProxyPrefix },
   callback
 ) {
   const { DD_API_KEY } = getConfig()
@@ -43,10 +48,20 @@ function uploadCoverageReport (
 
   let compressedCoverage
   try {
-    const coverageContent = readFileSync(filePath)
+    const fileDescriptor = openSync(filePath, COVERAGE_FILE_OPEN_FLAGS)
+    let coverageContent
+    try {
+      const fileStats = fstatSync(fileDescriptor)
+      if (!fileStats.isFile() || fileStats.dev !== fileDevice || fileStats.ino !== fileInode) {
+        throw new Error('Coverage report changed after discovery')
+      }
+      coverageContent = readFileSync(fileDescriptor)
+    } finally {
+      closeSync(fileDescriptor)
+    }
     compressedCoverage = gzipSync(coverageContent)
-  } catch (err) {
-    return callback(new Error(`Failed to read coverage report at ${filePath}: ${err.message}`))
+  } catch (error) {
+    return callback(new Error(`Failed to read coverage report at ${filePath}: ${error.message}`))
   }
 
   // Build the event payload with format, type, and all tags from test environment metadata

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -1173,11 +1173,11 @@ module.exports = class CiPlugin extends Plugin {
         return
       }
 
-      const { filePath, format } = coverageReports[reportIndex]
+      const { filePath, fileDevice, fileInode, format } = coverageReports[reportIndex]
       reportIndex++
 
       this.tracer._exporter.uploadCoverageReport(
-        { filePath, format, testEnvironmentMetadata: this.testEnvironmentMetadata },
+        { filePath, fileDevice, fileInode, format, testEnvironmentMetadata: this.testEnvironmentMetadata },
         (err) => {
           if (err) {
             failedCount++

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -324,20 +324,11 @@ describe('CiPlugin', () => {
     sinon.assert.calledWith(distributionMetric, 'code_coverage.files', {}, 3)
   })
 
-  it('uploads regular coverage reports and excludes symlinks', () => {
+  it('uploads regular coverage reports', () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
-    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-outside-'))
     const regularReportPath = path.join(rootDir, 'lcov.info')
-    const outsideReportPath = path.join(outsideDir, 'lcov.info')
-    const symlinkTargetPath = path.join(rootDir, 'symlink-target.info')
-    const symlinkReportPath = path.join(rootDir, 'clover.xml')
-    const symlinkDirPath = path.join(rootDir, 'coverage')
 
     fs.writeFileSync(regularReportPath, 'regular coverage')
-    fs.writeFileSync(outsideReportPath, 'outside coverage')
-    fs.writeFileSync(symlinkTargetPath, 'symlinked coverage')
-    fs.symlinkSync(symlinkTargetPath, symlinkReportPath)
-    fs.symlinkSync(outsideDir, symlinkDirPath)
 
     try {
       const plugin = createPlugin('jest_worker')
@@ -354,7 +345,78 @@ describe('CiPlugin', () => {
       })
     } finally {
       fs.rmSync(rootDir, { recursive: true, force: true })
-      fs.rmSync(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores invalid coverage report roots', () => {
+    const invalidRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    fs.rmSync(invalidRoot, { recursive: true })
+
+    const plugin = createPlugin('jest_worker')
+    const uploadCoverageReport = sinon.stub().yields()
+    plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+    try {
+      plugin.uploadCoverageReports({ rootDir: invalidRoot })
+      fs.writeFileSync(invalidRoot, 'not a directory')
+      plugin.uploadCoverageReports({ rootDir: invalidRoot })
+      plugin.uploadCoverageReports({ rootDir: Symbol('invalid-root') })
+
+      sinon.assert.notCalled(uploadCoverageReport)
+    } finally {
+      fs.rmSync(invalidRoot, { force: true })
+    }
+  })
+
+  it('excludes coverage reports reached through linked directories', () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    const rootDir = path.join(fixtureDir, 'root')
+    const outsideDir = path.join(fixtureDir, 'outside')
+    const linkedRootDir = path.join(fixtureDir, 'linked-root')
+    const outsideReportPath = path.join(outsideDir, 'lcov.info')
+    const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir'
+
+    fs.mkdirSync(rootDir)
+    fs.mkdirSync(outsideDir)
+    fs.writeFileSync(outsideReportPath, 'outside coverage')
+    fs.symlinkSync(outsideDir, path.join(rootDir, 'coverage'), directoryLinkType)
+    fs.symlinkSync(outsideDir, linkedRootDir, directoryLinkType)
+
+    try {
+      const plugin = createPlugin('jest_worker')
+      const uploadCoverageReport = sinon.stub().yields()
+      plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+      plugin.uploadCoverageReports({ rootDir })
+      plugin.uploadCoverageReports({ rootDir: linkedRootDir })
+
+      sinon.assert.notCalled(uploadCoverageReport)
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true })
+    }
+  })
+
+  it('excludes symlinked coverage report files', function () {
+    if (process.platform === 'win32') this.skip()
+
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    const rootDir = path.join(fixtureDir, 'root')
+    const outsideReportPath = path.join(fixtureDir, 'outside.info')
+
+    fs.mkdirSync(rootDir)
+    fs.writeFileSync(outsideReportPath, 'outside coverage')
+    fs.symlinkSync(outsideReportPath, path.join(rootDir, 'lcov.info'))
+
+    try {
+      const plugin = createPlugin('jest_worker')
+      const uploadCoverageReport = sinon.stub().yields()
+      plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+      plugin.uploadCoverageReports({ rootDir })
+
+      sinon.assert.notCalled(uploadCoverageReport)
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true })
     }
   })
 

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -326,15 +326,18 @@ describe('CiPlugin', () => {
 
   it('uploads regular coverage reports and excludes symlinks', () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
-    const coverageDir = path.join(rootDir, 'coverage')
-    const regularReportPath = path.join(coverageDir, 'lcov.info')
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-outside-'))
+    const regularReportPath = path.join(rootDir, 'lcov.info')
+    const outsideReportPath = path.join(outsideDir, 'lcov.info')
     const symlinkTargetPath = path.join(rootDir, 'symlink-target.info')
-    const symlinkReportPath = path.join(rootDir, 'lcov.info')
+    const symlinkReportPath = path.join(rootDir, 'clover.xml')
+    const symlinkDirPath = path.join(rootDir, 'coverage')
 
-    fs.mkdirSync(coverageDir)
     fs.writeFileSync(regularReportPath, 'regular coverage')
+    fs.writeFileSync(outsideReportPath, 'outside coverage')
     fs.writeFileSync(symlinkTargetPath, 'symlinked coverage')
     fs.symlinkSync(symlinkTargetPath, symlinkReportPath)
+    fs.symlinkSync(outsideDir, symlinkDirPath)
 
     try {
       const plugin = createPlugin('jest_worker')
@@ -351,6 +354,7 @@ describe('CiPlugin', () => {
       })
     } finally {
       fs.rmSync(rootDir, { recursive: true, force: true })
+      fs.rmSync(outsideDir, { recursive: true, force: true })
     }
   })
 

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -324,27 +324,76 @@ describe('CiPlugin', () => {
     sinon.assert.calledWith(distributionMetric, 'code_coverage.files', {}, 3)
   })
 
-  it('uploads regular coverage reports', () => {
+  it('uploads regular coverage reports from canonical paths', () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
-    const regularReportPath = path.join(rootDir, 'lcov.info')
+    const coverageDir = path.join(rootDir, 'coverage')
+    const nestedReportPath = path.join(coverageDir, 'lcov.info')
+    const rootReportPath = path.join(rootDir, 'lcov.info')
 
-    fs.writeFileSync(regularReportPath, 'regular coverage')
+    fs.mkdirSync(coverageDir)
+    fs.writeFileSync(nestedReportPath, 'nested coverage')
+    fs.writeFileSync(rootReportPath, 'root coverage')
 
     try {
       const plugin = createPlugin('jest_worker')
       const uploadCoverageReport = sinon.stub().yields()
       plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+      const nestedReportStats = fs.lstatSync(nestedReportPath)
+      const rootReportStats = fs.lstatSync(rootReportPath)
 
-      plugin.uploadCoverageReports({ rootDir })
+      plugin.uploadCoverageReports({ rootDir: path.relative(process.cwd(), rootDir) })
 
-      sinon.assert.calledOnce(uploadCoverageReport)
+      sinon.assert.calledTwice(uploadCoverageReport)
       assert.deepStrictEqual(uploadCoverageReport.firstCall.args[0], {
-        filePath: regularReportPath,
+        filePath: fs.realpathSync(nestedReportPath),
+        fileDevice: nestedReportStats.dev,
+        fileInode: nestedReportStats.ino,
+        format: 'lcov',
+        testEnvironmentMetadata: plugin.testEnvironmentMetadata,
+      })
+      assert.deepStrictEqual(uploadCoverageReport.secondCall.args[0], {
+        filePath: fs.realpathSync(rootReportPath),
+        fileDevice: rootReportStats.dev,
+        fileInode: rootReportStats.ino,
         format: 'lcov',
         testEnvironmentMetadata: plugin.testEnvironmentMetadata,
       })
     } finally {
       fs.rmSync(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('uploads coverage reports through a symlinked root ancestor from canonical paths', () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    const workspaceDir = path.join(fixtureDir, 'workspace')
+    const rootDir = path.join(workspaceDir, 'root')
+    const linkedWorkspaceDir = path.join(fixtureDir, 'linked-workspace')
+    const linkedRootDir = path.join(linkedWorkspaceDir, 'root')
+    const reportPath = path.join(rootDir, 'lcov.info')
+    const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir'
+
+    fs.mkdirSync(rootDir, { recursive: true })
+    fs.writeFileSync(reportPath, 'regular coverage')
+    fs.symlinkSync(workspaceDir, linkedWorkspaceDir, directoryLinkType)
+
+    try {
+      const plugin = createPlugin('jest_worker')
+      const uploadCoverageReport = sinon.stub().yields()
+      plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+      const reportStats = fs.lstatSync(reportPath)
+
+      plugin.uploadCoverageReports({ rootDir: linkedRootDir })
+
+      sinon.assert.calledOnce(uploadCoverageReport)
+      assert.deepStrictEqual(uploadCoverageReport.firstCall.args[0], {
+        filePath: fs.realpathSync(reportPath),
+        fileDevice: reportStats.dev,
+        fileInode: reportStats.ino,
+        format: 'lcov',
+        testEnvironmentMetadata: plugin.testEnvironmentMetadata,
+      })
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true })
     }
   })
 
@@ -365,6 +414,52 @@ describe('CiPlugin', () => {
       sinon.assert.notCalled(uploadCoverageReport)
     } finally {
       fs.rmSync(invalidRoot, { force: true })
+    }
+  })
+
+  it('ignores roots that change while their canonical path is resolved', () => {
+    const lstatSync = sinon.stub()
+    lstatSync.onCall(0).returns({
+      dev: 1,
+      ino: 1,
+      isDirectory: () => true,
+      isSymbolicLink: () => false,
+    })
+    lstatSync.onCall(1).returns({ dev: 1, ino: 2 })
+    lstatSync.onCall(2).returns({ isSymbolicLink: () => false })
+    lstatSync.onCall(3).returns({
+      dev: 1,
+      ino: 3,
+      isFile: () => true,
+      isSymbolicLink: () => false,
+    })
+    const { discoverCoverageReports } = proxyquire(
+      '../../src/ci-visibility/coverage-report-discovery',
+      {
+        'node:fs': {
+          lstatSync,
+          realpathSync: sinon.stub().returns('/resolved-root'),
+        },
+      }
+    )
+
+    assert.deepStrictEqual(discoverCoverageReports('/root'), [])
+  })
+
+  it('ignores coverage report paths with non-directory components', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    fs.writeFileSync(path.join(rootDir, 'coverage'), 'not a directory')
+
+    try {
+      const plugin = createPlugin('jest_worker')
+      const uploadCoverageReport = sinon.stub().yields()
+      plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+      plugin.uploadCoverageReports({ rootDir })
+
+      sinon.assert.notCalled(uploadCoverageReport)
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true })
     }
   })
 

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 const dc = require('dc-polyfill')
 const proxyquire = require('proxyquire')
@@ -319,6 +322,36 @@ describe('CiPlugin', () => {
     })
     sinon.assert.calledWith(incrementCountMetric, 'itr_unskippable', { testLevel: 'suite' }, 2)
     sinon.assert.calledWith(distributionMetric, 'code_coverage.files', {}, 3)
+  })
+
+  it('uploads regular coverage reports and excludes symlinks', () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    const coverageDir = path.join(rootDir, 'coverage')
+    const regularReportPath = path.join(coverageDir, 'lcov.info')
+    const symlinkTargetPath = path.join(rootDir, 'symlink-target.info')
+    const symlinkReportPath = path.join(rootDir, 'lcov.info')
+
+    fs.mkdirSync(coverageDir)
+    fs.writeFileSync(regularReportPath, 'regular coverage')
+    fs.writeFileSync(symlinkTargetPath, 'symlinked coverage')
+    fs.symlinkSync(symlinkTargetPath, symlinkReportPath)
+
+    try {
+      const plugin = createPlugin('jest_worker')
+      const uploadCoverageReport = sinon.stub().yields()
+      plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+      plugin.uploadCoverageReports({ rootDir })
+
+      sinon.assert.calledOnce(uploadCoverageReport)
+      assert.deepStrictEqual(uploadCoverageReport.firstCall.args[0], {
+        filePath: regularReportPath,
+        format: 'lcov',
+        testEnvironmentMetadata: plugin.testEnvironmentMetadata,
+      })
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true })
+    }
   })
 
   it('starts the DI breakpoint-hit timeout when waiting, not when preparing', async () => {

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -338,8 +338,8 @@ describe('CiPlugin', () => {
       const plugin = createPlugin('jest_worker')
       const uploadCoverageReport = sinon.stub().yields()
       plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
-      const nestedReportStats = fs.lstatSync(nestedReportPath)
-      const rootReportStats = fs.lstatSync(rootReportPath)
+      const nestedReportStats = fs.lstatSync(nestedReportPath, { bigint: true })
+      const rootReportStats = fs.lstatSync(rootReportPath, { bigint: true })
 
       plugin.uploadCoverageReports({ rootDir: path.relative(process.cwd(), rootDir) })
 
@@ -380,7 +380,7 @@ describe('CiPlugin', () => {
       const plugin = createPlugin('jest_worker')
       const uploadCoverageReport = sinon.stub().yields()
       plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
-      const reportStats = fs.lstatSync(reportPath)
+      const reportStats = fs.lstatSync(reportPath, { bigint: true })
 
       plugin.uploadCoverageReports({ rootDir: linkedRootDir })
 
@@ -491,6 +491,59 @@ describe('CiPlugin', () => {
     }
   })
 
+  for (const directoryName of ['root', 'nested']) {
+    it(`excludes coverage reports when the ${directoryName} directory becomes a symlink during discovery`, () => {
+      const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+      const rootDir = path.join(fixtureDir, 'root')
+      const coverageDir = path.join(rootDir, 'coverage')
+      const outsideDir = path.join(fixtureDir, 'root-outside')
+      const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir'
+
+      fs.mkdirSync(coverageDir, { recursive: true })
+      fs.mkdirSync(path.join(outsideDir, 'coverage'), { recursive: true })
+      fs.writeFileSync(path.join(coverageDir, 'lcov.info'), 'regular coverage')
+      fs.writeFileSync(path.join(outsideDir, 'lcov.info'), 'outside coverage')
+      fs.writeFileSync(path.join(outsideDir, 'coverage', 'lcov.info'), 'outside coverage')
+
+      const canonicalRootDir = fs.realpathSync(rootDir)
+      const swapPath = directoryName === 'root' ? canonicalRootDir : path.join(canonicalRootDir, 'coverage')
+      const swapOnCall = directoryName === 'root' && canonicalRootDir === path.resolve(rootDir) ? 2 : 1
+      const displacedPath = `${swapPath}-displaced`
+      const originalLstatSync = fs.lstatSync
+      let matchingCalls = 0
+      let swapped = false
+      const lstatSync = sinon.stub(fs, 'lstatSync').callsFake(
+        /**
+         * @param {import('node:fs').PathLike} checkedPath
+         * @param {import('node:fs').StatSyncOptions} [options]
+         */
+        (checkedPath, options) => {
+          const stats = originalLstatSync(checkedPath, options)
+          if (checkedPath === swapPath && ++matchingCalls === swapOnCall) {
+            fs.renameSync(swapPath, displacedPath)
+            fs.symlinkSync(outsideDir, swapPath, directoryLinkType)
+            swapped = true
+          }
+          return stats
+        }
+      )
+
+      try {
+        const plugin = createPlugin('jest_worker')
+        const uploadCoverageReport = sinon.stub().yields()
+        plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+        plugin.uploadCoverageReports({ rootDir })
+
+        assert.strictEqual(swapped, true)
+        sinon.assert.notCalled(uploadCoverageReport)
+      } finally {
+        lstatSync.restore()
+        fs.rmSync(fixtureDir, { recursive: true, force: true })
+      }
+    })
+  }
+
   it('excludes symlinked coverage report files', function () {
     if (process.platform === 'win32') this.skip()
 
@@ -501,6 +554,28 @@ describe('CiPlugin', () => {
     fs.mkdirSync(rootDir)
     fs.writeFileSync(outsideReportPath, 'outside coverage')
     fs.symlinkSync(outsideReportPath, path.join(rootDir, 'lcov.info'))
+
+    try {
+      const plugin = createPlugin('jest_worker')
+      const uploadCoverageReport = sinon.stub().yields()
+      plugin.tracer._exporter.uploadCoverageReport = uploadCoverageReport
+
+      plugin.uploadCoverageReports({ rootDir })
+
+      sinon.assert.notCalled(uploadCoverageReport)
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true })
+    }
+  })
+
+  it('excludes hard-linked coverage report files', () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
+    const rootDir = path.join(fixtureDir, 'root')
+    const outsideReportPath = path.join(fixtureDir, 'outside.info')
+
+    fs.mkdirSync(rootDir)
+    fs.writeFileSync(outsideReportPath, 'outside coverage')
+    fs.linkSync(outsideReportPath, path.join(rootDir, 'lcov.info'))
 
     try {
       const plugin = createPlugin('jest_worker')

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1377,13 +1377,28 @@ describe('CI Visibility Exporter', () => {
       return exporter
     }
 
+    /**
+     * @param {CiVisibilityExporter} exporter
+     * @param {(error: Error|null) => void} [callback]
+     */
     function upload (exporter, callback = () => {}) {
       exporter.uploadCoverageReport({
         filePath: '/tmp/coverage.xml',
+        fileDevice: 1,
+        fileInode: 2,
         format: 'cobertura',
         testEnvironmentMetadata: { 'git.commit.sha': 'abc123' },
       }, callback)
     }
+
+    it('forwards the discovered coverage report identity', () => {
+      const exporter = createExporter()
+
+      upload(exporter)
+
+      assert.strictEqual(uploadCoverageReportRequest.firstCall.args[0].fileDevice, 1)
+      assert.strictEqual(uploadCoverageReportRequest.firstCall.args[0].fileInode, 2)
+    })
 
     it('reuses exactly 32 coverage report flags for every upload', () => {
       const flags = Array.from({ length: 32 }, (_, index) => `flag-${index}`)

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1384,8 +1384,8 @@ describe('CI Visibility Exporter', () => {
     function upload (exporter, callback = () => {}) {
       exporter.uploadCoverageReport({
         filePath: '/tmp/coverage.xml',
-        fileDevice: 1,
-        fileInode: 2,
+        fileDevice: 1n,
+        fileInode: 9_007_199_254_740_993n,
         format: 'cobertura',
         testEnvironmentMetadata: { 'git.commit.sha': 'abc123' },
       }, callback)
@@ -1396,8 +1396,8 @@ describe('CI Visibility Exporter', () => {
 
       upload(exporter)
 
-      assert.strictEqual(uploadCoverageReportRequest.firstCall.args[0].fileDevice, 1)
-      assert.strictEqual(uploadCoverageReportRequest.firstCall.args[0].fileInode, 2)
+      assert.strictEqual(uploadCoverageReportRequest.firstCall.args[0].fileDevice, 1n)
+      assert.strictEqual(uploadCoverageReportRequest.firstCall.args[0].fileInode, 9_007_199_254_740_993n)
     })
 
     it('reuses exactly 32 coverage report flags for every upload', () => {

--- a/packages/dd-trace/test/ci-visibility/requests/upload-coverage-report.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-coverage-report.spec.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { mkdtempSync, rmSync, writeFileSync } = require('node:fs')
+const { lstatSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } = require('node:fs')
 const { tmpdir } = require('node:os')
 const { join } = require('node:path')
+const { promisify } = require('node:util')
 
-const { after, before, beforeEach, describe, it } = require('mocha')
+const { afterEach, beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
@@ -17,17 +18,11 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
   let tmpDir
   let uploadCoverageReport
 
-  before(() => {
+  beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'upload-coverage-report-'))
     filePath = join(tmpDir, 'coverage.xml')
     writeFileSync(filePath, '<coverage />')
-  })
 
-  after(() => {
-    rmSync(tmpDir, { recursive: true, force: true })
-  })
-
-  beforeEach(() => {
     requestStub = sinon.stub()
     const { uploadCoverageReport: upload } = proxyquire(
       '../../../src/ci-visibility/requests/upload-coverage-report',
@@ -39,7 +34,16 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
     uploadCoverageReport = upload
   })
 
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /**
+   * @param {string[]|undefined} flags
+   * @returns {Promise<Record<string, string|string[]>>}
+   */
   function uploadAndReadEvent (flags) {
+    const fileStats = lstatSync(filePath)
     return new Promise((resolve, reject) => {
       requestStub.callsFake((form, _options, callback) => {
         const chunks = []
@@ -58,6 +62,8 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
 
       uploadCoverageReport({
         filePath,
+        fileDevice: fileStats.dev,
+        fileInode: fileStats.ino,
         flags,
         format: 'cobertura',
         testEnvironmentMetadata: {
@@ -70,6 +76,21 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
           reject(error)
         }
       })
+    })
+  }
+
+  /**
+   * @param {import('node:fs').Stats} fileStats
+   * @returns {Promise<void>}
+   */
+  function uploadAndWait (fileStats) {
+    return promisify(uploadCoverageReport)({
+      filePath,
+      fileDevice: fileStats.dev,
+      fileInode: fileStats.ino,
+      format: 'cobertura',
+      testEnvironmentMetadata: {},
+      url: new URL('http://localhost:8126'),
     })
   }
 
@@ -97,4 +118,32 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
       })
     })
   }
+
+  it('rejects a report replaced with a different regular file after discovery', async () => {
+    const fileStats = lstatSync(filePath)
+    renameSync(filePath, join(tmpDir, 'discovered-coverage.xml'))
+    writeFileSync(filePath, '<replacement />')
+    requestStub.yields(null, 'ok', 200)
+
+    await assert.rejects(uploadAndWait(fileStats), {
+      message: /coverage report changed after discovery/i,
+    })
+    sinon.assert.notCalled(requestStub)
+  })
+
+  it('rejects a report replaced with a symlink after discovery', async function () {
+    if (process.platform === 'win32') this.skip()
+
+    const fileStats = lstatSync(filePath)
+    const outsidePath = join(tmpDir, 'outside.xml')
+    writeFileSync(outsidePath, '<outside />')
+    rmSync(filePath)
+    symlinkSync(outsidePath, filePath)
+    requestStub.yields(null, 'ok', 200)
+
+    await assert.rejects(uploadAndWait(fileStats), {
+      message: /failed to read coverage report/i,
+    })
+    sinon.assert.notCalled(requestStub)
+  })
 })

--- a/packages/dd-trace/test/ci-visibility/requests/upload-coverage-report.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-coverage-report.spec.js
@@ -1,7 +1,16 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { lstatSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } = require('node:fs')
+const {
+  constants,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} = require('node:fs')
 const { tmpdir } = require('node:os')
 const { join } = require('node:path')
 const { promisify } = require('node:util')
@@ -43,7 +52,7 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
    * @returns {Promise<Record<string, string|string[]>>}
    */
   function uploadAndReadEvent (flags) {
-    const fileStats = lstatSync(filePath)
+    const fileStats = lstatSync(filePath, { bigint: true })
     return new Promise((resolve, reject) => {
       requestStub.callsFake((form, _options, callback) => {
         const chunks = []
@@ -80,7 +89,7 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
   }
 
   /**
-   * @param {import('node:fs').Stats} fileStats
+   * @param {import('node:fs').BigIntStats} fileStats
    * @returns {Promise<void>}
    */
   function uploadAndWait (fileStats) {
@@ -120,7 +129,7 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
   }
 
   it('rejects a report replaced with a different regular file after discovery', async () => {
-    const fileStats = lstatSync(filePath)
+    const fileStats = lstatSync(filePath, { bigint: true })
     renameSync(filePath, join(tmpDir, 'discovered-coverage.xml'))
     writeFileSync(filePath, '<replacement />')
     requestStub.yields(null, 'ok', 200)
@@ -131,14 +140,85 @@ describe('ci-visibility/requests/upload-coverage-report', () => {
     sinon.assert.notCalled(requestStub)
   })
 
+  it('distinguishes adjacent file identities above Number.MAX_SAFE_INTEGER', async () => {
+    const discoveredFileInode = 9_007_199_254_740_992n
+    const replacementFileInode = 9_007_199_254_740_993n
+    const fstatSync = sinon.stub().returns({
+      dev: 1n,
+      ino: replacementFileInode,
+      isFile: () => true,
+    })
+    const { uploadCoverageReport: upload } = proxyquire(
+      '../../../src/ci-visibility/requests/upload-coverage-report',
+      {
+        'node:fs': { fstatSync },
+        '../../config': () => ({ DD_API_KEY: 'test-api-key' }),
+        '../../exporters/common/request': requestStub,
+      }
+    )
+
+    assert.strictEqual(Number(discoveredFileInode), Number(replacementFileInode))
+    await assert.rejects(promisify(upload)({
+      filePath,
+      fileDevice: 1n,
+      fileInode: discoveredFileInode,
+      format: 'cobertura',
+      testEnvironmentMetadata: {},
+      url: new URL('http://localhost:8126'),
+    }), {
+      message: /coverage report changed after discovery/i,
+    })
+    sinon.assert.notCalled(requestStub)
+  })
+
+  it('uploads reports when O_NOFOLLOW is unavailable', async () => {
+    const fileStats = lstatSync(filePath, { bigint: true })
+    const { uploadCoverageReport: upload } = proxyquire(
+      '../../../src/ci-visibility/requests/upload-coverage-report',
+      {
+        'node:fs': {
+          constants: {
+            O_NONBLOCK: constants.O_NONBLOCK,
+            O_RDONLY: constants.O_RDONLY,
+          },
+        },
+        '../../config': () => ({ DD_API_KEY: 'test-api-key' }),
+        '../../exporters/common/request': requestStub,
+      }
+    )
+    requestStub.yields(null, 'ok', 200)
+
+    await promisify(upload)({
+      filePath,
+      fileDevice: fileStats.dev,
+      fileInode: fileStats.ino,
+      format: 'cobertura',
+      testEnvironmentMetadata: {},
+      url: new URL('http://localhost:8126'),
+    })
+
+    sinon.assert.calledOnce(requestStub)
+  })
+
+  it('rejects a report replaced with a directory after discovery', async () => {
+    const fileStats = lstatSync(filePath, { bigint: true })
+    rmSync(filePath)
+    mkdirSync(filePath)
+    requestStub.yields(null, 'ok', 200)
+
+    await assert.rejects(uploadAndWait(fileStats), {
+      message: /failed to read coverage report/i,
+    })
+    sinon.assert.notCalled(requestStub)
+  })
+
   it('rejects a report replaced with a symlink after discovery', async function () {
     if (process.platform === 'win32') this.skip()
 
-    const fileStats = lstatSync(filePath)
-    const outsidePath = join(tmpDir, 'outside.xml')
-    writeFileSync(outsidePath, '<outside />')
-    rmSync(filePath)
-    symlinkSync(outsidePath, filePath)
+    const fileStats = lstatSync(filePath, { bigint: true })
+    const discoveredPath = join(tmpDir, 'discovered-coverage.xml')
+    renameSync(filePath, discoveredPath)
+    symlinkSync(discoveredPath, filePath)
     requestStub.yields(null, 'ok', 200)
 
     await assert.rejects(uploadAndWait(fileStats), {


### PR DESCRIPTION
## Summary
Coverage report discovery followed symlinks, so a report path could upload a different local file.

## Test plan
- [x] Run `packages/dd-trace/test/ci-visibility/ci-plugin.spec.js`
- [x] Check changed-line and branch coverage