### PR TITLE
fix(agentless): preserve span timestamp units

### DIFF
--- a/packages/dd-trace/src/encode/agentless-json.js
+++ b/packages/dd-trace/src/encode/agentless-json.js
@@ -45,8 +45,8 @@ function formatSpan (span, isFirstSpan) {
 
 /**
  * Converts a span to JSON-serializable format.
- * IDs are converted to lowercase hex strings. Start time is converted from
- * nanoseconds to seconds for the intake format.
+ * IDs are converted to lowercase hex strings. Start time and duration are kept
+ * in nanoseconds for the intake format.
  * @param {object} span - The formatted span
  * @returns {object} JSON-serializable span object
  */
@@ -59,7 +59,7 @@ function spanToJSON (span) {
     resource: span.resource,
     service: span.service,
     error: span.error,
-    start: Math.floor(span.start / 1e9),
+    start: span.start,
     duration: span.duration,
     meta: span.meta,
     metrics: span.metrics,

--- a/packages/dd-trace/test/encode/agentless-json.spec.js
+++ b/packages/dd-trace/test/encode/agentless-json.spec.js
@@ -119,7 +119,7 @@ describe('AgentlessJSONEncoder', () => {
       assert.strictEqual(span.meta['_dd.p.tid'], undefined)
     })
 
-    it('should include span fields with start time converted to seconds', () => {
+    it('should include span fields with start time in nanoseconds', () => {
       encoder.encode(data)
 
       const buffer = encoder.makePayload()
@@ -132,11 +132,32 @@ describe('AgentlessJSONEncoder', () => {
         service: 'test-service',
         type: 'web',
         error: 0,
-        start: 1234567890,
+        start: 1234567890000000000,
         duration: 5000000,
       })
       assert.deepStrictEqual(span.meta, { foo: 'bar', '_dd.compute_stats': '1' })
       assert.deepStrictEqual(span.metrics, { example: 1.5, _trace_root: 1 })
+    })
+
+    it('should preserve span timing across separately encoded distributed trace chunks', () => {
+      data[0].duration = 2_000_000_000
+
+      encoder.encode(data)
+      encoder.encode([childSpan])
+
+      const buffer = encoder.makePayload()
+      assert.ok(buffer.includes(Buffer.from('"start":1234567890000000000')))
+      assert.ok(buffer.includes(Buffer.from('"start":1234567891000000000')))
+
+      const decoded = JSON.parse(buffer.toString())
+      const parent = decoded.traces[0].spans[0]
+      const child = decoded.traces[1].spans[0]
+
+      assert.strictEqual(parent.start, data[0].start)
+      assert.strictEqual(child.start, childSpan.start)
+      assert.strictEqual(child.start - parent.start, 1_000_000_000)
+      assert.ok(child.start > parent.start)
+      assert.ok(child.start < parent.start + parent.duration)
     })
 
     it('should handle multiple spans in one trace', () => {


### PR DESCRIPTION
### What does this PR do?

Preserves agentless JSON span `start` values in nanoseconds, matching the
duration unit and intake schema. It also adds a regression for parent and child
chunks encoded separately in a distributed trace.

### Motivation

The encoder divided nanosecond start values by `1e9`, collapsing a one-second
child offset from `1,000,000,000` nanoseconds to `1`. This produced malformed
timing when serverless trace chunks were exported independently and later
merged.

The regression fails on `master` and passes with this change.

### Additional Notes

This PR intentionally does not change the agentless intake endpoint, writer
lifecycle, Vercel defaults, or serverless flushing.

Verification:

- Agentless JSON encoder suite: 30 passing
- Targeted ESLint: passing
- `git diff --check`: passing
- Concrete reproduction: separately encoded child offset remains
  `1,000,000,000` nanoseconds

