### PR TITLE
fix(test-optimization): support cucumber 13.1 results

### DIFF
--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -1178,7 +1178,8 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
       itrSkippedSuitesCh.publish({ skippedSuites, frameworkVersion })
     }
 
-    const success = await start.apply(this, arguments)
+    const result = await start.apply(this, arguments)
+    const success = satisfies(frameworkVersion, '>=13.1.0') ? result.success : result
 
     let untestedCoverage
     if (getCodeCoverageCh.hasSubscribers) {
@@ -1228,7 +1229,7 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
     logTestOptimizationSummary({ attemptToFixExecutions })
     loggedAttemptToFixTests.clear()
     eventDataCollector = null
-    return success
+    return result
   }
 }
 

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "7.29.0",
     "@babel/preset-typescript": "7.28.5",
     "@confluentinc/kafka-javascript": "1.10.0",
-    "@cucumber/cucumber": "13.0.0",
+    "@cucumber/cucumber": "13.1.0",
     "@datadog/openfeature-node-server": "2.0.0",
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/transport": "9.3.5",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the Cucumber instrumentation for the runtime result introduced in Cucumber 13.1.0. The wrapper now reads the `success` field for 13.1+ while returning Cucumber's original result object unchanged.

Also bumps the pinned `@cucumber/cucumber` test dependency from 13.0.0 to 13.1.0.

### Motivation
<!-- What inspired you to submit this pull request? -->

Cucumber 13.1 changed `Coordinator.run()` from returning a boolean to returning `{ success, exception? }`. The instrumentation treated that object as a boolean, so failed test sessions were reported as passing.

This fixes the failures from the [latest-version compatibility job](https://github.com/DataDog/test-environment/actions/runs/29395289612/job/87287428848).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:
- Cucumber 13.1 regression set: 7 passing through the integration coverage harness.
- Cucumber 13.0 compatibility check: 2 passing.
- Targeted ESLint and `git diff --check` pass.
