### PR TITLE
fix(test-optimization): contain Cypress RUM cookie errors

### DIFF
--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -218,6 +218,38 @@ moduleTypes.forEach(({
       ])
     })
 
+    it('does not fail tests when the RUM correlation cookie is rejected', async () => {
+      let testOutput = ''
+      const envVars = getCiVisAgentlessConfig(receiver.port)
+      const specToRun = 'cypress/e2e/rum-cookie-rejection.cy.js'
+      const command = version === '6.7.0'
+        ? `./node_modules/.bin/cypress run --config-file cypress-config.json --spec "${specToRun}"`
+        : testCommand
+
+      childProcess = exec(
+        command,
+        {
+          cwd,
+          env: {
+            ...envVars,
+            CYPRESS_BASE_URL: webAppBaseUrl,
+            CYPRESS_REJECT_DD_RUM_COOKIE: 'true',
+            SPEC_PATTERN: specToRun,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+
+      const [exitCode] = await once(childProcess, 'exit')
+
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
     if (DD_MAJOR < 6 && version !== 'latest' && semver.lt(version, '12.0.0')) {
       it('logs a warning if using a deprecated version of cypress', async () => {
         let stdout = ''

--- a/integration-tests/cypress/e2e/rum-cookie-rejection.cy.js
+++ b/integration-tests/cypress/e2e/rum-cookie-rejection.cy.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+describe('RUM correlation cookie rejection', () => {
+  it('continues running the test', () => {
+    expect(Cypress.env('DD_RUM_COOKIE_ATTEMPTED')).to.equal(true)
+  })
+})

--- a/integration-tests/cypress/support/e2e.js
+++ b/integration-tests/cypress/support/e2e.js
@@ -1,5 +1,21 @@
-// eslint-disable-next-line
+'use strict'
+
+/* global Cypress */
 if (Cypress.env('ENABLE_INCOMPATIBLE_PLUGIN')) {
   require('cypress-fail-fast')
+}
+if (Cypress.env('REJECT_DD_RUM_COOKIE')) {
+  const automation = Cypress.automation.bind(Cypress)
+  /**
+   * @param {string} event
+   * @param {{ name?: string }} options
+   */
+  Cypress.automation = function (event, options) {
+    if (event === 'set:cookie' && options.name === 'datadog-ci-visibility-test-execution-id') {
+      Cypress.env('DD_RUM_COOKIE_ATTEMPTED', true)
+      return Cypress.Promise.reject(new Error('RUM correlation cookie rejected'))
+    }
+    return automation(event, options)
+  }
 }
 require('dd-trace/ci/cypress/support')

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -129,6 +129,54 @@ function runBeforeEachTask (test) {
   })
 }
 
+/**
+ * @param {Error} error
+ * @returns {false}
+ */
+function handleRumCorrelationCookieError (error) {
+  Cypress.log({
+    name: 'dd-trace',
+    message: 'Could not set the RUM correlation cookie',
+    consoleProps: () => ({ Error: error }),
+  })
+  return false
+}
+
+/**
+ * @param {string} traceId
+ * @returns {Promise<boolean>}
+ */
+function setRumCorrelationCookie (traceId) {
+  // Execute the command immediately so a DD-owned failure can be handled without failing Cypress's command queue.
+  return cy.now('setCookie', DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME, traceId, { log: false })
+    .then(() => true, handleRumCorrelationCookieError)
+}
+
+/**
+ * @param {boolean} isCookieSet
+ * @returns {void}
+ */
+function restartRumSession (isCookieSet) {
+  if (!isCookieSet || isTestIsolationEnabled || !originalWindow) {
+    return
+  }
+
+  const rum = safeGetRum(originalWindow)
+  if (rum) {
+    try {
+      const evt = new originalWindow.MouseEvent('click', { bubbles: true, cancelable: true })
+      // The browser-sdk addEventListener wrapper filters out untrusted synthetic events
+      // unless __ddIsTrusted is set. Set it so the click triggers expandOrRenewSession().
+      // See: https://github.com/DataDog/browser-sdk/blob/v6.27.1/packages/core/src/browser/addEventListener.ts#L119
+      Object.defineProperty(evt, '__ddIsTrusted', { value: true })
+      originalWindow.dispatchEvent(evt)
+    } catch {}
+    if (rum.startView) {
+      rum.startView()
+    }
+  }
+}
+
 // Catch test failures for quarantined tests and suppress them
 // By not re-throwing the error, Cypress marks the test as passed
 // This allows quarantined tests to run but not affect the exit code
@@ -316,35 +364,15 @@ beforeEach(function () {
     if (shouldDiscard) {
       this.currentTest._ddShouldDiscard = true
     }
+    let rumCookiePromise
     if (traceId) {
-      cy.setCookie(DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME, traceId).then(() => {
-        // When testIsolation:false, the page is not reset between tests, so the RUM session
-        // stopped in afterEach must be explicitly restarted so events in this test are
-        // associated with the new testExecutionId.
-        //
-        // After stopSession(), the RUM SDK creates a new session upon a user interaction
-        // (click, scroll, keydown, or touchstart). We dispatch a synthetic click on the window
-        // to trigger session renewal, then call startView() to establish a view boundary.
-        if (!isTestIsolationEnabled && originalWindow) {
-          const rum = safeGetRum(originalWindow)
-          if (rum) {
-            try {
-              const evt = new originalWindow.MouseEvent('click', { bubbles: true, cancelable: true })
-              // The browser-sdk addEventListener wrapper filters out untrusted synthetic events
-              // unless __ddIsTrusted is set. Set it so the click triggers expandOrRenewSession().
-              // See: https://github.com/DataDog/browser-sdk/blob/v6.27.1/packages/core/src/browser/addEventListener.ts#L119
-              Object.defineProperty(evt, '__ddIsTrusted', { value: true })
-              originalWindow.dispatchEvent(evt)
-            } catch {}
-            if (rum.startView) {
-              rum.startView()
-            }
-          }
-        }
-      })
+      rumCookiePromise = setRumCorrelationCookie(traceId)
     }
     if (shouldSkip) {
       this.skip()
+    }
+    if (rumCookiePromise) {
+      return rumCookiePromise.then(restartRumSession)
     }
   }).then(() => {
     // Clear any commands accumulated during DD-owned setup (e.g. setCookie, RUM restart)


### PR DESCRIPTION
## Summary

Cypress turns rejected queued cookie commands into failed `beforeEach` hooks. This executes the same cookie command implementation directly so Datadog can report and contain its own RUM correlation failure without changing Cypress's cookie behavior.