### PR TITLE
fix(next): retain agentless exports for request lifetime

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -4,6 +4,7 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+const { scheduleVercelFlush } = require('../../dd-trace/src/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
@@ -86,6 +87,7 @@ class NextPlugin extends ServerPlugin {
     this.config.hooks.request(span, req, res)
 
     span.finish()
+    scheduleVercelFlush(this.tracer)
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false }) {

--- a/packages/datadog-plugin-next/test/request-flush.spec.js
+++ b/packages/datadog-plugin-next/test/request-flush.spec.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+
+const { storage } = require('../../datadog-core')
+
+const legacyStorage = storage('legacy')
+
+describe('Next request-lifetime flush', () => {
+  for (const [name, requestError] of [
+    ['successful request', undefined],
+    ['failed request', new Error('route failed')],
+  ]) {
+    it(`schedules agentless export after finishing the span for a ${name}`, () => {
+      const calls = []
+      const tracer = createTracer(calls)
+      const NextPlugin = proxyquire.noCallThru().load('../src', {
+        '../../dd-trace/src/serverless': {
+          scheduleVercelFlush (scheduledTracer) {
+            assert.strictEqual(scheduledTracer, tracer)
+            calls.push('schedule flush')
+          },
+        },
+        '../../dd-trace/src/plugins/util/web': {
+          addError: () => {},
+        },
+      })
+      const plugin = new NextPlugin(tracer, {})
+      const span = createSpan(calls)
+      const req = { error: requestError }
+
+      plugin.config = {
+        hooks: { request: () => {} },
+        validateStatus: code => code < 500,
+      }
+
+      legacyStorage.run({ span }, () => {
+        plugin.finish({ req, res: { statusCode: requestError ? 500 : 200 } })
+      })
+
+      assert.deepStrictEqual(calls, ['finish span', 'schedule flush'])
+    })
+  }
+})
+
+function createTracer (calls) {
+  return {
+    _service: 'test-service',
+    _nomenclature: {
+      serviceName: () => ({ name: 'next-service', source: 'schema' }),
+      opName: () => 'next.request',
+    },
+    calls,
+  }
+}
+
+function createSpan (calls) {
+  const tags = {}
+
+  return {
+    addTags: newTags => Object.assign(tags, newTags),
+    context: () => ({ getTag: key => tags[key] }),
+    setTag: (key, value) => {
+      tags[key] = value
+    },
+    finish: () => {
+      calls.push('finish span')
+    },
+  }
+}

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -2,6 +2,8 @@
 
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
 
+const NEXT_REQUEST_CONTEXT = Symbol.for('@next/request-context')
+
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
     getEnvironmentVariable('FUNCTION_NAME') !== undefined &&
@@ -42,9 +44,55 @@ function isInServerlessEnvironment () {
   return inAWSLambda || isGCPFunction || isAzureFunction
 }
 
+/**
+ * Register an agentless export with Vercel's active Next.js request lifetime.
+ *
+ * @param {import('./opentracing/tracer') | {_tracer: import('./opentracing/tracer')}} tracer Datadog tracer instance.
+ * @returns {boolean} Whether the export was registered with the request context.
+ */
+function scheduleVercelFlush (tracer) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return false
+
+  tracer = tracer?._tracer || tracer
+  if (tracer?._config?.experimental?.exporter !== 'agentless') return false
+  if (typeof tracer._exporter?.flush !== 'function') return false
+
+  let waitUntil
+  try {
+    waitUntil = globalThis[NEXT_REQUEST_CONTEXT]?.get?.()?.waitUntil
+  } catch {
+    return false
+  }
+  if (typeof waitUntil !== 'function') return false
+
+  let resolveFlush
+  const promise = new Promise(resolve => {
+    resolveFlush = resolve
+  })
+
+  try {
+    waitUntil(promise)
+  } catch {
+    resolveFlush()
+    return false
+  }
+
+  setImmediate(flushExporter, tracer._exporter, resolveFlush)
+  return true
+}
+
+function flushExporter (exporter, done) {
+  try {
+    exporter.flush(done)
+  } catch {
+    done()
+  }
+}
+
 module.exports = {
   getIsGCPFunction,
   getIsAzureFunction,
+  scheduleVercelFlush,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
   IS_SERVERLESS: isInServerlessEnvironment(),

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -61,6 +61,7 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'FUNCTIONS_WORKER_RUNTIME',
   'GCP_PROJECT',
   'K_SERVICE',
+  'VERCEL',
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -1,12 +1,19 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { AsyncLocalStorage } = require('node:async_hooks')
+const http = require('node:http')
 
 const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription } = require('../src/serverless')
