### PR TITLE
fix(test-optimization): complete Jest finish after subscriber loss

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -308,6 +308,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-jest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: jest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-kafkajs:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -1945,6 +1945,9 @@ function shouldFinishBailTestSession (globalConfig, results) {
   return !!globalConfig?.bail && getNumBailFailures(results) >= globalConfig.bail
 }
 
+/**
+ * @param {Record<string, unknown> & { onDone?: () => void }} payload
+ */
 async function waitForTestSessionFinish (payload) {
   if (!testSessionFinishCh.hasSubscribers || hasFinishedTestSession) return
 
@@ -1967,6 +1970,7 @@ async function waitForTestSessionFinish (payload) {
   })
 
   testSessionFinishCh.publish(payload)
+  if (!testSessionFinishCh.hasSubscribers) payload.onDone()
 
   const waitingResult = await Promise.race([flushPromise, timeoutPromise])
 
@@ -2131,9 +2135,14 @@ function getWrappedScheduleTests (scheduleTests, frameworkVersion) {
   }
 }
 
+/**
+ * @param {import('node:diagnostics_channel').Channel} channelToPublishTo
+ * @param {Record<string, unknown>} [payload]
+ */
 function getChannelPromise (channelToPublishTo, payload = {}) {
   return new Promise(resolve => {
     channelToPublishTo.publish({ ...payload, onDone: resolve })
+    if (!channelToPublishTo.hasSubscribers) resolve()
   })
 }
 
@@ -2485,9 +2494,7 @@ function getCliWrapper (isNewJestVersion) {
 
       if (codeCoverageReportCh.hasSubscribers) {
         const rootDir = result.globalConfig?.rootDir || process.cwd()
-        await new Promise((resolve) => {
-          codeCoverageReportCh.publish({ rootDir, onDone: resolve })
-        })
+        await getChannelPromise(codeCoverageReportCh, { rootDir })
       }
 
       logSessionSummary(ignoredFailuresSummary, getAttemptToFixExecutionsFromJestResults(result))
@@ -2505,6 +2512,10 @@ function shouldWaitForTestSuiteFinish (environment) {
   return isJestWorker && environment.globalConfig?.workerIdleMemoryLimit !== undefined
 }
 
+/**
+ * @param {Record<string, unknown>} payload
+ * @param {boolean} waitForFinish
+ */
 function publishTestSuiteFinish (payload, waitForFinish) {
   if (!testSuiteFinishCh.hasSubscribers) return
 
@@ -2519,6 +2530,7 @@ function publishTestSuiteFinish (payload, waitForFinish) {
       waitForFinish,
       onDone: resolve,
     })
+    if (!testSuiteFinishCh.hasSubscribers) resolve()
   })
 }
 

