### PR TITLE
refactor(llmobs): centralize session_id injection in handleLLMObsInjection

### DIFF
--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -4,6 +4,7 @@ module.exports = {
   SPAN_KINDS: ['llm', 'agent', 'workflow', 'task', 'tool', 'embedding', 'retrieval'],
   SPAN_KIND: '_ml_obs.meta.span.kind',
   SESSION_ID: '_ml_obs.session_id',
+  SESSION_ID_TRACE_DEFAULT_KEY: '_ml_obs.trace_session_id',
   DECORATOR: '_ml_obs.decorator',
   INTEGRATION: '_ml_obs.integration',
   METADATA: '_ml_obs.meta.metadata',

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -113,7 +113,7 @@ function disable () {
 }
 
 // since LLMObs traces can extend between services and be the same trace,
-// we need to propagate the parent id, mlApp, and sampling rate/decision.
+// we need to propagate the parent id, mlApp, session id, and sampling rate/decision.
 function handleLLMObsInjection ({ carrier }) {
   // Respect the standard propagator's gate: when trace tag propagation is
   // disabled, don't write `x-datadog-tags` for LLMObs either.

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -7,8 +7,11 @@ const { DD_MAJOR } = require('../../../../version')
 const startupLogs = require('../startup-log')
 const {
   ML_APP,
+  SESSION_ID,
+  SESSION_ID_TRACE_DEFAULT_KEY,
   PROPAGATED_ML_APP_KEY,
   PROPAGATED_PARENT_ID_KEY,
+  PROPAGATED_SESSION_ID_KEY,
   SAMPLE_RATE,
   SAMPLING_DECISION,
   PROPAGATED_SAMPLE_RATE_KEY,
@@ -130,8 +133,12 @@ function handleLLMObsInjection ({ carrier }) {
     mlObsSpanTags?.[SAMPLE_RATE] ?? parentContext?._trace?.tags?.[PROPAGATED_SAMPLE_RATE_KEY]
   const samplingDecision =
     mlObsSpanTags?.[SAMPLING_DECISION] ?? parentContext?._trace?.tags?.[PROPAGATED_SAMPLING_DECISION_KEY]
+  const sessionId =
+    mlObsSpanTags?.[SESSION_ID] ??
+    parentContext?._trace?.tags?.[SESSION_ID_TRACE_DEFAULT_KEY] ??
+    parentContext?._trace?.tags?.[PROPAGATED_SESSION_ID_KEY]
 
-  if (!parentId && !mlApp && samplingDecision == null) return
+  if (!parentId && !mlApp && samplingDecision == null && !sessionId) return
 
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.
@@ -139,6 +146,7 @@ function handleLLMObsInjection ({ carrier }) {
   let tags = existing || ''
   if (parentId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_ID_KEY}=${parentId}`
   if (mlApp) tags += `${tags ? ',' : ''}${PROPAGATED_ML_APP_KEY}=${mlApp}`
+  if (sessionId) tags += `${tags ? ',' : ''}${PROPAGATED_SESSION_ID_KEY}=${sessionId}`
   if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
   if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
   if (tags !== existing) carrier['x-datadog-tags'] = tags

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -7,6 +7,7 @@ const {
   MODEL_NAME,
   MODEL_PROVIDER,
   SESSION_ID,
+  SESSION_ID_TRACE_DEFAULT_KEY,
   ML_APP,
   SPAN_KIND,
   INPUT_VALUE,
@@ -141,7 +142,10 @@ class LLMObsTagger {
     if (modelProvider) this._setTag(span, MODEL_PROVIDER, modelProvider)
 
     const traceTags = span.context()._trace.tags
-    sessionId = sessionId || registry.get(parent)?.[SESSION_ID] || traceTags[PROPAGATED_SESSION_ID_KEY]
+    sessionId = sessionId ||
+      registry.get(parent)?.[SESSION_ID] ||
+      traceTags[SESSION_ID_TRACE_DEFAULT_KEY] ||
+      traceTags[PROPAGATED_SESSION_ID_KEY]
     if (sessionId) this._setTag(span, SESSION_ID, sessionId)
     if (integration) this._setTag(span, INTEGRATION, integration)
     if (_decorator) this._setTag(span, DECORATOR, _decorator)
@@ -756,14 +760,14 @@ class LLMObsTagger {
     tagsCarrier[key] = value
 
     // The first session set in a trace becomes the trace-level default, stored on the trace-shared
-    // propagating tags so later spans (incl. those under a session-less parent) inherit it and it
-    // rides `x-datadog-tags` across service boundaries. Established here, the single choke point for
-    // session writes, so sessions post-populated by integrations after span start also seed it.
-    // First-writer wins, so an explicit session still overrides locally.
+    // tags so later spans (incl. those under a session-less parent) inherit it in-process.
+    // Established here, the single choke point for session writes, so sessions post-populated by
+    // integrations after span start also seed it. First-writer wins, so an explicit session still
+    // overrides locally. Cross-service injection is handled centrally in `handleLLMObsInjection`.
     if (key === SESSION_ID && value) {
       const traceTags = span.context()._trace.tags
-      if (traceTags[PROPAGATED_SESSION_ID_KEY] === undefined) {
-        traceTags[PROPAGATED_SESSION_ID_KEY] = value
+      if (traceTags[SESSION_ID_TRACE_DEFAULT_KEY] === undefined) {
+        traceTags[SESSION_ID_TRACE_DEFAULT_KEY] = value
       }
     }
   }

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -10,7 +10,7 @@ const sinon = require('sinon')
 const { DD_MAJOR } = require('../../../../version')
 const { INCOMPATIBLE_INITIALIZATION } = require('../../src/llmobs/constants/text')
 const LLMObsTagger = require('../../src/llmobs/tagger')
-const { SAMPLE_RATE, SAMPLING_DECISION } = require('../../src/llmobs/constants/tags')
+const { SAMPLE_RATE, SAMPLING_DECISION, SESSION_ID } = require('../../src/llmobs/constants/tags')
 const { getConfigFresh } = require('../helpers/config')
 const { removeDestroyHandler } = require('./util')
 
@@ -136,6 +136,56 @@ describe('module', () => {
       assert.strictEqual(
         carrier['x-datadog-tags'],
         '_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test,_dd.p.llmobs_sr=0.5,_dd.p.llmobs_sd=0'
+      )
+    })
+
+    it('injects the session_id from the parent LLMObs span', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+      store.span = {
+        context () {
+          return {
+            toSpanId () {
+              return 'parent-id'
+            },
+          }
+        },
+      }
+      LLMObsTagger.tagMap.set(store.span, {
+        [SESSION_ID]: 'my-session',
+      })
+
+      const carrier = {
+        'x-datadog-tags': '',
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        '_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test,_dd.p.llmobs_sid=my-session'
+      )
+    })
+
+    it('injects the session_id from the trace-level default when the active span carries none', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+      store.span = {
+        context () {
+          return {
+            toSpanId () {
+              return 'parent-id'
+            },
+            _trace: { tags: { '_ml_obs.trace_session_id': 'trace-session' } },
+          }
+        },
+      }
+
+      const carrier = {
+        'x-datadog-tags': '',
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        '_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test,_dd.p.llmobs_sid=trace-session'
       )
     })
 

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -108,34 +108,42 @@ describe('tagger', () => {
         tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'my-session' })
 
         assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'my-session')
-        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'my-session')
+        assert.strictEqual(spanContext._trace.tags['_ml_obs.trace_session_id'], 'my-session')
       })
 
       it('inherits the trace-level default session when the span sets none', () => {
-        spanContext._trace.tags['_dd.p.llmobs_sid'] = 'trace-session'
+        spanContext._trace.tags['_ml_obs.trace_session_id'] = 'trace-session'
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
         assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'trace-session')
       })
 
+      it('inherits the session propagated from an upstream service', () => {
+        spanContext._trace.tags['_dd.p.llmobs_sid'] = 'propagated-session'
+
+        tagger.registerLLMObsSpan(span, { kind: 'llm' })
+
+        assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'propagated-session')
+      })
+
       it('lets an explicit session override without changing the established trace default', () => {
-        spanContext._trace.tags['_dd.p.llmobs_sid'] = 'trace-session'
+        spanContext._trace.tags['_ml_obs.trace_session_id'] = 'trace-session'
 
         tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'other-session' })
 
         assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'other-session')
-        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'trace-session')
+        assert.strictEqual(spanContext._trace.tags['_ml_obs.trace_session_id'], 'trace-session')
       })
 
       it('establishes the trace-level default when a session is post-populated via _setTag', () => {
         tagger.registerLLMObsSpan(span, { kind: 'llm' }) // no session at registration
-        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], undefined)
+        assert.strictEqual(spanContext._trace.tags['_ml_obs.trace_session_id'], undefined)
 
         tagger._setTag(span, '_ml_obs.session_id', 'late-session') // integration sets it after start
 
         assert.strictEqual(Tagger.tagMap.get(span)['_ml_obs.session_id'], 'late-session')
-        assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'late-session')
+        assert.strictEqual(spanContext._trace.tags['_ml_obs.trace_session_id'], 'late-session')
       })
 
       it('uses the name if provided', () => {


### PR DESCRIPTION
## What does this PR do?

Centralizes `session_id` cross-service injection into `handleLLMObsInjection`, so all four propagated LLMObs values (`parent_id`, `ml_app`, `session_id`, sampling) are emitted in one place.

## Motivation

Follow-up to the session-propagation work (#9279). Session was handled on a **different path** from the other propagated values: it was stored on `_trace.tags` under the `_dd.p.llmobs_sid` key and injected implicitly by the standard propagator's `_injectTags`, while `parent_id`/`ml_app` are injected explicitly in `handleLLMObsInjection`.

It was also a subtle correctness gap: `_injectTags` only runs when the `datadog` inject propagation style is enabled, whereas `handleLLMObsInjection` runs regardless. So with a non-`datadog` inject style, session would silently stop propagating while `parent_id`/`ml_app` still did.

## Changes

- In-process trace default moves to an internal, non-`_dd.p.` key `_ml_obs.trace_session_id` (constant `SESSION_ID_TRACE_DEFAULT_KEY`). It is used only for in-process sibling inheritance, so the standard propagator no longer auto-injects it.
- `handleLLMObsInjection` now emits `_dd.p.llmobs_sid` alongside `parent_id`/`ml_app`, reading the active span's session (`mlObsSpanTags[SESSION_ID]`) with fallbacks to the trace default and the extracted `_dd.p.llmobs_sid`.
- `registerLLMObsSpan` resolves a new span's session as explicit → parent → in-process trace default → cross-service propagated.
- `_setTag` seeds the internal trace-default key (first-writer-wins).

## Testing

- `tagger.spec.js`: trace-default establishment/inheritance/override updated to the internal key; added a case for inheriting an upstream-propagated session.
- `index.spec.js`: added injection cases for session from the active span and from the trace-level default.
- `packages/dd-trace/test/llmobs/{tagger,index,sdk/index}.spec.js` all pass (133 + 100).

Claude session: `3b93fe65-18d2-413f-b53e-2d95f370e1ed`
Resume: `claude --resume 3b93fe65-18d2-413f-b53e-2d95f370e1ed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
