### PR TITLE
fix(ai): activate explicitly configured bundled instrumentation

### DIFF
--- a/integration-tests/esbuild/ai-v7-app.js
+++ b/integration-tests/esbuild/ai-v7-app.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const tracer = require('dd-trace').init({ startupLogs: false })
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+const { tracingChannel } = require('node:diagnostics_channel')
+
+tracer.use('ai')
+
+if (!tracingChannel('ai:telemetry').hasSubscribers) {
+  throw new Error('AI SDK telemetry channel was not activated')
+}
+
+const { generateText } = require('ai')
+const { MockLanguageModelV4 } = require('ai/test')
+
+const model = new MockLanguageModelV4({
+  provider: 'test-provider',
+  modelId: 'test-model',
+  doGenerate: async () => ({
+    content: [{ type: 'text', text: 'bundled response' }],
+    finishReason: { unified: 'stop', raw: undefined },
+    usage: {
+      inputTokens: { total: 2, noCache: 2 },
+      outputTokens: { total: 2, text: 2 },
+    },
+    warnings: [],
+  }),
+})
+
+generateText({ model, prompt: 'bundled prompt' }).catch(error => {
+  process.stderr.write(`${error.stack ?? error}\n`)
+  process.exitCode = 1
+})

--- a/integration-tests/esbuild/ai-v7.integration.spec.js
+++ b/integration-tests/esbuild/ai-v7.integration.spec.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const { readFileSync } = require('node:fs')
+const path = require('node:path')
+
+const { FakeAgent, sandboxCwd, spawnProcAndExpectExit, useSandbox } = require('../helpers')
+const { NODE_MAJOR } = require('../../version')
+
+if (NODE_MAJOR < 22) return
+
+describe('esbuild bundling AI SDK v7', () => {
+  let agent
+  let cwd
+
+  useSandbox(['esbuild@0.28.0', 'ai@7.0.2', 'zod@4.1.8'], false, [__dirname])
+
+  before(() => {
+    cwd = sandboxCwd()
+  })
+
+  beforeEach(async () => {
+    agent = await new FakeAgent().start()
+  })
+
+  afterEach(() => agent.stop())
+
+  it('activates explicit AI tracing for a fully bundled SDK', async () => {
+    const builder = path.join(cwd, 'esbuild', 'build-ai-v7.js')
+    execFileSync(process.execPath, [builder], { cwd })
+
+    const appFile = path.join(cwd, 'esbuild', 'ai-v7-out.cjs')
+    const bundle = readFileSync(appFile, 'utf8')
+    assert.match(bundle, /AI_SDK_TELEMETRY_TRACING_CHANNEL/, 'expected the AI SDK implementation in the bundle')
+    assert.match(bundle, /require\("dd-trace"\)/, 'expected dd-trace to remain external')
+
+    await Promise.all([
+      agent.assertMessageReceived(({ payload }) => {
+        const aiSpanNames = payload
+          .flat(2)
+          .filter(span => span.meta?.component === 'ai_tracing_vercel_telemetry')
+          .map(span => span.name)
+          .sort()
+
+        assert.deepStrictEqual(aiSpanNames, ['generateText', 'languageModelCall', 'step'])
+      }, 20_000),
+      spawnProcAndExpectExit(appFile, {
+        cwd,
+        env: {
+          ...process.env,
+          DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
+          DD_TRACE_AI_ENABLED: 'true',
+        },
+      }),
+    ])
+  })
+})

--- a/integration-tests/esbuild/build-ai-v7.js
+++ b/integration-tests/esbuild/build-ai-v7.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const esbuild = require('esbuild')
+
+esbuild.buildSync({
+  entryPoints: ['esbuild/ai-v7-app.js'],
+  outfile: 'esbuild/ai-v7-out.cjs',
+  bundle: true,
+  external: ['dd-trace'],
+  format: 'cjs',
+  platform: 'node',
+  target: 'node22',
+})

--- a/packages/datadog-instrumentations/src/ai.js
+++ b/packages/datadog-instrumentations/src/ai.js
@@ -1,5 +1,7 @@
 'use strict'
 
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+const { TransformStream } = require('node:stream/web')
 const { channel, tracingChannel } = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
 const { addHook, getHooks } = require('./helpers/instrument')
