### PR TITLE
fix(cypress): isolate retry status by spec

### DIFF
--- a/integration-tests/cypress/cypress-final-status-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-final-status-impacted-tests.spec.js
@@ -30,6 +30,7 @@ const {
   TEST_EARLY_FLAKE_ENABLED,
   TEST_SESSION_NAME,
   TEST_RETRY_REASON,
+  TEST_HAS_FAILED_ALL_RETRIES,
   DD_CAPABILITIES_TEST_IMPACT_ANALYSIS,
   DD_CAPABILITIES_EARLY_FLAKE_DETECTION,
   DD_CAPABILITIES_AUTO_TEST_RETRIES,
@@ -329,6 +330,104 @@ moduleTypes.forEach(({
           ])
         }
       )
+
+      over10It('keeps retry status isolated for tests with the same full title in different specs', async () => {
+        receiver.setSettings({
+          flaky_test_retries_enabled: true,
+          flaky_test_retries_count: 1,
+          early_flake_detection: { enabled: false },
+        })
+
+        const specToRun = 'cypress/e2e/retry-identity-*.js'
+        const testName = 'retry identity has opposite outcomes'
+
+        const envVars = getCiVisEvpProxyConfig(receiver.port)
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec "${specToRun}"`,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: webAppBaseUrl,
+              DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+              SPEC_PATTERN: specToRun,
+            },
+          }
+        )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            /**
+             * @param {Array<{
+             *   payload: { events: Array<{ type: string, content: { meta: Record<string, string> } }> }
+             * }>} payloads
+             */
+            (payloads) => {
+              const testsBySuite = {}
+
+              for (const { payload } of payloads) {
+                for (const event of payload.events) {
+                  if (event.type !== 'test' || event.content.meta[TEST_NAME] !== testName) {
+                    continue
+                  }
+
+                  const testSuite = event.content.meta[TEST_SUITE]
+                  if (testsBySuite[testSuite]) {
+                    testsBySuite[testSuite].push(event.content)
+                  } else {
+                    testsBySuite[testSuite] = [event.content]
+                  }
+                }
+              }
+
+              const eventuallyPassingTests =
+                testsBySuite['cypress/e2e/retry-identity-eventually-passes.js']
+              assert.strictEqual(eventuallyPassingTests.length, 2)
+
+              let eventuallyPassingFinalStatus
+              let eventuallyPassingFailures = 0
+              let eventuallyPassingPasses = 0
+              for (const test of eventuallyPassingTests) {
+                if (test.meta[TEST_STATUS] === 'fail') {
+                  eventuallyPassingFailures++
+                } else if (test.meta[TEST_STATUS] === 'pass') {
+                  eventuallyPassingPasses++
+                }
+                eventuallyPassingFinalStatus ||= test.meta[TEST_FINAL_STATUS]
+              }
+              assert.strictEqual(eventuallyPassingFailures, 1)
+              assert.strictEqual(eventuallyPassingPasses, 1)
+              assert.strictEqual(eventuallyPassingFinalStatus, 'pass')
+
+              const neverPassingTests = testsBySuite['cypress/e2e/retry-identity-never-passes.js']
+              assert.strictEqual(neverPassingTests.length, 2)
+
+              let neverPassingFinalStatus
+              let neverPassingFailures = 0
+              for (const test of neverPassingTests) {
+                if (test.meta[TEST_STATUS] === 'fail') {
+                  neverPassingFailures++
+                }
+                neverPassingFinalStatus ||= test.meta[TEST_FINAL_STATUS]
+              }
+              assert.strictEqual(neverPassingFailures, 2)
+              assert.strictEqual(neverPassingFinalStatus, 'fail')
+              assert.strictEqual(
+                neverPassingTests[neverPassingTests.length - 1].meta[TEST_HAS_FAILED_ALL_RETRIES],
+                'true'
+              )
+            },
+            { hardTimeout: 60_000 }
+          )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+      })
 
       over10It('sets final_status tag on last retry (EFD active only)', async () => {
         const numRetriesEfd = 1

--- a/integration-tests/cypress/e2e/retry-identity-eventually-passes.js
+++ b/integration-tests/cypress/e2e/retry-identity-eventually-passes.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+let attempt = 0
+
+describe('retry identity', () => {
+  it('has opposite outcomes', () => {
+    expect(attempt++).to.equal(1)
+  })
+})

--- a/integration-tests/cypress/e2e/retry-identity-never-passes.js
+++ b/integration-tests/cypress/e2e/retry-identity-never-passes.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+describe('retry identity', () => {
+  it('has opposite outcomes', () => {
+    expect(true).to.equal(false)
+  })
+})

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -1835,13 +1835,13 @@ class CypressPlugin {
         }
         this.activeTestSpan.setTag(TEST_STATUS, testStatus)
 
-        // Save the test status to know if it has passed all retries
-        if (this.testStatuses[testName]) {
-          this.testStatuses[testName].push(testStatus)
+        const testIdentifier = `${testSuite}\0${testName}`
+        let testStatuses = this.testStatuses[testIdentifier]
+        if (testStatuses) {
+          testStatuses.push(testStatus)
         } else {
-          this.testStatuses[testName] = [testStatus]
+          testStatuses = this.testStatuses[testIdentifier] = [testStatus]
         }
-        const testStatuses = this.testStatuses[testName]
         const activeSpanTags = this.activeTestSpan.context().getTags()
 
         if (error) {


### PR DESCRIPTION
## Summary
Cypress full titles omit the spec path, so equal titles in separate files shared retry history and produced incorrect final status.

## Test plan
- [x] Run the regression on Cypress 12, 14, and latest CommonJS/ESM
- [x] Check changed-line and branch coverage