### PR TITLE
fix(playwright): handle RUM correlation cookie errors

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -252,6 +252,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/plugins/test
 
+  # Unit tests for the Playwright instrumentation/plugin boundary. The integration matrix above only
+  # runs `integration-tests/playwright/*.spec.js`, so it cannot exercise these focused contract specs.
+  playwright:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: playwright
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/plugins/test
+      - run: npm run test:instrumentations
+
   integration-cucumber:
     strategy:
       fail-fast: false

--- a/integration-tests/ci-visibility/playwright-tests-rum/rum-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-rum/rum-test.js
@@ -3,6 +3,11 @@
 const { test, expect } = require('@playwright/test')
 
 test.beforeEach(async ({ page }) => {
+  if (process.env.REJECT_RUM_COOKIE === 'true') {
+    page.context().addCookies = async () => {
+      throw new Error('RUM correlation cookie rejected')
+    }
+  }
   await page.goto(process.env.PW_BASE_URL)
 })
 

--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -190,7 +190,9 @@ versions.forEach((version) => {
             }
           )
 
-          await Promise.all([once(proc, 'exit'), testAssertionsPromise])
+          const [[exitCode]] = await Promise.all([once(proc, 'exit'), testAssertionsPromise])
+
+          assert.strictEqual(exitCode, isRedirecting ? 1 : 0)
         } finally {
           proc?.kill()
         }
