### PR TITLE
fix(graphql): preserve hook error overrides

### DIFF
--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -227,9 +227,13 @@ class GraphQLExecutePlugin extends TracingPlugin {
     if (!span) return
 
     // Synchronous execute() throw (e.g. execute(null, doc)) — error handler
-    // already tagged the span, just finish it.
+    // already tagged the span.
     if (ctx.error) {
-      this.#drain(ctx, span)
+      if (ctx.ddAborted) {
+        this.#drain(ctx, span)
+      } else {
+        this.#finishSpan(ctx, span)
+      }
       return ctx.parentStore
     }
 
@@ -238,10 +242,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
     if (typeof result?.then === 'function') {
       result.then(
         (res) => this.#finishSpan(ctx, span, res),
-        (err) => {
-          span.setTag('error', err)
-          this.#drain(ctx, span)
-        }
+        (err) => this.#finishSpan(ctx, span, undefined, err)
       )
     } else {
       this.#finishSpan(ctx, span, result)
@@ -260,8 +261,16 @@ class GraphQLExecutePlugin extends TracingPlugin {
     }
   }
 
-  #finishSpan (ctx, span, res) {
-    this.config.hooks.execute(span, ctx.ddArgs, res)
+  /**
+   * @param {object} ctx
+   * @param {import('../../dd-trace/src/opentracing/span')} span
+   * @param {import('graphql').ExecutionResult} [res]
+   * @param {unknown} [error]
+   */
+  #finishSpan (ctx, span, res, error) {
+    if (error !== undefined) {
+      span.setTag('error', error)
+    }
 
     if (res?.errors?.length) {
       span.setTag('error', res.errors[0])
@@ -269,6 +278,8 @@ class GraphQLExecutePlugin extends TracingPlugin {
         extractErrorIntoSpanEvent(this.config, span, err)
       }
     }
+
+    this.config.hooks.execute(span, ctx.ddArgs, res)
 
     this.#drain(ctx, span)
   }

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -230,7 +230,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
     // already tagged the span.
     if (ctx.error) {
       if (ctx.ddAborted) {
-        this.#drain(ctx, span)
+        span.finish()
       } else {
         this.#finishSpan(ctx, span)
       }
@@ -279,19 +279,16 @@ class GraphQLExecutePlugin extends TracingPlugin {
       }
     }
 
-    this.config.hooks.execute(span, ctx.ddArgs, res)
-
-    this.#drain(ctx, span)
-  }
-
-  #drain (ctx, span) {
-    span.finish()
     if (ctx.ddContextValue) {
       contexts.delete(ctx.ddContextValue)
     }
     if (ctx.ddInstrumentedArgs) {
       instrumentedArgs.delete(ctx.ddInstrumentedArgs)
     }
+
+    this.config.hooks.execute(span, ctx.ddArgs, res)
+
+    span.finish()
   }
 
   // Public — called from wrapResolve (free function, crosses class boundary).

