### PR TITLE
test(config): isolate span sampling rules fixture

### DIFF
--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -3277,7 +3277,7 @@ describe('Config', () => {
       this.skip()
       return
     }
-    const tempDir = mkdtempSync(path.join(process.cwd(), 'dd-trace-span-sampling-rules-'))
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'dd-trace-span-sampling-rules-'))
     const rulesPath = path.join(tempDir, 'span-sampling-rules.json')
     writeFileSync(rulesPath, '{"sample_rate":')
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Creates the malformed span-sampling-rules fixture under the OS temporary directory instead of the repository root.
This keeps the short-lived test file outside the Test Optimization validator's package approval snapshot.

### Motivation
<!-- What inspired you to submit this pull request? -->

The first macOS attempt in [APM Capabilities run 29734237488](https://github.com/DataDog/dd-trace-js/actions/runs/29734237488/attempts/1?pr=9418) failed with `ENOENT` while hashing `dd-trace-span-sampling-rules-*/span-sampling-rules.json`.
The core test runner executes spec files concurrently: the validator enumerated the config test's temporary file, then the config test removed it before the validator hashed it. The retry passed because the timing changed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verification:

- Ran the config and validator execution-phase specs together three times concurrently: 311 passing and 0 failing per run.
- `./node_modules/.bin/eslint packages/dd-trace/test/config/index.spec.js --max-warnings 0`
- `git diff --check`

