### PR TITLE
test(test-optimization): assert complete run payloads

### DIFF
--- a/integration-tests/ci-visibility-intake.spec.js
+++ b/integration-tests/ci-visibility-intake.spec.js
@@ -47,8 +47,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 3 } })
     child.simulateExit(0)
 
-    await clock.tickAsync(50)
-    await promise
+    await Promise.all([clock.tickAsync(50), promise])
   })
 
   it('does not resolve before child exit, even when the buffer would satisfy the assertion', async () => {
@@ -69,8 +68,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     assert.strictEqual(assertionRuns, 0, 'onPayload must not run before child exit')
 
     child.simulateExit(0)
-    await clock.tickAsync(50)
-    await promise
+    await Promise.all([clock.tickAsync(50), promise])
     assert.strictEqual(assertionRuns, 1, 'onPayload runs exactly once on the post-exit buffer')
   })
 
@@ -91,8 +89,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 2 } })
     })
 
-    await clock.tickAsync(100)
-    await promise
+    await Promise.all([clock.tickAsync(100), promise])
   })
 
   it('fails when a valid prefix is followed by a duplicate during the grace period', async () => {
@@ -113,8 +110,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
     })
 
-    await clock.tickAsync(50)
-    await rejection
+    await Promise.all([clock.tickAsync(50), rejection])
   })
 
   it('rejects with a clear error when the child exits without any matching payloads', async () => {

--- a/integration-tests/ci-visibility-intake.spec.js
+++ b/integration-tests/ci-visibility-intake.spec.js
@@ -129,8 +129,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
 
     child.simulateExit(1)
 
-    await clock.tickAsync(50)
-    await rejection
+    await Promise.all([clock.tickAsync(50), rejection])
   })
 
   it('rejects with the caller assertion error when the post-exit buffer fails the assertion', async () => {
@@ -148,8 +147,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
     child.simulateExit(0)
 
-    await clock.tickAsync(50)
-    await rejection
+    await Promise.all([clock.tickAsync(50), rejection])
   })
 
   it('settles once on hard timeout when the child does not exit', async () => {
@@ -165,8 +163,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     )
     const rejection = assert.rejects(promise, /hard timeout of 100ms/)
 
-    await clock.tickAsync(100)
-    await rejection
+    await Promise.all([clock.tickAsync(100), rejection])
 
     child.simulateExit(0)
     intake.emit('message', { url: '/api/v2/citestcycle', payload: {} })
@@ -193,8 +190,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       child.simulateExit(0)
     }, 80)
 
-    await clock.tickAsync(130)
-    await promise
+    await Promise.all([clock.tickAsync(130), promise])
   })
 
   it('treats a child that already exited as exit + grace', async () => {
@@ -211,7 +207,6 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     )
     const rejection = assert.rejects(promise, /child exited with no matching payloads/)
 
-    await clock.tickAsync(50)
-    await rejection
+    await Promise.all([clock.tickAsync(50), rejection])
   })
 })

--- a/integration-tests/ci-visibility-intake.spec.js
+++ b/integration-tests/ci-visibility-intake.spec.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict')
 const { EventEmitter } = require('node:events')
 
+const sinon = require('sinon')
+
 const { FakeCiVisIntake } = require('./ci-visibility-intake')
 
 function fakeChildProcess () {
@@ -17,13 +19,17 @@ function fakeChildProcess () {
 }
 
 describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
-  let intake
+  let clock, intake
 
   beforeEach(async () => {
     intake = await new FakeCiVisIntake().start()
+    clock = sinon.useFakeTimers()
   })
 
-  afterEach(() => intake.stop())
+  afterEach(() => {
+    clock.restore()
+    return intake.stop()
+  })
 
   it('runs the assertion once after child exit + grace and resolves on success', async () => {
     const child = fakeChildProcess()
@@ -41,6 +47,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 3 } })
     child.simulateExit(0)
 
+    await clock.tickAsync(50)
     await promise
   })
 
@@ -58,10 +65,11 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     )
 
     intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await clock.tickAsync(100)
     assert.strictEqual(assertionRuns, 0, 'onPayload must not run before child exit')
 
     child.simulateExit(0)
+    await clock.tickAsync(50)
     await promise
     assert.strictEqual(assertionRuns, 1, 'onPayload runs exactly once on the post-exit buffer')
   })
@@ -83,7 +91,30 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 2 } })
     })
 
+    await clock.tickAsync(100)
     await promise
