### PR TITLE
fix(graphql): skip Apollo health checks in Mercurius

### DIFF
--- a/packages/datadog-plugin-graphql/src/request.js
+++ b/packages/datadog-plugin-graphql/src/request.js
@@ -1,7 +1,24 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { extractErrorIntoSpanEvent, getCachedRequestOperation } = require('./utils')
+const { extractErrorIntoSpanEvent, getCachedRequestOperation, isApolloHealthCheckSource } = require('./utils')
+
+/**
+ * @typedef {object} GraphQLRequestStore
+ * @property {import('../../dd-trace/src/opentracing/span')} [span]
+ * @property {import('../../dd-trace/src/opentracing/span')} [graphqlRequestSpan]
+ * @property {string} [graphqlRequestOperationName]
+ * @property {unknown} [graphqlRequestSource]
+ */
+
+/**
+ * @typedef {object} GraphQLRequestContext
+ * @property {unknown[]} [arguments]
+ * @property {GraphQLRequestStore} [currentStore]
+ * @property {GraphQLRequestStore} [parentStore]
+ * @property {boolean} [ddSkipped]
+ * @property {{ errors?: import('graphql').GraphQLError[] }} [result]
+ */
 
 // Top-level GraphQL request span for drivers that funnel every operation
 // through a single entry point but parse/validate/execute internally (mercurius
@@ -25,9 +42,18 @@ class GraphQLRequestPlugin extends TracingPlugin {
   static kind = 'server'
   static prefix = 'tracing:orchestrion:mercurius:apm:graphql:request'
 
+  /**
+   * @param {GraphQLRequestContext} ctx
+   */
   bindStart (ctx) {
     // fastifyGraphQl(source, context, variables, operationName)
     const source = ctx.arguments?.[0]
+
+    if (isApolloHealthCheckSource(source)) {
+      ctx.ddSkipped = true
+      return ctx.currentStore
+    }
+
     const operationName = ctx.arguments?.[3]
 
     // `source` is the request text on the common path, but mercurius also
@@ -72,7 +98,12 @@ class GraphQLRequestPlugin extends TracingPlugin {
     return ctx.currentStore
   }
 
+  /**
+   * @param {GraphQLRequestContext} ctx
+   */
   asyncEnd (ctx) {
+    if (ctx.ddSkipped) return ctx.parentStore
+
     /* istanbul ignore next: currentStore is populated for the request lifecycle; activeSpan is base-plugin fallback. */
     const span = ctx?.currentStore?.span || this.activeSpan
     /* istanbul ignore if: startSpan always populates currentStore for the request lifecycle. */

--- a/packages/datadog-plugin-mercurius/test/index.spec.js
+++ b/packages/datadog-plugin-mercurius/test/index.spec.js
@@ -114,6 +114,51 @@ describe('Plugin', () => {
         return Promise.all([assertion, axios.post(`http://localhost:${port}/graphql`, { query })])
       })
 
+      it('skips only the exact Apollo health-check on cold and JIT paths', async () => {
+        const healthCheck = 'query __ApolloServiceHealthCheck__ { __typename }'
+        const sentinel = 'query __ApolloServiceHealthCheck__ { hello }'
+        const graphqlSpans = new Map()
+        /**
+         * @param {Array<Array<{ name: string }>>} traces
+         */
+        const collect = traces => {
+          for (const trace of traces) {
+            for (const span of trace) {
+              if (span.name.startsWith('graphql.')) {
+                graphqlSpans.set(span.name, (graphqlSpans.get(span.name) ?? 0) + 1)
+              }
+            }
+          }
+        }
+        agent.subscribe(collect)
+
+        try {
+          const assertion = agent.assertSomeTraces(() => {
+            assert.strictEqual(graphqlSpans.get(expectedSchema.server.opName), 1,
+              'only the sentinel may emit a graphql.request span')
+            assert.strictEqual(graphqlSpans.get('graphql.parse'), 1,
+              'only the sentinel may emit a graphql.parse span')
+            assert.strictEqual(graphqlSpans.get('graphql.validate'), 1,
+              'only the sentinel may emit a graphql.validate span')
+            assert.strictEqual(graphqlSpans.get('graphql.execute'), 1,
+              'only the sentinel may emit a graphql.execute span')
+            assert.strictEqual(graphqlSpans.get('graphql.resolve'), 1,
+              'only the sentinel may emit a graphql.resolve span')
+          }, { spanResourceMatch: /__ApolloServiceHealthCheck__/ })
+
+          await Promise.all([
+            assertion,
+            (async () => {
+              await axios.post(`http://localhost:${port}/graphql`, { query: healthCheck })
+              await axios.post(`http://localhost:${port}/graphql`, { query: healthCheck })
+              await axios.post(`http://localhost:${port}/graphql`, { query: sentinel })
+            })(),
+          ])
+        } finally {
+          agent.unsubscribe(collect)
+        }
+      })
+
       it('parents graphql.execute under graphql.request and shares its resource', () => {
         const query = 'query Nested { hello(name: "nested") }'
 


### PR DESCRIPTION
## Summary

Apollo Gateway health-check polls still emitted a `graphql.request` span for Mercurius because its request boundary runs before the graphql-js hooks. Skip the same exact fixed query at that boundary, while keeping similarly named user operations traced.

Refs: https://github.com/DataDog/dd-trace-js/pull/9134