### PR TITLE
fix(test-optimization): wait for Mocha session flush

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -348,6 +348,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-mocha:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: mocha
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-mongoose:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -240,6 +240,41 @@ function resetSuiteSkippingRunState () {
   writeCoverageBackfillToCache({})
 }
 
+/**
+ * @param {((failures: number) => void) | undefined} callback
+ * @returns {{ onRunDone: (failures: number) => void, onFlushDone: () => void }}
+ */
+function getRunCompletionCallbacks (callback) {
+  let failures
+  let hasRunFinished = false
+  let hasFlushFinished = false
+  let hasCompleted = false
+  const onDone = callback || (() => {})
+
+  const completeIfReady = () => {
+    if (hasCompleted || !hasRunFinished || !hasFlushFinished) return
+
+    hasCompleted = true
+    onDone(failures)
+  }
+
+  return {
+    onRunDone: (runFailures) => {
+      if (hasRunFinished) return
+
+      failures = runFailures
+      hasRunFinished = true
+      completeIfReady()
+    },
+    onFlushDone: () => {
+      if (hasFlushFinished) return
+
+      hasFlushFinished = true
+      completeIfReady()
+    },
+  }
+}
+
 function getOnStartHandler (frameworkVersion) {
   return function () {
     const processArgv = process.argv.slice(2).join(' ')
@@ -251,7 +286,7 @@ function getOnStartHandler (frameworkVersion) {
   }
 }
 
-function getOnEndHandler (isParallel) {
+function getOnEndHandler (isParallel, onDone) {
   return function () {
     let status = 'pass'
     let error
@@ -350,7 +385,11 @@ function getOnEndHandler (isParallel) {
       isEarlyFlakeDetectionFaulty: config.isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled: config.isTestManagementTestsEnabled,
       isParallel,
+      onDone,
     })
+    if (!testSessionFinishCh.hasSubscribers) {
+      onDone()
+    }
 
     logTestOptimizationSummary({ attemptToFixExecutions, newTestsWithDynamicNames })
     loggedAttemptToFixTests.clear()
@@ -642,6 +681,9 @@ addHook({
       return run.apply(this, args)
     }
 
+    const { onRunDone, onFlushDone } = getRunCompletionCallbacks(args[0])
+    args[0] = onRunDone
+
     const { suitesByTestFile, numSuitesByTestFile } = getSuitesByTestFile(this.suite)
     // Root-level tests (direct children of root, no describe wrapper) keyed by file.
     // Populated during the root 'suite' event so the normal finish path can include them
@@ -753,7 +795,7 @@ addHook({
       finishRootSuiteForFile(test.file)
     }
 
-    const onEnd = getOnEndHandler(false)
+    const onEnd = getOnEndHandler(false, onFlushDone)
 
     this.once('start', getOnStartHandler(frameworkVersion))
 
@@ -1043,8 +1085,11 @@ addHook({
       return run.apply(this, arguments)
     }
 
+    const { onRunDone, onFlushDone } = getRunCompletionCallbacks(cb)
+    arguments[0] = onRunDone
+
     this.once('start', getOnStartHandler(frameworkVersion))
-    this.once('end', getOnEndHandler(true))
+    this.once('end', getOnEndHandler(true, onFlushDone))
 
     // Populate unskippable suites before config is fetched (matches serial mode at Mocha.prototype.run)
     for (const filePath of files) {
@@ -1084,7 +1129,7 @@ addHook({
         skippedSuites = skippedFiles
         skippedSuitesCoverage = getSkippedSuitesCoverageForRun()
         writeCoverageBackfillToCache(skippedSuitesCoverage, getCoverageRootDir())
-        run.apply(this, [cb, { files: filteredFiles }])
+        run.apply(this, [onRunDone, { files: filteredFiles }])
       } else {
         run.apply(this, arguments)
       }

--- a/packages/datadog-instrumentations/test/mocha.spec.js
+++ b/packages/datadog-instrumentations/test/mocha.spec.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { setImmediate } = require('node:timers/promises')
+
+const { channel } = require('dc-polyfill')
+const Mocha = require('mocha')
+
+require('../src/mocha/main')
+
+const MOCHA_HOOKS = globalThis[Symbol.for('_ddtrace_instrumentations')].mocha
+const RUNNER_HOOK = MOCHA_HOOKS.find(entry => entry.file === 'lib/runner.js').hook
+
+RUNNER_HOOK(Mocha.Runner, '11.7.6')
+
+class SilentReporter {}
+
+/**
+ * @returns {Mocha}
+ */
+function createMocha () {
+  const mocha = new Mocha({ reporter: SilentReporter })
+  const suite = Mocha.Suite.create(mocha.suite, 'suite')
+  const test = new Mocha.Test('passes', () => {})
+
+  suite.file = '/project/test.spec.js'
+  test.file = suite.file
+  suite.addTest(test)
+
+  return mocha
+}
+
+describe('packages/datadog-instrumentations/src/mocha/main.js', () => {
+  it('waits for session finalization before completing the run', async () => {
+    const testFinishCh = channel('ci:mocha:test:finish')
+    const sessionFinishCh = channel('ci:mocha:session:finish')
+    let onDone
+    let resolveSessionFinish
+    const sessionFinishPromise = new Promise(resolve => {
+      resolveSessionFinish = resolve
+    })
+    const onTestFinish = () => {}
+    const onSessionFinish = ({ onDone: finish }) => {
+      onDone = finish
+      resolveSessionFinish()
+    }
+
+    testFinishCh.subscribe(onTestFinish)
+    sessionFinishCh.subscribe(onSessionFinish)
+
+    try {
+      let result
+      const runPromise = new Promise(resolve => {
+        createMocha().run(failures => {
+          result = failures
+          resolve(failures)
+        })
+      })
+
+      await sessionFinishPromise
+      await Promise.resolve()
+
+      assert.strictEqual(result, undefined)
+      onDone()
+      assert.strictEqual(await runPromise, 0)
+    } finally {
+      testFinishCh.unsubscribe(onTestFinish)
+      sessionFinishCh.unsubscribe(onSessionFinish)
+    }
+  })
+
+  it('completes when the session finish subscriber disables itself', async () => {
+    const testFinishCh = channel('ci:mocha:test:finish')
+    const sessionFinishCh = channel('ci:mocha:session:finish')
+    let resolveSessionFinish
+    const sessionFinishPromise = new Promise(resolve => {
+      resolveSessionFinish = resolve
+    })
+    const onTestFinish = () => {}
+    const onSessionFinish = () => {
+      sessionFinishCh.unsubscribe(onSessionFinish)
+      resolveSessionFinish()
+    }
+
+    testFinishCh.subscribe(onTestFinish)
+    sessionFinishCh.subscribe(onSessionFinish)
+
+    try {
+      let result
+      const runPromise = new Promise(resolve => {
+        createMocha().run(failures => {
+          result = failures
+          resolve(failures)
+        })
+      })
+
+      await sessionFinishPromise
+      await setImmediate()
+
+      assert.strictEqual(result, 0)
+      await runPromise
+    } finally {
+      testFinishCh.unsubscribe(onTestFinish)
+      sessionFinishCh.unsubscribe(onSessionFinish)
+    }
+  })
+})

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -390,6 +390,7 @@ class MochaPlugin extends CiPlugin {
       isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled,
       isParallel,
+      onDone,
     }) => {
       this._exportPendingWorkerTraces()
       if (this.testSessionSpan) {
@@ -456,7 +457,7 @@ class MochaPlugin extends CiPlugin {
         })
       }
       this.libraryConfig = null
-      this.tracer._exporter.flush()
+      this.tracer._exporter.flush(onDone)
     })
 
     this.addBind('ci:mocha:global:run', (ctx) => {


### PR DESCRIPTION
### What does this PR do?

Gates Mocha's serial and parallel completion callbacks until both the framework run and the session exporter flush have completed. Session finish now transfers `onDone` to the plugin, and the publisher completes the gate synchronously if publication removes the last subscriber.

### Motivation

Mocha previously invoked its completion callback immediately after publishing session finish. The process could exit before the exporter flushed, while a subscriber that disabled itself during publication could leave any naive flush wait pending forever.

### Additional Notes

The gate is callback-based and promise-free so Mocha keeps returning its runner across supported versions. Focused instrumentation coverage, changed-file lint, latest and oldest serial smoke tests, and latest parallel smoke coverage passed. The completion primitive remains framework-local for an independent backportable change; a shared fixed-`onDone` helper can follow after these framework fixes and #9348 land.