### PR TITLE
feat(graphql): add field schema coordinates

### DIFF
--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -314,6 +314,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
       type: 'graphql',
       startTime,
       meta: {
+        'graphql.field.coordinates': `${field.parentTypeName}.${fieldName}`,
         'graphql.field.name': fieldName,
         'graphql.field.path': collapsedKey,
         'graphql.field.type': baseTypeName,
@@ -438,6 +439,7 @@ function wrapResolve (resolve) {
       field = {
         fieldNode: info.fieldNodes?.[0],
         fieldName: info.fieldName,
+        parentTypeName: info.parentType.name,
         returnType: info.returnType,
         baseTypeName: getBaseTypeName(info.returnType),
         variableValues: info.variableValues,

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -435,8 +435,8 @@ function wrapResolve (resolve) {
     const parentTypeName = info.parentType.name
     let field = rootCtx.fields.get(fieldKey)
     const collapsedField = field
-    if (config.collapse && field?.parentTypeName !== parentTypeName) {
-      const parentTypeFields = field?.parentTypeFields
+    if (config.collapse && field !== undefined && field.parentTypeName !== parentTypeName) {
+      const parentTypeFields = field.parentTypeFields
       if (parentTypeFields?.parentTypeName === undefined) {
         field = parentTypeFields?.get(parentTypeName)
       } else if (parentTypeFields.parentTypeName === parentTypeName) {
@@ -639,6 +639,9 @@ function buildCachedPathString (path, cache, collapse) {
  * @param {object} field
  */
 function cacheFieldByPath (rootCtx, path, field) {
+  // Leaf fields cannot parent resolver spans, so their concrete paths are never read.
+  if (field.fieldNode?.selectionSet === undefined) return
+
   // Concrete info path objects cannot collide with collapsed path string keys.
   rootCtx.hasFieldsByPath = true
   rootCtx.fields.set(path, field)

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -432,14 +432,19 @@ function wrapResolve (resolve) {
     }
 
     const fieldKey = config.collapse ? pathString : infoPath
+    const parentTypeName = info.parentType.name
     let field = rootCtx.fields.get(fieldKey)
+    const collapsedField = field
+    if (config.collapse && field?.parentTypeName !== parentTypeName) {
+      field = field?.fieldsByParentType?.get(parentTypeName)
+    }
     const isFirst = !field
 
     if (isFirst) {
       field = {
         fieldNode: info.fieldNodes?.[0],
         fieldName: info.fieldName,
-        parentTypeName: info.parentType.name,
+        parentTypeName,
         returnType: info.returnType,
         baseTypeName: getBaseTypeName(info.returnType),
         variableValues: info.variableValues,
@@ -453,7 +458,18 @@ function wrapResolve (resolve) {
         parentStore: null,
         currentStore: null,
       }
-      rootCtx.fields.set(fieldKey, field)
+      if (config.collapse && collapsedField) {
+        if (collapsedField.fieldsByParentType) {
+          collapsedField.fieldsByParentType.set(parentTypeName, field)
+        } else {
+          collapsedField.fieldsByParentType = new Map([
+            [collapsedField.parentTypeName, collapsedField],
+            [parentTypeName, field],
+          ])
+        }
+      } else {
+        rootCtx.fields.set(fieldKey, field)
+      }
     }
 
     // Collapsed siblings still publish updateField (master's contract: one
@@ -624,7 +640,7 @@ function getParentField (rootCtx, field) {
   for (let curr = field.infoPath?.prev; curr; curr = curr.prev) {
     const fieldKey = rootCtx.config.collapse ? rootCtx.pathCache.get(curr) : curr
     const innerField = rootCtx.fields.get(fieldKey)
-    if (innerField) return innerField
+    if (innerField) return innerField.fieldsByParentType?.get(curr.typename) ?? innerField
   }
 
   return null

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -436,7 +436,14 @@ function wrapResolve (resolve) {
     let field = rootCtx.fields.get(fieldKey)
     const collapsedField = field
     if (config.collapse && field?.parentTypeName !== parentTypeName) {
-      field = field?.fieldsByParentType?.get(parentTypeName)
+      const parentTypeFields = field?.parentTypeFields
+      if (parentTypeFields?.parentTypeName === undefined) {
+        field = parentTypeFields?.get(parentTypeName)
+      } else if (parentTypeFields.parentTypeName === parentTypeName) {
+        field = parentTypeFields
+      } else {
+        field = undefined
+      }
     }
     const isFirst = !field
 
@@ -459,13 +466,17 @@ function wrapResolve (resolve) {
         currentStore: null,
       }
       if (config.collapse && collapsedField) {
-        if (collapsedField.fieldsByParentType) {
-          collapsedField.fieldsByParentType.set(parentTypeName, field)
+        const parentTypeFields = collapsedField.parentTypeFields
+        if (parentTypeFields === undefined) {
+          collapsedField.parentTypeFields = field
+        } else if (parentTypeFields.parentTypeName === undefined) {
+          parentTypeFields.set(parentTypeName, field)
         } else {
-          collapsedField.fieldsByParentType = new Map([
-            [collapsedField.parentTypeName, collapsedField],
-            [parentTypeName, field],
-          ])
+          const fieldsByParentType = new Map()
+            .set(collapsedField.parentTypeName, collapsedField)
+            .set(parentTypeFields.parentTypeName, parentTypeFields)
+            .set(parentTypeName, field)
+          collapsedField.parentTypeFields = fieldsByParentType
         }
       } else {
         rootCtx.fields.set(fieldKey, field)
@@ -640,7 +651,13 @@ function getParentField (rootCtx, field) {
   for (let curr = field.infoPath?.prev; curr; curr = curr.prev) {
     const fieldKey = rootCtx.config.collapse ? rootCtx.pathCache.get(curr) : curr
     const innerField = rootCtx.fields.get(fieldKey)
-    if (innerField) return innerField.fieldsByParentType?.get(curr.typename) ?? innerField
+    if (innerField) {
+      if (curr.typename === undefined || innerField.parentTypeName === curr.typename) return innerField
+
+      const parentTypeFields = innerField.parentTypeFields
+      if (parentTypeFields.parentTypeName === undefined) return parentTypeFields.get(curr.typename)
+      return parentTypeFields
+    }
   }
 
   return null

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -444,6 +444,9 @@ function wrapResolve (resolve) {
       } else {
         field = undefined
       }
+      if (field && infoPath.typename === undefined) {
+        cacheFieldByPath(rootCtx, infoPath, field)
+      }
     }
     const isFirst = !field
 
@@ -477,6 +480,9 @@ function wrapResolve (resolve) {
             .set(parentTypeFields.parentTypeName, parentTypeFields)
             .set(parentTypeName, field)
           collapsedField.parentTypeFields = fieldsByParentType
+        }
+        if (infoPath.typename === undefined) {
+          cacheFieldByPath(rootCtx, infoPath, field)
         }
       } else {
         rootCtx.fields.set(fieldKey, field)
@@ -627,6 +633,17 @@ function buildCachedPathString (path, cache, collapse) {
   return pathString
 }
 
+/**
+ * @param {{ hasFieldsByPath?: boolean, fields: Map<string|object, object> }} rootCtx
+ * @param {object} path
+ * @param {object} field
+ */
+function cacheFieldByPath (rootCtx, path, field) {
+  // Concrete info path objects cannot collide with collapsed path string keys.
+  rootCtx.hasFieldsByPath = true
+  rootCtx.fields.set(path, field)
+}
+
 // Depth filtering directly on the linked-list node — no array allocation needed.
 // config.depth < 0 means no limit. Only selection-set segments (string keys)
 // count toward depth; list indices are execution artifacts and are transparent.
@@ -652,7 +669,14 @@ function getParentField (rootCtx, field) {
     const fieldKey = rootCtx.config.collapse ? rootCtx.pathCache.get(curr) : curr
     const innerField = rootCtx.fields.get(fieldKey)
     if (innerField) {
-      if (curr.typename === undefined || innerField.parentTypeName === curr.typename) return innerField
+      if (curr.typename === undefined) {
+        if (rootCtx.hasFieldsByPath) {
+          const fieldByPath = rootCtx.fields.get(curr)
+          if (fieldByPath) return fieldByPath
+        }
+        return innerField
+      }
+      if (innerField.parentTypeName === curr.typename) return innerField
 
       const parentTypeFields = innerField.parentTypeFields
       if (parentTypeFields.parentTypeName === undefined) return parentTypeFields.get(curr.typename)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1207,16 +1207,14 @@ describe('Plugin', () => {
               'RobotProfile.value',
             ])
 
-            if (semver.satisfies(graphqlVersion, '>=15.0.0')) {
-              const spans = sort(traces[0])
-              for (const name of names) {
-                const profile = spans.find(span => span.meta['graphql.field.coordinates'] === `${name}.profile`)
-                const value = spans.find(span =>
-                  span.meta['graphql.field.coordinates'] === `${name}Profile.value`)
-                assert.ok(profile, `expected ${name}.profile span`)
-                assert.ok(value, `expected ${name}Profile.value span`)
-                assert.strictEqual(value.parent_id.toString(), profile.span_id.toString())
-              }
+            const spans = sort(traces[0])
+            for (const name of names) {
+              const profile = spans.find(span => span.meta['graphql.field.coordinates'] === `${name}.profile`)
+              const value = spans.find(span =>
+                span.meta['graphql.field.coordinates'] === `${name}Profile.value`)
+              assert.ok(profile, `expected ${name}.profile span`)
+              assert.ok(value, `expected ${name}Profile.value span`)
+              assert.strictEqual(value.parent_id.toString(), profile.span_id.toString())
             }
           }
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1030,6 +1030,7 @@ describe('Plugin', () => {
               name: 'graphql.resolve',
               resource: 'friends:[Human]',
               meta: {
+                'graphql.field.coordinates': 'RootQueryType.friends',
                 'graphql.field.path': 'friends',
                 'graphql.field.type': 'Human',
               },
@@ -1040,6 +1041,7 @@ describe('Plugin', () => {
               name: 'graphql.resolve',
               resource: 'name:String',
               meta: {
+                'graphql.field.coordinates': 'Human.name',
                 'graphql.field.path': 'friends.*.name',
                 'graphql.field.type': 'String',
               },
@@ -1050,6 +1052,7 @@ describe('Plugin', () => {
               name: 'graphql.resolve',
               resource: 'pets:[Pet!]',
               meta: {
+                'graphql.field.coordinates': 'Human.pets',
                 'graphql.field.path': 'friends.*.pets',
                 'graphql.field.type': 'Pet',
               },
@@ -1060,6 +1063,7 @@ describe('Plugin', () => {
               name: 'graphql.resolve',
               resource: 'name:String',
               meta: {
+                'graphql.field.coordinates': 'Pet.name',
                 'graphql.field.path': 'friends.*.pets.*.name',
                 'graphql.field.type': 'String',
               },

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1161,6 +1161,16 @@ describe('Plugin', () => {
                       profile: { __typename: 'AlienProfile', value: 'visitor' },
                     },
                     {
+                      __typename: 'Pet',
+                      name: 'rex',
+                      profile: { __typename: 'PetProfile', value: 'animal' },
+                    },
+                    {
+                      __typename: 'Robot',
+                      name: 'c3po',
+                      profile: { __typename: 'RobotProfile', value: 'machine' },
+                    },
+                    {
                       __typename: 'Human',
                       name: 'bob',
                       profile: { __typename: 'HumanProfile', value: 'person' },

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1125,7 +1125,7 @@ describe('Plugin', () => {
             })
           }
 
-          const names = ['Human', 'Pet', 'Robot']
+          const names = ['Human', 'Pet', 'Robot', 'Alien']
           const namedTypes = names.map(makeNamedType)
           const profileTypes = names.map(makeProfileType)
           const abstractSchema = new graphql.GraphQLSchema({
@@ -1146,9 +1146,19 @@ describe('Plugin', () => {
                       profile: { __typename: 'PetProfile', value: 'animal' },
                     },
                     {
+                      __typename: 'Pet',
+                      name: 'fido',
+                      profile: { __typename: 'PetProfile', value: 'animal' },
+                    },
+                    {
                       __typename: 'Robot',
                       name: 'r2d2',
                       profile: { __typename: 'RobotProfile', value: 'machine' },
+                    },
+                    {
+                      __typename: 'Alien',
+                      name: 'et',
+                      profile: { __typename: 'AlienProfile', value: 'visitor' },
                     },
                     {
                       __typename: 'Human',
@@ -1179,20 +1189,35 @@ describe('Plugin', () => {
             }
 
             assert.deepStrictEqual(coordinatesByPath['results.*.name'].sort(), [
+              'Alien.name',
               'Human.name',
               'Pet.name',
               'Robot.name',
             ])
             assert.deepStrictEqual(coordinatesByPath['results.*.profile'].sort(), [
+              'Alien.profile',
               'Human.profile',
               'Pet.profile',
               'Robot.profile',
             ])
             assert.deepStrictEqual(coordinatesByPath['results.*.profile.value'].sort(), [
+              'AlienProfile.value',
               'HumanProfile.value',
               'PetProfile.value',
               'RobotProfile.value',
             ])
+
+            if (semver.satisfies(graphqlVersion, '>=15.0.0')) {
+              const spans = sort(traces[0])
+              for (const name of names) {
+                const profile = spans.find(span => span.meta['graphql.field.coordinates'] === `${name}.profile`)
+                const value = spans.find(span =>
+                  span.meta['graphql.field.coordinates'] === `${name}Profile.value`)
+                assert.ok(profile, `expected ${name}.profile span`)
+                assert.ok(value, `expected ${name}Profile.value span`)
+                assert.strictEqual(value.parent_id.toString(), profile.span_id.toString())
+              }
+            }
           }
 
           const assertion = agent.assertSomeTraces(assertCoordinates, { spanResourceMatch: /results:\[Named\]/ })

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1074,6 +1074,134 @@ describe('Plugin', () => {
           return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
+        it('keeps collapsed abstract list fields distinct by schema coordinate', () => {
+          /**
+           * @param {{ __typename: string }} value
+           */
+          function resolveType (value) {
+            return value.__typename
+          }
+
+          const Profile = new graphql.GraphQLInterfaceType({
+            name: 'Profile',
+            fields: {
+              value: { type: graphql.GraphQLString },
+            },
+            resolveType,
+          })
+          const Named = new graphql.GraphQLInterfaceType({
+            name: 'Named',
+            fields: {
+              name: { type: graphql.GraphQLString },
+              profile: { type: Profile },
+            },
+            resolveType,
+          })
+
+          /**
+           * @param {string} name
+           */
+          function makeProfileType (name) {
+            return new graphql.GraphQLObjectType({
+              name: `${name}Profile`,
+              interfaces: [Profile],
+              fields: {
+                value: { type: graphql.GraphQLString },
+              },
+            })
+          }
+
+          /**
+           * @param {string} name
+           */
+          function makeNamedType (name) {
+            return new graphql.GraphQLObjectType({
+              name,
+              interfaces: [Named],
+              fields: {
+                name: { type: graphql.GraphQLString },
+                profile: { type: Profile },
+              },
+            })
+          }
+
+          const names = ['Human', 'Pet', 'Robot']
+          const namedTypes = names.map(makeNamedType)
+          const profileTypes = names.map(makeProfileType)
+          const abstractSchema = new graphql.GraphQLSchema({
+            query: new graphql.GraphQLObjectType({
+              name: 'Query',
+              fields: {
+                results: {
+                  type: new graphql.GraphQLList(Named),
+                  resolve: () => [
+                    {
+                      __typename: 'Human',
+                      name: 'alice',
+                      profile: { __typename: 'HumanProfile', value: 'person' },
+                    },
+                    {
+                      __typename: 'Pet',
+                      name: 'spot',
+                      profile: { __typename: 'PetProfile', value: 'animal' },
+                    },
+                    {
+                      __typename: 'Robot',
+                      name: 'r2d2',
+                      profile: { __typename: 'RobotProfile', value: 'machine' },
+                    },
+                    {
+                      __typename: 'Human',
+                      name: 'bob',
+                      profile: { __typename: 'HumanProfile', value: 'person' },
+                    },
+                  ],
+                },
+              },
+            }),
+            types: [...namedTypes, ...profileTypes],
+          })
+
+          /**
+           * @param {Array<Array<{ name: string, meta: Record<string, string> }>>} traces
+           */
+          function assertCoordinates (traces) {
+            const coordinatesByPath = {
+              'results.*.name': [],
+              'results.*.profile': [],
+              'results.*.profile.value': [],
+            }
+            for (const span of sort(traces[0])) {
+              const coordinates = coordinatesByPath[span.meta['graphql.field.path']]
+              if (span.name === 'graphql.resolve' && coordinates) {
+                coordinates.push(span.meta['graphql.field.coordinates'])
+              }
+            }
+
+            assert.deepStrictEqual(coordinatesByPath['results.*.name'].sort(), [
+              'Human.name',
+              'Pet.name',
+              'Robot.name',
+            ])
+            assert.deepStrictEqual(coordinatesByPath['results.*.profile'].sort(), [
+              'Human.profile',
+              'Pet.profile',
+              'Robot.profile',
+            ])
+            assert.deepStrictEqual(coordinatesByPath['results.*.profile.value'].sort(), [
+              'HumanProfile.value',
+              'PetProfile.value',
+              'RobotProfile.value',
+            ])
+          }
+
+          const assertion = agent.assertSomeTraces(assertCoordinates, { spanResourceMatch: /results:\[Named\]/ })
+          return Promise.all([
+            assertion,
+            graphql.graphql({ schema: abstractSchema, source: '{ results { name profile { value } } }' }),
+          ])
+        })
+
         it('caches path strings across nested list-of-lists items', async () => {
           // `[[Cell]]` puts two synthetic array-index nodes back-to-back; the
           // `friends { pets { name } }` sibling has a `pets` field between.


### PR DESCRIPTION
Resolver spans with the same field name and return type could not be distinguished across parent types. The schema coordinate makes `Human.name` and `Pet.name` independently queryable without changing existing resource names.

Fixes: https://github.com/DataDog/dd-trace-js/issues/2398
Refs: https://spec.graphql.org/draft/#sec-Schema-Coordinates