+const {
+  enableGCPPubSubPushSubscription,
+  scheduleVercelFlush,
+} = require('../src/serverless')
+
+const nextRequestContext = Symbol.for('@next/request-context')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -36,3 +43,255 @@ describe('enableGCPPubSubPushSubscription', () => {
     assert.strictEqual(enableGCPPubSubPushSubscription(), false)
   })
 })
+
+describe('scheduleVercelFlush', () => {
+  const originalVercel = process.env.VERCEL
+
+  afterEach(() => {
+    if (originalVercel === undefined) delete process.env.VERCEL
+    else process.env.VERCEL = originalVercel
+    delete globalThis[nextRequestContext]
+  })
+
+  it('keeps the request alive until asynchronous export completes', async () => {
+    process.env.VERCEL = '1'
+    let flushDone
+    let waitUntilTask
+    let settled = false
+    const tracer = createAgentlessTracer(done => {
+      flushDone = done
+    })
+    globalThis[nextRequestContext] = createRequestContext(promise => {
+      waitUntilTask = promise
+      promise.then(() => {
+        settled = true
+      })
+    })
+
+    assert.strictEqual(scheduleVercelFlush(tracer), true)
+    assert.ok(waitUntilTask instanceof Promise)
+
+    await nextImmediate()
+
+    assert.strictEqual(typeof flushDone, 'function')
+    assert.strictEqual(settled, false)
+
+    flushDone()
+    await waitUntilTask
+
+    assert.strictEqual(settled, true)
+  })
+
+  it('keeps a serverless invocation alive through a loopback intake request', async () => {
+    process.env.VERCEL = '1'
+    const requestContextStorage = new AsyncLocalStorage()
+    const waitUntilTasks = []
+    let intakeRequestStarted
+    let releaseIntakeResponse
+    let exported = false
+    const intakeRequest = new Promise(resolve => {
+      intakeRequestStarted = resolve
+    })
+    const intake = http.createServer((req, res) => {
+      intakeRequestStarted()
+      releaseIntakeResponse = () => res.end('accepted')
+    })
+
+    await listen(intake)
+
+    const tracer = createAgentlessTracer(done => {
+      const request = http.request({
+        hostname: '127.0.0.1',
+        port: intake.address().port,
+        method: 'POST',
+      }, response => {
+        response.resume()
+        response.once('end', () => {
+          exported = true
+          done()
+        })
+      })
+      request.end('trace payload')
+    })
+    globalThis[nextRequestContext] = {
+      get: () => requestContextStorage.getStore(),
+    }
+
+    try {
+      let responseComplete = false
+      requestContextStorage.run({
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, () => {
+        assert.strictEqual(scheduleVercelFlush(tracer), true)
+        responseComplete = true
+      })
+
+      assert.strictEqual(responseComplete, true)
+      assert.strictEqual(exported, false)
+      assert.strictEqual(waitUntilTasks.length, 1)
+
+      await intakeRequest
+
+      assert.strictEqual(exported, false)
+      releaseIntakeResponse()
+      await waitUntilTasks[0]
+
+      assert.strictEqual(exported, true)
+    } finally {
+      await close(intake)
+    }
+  })
+
+  it('tracks concurrent request flushes independently', async () => {
+    process.env.VERCEL = '1'
+    const flushCallbacks = []
+    const waitUntilTasks = []
+    const tracer = createAgentlessTracer(done => {
+      flushCallbacks.push(done)
+    })
+    globalThis[nextRequestContext] = createRequestContext(promise => {
+      waitUntilTasks.push(promise)
+    })
+
+    assert.strictEqual(scheduleVercelFlush(tracer), true)
+    assert.strictEqual(scheduleVercelFlush(tracer), true)
+
+    await nextImmediate()
+
+    assert.strictEqual(flushCallbacks.length, 2)
+    assert.strictEqual(waitUntilTasks.length, 2)
+    assert.notStrictEqual(waitUntilTasks[0], waitUntilTasks[1])
+
+    flushCallbacks[1]()
+    await waitUntilTasks[1]
+
+    let firstSettled = false
+    waitUntilTasks[0].then(() => {
+      firstSettled = true
+    })
+    await Promise.resolve()
+    assert.strictEqual(firstSettled, false)
+
+    flushCallbacks[0]()
+    await waitUntilTasks[0]
+    assert.strictEqual(firstSettled, true)
+  })
+
+  it('settles request-lifetime work when flush throws synchronously', async () => {
+    process.env.VERCEL = '1'
+    let waitUntilTask
+    const tracer = createAgentlessTracer(() => {
+      throw new Error('flush failed')
+    })
+    globalThis[nextRequestContext] = createRequestContext(promise => {
+      waitUntilTask = promise
+    })
+
+    assert.strictEqual(scheduleVercelFlush(tracer), true)
+    await waitUntilTask
+  })
+
+  it('settles request-lifetime work after an asynchronous export error', async () => {
+    process.env.VERCEL = '1'
+    let waitUntilTask
+    const tracer = createAgentlessTracer(done => {
+      setImmediate(done, new Error('intake failed'))
+    })
+    globalThis[nextRequestContext] = createRequestContext(promise => {
+      waitUntilTask = promise
+    })
+
+    assert.strictEqual(scheduleVercelFlush(tracer), true)
+    await waitUntilTask
+  })
+
+  it('does not schedule outside Vercel', async () => {
+    let flushes = 0
+    let waitUntilCalls = 0
+    const tracer = createAgentlessTracer(() => {
+      flushes++
+    })
+    globalThis[nextRequestContext] = createRequestContext(() => {
+      waitUntilCalls++
+    })
+
+    assert.strictEqual(scheduleVercelFlush(tracer), false)
+    await nextImmediate()
+
+    assert.strictEqual(flushes, 0)
+    assert.strictEqual(waitUntilCalls, 0)
+  })
+
+  it('does not schedule for the normal agent exporter', async () => {
+    process.env.VERCEL = '1'
+    let waitUntilCalls = 0
+    const tracer = {
+      _config: { experimental: { exporter: 'agent' } },
+      _exporter: { flush: assert.fail },
+    }
+    globalThis[nextRequestContext] = createRequestContext(() => {
+      waitUntilCalls++
+    })
+
+    assert.strictEqual(scheduleVercelFlush(tracer), false)
+    await nextImmediate()
+
+    assert.strictEqual(waitUntilCalls, 0)
+  })
+
+  it('does not schedule without an active Next request context', () => {
+    process.env.VERCEL = '1'
+
+    assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(assert.fail)), false)
+  })
+
+  it('does not schedule when the Next request context cannot be read', () => {
+    process.env.VERCEL = '1'
+    globalThis[nextRequestContext] = {
+      get: () => {
+        throw new Error('request context unavailable')
+      },
+    }
+
+    assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(assert.fail)), false)
+  })
+
+  it('settles its task when waitUntil rejects registration', async () => {
+    process.env.VERCEL = '1'
+    let flushes = 0
+    globalThis[nextRequestContext] = createRequestContext(() => {
+      throw new Error('request already completed')
+    })
+
+    const scheduled = scheduleVercelFlush(createAgentlessTracer(() => {
+      flushes++
+    }))
+
+    assert.strictEqual(scheduled, false)
+    await nextImmediate()
+    assert.strictEqual(flushes, 0)
+  })
+})
+
+function createAgentlessTracer (flush) {
+  return {
+    _config: { experimental: { exporter: 'agentless' } },
+    _exporter: { flush },
+  }
+}
+
+function createRequestContext (waitUntil) {
+  return { get: () => ({ waitUntil }) }
+}
+
+function nextImmediate () {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+function listen (server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+}
+
+function close (server) {
+  return new Promise(resolve => server.close(resolve))
+}


### PR DESCRIPTION
## What changed

- register agentless export work with the active Next.js request context on Vercel
- schedule export only after the `next.request` span finishes
- no-op outside Vercel, without a Next request context, or when the normal agent exporter is used
- settle request-lifetime work on synchronous and asynchronous export failures

## Why

Finishing a span starts agentless export, but a Vercel function may be suspended as soon as the response completes. That can terminate the intake request before Datadog receives the trace. Next exposes the platform request lifetime through `globalThis[Symbol.for('@next/request-context')]`; registering the export promise there keeps the invocation alive until intake completes without adding sleeps or route-local customer code.

This is intentionally limited to Vercel plus the agentless exporter. It does not affect normal agent export or non-Vercel Next.js applications.

## Dependency

This PR is stacked on #9384. It relies on `exporter.flush(done)` calling `done` only after the intake requests active at that flush complete. Retarget this PR to `master` after #9384 merges.

## Verification

- 15 focused tests passing
- delayed loopback HTTP intake proves response completion can precede export completion while the registered request-lifetime promise remains pending
- concurrent request flushes are tracked independently
- successful requests, failed requests, synchronous throws, asynchronous export errors, missing contexts, rejected registration, non-Vercel runtimes, and normal-agent export are covered
- targeted ESLint and `git diff --check`: passing
- prior Vercel request-context reproduction retained `GET /api/flow -> fetch /api/ping -> GET /api/ping` in trace `2697913726384499828`
- prior 10-request parallel Vercel proof retained all caller and downstream chunks with this request-context strategy

## Review note

The implementation uses the same built-in request context that Next reads for its documented `after()` adapter path. It does not import `next/server` or `@vercel/functions` and adds no runtime dependency.
