### PR TITLE
fix(test-optimization): contain Selenium RUM cookie errors

### DIFF
--- a/integration-tests/ci-visibility/test/selenium-test.js
+++ b/integration-tests/ci-visibility/test/selenium-test.js
@@ -1,12 +1,16 @@
 'use strict'
 
-const assert = require('assert')
+const assert = require('node:assert/strict')
 
 const { By, Builder } = require('selenium-webdriver')
 const { cleanChromeOptions, createChromeOptions } = require('../selenium-options')
 
+const RUM_COOKIE_NAME = 'datadog-ci-visibility-test-execution-id'
+
 describe('selenium', function () {
   let driver
+  let rejectedRumCookie
+  let rejectedRumCookieDeletion
   let userDataDir
 
   beforeEach(async function () {
@@ -14,10 +18,35 @@ describe('selenium', function () {
     userDataDir = chromeOptions.userDataDir
     const build = new Builder().forBrowser('chrome').setChromeOptions(chromeOptions.options)
     driver = await build.build()
+    if (process.env.REJECT_RUM_COOKIE === 'true') {
+      const manage = driver.manage.bind(driver)
+      driver.manage = () => {
+        const options = manage()
+        /**
+         * @param {{ name: string, value: string }} cookie
+         */
+        options.addCookie = (cookie) => {
+          rejectedRumCookie = cookie
+          return Promise.reject(new Error('RUM correlation cookie rejected'))
+        }
+        /**
+         * @param {string} name
+         */
+        options.deleteCookie = (name) => {
+          rejectedRumCookieDeletion = name
+          return Promise.reject(new Error('RUM correlation cookie deletion rejected'))
+        }
+        return options
+      }
+    }
   })
 
   it('can run selenium tests', async function () {
     await driver.get(process.env.WEB_APP_URL)
+    if (process.env.REJECT_RUM_COOKIE === 'true') {
+      assert.strictEqual(rejectedRumCookie.name, RUM_COOKIE_NAME)
+      assert.match(rejectedRumCookie.value, /^\d+$/)
+    }
 
     const title = await driver.getTitle()
     assert.strictEqual(title, 'Hello World')
@@ -35,6 +64,9 @@ describe('selenium', function () {
     try {
       if (driver !== undefined) {
         await driver.quit()
+      }
+      if (process.env.REJECT_RUM_COOKIE === 'true') {
+        assert.strictEqual(rejectedRumCookieDeletion, RUM_COOKIE_NAME)
       }
     } finally {
       cleanChromeOptions(userDataDir)

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -150,6 +150,32 @@ versionRange.forEach(version => {
       })
     })
 
+    it('does not fail tests when RUM correlation cookie operations reject', async () => {
+      let testOutput = ''
+      childProcess = exec(
+        './node_modules/.bin/mocha ./ci-visibility/test/selenium-test.js --timeout 60000',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            WEB_APP_URL: `http://localhost:${webAppPort}`,
+            TESTS_TO_RUN: '**/ci-visibility/test/selenium-test*',
+            REJECT_RUM_COOKIE: 'true',
+          },
+        }
+      )
+      childProcess.stdout?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+
+      const [exitCode] = await once(childProcess, 'exit')
+
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
     it('does not crash when used outside a known test framework', (done) => {
       let testOutput = ''
       childProcess = exec(

--- a/packages/datadog-instrumentations/src/selenium.js
+++ b/packages/datadog-instrumentations/src/selenium.js
@@ -5,6 +5,7 @@ const realSetTimeout = setTimeout
 
 const shimmer = require('../../datadog-shimmer')
 const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
+const log = require('../../dd-trace/src/log')
 const { addHook, channel } = require('./helpers/instrument')
 
 const ciSeleniumDriverGetStartCh = channel('ci:selenium:driver:get')
@@ -38,22 +39,26 @@ addHook({
     }
     const getResult = await get.apply(this, arguments)
 
-    const isRumActive = await this.executeScript(IS_RUM_ACTIVE_SCRIPT)
-    const capabilities = await this.getCapabilities()
+    try {
+      const isRumActive = await this.executeScript(IS_RUM_ACTIVE_SCRIPT)
+      const capabilities = await this.getCapabilities()
 
-    ciSeleniumDriverGetStartCh.publish({
-      setTraceId,
-      seleniumVersion,
-      browserName: capabilities.getBrowserName(),
-      browserVersion: capabilities.getBrowserVersion(),
-      isRumActive,
-    })
-
-    if (traceId && isRumActive) {
-      await this.manage().addCookie({
-        name: DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME,
-        value: traceId,
+      ciSeleniumDriverGetStartCh.publish({
+        setTraceId,
+        seleniumVersion,
+        browserName: capabilities.getBrowserName(),
+        browserVersion: capabilities.getBrowserVersion(),
+        isRumActive,
       })
+
+      if (traceId && isRumActive) {
+        await this.manage().addCookie({
+          name: DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME,
+          value: traceId,
+        })
+      }
+    } catch (error) {
+      log.error('Error setting up Selenium RUM correlation: %s', error.message, error)
     }
 
     return getResult
@@ -63,16 +68,20 @@ addHook({
     if (!ciSeleniumDriverGetStartCh.hasSubscribers) {
       return quit.apply(this, arguments)
     }
-    const isRumActive = await this.executeScript(RUM_STOP_SESSION_SCRIPT)
+    try {
+      const isRumActive = await this.executeScript(RUM_STOP_SESSION_SCRIPT)
 
-    if (isRumActive) {
-      // We'll have time for RUM to flush the events (there's no callback to know when it's done)
-      await new Promise(resolve => {
-        realSetTimeout(() => {
-          resolve()
-        }, DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS)
-      })
-      await this.manage().deleteCookie(DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME)
+      if (isRumActive) {
+        // We'll have time for RUM to flush the events (there's no callback to know when it's done)
+        await new Promise(resolve => {
+          realSetTimeout(() => {
+            resolve()
+          }, DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS)
+        })
+        await this.manage().deleteCookie(DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME)
+      }
+    } catch (error) {
+      log.error('Error cleaning up Selenium RUM correlation: %s', error.message, error)
     }
 
     return quit.apply(this, arguments)


### PR DESCRIPTION
## Summary

Selenium RUM correlation setup and cleanup currently surface WebDriver cookie failures through user `get()` and `quit()` calls. This keeps Datadog-owned failures from replacing successful navigation or preventing browser shutdown.