### PR TITLE
test(ci): tolerate coverage preload in clean env tests

### DIFF
--- a/packages/dd-trace/test/ci-visibility/setup-runner.spec.js
+++ b/packages/dd-trace/test/ci-visibility/setup-runner.spec.js
@@ -52,7 +52,7 @@ describe('test optimization validation setup runner', () => {
     const out = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-test-optimization-setup-'))
     const originalNodeOptions = process.env.NODE_OPTIONS
     const originalOtelTracesExporter = process.env.OTEL_TRACES_EXPORTER
-    process.env.NODE_OPTIONS = '--no-warnings'
+    process.env.NODE_OPTIONS = '--no-warnings -r dd-trace/ci/init'
     process.env.OTEL_TRACES_EXPORTER = 'otlp'
 
     try {
@@ -68,7 +68,8 @@ describe('test optimization validation setup runner', () => {
                 '-e',
                 [
                   'assert = require("node:assert/strict")',
-                  'assert.strictEqual(process.env.NODE_OPTIONS, undefined)',
+                  'assert.strictEqual(process.env.NODE_OPTIONS?.includes("--no-warnings") ?? false, false)',
+                  'assert.strictEqual(process.env.NODE_OPTIONS?.includes("dd-trace/ci/init") ?? false, false)',
                   'assert.strictEqual(process.env.OTEL_TRACES_EXPORTER, undefined)',
                   'assert.strictEqual(process.env.PROJECT_SETUP_ENV, "present")',
                 ].join(';'),

--- a/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
@@ -39,7 +39,7 @@ describe('test optimization validator-owned execution phases', () => {
     const jestEntrypoint = path.join(root, 'jest.js')
     fs.writeFileSync(
       jestEntrypoint,
-      'if (process.env.NODE_OPTIONS || process.env.DD_API_KEY) process.exit(42); ' +
+      'if (process.env.NODE_OPTIONS?.includes("dd-trace/ci/init") || process.env.DD_API_KEY) process.exit(42); ' +
         'console.log("Tests: 1 passed, 1 total")\n'
     )
     const framework = {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the two Test Optimization clean-environment tests added by #9323 so they reject the ambient values they own while tolerating unrelated Node.js preloads injected by the test harness.

The setup test now proves that its ambient `--no-warnings`, `dd-trace/ci/init`, and OTEL settings are removed. The preflight test still fails if `dd-trace/ci/init` or `DD_API_KEY` reaches the child process.

### Motivation
<!-- What inspired you to submit this pull request? -->

The APM Capabilities workflow runs the core suite through `scripts/c8-ci.js`. Its source-map coverage helper registers a `node-preload` spawn hook, which adds its own preload to child `NODE_OPTIONS` after the validator builds a clean environment.

The tests incorrectly required `NODE_OPTIONS` to be completely absent, so the harmless coverage preload made both tests report `ok: false` on every platform and supported Node.js version in [run 29731410417](https://github.com/DataDog/dd-trace-js/actions/runs/29731410417). The validator was still removing the Datadog, OTEL, and test-owned Node.js options correctly.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verification:

- Focused two-file run: 44 passing
- Focused run with the marked V8 coverage preload: 44 passing
- ESLint passed for both changed files
- `git diff --check` passed
- Full `npm run test:trace:core:ci`: the two reported failures pass; 4,003 tests pass overall. The only local failure is the unrelated `process-tags.spec.js` checkout-basename assertion because this workspace is named `cloud-dd-trace-js` instead of `dd-trace-js`.
