### PR TITLE
test(integration): extend loader-hang workaround to Node 22.0.0

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -278,9 +278,12 @@ describe('init.js', () => {
 // or on 18.0.0 in particular.
 if (semver.satisfies(process.versions.node, '>=14.13.1')) {
   describe('initialize.mjs', () => {
-    // Node 20.0.0 can leave short-lived loader-based children alive after they
-    // print the expected output, so terminate them after a short grace period.
-    setShouldKill(process.versions.node === '20.0.0')
+    // Node 20.0.0 and 22.0.0 can leave short-lived loader-based children alive after they
+    // print the expected output, so terminate them after a short grace period. Both are the
+    // first release of their major line to ship `module.register`'s off-thread hooks worker,
+    // which had known bugs around `process.exit()` not tearing down the hooks thread
+    // (e.g. nodejs/node#52706, #53097, #53182) that were fixed in later patch releases.
+    setShouldKill(['20.0.0', '22.0.0'].includes(process.versions.node))
     useSandbox()
     stubTracerIfNeeded()
 


### PR DESCRIPTION
### What does this PR do?

Extends the existing `setShouldKill` workaround in `integration-tests/init.spec.js` (`describe('initialize.mjs', ...)`) to also cover Node 22.0.0, so short-lived `--loader`-based children that print their expected output but never exit get force-killed after a 1s grace period, same as is already done for Node 20.0.0.

### Motivation

The `integration-guardrails (22.0.0)` CI job intermittently fails with `Error: Timeout of 30000ms exceeded` inside `initialize.mjs > as --loader > ... > when dd-trace in the app dir > with DD_INJECTION_ENABLED`, with a *different* sub-test timing out on different runs (ruling out a bug in one specific assertion). GitHub Actions logs an orphaned node process ("Terminate orphan process") at job cleanup, confirming a child process is genuinely hanging rather than a slow assertion.

This is **pre-existing on `master`, unrelated to PR #8863** — confirmed by checking multiple recent master CI runs where this exact job/file/timeout signature recurs.

**Root cause:** `initialize.mjs` calls `Module.register('./loader-hook.mjs', import.meta.url)` when used with `--loader`. Node's `module.register()` runs its hooks on a dedicated internal worker thread. I reproduced the hang locally by installing Node 22.0.0 via nvm and looping `./node_modules/.bin/mocha --timeout 30000 --grep "as --loader" integration-tests/init.spec.js`: the child scripts (`init/trace.mjs`, `init/instrument.mjs`) print their expected output and call `process.exit()`, but the process never exits — `ps aux` showed the leaked node process still alive with 12 threads (the hooks worker + libuv pool) after the test's own `timeout`/kill. `runAndCheckOutput`'s `proc.once('exit', ...)` promise in `integration-tests/helpers/index.js` therefore never resolves, and mocha's 30s test timeout fires.

Node 20.0.0 and 22.0.0 are each the first release of their major line to ship `module.register`'s off-thread hooks worker, and both shipped with known bugs where the hooks worker thread isn't reliably torn down around `process.exit()` (see nodejs/node#52706, #53097, #53182, and the "propagate `process.exit` from the loader thread to the main thread" fix) — bugs that were fixed in later patch releases of each line. This matches the comment already present for the Node 20.0.0 case in this file, just one major line later.

**Fix:** rather than papering over the symptom with a longer timeout (which wouldn't actually resolve — the child never exits at all, so no timeout is "long enough"), this extends the existing, purpose-built `setShouldKill` grace-period-kill mechanism to Node 22.0.0 as well, matching the established pattern and comment style for the Node 20.0.0 case.

### Additional Notes

- This is a Node.js runtime bug in the ESM loader hooks worker, not a leak in dd-trace's own source — the same class of bug is already worked around for Node 20.0.0 in this file, so this PR follows the same approach rather than introducing a new mechanism.
- Verified locally: installed Node 22.0.0 via `nvm`, reproduced the hang and the orphaned process before this change, then confirmed no 30s timeouts and no orphaned processes across repeated runs of `integration-tests/init.spec.js` after applying the fix.
- No production code paths are touched; this only affects the integration test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)