### PR TITLE
fix(express): preserve legacy middleware dispatch semantics

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/router-helper.js
+++ b/packages/datadog-instrumentations/src/helpers/router-helper.js
@@ -7,6 +7,17 @@ const routerMountPaths = new WeakMap() // to track mount paths for router instan
 const layerMeta = new WeakMap() // per-layer middleware dispatch metadata (resolved name + route matchers)
 const appMountedRouters = new WeakSet() // to track routers mounted via app.use()
 
+/**
+ * @typedef {object} LayerMeta
+ * @property {string} [name]
+ * @property {string} [captureRoute]
+ * @property {boolean} [needMultiMatch]
+ * @property {Array<{ path?: string, regex?: RegExp }> & {
+ *   hasStarPath?: boolean,
+ *   hasSlashPath?: boolean
+ * }} [matchers]
+ */
+
 const METHODS = [...require('http').METHODS.map(v => v.toLowerCase()), 'all']
 
 const routeAddedChannel = channel('apm:express:route:added')
@@ -121,10 +132,19 @@ function getRouterMountPaths (router) {
   return [...paths]
 }
 
+/**
+ * @param {object} layer
+ * @param {LayerMeta} meta
+ * @returns {void}
+ */
 function setLayerMeta (layer, meta) {
   layerMeta.set(layer, meta)
 }
 
+/**
+ * @param {object} layer
+ * @returns {LayerMeta | undefined}
+ */
 function getLayerMeta (layer) {
   return layerMeta.get(layer)
 }

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const METHODS = [...require('http').METHODS.map(v => v.toLowerCase()), 'all']
+const ROUTE_RESOLUTION_FAILED = Symbol('routeResolutionFailed')
 const shimmer = require('../../datadog-shimmer')
 const { addHook, channel, createErrorPublisher } = require('./helpers/instrument')
 const { getCompileToRegexp } = require('./path-to-regexp')
