### PR TITLE
feat(genkit): add LLMObs support

### DIFF
--- a/packages/datadog-plugin-genkit/src/index.js
+++ b/packages/datadog-plugin-genkit/src/index.js
@@ -1,3 +1,23 @@
 'use strict'
 
-module.exports = require('./tracing')
+const GenkitLLMObsPlugin = require('../../dd-trace/src/llmobs/plugins/genkit')
+const CompositePlugin = require('../../dd-trace/src/plugins/composite')
+const GenkitTracingPlugin = require('./tracing')
+
+class GenkitPlugin extends CompositePlugin {
+  static id = 'genkit'
+
+  /**
+   * Compose LLMObs enrichment before the tracing plugin finishes the shared span.
+   *
+   * @returns {object} Genkit plugin members.
+   */
+  static get plugins () {
+    return {
+      llmobs: GenkitLLMObsPlugin,
+      tracing: GenkitTracingPlugin,
+    }
+  }
+}
+
+module.exports = GenkitPlugin

--- a/packages/datadog-plugin-genkit/test/llmobs.spec.js
+++ b/packages/datadog-plugin-genkit/test/llmobs.spec.js
@@ -1,0 +1,673 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+const {
+  assertLlmObsSpanEvent,
+  MOCK_NUMBER,
+  MOCK_STRING,
+  useLlmObs,
+} = require('../../dd-trace/test/llmobs/util')
+
+describe('genkit LLMObs', () => {
+  const { getEvents } = useLlmObs({ plugin: 'genkit' })
+
+  withVersions('genkit', ['@genkit-ai/core'], version => {
+    let ai
+    let runInNewSpan
+
+    beforeEach(() => {
+      const packages = require(`../../../versions/genkit@${version}`)
+      const { genkit } = packages.get('genkit/beta')
+      ;({ runInNewSpan } = packages.get('@genkit-ai/core/tracing'))
+      ai = genkit({ name: 'datadog-genkit-llmobs-test' })
+    })
+
+    function findSpan (spans, name) {
+      const span = spans.find(span => span.resource === name || span.name === name)
+      assert.ok(span, `expected span ${name}; got ${spans.map(span => span.resource || span.name).join(', ')}`)
+      return span
+    }
+
+    function findSpanByOperation (spans, operation) {
+      const span = spans.find(span => span.meta['genkit.operation.type'] === operation)
+      assert.ok(span, `expected ${operation} span; got ${spans.map(span => span.resource || span.name).join(', ')}`)
+      return span
+    }
+
+    function findEvent (events, name) {
+      const event = events.find(event => event.name === name)
+      assert.ok(event, `expected LLMObs event ${name}`)
+      return event
+    }
+
+    function expectedTags (span, error = false) {
+      return {
+        span,
+        tags: { ml_app: 'test', integration: 'genkit' },
+        ...(error && {
+          error: {
+            type: span.meta['error.type'],
+            message: span.meta['error.message'],
+            stack: MOCK_STRING,
+          },
+        }),
+      }
+    }
+
+    it('normalizes model messages, tools, metrics, and allowlisted metadata', async () => {
+      const model = ai.defineModel({ name: 'local/normalization-model' }, async request => ({
+        message: {
+          role: 'model',
+          content: [
+            { text: 'done' },
+            { media: { url: 'https://example.invalid/secret' } },
+            { custom: { excludedSecret: 'do-not-capture' } },
+            { toolResponse: { name: 'weather', ref: 'weather-1', output: { temperature: 21 } } },
+          ],
+        },
+        finishReason: 'stop',
+        latencyMs: 12,
+        usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6, thoughtsTokens: 100 },
+      }))
+
+      await model({
+        messages: [{
+          role: 'user',
+          content: [
+            { text: 'weather?' },
+            { toolRequest: { name: 'weather', ref: 'weather-1', input: { city: 'Paris' } } },
+            { data: 'excluded-data' },
+          ],
+        }],
+        config: { version: 'v1', temperature: 0.2, maxOutputTokens: 20, topK: 3, topP: 0.8, secret: 'excluded' },
+        toolChoice: 'required',
+      })
+
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'local/normalization-model')
+      const event = llmobsSpans[0]
+
+      assertLlmObsSpanEvent(event, {
+        ...expectedTags(span),
+        spanKind: 'llm',
+        name: 'local/normalization-model',
+        modelName: 'local/normalization-model',
+        modelProvider: 'custom',
+        inputMessages: [{
+          role: 'user',
+          content: 'weather?',
+          tool_calls: [{ name: 'weather', arguments: { city: 'Paris' }, tool_id: 'weather-1' }],
+        }],
+        outputMessages: [{
+          role: 'assistant',
+          content: 'done',
+          tool_results: [{ name: 'weather', result: '{"temperature":21}', tool_id: 'weather-1' }],
+        }],
+        metrics: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+        metadata: {
+          version: 'v1',
+          temperature: 0.2,
+          max_output_tokens: 20,
+          top_k: 3,
+          top_p: 0.8,
+          tool_choice: 'required',
+          finish_reason: 'stop',
+          latency_ms: MOCK_NUMBER,
+        },
+      })
+
+      const serialized = JSON.stringify(event)
+      assert.doesNotMatch(serialized, /do-not-capture|excluded-data|example\.invalid|thoughtsTokens/)
+    })
+
+    it('records model runner errors with input and an empty output', async () => {
+      const model = ai.defineModel({ name: 'local/error-model' }, async () => {
+        throw new Error('model runner failed')
+      })
+
+      await assert.rejects(
+        model({ messages: [{ role: 'user', content: [{ text: 'fail' }] }] }),
+        { message: 'model runner failed' }
+      )
+
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'local/error-model')
+      assertLlmObsSpanEvent(llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'llm',
+        name: 'local/error-model',
+        modelName: 'local/error-model',
+        modelProvider: 'custom',
+        inputMessages: [{ role: 'user', content: 'fail' }],
+        outputMessages: [{ role: '', content: '' }],
+        metadata: {},
+      })
+    })
+
+    it('finishes streaming model spans after chunks and the final response', async () => {
+      const lifecycle = []
+      const model = ai.defineModel({ name: 'local/stream-model' }, async (request, sendChunk) => {
+        sendChunk({ content: [{ text: 'first' }] })
+        lifecycle.push('first')
+        await new Promise(resolve => setImmediate(resolve))
+        sendChunk({ content: [{ text: 'second' }] })
+        lifecycle.push('second')
+        return {
+          message: { role: 'model', content: [{ text: 'complete' }] },
+          finishReason: 'stop',
+          usage: { inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+        }
+      })
+
+      const { stream, response } = ai.generateStream({ model, prompt: 'stream' })
+      const chunks = []
+      for await (const chunk of stream) chunks.push(chunk.text)
+      const result = await response
+      lifecycle.push('response')
+
+      assert.deepStrictEqual(chunks, ['first', 'second'])
+      assert.strictEqual(result.text, 'complete')
+      assert.deepStrictEqual(lifecycle, ['first', 'second', 'response'])
+
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'local/stream-model')
+      assertLlmObsSpanEvent(llmobsSpans[0], {
+        ...expectedTags(span),
+        spanKind: 'llm',
+        name: 'local/stream-model',
+        modelName: 'local/stream-model',
+        modelProvider: 'custom',
+        inputMessages: [{ role: 'user', content: 'stream' }],
+        outputMessages: [{ role: 'assistant', content: 'complete' }],
+        metrics: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+        metadata: { finish_reason: 'stop', latency_ms: MOCK_NUMBER },
+      })
+    })
+
+    it('records streaming model errors', async () => {
+      const model = ai.defineModel({ name: 'local/stream-error-model' }, async () => {
+        throw new Error('stream runner failed')
+      })
+      const { stream, response } = ai.generateStream({ model, prompt: 'fail stream' })
+
+      await assert.rejects(async () => {
+        for await (const chunk of stream) assert.fail(`unexpected chunk ${chunk.text}`)
+        await response
+      }, { message: 'stream runner failed' })
+
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'local/stream-error-model')
+      assertLlmObsSpanEvent(llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'llm',
+        name: 'local/stream-error-model',
+        modelName: 'local/stream-error-model',
+        modelProvider: 'custom',
+        inputMessages: [{ role: 'user', content: 'fail stream' }],
+        outputMessages: [{ role: '', content: '' }],
+        metadata: {},
+      })
+    })
+
+    it('creates workflow spans for flows and named steps with correct parenting', async () => {
+      const flow = ai.defineFlow({ name: 'parentFlow' }, input => {
+        return ai.run('childStep', { input }, stepInput => ({ result: stepInput.input }))
+      })
+
+      await flow('hello')
+      const { apmSpans, llmobsSpans } = await getEvents(2)
+      const flowSpan = findSpan(apmSpans, 'parentFlow')
+      const stepSpan = findSpanByOperation(apmSpans, 'flowStep')
+      const flowEvent = findEvent(llmobsSpans, 'parentFlow')
+      const stepEvent = findEvent(llmobsSpans, 'childStep')
+
+      assert.strictEqual(stepSpan.resource, 'genkit.workflow')
+      assertLlmObsSpanEvent(flowEvent, {
+        ...expectedTags(flowSpan),
+        spanKind: 'workflow',
+        name: 'parentFlow',
+        inputValue: 'hello',
+        outputValue: JSON.stringify({ result: 'hello' }),
+        metadata: undefined,
+      })
+      assertLlmObsSpanEvent(stepEvent, {
+        ...expectedTags(stepSpan),
+        spanKind: 'workflow',
+        name: 'childStep',
+        inputValue: JSON.stringify({ input: 'hello' }),
+        outputValue: JSON.stringify({ result: 'hello' }),
+        parentId: flowEvent.span_id,
+        metadata: undefined,
+      })
+      assert.strictEqual(stepSpan.parent_id.toString(), flowSpan.span_id.toString())
+    })
+
+    it('records workflow, flow-step, retrieval, and embedding runner errors', async () => {
+      const failingFlow = ai.defineFlow({ name: 'failingFlow' }, async () => {
+        throw new Error('flow runner failed')
+      })
+      await assert.rejects(failingFlow({ requested: true }), { message: 'flow runner failed' })
+
+      let events = await getEvents()
+      let span = findSpan(events.apmSpans, 'failingFlow')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'workflow',
+        name: 'failingFlow',
+        inputValue: JSON.stringify({ requested: true }),
+        outputValue: '',
+        metadata: undefined,
+      })
+
+      await assert.rejects(
+        ai.run('failingStep', { requested: true }, async () => { throw new Error('step runner failed') }),
+        { message: 'step runner failed' }
+      )
+
+      events = await getEvents()
+      span = findSpanByOperation(events.apmSpans, 'flowStep')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'workflow',
+        name: 'failingStep',
+        inputValue: JSON.stringify({ requested: true }),
+        outputValue: '',
+        metadata: undefined,
+      })
+
+      const failingRetriever = ai.defineRetriever({ name: 'failingRetriever' }, async () => {
+        throw new Error('retriever runner failed')
+      })
+      await assert.rejects(
+        failingRetriever({ query: { content: [{ text: 'fail' }] } }),
+        { message: 'retriever runner failed' }
+      )
+
+      events = await getEvents()
+      span = findSpan(events.apmSpans, 'failingRetriever')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'retrieval',
+        name: 'failingRetriever',
+        inputValue: 'fail',
+        metadata: undefined,
+      })
+
+      const failingEmbedder = ai.defineEmbedder({ name: 'failingEmbedder' }, async () => {
+        throw new Error('embedder runner failed')
+      })
+      await assert.rejects(
+        failingEmbedder({ input: [{ content: [{ text: 'fail' }] }] }),
+        { message: 'embedder runner failed' }
+      )
+
+      events = await getEvents()
+      span = findSpan(events.apmSpans, 'failingEmbedder')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'embedding',
+        name: 'failingEmbedder',
+        modelName: 'failingEmbedder',
+        modelProvider: 'custom',
+        inputDocuments: [{ text: 'fail' }],
+        metadata: undefined,
+      })
+    })
+
+    it('records tool success and runner errors', async () => {
+      const tool = ai.defineTool({ name: 'weatherTool' }, async input => ({ city: input.city, temperature: 21 }))
+      await tool({ city: 'Paris' })
+
+      let events = await getEvents()
+      let span = findSpan(events.apmSpans, 'weatherTool')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span),
+        spanKind: 'tool',
+        name: 'weatherTool',
+        inputValue: JSON.stringify({ city: 'Paris' }),
+        outputValue: JSON.stringify({ city: 'Paris', temperature: 21 }),
+        metadata: undefined,
+      })
+
+      const failingTool = ai.defineTool({ name: 'failingTool' }, async () => {
+        throw new Error('tool runner failed')
+      })
+      await assert.rejects(failingTool({ requested: true }), { message: 'tool runner failed' })
+
+      events = await getEvents()
+      span = findSpan(events.apmSpans, 'failingTool')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span, true),
+        spanKind: 'tool',
+        name: 'failingTool',
+        inputValue: JSON.stringify({ requested: true }),
+        outputValue: '',
+        metadata: undefined,
+      })
+    })
+
+    it('records tool interrupts as tool errors and the outer generation as successful', async () => {
+      const interruptTool = ai.defineTool({ name: 'approvalRequired' }, async (input, { interrupt }) => {
+        interrupt({ reason: 'approval required', input })
+      })
+      const model = ai.defineModel({ name: 'local/interrupt-model', supports: { tools: true } }, async () => ({
+        message: {
+          role: 'model',
+          content: [{ toolRequest: { name: 'approvalRequired', ref: 'approval-1', input: { task: 'deploy' } } }],
+        },
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      }))
+
+      const response = await ai.generate({ model, prompt: 'deploy', tools: [interruptTool], maxTurns: 1 })
+      assert.strictEqual(response.finishReason, 'interrupted')
+
+      const { apmSpans, llmobsSpans } = await getEvents(2)
+      const modelSpan = findSpan(apmSpans, 'local/interrupt-model')
+      const modelEvent = findEvent(llmobsSpans, 'local/interrupt-model')
+      const toolEvent = findEvent(llmobsSpans, 'approvalRequired')
+
+      assertLlmObsSpanEvent(modelEvent, {
+        ...expectedTags(modelSpan),
+        spanKind: 'llm',
+        name: 'local/interrupt-model',
+        modelName: 'local/interrupt-model',
+        modelProvider: 'custom',
+        inputMessages: [{ role: 'user', content: 'deploy' }],
+        outputMessages: [{
+          role: 'assistant',
+          tool_calls: [{ name: 'approvalRequired', arguments: { task: 'deploy' }, tool_id: 'approval-1' }],
+        }],
+        metrics: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        metadata: { finish_reason: 'stop', latency_ms: MOCK_NUMBER },
+      })
+      assert.strictEqual(toolEvent.meta['span.kind'], 'tool')
+      assert.strictEqual(toolEvent.status, 'error')
+      assert.strictEqual(toolEvent.meta.input.value, JSON.stringify({ task: 'deploy' }))
+      assert.strictEqual(toolEvent.meta.output.value, undefined)
+      assert.strictEqual(toolEvent.meta['error.type'], 'ToolInterruptError')
+      assert.strictEqual(toolEvent.meta['error.message'], undefined)
+      assert.ok(toolEvent.tags.includes('error:1'))
+      assert.ok(toolEvent.tags.includes('integration:genkit'))
+    })
+
+    it('normalizes retrieval documents and allowlists reviewed metadata', async () => {
+      const retriever = ai.defineRetriever({ name: 'localRetriever' }, async query => ({
+        documents: [{
+          content: [{ text: `result:${query.text}` }, { media: { url: 'https://example.invalid/excluded-media' } }],
+          metadata: { name: 'doc', id: 'doc-1', score: 0.9, excludedSecret: 'do-not-capture' },
+        }],
+      }))
+
+      await retriever({
+        query: { content: [{ text: 'search' }, { media: { url: 'https://example.invalid/excluded-query' } }] },
+      })
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'localRetriever')
+      const event = llmobsSpans[0]
+      assertLlmObsSpanEvent(event, {
+        ...expectedTags(span),
+        spanKind: 'retrieval',
+        name: 'localRetriever',
+        inputValue: 'search',
+        outputDocuments: [{ text: 'result:search', name: 'doc', id: 'doc-1', score: 0.9 }],
+        metadata: undefined,
+      })
+      assert.doesNotMatch(JSON.stringify(event), /do-not-capture|excluded-query|excluded-media/)
+    })
+
+    it('summarizes embedding vectors without recording vector values or arbitrary metadata', async () => {
+      const embedder = ai.defineEmbedder({ name: 'localEmbedder' }, async documents => ({
+        embeddings: documents.map((document, index) => ({
+          embedding: [index + 0.12345, index + 0.23456, index + 0.34567],
+          metadata: { excludedSecret: 'do-not-capture' },
+        })),
+      }))
+
+      await embedder({
+        input: [
+          { content: [{ text: 'first' }], metadata: { name: 'one', id: '1', excludedSecret: 'secret' } },
+          { content: [{ text: 'second' }], metadata: { name: 'two', id: '2' } },
+        ],
+      })
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'localEmbedder')
+      const event = llmobsSpans[0]
+      assertLlmObsSpanEvent(event, {
+        ...expectedTags(span),
+        spanKind: 'embedding',
+        name: 'localEmbedder',
+        modelName: 'localEmbedder',
+        modelProvider: 'custom',
+        inputDocuments: [
+          { text: 'first', name: 'one', id: '1' },
+          { text: 'second', name: 'two', id: '2' },
+        ],
+        outputValue: '[2 embedding(s) returned with size 3]',
+        metadata: undefined,
+      })
+      assert.doesNotMatch(JSON.stringify(event), /0\.12345|0\.23456|0\.34567|do-not-capture|secret/)
+    })
+
+    it('demotes models owned by an enabled provider integration without raw payload or duplicate metrics', async () => {
+      const pluginManager = require('../../..')._pluginManager
+      const previousPlugin = pluginManager._pluginsByName['google-genai']
+      pluginManager._pluginsByName['google-genai'] = { llmobs: { _enabled: true } }
+
+      try {
+        const model = ai.defineModel({ name: 'googleai/provider-model' }, async () => ({
+          message: {
+            role: 'model',
+            content: [
+              { text: 'provider response' },
+              { custom: { hiddenResponseField: 'do-not-capture' } },
+            ],
+          },
+          finishReason: 'stop',
+          usage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 },
+          rawProviderSecret: 'do-not-capture',
+        }))
+
+        await model({
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { text: 'provider input' },
+                { custom: { hiddenInputField: 'do-not-capture' } },
+              ],
+            },
+          ],
+          config: { secret: 'do-not-capture' },
+        })
+
+        const { apmSpans, llmobsSpans } = await getEvents()
+        const span = findSpan(apmSpans, 'googleai/provider-model')
+        const event = findEvent(llmobsSpans, 'googleai/provider-model')
+        assert.deepStrictEqual(event.metrics, {})
+        assert.doesNotMatch(JSON.stringify(event), /do-not-capture|usage|inputTokens|outputTokens|totalTokens/)
+        assertLlmObsSpanEvent(event, {
+          ...expectedTags(span),
+          spanKind: 'workflow',
+          name: 'googleai/provider-model',
+          inputValue: JSON.stringify([{ role: 'user', content: 'provider input' }]),
+          outputValue: JSON.stringify([{ role: 'assistant', content: 'provider response' }]),
+          metadata: undefined,
+        })
+      } finally {
+        if (previousPlugin === undefined) {
+          delete pluginManager._pluginsByName['google-genai']
+        } else {
+          pluginManager._pluginsByName['google-genai'] = previousPlugin
+        }
+      }
+    })
+
+    it('demotes embedders owned by an enabled provider integration without raw vectors', async () => {
+      const pluginManager = require('../../..')._pluginManager
+      const previousPlugin = pluginManager._pluginsByName['google-genai']
+      pluginManager._pluginsByName['google-genai'] = { llmobs: { _enabled: true } }
+
+      try {
+        const embedder = ai.defineEmbedder({ name: 'googleai/provider-embedder' }, async documents => ({
+          embeddings: documents.map((document, index) => ({
+            embedding: [index + 0.12345, index + 0.23456, index + 0.34567],
+            metadata: { hiddenResponseField: 'do-not-capture' },
+          })),
+        }))
+
+        await embedder({
+          input: [
+            { content: [{ text: 'first' }], metadata: { name: 'one', id: '1', hiddenInputField: 'do-not-capture' } },
+            { content: [{ text: 'second' }], metadata: { name: 'two', id: '2' } },
+          ],
+        })
+
+        const { apmSpans, llmobsSpans } = await getEvents()
+        const span = findSpan(apmSpans, 'googleai/provider-embedder')
+        const event = findEvent(llmobsSpans, 'googleai/provider-embedder')
+        assert.deepStrictEqual(event.metrics, {})
+        assert.doesNotMatch(JSON.stringify(event), /0\.12345|0\.23456|0\.34567|do-not-capture/)
+        assertLlmObsSpanEvent(event, {
+          ...expectedTags(span),
+          spanKind: 'workflow',
+          name: 'googleai/provider-embedder',
+          inputValue: JSON.stringify([
+            { text: 'first', name: 'one', id: '1' },
+            { text: 'second', name: 'two', id: '2' },
+          ]),
+          outputValue: '[2 embedding(s) returned with size 3]',
+          metadata: undefined,
+        })
+      } finally {
+        if (previousPlugin === undefined) {
+          delete pluginManager._pluginsByName['google-genai']
+        } else {
+          pluginManager._pluginsByName['google-genai'] = previousPlugin
+        }
+      }
+    })
+
+    it('keeps googleai models authoritative when the provider integration is disabled', async () => {
+      const pluginManager = require('../../..')._pluginManager
+      const previousPlugin = pluginManager._pluginsByName['google-genai']
+      pluginManager._pluginsByName['google-genai'] = { llmobs: { _enabled: false } }
+
+      try {
+        const model = ai.defineModel({ name: 'googleai/unowned-model' }, async () => ({
+          message: { role: 'model', content: [{ text: 'owned by Genkit' }] },
+          finishReason: 'stop',
+          usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+        }))
+
+        await model({ messages: [{ role: 'user', content: [{ text: 'hello' }] }] })
+
+        const { apmSpans, llmobsSpans } = await getEvents()
+        const span = findSpan(apmSpans, 'googleai/unowned-model')
+        assertLlmObsSpanEvent(llmobsSpans[0], {
+          ...expectedTags(span),
+          spanKind: 'llm',
+          name: 'googleai/unowned-model',
+          modelName: 'googleai/unowned-model',
+          modelProvider: 'google',
+          inputMessages: [{ role: 'user', content: 'hello' }],
+          outputMessages: [{ role: 'assistant', content: 'owned by Genkit' }],
+          metrics: { input_tokens: 3, output_tokens: 2, total_tokens: 5 },
+          metadata: { finish_reason: 'stop', latency_ms: MOCK_NUMBER },
+        })
+      } finally {
+        if (previousPlugin === undefined) {
+          delete pluginManager._pluginsByName['google-genai']
+        } else {
+          pluginManager._pluginsByName['google-genai'] = previousPlugin
+        }
+      }
+    })
+
+    it('preserves selected parenting through ignored native labels', async () => {
+      const tool = ai.defineTool({ name: 'nestedTool' }, async input => input)
+      const flow = ai.defineFlow({ name: 'ignoredParentFlow' }, async () => {
+        return runInNewSpan({
+          metadata: { name: 'ignoredUtil' },
+          labels: { 'genkit:type': 'util' },
+        }, () => tool({ nested: true }))
+      })
+
+      await flow()
+      const { apmSpans, llmobsSpans } = await getEvents(2)
+      const flowSpan = findSpan(apmSpans, 'ignoredParentFlow')
+      const toolSpan = findSpan(apmSpans, 'nestedTool')
+      const flowEvent = findEvent(llmobsSpans, 'ignoredParentFlow')
+      const toolEvent = findEvent(llmobsSpans, 'nestedTool')
+
+      assert.strictEqual(llmobsSpans.some(span => span.name === 'ignoredUtil'), false)
+      assert.strictEqual(toolSpan.parent_id.toString(), flowSpan.span_id.toString())
+      assert.strictEqual(toolEvent.parent_id, flowEvent.span_id)
+    })
+
+    it('uses serialized output fallback and ignores malformed fallback JSON', async () => {
+      const validOptions = {
+        metadata: { name: 'fallbackTool' },
+        labels: { 'genkit:metadata:subtype': 'tool' },
+      }
+      await runInNewSpan(validOptions, metadata => {
+        metadata.input = { value: 'input' }
+        metadata.output = JSON.stringify({ value: 'fallback' })
+      })
+
+      let events = await getEvents()
+      let span = findSpan(events.apmSpans, 'fallbackTool')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span),
+        spanKind: 'tool',
+        name: 'fallbackTool',
+        inputValue: JSON.stringify({ value: 'input' }),
+        outputValue: JSON.stringify({ value: 'fallback' }),
+        metadata: undefined,
+      })
+
+      const malformedOptions = {
+        metadata: { name: 'malformedFallbackTool' },
+        labels: { 'genkit:metadata:subtype': 'tool' },
+      }
+      await runInNewSpan(malformedOptions, metadata => {
+        metadata.input = 'input'
+        metadata.output = '{invalid'
+      })
+
+      events = await getEvents()
+      span = findSpan(events.apmSpans, 'malformedFallbackTool')
+      assertLlmObsSpanEvent(events.llmobsSpans[0], {
+        ...expectedTags(span),
+        spanKind: 'tool',
+        name: 'malformedFallbackTool',
+        inputValue: 'input',
+        metadata: undefined,
+      })
+    })
+
+    it('extracts options from the three-argument runInNewSpan overload', async () => {
+      const options = {
+        metadata: { name: 'threeArgumentTool' },
+        labels: { 'genkit:metadata:subtype': 'tool' },
+      }
+      await runInNewSpan({}, options, metadata => {
+        metadata.input = { overload: 3 }
+        return { accepted: true }
+      })
+
+      const { apmSpans, llmobsSpans } = await getEvents()
+      const span = findSpan(apmSpans, 'threeArgumentTool')
+      assertLlmObsSpanEvent(llmobsSpans[0], {
+        ...expectedTags(span),
+        spanKind: 'tool',
+        name: 'threeArgumentTool',
+        inputValue: JSON.stringify({ overload: 3 }),
+        outputValue: JSON.stringify({ accepted: true }),
+        metadata: undefined,
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/llmobs/plugins/genkit/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/genkit/index.js
@@ -1,0 +1,477 @@
+'use strict'
+
+const LLMObsPlugin = require('../base')
+
+const providerIntegrations = {
+  googleai: { integration: 'google-genai', provider: 'google' },
+}
+
+const operationKinds = {
+  embedder: { kind: 'embedding', type: 'embedding' },
+  flow: { kind: 'workflow', type: 'flow' },
+  model: { kind: 'llm', type: 'generation' },
+  retriever: { kind: 'retrieval', type: 'retrieval' },
+  tool: { kind: 'tool', type: 'tool' },
+}
+
+/**
+ * Select the Genkit options argument for either supported runInNewSpan overload.
+ *
+ * @param {object} ctx Orchestrion call context.
+ * @returns {object|undefined} Genkit span options.
+ */
+function getOptions (ctx) {
+  return ctx.arguments?.length === 3 ? ctx.arguments[1] : ctx.arguments?.[0]
+}
+
+/**
+ * Resolve an allowlisted Genkit operation from its native labels.
+ *
+ * @param {object} options Genkit span options.
+ * @returns {{kind: string, type: string}|undefined} LLMObs operation definition.
+ */
+function getOperation (options) {
+  const labels = options?.labels
+  if (labels?.['genkit:type'] === 'flowStep') {
+    return { kind: 'workflow', type: 'flowStep' }
+  }
+
+  return operationKinds[labels?.['genkit:metadata:subtype']]
+}
+
+/**
+ * Resolve a source-proven provider prefix from a registered Genkit action name.
+ *
+ * @param {unknown} actionName Registered Genkit action name.
+ * @returns {{integration: string, provider: string}|undefined} Supported provider definition.
+ */
+function getProvider (actionName) {
+  if (typeof actionName !== 'string') return
+
+  const separator = actionName.indexOf('/')
+  if (separator === -1) return
+
+  return providerIntegrations[actionName.slice(0, separator)]
+}
+
+/**
+ * Determine whether a supported provider owns the authoritative LLMObs span.
+ *
+ * @param {{integration: string}|undefined} provider Supported provider definition.
+ * @returns {boolean} Whether the provider LLMObs plugin is enabled.
+ */
+function isProviderIntegrationEnabled (provider) {
+  const pluginManager = require('../../../../../..')._pluginManager
+  return !!provider && pluginManager?._pluginsByName[provider.integration]?.llmobs?._enabled === true
+}
+
+/**
+ * Determine whether Genkit should defer authoritative model or embedding ownership to a provider plugin.
+ *
+ * @param {{kind: string}} operation LLMObs operation definition.
+ * @param {{integration: string}|undefined} provider Supported provider definition.
+ * @returns {boolean} Whether this Genkit operation should be registered as a workflow.
+ */
+function isProviderOwned (operation, provider) {
+  return (operation.kind === 'llm' || operation.kind === 'embedding') && isProviderIntegrationEnabled(provider)
+}
+
+/**
+ * Parse Genkit's serialized output metadata without allowing malformed metadata to affect the application.
+ *
+ * @param {unknown} output Serialized output metadata.
+ * @returns {unknown} Parsed output, when available.
+ */
+function parseOutput (output) {
+  let parsed
+  if (typeof output === 'string') {
+    try {
+      parsed = JSON.parse(output)
+    } catch {}
+  }
+  return parsed
+}
+
+/**
+ * Read an operation result, falling back to Genkit's mutable serialized metadata.
+ *
+ * @param {object} ctx Orchestrion call context.
+ * @param {object} options Genkit span options.
+ * @returns {unknown} Operation result.
+ */
+function getResult (ctx, options) {
+  return ctx.result === undefined ? parseOutput(options?.metadata?.output) : ctx.result
+}
+
+/**
+ * Convert a value into the string field required by LLMObs tool results.
+ *
+ * @param {unknown} value Tool output.
+ * @returns {string} Safely serialized tool output.
+ */
+function stringifyToolResult (value) {
+  if (typeof value === 'string') return value
+  if (value === undefined) return ''
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+/**
+ * Convert a Genkit tool input into the object field required by LLMObs tool calls.
+ *
+ * @param {unknown} value Tool input.
+ * @returns {object|undefined} Tool arguments.
+ */
+function formatToolArguments (value) {
+  if (value == null) return
+  if (typeof value === 'object') return value
+  return { value }
+}
+
+/**
+ * Normalize Genkit messages and safe Part variants to the LLMObs message contract.
+ *
+ * @param {unknown} messages Genkit messages.
+ * @returns {object[]} Normalized messages.
+ */
+function formatMessages (messages) {
+  if (!Array.isArray(messages)) return []
+
+  const formatted = []
+  for (const message of messages) {
+    if (!message || typeof message !== 'object') continue
+
+    const parts = Array.isArray(message.content) ? message.content : []
+    const text = []
+    const toolCalls = []
+    const toolResults = []
+
+    for (const part of parts) {
+      if (!part || typeof part !== 'object') continue
+
+      if (typeof part.text === 'string') text.push(part.text)
+
+      const request = part.toolRequest
+      if (request && typeof request === 'object' && typeof request.name === 'string') {
+        const toolCall = { name: request.name }
+        const args = formatToolArguments(request.input)
+        if (args) toolCall.arguments = args
+        if (typeof request.ref === 'string') toolCall.toolId = request.ref
+        toolCalls.push(toolCall)
+      }
+
+      const response = part.toolResponse
+      if (response && typeof response === 'object' && typeof response.name === 'string') {
+        const toolResult = {
+          name: response.name,
+          result: stringifyToolResult(response.output),
+        }
+        if (typeof response.ref === 'string') toolResult.toolId = response.ref
+        toolResults.push(toolResult)
+      }
+    }
+
+    const formattedMessage = {
+      role: message.role === 'model' ? 'assistant' : message.role || '',
+    }
+    if (text.length) formattedMessage.content = text.join('')
+    if (toolCalls.length) formattedMessage.toolCalls = toolCalls
+    if (toolResults.length) formattedMessage.toolResults = toolResults
+    formatted.push(formattedMessage)
+  }
+
+  return formatted
+}
+
+/**
+ * Join only text parts from a Genkit document.
+ *
+ * @param {unknown} document Genkit document.
+ * @returns {string} Document text.
+ */
+function getDocumentText (document) {
+  if (!document || typeof document !== 'object' || !('content' in document) || !Array.isArray(document.content)) {
+    return ''
+  }
+
+  let text = ''
+  for (const part of document.content) {
+    if (typeof part?.text === 'string') text += part.text
+  }
+  return text
+}
+
+/**
+ * Convert Genkit documents to the strict LLMObs document shape.
+ *
+ * @param {unknown} documents Genkit documents.
+ * @param {boolean} includeScore Whether reviewed retrieval scores may be copied.
+ * @returns {object[]} Normalized documents.
+ */
+function formatDocuments (documents, includeScore = false) {
+  if (!Array.isArray(documents)) return []
+
+  const formatted = []
+  for (const document of documents) {
+    if (!document || typeof document !== 'object') continue
+
+    const item = { text: getDocumentText(document) }
+    const metadata = document.metadata
+    if (metadata && typeof metadata === 'object') {
+      if (typeof metadata.name === 'string') item.name = metadata.name
+      if (typeof metadata.id === 'string') item.id = metadata.id
+      if (includeScore && typeof metadata.score === 'number') item.score = metadata.score
+    }
+    formatted.push(item)
+  }
+
+  return formatted
+}
+
+/**
+ * Extract only reviewed scalar generation metadata.
+ *
+ * @param {object} input Genkit model input.
+ * @param {object} response Genkit model response.
+ * @returns {object} LLMObs metadata.
+ */
+function extractMetadata (input, response) {
+  const config = input?.config
+  const metadata = {}
+
+  if (config && typeof config === 'object') {
+    if (typeof config.version === 'string') metadata.version = config.version
+    if (typeof config.temperature === 'number') metadata.temperature = config.temperature
+    if (typeof config.maxOutputTokens === 'number') metadata.max_output_tokens = config.maxOutputTokens
+    if (typeof config.topK === 'number') metadata.top_k = config.topK
+    if (typeof config.topP === 'number') metadata.top_p = config.topP
+  }
+  if (typeof input?.toolChoice === 'string') metadata.tool_choice = input.toolChoice
+  if (typeof response?.finishReason === 'string') metadata.finish_reason = response.finishReason
+  if (typeof response?.latencyMs === 'number') metadata.latency_ms = response.latencyMs
+
+  return metadata
+}
+
+/**
+ * Extract standard Genkit token metrics without relabeling provider-specific usage.
+ *
+ * @param {object} response Genkit model response.
+ * @returns {object} Numeric token metrics.
+ */
+function extractMetrics (response) {
+  const usage = response?.usage
+  const metrics = {}
+  if (typeof usage?.inputTokens === 'number') metrics.inputTokens = usage.inputTokens
+  if (typeof usage?.outputTokens === 'number') metrics.outputTokens = usage.outputTokens
+  if (typeof usage?.totalTokens === 'number') metrics.totalTokens = usage.totalTokens
+  return metrics
+}
+
+/**
+ * Summarize embedding vectors without recording their numeric contents.
+ *
+ * @param {unknown} embeddings Genkit embedding output.
+ * @returns {string} Count and common vector size summary.
+ */
+function summarizeEmbeddings (embeddings) {
+  if (!Array.isArray(embeddings)) return ''
+
+  const count = embeddings.length
+  let size
+  for (const item of embeddings) {
+    const currentSize = Array.isArray(item?.embedding) ? item.embedding.length : undefined
+    if (currentSize === undefined || (size !== undefined && currentSize !== size)) {
+      size = undefined
+      break
+    }
+    size = currentSize
+  }
+
+  return size === undefined
+    ? `[${count} embedding(s) returned]`
+    : `[${count} embedding(s) returned with size ${size}]`
+}
+
+class GenkitLLMObsPlugin extends LLMObsPlugin {
+  static id = 'llmobs_genkit'
+  static integration = 'genkit'
+  static prefix = 'tracing:orchestrion:@genkit-ai/core:runInNewSpan'
+
+  /**
+   * Register an LLMObs span for an allowlisted Genkit operation.
+   *
+   * @param {object} ctx Orchestrion call context.
+   * @returns {object|undefined} LLMObs registration options.
+   */
+  getLLMObsSpanRegisterOptions (ctx) {
+    const options = getOptions(ctx)
+    const operation = getOperation(options)
+    if (!ctx.genkit || !operation) return
+
+    const actionName = ctx.genkit.actionName || options?.metadata?.name
+    const provider = getProvider(actionName)
+    const kind = isProviderOwned(operation, provider) ? 'workflow' : operation.kind
+
+    ctx.genkit.llmobsKind = kind
+
+    return {
+      kind,
+      name: actionName || `genkit.${operation.type}`,
+      ...(kind === 'llm' || kind === 'embedding'
+        ? { modelName: actionName, modelProvider: provider?.provider }
+        : undefined),
+    }
+  }
+
+  /**
+   * Apply normalized Genkit input, output, metadata, and metrics to the registered LLMObs span.
+   *
+   * @param {object} ctx Orchestrion call context.
+   * @returns {void}
+   */
+  setLLMObsTags (ctx) {
+    const span = ctx.currentStore?.span
+    const options = getOptions(ctx)
+    const operation = getOperation(options)
+    if (!span || !ctx.genkit || !operation) return
+
+    const input = options?.metadata?.input
+    const result = getResult(ctx, options)
+    const kind = ctx.genkit.llmobsKind || operation.kind
+
+    if (kind === 'workflow' && operation.kind === 'llm') {
+      this.#tagWorkflowLLM(span, input, result, ctx.error)
+      return
+    }
+
+    if (kind === 'workflow' && operation.kind === 'embedding') {
+      this.#tagWorkflowEmbedding(span, input, result, ctx.error)
+      return
+    }
+
+    switch (kind) {
+      case 'llm':
+        this.#tagLLM(span, input, result, ctx.error)
+        break
+      case 'workflow':
+      case 'tool':
+        this._tagger.tagTextIO(span, input, ctx.error ? '' : result)
+        break
+      case 'retrieval':
+        this.#tagRetrieval(span, input, result, ctx.error)
+        break
+      case 'embedding':
+        this.#tagEmbedding(span, input, result, ctx.error)
+        break
+    }
+  }
+
+  /**
+   * Leave APM error tagging to the tracing member of the composite plugin.
+   *
+   * @returns {void}
+   */
+  error () {}
+
+  /**
+   * Restore LLMObs context only for operations registered by this plugin.
+   *
+   * @param {object} ctx Orchestrion call context.
+   * @returns {void}
+   */
+  end (ctx) {
+    if (!ctx.llmobs) return
+    super.end(ctx)
+  }
+
+  /**
+   * Tag one Genkit model action.
+   *
+   * @param {object} span Datadog span.
+   * @param {object} input Genkit model input.
+   * @param {object} response Genkit model response.
+   * @param {unknown} error Operation error.
+   * @returns {void}
+   */
+  #tagLLM (span, input, response, error) {
+    const inputMessages = formatMessages(input?.messages)
+    const outputMessages = error
+      ? [{ content: '', role: '' }]
+      : formatMessages(response?.message ? [response.message] : [])
+
+    if (!outputMessages.length) outputMessages.push({ content: '', role: '' })
+    this._tagger.tagLLMIO(span, inputMessages, outputMessages)
+    this._tagger.tagMetadata(span, extractMetadata(input, response))
+    this._tagger.tagMetrics(span, extractMetrics(response))
+  }
+
+  /**
+   * Tag a provider-owned Genkit model action as a sanitized workflow wrapper.
+   *
+   * @param {object} span Datadog span.
+   * @param {object} input Genkit model input.
+   * @param {object} response Genkit model response.
+   * @param {unknown} error Operation error.
+   * @returns {void}
+   */
+  #tagWorkflowLLM (span, input, response, error) {
+    const inputMessages = formatMessages(input?.messages)
+    const outputMessages = error
+      ? [{ content: '', role: '' }]
+      : formatMessages(response?.message ? [response.message] : [])
+
+    this._tagger.tagTextIO(span, inputMessages, outputMessages)
+  }
+
+  /**
+   * Tag one Genkit retriever action.
+   *
+   * @param {object} span Datadog span.
+   * @param {object} input Genkit retriever input.
+   * @param {object} response Genkit retriever response.
+   * @param {unknown} error Operation error.
+   * @returns {void}
+   */
+  #tagRetrieval (span, input, response, error) {
+    const query = getDocumentText(input?.query)
+    const documents = error ? [] : formatDocuments(response?.documents, true)
+    this._tagger.tagRetrievalIO(span, query, documents)
+  }
+
+  /**
+   * Tag one Genkit embedder action without serializing vectors.
+   *
+   * @param {object} span Datadog span.
+   * @param {object} input Genkit embedder input.
+   * @param {object} response Genkit embedder response.
+   * @param {unknown} error Operation error.
+   * @returns {void}
+   */
+  #tagEmbedding (span, input, response, error) {
+    const documents = formatDocuments(input?.input)
+    const output = error ? '' : summarizeEmbeddings(response?.embeddings)
+    this._tagger.tagEmbeddingIO(span, documents, output)
+  }
+
+  /**
+   * Tag a provider-owned Genkit embedder action as a sanitized workflow wrapper.
+   *
+   * @param {object} span Datadog span.
+   * @param {object} input Genkit embedder input.
+   * @param {object} response Genkit embedder response.
+   * @param {unknown} error Operation error.
+   * @returns {void}
+   */
+  #tagWorkflowEmbedding (span, input, response, error) {
+    const documents = formatDocuments(input?.input)
+    const output = error ? '' : summarizeEmbeddings(response?.embeddings)
+    this._tagger.tagTextIO(span, documents, output)
+  }
+}
+
+module.exports = GenkitLLMObsPlugin