@@ -198,6 +200,12 @@ versions.forEach((version) => {
 
       it('can correlate tests and RUM sessions', async (receiver) => {
         await runRumTest(receiver, { isRedirecting: false })
+      })
+
+      it('does not crash when the RUM correlation cookie is rejected', async (receiver) => {
+        await runRumTest(receiver, { isRedirecting: false }, {
+          REJECT_RUM_COOKIE: 'true',
+        })
       })
 
       it('sends telemetry for RUM browser tests when telemetry is enabled', async (receiver) => {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1773,6 +1773,9 @@ addHook({
   return processHostPackage
 })
 
+/**
+ * @param {import('playwright-core').Page} page
+ */
 async function handlePageGoto (page) {
   try {
     if (page && typeof page.evaluate === 'function') {
@@ -1782,15 +1785,32 @@ async function handlePageGoto (page) {
       }
 
       if (isRumActive) {
+        let testExecutionId
+        /**
+         * @param {string} traceId
+         */
+        const onDone = (traceId) => {
+          testExecutionId = traceId
+        }
         testPageGotoCh.publish({
           isRumActive,
-          page,
+          browserVersion: page.context().browser()?.version(),
+          onDone,
         })
+        if (testExecutionId) {
+          const domain = new URL(page.url()).hostname
+          await page.context().addCookies([{
+            name: 'datadog-ci-visibility-test-execution-id',
+            value: testExecutionId,
+            domain,
+            path: '/',
+          }])
+        }
       }
     }
-  } catch (e) {
+  } catch (error) {
     // ignore errors such as redirects, context destroyed, etc
-    log.error('goto hook error', e)
+    log.error('goto hook error', error)
   }
 }
 

--- a/packages/datadog-instrumentations/test/playwright.spec.js
+++ b/packages/datadog-instrumentations/test/playwright.spec.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { channel } = require('dc-polyfill')
+const sinon = require('sinon')
+
+require('../src/playwright')
+
+const PLAYWRIGHT_HOOKS = globalThis[Symbol.for('_ddtrace_instrumentations')]['playwright-core']
+const PAGE_HOOK = PLAYWRIGHT_HOOKS.find(entry => entry.file === 'lib/client/page.js').hook
+
+describe('packages/datadog-instrumentations/src/playwright.js', () => {
+  it('owns rejected RUM correlation cookie promises', async () => {
+    const addCookies = sinon.stub().rejects(new Error('cookie rejected'))
+    const browserContext = {
+      addCookies,
+      browser: () => ({
+        version: () => 'browser-version',
+      }),
+    }
+
+    class Page {
+      async goto () {
+        return 'response'
+      }
+
+      async evaluate () {
+        return {
+          isRumActive: true,
+          isRumInstrumented: true,
+          rumSamplingRate: 100,
+        }
+      }
+
+      context () {
+        return browserContext
+      }
+
+      url () {
+        return 'https://example.com/test'
+      }
+    }
+
+    const pageGotoCh = channel('ci:playwright:test:page-goto')
+    let pageGotoEvent
+    const onPageGoto = (event) => {
+      pageGotoEvent = event
+      event.onDone?.('test-execution-id')
+    }
+    pageGotoCh.subscribe(onPageGoto)
+
+    try {
+      const { Page: WrappedPage } = PAGE_HOOK({ Page })
+      const response = await new WrappedPage().goto()
+
+      assert.strictEqual(response, 'response')
+      assert.strictEqual(pageGotoEvent.browserVersion, 'browser-version')
+      assert.strictEqual(pageGotoEvent.page, undefined)
+      sinon.assert.calledOnceWithExactly(addCookies, [{
+        name: 'datadog-ci-visibility-test-execution-id',
+        value: 'test-execution-id',
+        domain: 'example.com',
+        path: '/',
+      }])
+    } finally {
+      pageGotoCh.unsubscribe(onPageGoto)
+    }
+  })
+})

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -180,7 +180,8 @@ class PlaywrightPlugin extends CiPlugin {
 
     this.addSub('ci:playwright:test:page-goto', ({
       isRumActive,
-      page,
+      browserVersion,
+      onDone,
     }) => {
       const store = storage('legacy').getStore()
       const span = store && store.span
@@ -192,22 +193,10 @@ class PlaywrightPlugin extends CiPlugin {
       if (isRumActive) {
         span.setTag(TEST_IS_RUM_ACTIVE, 'true')
 
-        if (page) {
-          const browserVersion = page.context().browser().version()
-
-          if (browserVersion) {
-            span.setTag(TEST_BROWSER_VERSION, browserVersion)
-          }
-
-          const url = page.url()
-          const domain = new URL(url).hostname
-          page.context().addCookies([{
-            name: 'datadog-ci-visibility-test-execution-id',
-            value: span.context().toTraceId(),
-            domain,
-            path: '/',
-          }])
+        if (browserVersion) {
+          span.setTag(TEST_BROWSER_VERSION, browserVersion)
         }
+        onDone(span.context().toTraceId())
       }
     })
 

--- a/packages/datadog-plugin-playwright/test/index.spec.js
+++ b/packages/datadog-plugin-playwright/test/index.spec.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { channel } = require('dc-polyfill')
+const sinon = require('sinon')
+
+const { storage } = require('../../datadog-core')
+const {
+  TEST_BROWSER_VERSION,
+  TEST_IS_RUM_ACTIVE,
+} = require('../../dd-trace/src/plugins/util/test')
+const PlaywrightPlugin = require('../src')
+
+const legacyStorage = storage('legacy')
+
+describe('PlaywrightPlugin', () => {
+  let plugin
+
+  beforeEach(() => {
+    plugin = new PlaywrightPlugin({}, { testOptimization: {} })
+    plugin.configure({ enabled: true }, false)
+  })
+
+  afterEach(() => {
+    plugin.configure(false)
+  })
+
+  it('provides the active test identity without owning the Playwright page', () => {
+    const setTag = sinon.spy()
+    const span = {
+      context: () => ({
+        toTraceId: () => 'test-execution-id',
+      }),
+      setTag,
+    }
+    const onDone = sinon.spy()
+
+    legacyStorage.run({ span }, () => {
+      channel('ci:playwright:test:page-goto').publish({
+        browserVersion: 'browser-version',
+        isRumActive: true,
+        onDone,
+      })
+    })
+
+    sinon.assert.calledWithExactly(setTag, TEST_IS_RUM_ACTIVE, 'true')
+    sinon.assert.calledWithExactly(setTag, TEST_BROWSER_VERSION, 'browser-version')
+    sinon.assert.calledOnceWithExactly(onDone, 'test-execution-id')
+    assert.strictEqual(setTag.callCount, 2)
+  })
+})


### PR DESCRIPTION
## Summary

Playwright RUM correlation wrote cookies from a diagnostic-channel subscriber without owning the returned promise. Rejected writes could terminate the test worker as unhandled rejections, so the awaited navigation hook now owns page I/O and the plugin only provides the active test identity.