### PR TITLE
test(appsec): deflake RASP SSRF "should not detect threat" express tests

### DIFF
--- a/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
@@ -15,6 +15,8 @@ const { checkRaspExecutedAndNotThreat, checkRaspExecutedAndHasThreat } = require
 
 function noop () {}
 
+const UNRESOLVABLE_HOST = 'not-a-threat.invalid'
+
 describe('RASP - ssrf', () => {
   withVersions('express', 'express', expressVersion => {
     let app, server, axios
@@ -84,12 +86,12 @@ describe('RASP - ssrf', () => {
                 res.end('end')
               })
 
-              clientRequest.on('error', noop)
+              clientRequest.on('error', () => res.end('end'))
             }
 
             await Promise.all([
               checkRaspExecutedAndNotThreat(agent),
-              axios.get('/?host=www.datadoghq.com'),
+              axios.get(`/?host=${UNRESOLVABLE_HOST}`),
             ])
           })
 
@@ -152,7 +154,7 @@ describe('RASP - ssrf', () => {
             }
 
             await Promise.all([
-              axios.get('/?host=www.datadoghq.com'),
+              axios.get(`/?host=${UNRESOLVABLE_HOST}`),
               checkRaspExecutedAndNotThreat(agent),
             ])
           })
@@ -200,13 +202,13 @@ describe('RASP - ssrf', () => {
 
           it('Should not detect threat', async () => {
             app = (req, res) => {
-              requestToTest.get(`https://${req.query.host}`).on('response', () => {
-                res.end('end')
-              })
+              requestToTest.get(`https://${req.query.host}`)
+                .on('response', () => res.end('end'))
+                .on('error', () => res.end('end'))
             }
 
             await Promise.all([
-              axios.get('/?host=www.datadoghq.com'),
+              axios.get(`/?host=${UNRESOLVABLE_HOST}`),
               checkRaspExecutedAndNotThreat(agent),
             ])
           })

--- a/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
@@ -148,7 +148,7 @@ describe('RASP - ssrf', () => {
 
           it('Should not detect threat', async () => {
             app = (req, res) => {
-              axiosToTest.get(`https://${req.query.host}`)
+              axiosToTest.get(`https://${req.query.host}`, { proxy: false })
                 .catch(noop) // swallow network error
                 .then(() => res.end('end'))
             }
@@ -202,7 +202,7 @@ describe('RASP - ssrf', () => {
 
           it('Should not detect threat', async () => {
             app = (req, res) => {
-              requestToTest.get(`https://${req.query.host}`)
+              requestToTest.get(`https://${req.query.host}`, { proxy: false })
                 .on('response', () => res.end('end'))
                 .on('error', () => res.end('end'))
             }


### PR DESCRIPTION
### What does this PR do?
Points the SSRF RASP "should not detect threat" express tests at an unresolvable host (`not-a-threat.invalid`) instead of `www.datadoghq.com`, and ends the response on the outbound request's `error` event. The request now fails fast locally instead of depending on a live external connection.

### Motivation
Flaky test.

Ending the response waited on a live request to `www.datadoghq.com`, so slow CI networking pushed the web span past the 1000 ms assertion window (`No matching trace received`). The SSRF check runs at request start, before DNS, so it never needed the network.

### Additional Notes
Behaviour under assertion is unchanged: both hosts yield `_dd.appsec.rasp.rule.eval = 1` with no threat; the fix is more deterministic.


