### PR TITLE
fix(test-optimization): reject malformed settings policies

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -20,6 +20,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../../plugins/util/tags'
 const { sendGitMetadata: sendGitMetadataRequest } = require('./git/git_metadata')
 
 const hostname = getHostname()
+const EMPTY_SETTINGS = Object.freeze({})
 
 function getTestConfigurationTags (tags) {
   if (!tags) {
@@ -308,60 +309,58 @@ class CiVisibilityExporter extends BufferingExporter {
   }
 
   // Takes into account potential kill switches
-  filterConfiguration (remoteConfiguration) {
-    if (!remoteConfiguration) {
-      return {}
-    }
+  filterConfiguration (remoteConfiguration = EMPTY_SETTINGS) {
+    const { testOptimization } = this._config
     const {
-      isCodeCoverageEnabled,
-      isSuitesSkippingEnabled,
-      isItrEnabled,
-      requireGit,
-      isEarlyFlakeDetectionEnabled,
+      DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: isEarlyFlakeDetectionAllowed,
+      DD_CIVISIBILITY_FLAKY_RETRY_COUNT: flakyTestRetriesCount = 0,
+      DD_CIVISIBILITY_FLAKY_RETRY_ENABLED: isFlakyTestRetriesAllowed,
+      DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED: isImpactedTestsAllowed,
+      DD_TEST_EARLY_FLAKE_DETECTION_RETRY_COUNT: earlyFlakeDetectionRetryCount,
+      DD_TEST_FAILED_TEST_REPLAY_ENABLED: isFailedTestReplayAllowed,
+      DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES: configuredAttemptToFixRetries = 0,
+      DD_TEST_MANAGEMENT_ENABLED: isTestManagementAllowed,
+    } = testOptimization
+    const hasEarlyFlakeDetectionRetryCount = earlyFlakeDetectionRetryCount !== undefined
+    const configuredSlowTestRetries = remoteConfiguration.earlyFlakeDetectionSlowTestRetries ?? EMPTY_SETTINGS
+    const earlyFlakeDetectionSlowTestRetries = hasEarlyFlakeDetectionRetryCount
+      ? Object.freeze({
+        '5s': earlyFlakeDetectionRetryCount,
+        '10s': earlyFlakeDetectionRetryCount,
+        '30s': earlyFlakeDetectionRetryCount,
+        '5m': earlyFlakeDetectionRetryCount,
+      })
+      : Object.isFrozen(configuredSlowTestRetries)
+        ? configuredSlowTestRetries
+        : Object.freeze({ ...configuredSlowTestRetries })
+    const earlyFlakeDetectionNumRetries = hasEarlyFlakeDetectionRetryCount
+      ? earlyFlakeDetectionRetryCount
+      : remoteConfiguration.earlyFlakeDetectionNumRetries ?? 0
+    const testManagementAttemptToFixRetries =
+      remoteConfiguration.testManagementAttemptToFixRetries ?? configuredAttemptToFixRetries
+
+    return Object.freeze({
+      isCodeCoverageEnabled: remoteConfiguration.isCodeCoverageEnabled === true,
+      isSuitesSkippingEnabled: remoteConfiguration.isSuitesSkippingEnabled === true,
+      isItrEnabled: remoteConfiguration.isItrEnabled === true,
+      requireGit: remoteConfiguration.requireGit === true,
+      isEarlyFlakeDetectionEnabled:
+        remoteConfiguration.isEarlyFlakeDetectionEnabled === true && isEarlyFlakeDetectionAllowed === true,
       earlyFlakeDetectionNumRetries,
       earlyFlakeDetectionSlowTestRetries,
-      earlyFlakeDetectionFaultyThreshold,
-      isFlakyTestRetriesEnabled,
-      isDiEnabled,
-      isKnownTestsEnabled,
-      isTestManagementEnabled,
+      earlyFlakeDetectionFaultyThreshold: remoteConfiguration.earlyFlakeDetectionFaultyThreshold ?? 30,
+      isFlakyTestRetriesEnabled:
+        remoteConfiguration.isFlakyTestRetriesEnabled === true && isFlakyTestRetriesAllowed === true,
+      flakyTestRetriesCount,
+      isDiEnabled: remoteConfiguration.isDiEnabled === true && isFailedTestReplayAllowed === true,
+      isKnownTestsEnabled: remoteConfiguration.isKnownTestsEnabled === true,
+      isTestManagementEnabled:
+        remoteConfiguration.isTestManagementEnabled === true && isTestManagementAllowed === true,
       testManagementAttemptToFixRetries,
-      isImpactedTestsEnabled,
-      isCoverageReportUploadEnabled,
-    } = remoteConfiguration
-    const { testOptimization } = this._config
-    const earlyFlakeDetectionRetryCount =
-      testOptimization.DD_TEST_EARLY_FLAKE_DETECTION_RETRY_COUNT
-    const hasEarlyFlakeDetectionRetryCount = earlyFlakeDetectionRetryCount !== undefined
-    return {
-      isCodeCoverageEnabled,
-      isSuitesSkippingEnabled,
-      isItrEnabled,
-      requireGit,
-      isEarlyFlakeDetectionEnabled:
-        isEarlyFlakeDetectionEnabled && testOptimization.DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED,
-      earlyFlakeDetectionNumRetries:
-        hasEarlyFlakeDetectionRetryCount ? earlyFlakeDetectionRetryCount : earlyFlakeDetectionNumRetries,
-      earlyFlakeDetectionSlowTestRetries: hasEarlyFlakeDetectionRetryCount
-        ? {
-            '5s': earlyFlakeDetectionRetryCount,
-            '10s': earlyFlakeDetectionRetryCount,
-            '30s': earlyFlakeDetectionRetryCount,
-            '5m': earlyFlakeDetectionRetryCount,
-          }
-        : earlyFlakeDetectionSlowTestRetries,
-      earlyFlakeDetectionFaultyThreshold,
-      isFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled && testOptimization.DD_CIVISIBILITY_FLAKY_RETRY_ENABLED,
-      flakyTestRetriesCount: testOptimization.DD_CIVISIBILITY_FLAKY_RETRY_COUNT,
-      isDiEnabled: isDiEnabled && testOptimization.DD_TEST_FAILED_TEST_REPLAY_ENABLED,
-      isKnownTestsEnabled,
-      isTestManagementEnabled: isTestManagementEnabled && testOptimization.DD_TEST_MANAGEMENT_ENABLED,
-      testManagementAttemptToFixRetries:
-        testManagementAttemptToFixRetries ?? testOptimization.DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES,
       isImpactedTestsEnabled:
-        isImpactedTestsEnabled && testOptimization.DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED,
-      isCoverageReportUploadEnabled,
-    }
+        remoteConfiguration.isImpactedTestsEnabled === true && isImpactedTestsAllowed === true,
+      isCoverageReportUploadEnabled: remoteConfiguration.isCoverageReportUploadEnabled === true,
+    })
   }
 
   sendGitMetadata (repositoryUrl) {

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -12,12 +12,145 @@ const {
   TELEMETRY_GIT_REQUESTS_SETTINGS_RESPONSE,
 } = require('../telemetry')
 const { writeSettingsToCache } = require('../test-optimization-cache')
-const { validateSettingsResponse } = require('../test-optimization-http-cache-schema')
+const { MAX_RETRIES, validateSettingsResponse } = require('../test-optimization-http-cache-schema')
 const request = require('./request')
 
 const DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES = 2
-const DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES = { '5s': 10, '10s': 5, '30s': 3, '5m': 2 }
+const DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES = Object.freeze({
+  '5s': 10,
+  '10s': 5,
+  '30s': 3,
+  '5m': 2,
+})
 const DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD = 30
+const EARLY_FLAKE_DETECTION_RETRY_BUCKETS = Object.keys(DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES)
+
+/**
+ * @typedef {object} EarlyFlakeDetectionSettings
+ * @property {boolean} enabled
+ * @property {number} numRetries
+ * @property {Readonly<Record<string, number>>} slowTestRetries
+ * @property {number} faultyThreshold
+ */
+
+/**
+ * @typedef {object} TestManagementSettings
+ * @property {boolean} enabled
+ * @property {number|undefined} attemptToFixRetries
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord (value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is number}
+ */
+function isNonNegativeInteger (value) {
+  return Number.isInteger(value) && value >= 0
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is number}
+ */
+function isRetryCount (value) {
+  return isNonNegativeInteger(value) && value <= MAX_RETRIES
+}
+
+/**
+ * @param {unknown} value
+ * @returns {Readonly<Record<string, number>>|undefined}
+ */
+function parseSlowTestRetries (value) {
+  if (!isRecord(value)) return
+
+  const slowTestRetries = {}
+  for (const bucket of EARLY_FLAKE_DETECTION_RETRY_BUCKETS) {
+    if (!Object.hasOwn(value, bucket)) continue
+
+    const retries = value[bucket]
+    if (!isRetryCount(retries)) return
+    slowTestRetries[bucket] = retries
+  }
+  return Object.freeze(slowTestRetries)
+}
+
+/**
+ * @param {unknown} value
+ * @param {boolean} isKnownTestsEnabled
+ * @returns {EarlyFlakeDetectionSettings}
+ */
+function parseEarlyFlakeDetectionSettings (value, isKnownTestsEnabled) {
+  if (!isRecord(value) || value.enabled !== true) {
+    return {
+      enabled: false,
+      numRetries: DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
+      slowTestRetries: DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES,
+      faultyThreshold: DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD,
+    }
+  }
+
+  let isValid = true
+  let numRetries = DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES
+  let slowTestRetries = DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES
+  if (Object.hasOwn(value, 'slow_test_retries')) {
+    const parsedSlowTestRetries = parseSlowTestRetries(value.slow_test_retries)
+    if (parsedSlowTestRetries) {
+      slowTestRetries = parsedSlowTestRetries
+      numRetries = parsedSlowTestRetries['5s'] ?? DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES
+    } else {
+      isValid = false
+    }
+  }
+
+  let faultyThreshold = DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD
+  if (Object.hasOwn(value, 'faulty_session_threshold')) {
+    if (isNonNegativeInteger(value.faulty_session_threshold) && value.faulty_session_threshold <= 100) {
+      faultyThreshold = value.faulty_session_threshold
+    } else {
+      isValid = false
+    }
+  }
+
+  return {
+    enabled: isKnownTestsEnabled && isValid,
+    numRetries,
+    slowTestRetries,
+    faultyThreshold,
+  }
+}
+
+/**
+ * @param {unknown} value
+ * @returns {TestManagementSettings}
+ */
+function parseTestManagementSettings (value) {
+  if (!isRecord(value) || value.enabled !== true) {
+    return {
+      enabled: false,
+      attemptToFixRetries: undefined,
+    }
+  }
+
+  const attemptToFixRetries = value.attempt_to_fix_retries
+  if (attemptToFixRetries !== undefined && !isRetryCount(attemptToFixRetries)) {
+    return {
+      enabled: false,
+      attemptToFixRetries: undefined,
+    }
+  }
+
+  return {
+    enabled: true,
+    attemptToFixRetries,
+  }
+}
 
 function parseJsonResponse (rawJson) {
   return typeof rawJson === 'string' ? JSON.parse(rawJson) : rawJson
@@ -28,40 +161,35 @@ function parseLibraryConfigurationResponse (rawJson, config = getConfig(), optio
   if (options.validateRequiredFields) {
     validateSettingsResponse(parsedResponse, options)
   }
-  const {
-    code_coverage: isCodeCoverageEnabled,
-    tests_skipping: isSuitesSkippingEnabled,
-    itr_enabled: isItrEnabled,
-    require_git: requireGit,
-    early_flake_detection: earlyFlakeDetectionConfig,
-    flaky_test_retries_enabled: isFlakyTestRetriesEnabled,
-    di_enabled: isDiEnabled,
-    known_tests_enabled: isKnownTestsEnabled,
-    test_management: testManagementConfig,
-    impacted_tests_enabled: isImpactedTestsEnabled,
-    coverage_report_upload_enabled: isCoverageReportUploadEnabled,
-  } = parsedResponse?.data?.attributes ?? parsedResponse
+  const parsedAttributes = parsedResponse?.data?.attributes ?? parsedResponse
+  if (!isRecord(parsedAttributes)) {
+    throw new TypeError('Invalid settings response: attributes must be an object')
+  }
+  const attributes = parsedAttributes
+  const isKnownTestsEnabled = attributes.known_tests_enabled === true
+  const isFlakyTestRetriesEnabled = attributes.flaky_test_retries_enabled === true
+  const earlyFlakeDetection = parseEarlyFlakeDetectionSettings(
+    attributes.early_flake_detection,
+    isKnownTestsEnabled
+  )
+  const testManagement = parseTestManagementSettings(attributes.test_management)
 
   const settings = {
-    isCodeCoverageEnabled,
-    isSuitesSkippingEnabled,
-    isItrEnabled,
-    requireGit,
-    isEarlyFlakeDetectionEnabled: isKnownTestsEnabled && (earlyFlakeDetectionConfig?.enabled ?? false),
-    earlyFlakeDetectionNumRetries:
-      earlyFlakeDetectionConfig?.slow_test_retries?.['5s'] ?? DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
-    earlyFlakeDetectionSlowTestRetries:
-      earlyFlakeDetectionConfig?.slow_test_retries ?? DEFAULT_EARLY_FLAKE_DETECTION_SLOW_TEST_RETRIES,
-    earlyFlakeDetectionFaultyThreshold:
-      earlyFlakeDetectionConfig?.faulty_session_threshold ?? DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD,
+    isCodeCoverageEnabled: attributes.code_coverage === true,
+    isSuitesSkippingEnabled: attributes.tests_skipping === true,
+    isItrEnabled: attributes.itr_enabled === true,
+    requireGit: attributes.require_git === true,
+    isEarlyFlakeDetectionEnabled: earlyFlakeDetection.enabled,
+    earlyFlakeDetectionNumRetries: earlyFlakeDetection.numRetries,
+    earlyFlakeDetectionSlowTestRetries: earlyFlakeDetection.slowTestRetries,
+    earlyFlakeDetectionFaultyThreshold: earlyFlakeDetection.faultyThreshold,
     isFlakyTestRetriesEnabled,
-    isDiEnabled: isDiEnabled && isFlakyTestRetriesEnabled,
+    isDiEnabled: attributes.di_enabled === true && isFlakyTestRetriesEnabled,
     isKnownTestsEnabled,
-    isTestManagementEnabled: (testManagementConfig?.enabled ?? false),
-    testManagementAttemptToFixRetries:
-      testManagementConfig?.attempt_to_fix_retries,
-    isImpactedTestsEnabled,
-    isCoverageReportUploadEnabled: isCoverageReportUploadEnabled ?? false,
+    isTestManagementEnabled: testManagement.enabled,
+    testManagementAttemptToFixRetries: testManagement.attemptToFixRetries,
+    isImpactedTestsEnabled: attributes.impacted_tests_enabled === true,
+    isCoverageReportUploadEnabled: attributes.coverage_report_upload_enabled === true,
   }
 
   log.debug('Remote settings: %j', settings)
@@ -82,7 +210,7 @@ function parseLibraryConfigurationResponse (rawJson, config = getConfig(), optio
     log.debug('Code coverage report upload was disabled by the environment variable')
   }
 
-  return settings
+  return Object.freeze(settings)
 }
 
 function getLibraryConfiguration ({

--- a/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
@@ -75,7 +75,8 @@ function validateSettingsResponse (response, options = {}) {
   assertBooleanFields(attributes.test_management, ['enabled'], 'settings test_management')
   assertOptionalBoundedNumber(
     attributes.early_flake_detection.faulty_session_threshold,
-    'settings early_flake_detection faulty_session_threshold'
+    'settings early_flake_detection faulty_session_threshold',
+    { integer: true }
   )
   assertRetryMap(attributes.early_flake_detection.slow_test_retries)
   assertOptionalBoundedNumber(

--- a/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
@@ -30,7 +30,7 @@ const RETRY_THRESHOLD_PATTERN = /^\d+(?:ms|s|m|h)$/
 const MAX_VALIDATION_MODULES = 1000
 const MAX_VALIDATION_SUITES = 10_000
 const MAX_VALIDATION_TESTS = 100_000
-const MAX_VALIDATION_RETRIES = 100
+const MAX_RETRIES = 100
 const MAX_VALIDATION_STRING_BYTES = 4096
 
 function isObject (value) {
@@ -216,8 +216,8 @@ function assertBooleanFields (object, keys, endpoint) {
 function assertOptionalBoundedNumber (value, endpoint, { integer = false } = {}) {
   if (value === undefined) return
   if (!Number.isFinite(value) || (integer && !Number.isInteger(value)) ||
-    value < 0 || value > MAX_VALIDATION_RETRIES) {
-    throw new TypeError(`Invalid ${endpoint}: value must be between 0 and ${MAX_VALIDATION_RETRIES}`)
+    value < 0 || value > MAX_RETRIES) {
+    throw new TypeError(`Invalid ${endpoint}: value must be between 0 and ${MAX_RETRIES}`)
   }
 }
 
@@ -249,6 +249,7 @@ function assertValidationString (value, field) {
 }
 
 module.exports = {
+  MAX_RETRIES,
   validateKnownTestsResponse,
   validateSettingsResponse,
   validateSkippableTestsResponse,

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -332,8 +332,11 @@ module.exports = class CiPlugin extends Plugin {
           log.error('Known tests could not be fetched. %s', err.message)
           this._addRequestErrorTag(DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS, err)
           if (this.libraryConfig) {
-            this.libraryConfig.isEarlyFlakeDetectionEnabled = false
-            this.libraryConfig.isKnownTestsEnabled = false
+            this.libraryConfig = Object.freeze({
+              ...this.libraryConfig,
+              isEarlyFlakeDetectionEnabled: false,
+              isKnownTestsEnabled: false,
+            })
           }
         }
         onDone({ err, knownTests, requestErrorTags: this._getCurrentRequestErrorTags() })
@@ -353,7 +356,10 @@ module.exports = class CiPlugin extends Plugin {
           log.error('Test management tests could not be fetched. %s', err.message)
           this._addRequestErrorTag(DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS, err)
           if (this.libraryConfig) {
-            this.libraryConfig.isTestManagementEnabled = false
+            this.libraryConfig = Object.freeze({
+              ...this.libraryConfig,
+              isTestManagementEnabled: false,
+            })
           }
         }
         onDone({ err, testManagementTests, requestErrorTags: this._getCurrentRequestErrorTags() })

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -126,6 +126,37 @@ describe('CiPlugin', () => {
     sinon.assert.calledOnce(onDone)
   })
 
+  it('replaces frozen policy snapshots when dependent requests fail', () => {
+    const plugin = createPlugin('vitest_worker', true)
+    plugin.libraryConfig = Object.freeze({
+      isEarlyFlakeDetectionEnabled: true,
+      isKnownTestsEnabled: true,
+      isTestManagementEnabled: true,
+    })
+    plugin.tracer._exporter.getKnownTests = (configuration, done) => {
+      done(new Error('known tests failed'))
+    }
+    plugin.tracer._exporter.getTestManagementTests = (configuration, done) => {
+      done(new Error('test management failed'))
+    }
+
+    try {
+      dc.channel('ci:vitest:known-tests').publish({ onDone: () => {} })
+
+      assert.strictEqual(plugin.libraryConfig.isEarlyFlakeDetectionEnabled, false)
+      assert.strictEqual(plugin.libraryConfig.isKnownTestsEnabled, false)
+      assert.strictEqual(plugin.libraryConfig.isTestManagementEnabled, true)
+      assert.strictEqual(Object.isFrozen(plugin.libraryConfig), true)
+
+      dc.channel('ci:vitest:test-management-tests').publish({ onDone: () => {} })
+
+      assert.strictEqual(plugin.libraryConfig.isTestManagementEnabled, false)
+      assert.strictEqual(Object.isFrozen(plugin.libraryConfig), true)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
   it('starts the DI breakpoint-hit timeout when waiting, not when preparing', async () => {
     const plugin = createPlugin('jest_worker')
     const waitForDiOperation = sinon.stub(plugin, 'waitForDiOperation').resolves()
@@ -257,14 +288,14 @@ describe('CiPlugin', () => {
     assert.match(logMessage.logger.thread_name, /^(MainThread|WorkerThread:\d+)$/)
   })
 
-  function createPlugin (exporter) {
+  function createPlugin (exporter, enabled = false) {
     class TestPlugin extends CiPlugin {
       static id = 'vitest'
     }
 
     const plugin = new TestPlugin({ _exporter: {} })
     plugin.configure({
-      enabled: false,
+      enabled,
       experimental: {
         exporter,
       },

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -54,6 +54,83 @@ describe('CI Visibility Exporter', () => {
     sinon.restore()
   })
 
+  describe('filterConfiguration', () => {
+    const testOptimization = {
+      DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: true,
+      DD_CIVISIBILITY_FLAKY_RETRY_COUNT: 5,
+      DD_CIVISIBILITY_FLAKY_RETRY_ENABLED: true,
+      DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED: true,
+      DD_TEST_FAILED_TEST_REPLAY_ENABLED: true,
+      DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES: 20,
+      DD_TEST_MANAGEMENT_ENABLED: true,
+    }
+
+    it('creates a complete frozen policy from remote and local settings', () => {
+      const ciVisibilityExporter = new CiVisibilityExporter({ testOptimization })
+      const policy = ciVisibilityExporter.filterConfiguration({
+        isCodeCoverageEnabled: true,
+        isSuitesSkippingEnabled: true,
+        isItrEnabled: true,
+        requireGit: true,
+        isEarlyFlakeDetectionEnabled: true,
+        earlyFlakeDetectionNumRetries: 0,
+        earlyFlakeDetectionSlowTestRetries: { '5s': 0 },
+        earlyFlakeDetectionFaultyThreshold: 0,
+        isFlakyTestRetriesEnabled: true,
+        isDiEnabled: true,
+        isKnownTestsEnabled: true,
+        isTestManagementEnabled: true,
+        testManagementAttemptToFixRetries: 0,
+        isImpactedTestsEnabled: true,
+        isCoverageReportUploadEnabled: true,
+      })
+
+      assert.deepStrictEqual(policy, {
+        isCodeCoverageEnabled: true,
+        isSuitesSkippingEnabled: true,
+        isItrEnabled: true,
+        requireGit: true,
+        isEarlyFlakeDetectionEnabled: true,
+        earlyFlakeDetectionNumRetries: 0,
+        earlyFlakeDetectionSlowTestRetries: { '5s': 0 },
+        earlyFlakeDetectionFaultyThreshold: 0,
+        isFlakyTestRetriesEnabled: true,
+        flakyTestRetriesCount: 5,
+        isDiEnabled: true,
+        isKnownTestsEnabled: true,
+        isTestManagementEnabled: true,
+        testManagementAttemptToFixRetries: 0,
+        isImpactedTestsEnabled: true,
+        isCoverageReportUploadEnabled: true,
+      })
+      assert.strictEqual(Object.isFrozen(policy), true)
+      assert.strictEqual(Object.isFrozen(policy.earlyFlakeDetectionSlowTestRetries), true)
+    })
+
+    it('creates a complete disabled policy when remote settings are unavailable', () => {
+      const ciVisibilityExporter = new CiVisibilityExporter({ testOptimization })
+
+      assert.deepStrictEqual(ciVisibilityExporter.filterConfiguration(), {
+        isCodeCoverageEnabled: false,
+        isSuitesSkippingEnabled: false,
+        isItrEnabled: false,
+        requireGit: false,
+        isEarlyFlakeDetectionEnabled: false,
+        earlyFlakeDetectionNumRetries: 0,
+        earlyFlakeDetectionSlowTestRetries: {},
+        earlyFlakeDetectionFaultyThreshold: 30,
+        isFlakyTestRetriesEnabled: false,
+        flakyTestRetriesCount: 5,
+        isDiEnabled: false,
+        isKnownTestsEnabled: false,
+        isTestManagementEnabled: false,
+        testManagementAttemptToFixRetries: 20,
+        isImpactedTestsEnabled: false,
+        isCoverageReportUploadEnabled: false,
+      })
+    })
+  })
+
   describe('sendGitMetadata', () => {
     it('should resolve git upload readiness immediately when git upload is disabled', async () => {
       const clock = sinon.useFakeTimers()

--- a/packages/dd-trace/test/ci-visibility/requests/get-library-configuration.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/get-library-configuration.spec.js
@@ -76,6 +76,8 @@ describe('get-library-configuration', () => {
         isImpactedTestsEnabled: true,
         isCoverageReportUploadEnabled: true,
       })
+      assert.strictEqual(Object.isFrozen(settings), true)
+      assert.strictEqual(Object.isFrozen(settings.earlyFlakeDetectionSlowTestRetries), true)
     })
 
     it('accepts bare settings attributes like the Ruby cache reader', () => {
@@ -94,10 +96,141 @@ describe('get-library-configuration', () => {
       assert.strictEqual(settings.isEarlyFlakeDetectionEnabled, false)
     })
 
+    it('rejects non-object settings responses', () => {
+      for (const response of ['null', '[]', '"settings"']) {
+        assert.throws(
+          () => parseLibraryConfigurationResponse(response),
+          {
+            name: 'TypeError',
+            message: 'Invalid settings response: attributes must be an object',
+          }
+        )
+      }
+    })
+
+    it('does not enable boolean settings with non-boolean values', () => {
+      const booleanSettings = [
+        ['code_coverage', 'isCodeCoverageEnabled'],
+        ['tests_skipping', 'isSuitesSkippingEnabled'],
+        ['itr_enabled', 'isItrEnabled'],
+        ['require_git', 'requireGit'],
+        ['flaky_test_retries_enabled', 'isFlakyTestRetriesEnabled'],
+        ['di_enabled', 'isDiEnabled'],
+        ['known_tests_enabled', 'isKnownTestsEnabled'],
+        ['impacted_tests_enabled', 'isImpactedTestsEnabled'],
+        ['coverage_report_upload_enabled', 'isCoverageReportUploadEnabled'],
+      ]
+
+      for (const [responseKey, settingsKey] of booleanSettings) {
+        const attributes = {
+          ...COMPLETE_SETTINGS_ATTRIBUTES,
+          [responseKey]: 'true',
+        }
+        const settings = parseLibraryConfigurationResponse(attributes)
+
+        assert.strictEqual(settings[settingsKey], false, responseKey)
+      }
+    })
+
+    it('disables EFD when its retry policy is malformed', () => {
+      const malformedPolicies = [
+        { enabled: 'true' },
+        { enabled: true, slow_test_retries: [] },
+        { enabled: true, slow_test_retries: { '5s': -1 } },
+        { enabled: true, slow_test_retries: { '5s': 1.5 } },
+        { enabled: true, slow_test_retries: { '5s': '1' } },
+        { enabled: true, slow_test_retries: { '5s': 101 } },
+        { enabled: true, slow_test_retries: { '5s': Number.MAX_SAFE_INTEGER } },
+        { enabled: true, faulty_session_threshold: -1 },
+        { enabled: true, faulty_session_threshold: 101 },
+        { enabled: true, faulty_session_threshold: 1.5 },
+      ]
+
+      for (const earlyFlakeDetection of malformedPolicies) {
+        const settings = parseLibraryConfigurationResponse({
+          early_flake_detection: earlyFlakeDetection,
+          known_tests_enabled: true,
+        })
+
+        assert.strictEqual(settings.isEarlyFlakeDetectionEnabled, false)
+        assert.strictEqual(Object.isFrozen(settings.earlyFlakeDetectionSlowTestRetries), true)
+      }
+    })
+
+    it('ignores unknown settings and EFD retry buckets', () => {
+      const settings = parseLibraryConfigurationResponse({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': 0,
+            future: 'unknown',
+          },
+          future: true,
+        },
+        known_tests_enabled: true,
+        future: true,
+      })
+
+      assert.strictEqual(settings.isEarlyFlakeDetectionEnabled, true)
+      assert.strictEqual(settings.earlyFlakeDetectionNumRetries, 0)
+      assert.deepStrictEqual(settings.earlyFlakeDetectionSlowTestRetries, { '5s': 0 })
+    })
+
+    it('disables test management when its retry policy is malformed', () => {
+      for (const attemptToFixRetries of [-1, 1.5, '1', 101, Number.MAX_SAFE_INTEGER, Number.POSITIVE_INFINITY]) {
+        const settings = parseLibraryConfigurationResponse({
+          test_management: {
+            enabled: true,
+            attempt_to_fix_retries: attemptToFixRetries,
+          },
+        })
+
+        assert.strictEqual(settings.isTestManagementEnabled, false)
+        assert.strictEqual(settings.testManagementAttemptToFixRetries, undefined)
+      }
+
+      const settings = parseLibraryConfigurationResponse({
+        test_management: {
+          enabled: 'true',
+          attempt_to_fix_retries: 1,
+        },
+      })
+      assert.strictEqual(settings.isTestManagementEnabled, false)
+    })
+
+    it('accepts the maximum retry count', () => {
+      const settings = parseLibraryConfigurationResponse({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': 100,
+          },
+        },
+        known_tests_enabled: true,
+        test_management: {
+          enabled: true,
+          attempt_to_fix_retries: 100,
+        },
+      })
+
+      assert.strictEqual(settings.isEarlyFlakeDetectionEnabled, true)
+      assert.strictEqual(settings.earlyFlakeDetectionNumRetries, 100)
+      assert.strictEqual(settings.isTestManagementEnabled, true)
+      assert.strictEqual(settings.testManagementAttemptToFixRetries, 100)
+    })
+
     it('defaults missing EFD retry budgets without replacing an explicit zero', () => {
       const missingRetryBudget = parseLibraryConfigurationResponse({
         early_flake_detection: {
           enabled: true,
+        },
+      })
+      const missingFiveSecondRetryBudget = parseLibraryConfigurationResponse({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '10s': 1,
+          },
         },
       })
       const zeroRetryBudget = parseLibraryConfigurationResponse({
@@ -110,6 +243,7 @@ describe('get-library-configuration', () => {
       })
 
       assert.strictEqual(missingRetryBudget.earlyFlakeDetectionNumRetries, 2)
+      assert.strictEqual(missingFiveSecondRetryBudget.earlyFlakeDetectionNumRetries, 2)
       assert.strictEqual(zeroRetryBudget.earlyFlakeDetectionNumRetries, 0)
     })
 

--- a/packages/dd-trace/test/ci-visibility/test-optimization-http-cache.spec.js
+++ b/packages/dd-trace/test/ci-visibility/test-optimization-http-cache.spec.js
@@ -469,7 +469,7 @@ describe('test-optimization-http-cache', () => {
     assert.match(cache.getLastError().message, /exceeds 32 bytes/)
   })
 
-  it('rejects out-of-range and non-integer validation retry counts', () => {
+  it('rejects out-of-range and non-integer validation policy values', () => {
     const settings = structuredClone(SETTINGS_RESPONSE)
     settings.data.attributes.early_flake_detection.slow_test_retries['5s'] = 101
     const { manifestPath } = writeCacheLayout(tmpRoot, { settings })
@@ -478,6 +478,12 @@ describe('test-optimization-http-cache', () => {
     assert.match(cache.getLastError().message, /value must be between 0 and 100/)
 
     settings.data.attributes.early_flake_detection.slow_test_retries['5s'] = 1.5
+    writeHttpCacheFile(tmpRoot, 'settings.json', settings)
+    cache = new TestOptimizationHttpCache({ validationManifestPath: manifestPath })
+    assert.strictEqual(cache.readSettings(), CACHE_MISS)
+
+    settings.data.attributes.early_flake_detection.slow_test_retries['5s'] = 1
+    settings.data.attributes.early_flake_detection.faulty_session_threshold = 1.5
     writeHttpCacheFile(tmpRoot, 'settings.json', settings)
     cache = new TestOptimizationHttpCache({ validationManifestPath: manifestPath })
     assert.strictEqual(cache.readSettings(), CACHE_MISS)

--- a/packages/dd-trace/test/ci-visibility/test-optimization-http-cache.spec.js
+++ b/packages/dd-trace/test/ci-visibility/test-optimization-http-cache.spec.js
@@ -337,6 +337,33 @@ describe('test-optimization-http-cache', () => {
     }
   })
 
+  it('disables only the malformed feature in cached settings', () => {
+    writeCacheLayout(tmpRoot, {
+      settings: {
+        data: {
+          attributes: {
+            ...SETTINGS_RESPONSE.data.attributes,
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': -1,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const cache = new TestOptimizationHttpCache()
+    const settings = cache.readSettings()
+
+    assert.strictEqual(cache.isAvailable(), true)
+    assert.strictEqual(settings.isCodeCoverageEnabled, true)
+    assert.strictEqual(settings.isEarlyFlakeDetectionEnabled, false)
+    assert.strictEqual(settings.isTestManagementEnabled, true)
+    assert.strictEqual(Object.isFrozen(settings), true)
+  })
+
   it('ignores optional endpoint files after invalid settings disable the cache', () => {
     writeCacheLayout(tmpRoot, { settings: { data: { attributes: { code_coverage: true } } } })
     writeHttpCacheFile(tmpRoot, 'known_tests.json', KNOWN_TESTS_RESPONSE)


### PR DESCRIPTION
## Summary
Remote and cached settings accepted truthy non-boolean flags and malformed retry policies, allowing invalid policy to reach framework plugins. This rejects malformed values at ingestion, disables only the affected feature, and freezes normalized policy after local overrides.

## Why
Rejecting the whole response would disable unrelated features and make new backend fields incompatible with older tracers. Known malformed fields therefore disable their owning feature, while unknown fields are ignored.