+  })
+
+  it('fails when a valid prefix is followed by a duplicate during the grace period', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assert.strictEqual(payloads.length, 1, 'expected exactly one payload')
+      },
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+    const rejection = assert.rejects(promise, /expected exactly one payload/)
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
+    child.simulateExit(0)
+    setImmediate(() => {
+      intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
+    })
+
+    await clock.tickAsync(50)
+    await rejection
   })
 
   it('rejects with a clear error when the child exits without any matching payloads', async () => {
@@ -94,10 +125,12 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       () => assert.fail('onPayload must not run when no payloads matched'),
       { gracePeriod: 50, hardTimeout: 5000 }
     )
+    const rejection = assert.rejects(promise, /child exited with no matching payloads/)
 
     child.simulateExit(1)
 
-    await assert.rejects(promise, /child exited with no matching payloads/)
+    await clock.tickAsync(50)
+    await rejection
   })
 
   it('rejects with the caller assertion error when the post-exit buffer fails the assertion', async () => {
@@ -110,23 +143,38 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       },
       { gracePeriod: 50, hardTimeout: 5000 }
     )
+    const rejection = assert.rejects(promise, /expected five payloads/)
 
     intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
     child.simulateExit(0)
 
-    await assert.rejects(promise, /expected five payloads/)
+    await clock.tickAsync(50)
+    await rejection
   })
 
-  it('rejects with a hard-timeout error when the child neither exits nor produces payloads', async () => {
+  it('settles once on hard timeout when the child does not exit', async () => {
     const child = fakeChildProcess()
+    let assertionRuns = 0
     const promise = intake.gatherPayloadsUntilChildExit(
       child,
       () => false,
-      () => {},
+      () => {
+        assertionRuns += 1
+      },
       { gracePeriod: 50, hardTimeout: 100 }
     )
+    const rejection = assert.rejects(promise, /hard timeout of 100ms/)
 
-    await assert.rejects(promise, /hard timeout of 100ms/)
+    await clock.tickAsync(100)
+    await rejection
+
+    child.simulateExit(0)
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: {} })
+    await clock.tickAsync(50)
+
+    assert.strictEqual(assertionRuns, 0)
+    assert.strictEqual(intake.listenerCount('message'), 0)
+    assert.strictEqual(child.listenerCount('exit'), 0)
   })
 
   it('does not surface a hard-timeout error when the child exits just before the backstop', async () => {
@@ -145,6 +193,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       child.simulateExit(0)
     }, 80)
 
+    await clock.tickAsync(130)
     await promise
   })
 
@@ -160,7 +209,9 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
       () => assert.fail('pre-subscribe payloads must not be captured'),
       { gracePeriod: 50, hardTimeout: 5000 }
     )
+    const rejection = assert.rejects(promise, /child exited with no matching payloads/)
 
-    await assert.rejects(promise, /child exited with no matching payloads/)
+    await clock.tickAsync(50)
+    await rejection
   })
 })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6813,18 +6813,6 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           test_management: { enabled: true, attempt_to_fix_retries: 2 },
         })
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events
-              .filter(event => event.type === 'test')
-              .map(event => event.content)
-              .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
-              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
-
-            assertAttemptToFixFailThenPass(tests)
-          })
-
         childProcess = exec(
           runTestsCommand,
           {
@@ -6841,11 +6829,22 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           }
         )
 
-        const [[exitCode]] = await Promise.all([
-          once(childProcess, 'exit'),
-          eventsPromise,
-        ])
-        assert.strictEqual(exitCode, 1)
+        await receiver.gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            assertAttemptToFixFailThenPass(tests)
+          },
+          { hardTimeout: 60_000 }
+        )
+        assert.strictEqual(childProcess.exitCode, 1)
       })
 
       onlyLatestIt('does not suppress attempt-to-fix failures for modified tests in parallel mode', async () => {

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -494,26 +494,6 @@ versions.forEach((version) => {
             early_flake_detection: { enabled: false },
           })
 
-          const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-              // These serial tests never ran — abandoned when maxFailures cut the run after the
-              // non-serial test exhausted its retries. Each must appear exactly once: the fallback
-              // loop at the end of the run must not re-emit them as duplicates.
-              const abandonedTests = tests.filter(t =>
-                t.meta[TEST_NAME] === 'playwright serial should fail on first attempt' ||
-                t.meta[TEST_NAME] === 'playwright serial should be skipped when previous test fails'
-              )
-              assert.strictEqual(abandonedTests.length, 2)
-              abandonedTests.forEach(t => assert.strictEqual(t.meta[TEST_STATUS], 'skip'))
-
-              // Suite finalization must not be blocked by the abandoned tests staying in remainingTestsByFile
-              const suiteEvents = events.filter(event => event.type === 'test_suite_end')
-              assert.ok(suiteEvents.length > 0, 'Expected test_suite_end — suite must be finalized')
-            }, 30000)
-
           // --retries=1: `should eventually pass after retrying` needs retry>=2 to pass, so it exhausts
           // both attempts and fails. MAX_FAILURES=1 then cuts the run, abandoning the serial suite.
           // PLAYWRIGHT_WORKERS=1 ensures the non-serial test always runs (and fails) before the serial suite.