### PR DESCRIPTION
### What does this PR do?

Adds LLM Observability support for Genkit on top of #9360.

Reviewer map:

- Converts the Genkit plugin entrypoint to a composite tracing plus LLMObs plugin.
- Emits LLMObs spans for model generation, streaming generation, workflows, flow steps, tools, retrieval, and embeddings.
- Normalizes Genkit model messages, tool calls/results, retriever documents, embedding summaries, metrics, and reviewed metadata.
- Keeps provider-owned Google AI model and embedder actions as sanitized workflow wrappers when the provider integration is enabled, avoiding duplicate provider metrics and raw payload capture.
- Covers success, error, streaming, interrupt, malformed fallback, three-argument `runInNewSpan`, ignored-label parenting, and provider-ownership cases.

### Motivation

This is the LLMObs layer split from the generated experiment in #9321. The original experiment branch is left untouched, and no `.dd-apm-*` evidence/pipeline files are included.

### Stack

- Base APM tracing: #9360
- This PR: LLMObs additions only

### Verification

Local tests:

- `PLUGINS=genkit npm run test:plugins:ci` - 27 passing
- `npm run verify:config:types` - passing
- `./node_modules/.bin/mocha packages/dd-trace/test/plugins/plugin-structure.spec.js` - 171 passing
- Targeted ESLint on changed Genkit and OTel files - passing

