### PR TITLE
feat(cypress): upload test failure videos

### DIFF
--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -24,11 +24,10 @@ async function runCypress () {
         specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
       },
       // Mirror the env-driven gating in cypress.config.js: off by default so most
-      // specs do not capture screenshots; the failure-screenshot upload tests set
-      // CYPRESS_ENABLE_FAILURE_SCREENSHOTS=true for their runs.
+      // specs do not capture media; failure-media tests enable only what they exercise.
       // The 'esm' module type runs Cypress through this programmatic config rather
       // than cypress.config.js, so the same gating has to live here too.
-      video: false,
+      video: process.env.CYPRESS_ENABLE_VIDEO === 'true',
       screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_SCREENSHOTS === 'true',
     },
   })

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -60,8 +60,8 @@ module.exports = defineConfig({
     },
     specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
   },
-  // Off by default so most specs do not capture screenshots; the failure-screenshot
-  // upload tests set CYPRESS_ENABLE_FAILURE_SCREENSHOTS=true for their runs.
-  video: false,
+  // Off by default so most specs do not capture media; failure-media upload tests
+  // enable the Cypress artifact they exercise without changing product behavior.
+  video: process.env.CYPRESS_ENABLE_VIDEO === 'true',
   screenshotOnRunFailure: process.env.CYPRESS_ENABLE_FAILURE_SCREENSHOTS === 'true',
 })

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -931,7 +931,11 @@ moduleTypes.forEach(({
         // TODO: use over10It for evp proxy too once the Agent can forward the media endpoint.
         const onlyAgentlessIt = reportMethod === 'agentless' ? over10It : it.skip
 
-        function runCypressWithFailureScreenshots (specToRun) {
+        function runCypressWithFailureMedia (specToRun, {
+          captureVideo = false,
+          uploadScreenshots = true,
+          uploadVideo = false,
+        } = {}) {
           let testOutput = ''
           childProcess = exec(
             testCommand,
@@ -942,7 +946,9 @@ moduleTypes.forEach(({
                 CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
                 CYPRESS_ENABLE_FAILURE_SCREENSHOTS: 'true',
-                DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
+                CYPRESS_ENABLE_VIDEO: String(captureVideo),
+                DD_TEST_FAILURE_SCREENSHOTS_ENABLED: String(uploadScreenshots),
+                DD_TEST_FAILURE_VIDEO_ENABLED: String(uploadVideo),
               },
             }
           )
@@ -956,8 +962,8 @@ moduleTypes.forEach(({
           return hexFilename ? Buffer.from(hexFilename, 'hex').toString('utf8') : ''
         }
 
-        onlyAgentlessIt('uploads failure screenshots to the v2 media endpoint', async function () {
-          const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/basic-fail.js')
+        onlyAgentlessIt('uploads only failure screenshots when video upload is disabled', async function () {
+          const getTestOutput = runCypressWithFailureMedia('cypress/e2e/basic-fail.js', { captureVideo: true })
 
           const receiverPromise = receiver
             .gatherPayloadsUntilChildExit(
@@ -979,6 +985,10 @@ moduleTypes.forEach(({
 
                 const screenshotPayload = mediaPayloads.find(({ media }) => media.contentType === 'image/png')
                 assert.ok(screenshotPayload, `a screenshot should be uploaded to the v2 media endpoint\n${testOutput}`)
+                assert.ok(
+                  !mediaPayloads.some(({ media }) => media.contentType === 'video/mp4'),
+                  `the video should not be uploaded when its feature flag is disabled\n${testOutput}`
+                )
                 assert.strictEqual(
                   screenshotPayload.url.split('?')[0],
                   `/api/v2/ci/test-runs/${expectedTraceId}/media`
@@ -1028,8 +1038,100 @@ moduleTypes.forEach(({
           ])
         })
 
+        onlyAgentlessIt('uploads only the failure video when screenshot upload is disabled', async function () {
+          const getTestOutput = runCypressWithFailureMedia('cypress/e2e/basic-fail.js', {
+            captureVideo: true,
+            uploadScreenshots: false,
+            uploadVideo: true,
+          })
+
+          const receiverPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.startsWith('/api/v2/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const testOutput = getTestOutput()
+                const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/v2/ci/test-runs/'))
+                const failedTest = payloads
+                  .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
+                  .flatMap(({ payload }) => payload.events)
+                  .filter(event => event.type === 'test')
+                  .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
+
+                assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+                const expectedTraceId = failedTest.content.trace_id.toString()
+                const videoPayload = mediaPayloads.find(({ media }) => media.contentType === 'video/mp4')
+
+                assert.ok(videoPayload, `a video should be uploaded to the v2 media endpoint\n${testOutput}`)
+                assert.ok(
+                  !mediaPayloads.some(({ media }) => media.contentType === 'image/png'),
+                  `screenshots should not be uploaded when their feature flag is disabled\n${testOutput}`
+                )
+                assert.strictEqual(
+                  videoPayload.url.split('?')[0],
+                  `/api/v2/ci/test-runs/${expectedTraceId}/media`
+                )
+                assert.strictEqual(videoPayload.media.traceId, expectedTraceId)
+                assert.strictEqual(videoPayload.headers['dd-api-key'], '1')
+                assert.match(decodeKeyFilename(videoPayload.media.idempotencyKey), /basic-fail\.js\.mp4$/)
+
+                const capturedAt = Number(videoPayload.media.capturedAt)
+                assert.ok(
+                  Number.isInteger(capturedAt) && capturedAt > 0,
+                  `captured_at_ms should be a positive integer, got ${videoPayload.media.capturedAt}`
+                )
+                assert.strictEqual(videoPayload.media.content.subarray(4, 8).toString(), 'ftyp')
+              }, { hardTimeout: 60000 })
+            .catch((error) => {
+              error.message += `\nCypress output:\n${getTestOutput()}`
+              throw error
+            })
+
+          await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
+        })
+
+        onlyAgentlessIt('does not enable Cypress video recording when the upload flag is set', async function () {
+          const getTestOutput = runCypressWithFailureMedia('cypress/e2e/basic-fail.js', {
+            uploadScreenshots: false,
+            uploadVideo: true,
+          })
+
+          const receiverPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.startsWith('/api/v2/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const testOutput = getTestOutput()
+                const mediaPayloads = payloads.filter(({ url }) => url.startsWith('/api/v2/ci/test-runs/'))
+                const failedTest = payloads
+                  .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
+                  .flatMap(({ payload }) => payload.events)
+                  .filter(event => event.type === 'test')
+                  .find(event => event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail')
+
+                assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+                assert.strictEqual(
+                  mediaPayloads.length,
+                  0,
+                  `no media should be uploaded when Cypress video recording is disabled\n${testOutput}`
+                )
+              }, { hardTimeout: 60000 })
+            .catch((error) => {
+              error.message += `\nCypress output:\n${getTestOutput()}`
+              throw error
+            })
+
+          await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
+        })
+
         onlyAgentlessIt('uploads only the auto failure frame, not a manual cy.screenshot()', async function () {
-          const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/manual-screenshot-before-fail.js')
+          const getTestOutput = runCypressWithFailureMedia('cypress/e2e/manual-screenshot-before-fail.js')
 
           const receiverPromise = receiver
             .gatherPayloadsUntilChildExit(
@@ -1151,7 +1253,7 @@ moduleTypes.forEach(({
 
         onlyAgentlessIt('continues normally when the media upload endpoint fails', async function () {
           receiver.setMediaResponseStatusCode(500)
-          const getTestOutput = runCypressWithFailureScreenshots('cypress/e2e/basic-fail.js')
+          const getTestOutput = runCypressWithFailureMedia('cypress/e2e/basic-fail.js')
 
           const receiverPromise = receiver
             .gatherPayloadsUntilChildExit(

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -156,17 +156,16 @@ function isFailureScreenshotByMetadata (screenshot, screenshotFilePath) {
 }
 
 /**
- * Resolves a screenshot's capture time (epoch ms) for the media upload. Cypress
- * screenshot objects carry an ISO `takenAt`; falls back to the file's mtime, then
- * to the current time. Stamped once here and reused on retry via the idempotency
- * key, so the stored object is overwritten rather than duplicated.
+ * Resolves an artifact's capture time (epoch ms) for the media upload. Cypress
+ * screenshot objects carry an ISO `takenAt`; videos fall back to the file's mtime.
+ * The current time is used if the file cannot be read.
  *
- * @param {object|string} screenshot - Cypress screenshot object or path
- * @param {string} filePath - Resolved screenshot file path
+ * @param {object|string} artifact - Cypress screenshot object or media path
+ * @param {string} filePath - Resolved media file path
  * @returns {number} Capture time in epoch milliseconds
  */
-function getScreenshotCapturedAtMs (screenshot, filePath) {
-  const takenAt = screenshot !== null && typeof screenshot === 'object' ? screenshot.takenAt : undefined
+function getMediaCapturedAtMs (artifact, filePath) {
+  const takenAt = artifact !== null && typeof artifact === 'object' ? artifact.takenAt : undefined
   if (takenAt) {
     const parsedMs = new Date(takenAt).getTime()
     if (Number.isInteger(parsedMs) && parsedMs > 0) {
@@ -1423,12 +1422,13 @@ class CypressPlugin {
   }
 
   afterSpec (spec, results) {
-    const { tests, stats, screenshots } = results || {}
+    const { tests, stats, screenshots, video } = results || {}
     const cypressTests = tests || []
     const specScreenshots = screenshots || []
     const finishedTests = this.finishedTestsByFile[spec.relative] || []
-    const screenshotUploadPromises = []
+    const mediaUploadPromises = []
     const testSpanFinishPromises = []
+    const failedTestTraceIds = []
 
     if (!this.testSuiteSpan) {
       // dd:testSuiteStart hasn't been triggered for whatever reason
@@ -1539,13 +1539,14 @@ class CypressPlugin {
         let failedTestTraceId
         if (cypressTestStatus === 'fail' || finishedTest.testStatus === 'fail' || cypressTest.displayError) {
           failedTestTraceId = finishedTest.testSpan.context().toTraceId()
+          failedTestTraceIds.push(failedTestTraceId)
           const testScreenshots = getTestScreenshots(cypressTest, attemptIndex, specScreenshots)
           const screenshotUploadPromise = this.uploadTestScreenshots({
             screenshots: testScreenshots,
             traceId: failedTestTraceId,
           })
           if (screenshotUploadPromise) {
-            screenshotUploadPromises.push(screenshotUploadPromise)
+            mediaUploadPromises.push(screenshotUploadPromise)
           }
         }
 
@@ -1620,6 +1621,13 @@ class CypressPlugin {
       }
     }
 
+    if (video && failedTestTraceIds.length > 0) {
+      const videoUploadPromise = this.uploadTestVideo({ videoPath: video, traceIds: failedTestTraceIds })
+      if (videoUploadPromise) {
+        mediaUploadPromises.push(videoUploadPromise)
+      }
+    }
+
     const finishSuite = () => {
       if (this.testSuiteSpan) {
         const status = getSuiteStatus(stats)
@@ -1634,26 +1642,26 @@ class CypressPlugin {
       }
     }
 
-    const waitForScreenshotUploads = () => {
-      if (screenshotUploadPromises.length > 0 || this.pendingScreenshotUploads.length > 0) {
+    const waitForMediaUploads = () => {
+      if (mediaUploadPromises.length > 0 || this.pendingScreenshotUploads.length > 0) {
         const pendingScreenshotUploads = this.pendingScreenshotUploads
         this.pendingScreenshotUploads = []
-        return Promise.all([...pendingScreenshotUploads, ...screenshotUploadPromises]).then(() => null)
+        return Promise.all([...pendingScreenshotUploads, ...mediaUploadPromises]).then(() => null)
       }
     }
 
     finishSuite()
 
-    const screenshotUploadsPromise = waitForScreenshotUploads()
+    const mediaUploadsPromise = waitForMediaUploads()
     if (testSpanFinishPromises.length > 0) {
       const testSpansPromise = Promise.all(testSpanFinishPromises).then(() => null)
-      if (screenshotUploadsPromise) {
-        return Promise.all([testSpansPromise, screenshotUploadsPromise]).then(() => null)
+      if (mediaUploadsPromise) {
+        return Promise.all([testSpansPromise, mediaUploadsPromise]).then(() => null)
       }
       return testSpansPromise
     }
 
-    return screenshotUploadsPromise
+    return mediaUploadsPromise
   }
 
   /**
@@ -1684,7 +1692,7 @@ class CypressPlugin {
       // same stored object instead of duplicating; the Cypress filename encodes the
       // test name and attempt, so it is unique within the trace.
       const idempotencyKey = `${traceId}:${basename(filePath)}`
-      const capturedAtMs = getScreenshotCapturedAtMs(screenshot, filePath)
+      const capturedAtMs = getMediaCapturedAtMs(screenshot, filePath)
       uploadPromises.push(new Promise(resolve => {
         exporter.uploadTestScreenshot({
           filePath,
@@ -1701,6 +1709,44 @@ class CypressPlugin {
       const uploadPromise = Promise.all(uploadPromises).then(getScreenshotUploadResult)
       this.addScreenshotUploadPromise(traceId, uploadPromise)
       return uploadPromise
+    }
+  }
+
+  /**
+   * Uploads the per-spec Cypress video to each failed test run in the spec.
+   *
+   * @param {object} options - Upload options
+   * @param {string} options.videoPath - Path to the Cypress video
+   * @param {string[]} options.traceIds - Failed test trace ids that own the video
+   * @returns {Promise<void>|undefined}
+   */
+  uploadTestVideo ({ videoPath, traceIds }) {
+    const exporter = this.tracer?._tracer?._exporter
+    if (!videoPath || !traceIds.length ||
+      !exporter?.canUploadTestVideo?.() ||
+      !exporter.uploadTestScreenshot) {
+      return
+    }
+
+    const capturedAtMs = getMediaCapturedAtMs(videoPath, videoPath)
+    const videoFileName = basename(videoPath)
+    const uploadPromises = []
+
+    for (const traceId of traceIds) {
+      uploadPromises.push(new Promise(resolve => {
+        exporter.uploadTestScreenshot({
+          filePath: videoPath,
+          traceId,
+          idempotencyKey: `${traceId}:${videoFileName}`,
+          capturedAtMs,
+        }, () => {
+          resolve()
+        })
+      }))
+    }
+
+    if (uploadPromises.length > 0) {
+      return Promise.all(uploadPromises).then(() => {})
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-validation/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-validation/index.js
@@ -147,6 +147,15 @@ class CiValidationExporter extends CiVisibilityExporter {
   }
 
   /**
+   * Reports that Cypress video upload is unavailable.
+   *
+   * @returns {boolean}
+   */
+  canUploadTestVideo () {
+    return false
+  }
+
+  /**
    * Rejects screenshot upload in offline validation mode.
    *
    * @param {object} options ignored upload options

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -85,6 +85,8 @@ class CiVisibilityExporter extends BufferingExporter {
 
     this._isTestFailureScreenshotsEnabled =
       Boolean(config?.testOptimization?.DD_TEST_FAILURE_SCREENSHOTS_ENABLED)
+    this._isTestFailureVideoEnabled =
+      Boolean(config?.testOptimization?.DD_TEST_FAILURE_VIDEO_ENABLED)
 
     const gitUploadTimeoutId = setTimeout(() => {
       this._resolveGit(new Error('Timeout while uploading git metadata'))
@@ -536,6 +538,15 @@ class CiVisibilityExporter extends BufferingExporter {
    */
   canUploadTestScreenshots () {
     return Boolean(this._testScreenshotUploadUrl) && this._isTestFailureScreenshotsEnabled
+  }
+
+  /**
+   * Returns whether the exporter can upload Cypress test failure videos.
+   *
+   * @returns {boolean}
+   */
+  canUploadTestVideo () {
+    return Boolean(this._testScreenshotUploadUrl) && this._isTestFailureVideoEnabled
   }
 
   /**

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -23,6 +23,9 @@ function getContentType (filePath) {
   if (extension === '.webp') {
     return 'image/webp'
   }
+  if (extension === '.mp4') {
+    return 'video/mp4'
+  }
   return 'image/png'
 }
 

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -565,6 +565,7 @@ export interface GeneratedConfig {
     DD_TEST_EARLY_FLAKE_DETECTION_RETRY_COUNT: number | undefined;
     DD_TEST_FAILED_TEST_REPLAY_ENABLED: boolean;
     DD_TEST_FAILURE_SCREENSHOTS_ENABLED: boolean | undefined;
+    DD_TEST_FAILURE_VIDEO_ENABLED: boolean | undefined;
     DD_TEST_FLEET_CONFIG_PATH: string | undefined;
     DD_TEST_LOCAL_CONFIG_PATH: string | undefined;
     DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES: number;
@@ -800,6 +801,7 @@ export interface GeneratedEnvVarConfig {
   DD_TEST_EARLY_FLAKE_DETECTION_RETRY_COUNT: number | undefined;
   DD_TEST_FAILED_TEST_REPLAY_ENABLED: boolean;
   DD_TEST_FAILURE_SCREENSHOTS_ENABLED: boolean | undefined;
+  DD_TEST_FAILURE_VIDEO_ENABLED: boolean | undefined;
   DD_TEST_FLEET_CONFIG_PATH: string | undefined;
   DD_TEST_LOCAL_CONFIG_PATH: string | undefined;
   DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES: number;

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1844,6 +1844,14 @@
         "namespace": "testOptimization"
       }
     ],
+    "DD_TEST_FAILURE_VIDEO_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": null,
+        "namespace": "testOptimization"
+      }
+    ],
     "DD_TEST_FLEET_CONFIG_PATH": [
       {
         "implementation": "A",

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js
@@ -477,6 +477,7 @@ describe('CI validation exporter', () => {
 
     assert.strictEqual(exporter.canReportCodeCoverage(), false)
     assert.strictEqual(exporter.canUploadTestScreenshots(), false)
+    assert.strictEqual(exporter.canUploadTestVideo(), false)
     exporter.sendGitMetadata()
     exporter.exportDiLogs()
     exporter.uploadCoverageReport({}, coverageError => {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1298,4 +1298,38 @@ describe('CI Visibility Exporter', () => {
       assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), true)
     })
   })
+
+  describe('canUploadTestVideo', () => {
+    it('should return false when there is no upload URL', () => {
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_TEST_FAILURE_VIDEO_ENABLED: true },
+      })
+      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
+    })
+
+    it('should return false when the URL is set but video is disabled', () => {
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_TEST_FAILURE_VIDEO_ENABLED: false },
+      })
+      ciVisibilityExporter._testScreenshotUploadUrl = url
+      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
+    })
+
+    it('should return false when the URL is set but the video flag is absent', () => {
+      const ciVisibilityExporter = new CiVisibilityExporter({ url })
+      ciVisibilityExporter._testScreenshotUploadUrl = url
+      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), false)
+    })
+
+    it('should return true when the URL is set and video is enabled', () => {
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_TEST_FAILURE_VIDEO_ENABLED: true },
+      })
+      ciVisibilityExporter._testScreenshotUploadUrl = url
+      assert.strictEqual(ciVisibilityExporter.canUploadTestVideo(), true)
+    })
+  })
 })

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -80,6 +80,12 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       assert.strictEqual(headers['X-Datadog-EVP-Subdomain'], undefined)
     })
 
+    it('uses the Cypress video content type for MP4 files', () => {
+      const { headers } = uploadForFile('test-run.mp4')
+
+      assert.strictEqual(headers['Content-Type'], 'video/mp4')
+    })
+
     it('reports an error when the request helper drops the upload', () => {
       const basename = 'screenshot.png'
       const filePath = join(tmpDir, basename)

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -3528,6 +3528,7 @@ describe('Config', () => {
       delete process.env.DD_CIVISIBILITY_FLAKY_RETRY_ENABLED
       delete process.env.DD_CIVISIBILITY_FLAKY_RETRY_COUNT
       delete process.env.DD_TEST_FAILURE_SCREENSHOTS_ENABLED
+      delete process.env.DD_TEST_FAILURE_VIDEO_ENABLED
       delete process.env.DD_TEST_SESSION_NAME
       delete process.env.JEST_WORKER_ID
       delete process.env.DD_TEST_FAILED_TEST_REPLAY_ENABLED
@@ -3642,6 +3643,20 @@ describe('Config', () => {
         process.env.DD_TEST_FAILURE_SCREENSHOTS_ENABLED = 'false'
         const config = getConfig(options)
         assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_SCREENSHOTS_ENABLED, false)
+      })
+      it('should leave test failure video unset by default', () => {
+        const config = getConfig(options)
+        assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_VIDEO_ENABLED, undefined)
+      })
+      it('should enable test failure video if DD_TEST_FAILURE_VIDEO_ENABLED is true', () => {
+        process.env.DD_TEST_FAILURE_VIDEO_ENABLED = 'true'
+        const config = getConfig(options)
+        assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_VIDEO_ENABLED, true)
+      })
+      it('should disable test failure video if DD_TEST_FAILURE_VIDEO_ENABLED is false', () => {
+        process.env.DD_TEST_FAILURE_VIDEO_ENABLED = 'false'
+        const config = getConfig(options)
+        assert.strictEqual(config.testOptimization.DD_TEST_FAILURE_VIDEO_ENABLED, false)
       })
       it('should read DD_CIVISIBILITY_FLAKY_RETRY_COUNT if present', () => {
         process.env.DD_CIVISIBILITY_FLAKY_RETRY_COUNT = '4'


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds opt-in Cypress test failure video uploads behind `DD_TEST_FAILURE_VIDEO_ENABLED`.

When Cypress is already configured to record video and exposes a per-spec video in `after:spec`, the tracer uploads that MP4 once to the existing v2 test-run media intake. The video is associated with the failed test suite using its `test_suite_id`; it is not attached to each failed test. The tracer does not enable Cypress video recording.

The shared upload request is named for test media because it now handles both screenshots and videos. The screenshot and video feature flags remain independent.

### Motivation
<!-- What inspired you to submit this pull request? -->

PR #8981 added failure screenshot uploads to the v2 media intake. Cypress also produces useful per-spec videos, but dd-trace does not currently forward them when users have recording enabled.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:
- `353 passing, 5 pending` across the focused request/exporter/config unit specs
- full repository lint
- generated config type verification
- Cypress 14.5.4 CommonJS: screenshot-only, suite-owned video-only, and recording-disabled cases
- Cypress 14.5.4 ESM: screenshot-only, suite-owned video-only, and recording-disabled cases