@@ -35,6 +36,7 @@ function isFastSlash (layer, matchers) {
  * @param {{ handle: Function, name?: string, path?: string,
  *   regexp?: { fast_star?: boolean, fast_slash?: boolean } }} layer
  * @param {Array<{ path?: string, regex?: RegExp }> & { hasStarPath?: boolean, hasSlashPath?: boolean }} matchers
+ * @returns {void}
  */
 function annotateLayer (layer, matchers) {
   const handle = layer.handle
@@ -72,6 +74,25 @@ function resolveLayerRoute (meta, layer) {
 }
 
 /**
+ * Preserve the host Layer's error boundary while resolving a route outside its
+ * dispatch method. This path runs only for multi-pattern layers.
+ *
+ * @param {{ captureRoute?: string, needMultiMatch: boolean,
+ *   matchers: Array<{ path?: string, regex?: RegExp }> }} meta
+ * @param {{ path?: string }} layer
+ * @param {Function} next
+ * @returns {string | undefined | typeof ROUTE_RESOLUTION_FAILED}
+ */
+function resolveLayerRouteOrForwardError (meta, layer, next) {
+  try {
+    return resolveLayerRoute(meta, layer)
+  } catch (error) {
+    next(error)
+    return ROUTE_RESOLUTION_FAILED
+  }
+}
+
+/**
  * Build the request/error dispatch wrappers for one host (`express` / `router`).
  * They wrap the layer's prototype dispatch and read the side-table metadata, so
  * `layer.handle` is never replaced. The arity guard mirrors the host's own
@@ -79,6 +100,11 @@ function resolveLayerRoute (meta, layer) {
  * span is published only for the layer the host actually runs.
  *
  * @param {string} name Channel namespace (`apm:<name>:middleware:*`).
+ * @returns {{
+ *   wrapLayerRequest: (originalRequest: Function) => Function,
+ *   wrapLayerError: (originalError: Function) => Function,
+ *   wrapLegacyHandle: (layer: object, original: Function, guardRepeatedNext?: boolean) => Function
+ * }}
  */
 function createLayerDispatchWrappers (name) {
   const enterChannel = channel(`apm:${name}:middleware:enter`)
@@ -128,6 +154,10 @@ function createLayerDispatchWrappers (name) {
   // `wrappedNext` through captures both without a tracer-side try/catch; only
   // `exit` needs the `finally`. express 4's native dispatch converts only the
   // synchronous throw — exactly what the pre-refactor handle wrap caught.
+  /**
+   * @param {Function} originalRequest
+   * @returns {Function}
+   */
   function wrapLayerRequest (originalRequest) {
     return function (req, res, next) {
       if (!enterChannel.hasSubscribers) return originalRequest.call(this, req, res, next)
@@ -135,8 +165,14 @@ function createLayerDispatchWrappers (name) {
       const meta = getLayerMeta(this)
       if (meta === undefined || this.handle.length > 3) return originalRequest.call(this, req, res, next)
 
+      let route = meta.captureRoute
+      if (meta.needMultiMatch) {
+        route = resolveLayerRouteOrForwardError(meta, this, next)
+        if (route === ROUTE_RESOLUTION_FAILED) return
+      }
+
       const wrappedNext = typeof next === 'function' ? wrapNext(req, meta.name, next) : next
-      enterChannel.publish({ name: meta.name, req, route: resolveLayerRoute(meta, this), layer: this })
+      enterChannel.publish({ name: meta.name, req, route, layer: this })
 
       try {
         return originalRequest.call(this, req, res, wrappedNext)
@@ -146,6 +182,10 @@ function createLayerDispatchWrappers (name) {
     }
   }
 
+  /**
+   * @param {Function} originalError
+   * @returns {Function}
+   */
   function wrapLayerError (originalError) {
     return function (error, req, res, next) {
       if (!enterChannel.hasSubscribers) return originalError.call(this, error, req, res, next)
@@ -153,8 +193,14 @@ function createLayerDispatchWrappers (name) {
       const meta = getLayerMeta(this)
       if (meta === undefined || this.handle.length !== 4) return originalError.call(this, error, req, res, next)
 
+      let route = meta.captureRoute
+      if (meta.needMultiMatch) {
+        route = resolveLayerRouteOrForwardError(meta, this, next)
+        if (route === ROUTE_RESOLUTION_FAILED) return
+      }
+
       const wrappedNext = typeof next === 'function' ? wrapNext(req, meta.name, next) : next
-      enterChannel.publish({ name: meta.name, req, route: resolveLayerRoute(meta, this), layer: this })
+      enterChannel.publish({ name: meta.name, req, route, layer: this })
 
       try {
         return originalError.call(this, error, req, res, wrappedNext)
@@ -164,36 +210,164 @@ function createLayerDispatchWrappers (name) {
     }
   }
 
-  // express <4.6.0 has no `Layer` prototype dispatch: the router invokes
-  // `layer.handle` directly and routes errors by its arity. There the handle is
-  // replaced in place, with the arity preserved so the host still routes
-  // correctly. Newer express, express 5, and the router package keep `handle`
-  // pristine and are traced through the prototype wraps above.
-  function wrapLegacyHandle (layer, original) {
+  // express <4.6.0 dispatches `layer.handle` directly, so its replacement must preserve arity.
+  // It cannot replay `next` for a rejected promise; only express-async-errors needs the repeated-next guard.
+  /**
+   * @param {object} layer
+   * @param {Function} original
+   * @returns {Function}
+   */
+  function wrapNativeLegacyRequestHandle (layer, original) {
+    const meta = getLayerMeta(layer)
+    const { name, captureRoute, needMultiMatch } = meta
+    return shimmer.wrapFunction(original, inner => function (req, res, next) {
+      if (!enterChannel.hasSubscribers) return inner.call(this, req, res, next)
+
+      let calls = 0
+      if (typeof next === 'function') {
+        next = shimmer.wrapCallback(next, originalNext => function next (error) {
+          calls++
+          if (calls === 1) {
+            if (error && error !== 'route' && error !== 'router') {
+              publishError({ req, error })
+            }
+
+            nextChannel.publish({ req })
+            finishChannel.publish({ req })
+          } else if (calls === 2) {
+            repeatChannel.publish({ req, name, error })
+          }
+
+          originalNext.apply(this, arguments)
+        })
+      }
+
+      const route = needMultiMatch ? resolveLayerRoute(meta, layer) : captureRoute
+      enterChannel.publish({ name, req, route, layer })
+
+      try {
+        return inner.call(this, req, res, next)
+      } catch (error) {
+        if (calls === 0) {
+          calls = 1
+          publishError({ req, error })
+          nextChannel.publish({ req })
+          finishChannel.publish({ req })
+        }
+
+        throw error
+      } finally {
+        exitChannel.publish({ req })
+      }
+    })
+  }
+
+  /**
+   * @param {object} layer
+   * @param {Function} original
+   * @returns {Function}
+   */
+  function wrapNativeLegacyErrorHandle (layer, original) {
+    const meta = getLayerMeta(layer)
+    const { name, captureRoute, needMultiMatch } = meta
+    return shimmer.wrapFunction(original, inner => function (error, req, res, next) {
+      if (!enterChannel.hasSubscribers) return inner.call(this, error, req, res, next)
+
+      let calls = 0
+      if (typeof next === 'function') {
+        next = shimmer.wrapCallback(next, originalNext => function next (nextError) {
+          calls++
+          if (calls === 1) {
+            if (nextError && nextError !== 'route' && nextError !== 'router') {
+              publishError({ req, error: nextError })
+            }
+
+            nextChannel.publish({ req })
+            finishChannel.publish({ req })
+          } else if (calls === 2) {
+            repeatChannel.publish({ req, name, error: nextError })
+          }
+
+          originalNext.apply(this, arguments)
+        })
+      }
+
+      const route = needMultiMatch ? resolveLayerRoute(meta, layer) : captureRoute
+      enterChannel.publish({ name, req, route, layer })
+
+      try {
+        return inner.call(this, error, req, res, next)
+      } catch (caught) {
+        if (calls === 0) {
+          calls = 1
+          publishError({ req, error: caught })
+          nextChannel.publish({ req })
+          finishChannel.publish({ req })
+        }
+
+        throw caught
+      } finally {
+        exitChannel.publish({ req })
+      }
+    })
+  }
+
+  /**
+   * @param {object} layer
+   * @param {Function} original
+   * @param {boolean} [guardRepeatedNext]
+   * @returns {Function}
+   */
+  function wrapLegacyHandle (layer, original, guardRepeatedNext = false) {
+    if (!guardRepeatedNext) {
+      return original.length === 4
+        ? wrapNativeLegacyErrorHandle(layer, original)
+        : wrapNativeLegacyRequestHandle(layer, original)
+    }
+
     // `annotateLayer` always runs first in `wrapStack`, so the captured meta is
     // never undefined here (unlike the prototype wraps, where `this` can be any
     // layer the host dispatches).
     const meta = getLayerMeta(layer)
+    const { name, captureRoute, needMultiMatch } = meta
     const wrapped = shimmer.wrapFunction(original, inner => function (...args) {
       if (!enterChannel.hasSubscribers) return inner.apply(this, args)
 
       const isErrorHandler = original.length === 4
       const req = args[isErrorHandler ? 1 : 0]
       const nextIndex = isErrorHandler ? 3 : 2
-      if (typeof args[nextIndex] === 'function') args[nextIndex] = wrapNext(req, meta.name, args[nextIndex])
+      let calls = 0
+      if (typeof args[nextIndex] === 'function') {
+        args[nextIndex] = shimmer.wrapCallback(args[nextIndex], originalNext => function next (error) {
+          calls++
+          if (calls === 1) {
+            if (error && error !== 'route' && error !== 'router') {
+              publishError({ req, error })
+            }
 
-      enterChannel.publish({ name: meta.name, req, route: resolveLayerRoute(meta, layer), layer })
+            nextChannel.publish({ req })
+            finishChannel.publish({ req })
+          } else if (calls === 2) {
+            repeatChannel.publish({ req, name, error })
+          }
+
+          originalNext.apply(this, arguments)
+        })
+      }
+
+      const route = needMultiMatch ? resolveLayerRoute(meta, layer) : captureRoute
+      enterChannel.publish({ name, req, route, layer })
 
       try {
         return inner.apply(this, args)
       } catch (error) {
-        // Unlike the prototype hosts, this router catches a synchronous throw
-        // outside the layer and calls its own `next(error)`, never `wrappedNext`.
-        // Mirror `wrapNext` here so the throwing layer still tags its error and
-        // finishes, rather than lingering on the stack until request finish.
-        publishError({ req, error })
-        nextChannel.publish({ req })
-        finishChannel.publish({ req })
+        // Legacy hosts catch outside the layer and never call its wrapped `next`, so finish before rethrowing.
+        if (calls === 0) {
+          calls = 1
+          publishError({ req, error })
+          nextChannel.publish({ req })
+          finishChannel.publish({ req })
+        }
 
         throw error
       } finally {
@@ -209,6 +383,7 @@ function createLayerDispatchWrappers (name) {
 
 /**
  * @param {{ handle_request?: unknown, handleRequest?: unknown }} layer
+ * @returns {boolean}
  */
 function hasLayerDispatch (layer) {
   return typeof layer.handle_request === 'function' || typeof layer.handleRequest === 'function'
@@ -221,9 +396,11 @@ function hasLayerDispatch (layer) {
  *   Host-resolved path-to-regexp compile adapter, or undefined when the host
  *   instance ships no path-to-regexp. Captured here so each express/router
  *   instance keeps the dialect it actually loaded.
- * @param {((layer: object, original: Function) => Function) | undefined} [wrapLegacyHandle]
+ * @param {((layer: object, original: Function, guardRepeatedNext?: boolean) => Function) | undefined}
+ *   [wrapLegacyHandle]
  *   Fallback that replaces `layer.handle` for hosts without a `Layer` prototype
  *   dispatch (express <4.6.0). Omitted for hosts that always ship one.
+ * @returns {(original: Function) => Function}
  */
 function createWrapRouterMethod (name, compile, wrapLegacyHandle) {
   const routeAddedChannel = channel(`apm:${name}:route:added`)
@@ -234,7 +411,7 @@ function createWrapRouterMethod (name, compile, wrapLegacyHandle) {
 
       if (wrapLegacyHandle !== undefined && !hasLayerDispatch(layer)) {
         if (layer.__handle) { // express-async-errors
-          layer.__handle = wrapLegacyHandle(layer, layer.__handle)
+          layer.__handle = wrapLegacyHandle(layer, layer.__handle, true)
         } else {
           layer.handle = wrapLegacyHandle(layer, layer.handle)
         }

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -211,7 +211,6 @@ function createLayerDispatchWrappers (name) {
   }
 
   // express <4.6.0 dispatches `layer.handle` directly, so its replacement must preserve arity.
-  // It cannot replay `next` for a rejected promise; only express-async-errors needs the repeated-next guard.
   /**
    * @param {object} layer
    * @param {Function} original

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -990,6 +990,65 @@ describe('createWrapRouterMethod', () => {
       assert.strictEqual(events.at(-1).error, failure)
     })
 
+    it('publishes the lifecycle once and surfaces a repeated native request next call', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const lateError = new Error('late')
+      const wrappedUse = wrapMethod(legacyUse)
+      /**
+       * @param {object} req
+       * @param {object} res
+       * @param {Function} next
+       */
+      function doubleNext (req, res, next) {
+        next()
+        next(lateError)
+      }
+      wrappedUse.call(router, '/foo', doubleNext)
+
+      legacyDispatch(router.stack[0])
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'host-next', 'repeat', 'host-next', 'exit',
+      ])
+      assert.strictEqual(events[4].data.name, 'doubleNext')
+      assert.strictEqual(events[4].data.error, lateError)
+      assert.strictEqual(events.at(-2).error, lateError)
+    })
+
+    it('publishes the lifecycle once and surfaces a repeated native error next call', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const lateError = new Error('late')
+      const wrappedUse = wrapMethod(legacyUse)
+      /**
+       * @param {Error} error
+       * @param {object} req
+       * @param {object} res
+       * @param {Function} next
+       */
+      function doubleNext (error, req, res, next) {
+        next()
+        next(lateError)
+      }
+      wrappedUse.call(router, '/foo', doubleNext)
+
+      legacyDispatch(router.stack[0], { error: new Error('upstream') })
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'host-next', 'repeat', 'host-next', 'exit',
+      ])
+      assert.strictEqual(events[4].data.name, 'doubleNext')
+      assert.strictEqual(events[4].data.error, lateError)
+      assert.strictEqual(events.at(-2).error, lateError)
+    })
+
     it('leaves handle pristine when the layer has a prototype dispatch method', () => {
       const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
@@ -1123,6 +1182,7 @@ describe('createWrapRouterMethod', () => {
       assert.strictEqual(events.find(event => event.label === 'enter').data.route, '/foo')
       assert.strictEqual(events.find(event => event.label === 'error').data.error, failure)
       assert.strictEqual(events.filter(event => event.label === 'finish').length, 1)
+      assert.strictEqual(events.find(event => event.label === 'repeat').data.name, 'errorHandler')
     })
 
     it('publishes a synchronous express-async-errors throw before rethrowing', () => {
@@ -1150,7 +1210,7 @@ describe('createWrapRouterMethod', () => {
       ])
     })
 
-    it('publishes once when an express-async-errors __handle calls next twice', () => {
+    it('publishes the lifecycle once and surfaces a repeated express-async-errors next call', () => {
       subscribeAll()
       const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
@@ -1173,8 +1233,9 @@ describe('createWrapRouterMethod', () => {
       router.stack[0].__handle({}, {}, error => events.push({ label: 'host-next', error }))
 
       assert.deepStrictEqual(events.map(e => e.label), [
-        'enter', 'next', 'finish', 'host-next', 'host-next', 'exit',
+        'enter', 'next', 'finish', 'host-next', 'repeat', 'host-next', 'exit',
       ])
+      assert.strictEqual(events[4].data.error, lateError)
       assert.strictEqual(events.at(-2).error, lateError)
     })
   })

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -198,6 +198,26 @@ describe('createWrapRouterMethod', () => {
       assert.strictEqual(events.find(e => e.label === 'enter').data.route, undefined)
     })
 
+    it('forwards a multi-pattern matcher failure through next(error)', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = { stack: [] }
+
+      const failure = new Error('matcher failed')
+      const matcher = /users/
+      matcher.test = () => { throw failure }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/users' }))
+      wrappedUse.call(router, [matcher, /products/], function shouldNotRun () {
+        assert.fail('handler should not run')
+      })
+
+      let forwardedError
+      router.stack[0].handle_request({}, {}, (error) => { forwardedError = error })
+
+      assert.strictEqual(forwardedError, failure)
+      assert.strictEqual(events.length, 0)
+    })
+
     it('skips matcher analysis when the host passes a handler with no mount path', () => {
       subscribeAll()
       const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
@@ -391,6 +411,26 @@ describe('createWrapRouterMethod', () => {
       router.stack[0].handle_error(new Error('e'), {}, {}, () => {})
 
       assert.strictEqual(events.find(e => e.label === 'enter').data.route, '/products')
+    })
+
+    it('forwards a multi-pattern matcher failure from an error handler through next(error)', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = { stack: [] }
+
+      const failure = new Error('matcher failed')
+      const matcher = /users/
+      matcher.test = () => { throw failure }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/users' }))
+      wrappedUse.call(router, [matcher, /products/], function shouldNotRun (error, req, res, next) {
+        assert.fail('handler should not run')
+      })
+
+      let forwardedError
+      router.stack[0].handle_error(new Error('upstream'), {}, {}, (error) => { forwardedError = error })
+
+      assert.strictEqual(forwardedError, failure)
+      assert.strictEqual(events.length, 0)
     })
 
     it('skips work when the layer is a 3-arg handler the host would not run as an error handler', () => {
@@ -771,11 +811,8 @@ describe('createWrapRouterMethod', () => {
       this.stack.push({ handle: handler, path: '/foo', regexp: {} })
     }
 
-    // Mirror express <4.6.0's `router.handle`: it runs `layer.handle` itself and,
-    // on a synchronous throw, catches *outside* the layer and calls its own
-    // `next(error)` — never the `next` the layer was handed. The tracer cannot
-    // observe the throw through `wrappedNext`, so the legacy handle wrap has to
-    // catch and publish error/next/finish itself before rethrowing.
+    // Mirror express <4.6.0: catch outside the layer and route the throw through
+    // the host's `next`, not the one passed to the layer.
     function legacyDispatch (layer, { req = {}, res = {}, error } = {}) {
       const hostNext = (nextError) => events.push({ label: 'host-next', error: nextError })
       try {
@@ -813,6 +850,24 @@ describe('createWrapRouterMethod', () => {
       assertObjectContains(events[0].data, { name: 'originalHandler', req, route: '/foo', layer })
     })
 
+    it('captures a multi-pattern route and publishes an error passed by a request handler', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('request-next-error')
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, ['/foo', '/bar'], function requestError (req, res, next) {
+        next(failure)
+      })
+
+      legacyDispatch(router.stack[0])
+
+      assert.strictEqual(events.find(event => event.label === 'enter').data.route, '/foo')
+      assert.strictEqual(events.find(event => event.label === 'error').data.error, failure)
+    })
+
     it('preserves error-handler arity (4) so the host still routes errors', () => {
       subscribeAll()
       const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
@@ -833,6 +888,24 @@ describe('createWrapRouterMethod', () => {
       assert.strictEqual(enterEvent.data.req, req)
     })
 
+    it('captures a multi-pattern route and publishes an error passed by an error handler', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('error-next-error')
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, ['/foo', '/bar'], function errorHandler (error, req, res, next) {
+        next(failure)
+      })
+
+      legacyDispatch(router.stack[0], { error: new Error('upstream') })
+
+      assert.strictEqual(events.find(event => event.label === 'enter').data.route, '/foo')
+      assert.strictEqual(events.find(event => event.label === 'error').data.error, failure)
+    })
+
     it('publishes error/next/finish/exit when a request handler throws and rethrows to the host', () => {
       subscribeAll()
       const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
@@ -846,8 +919,6 @@ describe('createWrapRouterMethod', () => {
       const req = {}
       legacyDispatch(router.stack[0], { req })
 
-      // The host catches the rethrown error and routes it through its own next,
-      // but the tracer has already tagged and finished the throwing layer.
       assert.deepStrictEqual(events.map(e => e.label), [
         'enter', 'error', 'next', 'finish', 'exit', 'host-next',
       ])
@@ -874,6 +945,48 @@ describe('createWrapRouterMethod', () => {
       ])
       assert.strictEqual(events[1].data.error, failure)
       assert.strictEqual(events[1].data.req, req)
+      assert.strictEqual(events.at(-1).error, failure)
+    })
+
+    it('does not re-publish a finished lifecycle when a request handler calls next before throwing', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('throw-after-next')
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function nextThenThrow (req, res, next) {
+        next()
+        throw failure
+      })
+
+      legacyDispatch(router.stack[0])
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'host-next', 'exit', 'host-next',
+      ])
+      assert.strictEqual(events.at(-1).error, failure)
+    })
+
+    it('does not re-publish a finished lifecycle when an error handler calls next before throwing', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('throw-after-next')
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function nextThenThrow (error, req, res, next) {
+        next()
+        throw failure
+      })
+
+      legacyDispatch(router.stack[0], { error: new Error('upstream') })
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'host-next', 'exit', 'host-next',
+      ])
       assert.strictEqual(events.at(-1).error, failure)
     })
 
@@ -911,6 +1024,26 @@ describe('createWrapRouterMethod', () => {
       assert.strictEqual(events.length, 0)
     })
 
+    it('forwards an error handler without tracing when enterChannel has no subscribers', () => {
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      let handlerRan = false
+      const wrappedUse = wrapMethod(legacyUse)
+      wrappedUse.call(router, '/foo', function (error, req, res, next) {
+        handlerRan = true
+        next()
+      })
+
+      let nextCalled = false
+      router.stack[0].handle(new Error('upstream'), {}, {}, () => { nextCalled = true })
+
+      assert.strictEqual(handlerRan, true)
+      assert.strictEqual(nextCalled, true)
+      assert.strictEqual(events.length, 0)
+    })
+
     it('wraps __handle instead of handle for express-async-errors layers', () => {
       subscribeAll()
       const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
@@ -936,6 +1069,113 @@ describe('createWrapRouterMethod', () => {
 
       assert.ok(events.find(e => e.label === '__handle-called'))
       assert.ok(events.find(e => e.label === 'enter'))
+    })
+
+    it('forwards an express-async-errors __handle without tracing when enterChannel has no subscribers', () => {
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      let handlerRan = false
+      const wrappedUse = wrapMethod(function use (path, handler) {
+        this.stack.push({
+          handle: handler,
+          __handle (req, res, next) {
+            handlerRan = true
+            next()
+          },
+          path: '/foo',
+          regexp: {},
+        })
+      })
+      wrappedUse.call(router, '/foo', () => {})
+
+      let nextCalled = false
+      router.stack[0].__handle({}, {}, () => { nextCalled = true })
+
+      assert.strictEqual(handlerRan, true)
+      assert.strictEqual(nextCalled, true)
+      assert.strictEqual(events.length, 0)
+    })
+
+    it('captures a multi-pattern route and guards an express-async-errors error handler', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('late-error')
+      const wrappedUse = wrapMethod(function use (path, handler) {
+        this.stack.push({
+          handle: handler,
+          __handle (error, req, res, next) {
+            next(failure)
+            next()
+          },
+          path: '/foo',
+          regexp: {},
+        })
+      })
+      wrappedUse.call(router, ['/foo', '/bar'], function errorHandler (error, req, res, next) {})
+
+      router.stack[0].__handle(new Error('upstream'), {}, {}, () => {})
+
+      assert.strictEqual(events.find(event => event.label === 'enter').data.route, '/foo')
+      assert.strictEqual(events.find(event => event.label === 'error').data.error, failure)
+      assert.strictEqual(events.filter(event => event.label === 'finish').length, 1)
+    })
+
+    it('publishes a synchronous express-async-errors throw before rethrowing', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const failure = new Error('express-async-errors-throw')
+      const wrappedUse = wrapMethod(function use (path, handler) {
+        this.stack.push({
+          handle: handler,
+          __handle () {
+            throw failure
+          },
+          path: '/foo',
+          regexp: {},
+        })
+      })
+      wrappedUse.call(router, '/foo', () => {})
+
+      assert.throws(() => router.stack[0].__handle({}, {}, () => {}), error => error === failure)
+      assert.deepStrictEqual(events.map(event => event.label), [
+        'enter', 'error', 'next', 'finish', 'exit',
+      ])
+    })
+
+    it('publishes once when an express-async-errors __handle calls next twice', () => {
+      subscribeAll()
+      const { wrapLegacyHandle } = createLayerDispatchWrappers(namespace)
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex, wrapLegacyHandle)
+      const router = { stack: [] }
+
+      const lateError = new Error('late')
+      const wrappedUse = wrapMethod(function use (path, handler) {
+        this.stack.push({
+          handle: handler,
+          __handle (req, res, next) {
+            next()
+            next(lateError)
+          },
+          path: '/foo',
+          regexp: {},
+        })
+      })
+      wrappedUse.call(router, '/foo', () => {})
+
+      router.stack[0].__handle({}, {}, error => events.push({ label: 'host-next', error }))
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'host-next', 'host-next', 'exit',
+      ])
+      assert.strictEqual(events.at(-2).error, lateError)
     })
   })
 


### PR DESCRIPTION
Legacy Express can call next before throwing, and multi-pattern route matching can fail outside the host dispatch boundary. Keep lifecycle publishing at most once and forward matcher failures through next(error).

The native fallback reduced middleware dispatch from 350.10 to 299.50 ns/op on Node 18 and 224.67 to 204.93 ns/op on Node 24 (1M warm-up, seven 500K trials, trimmed mean).
