### PR TITLE
fix(vitest): prevent negative test durations

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/short-failed-test-runner.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/short-failed-test-runner.mjs
@@ -1,0 +1,16 @@
+import { VitestTestRunner } from 'vitest/runners'
+
+export default class ShortFailedTestRunner extends VitestTestRunner {
+  /**
+   * Reproduces a failed test duration below the plugin's adjustment threshold.
+   *
+   * @param {import('@vitest/runner').TaskPopulated} task
+   * @returns {Promise<void>}
+   */
+  async onAfterRunTask (task) {
+    await super.onAfterRunTask(task)
+    if (task.result?.state === 'fail') {
+      task.result.duration = 1
+    }
+  }
+}

--- a/integration-tests/ci-visibility/vitest-tests/short-failed-test.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/short-failed-test.mjs
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('reports a non-negative duration for a short failed test', () => {
+  expect(true).toBe(false)
+})

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -52,6 +52,10 @@ if (process.env.CUSTOM_SEQUENCER) {
   }
 }
 
+if (process.env.VITEST_RUNNER) {
+  config.test.runner = process.env.VITEST_RUNNER
+}
+
 if (process.env.PROJECT_POOL_CONFIG) {
   const projectConfigs = []
   const firstProjectConfig = {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -297,6 +297,42 @@ versions.forEach((version) => {
       })
     })
 
+    it('does not report negative durations for short failed tests', async () => {
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+          assert.strictEqual(tests.length, 1)
+          assert.strictEqual(tests[0].meta[TEST_NAME], 'reports a non-negative duration for a short failed test')
+          assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+          assert.strictEqual(Number(tests[0].duration), 0)
+        })
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            TEST_DIR: 'ci-visibility/vitest-tests/short-failed-test.mjs',
+            VITEST_RUNNER: 'ci-visibility/vitest-tests/short-failed-test-runner.mjs',
+            DD_SERVICE: undefined,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 1, testOutput)
+    })
+
     for (const workerPoolConfig of poolConfig) {
       it(`sets DD_VITEST_WORKER in workers with pool=${workerPoolConfig}`, async () => {
         const eventsPromise = receiver

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -264,8 +264,10 @@ class VitestPlugin extends CiPlugin {
         span.setTag(TEST_EARLY_FLAKE_ABORT_REASON, earlyFlakeAbortReason)
       }
       const finish = () => {
-        if (duration) {
-          span.finish(span._startTime + duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION) // milliseconds
+        if (Number.isFinite(duration) && duration >= 0) {
+          span.finish(
+            span._startTime + Math.max(duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION, 0)
+          ) // milliseconds
         } else {
           span.finish() // `duration` is empty for retries, so we'll use clock time
         }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Prevents failed Vitest tests shorter than five milliseconds from producing negative test span durations.

The duration adjustment is now clamped at zero. A Vitest core integration test runs a real failing test through the worker instrumentation, plugin, serialization, and fake intake paths with a deterministic one-millisecond framework duration.

### Motivation
<!-- What inspired you to submit this pull request? -->

Vitest reports the failed task duration to the plugin, which subtracts five milliseconds to avoid overlap with suite spans. Durations below that threshold previously finished before their start time.

The direct diagnostic-channel test in #9342 only exercised the arithmetic with a fabricated span. This version incorporates Ruben's production fix and verifies the original failure at the integration boundary instead.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Before the production change, the regression test reported `-4,000,000 ns` with both Vitest 1.6.0 and the latest supported version.

Validation:
- `SPEC=vitest.core npm run test:integration:vitest -- --grep "does not report negative durations"` — 2 passing
- Targeted ESLint for all five changed files
- `git diff --check`

