### PR TITLE
feat(next): support standalone preload packaging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,6 +70,8 @@
 /benchmark/sirun/url/ @DataDog/apm-idm-js
 
 /index.electron.js @DataDog/apm-idm-js
+/next.d.ts @DataDog/apm-idm-js
+/next.js @DataDog/apm-idm-js
 /integration-tests/electron/ @DataDog/apm-idm-js
 /integration-tests/esbuild/ @DataDog/apm-idm-js
 /integration-tests/webpack/ @DataDog/apm-idm-js
@@ -81,9 +83,11 @@
 /packages/datadog-plugin-*/ @DataDog/apm-idm-js
 /packages/datadog-instrumentations/ @DataDog/apm-idm-js
 /packages/dd-trace/index.electron.js @DataDog/apm-idm-js
+/packages/dd-trace/src/next.js @DataDog/apm-idm-js
 /packages/dd-trace/src/exporters/electron/ @DataDog/apm-idm-js
 /packages/dd-trace/src/plugins/ @DataDog/apm-idm-js
 /packages/dd-trace/test/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/test/next.spec.js @DataDog/apm-idm-js
 /packages/dd-trace/src/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/payload_tagging.spec.js @DataDog/apm-idm-js

--- a/README.md
+++ b/README.md
@@ -93,6 +93,45 @@ Regardless of where you open the issue, someone at Datadog will try to help.
 
 If you would like to trace your bundled application then please read this page on [bundling and dd-trace](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/#bundling). It includes information on how to use our ESBuild plugin and includes caveats for other bundlers.
 
+### Next.js standalone output
+
+Next.js output tracing cannot see modules loaded only through `NODE_OPTIONS`. With Next.js 15 or newer, use the
+Next.js config helper to externalize `dd-trace` and copy its installed runtime dependency closure into standalone
+output:
+
+```js
+const withDatadogConfig = require('dd-trace/next')
+
+module.exports = withDatadogConfig({
+  output: 'standalone',
+}, {
+  projectRoot: __dirname,
+})
+```
+
+Keep `NODE_OPTIONS="--import dd-trace/initialize.mjs"` when starting the generated server so the tracer and its ESM
+loader run before Next.js. In a monorepo, also set `outputFileTracingRoot` to a common parent of the application and
+its dependencies. The helper includes the Datadog OpenFeature provider when `@openfeature/server-sdk` is installed.
+Next.js applies tracing includes only to Node.js server routes, so use the import-anchor setup below for a static-only
+application.
+
+As an alternative without the config helper, make the preload statically visible to Next.js in `instrumentation.ts`:
+
+```ts
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs' && !globalThis[Symbol.for('dd-trace')]) {
+    await import('dd-trace/initialize.mjs')
+  }
+}
+```
+
+Keep `serverExternalPackages: ['dd-trace']` in `next.config.js` when using this fallback. The import must remain a
+literal so Next.js can trace it. Continue using the same `NODE_OPTIONS` value for early initialization. The runtime
+guard prevents the instrumentation hook from initializing the ESM loader a second time. This approach can produce a
+larger standalone artifact because Next.js decides which optional dependencies to copy. When using this fallback with
+OpenFeature, import `@datadog/openfeature-node-server` from server-side application code so Next.js can trace that
+dynamically loaded package.
+
 
 ## Security Vulnerabilities
 

--- a/next.d.ts
+++ b/next.d.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+interface DatadogNextOptions {
+  projectRoot?: string
+}
+
+declare function withDatadogConfig(config?: NextConfig, options?: DatadogNextOptions): NextConfig
+
+export = withDatadogConfig

--- a/next.js
+++ b/next.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./packages/dd-trace/src/next')

--- a/package.json
+++ b/package.json
@@ -153,6 +153,8 @@
     "LICENSE.Apache",
     "LICENSE.BSD3",
     "loader-hook.mjs",
+    "next.d.ts",
+    "next.js",
     "packages/*/index.js",
     "packages/*/index.electron.js",
     "packages/*/lib/**/*",

--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -42,7 +42,7 @@ const earlyLoadFrameworks = new Map([
   ['next', {
     // dist/server/next-server.js (>=11.1), dist/next-server/server/next-server.js (older)
     file: 'next-server.js',
-    guidance: "add 'dd-trace' to `serverExternalPackages` (Next.js >=15) or " +
+    guidance: "wrap `next.config.js` with `require('dd-trace/next')` (Next.js >=15), or add 'dd-trace' to " +
       '`experimental.serverComponentsExternalPackages` (13-14) so it is not bundled',
   }],
 ])

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
@@ -54,7 +54,7 @@ describe('check-require-cache', () => {
         assert.match(stderr, /'next' was loaded before dd-trace/)
         assert.match(stderr, /--require dd-trace\/init/)
         assert.match(stderr, /--import dd-trace\/initialize\.mjs/)
-        assert.match(stderr, /serverExternalPackages/)
+        assert.match(stderr, /dd-trace\/next/)
         done()
       })
     })

