### PR TITLE
test(agent): bind mock server to tracer address

### DIFF
--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -664,7 +664,7 @@ module.exports = {
     server.on('connection', socket => sockets.push(socket))
 
     const promise = /** @type {Promise<import('../../..').default>} */ (new Promise((resolve, _reject) => {
-      listener = server.listen(0, () => {
+      listener = server.listen(0, '127.0.0.1', () => {
         const port = this.port = listener.address().port
 
         tracer.init({

--- a/packages/dd-trace/test/plugins/agent.spec.js
+++ b/packages/dd-trace/test/plugins/agent.spec.js
@@ -19,6 +19,11 @@ describe('test agent helper', () => {
       assert.strictEqual(tracer, global._ddtrace)
     })
 
+    it('binds the mock agent on the IPv4 loopback address', async () => {
+      await agent.load([])
+      assert.strictEqual(agent.server.address().address, '127.0.0.1')
+    })
+
     it('reuses the cached tracer for repeat loads without close', async () => {
       const first = await agent.load([])
       const second = await agent.load([])


### PR DESCRIPTION
## Summary

An IPv6 wildcard mock-agent listener can receive the same numeric port as an existing IPv4 listener on macOS. Since the tracer exports to `127.0.0.1`, its trace request then reaches the unrelated process and `assertSomeTraces` times out with no payload.