### PR TITLE
fix(test-optimization): release removed replay probes

### DIFF
--- a/integration-tests/ci-visibility/dynamic-instrumentation/hold-probe-removal.js
+++ b/integration-tests/ci-visibility/dynamic-instrumentation/hold-probe-removal.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const { once } = require('node:events')
+const { join } = require('node:path')
+const { isMainThread } = require('node:worker_threads')
+
+const NativeMessageChannel = globalThis.MessageChannel
+const dynamicInstrumentationPath = join('ci-visibility', 'dynamic-instrumentation', 'index.js')
+
+let firstProbeRemovalAcknowledged
+let heldProbeId
+let heldProbeRemovalReleased = false
+let postProbeRemoval
+let probeSetAfterRelease = false
+
+if (isMainThread) {
+  globalThis.MessageChannel = class extends NativeMessageChannel {
+    constructor () {
+      super()
+
+      if (!new Error().stack?.includes(dynamicInstrumentationPath)) return
+
+      const postMessage = this.port2.postMessage.bind(this.port2)
+
+      /**
+       * @param {object|string} message
+       */
+      this.port2.postMessage = (message) => {
+        if (heldProbeId === undefined && typeof message === 'string') {
+          heldProbeId = message
+          postProbeRemoval = postMessage
+          firstProbeRemovalAcknowledged = once(this.port2, 'message')
+        } else {
+          if (heldProbeRemovalReleased && typeof message !== 'string' && message.file && message.line) {
+            probeSetAfterRelease = true
+          }
+          postMessage(message)
+        }
+      }
+    }
+  }
+}
+
+function releaseHeldProbeRemoval () {
+  if (heldProbeId === undefined) {
+    throw new Error('Dynamic Instrumentation probe removal was not held')
+  }
+  heldProbeRemovalReleased = true
+  postProbeRemoval(heldProbeId)
+}
+
+function assertNoProbeSetAfterRelease () {
+  if (probeSetAfterRelease) {
+    throw new Error('Dynamic Instrumentation set a canceled probe')
+  }
+}
+
+function waitForFirstProbeRemoval () {
+  if (!firstProbeRemovalAcknowledged) {
+    throw new Error('Dynamic Instrumentation removal channel was not created')
+  }
+  return firstProbeRemovalAcknowledged
+}
+
+module.exports = {
+  assertNoProbeSetAfterRelease,
+  releaseHeldProbeRemoval,
+  waitForFirstProbeRemoval,
+}

--- a/integration-tests/ci-visibility/dynamic-instrumentation/test-cancel-pending-probe.js
+++ b/integration-tests/ci-visibility/dynamic-instrumentation/test-cancel-pending-probe.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const sum = require('./dependency')
+const {
+  assertNoProbeSetAfterRelease,
+  releaseHeldProbeRemoval,
+  waitForFirstProbeRemoval,
+} = require('./hold-probe-removal')
+
+describe('dynamic-instrumentation', () => {
+  it('exhausts the first retry', function () {
+    assert.strictEqual(sum(11, 3), 14)
+  })
+
+  it('exhausts a later retry from the same location', function () {
+    assert.strictEqual(sum(11, 3), 14)
+  })
+
+  it('does not reinstall the canceled probe', async function () {
+    this.timeout(15_000)
+    releaseHeldProbeRemoval()
+    await waitForFirstProbeRemoval()
+    assertNoProbeSetAfterRelease()
+  })
+})

--- a/integration-tests/ci-visibility/dynamic-instrumentation/test-reinstall-probe.js
+++ b/integration-tests/ci-visibility/dynamic-instrumentation/test-reinstall-probe.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const sum = require('./dependency')
+
+let secondTestAttempt = 0
+
+describe('dynamic-instrumentation', () => {
+  it('exhausts retries for the first failure with DI', function () {
+    assert.strictEqual(sum(11, 3), 14)
+  })
+
+  it('retries a later failure from the same location with DI', function () {
+    const input = secondTestAttempt++ < 2 ? 11 : 1
+    assert.strictEqual(sum(input, 3), input + 3)
+  })
+})

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -4541,6 +4541,71 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
     })
 
