### PR TITLE
fix(test-optimization): wait for all worker writers

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/index.js
@@ -102,14 +102,30 @@ class TestWorkerCiVisibilityExporter {
     this._logsWriter.append({ testEnvironmentMetadata, logMessage })
   }
 
-  // TODO: add to other writers
+  /**
+   * @param {() => void} [onDone]
+   */
   flush (onDone) {
-    this._writer.flush(onDone)
-    this._coverageWriter.flush()
-    this._logsWriter.flush()
-    if (this._telemetryWriter) {
-      this._telemetryWriter.flush()
+    if (!onDone) {
+      this._writer.flush()
+      this._coverageWriter.flush()
+      this._logsWriter.flush()
+      if (this._telemetryWriter) {
+        this._telemetryWriter.flush()
+      }
+      return
     }
+
+    let pendingWriters = this._telemetryWriter ? 4 : 3
+    const onWriterFlushed = () => {
+      pendingWriters--
+      if (pendingWriters === 0) onDone()
+    }
+
+    this._writer.flush(onWriterFlushed)
+    this._coverageWriter.flush(onWriterFlushed)
+    this._logsWriter.flush(onWriterFlushed)
+    this._telemetryWriter?.flush(onWriterFlushed)
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
@@ -15,6 +15,9 @@ class Writer {
     this._interprocessCode = interprocessCode
   }
 
+  /**
+   * @param {() => void} [onDone]
+   */
   flush (onDone) {
     const count = this._encoder.count()
 
@@ -22,6 +25,8 @@ class Writer {
       const payload = this._encoder.makePayload()
 
       this._sendPayload(payload, onDone)
+    } else {
+      onDone?.()
     }
   }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const assert = require('node:assert/strict')
+
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const context = describe
 const proxyquire = require('proxyquire')
@@ -62,6 +64,49 @@ describe('CI Visibility Test Worker Exporter', () => {
       )
     })
 
+    it('signals completion after all queued payloads flush', () => {
+      const callbacks = []
+      send = sinon.stub().callsFake((payload, callback) => {
+        callbacks.push(callback)
+      })
+      process.send = send
+      const jestWorkerExporter = new TestWorkerCiVisibilityExporter()
+      const onDone = sinon.spy()
+
+      jestWorkerExporter.export([{ type: 'test' }])
+      jestWorkerExporter.exportCoverage({ sessionId: '1', suiteId: '1', files: ['test.js'] })
+      jestWorkerExporter.exportDiLogs({ testSessionId: '1' }, { message: 'test log' })
+      jestWorkerExporter.exportTelemetry({ type: 'ciVisEvent', name: 'test_event' })
+      jestWorkerExporter.flush(onDone)
+
+      assert.strictEqual(callbacks.length, 4)
+      callbacks[0]()
+      sinon.assert.notCalled(onDone)
+      callbacks[1]()
+      sinon.assert.notCalled(onDone)
+      callbacks[2]()
+      sinon.assert.notCalled(onDone)
+      callbacks[3]()
+      sinon.assert.calledOnce(onDone)
+    })
+
+    it('signals completion when only coverage is queued', () => {
+      const callbacks = []
+      send = sinon.stub().callsFake((payload, callback) => {
+        callbacks.push(callback)
+      })
+      process.send = send
+      const jestWorkerExporter = new TestWorkerCiVisibilityExporter()
+      const onDone = sinon.spy()
+
+      jestWorkerExporter.exportCoverage({ sessionId: '1', suiteId: '1', files: ['test.js'] })
+      jestWorkerExporter.flush(onDone)
+
+      assert.strictEqual(callbacks.length, 1)
+      callbacks[0]()
+      sinon.assert.calledOnce(onDone)
+    })
+
     it('does not break if process.send is undefined', () => {
       delete process.send
       const trace = [{ type: 'test' }]
@@ -88,6 +133,23 @@ describe('CI Visibility Test Worker Exporter', () => {
       cucumberWorkerExporter.export(traceSecond)
       cucumberWorkerExporter.flush()
       sinon.assert.calledWith(send, [CUCUMBER_WORKER_TRACE_PAYLOAD_CODE, JSON.stringify([trace, traceSecond])])
+    })
+
+    it('signals completion after traces flush', () => {
+      const callbacks = []
+      send = sinon.stub().callsFake((payload, callback) => {
+        callbacks.push(callback)
+      })
+      process.send = send
+      const cucumberWorkerExporter = new TestWorkerCiVisibilityExporter()
+      const onDone = sinon.spy()
+
+      cucumberWorkerExporter.export([{ type: 'test' }])
+      cucumberWorkerExporter.flush(onDone)
+
+      assert.strictEqual(callbacks.length, 1)
+      callbacks[0]()
+      sinon.assert.calledOnce(onDone)
     })
 
     it('does not break if process.send is undefined', () => {


### PR DESCRIPTION
## Summary
The worker flush callback now waits for trace, coverage, log, and telemetry payloads to complete.