--- a/packages/datadog-plugin-next/test/integration-test/standalone.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/standalone.spec.js
@@ -1,0 +1,340 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFileSync, spawn } = require('node:child_process')
+const { cpSync, mkdtempSync, rmSync } = require('node:fs')
+const { createServer } = require('node:net')
+const { tmpdir } = require('node:os')
+const path = require('node:path')
+const { setTimeout } = require('node:timers/promises')
+
+const axios = require('axios')
+const { describe, it } = require('mocha')
+
+const {
+  FakeAgent,
+  assertObjectContains,
+  curlAndAssertMessage,
+  sandboxCwd,
+  stopProc,
+  useSandbox,
+} = require('../../../../integration-tests/helpers')
+
+const commonFixtures = './packages/datadog-plugin-next/test/integration-test/standalone/common/*'
+const nextDependencies = ['next@^16', 'react@^19', 'react-dom@^19']
+const explicitOptionalDependency = '@datadog/openfeature-node-server'
+const tracerOptionalDependencies = [
+  '@datadog/libdatadog',
+  '@datadog/native-appsec',
+  '@datadog/native-iast-taint-tracking',
+  '@datadog/native-metrics',
+  explicitOptionalDependency,
+  '@datadog/pprof',
+  '@datadog/wasm-js-rewriter',
+  '@opentelemetry/api',
+  '@opentelemetry/api-logs',
+  'oxc-parser',
+]
+
+/**
+ * @returns {Promise<number>}
+ */
+function getAvailablePort () {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', function onListening () {
+      const address = server.address()
+      assert.notStrictEqual(address, null)
+      assert.strictEqual(typeof address, 'object')
+
+      /**
+       * @param {Error} [error]
+       */
+      function onClose (error) {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(address.port)
+        }
+      }
+
+      server.close(onClose)
+    })
+  })
+}
+
+/**
+ * @param {string} url
+ * @param {import('node:child_process').ChildProcess} childProcess
+ * @returns {Promise<void>}
+ */
+async function waitForServer (url, childProcess) {
+  let lastError
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (childProcess.exitCode !== null) {
+      throw new Error(`Next.js exited before listening with status ${childProcess.exitCode}.`)
+    }
+
+    try {
+      await axios.get(url)
+      return
+    } catch (error) {
+      lastError = error
+      await setTimeout(100)
+    }
+  }
+
+  throw lastError
+}
+
+/**
+ * @param {string} artifactPath
+ * @param {number} port
+ * @param {number} agentPort
+ * @param {string} nodeOptions
+ * @returns {{
+ *   childProcess: import('node:child_process').ChildProcessWithoutNullStreams,
+ *   readOutput: () => string
+ * }}
+ */
+function startStandaloneServer (artifactPath, port, agentPort, nodeOptions) {
+  const {
+    NODE_OPTIONS,
+    OTEL_LOGS_EXPORTER,
+    OTEL_METRICS_EXPORTER,
+    OTEL_TRACES_EXPORTER,
+    ...env
+  } = process.env
+
+  const childProcess = spawn(process.execPath, ['server.js'], {
+    cwd: artifactPath,
+    env: {
+      ...env,
+      DD_TRACE_AGENT_PORT: String(agentPort),
+      DD_TRACE_FLUSH_INTERVAL: '0',
+      HOSTNAME: '127.0.0.1',
+      NODE_OPTIONS: nodeOptions,
+      PORT: String(port),
+    },
+    stdio: 'pipe',
+  })
+
+  let output = ''
+
+  /**
+   * @param {Buffer} data
+   */
+  function collectOutput (data) {
+    output += data
+  }
+
+  childProcess.stdout.on('data', collectOutput)
+  childProcess.stderr.on('data', collectOutput)
+
+  return {
+    childProcess,
+    readOutput: () => output,
+  }
+}
+
+/**
+ * @param {Array<Array<Record<string, unknown>>>} traces
+ */
+function assertNextTrace (traces) {
+  for (const trace of traces) {
+    for (const span of trace) {
+      if (span.name === 'next.request') {
+        assertObjectContains(span, {
+          name: 'next.request',
+          type: 'web',
+          meta: {
+            'span.kind': 'server',
+            'http.method': 'GET',
+            'http.status_code': '200',
+            component: 'next',
+          },
+        })
+        return
+      }
+    }
+  }
+
+  assert.fail('Expected a next.request span.')
+}
+
+/**
+ * @param {{ payload: Array<Array<Record<string, unknown>>> }} message
+ */
+function assertNextMessage ({ payload }) {
+  assertNextTrace(payload)
+}
+
+/**
+ * @param {string} description
+ * @param {string[]} fixturePaths
+ * @param {{
+ *   applicationPath?: string[],
+ *   dependencies?: string[],
+ *   nodeOptions?: string,
+ *   removeOpenFeaturePeer?: boolean,
+ *   removeOptionalDependencies?: boolean,
+ *   removeServerRoutes?: boolean,
+ *   requestPath?: string,
+ *   standaloneOutputPath?: string[],
+ *   verifyOpenFeature?: boolean,
+ *   verifyOptionalDependencies?: boolean
+ * }} [options]
+ */
+function testStandaloneSetup (description, fixturePaths, options = {}) {
+  describe(description, () => {
+    let agent
+    let artifactRoot
+    let childProcess
+    let readOutput
+    let url
+
+    useSandbox(options.dependencies ?? nextDependencies, false, fixturePaths)
+
+    before(async function () {
+      this.timeout(300_000)
+      const { NODE_OPTIONS, ...env } = process.env
+
+      if (options.removeServerRoutes) {
+        rmSync(path.join(sandboxCwd(), 'app', 'api'), { recursive: true, force: true })
+      }
+
+      if (options.removeOptionalDependencies) {
+        for (const packageName of tracerOptionalDependencies) {
+          rmSync(path.join(sandboxCwd(), 'node_modules', ...packageName.split('/')), {
+            recursive: true,
+            force: true,
+          })
+        }
+      }
+
+      if (options.removeOpenFeaturePeer || options.removeOptionalDependencies) {
+        rmSync(path.join(sandboxCwd(), 'node_modules', '@openfeature', 'server-sdk'), {
+          recursive: true,
+          force: true,
+        })
+      }
+
+      execFileSync('npm', ['run', 'build'], {
+        cwd: sandboxCwd(),
+        env,
+        stdio: 'inherit',
+      })
+
+      artifactRoot = mkdtempSync(path.join(tmpdir(), 'dd-next-standalone-'))
+      const artifactPath = path.join(artifactRoot, 'app')
+      const standaloneOutputPath = options.standaloneOutputPath ?? ['.next', 'standalone']
+      cpSync(path.join(sandboxCwd(), ...standaloneOutputPath), artifactPath, { recursive: true })
+      const applicationPath = path.join(artifactPath, ...(options.applicationPath ?? []))
+
+      if (options.verifyOptionalDependencies) {
+        const packageNames = tracerOptionalDependencies.filter(packageName => {
+          return options.verifyOpenFeature || packageName !== explicitOptionalDependency
+        })
+        const script = `for (const name of ${JSON.stringify(packageNames)}) require.resolve(name)`
+        execFileSync(process.execPath, ['-e', script], { cwd: applicationPath })
+        if (!options.verifyOpenFeature) {
+          assert.throws(() => execFileSync(
+            process.execPath,
+            ['-e', `require.resolve('${explicitOptionalDependency}')`],
+            { cwd: applicationPath, stdio: 'pipe' }
+          ))
+        }
+      }
+
+      agent = await new FakeAgent().start()
+      const port = await getAvailablePort()
+      const nodeOptions = options.nodeOptions ?? '--import dd-trace/initialize.mjs'
+      const server = startStandaloneServer(applicationPath, port, agent.port, nodeOptions)
+      childProcess = server.childProcess
+      readOutput = server.readOutput
+      url = `http://127.0.0.1:${port}`
+      await waitForServer(url, childProcess)
+    })
+
+    after(async () => {
+      await stopProc(childProcess)
+      await agent?.stop()
+      if (artifactRoot) {
+        rmSync(artifactRoot, { recursive: true, force: true })
+      }
+    })
+
+    it('loads the tracer before Next.js and traces requests', async () => {
+      const requestPath = options.requestPath ?? '/api/health'
+      await curlAndAssertMessage(agent, `${url}${requestPath}`, assertNextMessage, undefined, undefined, true)
+      assert.doesNotMatch(readOutput(), /hook has already been initialized/)
+    })
+  })
+}
+
+describe('Next.js standalone output', function () {
+  this.timeout(300_000)
+
+  testStandaloneSetup(
+    'with dd-trace/next without the OpenFeature peer',
+    [
+      commonFixtures,
+      './packages/datadog-plugin-next/test/integration-test/standalone/helper/*',
+    ],
+    {
+      removeOpenFeaturePeer: true,
+      verifyOptionalDependencies: true,
+    }
+  )
+  testStandaloneSetup(
+    'with dd-trace/next and omitted optional dependencies',
+    [
+      commonFixtures,
+      './packages/datadog-plugin-next/test/integration-test/standalone/helper/*',
+    ],
+    {
+      nodeOptions: '--require dd-trace/init',
+      removeOptionalDependencies: true,
+    }
+  )
+  testStandaloneSetup(
+    'with dd-trace/next and OpenFeature installed',
+    [
+      commonFixtures,
+      './packages/datadog-plugin-next/test/integration-test/standalone/helper/*',
+    ],
+    {
+      dependencies: [...nextDependencies, '@openfeature/server-sdk@^1'],
+      verifyOpenFeature: true,
+      verifyOptionalDependencies: true,
+    }
+  )
+  testStandaloneSetup(
+    'with an instrumentation import anchor',
+    [
+      commonFixtures,
+      './packages/datadog-plugin-next/test/integration-test/standalone/import-anchor/*',
+    ],
+  )
+  testStandaloneSetup(
+    'with an instrumentation import anchor and only static routes',
+    [
+      commonFixtures,
+      './packages/datadog-plugin-next/test/integration-test/standalone/import-anchor/*',
+    ],
+    {
+      removeServerRoutes: true,
+      requestPath: '/',
+    }
+  )
+  testStandaloneSetup(
+    'with dd-trace/next in a monorepo',
+    ['./packages/datadog-plugin-next/test/integration-test/standalone/monorepo/*'],
+    {
+      applicationPath: ['apps', 'web'],
+      standaloneOutputPath: ['apps', 'web', '.next', 'standalone'],
+    }
+  )
+})

