### PR TITLE
fix(test-optimization): preserve zero EFD retry budgets

### DIFF
--- a/integration-tests/ci-visibility/cucumber-worker-message-delay.js
+++ b/integration-tests/ci-visibility/cucumber-worker-message-delay.js
@@ -2,18 +2,32 @@
 
 const CUCUMBER_WORKER_TRACE_PAYLOAD_CODE = 70
 const delayCucumberWorkerMessagesMs = Number(process.env.DD_TEST_DELAY_CUCUMBER_WORKER_MESSAGES_MS) || 0
+const dropEfdRetryCountMessages = process.env.DD_TEST_DROP_CUCUMBER_EFD_RETRY_COUNT_MESSAGES === '1'
 
+/**
+ * @param {unknown} message
+ */
 function isDdTraceWorkerTraceMessage (message) {
   return Array.isArray(message) && message[0] === CUCUMBER_WORKER_TRACE_PAYLOAD_CODE
 }
 
-if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID && process.send) {
+if (
+  (delayCucumberWorkerMessagesMs > 0 || dropEfdRetryCountMessages) &&
+  process.env.CUCUMBER_WORKER_ID &&
+  process.send
+) {
   const originalProcessSend = process.send
 
+  /**
+   * @param {...unknown} args
+   */
   process.send = function (...args) {
     const [message] = args
 
-    if (isDdTraceWorkerTraceMessage(message)) {
+    if (dropEfdRetryCountMessages && message?._ddEfdRetryCount) {
+      return true
+    }
+    if (delayCucumberWorkerMessagesMs === 0 || isDdTraceWorkerTraceMessage(message)) {
       return originalProcessSend.apply(process, args)
     }
 
@@ -25,17 +39,26 @@ if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID && proce
   }
 }
 
-if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID) {
+if (
+  (delayCucumberWorkerMessagesMs > 0 || dropEfdRetryCountMessages) &&
+  process.env.CUCUMBER_WORKER_ID
+) {
   try {
     const { isMainThread, parentPort } = require('node:worker_threads')
 
     if (!isMainThread && parentPort) {
       const originalPostMessage = parentPort.postMessage
 
+      /**
+       * @param {...unknown} args
+       */
       parentPort.postMessage = function (...args) {
         const [message] = args
 
-        if (isDdTraceWorkerTraceMessage(message)) {
+        if (dropEfdRetryCountMessages && message?._ddEfdRetryCount) {
+          return
+        }
+        if (delayCucumberWorkerMessagesMs === 0 || isDdTraceWorkerTraceMessage(message)) {
           return originalPostMessage.apply(parentPort, args)
         }
 

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -1944,6 +1944,56 @@ describe(`cucumber@${version} commonJS`, () => {
             await eventsPromise
           })
 
+          onlyLatestIt('preserves an all-zero EFD framework retry budget without a worker count', async () => {
+            const testSuitePath = 'ci-visibility/features/farewell.feature'
+            receiver.setSettings({
+              early_flake_detection: {
+                enabled: true,
+                slow_test_retries: {
+                  '10s': 0,
+                },
+              },
+              known_tests_enabled: true,
+            })
+            receiver.setKnownTests({
+              cucumber: {},
+            })
+
+            childProcess = exec(
+              `./node_modules/.bin/cucumber-js ${testSuitePath} --parallel 2 ` +
+                `--require-module "${path.join(cwd, 'ci-visibility/cucumber-worker-message-delay.js')}"`,
+              {
+                cwd,
+                env: {
+                  ...envVars,
+                  DD_TEST_DROP_CUCUMBER_EFD_RETRY_COUNT_MESSAGES: '1',
+                },
+              }
+            )
+
+            await receiver.gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const tests = events
+                  .filter(event => event.type === 'test')
+                  .map(event => event.content)
+                  .filter(test => test.meta[TEST_SUITE] === testSuitePath)
+                const testSuites = events
+                  .filter(event => event.type === 'test_suite_end')
+                  .map(event => event.content)
+                  .filter(testSuite => testSuite.meta[TEST_SUITE] === testSuitePath)
+
+                assert.strictEqual(tests.length, 2)
+                assert.strictEqual(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 0)
+                assert.strictEqual(testSuites.length, 1)
+              },
+              { hardTimeout: 60_000 }
+            )
+            assert.strictEqual(childProcess.exitCode, 0)
+          })
+
           onlyLatestIt('bails out of EFD if the percentage of new tests is too high', (done) => {
             const NUM_RETRIES_EFD = 3
             receiver.setSettings({

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -180,7 +180,7 @@ function getSuiteStatusFromTestStatuses (testStatuses) {
 
 function getConfiguredEfdRetryCount () {
   const maxSlowTestRetryCount = getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries)
-  return maxSlowTestRetryCount || earlyFlakeDetectionNumRetries
+  return maxSlowTestRetryCount ?? earlyFlakeDetectionNumRetries
 }
 
 function publishWorkerEfdRetryCount (pickle, retryCount) {

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -49,7 +49,7 @@ function parseLibraryConfigurationResponse (rawJson, config = getConfig(), optio
     requireGit,
     isEarlyFlakeDetectionEnabled: isKnownTestsEnabled && (earlyFlakeDetectionConfig?.enabled ?? false),
     earlyFlakeDetectionNumRetries:
-      earlyFlakeDetectionConfig?.slow_test_retries?.['5s'] || DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
+      earlyFlakeDetectionConfig?.slow_test_retries?.['5s'] ?? DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
     earlyFlakeDetectionSlowTestRetries:
       earlyFlakeDetectionConfig?.slow_test_retries ?? DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES,
     earlyFlakeDetectionFaultyThreshold:

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1469,12 +1469,17 @@ function getEfdRetryCount (durationMs, slowTestRetries) {
 /**
  * Returns the maximum retry count configured by the backend for EFD.
  *
- * @param {Record<string, number>} slowTestRetries e.g. { '5s': 10, '10s': 5, '30s': 3, '5m': 2 }
- * @returns {number}
+ * @param {Record<string, number> | undefined} slowTestRetries
+ * @returns {number | undefined}
  */
 function getMaxEfdRetryCount (slowTestRetries) {
+  if (slowTestRetries === undefined) return
+
+  const retryCounts = Object.values(slowTestRetries)
+  if (retryCounts.length === 0) return
+
   let maxRetries = 0
-  for (const retryCount of Object.values(slowTestRetries || {})) {
+  for (const retryCount of retryCounts) {
     if (retryCount > maxRetries) {
       maxRetries = retryCount
     }

--- a/packages/dd-trace/test/ci-visibility/requests/get-library-configuration.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/get-library-configuration.spec.js
@@ -92,6 +92,25 @@ describe('get-library-configuration', () => {
       assert.strictEqual(settings.isEarlyFlakeDetectionEnabled, false)
     })
 
+    it('defaults missing EFD retry budgets without replacing an explicit zero', () => {
+      const missingRetryBudget = parseLibraryConfigurationResponse({
+        early_flake_detection: {
+          enabled: true,
+        },
+      })
+      const zeroRetryBudget = parseLibraryConfigurationResponse({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': 0,
+          },
+        },
+      })
+
+      assert.strictEqual(missingRetryBudget.earlyFlakeDetectionNumRetries, 2)
+      assert.strictEqual(zeroRetryBudget.earlyFlakeDetectionNumRetries, 0)
+    })
+
     it('validates complete cached settings attributes', () => {
       const apiSettings = parseLibraryConfigurationResponse(JSON.stringify({
         data: {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -1284,13 +1284,14 @@ describe('getMaxEfdRetryCount', () => {
     assert.strictEqual(getMaxEfdRetryCount({ '5s': 10, '10s': 5, '30s': 3, '5m': 2 }), 10)
   })
 
-  it('preserves an explicit all-zero configuration', () => {
+  it('preserves an explicit all-zero configuration and selects a nonzero sibling', () => {
     assert.strictEqual(getMaxEfdRetryCount({ '5s': 0, '10s': 0 }), 0)
+    assert.strictEqual(getMaxEfdRetryCount({ '5s': 0, '10s': 3 }), 3)
   })
 
-  it('returns 0 when no slow test retry buckets are configured', () => {
-    assert.strictEqual(getMaxEfdRetryCount({}), 0)
-    assert.strictEqual(getMaxEfdRetryCount(undefined), 0)
+  it('returns undefined when no slow test retry buckets are configured', () => {
+    assert.strictEqual(getMaxEfdRetryCount({}), undefined)
+    assert.strictEqual(getMaxEfdRetryCount(undefined), undefined)
   })
 })
 


### PR DESCRIPTION
## Summary
Falsy fallback logic replaced explicit zero EFD retry budgets with defaults, scheduling retries the backend disabled.

## Test plan
- [x] Run settings-parser and retry-budget unit specs
- [x] Run the Cucumber parallel regression through agentless and EVP proxy modes
- [x] Check changed-line and branch coverage