### PR TITLE
fix(test-optimization): complete Playwright finish after subscriber loss

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -464,6 +464,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-playwright:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: playwright
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-promise-js:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -575,9 +575,14 @@ function getTestByTestId (dispatcher, testId) {
   }
 }
 
+/**
+ * @param {import('node:diagnostics_channel').Channel} channelToPublishTo
+ * @param {Record<string, unknown>} [params]
+ */
 function getChannelPromise (channelToPublishTo, params) {
   return new Promise(resolve => {
     channelToPublishTo.publish({ onDone: resolve, ...params })
+    if (!channelToPublishTo.hasSubscribers) resolve()
   })
 }
 
@@ -1142,8 +1147,6 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
 function runAllTestsWrapper (runAllTests, playwrightVersion) {
   // Config parameter is only available from >=1.55.0
   return async function (config) {
-    let onDone
-
     rootDir = getRootDir(this, config)
     const processArgv = process.argv.slice(2).join(' ')
     const command = `playwright ${processArgv}`
@@ -1308,17 +1311,12 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     logTestOptimizationSummary({ attemptToFixExecutions, newTestsWithDynamicNames })
     loggedAttemptToFixTests.clear()
 
-    const flushWait = new Promise(resolve => {
-      onDone = resolve
-    })
-    testSessionFinishCh.publish({
+    await getChannelPromise(testSessionFinishCh, {
       status: preventedToFail ? 'pass' : STATUS_TO_TEST_STATUS[sessionStatus],
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
-      onDone,
     })
-    await flushWait
 
     startedSuites = []
     remainingTestsByFile = {}
@@ -1979,12 +1977,6 @@ function instrumentWorkerMainMethods (workerMain) {
       annotationTags = parseAnnotations(annotations)
     }
 
-    let onDone
-
-    const flushPromise = new Promise(resolve => {
-      onDone = resolve
-    })
-
     // Wait for the properties to be received, but do not block the worker forever if IPC fails.
     const ddPropertiesTimeoutPromise = new Promise(resolve => {
       const ddPropertiesTimeout = realSetTimeout(() => {
@@ -2010,7 +2002,7 @@ function instrumentWorkerMainMethods (workerMain) {
       testStatus: STATUS_TO_TEST_STATUS[status],
     })
 
-    testFinishCh.publish({
+    await getChannelPromise(testFinishCh, {
       testStatus: STATUS_TO_TEST_STATUS[status],
       steps: steps.filter(step => step.testId === testId),
       error,
@@ -2028,13 +2020,10 @@ function instrumentWorkerMainMethods (workerMain) {
       hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
       isAtrRetry: test._ddIsAtrRetry,
       isModified: test._ddIsModified,
-      onDone,
       finalStatus,
       earlyFlakeAbortReason: test._ddEarlyFlakeAbortReason,
       ...testCtx.currentStore,
     })
-
-    await flushPromise
 
     return res
   })

--- a/packages/datadog-instrumentations/test/playwright.spec.js
+++ b/packages/datadog-instrumentations/test/playwright.spec.js
@@ -1,0 +1,177 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { setImmediate } = require('node:timers/promises')
+
+const { channel } = require('dc-polyfill')
+const { describe, it } = require('mocha')
+
+require('../src/playwright')
+
+const PLAYWRIGHT_HOOKS = globalThis[Symbol.for('_ddtrace_instrumentations')].playwright
+const RUNNER_HOOK = PLAYWRIGHT_HOOKS.find(entry => entry.file === 'lib/runner/runner.js').hook
+const WORKER_HOOK = PLAYWRIGHT_HOOKS.find(entry => entry.file === 'lib/worker/workerMain.js').hook
+
+class Runner {
+  constructor () {
+    this._config = {
+      config: {
+        rootDir: process.cwd(),
+      },
+      projects: [],
+    }
+  }
+
+  /**
+   * @returns {Promise<string>}
+   */
+  async runAllTests () {
+    return 'passed'
+  }
+}
+
+class WorkerMain {
+  constructor () {
+    this._project = { project: { name: 'chromium' } }
+  }
+
+  /**
+   * @param {object} test
+   * @returns {Promise<string>}
+   */
+  async _runTest (test) {
+    this._currentTest = {
+      annotations: [],
+      retry: 0,
+      status: 'passed',
+      testId: test.id,
+    }
+    return 'passed'
+  }
+
+  runTestGroup () {}
+
+  dispatchEvent () {}
+}
+
+RUNNER_HOOK({ Runner }, '1.38.0')
+WORKER_HOOK({ WorkerMain }, '1.38.0')
+
+describe('packages/datadog-instrumentations/src/playwright.js', () => {
+  it('waits for session finalization before resolving the run', async () => {
+    const libraryConfigurationCh = channel('ci:playwright:library-configuration')
+    const sessionFinishCh = channel('ci:playwright:session:finish')
+    let onDone
+    let resolveSessionFinish
+    const sessionFinishPromise = new Promise(resolve => {
+      resolveSessionFinish = resolve
+    })
+    const onLibraryConfiguration = ({ onDone }) => onDone({ libraryConfig: {} })
+    const onSessionFinish = ({ onDone: finish }) => {
+      onDone = finish
+      resolveSessionFinish()
+    }
+
+    libraryConfigurationCh.subscribe(onLibraryConfiguration)
+    sessionFinishCh.subscribe(onSessionFinish)
+
+    try {
+      const runPromise = new Runner().runAllTests()
+
+      await sessionFinishPromise
+
+      let hasCompleted = false
+      const completedPromise = (async () => {
+        await runPromise
+        hasCompleted = true
+      })()
+
+      await Promise.resolve()
+
+      assert.strictEqual(hasCompleted, false)
+      onDone()
+      assert.strictEqual(await runPromise, 'passed')
+      await completedPromise
+    } finally {
+      libraryConfigurationCh.unsubscribe(onLibraryConfiguration)
+      sessionFinishCh.unsubscribe(onSessionFinish)
+    }
+  })
+
+  it('completes when the session finish subscriber disables itself', async () => {
+    const libraryConfigurationCh = channel('ci:playwright:library-configuration')
+    const sessionFinishCh = channel('ci:playwright:session:finish')
+    let resolveSessionFinish
+    const sessionFinishPromise = new Promise(resolve => {
+      resolveSessionFinish = resolve
+    })
+    const onLibraryConfiguration = ({ onDone }) => onDone({ libraryConfig: {} })
+    const onSessionFinish = () => {
+      sessionFinishCh.unsubscribe(onSessionFinish)
+      resolveSessionFinish()
+    }
+
+    libraryConfigurationCh.subscribe(onLibraryConfiguration)
+    sessionFinishCh.subscribe(onSessionFinish)
+
+    try {
+      const runPromise = new Runner().runAllTests()
+      let result
+      const completedPromise = (async () => {
+        result = await runPromise
+      })()
+
+      await sessionFinishPromise
+      await setImmediate()
+
+      assert.strictEqual(result, 'passed')
+      await completedPromise
+    } finally {
+      libraryConfigurationCh.unsubscribe(onLibraryConfiguration)
+      sessionFinishCh.unsubscribe(onSessionFinish)
+    }
+  })
+
+  it('completes a worker test when the finish subscriber disables itself', async () => {
+    const testFinishCh = channel('ci:playwright:test:finish')
+    let resolveTestFinish
+    const testFinishPromise = new Promise(resolve => {
+      resolveTestFinish = resolve
+    })
+    const onTestFinish = () => {
+      testFinishCh.unsubscribe(onTestFinish)
+      resolveTestFinish()
+    }
+    const test = {
+      id: 'test-id',
+      expectedStatus: 'passed',
+      location: {
+        file: '/project/test.spec.js',
+        line: 1,
+      },
+      parent: {
+        _hooks: [],
+      },
+      title: 'test name',
+      _requireFile: '/project/test.spec.js',
+    }
+
+    testFinishCh.subscribe(onTestFinish)
+
+    try {
+      const runPromise = new WorkerMain()._runTest(test)
+      let result
+      const completedPromise = (async () => {
+        result = await runPromise
+      })()
+
+      await testFinishPromise
+      await setImmediate()
+
+      assert.strictEqual(result, 'passed')
+      await completedPromise
+    } finally {
+      testFinishCh.unsubscribe(onTestFinish)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Playwright could wait forever when a finish subscriber disabled itself during publication and therefore never called `onDone`. Rechecking channel ownership after publication preserves deferred exporter flushes while completing when no subscriber remains.