--- a/packages/datadog-plugin-next/test/integration-test/standalone/common/app/api/health/route.jsx
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/common/app/api/health/route.jsx
@@ -1,0 +1,3 @@
+export function GET () {
+  return Response.json({ status: 'ok' })
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/common/app/layout.jsx
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/common/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout ({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/common/app/page.jsx
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/common/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Page () {
+  return <main>Next.js standalone test</main>
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/common/package.json
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/common/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dd-trace-next-standalone-test",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build": "next build"
+  }
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/common/type-test.ts
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/common/type-test.ts
@@ -1,0 +1,11 @@
+import withDatadogConfig = require('dd-trace/next')
+
+import type { NextConfig } from 'next'
+
+const config: NextConfig = withDatadogConfig({
+  output: 'standalone',
+}, {
+  projectRoot: __dirname,
+})
+
+void config

--- a/packages/datadog-plugin-next/test/integration-test/standalone/helper/next.config.js
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/helper/next.config.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const withDatadogConfig = require('dd-trace/next')
+
+module.exports = withDatadogConfig({
+  output: 'standalone',
+}, {
+  projectRoot: __dirname,
+})

--- a/packages/datadog-plugin-next/test/integration-test/standalone/import-anchor/instrumentation.ts
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/import-anchor/instrumentation.ts
@@ -1,0 +1,5 @@
+export async function register () {
+  if (process.env.NEXT_RUNTIME === 'nodejs' && !globalThis[Symbol.for('dd-trace')]) {
+    await import('dd-trace/initialize.mjs')
+  }
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/import-anchor/next.config.js
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/import-anchor/next.config.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  output: 'standalone',
+  serverExternalPackages: ['dd-trace'],
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/app/api/health/route.jsx
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/app/api/health/route.jsx
@@ -1,0 +1,3 @@
+export function GET () {
+  return Response.json({ status: 'ok' })
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/app/layout.jsx
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout ({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/app/page.jsx
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Page () {
+  return <main>Next.js standalone monorepo test</main>
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/next.config.js
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/next.config.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const path = require('node:path')
+
+const withDatadogConfig = require('dd-trace/next')
+
+module.exports = withDatadogConfig({
+  output: 'standalone',
+  outputFileTracingRoot: path.join(__dirname, '../..'),
+}, {
+  projectRoot: __dirname,
+})

--- a/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/package.json
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/apps/web/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dd-trace-next-standalone-monorepo-web-test",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/package.json
+++ b/packages/datadog-plugin-next/test/integration-test/standalone/monorepo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dd-trace-next-standalone-monorepo-test",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build": "next build apps/web"
+  }
+}

--- a/packages/dd-trace/src/next.js
+++ b/packages/dd-trace/src/next.js
@@ -1,0 +1,202 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { createRequire } = require('node:module')
+
+const GLOBAL_ROUTE = '/*'
+const packageRoot = path.join(__dirname, '../../..')
+
+/**
+ * @typedef {object} PackageManifest
+ * @property {string} name
+ * @property {Record<string, string>} [dependencies]
+ * @property {Record<string, string>} [optionalDependencies]
+ * @property {Record<string, string>} [peerDependencies]
+ * @property {Record<string, { optional?: boolean }>} [peerDependenciesMeta]
+ */
+
+/**
+ * @typedef {Record<string, unknown> & {
+ *   output?: string,
+ *   outputFileTracingRoot?: string,
+ *   outputFileTracingIncludes?: Record<string, string[]>,
+ *   serverExternalPackages?: string[]
+ * }} NextConfig
+ */
+
+/**
+ * @param {string} packageJsonPath
+ * @returns {PackageManifest}
+ */
+function readPackageManifest (packageJsonPath) {
+  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+}
+
+/**
+ * @param {string} packageName
+ * @param {NodeJS.Require} packageRequire
+ * @returns {string}
+ */
+function resolvePackageJson (packageName, packageRequire) {
+  try {
+    return packageRequire.resolve(`${packageName}/package.json`)
+  } catch (error) {
+    if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      throw error
+    }
+  }
+
+  let directory = path.dirname(packageRequire.resolve(packageName))
+
+  while (directory !== path.dirname(directory)) {
+    const packageJsonPath = path.join(directory, 'package.json')
+
+    if (fs.existsSync(packageJsonPath)) {
+      return packageJsonPath
+    }
+
+    directory = path.dirname(directory)
+  }
+
+  throw new Error(`Could not resolve the package manifest for '${packageName}'.`)
+}
+
+/**
+ * @param {string} packageName
+ * @param {NodeJS.Require} packageRequire
+ * @returns {string|undefined}
+ */
+function resolveOptionalPackageJson (packageName, packageRequire) {
+  try {
+    return resolvePackageJson(packageName, packageRequire)
+  } catch (error) {
+    if (error.code !== 'MODULE_NOT_FOUND') {
+      throw error
+    }
+  }
+}
+
+/**
+ * @param {string} packageJsonPath
+ * @param {Set<string>} packageJsonPaths
+ */
+function collectOptionalPackageJsonPath (packageJsonPath, packageJsonPaths) {
+  const { peerDependencies, peerDependenciesMeta } = readPackageManifest(packageJsonPath)
+  const packageRequire = createRequire(packageJsonPath)
+
+  for (const peerName of Object.keys(peerDependencies ?? {})) {
+    const peerPackageJsonPath = resolveOptionalPackageJson(peerName, packageRequire)
+    if (peerPackageJsonPath === undefined) {
+      if (!peerDependenciesMeta?.[peerName]?.optional) return
+    } else {
+      collectPackageJsonPaths(peerPackageJsonPath, packageJsonPaths)
+    }
+  }
+
+  collectPackageJsonPaths(packageJsonPath, packageJsonPaths)
+}
+
+/**
+ * @param {string} packageJsonPath
+ * @param {Set<string>} packageJsonPaths
+ */
+function collectPackageJsonPaths (packageJsonPath, packageJsonPaths) {
+  if (packageJsonPaths.has(packageJsonPath)) return
+
+  packageJsonPaths.add(packageJsonPath)
+
+  const { dependencies, optionalDependencies } = readPackageManifest(packageJsonPath)
+  const packageRequire = createRequire(packageJsonPath)
+
+  for (const dependencyName of Object.keys(dependencies ?? {})) {
+    collectPackageJsonPaths(resolvePackageJson(dependencyName, packageRequire), packageJsonPaths)
+  }
+
+  for (const dependencyName of Object.keys(optionalDependencies ?? {})) {
+    const dependencyPackageJsonPath = resolveOptionalPackageJson(dependencyName, packageRequire)
+    if (dependencyPackageJsonPath !== undefined) {
+      collectOptionalPackageJsonPath(dependencyPackageJsonPath, packageJsonPaths)
+    }
+  }
+}
+
+/**
+ * @param {string[]} existingValues
+ * @param {Iterable<string>} additionalValues
+ * @returns {string[]}
+ */
+function appendUnique (existingValues, additionalValues) {
+  const result = [...existingValues]
+  const seen = new Set(result)
+
+  for (const value of additionalValues) {
+    if (!seen.has(value)) {
+      seen.add(value)
+      result.push(value)
+    }
+  }
+
+  return result
+}
+
+/**
+ * @param {string} parentPath
+ * @param {string} childPath
+ * @returns {boolean}
+ */
+function containsPath (parentPath, childPath) {
+  const relativePath = path.relative(parentPath, childPath)
+  return relativePath === '' || (!relativePath.startsWith(`..${path.sep}`) &&
+    relativePath !== '..' &&
+    !path.isAbsolute(relativePath))
+}
+
+/**
+ * @param {NextConfig} config
+ * @param {{ projectRoot?: string }} options
+ * @returns {NextConfig}
+ */
+function withDatadogConfig (config = {}, options = {}) {
+  const serverExternalPackages = appendUnique(config.serverExternalPackages ?? [], ['dd-trace'])
+
+  if (config.output !== 'standalone') {
+    return {
+      ...config,
+      serverExternalPackages,
+    }
+  }
+
+  const packageJsonPaths = new Set()
+  collectPackageJsonPaths(path.join(packageRoot, 'package.json'), packageJsonPaths)
+
+  const packageGlobs = []
+  const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
+  const outputFileTracingRoot = path.resolve(projectRoot, config.outputFileTracingRoot ?? '.')
+  for (const packageJsonPath of packageJsonPaths) {
+    const dependencyRoot = path.dirname(packageJsonPath)
+    if (!containsPath(outputFileTracingRoot, dependencyRoot)) {
+      const { name } = readPackageManifest(packageJsonPath)
+      throw new Error(
+        `'${name}' resolves outside outputFileTracingRoot. ` +
+        'Set outputFileTracingRoot to a common parent of the Next.js app and its dependencies.'
+      )
+    }
+
+    const relativeDependencyRoot = path.relative(projectRoot, dependencyRoot).replaceAll(path.sep, '/') || '.'
+    packageGlobs.push(`${relativeDependencyRoot}/**/*`)
+  }
+
+  const outputFileTracingIncludes = config.outputFileTracingIncludes ?? {}
+
+  return {
+    ...config,
+    outputFileTracingIncludes: {
+      ...outputFileTracingIncludes,
+      [GLOBAL_ROUTE]: appendUnique(outputFileTracingIncludes[GLOBAL_ROUTE] ?? [], packageGlobs),
+    },
+    serverExternalPackages,
+  }
+}
+
+module.exports = withDatadogConfig

--- a/packages/dd-trace/test/next.spec.js
+++ b/packages/dd-trace/test/next.spec.js
@@ -1,0 +1,211 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const { createRequire } = require('node:module')
+const path = require('node:path')
+
+const { describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+
+const withDatadogConfig = require('../../../next')
+
+/**
+ * @param {string} code
+ * @returns {NodeJS.ErrnoException}
+ */
+function createModuleError (code) {
+  return Object.assign(new Error(code), { code })
+}
+
+/**
+ * @param {(specifier: string, packageJsonPath: string) => string|Error|undefined} resolveOverride
+ * @returns {typeof withDatadogConfig}
+ */
+function loadWithResolve (resolveOverride) {
+  /**
+   * @param {string} packageJsonPath
+   * @returns {{ resolve: (specifier: string) => string }}
+   */
+  function createRequireStub (packageJsonPath) {
+    const packageRequire = createRequire(packageJsonPath)
+
+    /**
+     * @param {string} specifier
+     * @returns {string}
+     */
+    function resolve (specifier) {
+      const override = resolveOverride(specifier, packageJsonPath)
+      if (override instanceof Error) throw override
+      return override ?? packageRequire.resolve(specifier)
+    }
+
+    return { resolve }
+  }
+
+  return proxyquire('../src/next', {
+    'node:module': {
+      createRequire: createRequireStub,
+    },
+  })
+}
+
+describe('Next.js config helper', () => {
+  it('externalizes dd-trace without changing other Next.js config', () => {
+    const original = {
+      poweredByHeader: false,
+      serverExternalPackages: ['pg'],
+    }
+
+    assert.deepStrictEqual(withDatadogConfig(original), {
+      poweredByHeader: false,
+      serverExternalPackages: ['pg', 'dd-trace'],
+    })
+    assert.deepStrictEqual(original.serverExternalPackages, ['pg'])
+    assert.deepStrictEqual(withDatadogConfig(), {
+      serverExternalPackages: ['dd-trace'],
+    })
+  })
+
+  it('uses default project and tracing roots', () => {
+    const parentRoot = path.dirname(process.cwd())
+    const withDefaultProjectRoot = withDatadogConfig({
+      output: 'standalone',
+      outputFileTracingRoot: parentRoot,
+    })
+    const withDefaultTracingRoot = withDatadogConfig({
+      output: 'standalone',
+    }, {
+      projectRoot: parentRoot,
+    })
+
+    assert.ok(withDefaultProjectRoot.outputFileTracingIncludes['/*'].length > 0)
+    assert.ok(withDefaultTracingRoot.outputFileTracingIncludes['/*'].length > 0)
+  })
+
+  it('includes the tracer runtime dependency closure in standalone output', () => {
+    const existingGlobalInclude = 'assets/**/*'
+    const config = withDatadogConfig({
+      output: 'standalone',
+      outputFileTracingRoot: path.dirname(process.cwd()),
+      outputFileTracingIncludes: {
+        '/*': [existingGlobalInclude],
+        '/api/*': ['api-assets/**/*'],
+      },
+      serverExternalPackages: ['dd-trace', 'pg'],
+    }, {
+      projectRoot: process.cwd(),
+    })
+
+    assert.deepStrictEqual(config.serverExternalPackages, ['dd-trace', 'pg'])
+    assert.deepStrictEqual(config.outputFileTracingIncludes['/api/*'], ['api-assets/**/*'])
+
+    const globalIncludes = config.outputFileTracingIncludes['/*']
+    assert.strictEqual(globalIncludes[0], existingGlobalInclude)
+    assert.strictEqual(new Set(globalIncludes).size, globalIncludes.length)
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/dc-polyfill/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/import-in-the-middle/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/opentracing/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/cjs-module-lexer/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@datadog/libdatadog/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@datadog/native-appsec/**/*')))
+    assert.ok(globalIncludes.some(
+      include => include.endsWith('/node_modules/@datadog/native-iast-taint-tracking/**/*')
+    ))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@datadog/native-metrics/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@datadog/pprof/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@datadog/wasm-js-rewriter/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@opentelemetry/api/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@opentelemetry/api-logs/**/*')))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/oxc-parser/**/*')))
+    assert.ok(globalIncludes.some(
+      include => include.endsWith('/node_modules/@datadog/openfeature-node-server/**/*')
+    ))
+    assert.ok(globalIncludes.some(include => include.endsWith('/node_modules/@openfeature/server-sdk/**/*')))
+  })
+
+  it('rejects dependency paths outside outputFileTracingRoot', () => {
+    const projectRoot = path.join(process.cwd(), 'packages', 'dd-trace')
+
+    assert.throws(() => withDatadogConfig({
+      output: 'standalone',
+      outputFileTracingRoot: projectRoot,
+    }, {
+      projectRoot,
+    }), {
+      message: /outputFileTracingRoot/,
+    })
+  })
+
+  it('rejects a resolved dependency without a package manifest', () => {
+    const existsSync = fs.existsSync
+    let resolvingDependency = false
+
+    /**
+     * @param {string} filePath
+     * @returns {boolean}
+     */
+    function existsSyncWithoutDependencyManifest (filePath) {
+      if (filePath.includes(`${path.sep}dc-polyfill${path.sep}`)) {
+        resolvingDependency = true
+      }
+      return resolvingDependency ? false : existsSync(filePath)
+    }
+
+    const configHelper = proxyquire('../src/next', {
+      'node:fs': {
+        existsSync: existsSyncWithoutDependencyManifest,
+      },
+    })
+
+    assert.throws(() => configHelper({
+      output: 'standalone',
+      outputFileTracingRoot: path.dirname(process.cwd()),
+    }), {
+      message: /Could not resolve the package manifest/,
+    })
+  })
+
+  it('propagates errors resolving optional dependencies', () => {
+    /**
+     * @param {string} specifier
+     * @returns {Error|undefined}
+     */
+    function failOptionalDependency (specifier) {
+      if (specifier === '@datadog/libdatadog/package.json') {
+        return createModuleError('EACCES')
+      }
+    }
+
+    const configHelper = loadWithResolve(failOptionalDependency)
+
+    assert.throws(() => configHelper({
+      output: 'standalone',
+      outputFileTracingRoot: path.dirname(process.cwd()),
+    }), {
+      code: 'EACCES',
+    })
+  })
+
+  it('skips an optional dependency whose required peer is absent', () => {
+    /**
+     * @param {string} specifier
+     * @returns {Error|undefined}
+     */
+    function omitOpenFeaturePeer (specifier) {
+      if (specifier === '@openfeature/server-sdk/package.json') {
+        return createModuleError('MODULE_NOT_FOUND')
+      }
+    }
+
+    const configHelper = loadWithResolve(omitOpenFeaturePeer)
+    const config = configHelper({
+      output: 'standalone',
+      outputFileTracingRoot: path.dirname(process.cwd()),
+    })
+
+    assert.ok(config.outputFileTracingIncludes['/*'].every(
+      include => !include.endsWith('/node_modules/@datadog/openfeature-node-server/**/*')
+    ))
+  })
+})


### PR DESCRIPTION
## Summary
Next.js standalone output tracing cannot see `dd-trace` when it is loaded only through `NODE_OPTIONS`. This adds a `dd-trace/next` config helper that externalizes the tracer and copies its installed dependency closure, plus a literal `instrumentation.ts` import fallback for static-only applications and users who do not want the helper.

## Why
Manual package globs drift as regular, optional, and peer dependencies change. The helper derives the closure from installed package metadata, includes required peers only when present, and rejects monorepo roots that cannot contain the resolved files. Config evaluation is the only affected runtime boundary.

## Test plan
$23 `./node_modules/.bin/mocha packages/dd-trace/test/next.spec.js packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js`
$24 `./node_modules/.bin/mocha --timeout 600000 packages/datadog-plugin-next/test/integration-test/standalone.spec.js`
$25 `npm run lint`

Refs: https://github.com/DataDog/dd-trace-js/pull/8901#issuecomment-4990139855