### PR TITLE
docs(electron): replace README with internal-use-only notice on publish

### DIFF
--- a/README.electron.md
+++ b/README.electron.md
@@ -1,0 +1,7 @@
+# dd-trace-electron
+
+> **Internal use only.**
+>
+> This package is intended to be used by the
+> [Datadog Electron SDK](https://github.com/DataDog/electron-sdk) and is not
+> meant for direct consumption. Only direct usage of `dd-trace` is supported.

--- a/scripts/release/publish-electron.js
+++ b/scripts/release/publish-electron.js
@@ -12,6 +12,9 @@ const ROOT = path.join(__dirname, '..', '..')
 const PACKAGE_JSON = path.join(ROOT, 'package.json')
 const ELECTRON_JSON = path.join(ROOT, 'package.electron.json')
 const BACKUP = path.join(ROOT, 'package.json.bak')
+const README = path.join(ROOT, 'README.md')
+const ELECTRON_README = path.join(ROOT, 'README.electron.md')
+const README_BACKUP = path.join(ROOT, 'README.md.bak')
 
 function run (cmd) {
   execSync(cmd, { cwd: ROOT, stdio: 'inherit' })
@@ -31,8 +34,10 @@ const { version } = JSON.parse(readFileSync(ELECTRON_JSON, 'utf8'))
 let backupCreated = false
 try {
   copyFileSync(PACKAGE_JSON, BACKUP)
+  copyFileSync(README, README_BACKUP)
   backupCreated = true
   copyFileSync(ELECTRON_JSON, PACKAGE_JSON)
+  copyFileSync(ELECTRON_README, README)
 
   let skip = false
   try {
@@ -52,5 +57,8 @@ try {
     run(`npm publish ${process.argv.slice(2).join(' ')}`)
   }
 } finally {
-  if (backupCreated) renameSync(BACKUP, PACKAGE_JSON)
+  if (backupCreated) {
+    renameSync(BACKUP, PACKAGE_JSON)
+    renameSync(README_BACKUP, README)
+  }
 }

--- a/scripts/release/publish-electron.js
+++ b/scripts/release/publish-electron.js
@@ -6,15 +6,17 @@
 
 const { execSync } = require('node:child_process')
 const { copyFileSync, existsSync, readFileSync, renameSync } = require('node:fs')
+const os = require('node:os')
 const path = require('node:path')
 
 const ROOT = path.join(__dirname, '..', '..')
 const PACKAGE_JSON = path.join(ROOT, 'package.json')
 const ELECTRON_JSON = path.join(ROOT, 'package.electron.json')
-const BACKUP = path.join(ROOT, 'package.json.bak')
 const README = path.join(ROOT, 'README.md')
 const ELECTRON_README = path.join(ROOT, 'README.electron.md')
-const README_BACKUP = path.join(ROOT, 'README.md.bak')
+// Store backups outside the package root so they are never picked up by npm publish.
+const BACKUP = path.join(os.tmpdir(), 'dd-trace-package.json.bak')
+const README_BACKUP = path.join(os.tmpdir(), 'dd-trace-readme.md.bak')
 
 function run (cmd) {
   execSync(cmd, { cwd: ROOT, stdio: 'inherit' })


### PR DESCRIPTION
## Summary

- Add `README.electron.md` with an internal-use-only notice and a link to the [Datadog Electron SDK](https://github.com/DataDog/electron-sdk)
- Update `scripts/release/publish-electron.js` to swap in `README.electron.md` during `npm publish`, using the same backup/restore pattern already in place for `package.json`

## Test plan

- [ ] Verify `README.electron.md` content looks correct on npm after a publish
- [ ] Verify the original `README.md` is restored after publish completes (or fails)

> Generated by [Claude Code](https://claude.ai/claude-code)