### PR TITLE
test(electron): give HTTP trace assertions the same timeout as IPC tests

### DIFF
--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -8,7 +8,11 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
-const IPC_TIMEOUT_MS = 10_000
+// Each test spawns a fresh Electron app, so its first traced operation pays cold-start cost (process
+// warm-up plus an IPC or network round-trip); on a loaded CI runner that can exceed a second. Give trace
+// assertions generous headroom to avoid flakes — they still resolve the moment the matching trace arrives,
+// so passing runs are unaffected.
+const TRACE_TIMEOUT_MS = 10_000
 
 describe('Plugin', () => {
   let child
@@ -55,7 +59,7 @@ describe('Plugin', () => {
 
     describe('electron', () => {
       describe('without configuration', function () {
-        this.timeout(IPC_TIMEOUT_MS + 5_000)
+        this.timeout(TRACE_TIMEOUT_MS + 5_000)
         beforeEach(() => agent.load('electron'))
         beforeEach(function (done) {
           this.timeout(30_000)
@@ -91,7 +95,7 @@ describe('Plugin', () => {
               assert.strictEqual(meta['http.url'], `http://127.0.0.1:${port}/`)
               assert.strictEqual(meta['http.method'], 'GET')
               assert.strictEqual(meta['http.status_code'], '200')
-            })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -115,7 +119,7 @@ describe('Plugin', () => {
               assert.strictEqual(meta['http.url'], `http://127.0.0.1:${port}/`)
               assert.strictEqual(meta['http.method'], 'GET')
               assert.strictEqual(meta['http.status_code'], '200')
-            })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -138,7 +142,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'consumer')
-            }, { timeoutMs: IPC_TIMEOUT_MS })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -160,7 +164,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'consumer')
-            }, { timeoutMs: IPC_TIMEOUT_MS })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -181,7 +185,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'producer')
-            }, { timeoutMs: IPC_TIMEOUT_MS })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -204,7 +208,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'consumer')
-            }, { timeoutMs: IPC_TIMEOUT_MS })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -228,7 +232,7 @@ describe('Plugin', () => {
               assert.strictEqual(meta['http.url'], `http://127.0.0.1:${port}/utility`)
               assert.strictEqual(meta['http.method'], 'GET')
               assert.strictEqual(meta['http.status_code'], '200')
-            })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -249,7 +253,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'producer')
-            }, { timeoutMs: IPC_TIMEOUT_MS })
+            }, { timeoutMs: TRACE_TIMEOUT_MS })
             .then(done)
             .catch(done)
 


### PR DESCRIPTION
### What does this PR do?

Gives the Electron plugin's HTTP-producing tests (`fetch`, `request`, `utility-request`) the same generous trace-assertion timeout the IPC tests already use, fixing an intermittent `No matching trace received within 1000ms` failure in the `electron` job.

### Motivation

The three HTTP tests asserted traces with the **1000ms default**, while every IPC test used **10s**. A freshly-spawned Electron app's first traced operation pays cold-start cost, so the first version's `fetch` consistently exceeded 1000ms on loaded CI runners — e.g. [run 29536649270](https://github.com/DataDog/dd-trace-js/actions/runs/29536649270) failed on `should do automatic instrumentation for fetch` on **both** attempts while all 55 other tests (including the 10s IPC tests) passed.

This is cold-start latency, **not** trace loss: the tracer uses `flushInterval: 0`, other versions' `fetch` passes, and the same cold `(37.0.0)` app's IPC tests deliver their traces within 10s — proving the span is produced and the 1s window was simply too tight.

### Additional Notes

- Renamed `IPC_TIMEOUT_MS` → `TRACE_TIMEOUT_MS` (it now covers all trace assertions) and documented the headroom. Assertions still resolve the instant the matching trace arrives, so passing runs are unaffected.
- The integration test helper uses a 2s default and is a possible sibling flake (heavier packaged-binary cold start); intentionally left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
