### PR TITLE
fix(id): refresh remaining runtime-id/client-id copies on MicroVM clone resume (option A)

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -19,9 +19,9 @@ const {
 class Writer extends BaseWriter {
   constructor ({ url, tags, evpProxyPrefix = '' }) {
     super(...arguments)
-    const { 'runtime-id': runtimeId, env, service } = tags
+    const { env, service } = tags
     this._url = url
-    this._encoder = new AgentlessCiVisibilityEncoder(this, { runtimeId, env, service })
+    this._encoder = new AgentlessCiVisibilityEncoder(this, { tags, env, service })
     this._evpProxyPrefix = evpProxyPrefix
   }
 

--- a/packages/dd-trace/src/debugger/devtools_client/config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/config.js
@@ -24,4 +24,5 @@ function updateConfig (updates) {
   // reconstructed into a URL here rather than read directly off a Config instance.
   config.url = new URL(updates.url)
   config.dynamicInstrumentation.captureTimeoutNs = BigInt(updates.dynamicInstrumentation.captureTimeoutMs) * 1_000_000n
+  config.runtimeId = updates.runtimeId
 }

--- a/packages/dd-trace/src/debugger/devtools_client/status.js
+++ b/packages/dd-trace/src/debugger/devtools_client/status.js
@@ -17,7 +17,6 @@ module.exports = {
 
 const ddsource = 'dd_debugger'
 const service = config.service
-const runtimeId = config.runtimeId
 
 const cache = new TTLSet(60 * 60 * 1000) // 1 hour
 
@@ -110,7 +109,7 @@ function statusPayload (probeId, probeVersion, status) {
     ddsource,
     service,
     debugger: {
-      diagnostics: { probeId, runtimeId, probeVersion, status },
+      diagnostics: { probeId, runtimeId: config.runtimeId, probeVersion, status },
     },
   }
 }

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -47,6 +47,18 @@ class DogStatsDClient {
     this._udp6 = this._socket('udp6')
   }
 
+  /**
+   * Regenerates the cached tags string used by every `_add()` call. Needed because `#tagsPrefix`
+   * is computed once in the constructor for hot-path performance, so a tag value change (e.g. a
+   * reseeded `runtime-id`) would otherwise never reach it.
+   *
+   * @param {string[]} tags - Freshly generated tags, in `key:value` form
+   */
+  updateTags (tags) {
+    this._tags = tags
+    this.#tagsPrefix = this._tags?.length ? `|#${this._tags.join(',')}` : ''
+  }
+
   increment (stat, value, tags) {
     this._add(stat, value, TYPE_COUNTER, tags)
   }
@@ -212,6 +224,13 @@ class MetricsAggregationClient {
     this.reset()
   }
 
+  /**
+   * @param {string[]} tags - Freshly generated tags, in `key:value` form
+   */
+  updateTags (tags) {
+    this._client.updateTags(tags)
+  }
+
   flush () {
     this._captureCounters()
     this._captureGauges()
@@ -370,6 +389,13 @@ class CustomMetrics {
     setInterval(flush, 10 * 1000).unref?.()
 
     globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(flush)
+  }
+
+  /**
+   * @param {string[]} tags - Freshly generated tags, in `key:value` form
+   */
+  updateTags (tags) {
+    this.#client.updateTags(tags)
   }
 
   increment (stat, value = 1, tags) {

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -69,9 +69,9 @@ function truncateTestLevelMetadataTags (tags) {
 }
 
 class AgentlessCiVisibilityEncoder extends AgentEncoder {
-  constructor (writer, { runtimeId, service, env }) {
+  constructor (writer, { tags, service, env }) {
     super(writer, INTAKE_SOFT_LIMIT)
-    this.runtimeId = runtimeId
+    this.tags = tags
     this.service = service
     this.env = env
 
@@ -409,8 +409,9 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     if (this.env) {
       payload.metadata['*'].env = this.env
     }
-    if (this.runtimeId) {
-      payload.metadata['*']['runtime-id'] = this.runtimeId
+    const runtimeId = this.tags?.['runtime-id']
+    if (runtimeId) {
+      payload.metadata['*']['runtime-id'] = runtimeId
     }
 
     bytes.writeMapPrefix(Object.keys(payload).length)

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -44,7 +44,7 @@ class AgentlessExporter {
       languageName: 'nodejs',
       languageVersion: process.version,
       tracerVersion,
-      runtimeID: config.tags?.['runtime-id'],
+      get runtimeID () { return config.tags?.['runtime-id'] },
       ...(entityId ? { containerID: entityId } : {}),
     }
 

--- a/packages/dd-trace/src/opentelemetry/metrics/index.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/index.js
@@ -14,6 +14,12 @@ const OtlpHttpMetricExporter = require('./otlp_http_metric_exporter')
  * @typedef {import('../../config')} Config
  */
 
+// Tracks the currently-active exporters so `refreshResourceAttributes` can push updated
+// resource attributes (e.g. a reseeded `runtime-id`) into their caches. Undefined if OTel
+// metrics / span-stats were never initialized.
+let activeMetricsExporter
+let activeStatsExporter
+
 /**
  * @file OpenTelemetry Metrics Implementation for dd-trace-js
  *
@@ -37,10 +43,11 @@ const OtlpHttpMetricExporter = require('./otlp_http_metric_exporter')
  */
 
 /**
- * Initializes OpenTelemetry Metrics support
+ * Builds the resource attributes for the OTel metrics (non-span-stats) exporter.
  * @param {import('../../config/config-base')} config - Tracer configuration instance
+ * @returns {object} Resource attributes
  */
-function initializeOpenTelemetryMetrics (config) {
+function buildMetricsResourceAttributes (config) {
   const resourceAttributes = {
     'service.name': config.service,
     'service.version': config.version,
@@ -59,6 +66,16 @@ function initializeOpenTelemetryMetrics (config) {
     resourceAttributes['host.name'] = os.hostname()
   }
 
+  return resourceAttributes
+}
+
+/**
+ * Initializes OpenTelemetry Metrics support
+ * @param {import('../../config/config-base')} config - Tracer configuration instance
+ */
+function initializeOpenTelemetryMetrics (config) {
+  const resourceAttributes = buildMetricsResourceAttributes(config)
+
   const exporter = new OtlpHttpMetricExporter(
     config.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     config.OTEL_EXPORTER_OTLP_METRICS_HEADERS,
@@ -66,6 +83,7 @@ function initializeOpenTelemetryMetrics (config) {
     config.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
     resourceAttributes
   )
+  activeMetricsExporter = exporter
 
   const reader = new PeriodicMetricReader(
     exporter,
@@ -101,17 +119,26 @@ function buildResourceAttributes (tags, { reportHostname, otelSemanticsEnabled, 
   return attrs
 }
 
-function createOtlpSpanStatsExporter (config) {
-  const { OtlpStatsExporter } = require('./otlp_span_stats_exporter')
-  const protocol = config.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL || 'http/json'
-  const resourceAttributes = buildResourceAttributes(config.tags, {
+/**
+ * Builds the resource attributes for the OTLP span-stats exporter.
+ * @param {import('../../config/config-base')} config - Tracer configuration instance
+ * @returns {object} Resource attributes
+ */
+function buildStatsResourceAttributes (config) {
+  return buildResourceAttributes(config.tags, {
     reportHostname: config.reportHostname,
     otelSemanticsEnabled: config.DD_TRACE_OTEL_SEMANTICS_ENABLED,
     service: config.service,
     env: config.env,
     serviceVersion: config.version,
   })
-  return new OtlpStatsExporter(
+}
+
+function createOtlpSpanStatsExporter (config) {
+  const { OtlpStatsExporter } = require('./otlp_span_stats_exporter')
+  const protocol = config.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL || 'http/json'
+  const resourceAttributes = buildStatsResourceAttributes(config)
+  const exporter = new OtlpStatsExporter(
     config.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     protocol,
     resourceAttributes,
@@ -120,6 +147,20 @@ function createOtlpSpanStatsExporter (config) {
     config.OTEL_EXPORTER_OTLP_METRICS_HEADERS,
     config.OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
   )
+  activeStatsExporter = exporter
+  return exporter
+}
+
+/**
+ * Recomputes and pushes fresh resource attributes (e.g. after a reseeded `runtime-id`) into
+ * whichever OTel metrics exporters are currently active. No-op for any exporter that was never
+ * initialized.
+ *
+ * @param {import('../../config/config-base')} config - Tracer configuration
+ */
+function refreshResourceAttributes (config) {
+  activeMetricsExporter?.updateResourceAttributes(buildMetricsResourceAttributes(config))
+  activeStatsExporter?.updateResourceAttributes(buildStatsResourceAttributes(config))
 }
 
 module.exports = {
@@ -127,4 +168,5 @@ module.exports = {
   initializeOpenTelemetryMetrics,
   buildResourceAttributes,
   createOtlpSpanStatsExporter,
+  refreshResourceAttributes,
 }

--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_http_metric_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_http_metric_exporter.js
@@ -30,6 +30,15 @@ class OtlpHttpMetricExporter extends OtlpHttpExporterBase {
   }
 
   /**
+   * Recomputes the transformer's cached resource attributes (e.g. after a reseeded `runtime-id`).
+   *
+   * @param {Resource} resource - Resource attributes
+   */
+  updateResourceAttributes (resource) {
+    this.transformer.updateResourceAttributes(resource)
+  }
+
+  /**
    * Exports metrics via OTLP over HTTP.
    *
    * @param {Map<string, AggregatedMetric>} metrics - Map of metric data to export

--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_span_stats_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_span_stats_exporter.js
@@ -23,6 +23,15 @@ class OtlpStatsExporter extends OtlpHttpExporterBase {
   }
 
   /**
+   * Recomputes the transformer's cached resource attributes (e.g. after a reseeded `runtime-id`).
+   *
+   * @param {import('@opentelemetry/api').Attributes} resourceAttributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.#transformer.updateResourceAttributes(resourceAttributes)
+  }
+
+  /**
    * @param {Array<{timeNs: number, bucket: import('../../span_stats').SpanBuckets}>} drained
    * @param {number} bucketSizeNs
    */

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
@@ -76,6 +76,17 @@ class OtlpTransformerBase {
   }
 
   /**
+   * Recomputes the cached OTLP resource attributes from a fresh attributes object (e.g. after a
+   * reseeded `runtime-id`). `#resourceAttributes` is otherwise only ever set once, in the
+   * constructor, for hot-path fitness on every export.
+   *
+   * @param {Attributes} resourceAttributes - Resource attributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.#resourceAttributes = this.transformAttributes(resourceAttributes)
+  }
+
+  /**
    * Transforms attributes to OTLP KeyValue format.
    * @param {Attributes} attributes - Attributes to transform
    * @returns {object[]} Array of OTLP KeyValue objects

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -312,6 +312,27 @@ class Tracer extends NoopProxy {
     getConfig.refreshRuntimeId(config)
     require('./remote_config').refreshClientId(config)
     this._tracer?.refreshMetadata(config)
+    this.#refreshDogStatsDTags(config)
+    require('./opentelemetry/metrics').refreshResourceAttributes(config)
+    if (DynamicInstrumentation.isStarted()) DynamicInstrumentation.configure(config)
+  }
+
+  /**
+   * Regenerates the cached DogStatsD tags for whichever clients are already constructed. Clients
+   * that haven't been constructed yet (e.g. the lazily-created Custom Metrics client outside
+   * serverless) naturally pick up the fresh config on their first access, so they're left alone.
+   *
+   * @param {import('./config/config-base')} config
+   */
+  #refreshDogStatsDTags (config) {
+    const dogstatsdDescriptor = Object.getOwnPropertyDescriptor(this, 'dogstatsd')
+    if (!dogstatsdDescriptor || typeof dogstatsdDescriptor.get !== 'function') {
+      const { CustomMetrics, DogStatsDClient } = require('./dogstatsd')
+      if (this.dogstatsd instanceof CustomMetrics) {
+        this.dogstatsd.updateTags(DogStatsDClient.generateClientConfig(config).tags)
+      }
+    }
+    runtimeMetrics.updateTags(config)
   }
 
   /**

--- a/packages/dd-trace/src/runtime_metrics/client.js
+++ b/packages/dd-trace/src/runtime_metrics/client.js
@@ -4,27 +4,40 @@ const { DogStatsDClient, MetricsAggregationClient } = require('../dogstatsd')
 const processTags = require('../process-tags')
 
 /**
- * Builds the aggregating DogStatsD client used to emit DD-proprietary tracer
- * metrics (runtime.node.*, datadog.tracer.*). Shared by both runtime-metrics
- * paths (DogStatsD and OTLP) so their client construction can't drift apart.
+ * Derives the tags array for the runtime-metrics DogStatsD client from the current config.
+ * Shared by `createMetricsClient` and `updateTags` so they can't drift apart.
  *
  * Process tags are applied here, not via config/generateClientConfig, so they only
  * reach this bounded set of runtime metrics. Putting them on the global tags would
  * also tag user-facing custom metrics, inflating their cardinality (and billing).
  *
  * @param {import('../config/config-base')} config - Tracer configuration
+ * @returns {string[]}
+ */
+function generateMetricsClientTags (config) {
+  const { tags } = DogStatsDClient.generateClientConfig(config)
+
+  if (config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED) {
+    for (const tag of processTags.tagsArray) {
+      tags.push(tag)
+    }
+  }
+
+  return tags
+}
+
+/**
+ * Builds the aggregating DogStatsD client used to emit DD-proprietary tracer
+ * metrics (runtime.node.*, datadog.tracer.*).
+ *
+ * @param {import('../config/config-base')} config - Tracer configuration
  * @returns {MetricsAggregationClient}
  */
 function createMetricsClient (config) {
   const clientConfig = DogStatsDClient.generateClientConfig(config)
-
-  if (config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED) {
-    for (const tag of processTags.tagsArray) {
-      clientConfig.tags.push(tag)
-    }
-  }
+  clientConfig.tags = generateMetricsClientTags(config)
 
   return new MetricsAggregationClient(new DogStatsDClient(clientConfig))
 }
 
-module.exports = { createMetricsClient }
+module.exports = { createMetricsClient, generateMetricsClientTags }

--- a/packages/dd-trace/src/runtime_metrics/index.js
+++ b/packages/dd-trace/src/runtime_metrics/index.js
@@ -6,6 +6,7 @@ let runtimeMetrics
 
 const noop = runtimeMetrics = {
   stop () {},
+  updateTags () {},
   track () {},
   boolean () {},
   histogram () {},

--- a/packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js
@@ -5,7 +5,7 @@ const process = require('node:process')
 const { performance, monitorEventLoopDelay, PerformanceObserver, constants } = require('node:perf_hooks')
 const { metrics } = require('@opentelemetry/api')
 const log = require('../log')
-const { createMetricsClient } = require('./client')
+const { createMetricsClient, generateMetricsClientTags } = require('./client')
 
 const METER_NAME = 'datadog.runtime_metrics'
 
@@ -222,6 +222,16 @@ module.exports = {
       flushInterval = null
     }
     client = null
+  },
+
+  /**
+   * Regenerates the DogStatsD client's tags (e.g. after a reseeded `runtime-id`). No-op if
+   * runtime metrics were never started.
+   *
+   * @param {import('../config/config-base')} config - Tracer configuration
+   */
+  updateTags (config) {
+    client?.updateTags(generateMetricsClientTags(config))
   },
 
   // Tied to @datadog/native-metrics which the OTLP path doesn't enable; noop with expected shape.

--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -8,7 +8,7 @@ const process = require('process')
 const { performance, PerformanceObserver, monitorEventLoopDelay } = require('perf_hooks')
 const log = require('../log')
 const { NODE_MAJOR, NODE_MINOR } = require('../../../../version')
-const { createMetricsClient } = require('./client')
+const { createMetricsClient, generateMetricsClientTags } = require('./client')
 
 const eventLoopDelayResolution = 4
 const EVENT_LOOP_SAMPLE_PER_ITERATION_AVAILABLE = NODE_MAJOR > 26 || (NODE_MAJOR === 26 && NODE_MINOR >= 5)
@@ -119,6 +119,16 @@ module.exports = {
 
     eventLoopDelayObserver?.disable()
     eventLoopDelayObserver = null
+  },
+
+  /**
+   * Regenerates the DogStatsD client's tags (e.g. after a reseeded `runtime-id`). No-op if
+   * runtime metrics were never started.
+   *
+   * @param {import('../config/config-base')} config - Tracer configuration
+   */
+  updateTags (config) {
+    client?.updateTags(generateMetricsClientTags(config))
   },
 
   track (span) {

--- a/packages/dd-trace/src/telemetry/session-propagation.js
+++ b/packages/dd-trace/src/telemetry/session-propagation.js
@@ -4,15 +4,18 @@ const dc = /** @type {typeof import('diagnostics_channel')} */ (require('dc-poly
 const childProcessChannel = dc.tracingChannel('datadog:child_process:execution')
 
 let subscribed = false
-let runtimeId
+let savedConfig
 
 function isOptionsObject (value) {
   return value != null && typeof value === 'object' && !Array.isArray(value) && value
 }
 
 function getEnvWithRuntimeId (env) {
-  // eslint-disable-next-line eslint-rules/eslint-process-env
-  return { ...(env ?? process.env), DD_ROOT_JS_SESSION_ID: runtimeId }
+  return {
+    // eslint-disable-next-line eslint-rules/eslint-process-env
+    ...(env ?? process.env),
+    DD_ROOT_JS_SESSION_ID: savedConfig.DD_ROOT_JS_SESSION_ID || savedConfig.tags['runtime-id'],
+  }
 }
 
 function onChildProcessStart (context) {
@@ -43,7 +46,7 @@ function start (config) {
   if (!config.telemetry.DD_INSTRUMENTATION_TELEMETRY_ENABLED || subscribed) return
   subscribed = true
 
-  runtimeId = config.DD_ROOT_JS_SESSION_ID || config.tags['runtime-id']
+  savedConfig = config
 
   childProcessChannel.subscribe(
     /** @type {import('diagnostics_channel').TracingChannelSubscribers<object>} */ ({ start: onChildProcessStart })

--- a/packages/dd-trace/test/debugger/devtools_client/config.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/config.spec.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { MessageChannel } = require('node:worker_threads')
+
+const { describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+
+require('../../setup/mocha')
+
+describe('devtools_client/config', () => {
+  function loadConfig (parentConfig = {}) {
+    const configChannel = new MessageChannel()
+    const config = proxyquire('../../../src/debugger/devtools_client/config', {
+      'node:worker_threads': {
+        workerData: {
+          config: {
+            url: 'http://localhost:8126',
+            dynamicInstrumentation: { captureTimeoutMs: 100 },
+            runtimeId: 'initial-id',
+            ...parentConfig,
+          },
+          parentThreadId: 1,
+          configPort: configChannel.port1,
+        },
+      },
+    })
+    return { config, configChannel }
+  }
+
+  it('seeds the config from the worker data snapshot', () => {
+    const { config } = loadConfig()
+
+    assert.strictEqual(config.url.toString(), 'http://localhost:8126/')
+    assert.strictEqual(config.dynamicInstrumentation.captureTimeoutNs, 100_000_000n)
+    assert.strictEqual(config.runtimeId, 'initial-id')
+  })
+
+  it('applies url, captureTimeoutNs and runtimeId from an update received over the config port', (done) => {
+    const { config, configChannel } = loadConfig()
+
+    // Registered after the module's own `configPort.on('message', updateConfig)` listener, so it
+    // runs after `updateConfig` has already applied the update.
+    configChannel.port1.on('message', () => {
+      assert.strictEqual(config.url.toString(), 'http://updated:8126/')
+      assert.strictEqual(config.dynamicInstrumentation.captureTimeoutNs, 5_000_000n)
+      assert.strictEqual(config.runtimeId, 'reseeded-id')
+      done()
+    })
+
+    configChannel.port2.postMessage({
+      url: 'http://updated:8126',
+      dynamicInstrumentation: { captureTimeoutMs: 5 },
+      runtimeId: 'reseeded-id',
+    })
+  })
+})

--- a/packages/dd-trace/test/debugger/devtools_client/status.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/status.spec.js
@@ -16,7 +16,7 @@ const service = 'my-service'
 const runtimeId = 'my-runtime-id'
 
 describe('diagnostic message http requests', function () {
-  let clock, statusproxy, request, jsonBuffer
+  let clock, statusproxy, request, jsonBuffer, configMock
 
   /** @type {Array<[string, string] | [string, string, Error]>} */
   const acks = [
@@ -42,16 +42,18 @@ describe('diagnostic message http requests', function () {
       }
     }
 
-    statusproxy = proxyquire('../../../src/debugger/devtools_client/status', {
-      './config': {
-        service,
-        runtimeId,
-        maxTotalPayloadSize: 5 * 1024 * 1024, // 5MB
-        dynamicInstrumentation: {
-          uploadIntervalSeconds: 1,
-        },
-        '@noCallThru': true,
+    configMock = {
+      service,
+      runtimeId,
+      maxTotalPayloadSize: 5 * 1024 * 1024, // 5MB
+      dynamicInstrumentation: {
+        uploadIntervalSeconds: 1,
       },
+      '@noCallThru': true,
+    }
+
+    statusproxy = proxyquire('../../../src/debugger/devtools_client/status', {
+      './config': configMock,
       './json-buffer': JSONBufferSpy,
       '../../exporters/common/request': request,
     })
@@ -148,10 +150,20 @@ describe('diagnostic message http requests', function () {
       })
     })
   }
+
+  it('reflects a runtimeId mutated on the config after load (e.g. a main-thread identity refresh)', function (done) {
+    configMock.runtimeId = 'reseeded-runtime-id'
+
+    statusproxy.ackReceived({ id: 'foo', version: 0 })
+
+    const event = formatAsDiagnosticsEvent({ probeId: 'foo', version: 0, status: 'RECEIVED' }, 'reseeded-runtime-id')
+    sinon.assert.calledOnceWithExactly(jsonBuffer.write, JSON.stringify(event))
+    done()
+  })
 })
 
-function formatAsDiagnosticsEvent ({ probeId, version, status, exception }) {
-  const diagnostics = { probeId, runtimeId, probeVersion: version, status }
+function formatAsDiagnosticsEvent ({ probeId, version, status, exception }, expectedRuntimeId = runtimeId) {
+  const diagnostics = { probeId, runtimeId: expectedRuntimeId, probeVersion: version, status }
 
   // Error requests will also contain an `exception` property
   if (exception) diagnostics.exception = exception

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -331,6 +331,21 @@ describe('dogstatsd', () => {
     assert.strictEqual(noopDuringSend, true)
   })
 
+  it('reflects tags updated via updateTags() on the next _add() call', () => {
+    client = createDogStatsDClient({ tags: ['foo:bar'] })
+
+    client.gauge('test.avg', 1)
+    client.flush()
+    assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:1|g|#foo:bar\n')
+
+    client.updateTags(['baz:qux'])
+    client.gauge('test.avg', 2)
+    client.flush()
+
+    sinon.assert.calledTwice(udp4.send)
+    assert.strictEqual(udp4.send.secondCall.args[0].toString(), 'test.avg:2|g|#baz:qux\n')
+  })
+
   it('should support configuration', () => {
     client = createDogStatsDClient({
       host: '::1',
@@ -706,6 +721,24 @@ describe('dogstatsd', () => {
       } finally {
         clock.restore()
       }
+    })
+
+    it('reflects tags updated via updateTags() (e.g. a reseeded runtime-id) on the next metric', () => {
+      client = createCustomMetrics()
+
+      client.gauge('test.avg', 1, { foo: 'bar' })
+      client.flush()
+      assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:1|g|#foo:bar\n')
+
+      client.updateTags(['runtime-id:reseeded-id'])
+      client.gauge('test.avg', 2, { foo: 'bar' })
+      client.flush()
+
+      sinon.assert.calledTwice(udp4.send)
+      assert.strictEqual(
+        udp4.send.secondCall.args[0].toString(),
+        'test.avg:2|g|#runtime-id:reseeded-id,foo:bar\n'
+      )
     })
 
     it('should send the Docker entity ID when available', () => {

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -112,6 +112,20 @@ describe('agentless-ci-visibility-encode', () => {
     assert.strictEqual(spanEvent.content.metrics.negative, -123456712345)
   })
 
+  it('reflects a runtime-id mutated on the shared tags object after construction (e.g. MicroVM clone resume)', () => {
+    const tags = { 'runtime-id': 'current-id' }
+    const { AgentlessCiVisibilityEncoder } = require('../../src/encode/agentless-ci-visibility')
+    const liveEncoder = new AgentlessCiVisibilityEncoder(writer, { tags })
+
+    tags['runtime-id'] = 'reseeded-id'
+
+    liveEncoder.encode(trace)
+    const buffer = liveEncoder.makePayload()
+    const decoded = msgpack.decode(buffer, { useBigInt64: true })
+
+    assert.strictEqual(decoded.metadata['*']['runtime-id'], 'reseeded-id')
+  })
+
   it('should report its count', () => {
     assert.strictEqual(encoder.count(), 0)
 

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -120,6 +120,25 @@ describe('AgentlessExporter', () => {
         languageName: 'nodejs',
       })
     })
+
+    it('should reflect a runtime-id mutated on config after construction (e.g. MicroVM clone resume)', () => {
+      const writerOptions = {}
+      const Writer = function (opts) {
+        Object.assign(writerOptions, opts)
+        return writer
+      }
+
+      Exporter = proxyquire('../../../src/exporters/agentless', {
+        './writer': Writer,
+      })
+
+      const config = { site: 'datadoghq.com', tags: { 'runtime-id': 'test-uuid' } }
+      exporter = new Exporter(config)
+
+      config.tags['runtime-id'] = 'reseeded-uuid'
+
+      assert.strictEqual(writerOptions.metadata.runtimeID, 'reseeded-uuid')
+    })
   })
 
   describe('export', () => {

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -54,12 +54,12 @@ describe('OpenTelemetry Meter Provider', () => {
 
     metrics.disable()
     const config = getConfigFresh()
+    let otelMetricsModule
     if (config.DD_METRICS_OTEL_ENABLED) {
-      const { initializeOpenTelemetryMetrics } =
-        proxyquire.noPreserveCache()('../../src/opentelemetry/metrics', {})
-      initializeOpenTelemetryMetrics(config)
+      otelMetricsModule = proxyquire.noPreserveCache()('../../src/opentelemetry/metrics', {})
+      otelMetricsModule.initializeOpenTelemetryMetrics(config)
     }
-    return { config, meterProvider: metrics.getMeterProvider() }
+    return { config, meterProvider: metrics.getMeterProvider(), otelMetricsModule }
   }
 
   function mockOtlpExport (validator) {
@@ -385,6 +385,26 @@ describe('OpenTelemetry Meter Provider', () => {
 
       setTimeout(() => { validator(); done() }, 150)
     })
+
+    it('reflects resource attributes refreshed via refreshResourceAttributes() (e.g. a reseeded runtime-id)',
+      (done) => {
+        const validator = mockOtlpExport((decoded) => {
+          const attrs = {}
+          decoded.resourceMetrics[0].resource.attributes.forEach(attr => {
+            attrs[attr.key] = attr.value.stringValue || attr.value.intValue
+          })
+          assert.strictEqual(attrs['service.name'], 'reseeded-service')
+        })
+
+        const { config, otelMetricsModule } = setupMetrics({ DD_SERVICE: 'original-service' })
+        config.service = 'reseeded-service'
+        otelMetricsModule.refreshResourceAttributes(config)
+
+        const meter = metrics.getMeter('app')
+        meter.createCounter('test').add(1)
+
+        setTimeout(() => { validator(); done() }, 150)
+      })
 
     it('supports multiple attributes and data points', (done) => {
       const validator = mockOtlpExport((decoded) => {

--- a/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_exporter.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_exporter.spec.js
@@ -172,6 +172,20 @@ describe('OtlpStatsExporter', () => {
     assert.ok(httpStub.calledOnce)
   })
 
+  it('reflects resource attributes pushed via updateResourceAttributes on the next export', () => {
+    exporter.updateResourceAttributes({ 'service.name': 'reseeded-svc' })
+
+    const drained = makeDrained([makeSpan()])
+    exporter.export(drained, BUCKET_SIZE_NS)
+
+    const payload = JSON.parse(mockReq.write.firstCall.args[0].toString())
+    const { attributes } = payload.resourceMetrics[0].resource
+    assert.deepStrictEqual(
+      attributes.find(attr => attr.key === 'service.name'),
+      { key: 'service.name', value: { stringValue: 'reseeded-svc' } }
+    )
+  })
+
   it('handles request error without throwing', () => {
     mockReq.on = (event, handler) => { if (event === 'error') handler(new Error('connection refused')) }
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -114,6 +114,7 @@ describe('TracerProxy', () => {
       class FauxDogStatsDClient {
         constructor (cfg) {
           dogstatsdConfig = cfg
+          this.updateTags = sinon.spy()
         }
 
         increment () {
@@ -127,6 +128,7 @@ describe('TracerProxy', () => {
 
       dogStatsD = {
         CustomMetrics: FauxDogStatsDClient,
+        DogStatsDClient: { generateClientConfig: sinon.stub().returns({ tags: [] }) },
         _increments: () => dogstatsdIncrements,
         _config: () => dogstatsdConfig,
         _flushes: () => dogstatsdFlushes,
@@ -176,6 +178,7 @@ describe('TracerProxy', () => {
 
     runtimeMetrics = {
       start: sinon.spy(),
+      updateTags: sinon.spy(),
     }
 
     profiler = {
@@ -1002,6 +1005,8 @@ describe('TracerProxy', () => {
     let idMock
     let channelMock
     let diagnosticsChannelMock
+    let dynamicInstrumentationMock
+    let otelMetricsMock
     let MicroVmProxy
     let microProxy
     let origEnv
@@ -1019,6 +1024,17 @@ describe('TracerProxy', () => {
 
       diagnosticsChannelMock = {
         channel: sinon.stub().returns(channelMock),
+      }
+
+      dynamicInstrumentationMock = {
+        isStarted: sinon.stub().returns(false),
+        configure: sinon.stub(),
+        start: sinon.stub(),
+        stop: sinon.stub(),
+      }
+
+      otelMetricsMock = {
+        refreshResourceAttributes: sinon.stub(),
       }
 
       Config.refreshRuntimeId = sinon.stub()
@@ -1044,6 +1060,8 @@ describe('TracerProxy', () => {
         './openfeature': openfeature,
         './openfeature/flagging_provider': OpenFeatureProvider,
         './id': idMock,
+        './debugger': dynamicInstrumentationMock,
+        './opentelemetry/metrics': otelMetricsMock,
         'dc-polyfill': diagnosticsChannelMock,
       })
 
@@ -1121,6 +1139,53 @@ describe('TracerProxy', () => {
       assert.ok(idMock.reseed.calledBefore(Config.refreshRuntimeId))
       assert.ok(Config.refreshRuntimeId.calledBefore(RemoteConfig.refreshClientId))
       assert.ok(RemoteConfig.refreshClientId.calledBefore(tracer.refreshMetadata))
+    })
+
+    it('should refresh runtime-metrics DogStatsD tags and OTel resource attributes', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.calledWith(runtimeMetrics.updateTags, config)
+      sinon.assert.calledWith(otelMetricsMock.refreshResourceAttributes, config)
+    })
+
+    it('should refresh an already-constructed Custom Metrics DogStatsD client', () => {
+      config.dogstatsd = { hostname: 'localhost', port: 8125 }
+      dogStatsD.DogStatsDClient.generateClientConfig.returns({ tags: ['runtime-id:reseeded-id'] })
+
+      microProxy.init()
+      const customMetricsClient = microProxy.dogstatsd
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.calledOnceWithExactly(customMetricsClient.updateTags, ['runtime-id:reseeded-id'])
+    })
+
+    it('should NOT reconfigure the debugger when it is not started', () => {
+      dynamicInstrumentationMock.isStarted.returns(false)
+
+      microProxy.init()
+      dynamicInstrumentationMock.configure.resetHistory() // init() itself reconfigures the debugger once
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.notCalled(dynamicInstrumentationMock.configure)
+    })
+
+    it('should reconfigure the debugger when it is already started', () => {
+      dynamicInstrumentationMock.isStarted.returns(true)
+
+      microProxy.init()
+      dynamicInstrumentationMock.configure.resetHistory() // init() itself reconfigures the debugger once
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.calledWith(dynamicInstrumentationMock.configure, config)
     })
 
     it('should call refreshIdentity from resetRuntimeId when initialized and env var set', () => {

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -175,6 +175,7 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
             increment: wrapSpy(client, client.increment),
             histogram: wrapSpy(client, client.histogram),
             flush: client.flush.bind(client),
+            updateTags: client.updateTags.bind(client),
           }
         })
 
@@ -185,6 +186,7 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
           increment: sinon.spy(),
           histogram: sinon.spy(),
           flush: sinon.spy(),
+          updateTags: sinon.spy(),
         }
 
         const proxiedObject = {
@@ -295,6 +297,33 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
           const call = Client.lastCall
           const tags = call.args[0].tags
           assert.ok(!tags.some(tag => tag.startsWith('entrypoint.')), 'expected no entrypoint tags')
+        })
+
+        it('reflects a reseeded runtime-id and client-id via updateTags(), respecting the runtimeMetricsRuntimeId ' +
+          'gate', () => {
+          config.runtimeMetricsRuntimeId = true
+          config.tags['runtime-id'] = 'reseeded-id'
+          config.tags['_dd.rc.client_id'] = 'reseeded-client-id'
+
+          runtimeMetrics.updateTags(config)
+
+          sinon.assert.calledWith(client.updateTags, [
+            'str:bar',
+            'invalid:t_e_s_t5-:./',
+            'runtime-id:reseeded-id',
+            '_dd.rc.client_id:reseeded-client-id',
+          ])
+        })
+
+        it('omits runtime-id from updateTags() when the runtimeMetricsRuntimeId gate is off', () => {
+          config.tags['runtime-id'] = 'reseeded-id'
+
+          runtimeMetrics.updateTags(config)
+
+          sinon.assert.calledWith(client.updateTags, [
+            'str:bar',
+            'invalid:t_e_s_t5-:./',
+          ])
         })
 
         it('should start collecting runtimeMetrics every 10 seconds', async () => {
@@ -1117,6 +1146,7 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
     count (name, count, tag, monotonic) { statsdCalls.push(['count', name, count, tag, monotonic]) },
     gauge (name, value, tag) { statsdCalls.push(['gauge', name, value, tag]) },
     flush () {},
+    updateTags: sinon.spy(),
   }
 
   const monitorEventLoopDelay = overrides.monitorEventLoopDelay ?? realPerfHooks.monitorEventLoopDelay
@@ -1134,6 +1164,7 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
     },
     './client': {
       createMetricsClient: () => fakeMetricsClient,
+      generateMetricsClientTags: require('../src/runtime_metrics/client').generateMetricsClientTags,
     },
   })
 
@@ -1271,6 +1302,23 @@ describe('otlp_runtime_metrics', () => {
       }
       assert.doesNotMatch(name, /^runtime\.node\./, `${name} should not use DD-proprietary naming`)
     }
+  })
+
+  it('reflects a reseeded runtime-id via updateTags() on the underlying DogStatsD client', () => {
+    const ctx = loadOtlpRuntimeMetricsTestModule()
+    ctx.otlpMetrics.start({ runtimeMetrics: { eventLoop: true } })
+
+    const config = {
+      dogstatsd: { hostname: 'localhost', port: 8125 },
+      runtimeMetricsRuntimeId: true,
+      tags: { 'runtime-id': 'reseeded-id' },
+    }
+    ctx.otlpMetrics.updateTags(config)
+
+    sinon.assert.calledOnce(ctx.fakeMetricsClient.updateTags)
+    assert.deepStrictEqual(ctx.fakeMetricsClient.updateTags.firstCall.args[0], ['runtime-id:reseeded-id'])
+
+    ctx.otlpMetrics.stop()
   })
 
   it('observes positive values and emits required attributes', () => {

--- a/packages/dd-trace/test/telemetry/session-propagation.spec.js
+++ b/packages/dd-trace/test/telemetry/session-propagation.spec.js
@@ -228,6 +228,21 @@ describe('session-propagation', () => {
       ])
     })
 
+    it('reflects a runtime-id mutated on the config after start (e.g. MicroVM clone resume)', () => {
+      const config = createConfig()
+      sessionPropagation.start(config)
+
+      config.tags['runtime-id'] = 'reseeded-id'
+
+      const context = publishStart({ callArgs: ['node', ['test.js'], {}], shell: false })
+
+      assert.deepStrictEqual(context.callArgs, [
+        'node',
+        ['test.js'],
+        { env: createExpectedEnv({ DD_ROOT_JS_SESSION_ID: 'reseeded-id' }) },
+      ])
+    })
+
     it('ignores execution contexts without call arguments', () => {
       sessionPropagation.start(createConfig())
 


### PR DESCRIPTION
### What does this PR do?

#9075 made `proxy.js#refreshIdentity` reseed `id.js`, `config.tags['runtime-id']`, RC's `clientId`, and process-discovery metadata when the Lambda MicroVM `/run` lifecycle hook fires. An offline follow-up review on that PR found more subsystems that copy those tag values by value and never see the refreshed identity — this PR closes those remaining gaps.

**Subsystems fixed:**
- `telemetry/session-propagation.js`, `exporters/agentless/index.js` (APM agentless trace metadata), and `ci-visibility/exporters/agentless/writer.js` + `encode/agentless-ci-visibility.js` (Test Optimization) each cached a copied primitive instead of holding a live reference to `config`/`config.tags`. Switched to read live so they self-heal with **no explicit trigger needed**.
- `dogstatsd.js` caches a precomputed tags string (`#tagsPrefix`) per client for hot-path performance (never touched per-metric, by design). Added `updateTags()` to regenerate it.
- `opentelemetry/metrics/index.js` + `otlp_transformer_base.js` cache transformed OTLP resource attributes once at construction. Added `updateResourceAttributes()`.
- `debugger/devtools_client`: the Dynamic Instrumentation worker thread's config is a structured-clone snapshot taken at spawn — nothing in the main thread can mutate it directly. A hot-reload path already existed (`configure()` posts a fresh config over `configChannel`) but silently dropped `runtimeId`; fixed `updateConfig()` to apply it, and stopped `status.js` from caching it in a module-level `const`.

**How subsystems get triggered — Option A:** `proxy.js#refreshIdentity` calls each of the above explicitly, mirroring the existing `refreshRuntimeId`/`refreshClientId`/`refreshMetadata` calls already there (including reusing the existing `DynamicInstrumentation.configure(config)` path for the debugger, already used elsewhere in this file for RC-driven reconfiguration).

```mermaid
flowchart TD
    A["Lambda MicroVM /run hook fires<br/>(http.server.request.start channel)"] --> B["proxy.js#refreshIdentity(config)"]
    B --> C["id.reseed()"]
    B --> D["config.refreshRuntimeId(config)"]
    B --> E["remote_config.refreshClientId(config)"]
    B --> F["tracer.refreshMetadata(config)"]
    B --> G["#refreshDogStatsDTags(config)"]
    B --> H["opentelemetry/metrics.refreshResourceAttributes(config)"]
    B --> I["DynamicInstrumentation.configure(config)<br/>(only if isStarted())"]

    G --> G1["this.dogstatsd.updateTags(...)<br/>(Custom Metrics client)"]
    G --> G2["runtimeMetrics.updateTags(config)"]
    I --> I1["configChannel.postMessage(...)<br/>→ debugger worker thread"]

    style B fill:#e8d5f5
```

`refreshIdentity` has a direct call for every consumer — it "knows" about `dogstatsd`, `opentelemetry/metrics`, and the debugger by name.

An identical companion PR, #9355, implements **Option B** — a shared "identity refreshed" event instead of explicit per-subsystem calls — for side-by-side comparison. Only one should merge.

### Motivation

On a Firecracker MicroVM, every clone resuming from the same snapshot starts with identical frozen state. #9075 covered the three obvious PRNG-derived identifiers, but several other subsystems independently copy `runtime-id`/`_dd.rc.client_id` out of `config.tags` at their own construction time, so they kept reporting the pre-snapshot identity indefinitely after a clone resumed — even after #9075 landed.

### Pros / cons of this approach (explicit calls)

**Pros**
- Minimal diff, consistent with the pattern #9075 already established for RC/metadata.
- Easy to review line-by-line: every trigger is a single, explicit call in one place (`refreshIdentity`).
- No new cross-cutting abstraction (event bus / diagnostics channel) to reason about.

**Cons**
- `proxy.js` has to import and know about every consumer by name. Every future subsystem that captures `runtime-id` (or a similar identity-derived tag) has to remember to add itself here — the same drift risk that produced this bug in the first place (the RC/metadata fixes in #9075 were added ad hoc as they were found; it took a second review pass to find the rest).

### Additional Notes

- Two coverage gaps found during review (already-constructed Custom Metrics DogStatsD client never exercised in a test; the OTLP runtime-metrics `updateTags` path never executed) have been fixed with dedicated tests.
- One pre-existing, unrelated flaky test was identified (`dogstatsd.spec.js`'s UDP-failover-timeout case) — verified to fail identically on the unmodified base branch, not touched here.
