### PR TITLE
fix(test-optimization): resolve disabled git upload immediately

### DIFF
--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -289,6 +289,51 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       )
     })
 
+    it('does not wait for git readiness when git upload is disabled', async () => {
+      receiver.setSettings({
+        itr_enabled: true,
+        code_coverage: false,
+        tests_skipping: true,
+        require_git: true,
+      })
+
+      const settingsPath = '/api/v2/libraries/tests/services/setting'
+      const skippablePath = '/api/v2/ci/tests/skippable'
+
+      /**
+       * @param {{ url: string }} message
+       */
+      const isReadinessRequest = ({ url }) => url === settingsPath || url === skippablePath
+
+      /**
+       * @param {{ url: string }[]} payloads
+       */
+      const assertReadinessRequests = (payloads) => {
+        assert.strictEqual(payloads.filter(({ url }) => url === settingsPath).length, 2)
+        assert.strictEqual(payloads.filter(({ url }) => url === skippablePath).length, 1)
+      }
+
+      const requestsPromise = receiver.gatherPayloadsMaxTimeout(
+        isReadinessRequest,
+        assertReadinessRequests
+      )
+
+      childProcess = exec(runTestsCommand, {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: 'false',
+        },
+      })
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        requestsPromise,
+      ])
+
+      assert.strictEqual(exitCode, 0)
+    })
+
     it('can skip suites received by the intelligent test runner API and still reports code coverage', (done) => {
       receiver.setSuitesToSkip([{
         type: 'suite',

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -318,6 +318,7 @@ class CiVisibilityExporter extends BufferingExporter {
 
   sendGitMetadata (repositoryUrl) {
     if (!this._config.testOptimization.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED) {
+      this._resolveGit()
       return
     }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -42,6 +42,29 @@ describe('CI Visibility Exporter', () => {
   })
 
   describe('sendGitMetadata', () => {
+    it('should resolve git upload readiness immediately when git upload is disabled', async () => {
+      const clock = sinon.useFakeTimers()
+      const scope = nock(url)
+        .post('/api/v2/git/repository/search_commits')
+        .reply(200)
+        .post('/api/v2/git/repository/packfile')
+        .reply(202)
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: false },
+      })
+      const onGitUploadReady = sinon.spy()
+
+      ciVisibilityExporter._gitUploadPromise.then(onGitUploadReady)
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.sendGitMetadata()
+      await Promise.resolve()
+
+      sinon.assert.calledOnceWithExactly(onGitUploadReady, undefined)
+      assert.strictEqual(clock.now, 0)
+      assert.strictEqual(scope.isDone(), false)
+    })
+
     it('should resolve _gitUploadPromise when git metadata is fetched', (done) => {
       const scope = nock(url)
         .post('/api/v2/git/repository/search_commits')
@@ -286,8 +309,13 @@ describe('CI Visibility Exporter', () => {
           }))
 
         const ciVisibilityExporter = new CiVisibilityExporter({
-          url, testOptimization: { DD_CIVISIBILITY_ITR_ENABLED: true },
+          url,
+          testOptimization: {
+            DD_CIVISIBILITY_ITR_ENABLED: true,
+            DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: true,
+          },
         })
+        sinon.stub(ciVisibilityExporter, 'sendGitMetadata')
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
         ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           assert.strictEqual(scope.isDone(), true)


### PR DESCRIPTION
## Summary
Disabling git upload left readiness unresolved, so settings and skippable-test requests waited for the 60-second fallback.

## Test plan
- [x] Run the CI Visibility exporter spec
- [x] Check changed-line and branch coverage