@@ -236,46 +238,31 @@ for (const hook of getHooks('ai')) {
 const aiSdkTelemetryChannel = tracingChannel('ai:telemetry')
 const aiSdkTelemetryStreamedChunkChannel = channel('dd-trace:vercel-ai:chunk')
 
-// for testing, and possibly actual instrumentation use, we want to
-// guard against double-subscribing to the asyncEnd channel of the
-// vercel ai-provided tracingChannel
-let subscribed = false
-
 // as of the v7 release, the ai sdk does not automatically aggregate streamed responses
 // we will handle emitting the chunks directly for products to handle
-addHook({ name: 'ai', versions: ['>=7.0.0'] }, exports => {
-  if (subscribed) return exports
-  subscribed = true
+aiSdkTelemetryChannel.subscribe({
+  asyncEnd (ctx) {
+    // guard against this event being re-emitted.
+    if (!ctx.isStream || !ctx.result?.stream || ctx.streamConsumed) return
 
-  // ai sdk v7 only supported on node.js 22+
-  // inlining this import here so we only import in those cases
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  const { TransformStream } = require('node:stream/web')
+    const transform = new TransformStream({
+      transform (chunk, controller) {
+        const done = chunk.type === 'finish'
 
-  aiSdkTelemetryChannel.subscribe({
-    asyncEnd (ctx) {
-      // guard against this event being re-emitted.
-      if (!ctx.isStream || !ctx.result?.stream || ctx.streamConsumed) return
+        aiSdkTelemetryStreamedChunkChannel.publish({ ctx, chunk, done })
 
-      const transform = new TransformStream({
-        transform (chunk, controller) {
-          const done = chunk.type === 'finish'
+        if (done) {
+          aiSdkTelemetryChannel.asyncEnd.publish(ctx)
+        }
 
-          aiSdkTelemetryStreamedChunkChannel.publish({ ctx, chunk, done })
+        controller.enqueue(chunk) // pass through value
+      },
+    })
 
-          if (done) {
-            aiSdkTelemetryChannel.asyncEnd.publish(ctx)
-          }
-
-          controller.enqueue(chunk) // pass through value
-        },
-      })
-
-      ctx.result.stream = ctx.result.stream.pipeThrough(transform)
-    },
-  })
-
-  return exports
+    ctx.result.stream = ctx.result.stream.pipeThrough(transform)
+  },
 })
+
+addHook({ name: 'ai', versions: ['>=7.0.0'] }, exports => exports)
 
 module.exports = { wrapModelWithLifecycle }

--- a/packages/datadog-instrumentations/src/helpers/register-instrumentation.js
+++ b/packages/datadog-instrumentations/src/helpers/register-instrumentation.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const hooks = require('./hooks')
+
+module.exports = function registerInstrumentation (name) {
+  const hook = hooks[name]
+  const hookFn = hook?.fn ?? hook
+
+  if (typeof hookFn === 'function') hookFn()
+}

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -2,6 +2,7 @@
 
 const { channel } = require('dc-polyfill')
 
+const registerInstrumentation = require('../../datadog-instrumentations/src/helpers/register-instrumentation')
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
 const { isFalse, isTrue, normalizePluginEnvName } = require('./util')
 const plugins = require('./plugins')
@@ -115,6 +116,11 @@ module.exports = class PluginManager {
   // TODO: merge config instead of replacing
   configurePlugin (name, pluginConfig) {
     const enabled = this._isEnabled(pluginConfig)
+
+    if (enabled) {
+      registerInstrumentation(name)
+      maybeEnable(plugins[name])
+    }
 
     this._configsByName[name] = {
       ...pluginConfig,

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -24,6 +24,7 @@ describe('Plugin Manager', () => {
   let Graphql
   let pm
   let registeredDefaults
+  let registerInstrumentation
 
   function makeTracerConfig (overrides = {}) {
     return {
@@ -98,9 +99,11 @@ describe('Plugin Manager', () => {
     // default is returned unless the caller passes skipDefault. registeredDefaults lets a test
     // model a plugin whose default-enabled flag is `false` (e.g. an experimental plugin).
     registeredDefaults = {}
+    registerInstrumentation = sinon.stub()
     PluginManager = proxyquire.noPreserveCache()('../src/plugin_manager', {
       './plugins': { ...plugins, '@noCallThru': true },
       '../../datadog-instrumentations': {},
+      '../../datadog-instrumentations/src/helpers/register-instrumentation': registerInstrumentation,
       '../../dd-trace/src/config/helper': {
         getEnvironmentVariable (name) {
           return process.env[name]
@@ -125,6 +128,18 @@ describe('Plugin Manager', () => {
   describe('configurePlugin', () => {
     it('does not throw for old-style plugins', () => {
       pm.configurePlugin('one', false)
+    })
+
+    it('registers instrumentation before the package is loaded', () => {
+      pm.configurePlugin('two')
+
+      sinon.assert.calledOnceWithExactly(registerInstrumentation, 'two')
+    })
+
+    it('does not register instrumentation when the plugin is disabled', () => {
+      pm.configurePlugin('two', false)
+
+      sinon.assert.notCalled(registerInstrumentation)
     })
 
     describe('without configure', () => {
@@ -301,11 +316,11 @@ describe('Plugin Manager', () => {
 
   describe('configure', () => {
     describe('without the load event', () => {
-      it('should not instantiate plugins', () => {
+      it('should instantiate explicitly configured plugins', () => {
         pm.configure(makeTracerConfig())
         pm.configurePlugin('two')
-        assert.strictEqual(instantiated.length, 0)
-        sinon.assert.notCalled(Two.prototype.configure)
+        assert.deepStrictEqual(instantiated, ['two'])
+        sinon.assert.calledOnceWithMatch(Two.prototype.configure, { enabled: true })
       })
     })
 


### PR DESCRIPTION
## What changed

- make explicit `tracer.use(name)` register that integration's existing instrumentation before configuring its plugin
- install the AI SDK v7 native telemetry subscriber when AI instrumentation initializes, while preserving the version-gated package hook
- add a real esbuild fixture where AI SDK v7 is fully bundled and `dd-trace` remains external

## Why

Bundlers can remove the runtime `require('ai')` boundary that normally emits the instrumentation load event. In that shape, `tracer.use('ai')` stored configuration but had no registered plugin class or AI telemetry subscriber, so the bundled application produced no AI spans.

Explicit plugin configuration is the deterministic activation signal when package-load discovery is unavailable. Disabled configurations do not register instrumentation.

## Impact

Applications can explicitly activate instrumentation for a bundled dependency without relying on a package-load event. The bundled AI SDK v7 regression produces `generateText`, `languageModelCall`, and `step` spans through the existing AI tracing plugin.

This does not automatically discover opaque bundled dependencies. A Vercel or bundler integration still needs to issue the explicit activation based on build metadata so customers do not need custom application code.

## Verification

- `37 passing` in `packages/dd-trace/test/plugin_manager.spec.js`
- real AI SDK `7.0.2` esbuild test: `1 passing`
- fake agent received the three expected AI spans
- targeted ESLint passed
- `git diff --check` passed

Provider-backed AI tests were not run because the local VCR service was unavailable; the new test uses AI SDK's real mock model and a real fake-agent intake.
