### PR TITLE
fix(vitest): prevent negative test durations

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -472,3 +472,13 @@ jobs:
       - uses: ./.github/actions/coverage
         with:
           flags: test-optimization-vitest-${{ matrix.version }}
+
+  vitest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: vitest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/plugins/test

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -264,8 +264,10 @@ class VitestPlugin extends CiPlugin {
         span.setTag(TEST_EARLY_FLAKE_ABORT_REASON, earlyFlakeAbortReason)
       }
       const finish = () => {
-        if (duration) {
-          span.finish(span._startTime + duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION) // milliseconds
+        if (Number.isFinite(duration) && duration >= 0) {
+          span.finish(
+            span._startTime + Math.max(duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION, 0)
+          ) // milliseconds
         } else {
           span.finish() // `duration` is empty for retries, so we'll use clock time
         }

--- a/packages/datadog-plugin-vitest/test/index.spec.js
+++ b/packages/datadog-plugin-vitest/test/index.spec.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { channel } = require('dc-polyfill')
+const sinon = require('sinon')
+
+const VitestPlugin = require('../src')
+
+const testErrorCh = channel('ci:vitest:test:error')
+
+describe('VitestPlugin', () => {
+  let plugin
+
+  before(() => {
+    plugin = new VitestPlugin({}, {})
+    plugin.configure({ enabled: true }, false)
+  })
+
+  after(() => {
+    plugin.configure(false, false)
+  })
+
+  for (const [duration, adjustedDuration] of [
+    [0, 0],
+    [1, 0],
+    [4, 0],
+    [5, 0],
+    [100, 95],
+  ]) {
+    it(`finishes failed tests with a non-negative duration for ${duration} ms`, () => {
+      const span = createSpan()
+
+      testErrorCh.publish({ duration, span })
+
+      assert.deepStrictEqual(span.finish.args, [[span._startTime + adjustedDuration]])
+    })
+  }
+
+  for (const duration of [-1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    it(`uses clock time for invalid duration ${duration}`, () => {
+      const span = createSpan()
+
+      testErrorCh.publish({ duration, span })
+
+      assert.deepStrictEqual(span.finish.args, [[]])
+    })
+  }
+})
+
+function createSpan () {
+  const spanContext = {
+    _trace: {
+      started: [],
+    },
+    getTags: () => ({}),
+  }
+  const span = {
+    _startTime: 100,
+    context: () => spanContext,
+    finish: sinon.spy(),
+    setTag: sinon.spy(),
+  }
+  spanContext._trace.started.push(span)
+  return span
+}


### PR DESCRIPTION
## Summary
Failed Vitest tests shorter than five milliseconds finished before their start time because the overlap adjustment was not bounded.

## Test plan
- [x] Run exact 0, 1, 4, and 5 ms duration boundaries plus invalid inputs
- [x] Verify the plugin spec is exercised by CI
- [x] Check changed-line and branch coverage