+    onlyLatestIt('reinstalls a probe for a later failure from the same location', async () => {
+      receiver.setSettings({
+        flaky_test_retries_enabled: true,
+        di_enabled: true,
+      })
+
+      const testNamesWithDebugInfo = new Set()
+      let testOutput = ''
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const retriedTests = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
+
+          assert.strictEqual(retriedTests.length, 4)
+          for (const retriedTest of retriedTests) {
+            if (retriedTest.meta[DI_ERROR_DEBUG_INFO_CAPTURED] === 'true') {
+              testNamesWithDebugInfo.add(retriedTest.meta[TEST_NAME])
+            }
+          }
+          assert.strictEqual(testNamesWithDebugInfo.size, 2)
+          assert.ok(testNamesWithDebugInfo.has(
+            'dynamic-instrumentation exhausts retries for the first failure with DI'
+          ))
+          assert.ok(testNamesWithDebugInfo.has(
+            'dynamic-instrumentation retries a later failure from the same location with DI'
+          ))
+        })
+
+      childProcess = exec(
+        'node ./ci-visibility/run-mocha.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: JSON.stringify([
+              './dynamic-instrumentation/test-reinstall-probe',
+            ]),
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '2',
+            _DD_TRACE_INTEGRATION_COVERAGE_DISABLE: '1',
+          },
+        }
+      )
+
+      childProcess.stdout?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      const stdoutEndPromise = childProcess.stdout ? once(childProcess.stdout, 'end') : Promise.resolve()
+      const stderrEndPromise = childProcess.stderr ? once(childProcess.stderr, 'end') : Promise.resolve()
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+        stdoutEndPromise,
+        stderrEndPromise,
+      ])
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
     onlyLatestIt('drains in-flight dynamic instrumentation hits before the next retry', async () => {
       receiver.setSettings({
         flaky_test_retries_enabled: true,

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -4606,6 +4606,64 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       assert.strictEqual(exitCode, 0, testOutput)
     })
 
+    onlyLatestIt('cancels a queued probe while a prior removal is pending', async () => {
+      receiver.setSettings({
+        flaky_test_retries_enabled: true,
+        di_enabled: true,
+      })
+
+      let retriedTests = []
+      let testOutput = ''
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          retriedTests = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
+        })
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '-r ./ci-visibility/dynamic-instrumentation/hold-probe-removal -r dd-trace/ci/init',
+            TESTS_TO_RUN: JSON.stringify([
+              './dynamic-instrumentation/test-cancel-pending-probe',
+            ]),
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            DD_TRACE_DEBUG: 'true',
+            _DD_TRACE_INTEGRATION_COVERAGE_DISABLE: '1',
+          },
+        }
+      )
+
+      childProcess.stdout?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      const stdoutEndPromise = childProcess.stdout ? once(childProcess.stdout, 'end') : Promise.resolve()
+      const stderrEndPromise = childProcess.stderr ? once(childProcess.stderr, 'end') : Promise.resolve()
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+        stdoutEndPromise,
+        stderrEndPromise,
+      ])
+      assert.strictEqual(exitCode, 0, testOutput)
+      assert.strictEqual(testOutput.includes('Unknown probe id'), false)
+      assert.strictEqual(retriedTests.length, 2)
+      for (const retriedTest of retriedTests) {
+        assert.strictEqual(retriedTest.meta[TEST_STATUS], 'fail')
+      }
+    })
+
     onlyLatestIt('drains in-flight dynamic instrumentation hits before the next retry', async () => {
       receiver.setSettings({
         flaky_test_retries_enabled: true,

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -11,11 +11,18 @@ const probeIdToResolveBreakpointSet = new Map()
 const probeIdToResolveBreakpointRemove = new Map()
 const drainRequestIdToResolveBreakpointHit = new Map()
 
+/**
+ * @typedef {object} ProbeState
+ * @property {string} locationKey
+ * @property {Promise<void>} setPromise
+ * @property {boolean} setPosted
+ */
+
 class TestVisDynamicInstrumentation {
   /** @type {Map<string, Promise<void>>} */
   #pendingProbeRemovalByLocation = new Map()
-  /** @type {Map<string, string>} */
-  #probeLocationById = new Map()
+  /** @type {Map<string, ProbeState>} */
+  #probeStateById = new Map()
 
   /**
    * @param {import('../../config/config-base')} config - Tracer configuration
@@ -33,24 +40,32 @@ class TestVisDynamicInstrumentation {
   }
 
   /**
-   * @param {string} probeId
+   * @param {string|undefined} probeId
    */
   removeProbe (probeId) {
-    const removePromise = new Promise(resolve => {
-      this.breakpointRemoveChannel.port2.postMessage(probeId)
+    const probeState = probeId === undefined ? undefined : this.#probeStateById.get(probeId)
+    if (!probeState) return Promise.resolve()
 
+    this.#probeStateById.delete(probeId)
+    if (!probeState.setPosted) {
+      const resolveSetProbe = probeIdToResolveBreakpointSet.get(probeId)
+      probeIdToResolveBreakpointSet.delete(probeId)
+      resolveSetProbe()
+      this.onHitBreakpointByProbeId.delete(probeId)
+      return Promise.resolve()
+    }
+
+    const postRemoval = () => new Promise(resolve => {
+      this.breakpointRemoveChannel.port2.postMessage(probeId)
       probeIdToResolveBreakpointRemove.set(probeId, resolve)
     })
-    const activeProbeKey = this.#probeLocationById.get(probeId)
-    if (activeProbeKey) {
-      this.#probeLocationById.delete(probeId)
-      this.#pendingProbeRemovalByLocation.set(activeProbeKey, removePromise)
-      removePromise.then(() => {
-        if (this.#pendingProbeRemovalByLocation.get(activeProbeKey) === removePromise) {
-          this.#pendingProbeRemovalByLocation.delete(activeProbeKey)
-        }
-      })
-    }
+    const removePromise = probeState.setPromise.then(postRemoval)
+    this.#pendingProbeRemovalByLocation.set(probeState.locationKey, removePromise)
+    removePromise.then(() => {
+      if (this.#pendingProbeRemovalByLocation.get(probeState.locationKey) === removePromise) {
+        this.#pendingProbeRemovalByLocation.delete(probeState.locationKey)
+      }
+    })
     return removePromise
   }
 
@@ -63,20 +78,29 @@ class TestVisDynamicInstrumentation {
       this.start()
     }
     const probeId = randomUUID()
-    const activeProbeKey = `${file}:${line}`
-    const pendingRemoval = this.#pendingProbeRemovalByLocation.get(activeProbeKey)
-    const setProbe = () => {
-      this.breakpointSetChannel.port2.postMessage(
-        { id: probeId, file, line }
-      )
-    }
+    const locationKey = `${file}:${line}`
+    const pendingRemoval = this.#pendingProbeRemovalByLocation.get(locationKey)
 
     this.onHitBreakpointByProbeId.set(probeId, onHitBreakpoint)
-    this.#probeLocationById.set(probeId, activeProbeKey)
 
     const setProbePromise = new Promise(resolve => {
       probeIdToResolveBreakpointSet.set(probeId, resolve)
     })
+    const probeState = {
+      locationKey,
+      setPromise: setProbePromise,
+      setPosted: false,
+    }
+    this.#probeStateById.set(probeId, probeState)
+
+    const setProbe = () => {
+      if (this.#probeStateById.get(probeId) === probeState) {
+        probeState.setPosted = true
+        this.breakpointSetChannel.port2.postMessage(
+          { id: probeId, file, line }
+        )
+      }
+    }
     if (pendingRemoval) {
       pendingRemoval.then(setProbe)
     } else {

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -12,6 +12,11 @@ const probeIdToResolveBreakpointRemove = new Map()
 const drainRequestIdToResolveBreakpointHit = new Map()
 
 class TestVisDynamicInstrumentation {
+  /** @type {Map<string, Promise<void>>} */
+  #pendingProbeRemovalByLocation = new Map()
+  /** @type {Map<string, string>} */
+  #probeLocationById = new Map()
+
   /**
    * @param {import('../../config/config-base')} config - Tracer configuration
    */
@@ -27,34 +32,60 @@ class TestVisDynamicInstrumentation {
     this.onHitBreakpointByProbeId = new Map()
   }
 
+  /**
+   * @param {string} probeId
+   */
   removeProbe (probeId) {
-    return new Promise(resolve => {
+    const removePromise = new Promise(resolve => {
       this.breakpointRemoveChannel.port2.postMessage(probeId)
 
       probeIdToResolveBreakpointRemove.set(probeId, resolve)
     })
+    const activeProbeKey = this.#probeLocationById.get(probeId)
+    if (activeProbeKey) {
+      this.#probeLocationById.delete(probeId)
+      this.#pendingProbeRemovalByLocation.set(activeProbeKey, removePromise)
+      removePromise.then(() => {
+        if (this.#pendingProbeRemovalByLocation.get(activeProbeKey) === removePromise) {
+          this.#pendingProbeRemovalByLocation.delete(activeProbeKey)
+        }
+      })
+    }
+    return removePromise
   }
 
-  // Return 2 elements:
-  // 1. Probe ID
-  // 2. Promise that's resolved when the breakpoint is set
+  /**
+   * @param {{ file: string, line: number }} location
+   * @param {(breakpoint: object) => void} onHitBreakpoint
+   */
   addLineProbe ({ file, line }, onHitBreakpoint) {
     if (!this.worker) { // not init yet
       this.start()
     }
     const probeId = randomUUID()
-
-    this.breakpointSetChannel.port2.postMessage(
-      { id: probeId, file, line }
-    )
+    const activeProbeKey = `${file}:${line}`
+    const pendingRemoval = this.#pendingProbeRemovalByLocation.get(activeProbeKey)
+    const setProbe = () => {
+      this.breakpointSetChannel.port2.postMessage(
+        { id: probeId, file, line }
+      )
+    }
 
     this.onHitBreakpointByProbeId.set(probeId, onHitBreakpoint)
+    this.#probeLocationById.set(probeId, activeProbeKey)
+
+    const setProbePromise = new Promise(resolve => {
+      probeIdToResolveBreakpointSet.set(probeId, resolve)
+    })
+    if (pendingRemoval) {
+      pendingRemoval.then(setProbe)
+    } else {
+      setProbe()
+    }
 
     return [
       probeId,
-      new Promise(resolve => {
-        probeIdToResolveBreakpointSet.set(probeId, resolve)
-      }),
+      setProbePromise,
     ]
   }
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -7,13 +7,15 @@ const log = require('../../log')
 const { getEnvironmentVariables } = require('../../config/helper')
 const getDebuggerConfig = require('../../debugger/config')
 
-const probeIdToResolveBreakpointSet = new Map()
-const probeIdToResolveBreakpointRemove = new Map()
 const drainRequestIdToResolveBreakpointHit = new Map()
 
 /**
  * @typedef {object} ProbeState
  * @property {string} locationKey
+ * @property {(breakpoint: object) => void} onHitBreakpoint
+ * @property {Promise<void>|undefined} removePromise
+ * @property {(() => void)|undefined} resolveRemove
+ * @property {(() => void)|undefined} resolveSet
  * @property {Promise<void>} setPromise
  * @property {boolean} setPosted
  */
@@ -36,7 +38,6 @@ class TestVisDynamicInstrumentation {
     this.breakpointSetChannel = new MessageChannel()
     this.breakpointHitChannel = new MessageChannel()
     this.breakpointRemoveChannel = new MessageChannel()
-    this.onHitBreakpointByProbeId = new Map()
   }
 
   /**
@@ -45,25 +46,31 @@ class TestVisDynamicInstrumentation {
   removeProbe (probeId) {
     const probeState = probeId === undefined ? undefined : this.#probeStateById.get(probeId)
     if (!probeState) return Promise.resolve()
+    if (probeState.removePromise) return probeState.removePromise
 
-    this.#probeStateById.delete(probeId)
     if (!probeState.setPosted) {
-      const resolveSetProbe = probeIdToResolveBreakpointSet.get(probeId)
-      probeIdToResolveBreakpointSet.delete(probeId)
-      resolveSetProbe()
-      this.onHitBreakpointByProbeId.delete(probeId)
+      this.#probeStateById.delete(probeId)
+      probeState.resolveSet?.()
+      probeState.resolveSet = undefined
       return Promise.resolve()
     }
 
     const postRemoval = () => new Promise(resolve => {
+      probeState.resolveRemove = resolve
       this.breakpointRemoveChannel.port2.postMessage(probeId)
-      probeIdToResolveBreakpointRemove.set(probeId, resolve)
     })
-    const removePromise = probeState.setPromise.then(postRemoval)
-    this.#pendingProbeRemovalByLocation.set(probeState.locationKey, removePromise)
-    removePromise.then(() => {
-      if (this.#pendingProbeRemovalByLocation.get(probeState.locationKey) === removePromise) {
+    const removeAcknowledgedPromise = probeState.setPromise.then(postRemoval)
+    const removePromise = removeAcknowledgedPromise.then(() => this.waitForInFlightBreakpointHits())
+    probeState.removePromise = removePromise
+    this.#pendingProbeRemovalByLocation.set(probeState.locationKey, removeAcknowledgedPromise)
+    removeAcknowledgedPromise.then(() => {
+      if (this.#pendingProbeRemovalByLocation.get(probeState.locationKey) === removeAcknowledgedPromise) {
         this.#pendingProbeRemovalByLocation.delete(probeState.locationKey)
+      }
+    })
+    removePromise.then(() => {
+      if (this.#probeStateById.get(probeId) === probeState) {
+        this.#probeStateById.delete(probeId)
       }
     })
     return removePromise
@@ -81,13 +88,16 @@ class TestVisDynamicInstrumentation {
     const locationKey = `${file}:${line}`
     const pendingRemoval = this.#pendingProbeRemovalByLocation.get(locationKey)
 
-    this.onHitBreakpointByProbeId.set(probeId, onHitBreakpoint)
-
+    let resolveSet
     const setProbePromise = new Promise(resolve => {
-      probeIdToResolveBreakpointSet.set(probeId, resolve)
+      resolveSet = resolve
     })
     const probeState = {
       locationKey,
+      onHitBreakpoint,
+      removePromise: undefined,
+      resolveRemove: undefined,
+      resolveSet,
       setPromise: setProbePromise,
       setPosted: false,
     }
@@ -194,10 +204,10 @@ class TestVisDynamicInstrumentation {
     this.worker.unref?.()
 
     this.breakpointSetChannel.port2.on('message', (probeId) => {
-      const resolve = probeIdToResolveBreakpointSet.get(probeId)
-      if (resolve) {
-        resolve()
-        probeIdToResolveBreakpointSet.delete(probeId)
+      const probeState = this.#probeStateById.get(probeId)
+      if (probeState?.resolveSet) {
+        probeState.resolveSet()
+        probeState.resolveSet = undefined
       }
     }).unref?.()
 
@@ -212,19 +222,19 @@ class TestVisDynamicInstrumentation {
       }
 
       const { probe: { id: probeId } } = snapshot
-      const onHit = this.onHitBreakpointByProbeId.get(probeId)
-      if (onHit) {
-        onHit({ snapshot })
+      const probeState = this.#probeStateById.get(probeId)
+      if (probeState) {
+        probeState.onHitBreakpoint({ snapshot })
       } else {
         log.warn('Received a breakpoint hit for an unknown probe')
       }
     }).unref?.()
 
     this.breakpointRemoveChannel.port2.on('message', (probeId) => {
-      const resolve = probeIdToResolveBreakpointRemove.get(probeId)
-      if (resolve) {
-        resolve()
-        probeIdToResolveBreakpointRemove.delete(probeId)
+      const probeState = this.#probeStateById.get(probeId)
+      if (probeState?.resolveRemove) {
+        probeState.resolveRemove()
+        probeState.resolveRemove = undefined
       }
     }).unref?.()
   }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -958,17 +958,28 @@ module.exports = class CiPlugin extends Plugin {
     }
     log.debug('Removing all Dynamic Instrumentation probes')
     const promises = []
-    for (const fileLine of this.fileLineToProbeId.keys()) {
-      const [file, line] = fileLine.split(':')
-      promises.push(this.removeDiProbe({ file, line }))
+    for (const [activeProbeKey, probeId] of this.fileLineToProbeId) {
+      promises.push(this.#removeDiProbe(activeProbeKey, probeId))
     }
     return Promise.all(promises)
   }
 
+  /**
+   * @param {{ file: string, line: number }} location
+   */
   removeDiProbe ({ file, line }) {
-    const probeId = this.fileLineToProbeId.get(`${file}:${line}`)
-    log.warn('Removing probe from %s:%s, with id: %s', file, line, probeId)
-    this.fileLineToProbeId.delete(probeId)
+    const activeProbeKey = `${file}:${line}`
+    const probeId = this.fileLineToProbeId.get(activeProbeKey)
+    return this.#removeDiProbe(activeProbeKey, probeId)
+  }
+
+  /**
+   * @param {string} activeProbeKey
+   * @param {string|undefined} probeId
+   */
+  #removeDiProbe (activeProbeKey, probeId) {
+    log.warn('Removing probe from %s, with id: %s', activeProbeKey, probeId)
+    this.fileLineToProbeId.delete(activeProbeKey)
     return this.di.removeProbe(probeId)
   }
 

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -164,6 +164,56 @@ describe('CiPlugin', () => {
     assert.deepStrictEqual(plugin.diBreakpointHitResolvers, [])
   })
 
+  it('adds a new DI probe after removing one from the same location', async () => {
+    const plugin = createPlugin('jest_worker')
+    const setProbePromise = Promise.resolve()
+    const addLineProbe = sinon.stub()
+      .onFirstCall().returns(['probe-1', setProbePromise])
+      .onSecondCall().returns(['probe-2', setProbePromise])
+    const removeProbe = sinon.stub().resolves()
+    const file = `${plugin.repositoryRoot}/test.js`
+    const line = 23
+    const error = { stack: `Error: test failed\n    at test (${file}:${line}:5)` }
+    plugin.di = { addLineProbe, removeProbe }
+
+    const firstProbe = plugin.addDiProbe(error)
+    await plugin.removeDiProbe({ file, line })
+    const secondProbe = plugin.addDiProbe(error)
+
+    assert.strictEqual(firstProbe.probeId, 'probe-1')
+    assert.strictEqual(secondProbe.probeId, 'probe-2')
+    sinon.assert.calledTwice(addLineProbe)
+    sinon.assert.calledOnceWithExactly(removeProbe, 'probe-1')
+  })
+
+  it('removes all DI probes with Windows-style file paths', async () => {
+    const plugin = createPlugin('jest_worker')
+    const setProbePromise = Promise.resolve()
+    const addLineProbe = sinon.stub()
+      .onCall(0).returns(['probe-1', setProbePromise])
+      .onCall(1).returns(['probe-2', setProbePromise])
+      .onCall(2).returns(['probe-3', setProbePromise])
+      .onCall(3).returns(['probe-4', setProbePromise])
+    const removeProbe = sinon.stub().resolves()
+    const firstFile = 'C:\\repo\\first.spec.js'
+    const secondFile = 'C:\\repo\\second.spec.js'
+    const firstError = { stack: `Error: first failure\n    at first (${firstFile}:23:5)` }
+    const secondError = { stack: `Error: second failure\n    at second (${secondFile}:42:5)` }
+    plugin.di = { addLineProbe, removeProbe }
+    plugin._setRepositoryRoot('C:\\repo', [])
+
+    plugin.addDiProbe(firstError)
+    plugin.addDiProbe(secondError)
+    await plugin.removeAllDiProbes()
+
+    assert.deepStrictEqual(removeProbe.args, [['probe-1'], ['probe-2']])
+
+    plugin.addDiProbe(firstError)
+    plugin.addDiProbe(secondError)
+
+    sinon.assert.callCount(addLineProbe, 4)
+  })
+
   it('exports DI breakpoint hits with the debugger log envelope', () => {
     const plugin = createPlugin('vitest_worker')
     const exportDiLogs = sinon.spy()

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
@@ -473,7 +473,7 @@ describe('test visibility with dynamic instrumentation', () => {
     })
   })
 
-  it('waits for probe removal before reinstalling the same location', async () => {
+  it('serializes removal with pending setup and cancels its queued replacement', async () => {
     const worker = new EventEmitter()
     worker.unref = sinon.stub()
     const Worker = sinon.stub().returns(worker)
@@ -501,29 +501,32 @@ describe('test visibility with dynamic instrumentation', () => {
       { file: 'test.js', line: 23 },
       sinon.stub()
     )
-    dynamicInstrumentation.breakpointSetChannel.port1.postMessage(firstProbeId)
-    await firstSetPromise
-
-    const removePromise = dynamicInstrumentation.removeProbe(firstProbeId)
+    const firstRemovePromise = dynamicInstrumentation.removeProbe(firstProbeId)
     const [secondProbeId, secondSetPromise] = dynamicInstrumentation.addLineProbe(
       { file: 'test.js', line: 23 },
       sinon.stub()
     )
+    const secondRemovePromise = dynamicInstrumentation.removeProbe(secondProbeId)
+
+    sinon.assert.calledOnce(setPostMessage)
+    sinon.assert.notCalled(removePostMessage)
+
+    await Promise.all([
+      secondSetPromise,
+      secondRemovePromise,
+      dynamicInstrumentation.removeProbe(secondProbeId),
+      dynamicInstrumentation.removeProbe(),
+    ])
+
+    dynamicInstrumentation.breakpointSetChannel.port1.postMessage(firstProbeId)
+    await firstSetPromise
+    await setImmediatePromise()
 
     sinon.assert.calledOnce(setPostMessage)
     sinon.assert.calledOnceWithExactly(removePostMessage, firstProbeId)
 
     dynamicInstrumentation.breakpointRemoveChannel.port1.postMessage(firstProbeId)
-    await removePromise
-    await setImmediatePromise()
-
-    assert.deepStrictEqual(setPostMessage.args, [
-      [{ id: firstProbeId, file: 'test.js', line: 23 }],
-      [{ id: secondProbeId, file: 'test.js', line: 23 }],
-    ])
-
-    dynamicInstrumentation.breakpointSetChannel.port1.postMessage(secondProbeId)
-    await secondSetPromise
+    await firstRemovePromise
 
     dynamicInstrumentation.breakpointSetChannel.port1.close()
     dynamicInstrumentation.breakpointSetChannel.port2.close()

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 const { fork } = require('node:child_process')
-const { EventEmitter } = require('node:events')
+const { EventEmitter, once } = require('node:events')
 const path = require('node:path')
 const { setImmediate: setImmediatePromise } = require('node:timers/promises')
 
@@ -473,13 +473,14 @@ describe('test visibility with dynamic instrumentation', () => {
     })
   })
 
-  it('serializes removal with pending setup and cancels its queued replacement', async () => {
+  it('serializes probe replacement, cancels queued setup, and releases removed state', async () => {
     const worker = new EventEmitter()
     worker.unref = sinon.stub()
     const Worker = sinon.stub().returns(worker)
     const randomUUID = sinon.stub()
     randomUUID.onFirstCall().returns('probe-1')
     randomUUID.onSecondCall().returns('probe-2')
+    randomUUID.onThirdCall().returns('drain-1')
     const createDynamicInstrumentation = proxyquire('../../../src/ci-visibility/dynamic-instrumentation', {
       worker_threads: {
         Worker,
@@ -496,12 +497,14 @@ describe('test visibility with dynamic instrumentation', () => {
     const dynamicInstrumentation = createDynamicInstrumentation({})
     const setPostMessage = sinon.spy(dynamicInstrumentation.breakpointSetChannel.port2, 'postMessage')
     const removePostMessage = sinon.spy(dynamicInstrumentation.breakpointRemoveChannel.port2, 'postMessage')
+    const onHitFirstProbe = sinon.spy()
 
     const [firstProbeId, firstSetPromise] = dynamicInstrumentation.addLineProbe(
       { file: 'test.js', line: 23 },
-      sinon.stub()
+      onHitFirstProbe
     )
     const firstRemovePromise = dynamicInstrumentation.removeProbe(firstProbeId)
+    assert.strictEqual(dynamicInstrumentation.removeProbe(firstProbeId), firstRemovePromise)
     const [secondProbeId, secondSetPromise] = dynamicInstrumentation.addLineProbe(
       { file: 'test.js', line: 23 },
       sinon.stub()
@@ -525,8 +528,20 @@ describe('test visibility with dynamic instrumentation', () => {
     sinon.assert.calledOnce(setPostMessage)
     sinon.assert.calledOnceWithExactly(removePostMessage, firstProbeId)
 
+    const firstProbeSnapshot = { probe: { id: firstProbeId } }
+    dynamicInstrumentation.breakpointHitChannel.port1.postMessage({ snapshot: firstProbeSnapshot })
+    await setImmediatePromise()
+    sinon.assert.calledOnceWithExactly(onHitFirstProbe, { snapshot: firstProbeSnapshot })
+
+    const drainRequestPromise = once(dynamicInstrumentation.breakpointHitChannel.port1, 'message')
     dynamicInstrumentation.breakpointRemoveChannel.port1.postMessage(firstProbeId)
+    const [{ drainRequestId }] = await drainRequestPromise
+    dynamicInstrumentation.breakpointHitChannel.port1.postMessage({ drainRequestId })
     await firstRemovePromise
+
+    dynamicInstrumentation.breakpointHitChannel.port1.postMessage({ snapshot: firstProbeSnapshot })
+    await setImmediatePromise()
+    sinon.assert.calledOnce(onHitFirstProbe)
 
     dynamicInstrumentation.breakpointSetChannel.port1.close()
     dynamicInstrumentation.breakpointSetChannel.port2.close()

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
@@ -472,4 +472,64 @@ describe('test visibility with dynamic instrumentation', () => {
       'package.json.name': 'dd-trace',
     })
   })
+
+  it('waits for probe removal before reinstalling the same location', async () => {
+    const worker = new EventEmitter()
+    worker.unref = sinon.stub()
+    const Worker = sinon.stub().returns(worker)
+    const randomUUID = sinon.stub()
+    randomUUID.onFirstCall().returns('probe-1')
+    randomUUID.onSecondCall().returns('probe-2')
+    const createDynamicInstrumentation = proxyquire('../../../src/ci-visibility/dynamic-instrumentation', {
+      worker_threads: {
+        Worker,
+        threadId: 0,
+      },
+      crypto: {
+        randomUUID,
+      },
+      '../../config/helper': {
+        getEnvironmentVariables: sinon.stub().returns({}),
+      },
+      '../../debugger/config': sinon.stub().returns({}),
+    })
+    const dynamicInstrumentation = createDynamicInstrumentation({})
+    const setPostMessage = sinon.spy(dynamicInstrumentation.breakpointSetChannel.port2, 'postMessage')
+    const removePostMessage = sinon.spy(dynamicInstrumentation.breakpointRemoveChannel.port2, 'postMessage')
+
+    const [firstProbeId, firstSetPromise] = dynamicInstrumentation.addLineProbe(
+      { file: 'test.js', line: 23 },
+      sinon.stub()
+    )
+    dynamicInstrumentation.breakpointSetChannel.port1.postMessage(firstProbeId)
+    await firstSetPromise
+
+    const removePromise = dynamicInstrumentation.removeProbe(firstProbeId)
+    const [secondProbeId, secondSetPromise] = dynamicInstrumentation.addLineProbe(
+      { file: 'test.js', line: 23 },
+      sinon.stub()
+    )
+
+    sinon.assert.calledOnce(setPostMessage)
+    sinon.assert.calledOnceWithExactly(removePostMessage, firstProbeId)
+
+    dynamicInstrumentation.breakpointRemoveChannel.port1.postMessage(firstProbeId)
+    await removePromise
+    await setImmediatePromise()
+
+    assert.deepStrictEqual(setPostMessage.args, [
+      [{ id: firstProbeId, file: 'test.js', line: 23 }],
+      [{ id: secondProbeId, file: 'test.js', line: 23 }],
+    ])
+
+    dynamicInstrumentation.breakpointSetChannel.port1.postMessage(secondProbeId)
+    await secondSetPromise
+
+    dynamicInstrumentation.breakpointSetChannel.port1.close()
+    dynamicInstrumentation.breakpointSetChannel.port2.close()
+    dynamicInstrumentation.breakpointHitChannel.port1.close()
+    dynamicInstrumentation.breakpointHitChannel.port2.close()
+    dynamicInstrumentation.breakpointRemoveChannel.port1.close()
+    dynamicInstrumentation.breakpointRemoveChannel.port2.close()
+  })
 })


### PR DESCRIPTION
## Summary
Removed Failed Test Replay probes stayed indexed by source location, so later failures reused IDs that no longer existed. Bulk cleanup also split Windows drive paths at the volume separator.

## Test plan
- [x] Run `packages/dd-trace/test/ci-visibility/ci-plugin.spec.js`
- [x] Check changed-line and branch coverage