--- a/packages/datadog-instrumentations/test/jest.spec.js
+++ b/packages/datadog-instrumentations/test/jest.spec.js
@@ -1,0 +1,196 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { channel } = require('dc-polyfill')
+const { after, before, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+function createCli () {
+  const result = {
+    globalConfig: {
+      rootDir: process.cwd(),
+    },
+    results: {
+      numFailedTestSuites: 0,
+      numFailedTests: 0,
+      numTotalTests: 1,
+      numTotalTestSuites: 1,
+      success: true,
+      testResults: [],
+    },
+  }
+  return {
+    result,
+    cli: {
+      async runCLI () {
+        return result
+      },
+    },
+  }
+}
+
+/**
+ * @param {{ onDone: (result: object) => void }} options
+ */
+function onLibraryConfiguration ({ onDone }) {
+  onDone({
+    libraryConfig: {
+      isCodeCoverageEnabled: false,
+      isCoverageReportUploadEnabled: false,
+      isItrEnabled: false,
+      isEarlyFlakeDetectionEnabled: false,
+      isKnownTestsEnabled: false,
+      isTestManagementEnabled: false,
+      isImpactedTestsEnabled: false,
+    },
+  })
+}
+
+describe('packages/datadog-instrumentations/src/jest.js', () => {
+  let clock
+  let jestAdapterHook
+  let jestWorkerId
+  let runCLIHook
+
+  before(() => {
+    jestWorkerId = process.env.JEST_WORKER_ID
+    process.env.JEST_WORKER_ID = '1'
+    clock = sinon.useFakeTimers()
+    require('../src/jest')
+    const instrumentationHooks = globalThis[Symbol.for('_ddtrace_instrumentations')]
+    runCLIHook = instrumentationHooks['@jest/core'].find(entry => entry.file === 'build/cli/index.js').hook
+    jestAdapterHook = instrumentationHooks['jest-circus']
+      .find(entry => entry.file === 'build/legacy-code-todo-rewrite/jestAdapter.js')
+      .hook
+  })
+
+  after(() => {
+    clock.restore()
+    if (jestWorkerId === undefined) {
+      delete process.env.JEST_WORKER_ID
+    } else {
+      process.env.JEST_WORKER_ID = jestWorkerId
+    }
+  })
+
+  it('completes when the session finish subscriber disables itself during publication', async () => {
+    const libraryConfigurationCh = channel('ci:jest:library-configuration')
+    const sessionFinishCh = channel('ci:jest:session:finish')
+    let resolveSessionFinish
+    const sessionFinishPromise = new Promise(resolve => {
+      resolveSessionFinish = resolve
+    })
+    const onSessionFinish = () => {
+      sessionFinishCh.unsubscribe(onSessionFinish)
+      resolveSessionFinish()
+    }
+    const { cli, result: expectedResult } = createCli()
+
+    libraryConfigurationCh.subscribe(onLibraryConfiguration)
+    sessionFinishCh.subscribe(onSessionFinish)
+
+    try {
+      const wrappedCli = runCLIHook(cli, '29.0.0')
+      const timerCount = clock.countTimers()
+      const runPromise = wrappedCli.runCLI()
+      let result
+      const completedPromise = (async () => {
+        result = await runPromise
+      })()
+
+      await sessionFinishPromise
+      await clock.tickAsync(0)
+
+      assert.strictEqual(result, expectedResult)
+      assert.strictEqual(clock.countTimers(), timerCount)
+      await completedPromise
+    } finally {
+      libraryConfigurationCh.unsubscribe(onLibraryConfiguration)
+      sessionFinishCh.unsubscribe(onSessionFinish)
+    }
+  })
+
+  it('completes when the coverage subscriber disables itself during publication', async () => {
+    const libraryConfigurationCh = channel('ci:jest:library-configuration')
+    const sessionFinishCh = channel('ci:jest:session:finish')
+    const coverageReportCh = channel('ci:jest:coverage-report')
+    let resolveCoverageReport
+    const coverageReportPromise = new Promise(resolve => {
+      resolveCoverageReport = resolve
+    })
+    const onSessionFinish = ({ onDone }) => onDone()
+    const onCoverageReport = () => {
+      coverageReportCh.unsubscribe(onCoverageReport)
+      resolveCoverageReport()
+    }
+    const { cli, result: expectedResult } = createCli()
+
+    libraryConfigurationCh.subscribe(onLibraryConfiguration)
+    sessionFinishCh.subscribe(onSessionFinish)
+    coverageReportCh.subscribe(onCoverageReport)
+
+    try {
+      const wrappedCli = runCLIHook(cli, '29.0.0')
+      const runPromise = wrappedCli.runCLI()
+      let result
+      const completedPromise = (async () => {
+        result = await runPromise
+      })()
+
+      await coverageReportPromise
+      await clock.tickAsync(0)
+
+      assert.strictEqual(result, expectedResult)
+      await completedPromise
+    } finally {
+      libraryConfigurationCh.unsubscribe(onLibraryConfiguration)
+      sessionFinishCh.unsubscribe(onSessionFinish)
+      coverageReportCh.unsubscribe(onCoverageReport)
+    }
+  })
+
+  it('completes when an awaited suite finish subscriber disables itself', async () => {
+    const suiteFinishCh = channel('ci:jest:test-suite:finish')
+    let resolveSuiteFinish
+    const suiteFinishPromise = new Promise(resolve => {
+      resolveSuiteFinish = resolve
+    })
+    const onSuiteFinish = () => {
+      suiteFinishCh.unsubscribe(onSuiteFinish)
+      resolveSuiteFinish()
+    }
+    const expectedResult = {
+      failureMessage: undefined,
+      numFailingTests: 0,
+      skipped: false,
+    }
+    const environment = {
+      globalConfig: {
+        workerIdleMemoryLimit: '512MB',
+      },
+      testEnvironmentOptions: {},
+      testSuiteAbsolutePath: '/project/test.spec.js',
+    }
+    const adapter = async () => expectedResult
+
+    suiteFinishCh.subscribe(onSuiteFinish)
+
+    try {
+      const wrappedAdapter = jestAdapterHook(adapter, '29.0.0')
+      const adapterPromise = wrappedAdapter(undefined, undefined, environment)
+      let result
+      const completedPromise = (async () => {
+        result = await adapterPromise
+      })()
+
+      await suiteFinishPromise
+      await clock.tickAsync(0)
+
+      assert.strictEqual(result, expectedResult)
+      await completedPromise
+    } finally {
+      suiteFinishCh.unsubscribe(onSuiteFinish)
+    }
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Makes Jest session, suite, and coverage finish waits resolve when publishing the finish event synchronously removes the last subscriber. Finish waits share the same publish/re-check contract, and focused instrumentation coverage pins the callback-owned and subscriber-loss paths.

### Motivation

A plugin can disable and unsubscribe itself while handling a diagnostic-channel finish event. When that happened before invoking `onDone`, Jest retained the promise until its 10-second fallback timer elapsed even though no subscriber remained capable of completing the flush.

### Additional Notes

The existing 10-second timeout remains for the distinct case where a live subscriber accepts the event but its exporter never invokes the callback. Verification passed for the focused Jest spec with changed-source coverage, changed-file lint, `jest.core`, and the instrumentation workflow integrity specs.