### PR TITLE
fix(agentless): wait for active requests on flush

### DIFF
--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -14,7 +14,10 @@ const { computeIntakeUrl, INTAKE_PATH } = require('./intake')
  * Sends traces directly to the Datadog intake endpoint without an agent.
  */
 class AgentlessWriter extends BaseWriter {
+  #activeRequests = new Set()
   #apiKeyMissing = false
+  #flushWaiters = new Set()
+  #lastRequestId = 0
   #urlMissing = false
 
   /**
@@ -64,14 +67,14 @@ class AgentlessWriter extends BaseWriter {
         log.error('Maximum number of active requests reached. Dropping %d trace(s).', count)
       }
       this._encoder.reset()
-      done()
+      this.#callWhenRequestsComplete(done)
       return
     }
 
     const count = this._encoder.count()
 
     if (count === 0) {
-      done()
+      this.#callWhenRequestsComplete(done)
       return
     }
 
@@ -79,23 +82,22 @@ class AgentlessWriter extends BaseWriter {
 
     if (payload.length === 0) {
       log.debug('Skipping send of empty payload')
-      done()
+      this.#callWhenRequestsComplete(done)
       return
     }
 
-    this._sendPayload(payload, count, done)
+    this._sendPayload(payload, count)
+    this.#callWhenRequestsComplete(done)
   }
 
   /**
    * Sends the encoded payload to the intake endpoint.
    * @param {Buffer} data - The encoded JSON payload
    * @param {number} count - Number of traces in the payload
-   * @param {Function} done - Callback when complete
    */
-  _sendPayload (data, count, done) {
+  _sendPayload (data, count) {
     if (!data || data.length === 0) {
       log.debug('Skipping send of empty payload')
-      done()
       return
     }
 
@@ -105,7 +107,6 @@ class AgentlessWriter extends BaseWriter {
         log.error('No valid URL configured for agentless trace intake. Traces will not be sent.')
       }
       log.debug('Dropping %d trace(s) due to missing URL', count)
-      done()
       return
     }
 
@@ -116,7 +117,6 @@ class AgentlessWriter extends BaseWriter {
         log.error('DD_API_KEY is required for agentless trace intake. Set DD_API_KEY. Traces will not be sent.')
       }
       log.debug('Dropping %d trace(s) due to missing DD_API_KEY', count)
-      done()
       return
     }
     this.#apiKeyMissing = false
@@ -139,16 +139,66 @@ class AgentlessWriter extends BaseWriter {
 
     log.debug('Request to the agentless intake: %j', options)
 
-    request(data, options, (err, res, statusCode) => {
-      if (err) {
-        this.#logRequestError(err, statusCode, count)
-        done()
-        return
-      }
+    const activeRequest = ++this.#lastRequestId
+    this.#activeRequests.add(activeRequest)
 
-      log.debug('Response from the agentless intake: %s', res)
+    try {
+      request(data, options, (err, res, statusCode) => {
+        if (err) {
+          this.#logRequestError(err, statusCode, count)
+        } else {
+          log.debug('Response from the agentless intake: %s', res)
+        }
+
+        this.#finishRequest(activeRequest)
+      })
+    } catch (err) {
+      this.#finishRequest(activeRequest)
+      throw err
+    }
+  }
+
+  /**
+   * Waits for the intake requests that were active when this method was called.
+   * Requests started by later flushes do not delay this callback.
+   * @param {Function} done - Callback when the current requests have completed
+   */
+  #callWhenRequestsComplete (done) {
+    if (this.#activeRequests.size === 0) {
       done()
-    })
+      return
+    }
+
+    this.#flushWaiters.add({ done, lastRequestId: this.#lastRequestId })
+  }
+
+  /**
+   * Completes waiters whose request snapshot no longer contains an active request.
+   * @param {number} activeRequest - Identifier of the completed request
+   */
+  #finishRequest (activeRequest) {
+    if (!this.#activeRequests.delete(activeRequest)) return
+
+    // Request IDs increase with Set insertion order, so the first value is the oldest active request.
+    const oldestActiveRequest = this.#activeRequests.values().next().value
+    const callbacks = []
+    for (const waiter of this.#flushWaiters) {
+      if (oldestActiveRequest === undefined || oldestActiveRequest > waiter.lastRequestId) {
+        this.#flushWaiters.delete(waiter)
+        callbacks.push(waiter.done)
+      }
+    }
+
+    let callbackError
+    for (const callback of callbacks) {
+      try {
+        callback()
+      } catch (err) {
+        callbackError ??= err
+      }
+    }
+
+    if (callbackError) throw callbackError
   }
 
   /**

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -128,6 +128,182 @@ describe('AgentlessWriter', () => {
       writer.flush(done)
     })
 
+    it('should wait for an active intake request when empty', (done) => {
+      let requestCallback
+      let flushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.onSecondCall().returns(0)
+
+      writer.flush()
+      writer.flush(() => {
+        flushed = true
+        done()
+      })
+
+      assert.strictEqual(flushed, false)
+      requestCallback(null, '{}', 200)
+    })
+
+    it('should wait for an active intake request when the new payload is empty', (done) => {
+      let requestCallback
+      let flushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.returns(1)
+      encoder.makePayload.onSecondCall().returns(Buffer.alloc(0))
+
+      writer.flush()
+      writer.flush(() => {
+        flushed = true
+        done()
+      })
+
+      sinon.assert.calledOnce(request)
+      assert.strictEqual(flushed, false)
+      requestCallback(null, '{}', 200)
+    })
+
+    it('should wait for prior and newly submitted intake requests', (done) => {
+      const requestCallbacks = []
+      let flushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush()
+      writer.flush(() => {
+        flushed = true
+        done()
+      })
+
+      requestCallbacks[1](null, '{}', 200)
+      assert.strictEqual(flushed, false)
+      requestCallbacks[0](null, '{}', 200)
+    })
+
+    it('should wait for the request submitted by the flush', (done) => {
+      const requestCallbacks = []
+      let flushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush()
+      writer.flush(() => {
+        flushed = true
+        done()
+      })
+
+      requestCallbacks[0](null, '{}', 200)
+      assert.strictEqual(flushed, false)
+      requestCallbacks[1](null, '{}', 200)
+    })
+
+    it('should not wait for requests submitted by a later flush', () => {
+      const requestCallbacks = []
+      let firstFlushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush(() => {
+        firstFlushed = true
+      })
+      writer.flush()
+
+      requestCallbacks[0](null, '{}', 200)
+      assert.strictEqual(firstFlushed, true)
+      requestCallbacks[1](null, '{}', 200)
+    })
+
+    it('should release an empty flush when an active request fails', (done) => {
+      let requestCallback
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.onSecondCall().returns(0)
+
+      writer.flush()
+      writer.flush(done)
+
+      requestCallback(new Error('ECONNRESET'))
+    })
+
+    it('should release every waiter when one callback throws', () => {
+      const error = new Error('flush callback failed')
+      let requestCallback
+      let secondCallbackCalled = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.returns(0)
+
+      writer.flush()
+      writer.flush(() => {
+        throw error
+      })
+      writer.flush(() => {
+        secondCallbackCalled = true
+      })
+
+      assert.throws(() => requestCallback(null, '{}', 200), error)
+      assert.strictEqual(secondCallbackCalled, true)
+    })
+
+    it('should allow a waiter to flush reentrantly', () => {
+      const requestCallbacks = []
+      let reentrantFlushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush(() => {
+        writer.flush(() => {
+          reentrantFlushed = true
+        })
+      })
+
+      requestCallbacks[0](null, '{}', 200)
+      assert.strictEqual(reentrantFlushed, false)
+      requestCallbacks[1](null, '{}', 200)
+      assert.strictEqual(reentrantFlushed, true)
+    })
+
+    it('should not retain a request when submission throws', () => {
+      const error = new Error('submission failed')
+
+      request.throws(error)
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.onSecondCall().returns(0)
+
+      assert.throws(() => writer.flush(), error)
+
+      request.resetBehavior()
+      let flushed = false
+      writer.flush(() => {
+        flushed = true
+      })
+      assert.strictEqual(flushed, true)
+    })
+
     it('should flush traces to the intake with correct headers', (done) => {
       const expectedData = Buffer.from('{"traces":[]}')
 


### PR DESCRIPTION
### What does this PR do?

Makes an agentless writer flush callback wait for the intake requests that were
active when that flush began, including the payload submitted by that flush.
Requests created by later flushes do not delay the earlier callback.

The implementation covers out-of-order completion, concurrent waiters,
reentrant flushes, asynchronous request failures, synchronous request throws,
and callbacks that throw.

### Motivation

The writer previously invoked the flush callback before its HTTP request
completed. Short-lived serverless runtimes could therefore terminate after the
callback while trace delivery was still in flight.

A delayed loopback intake reproduced the behavior: `master` returned in about
2 ms before the response; this change returned after the 250 ms response at
about 259 ms.

### Additional Notes

This PR intentionally does not add Vercel `after()`/`waitUntil()` scheduling,
change the intake endpoint, or modify encoding.

Verification:

- Combined agentless exporter/intake/writer/encoder suite: 93 passing
- Agentless writer suite: 33 passing
- Normal agent writer suite: 22 passing
- Shared request callback suite: 31 passing
- Targeted ESLint: passing
- `git diff --check`: passing