Mock-agent smoke:

- CommonJS sample app - 14 sample operations, 22 APM spans, 21 LLMObs events
- ESM smoke app - `local/esm-model` APM span and LLMObs event emitted

Live Datadog verification:

- Ran the Genkit sample app against a real Datadog Agent using org2 credentials.
- Run ID: `20260715T002543Z`
- `DD_LLMOBS_ML_APP=genkit-live-e2e`
- Sample app result: 14 operations exercised, 0 unexpected errors.
- The tracer sent LLMObs event batches through the Agent: 2 events, then 19 events.
- LLMObs backend readback found 7 spans, all `ok`, for trace/APM trace `6a56d389000000003878d2a64208afd4`.
- LLMObs trace link: https://app.datadoghq.com/api/v2/switch_to_user/c44131a2-fd67-11ec-a863-da7ad0900002?next=%2Fllm%2Ftraces%3Fend%3D1784075445639%26paused%3Dtrue%26query%3Dtrace_id%253A6a56d389000000003878d2a64208afd4%26start%3D1784074845626&flow=org_switch

LLMObs span tree verified in Datadog:

```text
offlineWorkflow - workflow - span 4069233874843512788
└─ offlineFlowStep - workflow - span 6158085366574518337
   ├─ localRetriever - retrieval - span 6124733902100793893
   ├─ localEmbedder - embedding - span 8439299663973603833
   ├─ local/offline-model - llm - span 1777889941603809180
   ├─ lookupWeather - tool - span 255722127890546734
   └─ local/offline-model - llm - span 1785661058182891185
```

### Additional Notes

The older `llm-obs-mcp` read path failed with a release-routing header error, but the dedicated Datadog LLMObs MCP read path succeeded for this trace and span tree.
