### PR TITLE
fix(openfeature): keep provider stable across RC updates

### DIFF
--- a/packages/dd-trace/src/openfeature/register.js
+++ b/packages/dd-trace/src/openfeature/register.js
@@ -2,9 +2,21 @@
 
 const { registerFeature } = require('../feature-registry')
 
+const noop = new (require('./noop'))()
+
+/**
+ * @param {object} proxy
+ * @returns {boolean}
+ */
+function hasFlaggingProvider (proxy) {
+  const descriptor = Reflect.getOwnPropertyDescriptor(proxy, 'openfeature')
+
+  return descriptor?.value !== undefined && descriptor.value !== noop
+}
+
 registerFeature({
   name: 'openfeature',
-  noop: new (require('./noop'))(),
+  noop,
   factory: () => require('./index'),
 
   /**
@@ -26,7 +38,11 @@ registerFeature({
   enable (config, tracer, proxy, lazyProxy) {
     if (config.experimental.flaggingProvider.enabled) {
       proxy._modules.openfeature.enable(config)
-      lazyProxy(proxy, 'openfeature', () => require('./flagging_provider'), tracer, config)
+      // APM_TRACING remote config updates call this path again. Keep the provider
+      // instance stable so OpenFeature stays bound to the object receiving FFE_FLAGS.
+      if (!hasFlaggingProvider(proxy)) {
+        lazyProxy(proxy, 'openfeature', () => require('./flagging_provider'), tracer, config)
+      }
     }
   },
 })

--- a/packages/dd-trace/test/openfeature/register.spec.js
+++ b/packages/dd-trace/test/openfeature/register.spec.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+describe('OpenFeature register', () => {
+  let config
+  let feature
+  let lazyProxy
+  let openfeatureModule
+  let proxy
+  let registerFeature
+  let tracer
+
+  function NoopFlaggingProvider () {}
+
+  function FlaggingProvider (...args) {
+    this.args = args
+  }
+
+  beforeEach(() => {
+    registerFeature = sinon.spy(registeredFeature => {
+      feature = registeredFeature
+    })
+    openfeatureModule = {
+      enable: sinon.spy(),
+      disable: sinon.spy(),
+    }
+
+    delete require.cache[require.resolve('../../src/openfeature/register')]
+    proxyquire('../../src/openfeature/register', {
+      '../feature-registry': { registerFeature },
+      './flagging_provider': FlaggingProvider,
+      './index': openfeatureModule,
+      './noop': NoopFlaggingProvider,
+    })
+
+    config = {
+      experimental: {
+        flaggingProvider: {
+          enabled: true,
+        },
+      },
+    }
+    tracer = {}
+    proxy = {
+      openfeature: feature.noop,
+      _modules: {
+        openfeature: {
+          enable: sinon.spy(),
+        },
+      },
+    }
+    lazyProxy = sinon.spy((target, property, getClass, ...args) => {
+      const RealClass = getClass()
+      target[property] = new RealClass(...args)
+    })
+  })
+
+  it('registers the openfeature feature', () => {
+    sinon.assert.calledOnce(registerFeature)
+
+    assert.strictEqual(feature.name, 'openfeature')
+    assert.ok(feature.noop instanceof NoopFlaggingProvider)
+    assert.strictEqual(feature.factory(), openfeatureModule)
+  })
+
+  it('defines the flagging provider when enabled', () => {
+    feature.enable(config, tracer, proxy, lazyProxy)
+
+    sinon.assert.calledOnceWithExactly(proxy._modules.openfeature.enable, config)
+    sinon.assert.calledOnce(lazyProxy)
+    assert.ok(proxy.openfeature instanceof FlaggingProvider)
+    assert.deepStrictEqual(proxy.openfeature.args, [tracer, config])
+  })
+
+  it('keeps an existing flagging provider on repeated enable calls', () => {
+    feature.enable(config, tracer, proxy, lazyProxy)
+    const provider = proxy.openfeature
+
+    feature.enable(config, tracer, proxy, lazyProxy)
+
+    sinon.assert.calledTwice(proxy._modules.openfeature.enable)
+    sinon.assert.calledOnce(lazyProxy)
+    assert.strictEqual(proxy.openfeature, provider)
+  })
+
+  it('does not define the flagging provider when disabled', () => {
+    config.experimental.flaggingProvider.enabled = false
+
+    feature.enable(config, tracer, proxy, lazyProxy)
+
+    sinon.assert.notCalled(proxy._modules.openfeature.enable)
+    sinon.assert.notCalled(lazyProxy)
+    assert.strictEqual(proxy.openfeature, feature.noop)
+  })
+})

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -200,11 +200,12 @@ describe('TracerProxy', () => {
       disable: sinon.spy(),
     }
 
-    openfeatureProvider = {
-      _setConfiguration: sinon.spy(),
-    }
-
-    OpenFeatureProvider = sinon.stub().returns(openfeatureProvider)
+    OpenFeatureProvider = sinon.stub().callsFake(function () {
+      openfeatureProvider = {
+        _setConfiguration: sinon.spy(),
+      }
+      return openfeatureProvider
+    })
 
     flare = {
       enable: sinon.spy(),
@@ -258,9 +259,16 @@ describe('TracerProxy', () => {
     })
 
     const { enable: openfeatureRcEnable } = require('../src/openfeature/remote_config')
+    const noopOpenfeature = {}
+    function hasOpenfeatureProvider (proxy) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(proxy, 'openfeature')
+
+      return descriptor?.value !== undefined && descriptor.value !== noopOpenfeature
+    }
+
     featureRegistry.registerFeature({
       name: 'openfeature',
-      noop: {},
+      noop: noopOpenfeature,
       factory: () => openfeature,
       remoteConfig (rc, config, proxy) {
         openfeatureRcEnable(rc, config, () => proxy.openfeature)
@@ -268,7 +276,9 @@ describe('TracerProxy', () => {
       enable (config, tracer, proxy, lazyProxy) {
         if (config.experimental.flaggingProvider.enabled) {
           proxy._modules.openfeature.enable(config)
-          lazyProxy(proxy, 'openfeature', () => OpenFeatureProvider, tracer, config)
+          if (!hasOpenfeatureProvider(proxy)) {
+            lazyProxy(proxy, 'openfeature', () => OpenFeatureProvider, tracer, config)
+          }
         }
       },
     })
@@ -408,6 +418,24 @@ describe('TracerProxy', () => {
         handlers.get('FFE_FLAGS')('modify', flagConfig)
 
         sinon.assert.calledWith(openfeatureProvider._setConfiguration, flagConfig)
+      })
+
+      it('should keep OpenFeature bound to the provider that receives FFE_FLAGS after APM_TRACING updates', () => {
+        config.experimental.flaggingProvider.enabled = true
+
+        proxy.init()
+        const boundProvider = proxy.openfeature
+
+        handlers.get('APM_TRACING')(createApmTracingTransaction('test-config', {
+          tracing_enabled: true,
+        }))
+
+        const flagConfig = { flags: { 'test-flag': {} } }
+        handlers.get('FFE_FLAGS')('apply', flagConfig)
+
+        sinon.assert.calledOnce(OpenFeatureProvider)
+        assert.strictEqual(proxy.openfeature, boundProvider)
+        sinon.assert.calledOnceWithExactly(boundProvider._setConfiguration, flagConfig)
       })
 
       it('should support applying remote config', () => {


### PR DESCRIPTION
### What does this PR do?
Keep `tracer.openfeature` stable after the real FlaggingProvider is installed. The OpenFeature registration now skips recreating the provider during later tracing reconfiguration while still enabling the OpenFeature module.

### Motivation

I ran into this issue in https://github.com/DataDog/ffe-dogfooding/pull/94 where the provider appeared stuck in a not-ready state.

Apps can bind OpenFeature to `tracer.openfeature` before Remote Config delivers flag configuration. A later `APM_TRACING` Remote Config update reran `#updateTracing()`, recreated `tracer.openfeature`, and caused `FFE_FLAGS` updates to target the new provider while the app remained bound to the old one. That left the bound provider without configuration and required app-level polling such as `waitForTracerOpenFeatureProvider` ([see example here](https://github.com/DataDog/ffe-dogfooding/blob/8f9a626c84782a2b493eb1a68a72cf18a4af7d7d/apps/nodejs/app.js#L95)).

This keeps the provider instance that OpenFeature binds to as the same instance that receives `FFE_FLAGS` configuration updates.

### Additional Notes
Validated with:

- `./node_modules/.bin/mocha packages/dd-trace/test/proxy.spec.js`
- `npm run test:openfeature`
- targeted ESLint on the touched files

Full `npm run lint -- ...` currently stops before ESLint because the local `vendor/node_modules` tree has existing invalid dependency versions reported by the license check.