### PR TITLE
fix(test-optimization): complete Vitest finish after subscriber loss

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -534,6 +534,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-vitest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: vitest-util
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-when:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
+++ b/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
@@ -419,7 +419,7 @@ function createMainProcessReporter (reporterState) {
     testSuiteFinishCh.publish({
       status: getDatadogStatus(testSuiteResult),
       deferFlush: true,
-      onFinish: noop,
+      onDone: noop,
       ...testSuiteCtx.currentStore,
     })
     testSuiteContexts.delete(testModuleId)

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -812,18 +812,13 @@ function getFinishWrapper (exitOrClose) {
       return exitOrClose.apply(this, arguments)
     }
 
-    let onFinish
-
-    const flushPromise = new Promise(resolve => {
-      onFinish = resolve
-    })
     const failedSuites = this.state.getFailedFilepaths()
     let error
     if (failedSuites.length) {
       error = new Error(`Test suites failed: ${failedSuites.length}.`)
     }
 
-    testSessionFinishCh.publish({
+    const flushPromise = getChannelPromise(testSessionFinishCh, undefined, {
       status: getSessionStatus(this.state),
       testCodeCoverageLinesTotal,
       error,
@@ -833,7 +828,6 @@ function getFinishWrapper (exitOrClose) {
       requestErrorTags,
       vitestPool,
       isVitestNoWorkerInitActive,
-      onFinish,
     })
 
     logTestOptimizationSummary({ attemptToFixExecutions, newTestsWithDynamicNames })
@@ -842,9 +836,7 @@ function getFinishWrapper (exitOrClose) {
 
     // If coverage was generated, publish coverage report channel for upload
     if (coverageRootDir && codeCoverageReportCh.hasSubscribers) {
-      await new Promise((resolve) => {
-        codeCoverageReportCh.publish({ rootDir: coverageRootDir, onDone: resolve })
-      })
+      await getChannelPromise(codeCoverageReportCh, undefined, { rootDir: coverageRootDir })
     }
 
     return exitOrClose.apply(this, arguments)
@@ -1213,16 +1205,10 @@ async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion
     testSuiteErrorCh.runStores(testSuiteCtx, () => {})
   }
 
-  let onFinish
-  const onFinishPromise = new Promise(resolve => {
-    onFinish = resolve
-  })
-  testSuiteFinishCh.publish({
+  await getChannelPromise(testSuiteFinishCh, frameworkVersion, {
     status: getTypecheckTaskStatus(file),
-    onFinish,
     ...testSuiteCtx.currentStore,
   })
-  await onFinishPromise
 }
 
 async function reportTypecheckResults (result, frameworkVersion, ctx, typechecker) {

--- a/packages/datadog-instrumentations/src/vitest-util.js
+++ b/packages/datadog-instrumentations/src/vitest-util.js
@@ -39,9 +39,15 @@ function findExportByName (pkg, name) {
   }
 }
 
+/**
+ * @param {import('node:diagnostics_channel').Channel} channelToPublishTo
+ * @param {string} [frameworkVersion]
+ * @param {Record<string, unknown>} [payload]
+ */
 function getChannelPromise (channelToPublishTo, frameworkVersion, payload) {
   return new Promise(resolve => {
     channelToPublishTo.publish({ ...payload, onDone: resolve, frameworkVersion })
+    if (!channelToPublishTo.hasSubscribers) resolve()
   })
 }
 

--- a/packages/datadog-instrumentations/src/vitest-worker.js
+++ b/packages/datadog-instrumentations/src/vitest-worker.js
@@ -22,6 +22,7 @@ const {
   testSuiteFinishCh,
   testSuiteErrorCh,
   findExportByName,
+  getChannelPromise,
   getTestRunnerExport,
   getTypeTasks,
   getTestName,
@@ -661,11 +662,6 @@ addHook({
     testSuiteStartCh.runStores(testSuiteCtx, () => {})
     const startTestsResponse = await startTests.apply(this, arguments)
 
-    let onFinish = null
-    const onFinishPromise = new Promise(resolve => {
-      onFinish = resolve
-    })
-
     const testTasks = getTypeTasks(startTestsResponse[0].tasks)
     const testEventPromises = []
 
@@ -811,9 +807,10 @@ addHook({
       testSuiteErrorCh.runStores(testSuiteCtx, () => {})
     }
 
-    testSuiteFinishCh.publish({ status: testSuiteResult.state, onFinish, ...testSuiteCtx.currentStore })
-
-    await onFinishPromise
+    await getChannelPromise(testSuiteFinishCh, frameworkVersion, {
+      status: testSuiteResult.state,
+      ...testSuiteCtx.currentStore,
+    })
 
     return startTestsResponse
   })

--- a/packages/datadog-instrumentations/test/vitest-util.spec.js
+++ b/packages/datadog-instrumentations/test/vitest-util.spec.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { setImmediate } = require('node:timers/promises')
+
+const { channel } = require('dc-polyfill')
+const { describe, it } = require('mocha')
+
+const { getChannelPromise } = require('../src/vitest-util')
+
+describe('packages/datadog-instrumentations/src/vitest-util.js', () => {
+  it('waits while a subscriber owns completion', async () => {
+    const finishCh = channel('ci:vitest-util:test:finish')
+    let onDone
+    const onFinish = ({ onDone: finish }) => {
+      onDone = finish
+    }
+
+    finishCh.subscribe(onFinish)
+
+    try {
+      const finishPromise = getChannelPromise(finishCh, '3.2.0', { status: 'pass' })
+      let hasCompleted = false
+      const completedPromise = (async () => {
+        await finishPromise
+        hasCompleted = true
+      })()
+
+      await Promise.resolve()
+
+      assert.strictEqual(hasCompleted, false)
+      onDone()
+      assert.strictEqual(await finishPromise, undefined)
+      await completedPromise
+    } finally {
+      finishCh.unsubscribe(onFinish)
+    }
+  })
+
+  it('completes when the subscriber disables itself during publication', async () => {
+    const finishCh = channel('ci:vitest-util:test:finish')
+    const onFinish = () => {
+      finishCh.unsubscribe(onFinish)
+    }
+
+    finishCh.subscribe(onFinish)
+
+    try {
+      let hasCompleted = false
+      const completedPromise = (async () => {
+        await getChannelPromise(finishCh, '3.2.0', { status: 'pass' })
+        hasCompleted = true
+      })()
+
+      await setImmediate()
+
+      assert.strictEqual(hasCompleted, true)
+      await completedPromise
+    } finally {
+      finishCh.unsubscribe(onFinish)
+    }
+  })
+})

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -398,7 +398,7 @@ class VitestPlugin extends CiPlugin {
       return ctx.currentStore
     })
 
-    this.addSub('ci:vitest:test-suite:finish', ({ testSuiteSpan, status, deferFlush, onFinish }) => {
+    this.addSub('ci:vitest:test-suite:finish', ({ testSuiteSpan, status, deferFlush, onDone }) => {
       if (testSuiteSpan) {
         testSuiteSpan.setTag(TEST_STATUS, status)
         testSuiteSpan.finish()
@@ -406,10 +406,10 @@ class VitestPlugin extends CiPlugin {
       }
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       if (deferFlush) {
-        onFinish()
+        onDone()
         return
       }
-      this.tracer._exporter.flush(onFinish)
+      this.tracer._exporter.flush(onDone)
       if (this.runningTestProbe) {
         this.removeDiProbe(this.runningTestProbe)
       }
@@ -440,7 +440,7 @@ class VitestPlugin extends CiPlugin {
       requestErrorTags,
       vitestPool,
       isVitestNoWorkerInitActive,
-      onFinish,
+      onDone,
     }) => {
       for (const [tag, value] of Object.entries(requestErrorTags || {})) {
         this.testSessionSpan.setTag(tag, value)
@@ -479,7 +479,7 @@ class VitestPlugin extends CiPlugin {
         provider: this.ciProviderName,
         autoInjected: !!this._tracerConfig.testOptimization.DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER,
       })
-      this.tracer._exporter.flush(onFinish)
+      this.tracer._exporter.flush(onDone)
     })
 
     this.addSub('ci:vitest:coverage-report', ({ rootDir, onDone }) => {


### PR DESCRIPTION
## Summary

Vitest could wait forever when a finish or coverage subscriber disabled itself during publication without calling its completion callback. Standardizing the callback contract and rechecking channel ownership keeps live exporter flushes awaited without leaving abandoned waits.