@@ -531,7 +511,29 @@ versions.forEach((version) => {
             }
           )
 
-          await Promise.all([once(proc, 'exit'), receiverPromise])
+          await receiver.gatherPayloadsUntilChildExit(
+            proc,
+            ({ url }) => url === '/api/v2/citestcycle',
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // These serial tests never ran — abandoned when maxFailures cut the run after the
+              // non-serial test exhausted its retries. Each must appear exactly once: the fallback
+              // loop at the end of the run must not re-emit them as duplicates.
+              const abandonedTests = tests.filter(t =>
+                t.meta[TEST_NAME] === 'playwright serial should fail on first attempt' ||
+                t.meta[TEST_NAME] === 'playwright serial should be skipped when previous test fails'
+              )
+              assert.strictEqual(abandonedTests.length, 2)
+              abandonedTests.forEach(t => assert.strictEqual(t.meta[TEST_STATUS], 'skip'))
+
+              // Suite finalization must not be blocked by the abandoned tests staying in remainingTestsByFile
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end')
+              assert.ok(suiteEvents.length > 0, 'Expected test_suite_end — suite must be finalized')
+            },
+            { hardTimeout: 30_000 }
+          )
         })
     })
   })

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -634,30 +634,6 @@ versions.forEach((version) => {
           },
         })
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events
-              .filter(event => event.type === 'test')
-              .map(test => test.content)
-              .filter(test => test.meta[TEST_SOURCE_FILE].startsWith(
-                'ci-visibility/vitest-tests-programmatic-api/test-programmatic-api-'
-              ))
-
-            const testDetails = events
-              .filter(event => event.type === 'test')
-              .map(test => ({
-                name: test.content.meta[TEST_NAME],
-                sourceFile: test.content.meta[TEST_SOURCE_FILE],
-              }))
-            assert.strictEqual(tests.length, 2, inspect(testDetails))
-
-            const disabledTest = tests.find(test => test.meta[TEST_NAME] === disabledTestName)
-            assert.ok(disabledTest, inspect(tests.map(test => test.meta[TEST_NAME])))
-            assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
-            assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
-          })
-
         childProcess = exec(
           'node run-programmatic-api-rerun.mjs',
           {
@@ -672,12 +648,36 @@ versions.forEach((version) => {
         childProcess.stdout.on('data', data => { testOutput += data })
         childProcess.stderr.on('data', data => { testOutput += data })
 
-        const [[exitCode]] = await Promise.all([
-          once(childProcess, 'exit'),
-          eventsPromise,
-        ])
+        await receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url === '/api/v2/citestcycle',
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events
+                .filter(event => event.type === 'test')
+                .map(test => test.content)
+                .filter(test => test.meta[TEST_SOURCE_FILE].startsWith(
+                  'ci-visibility/vitest-tests-programmatic-api/test-programmatic-api-'
+                ))
 
-        assert.strictEqual(exitCode, 0, testOutput)
+              const testDetails = events
+                .filter(event => event.type === 'test')
+                .map(test => ({
+                  name: test.content.meta[TEST_NAME],
+                  sourceFile: test.content.meta[TEST_SOURCE_FILE],
+                }))
+              assert.strictEqual(tests.length, 2, inspect(testDetails))
+
+              const disabledTest = tests.find(test => test.meta[TEST_NAME] === disabledTestName)
+              assert.ok(disabledTest, inspect(tests.map(test => test.meta[TEST_NAME])))
+              assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+            },
+            { hardTimeout: 30_000 }
+          )
+
+        assert.strictEqual(childProcess.exitCode, 0, testOutput)
       })
     })
 


### PR DESCRIPTION
## Summary

Payload assertions that resolve as soon as a valid prefix arrives can miss duplicate or late events emitted before the test process finishes. This moves repeated-run, finalization, and retry contracts to the existing child-exit-plus-drain collector and pins that collector's timing behavior with fake timers.