### PR TITLE
fix(test-optimization): clear policies after settings failure

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -47,6 +47,7 @@ const DEFAULT_TEST_MANAGEMENT_TESTS_RESPONSE_STATUS = 200
 class FakeCiVisIntake extends FakeAgent {
   #settings = DEFAULT_SETTINGS
   #settingsResponseStatusCode = 200
+  #settingsResponseStatusCodes = []
   #mediaResponseStatusCode = 201
   #suitesToSkip = DEFAULT_SUITES_TO_SKIP
   #skippableCoverage = DEFAULT_SKIPPABLE_COVERAGE
@@ -103,6 +104,13 @@ class FakeCiVisIntake extends FakeAgent {
 
   setSettingsResponseCode (statusCode) {
     this.#settingsResponseStatusCode = statusCode
+  }
+
+  /**
+   * @param {number[]} statusCodes
+   */
+  setSettingsResponseStatusCodes (statusCodes) {
+    this.#settingsResponseStatusCodes = statusCodes.slice()
   }
 
   // Lets a test simulate the media endpoint failing (e.g. 500) to verify the
@@ -253,8 +261,10 @@ class FakeCiVisIntake extends FakeAgent {
       '/api/v2/libraries/tests/services/setting',
       '/evp_proxy/:version/api/v2/libraries/tests/services/setting',
     ], (req, res) => {
-      res.status(this.#settingsResponseStatusCode)
-      if (this.#settingsResponseStatusCode >= 200 && this.#settingsResponseStatusCode < 300) {
+      const settingsResponseStatusCode = this.#settingsResponseStatusCodes.shift() ??
+        this.#settingsResponseStatusCode
+      res.status(settingsResponseStatusCode)
+      if (settingsResponseStatusCode >= 200 && settingsResponseStatusCode < 300) {
         res.send(JSON.stringify({
           data: {
             attributes: this.#settings,
@@ -389,6 +399,7 @@ class FakeCiVisIntake extends FakeAgent {
   stop () {
     this.#settings = DEFAULT_SETTINGS
     this.#settingsResponseStatusCode = 200
+    this.#settingsResponseStatusCodes = []
     this.#suitesToSkip = DEFAULT_SUITES_TO_SKIP
     this.#skippableCoverage = DEFAULT_SKIPPABLE_COVERAGE
     this.#gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -47,6 +47,7 @@ const {
   TEST_FINAL_STATUS,
   GIT_COMMIT_SHA,
   GIT_REPOSITORY_URL,
+  ITR_CORRELATION_ID,
   TEST_PARAMETERS,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { TELEMETRY_COVERAGE_UPLOAD } = require('../../packages/dd-trace/src/ci-visibility/telemetry')
@@ -189,7 +190,9 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     })
 
     it('clears test optimization policies when a later settings request fails', async () => {
+      const itrCorrelationId = '4321'
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+      receiver.setItrCorrelationId(itrCorrelationId)
       receiver.setKnownTests({
         jest: {
           'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests'],
@@ -201,29 +204,42 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           enabled: true,
         },
         flaky_test_retries_enabled: true,
+        itr_enabled: true,
         known_tests_enabled: true,
         test_management: {
           enabled: true,
           attempt_to_fix_retries: 2,
         },
+        tests_skipping: true,
       })
       receiver.setSettingsResponseStatusCodes([200, 404])
 
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
-          const testSessions = events
-            .filter(event => event.type === 'test_session_end')
-            .map(event => event.content)
+          const testSessions = []
+          const testSuites = []
+          for (const event of events) {
+            if (event.type === 'test_session_end') {
+              testSessions.push(event.content)
+            } else if (event.type === 'test_suite_end') {
+              testSuites.push(event.content)
+            }
+          }
           const [firstSession, secondSession] = testSessions
+          const [firstSuite, secondSuite] = testSuites
 
           assert.ok(firstSession, inspect(testSessions))
           assert.ok(secondSession, inspect(testSessions))
+          assert.ok(firstSuite, inspect(testSuites))
+          assert.ok(secondSuite, inspect(testSuites))
           assert.strictEqual(firstSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
           assert.strictEqual(firstSession.meta[TEST_MANAGEMENT_ENABLED], 'true')
+          assert.strictEqual(firstSuite[ITR_CORRELATION_ID], itrCorrelationId)
           assert.ok(!(TEST_EARLY_FLAKE_ENABLED in secondSession.meta), inspect(secondSession.meta))
           assert.ok(!(TEST_EARLY_FLAKE_ABORT_REASON in secondSession.meta), inspect(secondSession.meta))
           assert.ok(!(TEST_MANAGEMENT_ENABLED in secondSession.meta), inspect(secondSession.meta))
+          assert.ok(!(ITR_CORRELATION_ID in secondSuite), inspect(secondSuite))
         })
 
       childProcess = exec(

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -23,6 +23,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_NAME,
   TEST_RETRY_REASON,
   TEST_SESSION_NAME,
@@ -173,6 +174,65 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           cwd,
           env: {
             ...getCiVisEvpProxyConfig(receiver.port),
+            DD_ENABLE_LAGE_PACKAGE_NAME: 'true',
+            LAGE_PACKAGE_NAME: 'my-initial-lage-package',
+          },
+        }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(exitCode, 0)
+    })
+
+    it('clears test optimization policies when a later settings request fails', async () => {
+      receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+      receiver.setKnownTests({
+        jest: {
+          'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests'],
+          'ci-visibility/test/ci-visibility-test-2.js': ['ci visibility 2 can report tests 2'],
+        },
+      })
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+        },
+        flaky_test_retries_enabled: true,
+        known_tests_enabled: true,
+        test_management: {
+          enabled: true,
+          attempt_to_fix_retries: 2,
+        },
+      })
+      receiver.setSettingsResponseStatusCodes([200, 404])
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSessions = events
+            .filter(event => event.type === 'test_session_end')
+            .map(event => event.content)
+          const [firstSession, secondSession] = testSessions
+
+          assert.ok(firstSession, inspect(testSessions))
+          assert.ok(secondSession, inspect(testSessions))
+          assert.strictEqual(firstSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+          assert.strictEqual(firstSession.meta[TEST_MANAGEMENT_ENABLED], 'true')
+          assert.ok(!(TEST_EARLY_FLAKE_ENABLED in secondSession.meta), inspect(secondSession.meta))
+          assert.ok(!(TEST_EARLY_FLAKE_ABORT_REASON in secondSession.meta), inspect(secondSession.meta))
+          assert.ok(!(TEST_MANAGEMENT_ENABLED in secondSession.meta), inspect(secondSession.meta))
+        })
+
+      childProcess = exec(
+        'node ./ci-visibility/run-jest-lage-multi.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisEvpProxyConfig(receiver.port),
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '2',
             DD_ENABLE_LAGE_PACKAGE_NAME: 'true',
             LAGE_PACKAGE_NAME: 'my-initial-lage-package',
           },

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -1858,6 +1858,26 @@ function resetSuiteSkippingRunState () {
   coverageBackfillFiles = undefined
 }
 
+function resetLibraryConfiguration () {
+  knownTests = {}
+  isCodeCoverageEnabled = false
+  isCoverageReportUploadEnabled = false
+  isItrEnabled = false
+  isSuitesSkippingEnabled = false
+  isEarlyFlakeDetectionEnabled = false
+  earlyFlakeDetectionNumRetries = 0
+  earlyFlakeDetectionSlowTestRetries = {}
+  earlyFlakeDetectionFaultyThreshold = 30
+  isEarlyFlakeDetectionFaulty = false
+  isKnownTestsEnabled = false
+  isTestManagementTestsEnabled = false
+  testManagementTests = {}
+  testManagementAttemptToFixRetries = 0
+  isImpactedTestsEnabled = false
+  modifiedFiles = {}
+  repositoryRoot = undefined
+}
+
 function applySuiteSkipping (originalTests, rootDir, frameworkVersion) {
   if (!isItrEnabled || !isSuitesSkippingEnabled) return originalTests
 
@@ -2205,11 +2225,13 @@ function getCliWrapper (isNewJestVersion) {
       resetSuiteSkippingRunState()
       hasFinishedTestSession = false
 
+      let shouldResetLibraryConfiguration = true
       try {
         const { err, libraryConfig } = await getChannelPromise(libraryConfigurationCh, {
           frameworkVersion: jestVersion,
         })
         if (!err) {
+          shouldResetLibraryConfiguration = false
           isCodeCoverageEnabled = libraryConfig.isCodeCoverageEnabled
           isCoverageReportUploadEnabled = libraryConfig.isCoverageReportUploadEnabled
           isItrEnabled = libraryConfig.isItrEnabled
@@ -2225,6 +2247,10 @@ function getCliWrapper (isNewJestVersion) {
         }
       } catch (err) {
         log.error('Jest library configuration error', err)
+      } finally {
+        if (shouldResetLibraryConfiguration) {
+          resetLibraryConfiguration()
+        }
       }
 
       const {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -182,6 +182,8 @@ module.exports = class CiPlugin extends Plugin {
       this.tracer._exporter.getLibraryConfiguration(this.testConfiguration, (err, libraryConfig) => {
         if (err) {
           this.libraryConfig = undefined
+          this.itrCorrelationId = undefined
+          this.skippableSuitesCoverage = undefined
           log.error('Library configuration could not be fetched. %s', err.message)
           this._addRequestErrorTag(DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS, err)
         } else {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -181,6 +181,7 @@ module.exports = class CiPlugin extends Plugin {
       }
       this.tracer._exporter.getLibraryConfiguration(this.testConfiguration, (err, libraryConfig) => {
         if (err) {
+          this.libraryConfig = undefined
           log.error('Library configuration could not be fetched. %s', err.message)
           this._addRequestErrorTag(DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS, err)
         } else {

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 
+const dc = require('dc-polyfill')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
@@ -91,6 +92,38 @@ describe('CiPlugin', () => {
     assert.strictEqual(plugin.shouldSkipGitMetadataExtraction, true)
     sinon.assert.calledOnce(getRepositoryRoot)
     sinon.assert.calledOnceWithExactly(getCodeOwnersFileEntries, '/repo-root')
+  })
+
+  it('clears ITR state when library configuration fails', () => {
+    const getLibraryConfiguration = sinon.stub().callsArgWith(1, new Error('settings failed'))
+    const addMetadataTags = sinon.stub()
+    const onDone = sinon.stub()
+    const plugin = createPlugin('jest_worker')
+    plugin.tracer._exporter = {
+      addMetadataTags,
+      getLibraryConfiguration,
+    }
+    plugin.libraryConfig = { isSuitesSkippingEnabled: true }
+    plugin.itrCorrelationId = 'correlation-id'
+    plugin.skippableSuitesCoverage = { 'suite.js': 'coverage' }
+    plugin.configure({
+      enabled: true,
+      experimental: {
+        exporter: 'jest_worker',
+      },
+    })
+
+    dc.channel('ci:vitest:library-configuration').publish({
+      frameworkVersion: '1.0.0',
+      onDone,
+    })
+    plugin.configure(false)
+
+    assert.strictEqual(plugin.libraryConfig, undefined)
+    assert.strictEqual(plugin.itrCorrelationId, undefined)
+    assert.strictEqual(plugin.skippableSuitesCoverage, undefined)
+    sinon.assert.calledOnce(getLibraryConfiguration)
+    sinon.assert.calledOnce(onDone)
   })
 
   it('starts the DI breakpoint-hit timeout when waiting, not when preparing', async () => {


### PR DESCRIPTION
## Summary
A failed settings response must leave Test Management, EFD, and ITR disabled.