--- a/packages/datadog-plugin-graphql/src/validate.js
+++ b/packages/datadog-plugin-graphql/src/validate.js
@@ -68,14 +68,14 @@ class GraphQLValidatePlugin extends TracingPlugin {
     const errors = ctx.result
     const span = ctx?.currentStore?.span || this.activeSpan
 
-    this.config.hooks.validate(span, document, errors)
-
     if (errors?.length) {
       span.setTag('error', errors[0])
       for (const err of errors) {
         extractErrorIntoSpanEvent(this.config, span, err)
       }
     }
+
+    this.config.hooks.validate(span, document, errors)
 
     span.finish()
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2735,11 +2735,33 @@ describe('Plugin', () => {
       })
 
       describe('with hooks configuration', () => {
+        /**
+         * @param {import('../../dd-trace/src/opentracing/span')} span
+         * @param {object} context
+         * @param {import('graphql').ExecutionResult} [res]
+         */
+        function executeHook (span, context, res) {
+          if (res?.errors?.some(error => error.message === 'Expected failure')) {
+            span.setTag('error', false)
+          }
+        }
+
+        /**
+         * @param {import('../../dd-trace/src/opentracing/span')} span
+         * @param {import('graphql').DocumentNode} document
+         * @param {readonly import('graphql').GraphQLError[]} [errors]
+         */
+        function validateHook (span, document, errors) {
+          if (errors?.length) {
+            span.setTag('error', false)
+          }
+        }
+
         const config = {
           hooks: {
-            execute: sinon.spy((span, context, res) => {}),
+            execute: sinon.spy(executeHook),
             parse: sinon.spy((span, document, operation) => {}),
-            validate: sinon.spy((span, document, error) => {}),
+            validate: sinon.spy(validateHook),
             resolve: sinon.spy((span, field) => {}),
           },
         }
@@ -2826,6 +2848,131 @@ describe('Plugin', () => {
           return Promise.all([assertion, action])
         })
 
+        it('should preserve an execute hook error override for synchronous results', () => {
+          const source = '{ expectedFailure }'
+          const document = graphql.parse(source)
+          const localSchema = graphql.buildSchema('type Query { expectedFailure: String }')
+          const rootValue = {
+            expectedFailure () {
+              throw new Error('Expected failure')
+            },
+          }
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+            const executeSpan = spans.find(span => span.name === expectedSchema.server.opName)
+
+            assert.ok(executeSpan, 'expected graphql.execute span')
+            assert.strictEqual(executeSpan.error, 0)
+            assert.strictEqual(executeSpan.meta[ERROR_TYPE], undefined)
+            assert.strictEqual(executeSpan.meta[ERROR_MESSAGE], undefined)
+            assert.strictEqual(executeSpan.meta[ERROR_STACK], undefined)
+
+            const spanEvents = agent.unformatSpanEvents(executeSpan)
+            assert.strictEqual(spanEvents.length, 1)
+            assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
+            assert.strictEqual(spanEvents[0].attributes.message, 'Expected failure')
+          }, { spanResourceMatch: /expectedFailure/ })
+
+          return Promise.all([
+            assertion,
+            graphql.execute({ schema: localSchema, document, rootValue }),
+          ])
+        })
+
+        it('should preserve an execute hook error override for asynchronous results', () => {
+          const source = '{ expectedFailure }'
+          const document = graphql.parse(source)
+          const localSchema = graphql.buildSchema('type Query { expectedFailure: String }')
+          const rootValue = {
+            expectedFailure () {
+              return Promise.reject(new Error('Expected failure'))
+            },
+          }
+
+          return Promise.all([
+            agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              const executeSpan = spans.find(span => span.name === expectedSchema.server.opName)
+
+              assert.ok(executeSpan, 'expected graphql.execute span')
+              assert.strictEqual(executeSpan.error, 0)
+            }, { spanResourceMatch: /expectedFailure/ }),
+            graphql.execute({ schema: localSchema, document, rootValue }),
+          ])
+        })
+
+        it('should preserve the default error for unmatched execute errors', () => {
+          const source = '{ unexpectedFailure }'
+          const document = graphql.parse(source)
+          const localSchema = graphql.buildSchema('type Query { unexpectedFailure: String }')
+          const rootValue = {
+            unexpectedFailure () {
+              throw new Error('Unexpected failure')
+            },
+          }
+
+          return Promise.all([
+            agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              const executeSpan = spans.find(span => span.name === expectedSchema.server.opName)
+
+              assert.ok(executeSpan, 'expected graphql.execute span')
+              assert.strictEqual(executeSpan.error, 1)
+              assert.strictEqual(executeSpan.meta[ERROR_MESSAGE], 'Unexpected failure')
+            }, { spanResourceMatch: /unexpectedFailure/ }),
+            graphql.execute({ schema: localSchema, document, rootValue }),
+          ])
+        })
+
+        it('should run the execute hook for synchronous exceptions', () => {
+          const document = graphql.parse('{ hello }')
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            assert.strictEqual(spans[0].error, 1)
+            sinon.assert.calledOnce(config.hooks.execute)
+            assert.strictEqual(config.hooks.execute.firstCall.args[2], undefined)
+          })
+
+          assert.throws(() => graphql.execute(null, document))
+
+          return assertion
+        })
+
+        it('should run the execute hook for a rejected executor result', () => {
+          const document = graphql.parse('{ hello }')
+          const error = new Error('Executor rejected')
+          // Match the Sync orchestrion wrapper around @graphql-tools/executor while providing its rejected result.
+          const executeChannel = dc.tracingChannel(
+            'orchestrion:@graphql-tools/executor:apm:graphql:execute'
+          )
+          const context = {
+            arguments: [{ schema, document }],
+          }
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+            assert.strictEqual(spans[0].error, 1)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], error.message)
+            sinon.assert.calledOnce(config.hooks.execute)
+            assert.strictEqual(config.hooks.execute.firstCall.args[2], undefined)
+          }, { spanResourceMatch: /hello/ })
+
+          const execution = executeChannel.traceSync(() => Promise.reject(error), context)
+
+          return Promise.all([
+            assertion,
+            assert.rejects(execution, error),
+          ])
+        })
+
         it('should run the validate hook before graphql.validate span is finished', () => {
           const document = graphql.parse(source)
 
@@ -2847,6 +2994,29 @@ describe('Plugin', () => {
           })
 
           const errors = graphql.validate(schema, document)
+
+          return assertion
+        })
+
+        it('should preserve a validate hook error override', () => {
+          const document = graphql.parse('{ human { address } }')
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].name, 'graphql.validate')
+            assert.strictEqual(spans[0].error, 0)
+            assert.strictEqual(spans[0].meta[ERROR_TYPE], undefined)
+            assert.strictEqual(spans[0].meta[ERROR_MESSAGE], undefined)
+            assert.strictEqual(spans[0].meta[ERROR_STACK], undefined)
+
+            const spanEvents = agent.unformatSpanEvents(spans[0])
+            assert.strictEqual(spanEvents.length, 1)
+            assert.strictEqual(spanEvents[0].name, 'dd.graphql.query.error')
+          })
+
+          graphql.validate(schema, document)
 
           return assertion
         })

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2744,6 +2744,8 @@ describe('Plugin', () => {
           if (res?.errors?.some(error => error.message === 'Expected failure')) {
             span.setTag('error', false)
           }
+
+          context.contextValue?.executeHook?.()
         }
 
         /**
@@ -2846,6 +2848,44 @@ describe('Plugin', () => {
             })
 
           return Promise.all([assertion, action])
+        })
+
+        it('should trace executions started by the execute hook', () => {
+          const localSchema = graphql.buildSchema('type Query { outer: String, nested: String }')
+          const outerDocument = graphql.parse('query Outer { outer }')
+          const nestedDocument = graphql.parse('query Nested { nested }')
+          const contextValue = {}
+
+          contextValue.executeHook = () => {
+            contextValue.executeHook = undefined
+            graphql.execute({
+              schema: localSchema,
+              document: nestedDocument,
+              contextValue,
+              rootValue: { nested: 'nested' },
+            })
+          }
+
+          const assertion = agent.assertSomeTraces(traces => {
+            const spans = sort(traces[0])
+            const executeSpans = spans.filter(span => span.name === expectedSchema.server.opName)
+
+            assert.strictEqual(executeSpans.length, 2)
+            assert.deepStrictEqual(
+              executeSpans.map(span => span.resource).sort(),
+              ['query Nested{nested}', 'query Outer{outer}']
+            )
+            sinon.assert.calledTwice(config.hooks.execute)
+          }, { spanResourceMatch: /Outer/ })
+
+          graphql.execute({
+            schema: localSchema,
+            document: outerDocument,
+            contextValue,
+            rootValue: { outer: 'outer' },
+          })
+
+          return assertion
         })
 
         it('should preserve an execute hook error override for synchronous results', () => {


### PR DESCRIPTION
## Summary
The orchestrion migration moved GraphQL error handling after application hooks, so hooks could no longer clear expected failures. This restores hooks as the final span writer for execute and validate errors, including synchronous throws and rejected executor results, while retaining GraphQL error events.

Execute re-entry guards are now released before application hooks run. A hook can start another operation with the same context without silently suppressing its trace.

Fixes: https://github.com/DataDog/dd-trace-js/issues/9423