### PR TITLE
perf(graphql): reuse path-string cache for collapsed fields

### DIFF
--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -197,7 +197,6 @@ class GraphQLExecutePlugin extends TracingPlugin {
       config: this.config,
       fields: new Map(),
       pathCache: new Map(),
-      collapsedPathCache: this.config.collapse ? { byPath: new Map(), byParent: new Map() } : undefined,
       abortController,
       executeSpan: span,
       plugin: this,
@@ -423,7 +422,7 @@ function wrapResolve (resolve) {
       return resolve.apply(this, arguments)
     }
 
-    const fieldKey = config.collapse ? buildCachedCollapsedPath(infoPath, rootCtx.collapsedPathCache) : infoPath
+    const fieldKey = config.collapse ? pathString : infoPath
     let field = rootCtx.fields.get(fieldKey)
     const isFirst = !field
 
@@ -436,7 +435,6 @@ function wrapResolve (resolve) {
         variableValues: info.variableValues,
         args,
         infoPath,
-        fieldKey,
         pathString,
         collapsedKey: collapsedKey ?? pathString,
         span: null,
@@ -592,33 +590,6 @@ function buildCachedPathString (path, cache, collapse) {
   return pathString
 }
 
-function buildCachedCollapsedPath (path, cache) {
-  if (!path) return
-
-  const cached = cache.byPath.get(path)
-  if (cached !== undefined) return cached
-
-  const segment = typeof path.key === 'string' ? path.key : '*'
-  const prev = path.prev === undefined
-    ? undefined
-    : buildCachedCollapsedPath(path.prev, cache)
-
-  let siblings = cache.byParent.get(prev)
-  if (siblings === undefined) {
-    siblings = new Map()
-    cache.byParent.set(prev, siblings)
-  }
-
-  let collapsedPath = siblings.get(segment)
-  if (collapsedPath === undefined) {
-    collapsedPath = { key: segment, prev }
-    siblings.set(segment, collapsedPath)
-  }
-
-  cache.byPath.set(path, collapsedPath)
-  return collapsedPath
-}
-
 // Depth filtering directly on the linked-list node — no array allocation needed.
 // config.depth < 0 means no limit. Only selection-set segments (string keys)
 // count toward depth; list indices are execution artifacts and are transparent.
@@ -640,8 +611,9 @@ function shouldInstrumentNode (config, path) {
 }
 
 function getParentField (rootCtx, field) {
-  for (let curr = field.fieldKey?.prev; curr; curr = curr.prev) {
-    const innerField = rootCtx.fields.get(curr)
+  for (let curr = field.infoPath?.prev; curr; curr = curr.prev) {
+    const fieldKey = rootCtx.config.collapse ? rootCtx.pathCache.get(curr) : curr
+    const innerField = rootCtx.fields.get(fieldKey)
     if (innerField) return innerField
   }
 


### PR DESCRIPTION
## Summary
Collapsed list resolvers built both a dotted path string and a parallel object path for the same collapse key, repeating map lookups and allocations on each resolver. Reusing the existing path string removes the second cache while preserving collapsed field grouping and parent lookups.

## Why
A five-item list with four fields per item dropped from 4.10-4.16 us to 3.68-3.69 us per bookkeeping pass (10.1-11.2%) on Node v24.18.0 / V8 13.6.233.17-node.50.