### PR TITLE
fix(instrumentation): preserve ESM export aliases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -353,6 +353,7 @@
 /integration-tests/coverage-fixtures/ @DataDog/lang-platform-js
 /integration-tests/crashtracking/ @DataDog/lang-platform-js
 /integration-tests/helpers/ @DataDog/lang-platform-js
+/integration-tests/import-variants.spec.js @DataDog/lang-platform-js
 /integration-tests/init/ @DataDog/lang-platform-js
 /integration-tests/init.spec.js @DataDog/lang-platform-js
 /integration-tests/memory-leak/ @DataDog/lang-platform-js

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -670,80 +670,119 @@ async function createSandbox (
 }
 
 /**
- * @typedef {{ default?: string, star: string, destructure: string }} Variants
+ * @typedef {'destructure' | 'direct' | 'namespace'} NamedExportBinding
+ * @typedef {object} ImportVariantOptions
+ * @property {string} bindingName
+ * @property {string} packageName
+ * @property {boolean} defaultExport
+ * @property {string[]} namedExports
+ * @property {NamedExportBinding} [namedExportBinding]
+ * @typedef {Record<string, string>} ImportVariants
+ * @typedef {Record<string, string>} ImportVariantFiles
  */
+
 /**
- * @overload
- * @param {string} filename - The file that will be copied and modified for each variant.
- * @param {string} bindingName - The binding name that will be use to bind to the packageName.
- * @param {string} [namedExport] - The name of the named variant to use.
- * @param {string} [packageName] - The name of the package. If not provided, the binding name will be used.
- * @param {boolean} [byPassDefault] - Skip default export variant generation.
- * @returns {Variants} A map from variant names to resulting filenames
+ * @param {ImportVariantOptions} options
+ * @returns {ImportVariants}
  */
-/**
- * Creates a bunch of files based on an original file in sandbox. Useful for varying test files
- * without having to create a bunch of them yourself.
- *
- * The variants object should have keys that are named variants, and values that are the text
- * in the file that's different in each variant. There must always be a "default" variant,
- * whose value is the original text within the file that will be replaced.
- *
- * @param {string} filename - The file that will be copied and modified for each variant.
- * @param {Variants|string} variants - The variants or binding name.
- * @param {string} [namedExport] - Named export to use for star/destructure variants.
- * @param {string} [packageName] - Module specifier for the import.
- * @param {boolean} [byPassDefault] - Skip default export variant generation.
- * @returns {Variants} A map from variant names to resulting filenames
- */
-function varySandbox (filename, variants, namedExport, packageName, byPassDefault) {
-  if (typeof variants === 'string') {
-    const bindingName = variants
-    const resolvedName = packageName || bindingName
-    // Default namedVariant to bindingName when bypassing default export
-    if (byPassDefault && !namedExport) namedExport = bindingName
-    variants = byPassDefault
-      ? {
-          // eslint-disable-next-line @stylistic/max-len
-          star: `import * as mod${bindingName} from '${resolvedName}'; const ${bindingName} = mod${bindingName}.${namedExport}`,
-          destructure: `import { ${namedExport} } from '${resolvedName}'`,
-        }
-      : {
-          default: `import ${bindingName} from '${resolvedName}'`,
-          star: namedExport
-            ? `import * as ${bindingName} from '${resolvedName}'`
-            : `import * as mod${bindingName} from '${resolvedName}'; const ${bindingName} = mod${bindingName}.default`,
-          destructure: namedExport
-            ? `import { ${namedExport} } from '${resolvedName}'; const ${bindingName} = { ${namedExport} }`
-            : `import { default as ${bindingName}} from '${resolvedName}'`,
-        }
+function createImportVariants (options) {
+  const {
+    bindingName,
+    packageName,
+    defaultExport,
+    namedExports,
+    namedExportBinding,
+  } = options
+  assert(defaultExport || namedExports.length, 'At least one default or named export is required')
+  assert(!namedExports.length || namedExportBinding, 'Named exports require a binding style')
+  assert(
+    !namedExportBinding ||
+    namedExportBinding === 'destructure' ||
+    namedExportBinding === 'direct' ||
+    namedExportBinding === 'namespace',
+    `Unknown named export binding style: ${namedExportBinding}`
+  )
+  assert(
+    namedExportBinding !== 'direct' || namedExports.length === 1,
+    'Direct named export bindings require exactly one export'
+  )
+
+  const variants = {}
+  const namespaceName = `mod${bindingName[0].toUpperCase()}${bindingName.slice(1)}`
+
+  if (defaultExport) {
+    variants.default = `import ${bindingName} from '${packageName}'`
+    variants['default-as-named'] = `import { default as ${bindingName} } from '${packageName}'`
+    variants['default-from-namespace'] =
+      `import * as ${namespaceName} from '${packageName}'; const ${bindingName} = ${namespaceName}.default`
   }
 
+  if (namedExports.length) {
+    if (namedExportBinding === 'direct') {
+      const [namedExport] = namedExports
+      const importBinding = namedExport === bindingName ? namedExport : `${namedExport} as ${bindingName}`
+      variants.named = `import { ${importBinding} } from '${packageName}'`
+      variants['named-from-namespace'] =
+        `import * as ${namespaceName} from '${packageName}'; const ${bindingName} = ${namespaceName}.${namedExport}`
+    } else if (namedExportBinding === 'namespace') {
+      const exportsList = namedExports.join(', ')
+      variants.named = `import { ${exportsList} } from '${packageName}'; const ${bindingName} = { ${exportsList} }`
+      variants['named-from-namespace'] = `import * as ${bindingName} from '${packageName}'`
+    } else {
+      const exportsList = namedExports.join(', ')
+      variants.named = `import { ${exportsList} } from '${packageName}'`
+      variants['named-from-namespace'] =
+        `import * as ${bindingName} from '${packageName}'; const { ${exportsList} } = ${bindingName}`
+    }
+  }
+
+  return variants
+}
+
+/**
+ * @param {string} filename - The file that will be copied and modified for each variant.
+ * @param {ImportVariants} variants - Import statements keyed by variant name.
+ * @param {ImportVariantFiles} variantFilenames - Resulting filenames keyed by variant name.
+ */
+function writeSandboxVariants (filename, variants, variantFilenames) {
   const origFileData = readFileSync(path.join(sandbox.folder, filename), 'utf8')
-  const { name: prefix, ext: suffix } = path.parse(filename)
-  const variantFilenames = /** @type {Variants} */ ({})
-  const baseVariant = byPassDefault ? 'destructure' : 'default'
+  const baseVariant = variants.default ? 'default' : 'named'
 
   for (const [variant, value] of Object.entries(variants)) {
-    const variantFilename = `${prefix}-${variant}${suffix}`
-    variantFilenames[variant] = variantFilename
+    const variantFilename = variantFilenames[variant]
     let newFileData = origFileData
     if (variant !== baseVariant) {
       const baseValue = variants[baseVariant]
       assert(baseValue, `Missing ${baseVariant} variant`)
       newFileData = origFileData.replace(baseValue, `${value}`)
-      // Error out when the default import does not match that of server.mjs
       if (newFileData === origFileData) throw Error(`Unable to match ${baseVariant}`)
     }
     writeFileSync(path.join(sandbox.folder, variantFilename), newFileData)
   }
-  return variantFilenames
 }
 
 /**
- * @type {['default', 'star', 'destructure']}
+ * Call after useSandbox so variant materialization runs after the sandbox setup.
+ *
+ * @param {string} filename - The file that will be copied and modified for each import variant.
+ * @param {ImportVariantOptions} options
+ * @returns {ImportVariantFiles} Resulting filenames keyed by variant name.
  */
-varySandbox.VARIANTS = ['default', 'star', 'destructure']
+function varySandbox (filename, options) {
+  const variants = createImportVariants(options)
+  const { name: prefix, ext: suffix } = path.parse(filename)
+  const variantFilenames = {}
+
+  for (const variant of Object.keys(variants)) {
+    variantFilenames[variant] = `${prefix}-${variant}${suffix}`
+  }
+
+  before(function () {
+    writeSandboxVariants(filename, variants, variantFilenames)
+  })
+
+  return variantFilenames
+}
 
 /**
  * @param {boolean} shouldExpectTelemetryPoints

--- a/integration-tests/import-variants.spec.js
+++ b/integration-tests/import-variants.spec.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const sinon = require('sinon')
+
+const { varySandbox } = require('./helpers')
+
+describe('varySandbox', () => {
+  beforeEach(() => {
+    sinon.stub(global, 'before')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('creates every default export form', () => {
+    assert.deepStrictEqual(varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: true,
+      namedExports: [],
+    }), {
+      default: 'logger-default.mjs',
+      'default-as-named': 'logger-default-as-named.mjs',
+      'default-from-namespace': 'logger-default-from-namespace.mjs',
+    })
+  })
+
+  it('creates every direct named export form', () => {
+    assert.deepStrictEqual(varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: true,
+      namedExports: ['createLogger'],
+      namedExportBinding: 'direct',
+    }), {
+      default: 'logger-default.mjs',
+      'default-as-named': 'logger-default-as-named.mjs',
+      'default-from-namespace': 'logger-default-from-namespace.mjs',
+      named: 'logger-named.mjs',
+      'named-from-namespace': 'logger-named-from-namespace.mjs',
+    })
+  })
+
+  it('creates every namespace-shaped named export form', () => {
+    assert.deepStrictEqual(varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: true,
+      namedExports: ['createLogger', 'levels'],
+      namedExportBinding: 'namespace',
+    }), {
+      default: 'logger-default.mjs',
+      'default-as-named': 'logger-default-as-named.mjs',
+      'default-from-namespace': 'logger-default-from-namespace.mjs',
+      named: 'logger-named.mjs',
+      'named-from-namespace': 'logger-named-from-namespace.mjs',
+    })
+  })
+
+  it('creates named-only forms', () => {
+    assert.deepStrictEqual(varySandbox('logger.mjs', {
+      bindingName: 'Logger',
+      packageName: 'logger',
+      defaultExport: false,
+      namedExports: ['Logger'],
+      namedExportBinding: 'direct',
+    }), {
+      named: 'logger-named.mjs',
+      'named-from-namespace': 'logger-named-from-namespace.mjs',
+    })
+  })
+
+  it('creates separately bound named export forms', () => {
+    assert.deepStrictEqual(varySandbox('logger.mjs', {
+      bindingName: 'loggerModule',
+      packageName: 'logger',
+      defaultExport: false,
+      namedExports: ['createLogger', 'levels'],
+      namedExportBinding: 'destructure',
+    }), {
+      named: 'logger-named.mjs',
+      'named-from-namespace': 'logger-named-from-namespace.mjs',
+    })
+  })
+
+  it('rejects an impossible export configuration', () => {
+    assert.throws(() => varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: false,
+      namedExports: [],
+    }), {
+      message: 'At least one default or named export is required',
+    })
+  })
+
+  it('requires a named export binding style', () => {
+    assert.throws(() => varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: false,
+      namedExports: ['createLogger'],
+    }), {
+      message: 'Named exports require a binding style',
+    })
+  })
+
+  it('rejects an unknown named export binding style', () => {
+    assert.throws(() => varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: false,
+      namedExports: ['createLogger'],
+      namedExportBinding: 'unknown',
+    }), {
+      message: 'Unknown named export binding style: unknown',
+    })
+  })
+
+  it('rejects multiple direct named exports', () => {
+    assert.throws(() => varySandbox('logger.mjs', {
+      bindingName: 'logger',
+      packageName: 'logger',
+      defaultExport: false,
+      namedExports: ['Logger', 'levels'],
+      namedExportBinding: 'direct',
+    }), {
+      message: 'Direct named export bindings require exactly one export',
+    })
+  })
+})

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -54,7 +54,7 @@ function Hook (modules, hookOptions, onrequire) {
    * @param {string} moduleName
    * @param {string|undefined} moduleBaseDir
    * @param {string|undefined} moduleVersion
-   * @param {boolean} isIitm
+   * @param {boolean|undefined} isIitm
    */
   const safeHook = (moduleExports, moduleName, moduleBaseDir, moduleVersion, isIitm) => {
     const parts = [moduleBaseDir, moduleName].filter(Boolean)

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -90,13 +90,15 @@ function Hook (modules, hookOptions, onrequire) {
       (typeof defaultExport === 'object' ||
       typeof defaultExport === 'function')
     ) {
-      defaultExportAliases = []
-      for (const exportName of Object.keys(moduleExports)) {
-        if (exportName !== 'default' && moduleExports[exportName] === defaultExport) {
-          defaultExportAliases.push(exportName)
+      defaultWrapResult = wrappedOnrequire(defaultExport, moduleName, moduleBaseDir, moduleVersion, isIitm)
+      if (defaultWrapResult && defaultWrapResult !== defaultExport) {
+        defaultExportAliases = []
+        for (const exportName of Object.keys(moduleExports)) {
+          if (exportName !== 'default' && moduleExports[exportName] === defaultExport) {
+            defaultExportAliases.push(exportName)
+          }
         }
       }
-      defaultWrapResult = wrappedOnrequire(defaultExport, moduleName, moduleBaseDir, moduleVersion, isIitm)
     }
 
     const newExports = wrappedOnrequire(moduleExports, moduleName, moduleBaseDir, moduleVersion, isIitm)

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -49,10 +49,19 @@ function Hook (modules, hookOptions, onrequire) {
   this._patched = Object.create(null)
   const patched = new WeakMap()
 
+  /**
+   * @param {object|Function} moduleExports
+   * @param {string} moduleName
+   * @param {string|undefined} moduleBaseDir
+   * @param {string|undefined} moduleVersion
+   * @param {boolean} isIitm
+   */
   const safeHook = (moduleExports, moduleName, moduleBaseDir, moduleVersion, isIitm) => {
     const parts = [moduleBaseDir, moduleName].filter(Boolean)
     const filename = path.join(...parts)
 
+    const defaultExport = moduleExports.default
+    let defaultExportAliases
     let defaultWrapResult
 
     const wrappedOnrequire = (moduleExports, ...args) => {
@@ -78,16 +87,27 @@ function Hook (modules, hookOptions, onrequire) {
 
     if (
       isIitm &&
-      moduleExports.default &&
-      (typeof moduleExports.default === 'object' ||
-      typeof moduleExports.default === 'function')
+      defaultExport &&
+      (typeof defaultExport === 'object' ||
+      typeof defaultExport === 'function')
     ) {
-      defaultWrapResult = wrappedOnrequire(moduleExports.default, moduleName, moduleBaseDir, moduleVersion, isIitm)
+      defaultExportAliases = []
+      for (const exportName of Object.keys(moduleExports)) {
+        if (exportName !== 'default' && moduleExports[exportName] === defaultExport) {
+          defaultExportAliases.push(exportName)
+        }
+      }
+      defaultWrapResult = wrappedOnrequire(defaultExport, moduleName, moduleBaseDir, moduleVersion, isIitm)
     }
 
     const newExports = wrappedOnrequire(moduleExports, moduleName, moduleBaseDir, moduleVersion, isIitm)
 
-    if (defaultWrapResult) newExports.default = defaultWrapResult
+    if (defaultWrapResult && defaultExportAliases) {
+      newExports.default = defaultWrapResult
+      for (const exportName of defaultExportAliases) {
+        newExports[exportName] = defaultWrapResult
+      }
+    }
 
     this._patched[filename] = true
 

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -50,7 +50,7 @@ function Hook (modules, hookOptions, onrequire) {
   const patched = new WeakMap()
 
   /**
-   * @param {object|Function} moduleExports
+   * @param {object|Function|undefined} moduleExports
    * @param {string} moduleName
    * @param {string|undefined} moduleBaseDir
    * @param {string|undefined} moduleVersion
@@ -60,7 +60,7 @@ function Hook (modules, hookOptions, onrequire) {
     const parts = [moduleBaseDir, moduleName].filter(Boolean)
     const filename = path.join(...parts)
 
-    const defaultExport = moduleExports.default
+    const defaultExport = isIitm && moduleExports.default
     let defaultExportAliases
     let defaultWrapResult
 
@@ -86,7 +86,6 @@ function Hook (modules, hookOptions, onrequire) {
     }
 
     if (
-      isIitm &&
       defaultExport &&
       (typeof defaultExport === 'object' ||
       typeof defaultExport === 'function')
@@ -105,7 +104,7 @@ function Hook (modules, hookOptions, onrequire) {
     if (defaultWrapResult && defaultExportAliases) {
       newExports.default = defaultWrapResult
       for (const exportName of defaultExportAliases) {
-        newExports[exportName] = defaultWrapResult
+        moduleExports[exportName] = defaultWrapResult
       }
     }
 

--- a/packages/datadog-instrumentations/src/process.js
+++ b/packages/datadog-instrumentations/src/process.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { syncBuiltinESMExports } = require('node:module')
+
 const { channel } = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
 
@@ -26,4 +28,5 @@ if (process.setUncaughtExceptionCaptureCallback) {
         return result
       }
     })
+  syncBuiltinESMExports()
 }

--- a/packages/datadog-instrumentations/test/helpers/hook.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/hook.spec.js
@@ -52,4 +52,22 @@ describe('Hook', () => {
     assert.strictEqual(namespace.named, wrapped)
     assert.strictEqual(wrapped.default, wrapped)
   })
+
+  it('does not inspect named ESM exports when the default export is unchanged', () => {
+    const original = sinon.stub()
+    const ownKeys = sinon.stub().returns(['default', 'named'])
+    const namespace = new Proxy({
+      default: original,
+      named: original,
+    }, { ownKeys })
+    const onrequire = sinon.stub()
+    onrequire.withArgs(original).returns(original)
+    onrequire.withArgs(namespace).returns(namespace)
+
+    Hook(['test-package'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'test-package', '/test-package'), namespace)
+    sinon.assert.notCalled(ownKeys)
+  })
 })

--- a/packages/datadog-instrumentations/test/helpers/hook.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/hook.spec.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const proxyquire = require('proxyquire').noCallThru()
+const sinon = require('sinon')
+
+describe('Hook', () => {
+  let Hook
+  let iitm
+  let ritm
+
+  beforeEach(() => {
+    iitm = sinon.stub()
+    ritm = sinon.stub()
+    Hook = proxyquire('../../src/helpers/hook', {
+      '../../../dd-trace/src/iitm': iitm,
+      '../../../dd-trace/src/require-package-json': sinon.stub().returns({ version: '1.0.0' }),
+      '../../../dd-trace/src/ritm': ritm,
+    })
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('does not read ESM exports from a CommonJS hook result', () => {
+    const onrequire = sinon.stub()
+
+    Hook(['test-package'], onrequire)
+
+    const hook = ritm.args[0][2]
+    assert.strictEqual(hook(undefined, 'test-package', '/test-package', '1.0.0'), undefined)
+    sinon.assert.calledOnceWithExactly(onrequire, undefined, 'test-package', '/test-package', '1.0.0', undefined)
+  })
+
+  it('rebinds named aliases on the ESM namespace', () => {
+    const original = sinon.stub()
+    const wrapped = sinon.stub()
+    const namespace = {
+      default: original,
+      named: original,
+    }
+    const onrequire = sinon.stub()
+    onrequire.withArgs(original).returns(wrapped)
+    onrequire.withArgs(namespace).returns(wrapped)
+
+    Hook(['test-package'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'test-package', '/test-package'), wrapped)
+    assert.strictEqual(namespace.named, wrapped)
+    assert.strictEqual(wrapped.default, wrapped)
+  })
+})

--- a/packages/datadog-plugin-ai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ai/test/integration-test/client.spec.js
@@ -33,7 +33,6 @@ function getOpenaiRange (realVersion) {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('ai', 'ai', (version, _, realVersion) => {
     useSandbox([
@@ -48,8 +47,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'generateText', undefined, 'ai', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'generateText',
+      packageName: 'ai',
+      defaultExport: false,
+      namedExports: ['generateText'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -57,7 +60,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('amqp10', 'amqp10', version => {
     useSandbox([`'amqp10@${version}'`, 'rhea'], false, [
@@ -26,8 +25,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'amqp', 'Client', 'amqp10')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'amqp',
+      packageName: 'amqp10',
+      defaultExport: true,
+      namedExports: ['Client'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -35,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -16,15 +16,18 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('amqplib', 'amqplib', '>=0.10.0', version => {
     useSandbox([`'amqplib@${version}'`], false,
       ['./packages/datadog-plugin-amqplib/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'amqplib', 'connect')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'amqplib',
+      packageName: 'amqplib',
+      defaultExport: true,
+      namedExports: ['connect'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-anthropic/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-anthropic/test/integration-test/client.spec.js
@@ -18,7 +18,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('anthropic', ['@anthropic-ai/sdk'], version => {
     useSandbox([
@@ -31,8 +30,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Anthropic', undefined, '@anthropic-ai/sdk')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Anthropic',
+      packageName: '@anthropic-ai/sdk',
+      defaultExport: true,
+      namedExports: ['Anthropic'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -40,7 +43,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-aws-durable-execution-sdk-js/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-durable-execution-sdk-js/test/integration-test/client.spec.js
@@ -22,7 +22,6 @@ const COMPONENT = 'aws-durable-execution-sdk-js'
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // Ride the same SDK version matrix as the unit suite (createIntegrationTestSuite). The local
   // test runner is a separate companion package; like the unit suite (versions/package.json),
@@ -35,8 +34,12 @@ describe('esm', () => {
       './packages/datadog-plugin-aws-durable-execution-sdk-js/test/integration-test/*',
     ])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'withDurableExecution', undefined, '@aws/durable-execution-sdk-js', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'withDurableExecution',
+      packageName: '@aws/durable-execution-sdk-js',
+      defaultExport: false,
+      namedExports: ['withDurableExecution'],
+      namedExportBinding: 'direct',
     })
 
     beforeEach(async () => {
@@ -50,7 +53,7 @@ describe('esm', () => {
 
     // The SDK is instrumented via Orchestrion source rewriting, so the import shape on the
     // consumer side should not matter. Exercise both to guard the ESM rewrite path.
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withAwsSdkV2Versions } = require('../spec_helpers')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withAwsSdkV2Versions(version => {
     useSandbox([`'aws-sdk@${version}'`], false, [
@@ -26,8 +25,11 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'AWS', undefined, 'aws-sdk')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'AWS',
+      packageName: 'aws-sdk',
+      defaultExport: true,
+      namedExports: [],
     })
 
     afterEach(async () => {
@@ -35,7 +37,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-axios/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-axios/test/integration-test/client.spec.js
@@ -15,7 +15,6 @@ const {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   useSandbox(['axios'], false, [
     './packages/datadog-plugin-axios/test/integration-test/*'])
@@ -24,8 +23,11 @@ describe('esm', () => {
     agent = await new FakeAgent().start()
   })
 
-  before(async function () {
-    variants = varySandbox('server.mjs', 'axios')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'axios',
+    packageName: 'axios',
+    defaultExport: true,
+    namedExports: [],
   })
 
   afterEach(async () => {
@@ -34,7 +36,7 @@ describe('esm', () => {
   })
 
   context('axios', () => {
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-azure-cosmos/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/integration-test/client.spec.js
@@ -16,15 +16,18 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   let spawnEnv
 
   withVersions('azure-cosmos', '@azure/cosmos', (version) => {
     useSandbox([`'@azure/cosmos@${version}'`], false, [
       './packages/datadog-plugin-azure-cosmos/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'CosmosClient', undefined, '@azure/cosmos', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'CosmosClient',
+      packageName: '@azure/cosmos',
+      defaultExport: false,
+      namedExports: ['CosmosClient'],
+      namedExportBinding: 'direct',
     })
 
     beforeEach(async () => {
@@ -37,7 +40,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-azure-event-hubs/test/integration-test/core-test/client.spec.js
+++ b/packages/datadog-plugin-azure-event-hubs/test/integration-test/core-test/client.spec.js
@@ -20,7 +20,6 @@ describe('esm', () => {
   let agent
   let proc
   let spawnEnv
-  let variants
 
   withVersions('azure-event-hubs', '@azure/event-hubs', version => {
     useSandbox([`'@azure/event-hubs@${version}'`], false, [
@@ -37,11 +36,15 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'EventHubProducerClient', undefined, '@azure/event-hubs', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'EventHubProducerClient',
+      packageName: '@azure/event-hubs',
+      defaultExport: false,
+      namedExports: ['EventHubProducerClient'],
+      namedExportBinding: 'direct',
     })
 
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-azure-service-bus/test/integration-test/core-test/client.spec.js
+++ b/packages/datadog-plugin-azure-service-bus/test/integration-test/core-test/client.spec.js
@@ -22,7 +22,6 @@ const spawnEnv = {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('azure-service-bus', '@azure/service-bus', version => {
     useSandbox([`'@azure/service-bus@${version}'`], false, [
@@ -33,8 +32,12 @@ describe('esm', () => {
       process.env.DD_TRACE_DISABLED_PLUGINS = 'amqplib,amqp10,rhea,net'
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'ServiceBusClient', undefined, '@azure/service-bus', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'ServiceBusClient',
+      packageName: '@azure/service-bus',
+      defaultExport: false,
+      namedExports: ['ServiceBusClient'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -42,7 +45,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-body-parser/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-body-parser/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('body-parser', 'body-parser', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'body-parser@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-body-parser/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'bodyParser', undefined, 'body-parser')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'bodyParser',
+      packageName: 'body-parser',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('body-parser', 'body-parser', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await axios.post(`${proc.url}/`, { key: 'value' })

--- a/packages/datadog-plugin-bullmq/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bullmq/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('bullmq', 'bullmq', '>=5.66.0', version => {
     useSandbox([`'bullmq@${version}'`], false, [
@@ -32,12 +31,18 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    describe('Queue.add()', () => {
-      beforeEach(async () => {
-        variants = varySandbox('server-queue-add.mjs', 'bullmq', 'Queue')
-      })
+    const queueImportOptions = {
+      bindingName: 'bullmq',
+      packageName: 'bullmq',
+      defaultExport: true,
+      namedExports: ['Queue'],
+      namedExportBinding: 'namespace',
+    }
 
-      for (const variant of varySandbox.VARIANTS) {
+    describe('Queue.add()', () => {
+      const variants = varySandbox('server-queue-add.mjs', queueImportOptions)
+
+      for (const variant of Object.keys(variants)) {
         it(`is instrumented ${variant}`, async () => {
           const res = agent.assertMessageReceived(({ headers, payload }) => {
             assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
@@ -53,11 +58,9 @@ describe('esm', () => {
     })
 
     describe('Queue.addBulk()', () => {
-      beforeEach(async () => {
-        variants = varySandbox('server-queue-add-bulk.mjs', 'bullmq', 'Queue')
-      })
+      const variants = varySandbox('server-queue-add-bulk.mjs', queueImportOptions)
 
-      for (const variant of varySandbox.VARIANTS) {
+      for (const variant of Object.keys(variants)) {
         it(`is instrumented ${variant}`, async () => {
           const res = agent.assertMessageReceived(({ headers, payload }) => {
             assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
@@ -73,11 +76,15 @@ describe('esm', () => {
     })
 
     describe('FlowProducer.add()', () => {
-      beforeEach(async () => {
-        variants = varySandbox('server-flow-producer-add.mjs', 'bullmq', 'FlowProducer')
+      const variants = varySandbox('server-flow-producer-add.mjs', {
+        bindingName: 'bullmq',
+        packageName: 'bullmq',
+        defaultExport: true,
+        namedExports: ['FlowProducer'],
+        namedExportBinding: 'namespace',
       })
 
-      for (const variant of varySandbox.VARIANTS) {
+      for (const variant of Object.keys(variants)) {
         it(`is instrumented ${variant}`, async () => {
           const res = agent.assertMessageReceived(({ headers, payload }) => {
             assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
@@ -97,11 +104,15 @@ describe('esm', () => {
     })
 
     describe('Worker.callProcessJob()', () => {
-      beforeEach(async () => {
-        variants = varySandbox('server-worker-process-job.mjs', 'bullmq', 'Queue, Worker, QueueEvents')
+      const variants = varySandbox('server-worker-process-job.mjs', {
+        bindingName: 'bullmq',
+        packageName: 'bullmq',
+        defaultExport: true,
+        namedExports: ['Queue', 'Worker', 'QueueEvents'],
+        namedExportBinding: 'namespace',
       })
 
-      for (const variant of varySandbox.VARIANTS) {
+      for (const variant of Object.keys(variants)) {
         it(`is instrumented ${variant}`, async () => {
           const res = agent.assertMessageReceived(({ headers, payload }) => {
             assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -15,14 +15,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('bunyan', 'bunyan', version => {
     useSandbox([`'bunyan@${version}'`], false,
       ['./packages/datadog-plugin-bunyan/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'bunyan')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'bunyan',
+      packageName: 'bunyan',
+      defaultExport: true,
+      namedExports: ['createLogger'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -33,7 +36,7 @@ describe('esm', () => {
       await stopProc(proc)
       await agent.stop()
     })
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProcAndExpectExit(
           sandboxCwd(),

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -16,15 +16,18 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
     useSandbox([`'cassandra-driver@${version}'`], false, [
       './packages/datadog-plugin-cassandra-driver/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'cassandra', 'Client', 'cassandra-driver')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'cassandra',
+      packageName: 'cassandra-driver',
+      defaultExport: true,
+      namedExports: ['Client'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-claude-agent-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-claude-agent-sdk/test/integration-test/client.spec.js
@@ -7,7 +7,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { describe, it, before, beforeEach, afterEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 const {
   FakeAgent,
   sandboxCwd,
@@ -19,16 +19,9 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
-// claude-agent-sdk has no default export; base variant is destructure, star is explicit
-const IMPORT_DESTRUCTURE = "import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk'"
-const IMPORT_STAR =
-  "import * as _sdk from '@anthropic-ai/claude-agent-sdk'; " +
-  'const { query, tool, createSdkMcpServer } = _sdk'
-
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('claude-agent-sdk', ['@anthropic-ai/claude-agent-sdk'], version => {
     useSandbox([
@@ -41,11 +34,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', {
-        star: IMPORT_STAR,
-        destructure: IMPORT_DESTRUCTURE,
-      }, undefined, undefined, true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: '_sdk',
+      packageName: '@anthropic-ai/claude-agent-sdk',
+      defaultExport: false,
+      namedExports: ['query', 'tool', 'createSdkMcpServer'],
+      namedExportBinding: 'destructure',
     })
 
     afterEach(async () => {
@@ -53,7 +47,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('confluentinc-kafka-javascript', '@confluentinc/kafka-javascript', version => {
     useSandbox([`'@confluentinc/kafka-javascript@${version}'`], false, [
@@ -27,8 +26,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'kafkaLib', 'KafkaJS', '@confluentinc/kafka-javascript')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'kafkaLib',
+      packageName: '@confluentinc/kafka-javascript',
+      defaultExport: true,
+      namedExports: ['KafkaJS'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -17,14 +17,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   // test against later versions because server.mjs uses newer package syntax
   withVersions('connect', 'connect', version => {
     useSandbox([`'connect@${version}'`], false, [
       './packages/datadog-plugin-connect/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'connect')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'connect',
+      packageName: 'connect',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -36,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-cookie-parser/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cookie-parser/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('cookie-parser', 'cookie-parser', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'cookie-parser@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-cookie-parser/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'cookieParser', undefined, 'cookie-parser')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'cookieParser',
+      packageName: 'cookie-parser',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('cookie-parser', 'cookie-parser', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-cookie/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cookie/test/integration-test/client.spec.js
@@ -23,15 +23,17 @@ withVersions('cookie', 'cookie', (version, _moduleName, resolvedVersion) => {
   describe('ESM', () => {
     if (isEsmOnly && NODE_MAJOR < 22) return
 
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'cookie@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-cookie/test/integration-test/*'])
 
-    before(function () {
-      variants = isEsmOnly
-        ? varySandbox('server-v2.mjs', 'parseCookie', 'parseCookie', 'cookie', true)
-        : varySandbox('server.mjs', 'cookie')
+    const variants = varySandbox(isEsmOnly ? 'server-v2.mjs' : 'server.mjs', {
+      bindingName: isEsmOnly ? 'parseCookie' : 'cookie',
+      packageName: 'cookie',
+      defaultExport: !isEsmOnly,
+      namedExports: isEsmOnly ? ['parseCookie'] : [],
+      namedExportBinding: isEsmOnly ? 'direct' : undefined,
     })
 
     beforeEach(async () => {
@@ -43,8 +45,7 @@ withVersions('cookie', 'cookie', (version, _moduleName, resolvedVersion) => {
       await agent.stop()
     })
 
-    const variantNames = isEsmOnly ? ['star', 'destructure'] : varySandbox.VARIANTS
-    for (const variant of variantNames) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('couchbase', 'couchbase', '>=4.0.0', version => {
@@ -28,8 +27,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'couch', 'connect', 'couchbase')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'couch',
+      packageName: 'couchbase',
+      defaultExport: true,
+      namedExports: ['connect'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -37,7 +40,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-crypto/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-crypto/test/integration-test/client.spec.js
@@ -12,13 +12,17 @@ const {
 } = require('../../../../integration-tests/helpers')
 
 describe('ESM', () => {
-  let variants, proc, agent
+  let proc, agent
 
   useSandbox(['crypto', 'express'], false,
     ['./packages/datadog-plugin-crypto/test/integration-test/*'])
 
-  before(function () {
-    variants = varySandbox('server.mjs', 'crypto', 'createHash', 'node:crypto')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'crypto',
+    packageName: 'node:crypto',
+    defaultExport: true,
+    namedExports: ['createHash'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -30,7 +34,7 @@ describe('ESM', () => {
     await agent.stop()
   })
 
-  for (const variant of varySandbox.VARIANTS) {
+  for (const variant of Object.keys(variants)) {
     it(`is instrumented loaded with ${variant}`, async () => {
       proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
       const response = await curl(proc)

--- a/packages/datadog-plugin-dns/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-dns/test/integration-test/client.spec.js
@@ -15,13 +15,16 @@ const {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   useSandbox([], false, [
     './packages/datadog-plugin-dns/test/integration-test/*'])
 
-  before(async function () {
-    variants = varySandbox('server.mjs', 'dns', 'lookup')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'dns',
+    packageName: 'dns',
+    defaultExport: true,
+    namedExports: ['lookup'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -34,7 +37,7 @@ describe('esm', () => {
   })
 
   context('dns', () => {
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -18,20 +18,19 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // excluding 8.16.0 for esm tests, because it is not working: https://github.com/elastic/elasticsearch-js/issues/2466
   withVersions('elasticsearch', ['@elastic/elasticsearch'], '<8.16.0 || >8.16.0', (version, _, resolvedVersion) => {
+    const hasDefaultExport = semver.satisfies(resolvedVersion, '<9.3.2')
     useSandbox([`'@elastic/elasticsearch@${version}'`], false, [
       './packages/datadog-plugin-elasticsearch/test/integration-test/*'])
 
-    before(async function () {
-      const hasDefaultExport = semver.satisfies(resolvedVersion, '<9.3.2')
-      if (hasDefaultExport) {
-        variants = varySandbox('server.mjs', 'elasticsearch', undefined, '@elastic/elasticsearch')
-      } else {
-        variants = varySandbox('server-v9.mjs', 'Client', undefined, '@elastic/elasticsearch', true)
-      }
+    const variants = varySandbox(hasDefaultExport ? 'server.mjs' : 'server-v9.mjs', {
+      bindingName: hasDefaultExport ? 'elasticsearch' : 'Client',
+      packageName: '@elastic/elasticsearch',
+      defaultExport: hasDefaultExport,
+      namedExports: hasDefaultExport ? [] : ['Client'],
+      namedExportBinding: hasDefaultExport ? undefined : 'direct',
     })
 
     beforeEach(async () => {
@@ -43,12 +42,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
-      it(`is instrumented loaded with ${variant}`, async function () {
-        if (!variants[variant]) {
-          this.skip()
-        }
-
+    for (const variant of Object.keys(variants)) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
           assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)

--- a/packages/datadog-plugin-express-mongo-sanitize/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express-mongo-sanitize/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('express-mongo-sanitize', 'express-mongo-sanitize', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'express-mongo-sanitize@${version}'`, 'express@<=4.0.0'], false,
       ['./packages/datadog-plugin-express-mongo-sanitize/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'expressMongoSanitize', undefined, 'express-mongo-sanitize')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'expressMongoSanitize',
+      packageName: 'express-mongo-sanitize',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('express-mongo-sanitize', 'express-mongo-sanitize', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await axios.get(`${proc.url}/?param=paramvalue`)

--- a/packages/datadog-plugin-express-session/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express-session/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('express-session', 'express-session', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'express-session@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-express-session/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'expressSession', undefined, 'express-session')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'expressSession',
+      packageName: 'express-session',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('express-session', 'express-session', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -19,13 +19,15 @@ describe('esm', () => {
   withVersions('express', 'express', version => {
     let agent
     let proc
-    let variants
 
     useSandbox([`'express@${version}'`], false,
       ['./packages/datadog-plugin-express/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'express')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'express',
+      packageName: 'express',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -36,7 +38,7 @@ describe('esm', () => {
       await stopProc(proc)
       await agent.stop()
     })
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       describe('with DD_TRACE_MIDDLEWARE_TRACING_ENABLED unset', () => {
         it(`is instrumented loaded with ${variant}`, async () => {
           proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -2,27 +2,44 @@
 
 const assert = require('node:assert/strict')
 
-const { join } = require('path')
 const { inspect } = require('node:util')
+
+const semver = require('semver')
+
 const {
   FakeAgent,
   curlAndAssertMessage,
   checkSpansForServiceName,
+  sandboxCwd,
   spawnPluginIntegrationTestProc,
   stopProc,
+  useSandbox,
+  varySandbox,
 } = require('../../../../integration-tests/helpers')
-const { withVersions, insertVersionDep } = require('../../../dd-trace/test/setup/mocha')
+const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 describe('esm', () => {
   let agent
   let proc
   const env = {
-    NODE_OPTIONS: `--loader=${join(__dirname, '..', '..', '..', '..', 'initialize.mjs')}`,
+    NODE_OPTIONS: '--import dd-trace/initialize.mjs',
   }
 
   // skip older versions of fastify due to syntax differences
-  withVersions('fastify', 'fastify', '>=3', (version, _, specificVersion) => {
-    insertVersionDep(__dirname, 'fastify', version)
+  withVersions('fastify', 'fastify', '>=3', (version, _, realVersion) => {
+    useSandbox([`fastify@${version}`], false, [
+      './packages/datadog-plugin-fastify/test/integration-test/*',
+    ])
+
+    const hasNamedExport = semver.satisfies(realVersion, '>=3.9.2')
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'fastify',
+      packageName: 'fastify',
+      defaultExport: true,
+      namedExports: hasNamedExport ? ['fastify'] : [],
+      namedExportBinding: hasNamedExport ? 'direct' : undefined,
+    })
 
     beforeEach(async () => {
       agent = await new FakeAgent().start()
@@ -33,30 +50,22 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(__dirname, 'server.mjs', agent.port, env)
+    for (const variant of Object.keys(variants)) {
+      it(`is instrumented with ${variant} import`, async () => {
+        proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port, env)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
-        assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
-        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
-      })
-    }).timeout(20000)
+        await curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
+          assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
+          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+        })
+      }).timeout(20000)
+    }
 
-    it('* import fastify is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(__dirname, 'server1.mjs', agent.port, env)
+    it('is instrumented through the default export property', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandboxCwd(), 'server2.mjs', agent.port, env)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
-        assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
-        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
-      })
-    }).timeout(20000)
-
-    it('Fastify import fastify is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(__dirname, 'server2.mjs', agent.port, env)
-
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+      await curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
         assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
         assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
         assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)

--- a/packages/datadog-plugin-fastify/test/integration-test/server1.mjs
+++ b/packages/datadog-plugin-fastify/test/integration-test/server1.mjs
@@ -1,6 +1,0 @@
-import * as Fastify from 'fastify'
-import { createAndStartServer } from './helper.mjs'
-
-const app = Fastify.default()
-
-createAndStartServer(app)

--- a/packages/datadog-plugin-generic-pool/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-generic-pool/test/integration-test/client.spec.js
@@ -14,13 +14,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('generic-pool', 'generic-pool', '<3', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'generic-pool@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-generic-pool/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'genericPool', undefined, 'generic-pool')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'genericPool',
+      packageName: 'generic-pool',
+      defaultExport: true,
+      namedExports: ['Pool'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -32,7 +36,7 @@ withVersions('generic-pool', 'generic-pool', '<3', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   // test against later versions because server.mjs uses newer package syntax
   withVersions('google-cloud-pubsub', '@google-cloud/pubsub', '>=4.0.0', version => {
     useSandbox([`'@google-cloud/pubsub@${version}'`], false, ['./packages/dd-trace/src/id.js',
@@ -27,8 +26,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'pubLib', 'PubSub', '@google-cloud/pubsub')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'pubLib',
+      packageName: '@google-cloud/pubsub',
+      defaultExport: true,
+      namedExports: ['PubSub'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-google-cloud-vertexai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('google-cloud-vertexai', '@google-cloud/vertexai', '>=1', version => {
     useSandbox([
@@ -31,8 +30,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'vertexLib', 'VertexAI', '@google-cloud/vertexai')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'vertexLib',
+      packageName: '@google-cloud/vertexai',
+      defaultExport: true,
+      namedExports: ['VertexAI'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -40,7 +43,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-google-genai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-genai/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('google-genai', ['@google/genai'], version => {
     useSandbox([
@@ -30,8 +29,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'GoogleGenAI', undefined, '@google/genai', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'GoogleGenAI',
+      packageName: '@google/genai',
+      defaultExport: false,
+      namedExports: ['GoogleGenAI'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -39,7 +42,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['destructure', 'star']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('graphql', 'graphql', version => {
     useSandbox([`'graphql@${version}'`], false, [
@@ -26,9 +25,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'graphqlLib', 'GraphQLSchema, GraphQLString, graphql, GraphQLObjectType',
-        'graphql')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'graphqlLib',
+      packageName: 'graphql',
+      defaultExport: true,
+      namedExports: ['GraphQLSchema', 'GraphQLString', 'graphql', 'GraphQLObjectType'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -36,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -18,7 +18,6 @@ const { NODE_MAJOR } = require('../../../../version')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('grpc', '@grpc/grpc-js', NODE_MAJOR >= 25 ? '>=1.3.0' : '*', version => {
     useSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader'], false, [
@@ -29,9 +28,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'grpc', 'loadPackageDefinition, Server, ServerCredentials, credentials',
-        '@grpc/grpc-js')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'grpc',
+      packageName: '@grpc/grpc-js',
+      defaultExport: true,
+      namedExports: ['loadPackageDefinition', 'Server', 'ServerCredentials', 'credentials'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -39,7 +41,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-handlebars/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-handlebars/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('handlebars', 'handlebars', '>=4.0.0', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'handlebars@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-handlebars/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'Handlebars', undefined, 'handlebars')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Handlebars',
+      packageName: 'handlebars',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('handlebars', 'handlebars', '>=4.0.0', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
@@ -19,7 +19,6 @@ const { assertObjectContains } = require('../../../../integration-tests/helpers'
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('hapi', '@hapi/hapi', version => {
     useSandbox([`'@hapi/hapi@${version}'`], false, [
@@ -29,8 +28,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async () => {
-      variants = varySandbox('server.mjs', 'Hapi', 'server', '@hapi/hapi')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Hapi',
+      packageName: '@hapi/hapi',
+      defaultExport: true,
+      namedExports: ['server'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -38,7 +41,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-hono/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hono/test/integration-test/client.spec.js
@@ -15,7 +15,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm integration test', () => {
   let agent
   let proc
-  let variants
 
   withVersions('hono', 'hono', (range, _moduleName_, version) => {
     useSandbox([`'hono@${range}'`, '@hono/node-server@1.15.0'], false,
@@ -25,8 +24,12 @@ describe('esm integration test', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Hono', undefined, 'hono', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Hono',
+      packageName: 'hono',
+      defaultExport: false,
+      namedExports: ['Hono'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -34,7 +37,7 @@ describe('esm integration test', () => {
       await agent.stop()
     })
 
-    for (const variant of ['destructure', 'star']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port, {
           VERSION: version,

--- a/packages/datadog-plugin-http/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http/test/integration-test/client.spec.js
@@ -15,7 +15,6 @@ const {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   useSandbox([], false, [
     './packages/datadog-plugin-http/test/integration-test/*'])
@@ -24,8 +23,12 @@ describe('esm', () => {
     agent = await new FakeAgent().start()
   })
 
-  before(async function () {
-    variants = varySandbox('server.mjs', 'http', 'createServer')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'http',
+    packageName: 'http',
+    defaultExport: true,
+    namedExports: ['createServer'],
+    namedExportBinding: 'namespace',
   })
 
   afterEach(async () => {
@@ -34,7 +37,7 @@ describe('esm', () => {
   })
 
   context('http', () => {
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-http2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/integration-test/client.spec.js
@@ -16,13 +16,16 @@ const {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   useSandbox(['http2'], false, [
     './packages/datadog-plugin-http2/test/integration-test/*'])
 
-  before(async function () {
-    variants = varySandbox('server.mjs', 'http2', 'createServer')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'http2',
+    packageName: 'http2',
+    defaultExport: true,
+    namedExports: ['createServer'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -35,7 +38,7 @@ describe('esm', () => {
   })
 
   context('http2', () => {
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const resultPromise = agent.assertMessageReceived(({ headers, payload }) => {

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -25,8 +25,7 @@ describe('esm', () => {
       bindingName: 'Redis',
       packageName: 'ioredis',
       defaultExport: true,
-      namedExports: ['Redis'],
-      namedExportBinding: 'direct',
+      namedExports: [],
     })
 
     beforeEach(async () => {

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -17,13 +17,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   withVersions('ioredis', 'ioredis', version => {
     useSandbox([`'ioredis@${version}'`], false, [
       './packages/datadog-plugin-ioredis/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Redis', undefined, 'ioredis')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Redis',
+      packageName: 'ioredis',
+      defaultExport: true,
+      namedExports: ['Redis'],
+      namedExportBinding: 'direct',
     })
 
     beforeEach(async () => {
@@ -35,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-iovalkey/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-iovalkey/test/integration-test/client.spec.js
@@ -30,8 +30,7 @@ describe('esm', () => {
       bindingName: 'Valkey',
       packageName: 'iovalkey',
       defaultExport: true,
-      namedExports: ['Valkey'],
-      namedExportBinding: 'direct',
+      namedExports: [],
     })
 
     afterEach(async () => {

--- a/packages/datadog-plugin-iovalkey/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-iovalkey/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('iovalkey', 'iovalkey', version => {
     useSandbox([`'iovalkey@${version}'`], false, [
@@ -27,8 +26,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Valkey', undefined, 'iovalkey')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Valkey',
+      packageName: 'iovalkey',
+      defaultExport: true,
+      namedExports: ['Valkey'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('kafkajs', 'kafkajs', version => {
     useSandbox([`'kafkajs@${version}'`], false, [
@@ -26,8 +25,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'kafkaLib', 'Kafka', 'kafkajs')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'kafkaLib',
+      packageName: 'kafkajs',
+      defaultExport: true,
+      namedExports: ['Kafka'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -35,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-knex/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-knex/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('knex', 'knex', (version, _, resolvedVersion) => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     // knex 1.x routes the `sqlite3` client through the @vscode/sqlite3 fork; every other major uses sqlite3.
     const sqlite3Driver = semver.satisfies(resolvedVersion, '1.x') ? '@vscode/sqlite3' : 'sqlite3'
@@ -25,8 +25,11 @@ withVersions('knex', 'knex', (version, _, resolvedVersion) => {
     useSandbox([`'knex@${version}'`, 'express', sqlite3Driver], false,
       ['./packages/datadog-plugin-knex/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'knex')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'knex',
+      packageName: 'knex',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -38,7 +41,7 @@ withVersions('knex', 'knex', (version, _, resolvedVersion) => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('koa', 'koa', version => {
     useSandbox([`'koa@${version}'`], false,
@@ -32,11 +31,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Koa', undefined, 'koa')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Koa',
+      packageName: 'koa',
+      defaultExport: true,
+      namedExports: [],
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // TODO(sabrenner, MLOB-4410): follow-up on re-enabling this test in a different PR once a fix lands
   withVersions('langchain', ['@langchain/core'], '>=0.1 <1.0.0', version => {
@@ -31,8 +30,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'StringOutputParser', undefined, '@langchain/core/output_parsers', true)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'StringOutputParser',
+      packageName: '@langchain/core/output_parsers',
+      defaultExport: false,
+      namedExports: ['StringOutputParser'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -40,7 +43,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['star', 'destructure']) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-ldapjs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ldapjs/test/integration-test/client.spec.js
@@ -23,8 +23,7 @@ withVersions('ldapjs', 'ldapjs', '>=2', version => {
       bindingName: 'ldapjs',
       packageName: 'ldapjs',
       defaultExport: true,
-      namedExports: ['createClient'],
-      namedExportBinding: 'namespace',
+      namedExports: [],
     })
 
     beforeEach(async () => {

--- a/packages/datadog-plugin-ldapjs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ldapjs/test/integration-test/client.spec.js
@@ -14,13 +14,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('ldapjs', 'ldapjs', '>=2', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'ldapjs@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-ldapjs/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'ldapjs')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'ldapjs',
+      packageName: 'ldapjs',
+      defaultExport: true,
+      namedExports: ['createClient'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -32,7 +36,7 @@ withVersions('ldapjs', 'ldapjs', '>=2', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-light-my-request/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-light-my-request/test/integration-test/client.spec.js
@@ -2,6 +2,9 @@
 
 const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
+
+const semver = require('semver')
+
 const {
   FakeAgent,
   sandboxCwd,
@@ -16,9 +19,8 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
-  withVersions('light-my-request', 'light-my-request', version => {
+  withVersions('light-my-request', 'light-my-request', (version, _, realVersion) => {
     useSandbox([`'light-my-request@${version}'`], false, [
       './packages/datadog-plugin-light-my-request/test/integration-test/*'])
 
@@ -26,8 +28,14 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'inject', undefined, 'light-my-request')
+    const hasNamedExport = semver.satisfies(realVersion, '>=4.0.0')
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'inject',
+      packageName: 'light-my-request',
+      defaultExport: true,
+      namedExports: hasNamedExport ? ['inject'] : [],
+      namedExportBinding: hasNamedExport ? 'direct' : undefined,
     })
 
     afterEach(async () => {
@@ -35,12 +43,12 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
           assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mariadb.query'), true)
+          assert.strictEqual(checkSpansForServiceName(payload, 'web.request'), true)
         })
 
         proc = await spawnPluginIntegrationTestProcAndExpectExit(sandboxCwd(), variants[variant], agent.port)

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -16,14 +16,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('limitd-client', 'limitd-client', version => {
     useSandbox([`'limitd-client@${version}'`], false, [
       './packages/datadog-plugin-limitd-client/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'LimitdClient', undefined, 'limitd-client')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'LimitdClient',
+      packageName: 'limitd-client',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -34,7 +36,7 @@ describe('esm', () => {
       await stopProc(proc)
       await agent.stop()
     })
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-lodash/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-lodash/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('lodash', 'lodash', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'lodash@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-lodash/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'lodash')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'lodash',
+      packageName: 'lodash',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('lodash', 'lodash', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('mariadb', 'mariadb', '>=3.0.0', version => {
@@ -27,8 +26,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'mariadb', 'createPool')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'mariadb',
+      packageName: 'mariadb',
+      defaultExport: true,
+      namedExports: ['createPool'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('memcached', 'memcached', version => {
     useSandbox([`'memcached@${version}'`], false, [
@@ -31,11 +30,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Memcached', undefined, 'memcached')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Memcached',
+      packageName: 'memcached',
+      defaultExport: true,
+      namedExports: [],
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mercurius/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mercurius/test/integration-test/client.spec.js
@@ -20,7 +20,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // mercurius 15+ ships fastify 5, which requires Node 20.9+; restrict to the
   // 13/14 line on older Node so the oldest-LTS CI leg does not sandbox an
@@ -34,8 +33,11 @@ describe('esm', () => {
     useSandbox([`'mercurius@${version}'`, `'${fastifyDep}'`], false, [
       './packages/datadog-plugin-mercurius/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'mercurius')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'mercurius',
+      packageName: 'mercurius',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -47,7 +49,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('microgateway-core', 'microgateway-core', '>=3.0.0', version => {
@@ -28,8 +27,11 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'Gateway', undefined, 'microgateway-core')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'Gateway',
+      packageName: 'microgateway-core',
+      defaultExport: true,
+      namedExports: [],
     })
 
     afterEach(async () => {
@@ -37,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('moleculer', 'moleculer', '>0.14.0', version => {
@@ -28,8 +27,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'moleculer', 'ServiceBroker')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'moleculer',
+      packageName: 'moleculer',
+      defaultExport: true,
+      namedExports: ['ServiceBroker'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -37,7 +40,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -16,14 +16,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   // test against later versions because server.mjs uses newer package syntax
   withVersions('mongodb-core', 'mongodb', '>=4', version => {
     useSandbox([`'mongodb@${version}'`], false, [
       './packages/datadog-plugin-mongodb-core/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'mongodb', 'MongoClient')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'mongodb',
+      packageName: 'mongodb',
+      defaultExport: true,
+      namedExports: ['MongoClient'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -35,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
@@ -55,8 +58,11 @@ describe('esm', () => {
     useSandbox([`'mongodb-core@${version}'`], false, [
       './packages/datadog-plugin-mongodb-core/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server2.mjs', 'MongoDBCore', undefined, 'mongodb-core')
+    const variants = varySandbox('server2.mjs', {
+      bindingName: 'MongoDBCore',
+      packageName: 'mongodb-core',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -68,7 +74,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -13,6 +13,8 @@ const { withNamingSchema, withPeerService, withVersions } = require('../../dd-tr
 const { temporaryWarningExceptions } = require('../../dd-trace/test/setup/core')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
+const traceTimeoutMs = 2_000
+
 const withTopologies = fn => {
   withVersions('mongodb-core', 'mongodb', '>=2', (version, moduleName, resolvedVersion) => {
     describe('using the default topology', () => {
@@ -134,7 +136,10 @@ describe('Plugin', () => {
                   'out.host': '127.0.0.1',
                   component: 'mongodb',
                 },
-              }, { spanResourceMatch: new RegExp(`^insert test\\.${collectionName}$`) })
+              }, {
+                spanResourceMatch: new RegExp(`^insert test\\.${collectionName}$`),
+                timeoutMs: traceTimeoutMs,
+              })
               .then(done)
               .catch(done)
 
@@ -215,7 +220,10 @@ describe('Plugin', () => {
                 `insert test.${collectionName}`,
                 `update test.${collectionName}`,
               ].sort())
-            }, { spanResourceMatch: /^bulkWrite test\./ })
+            }, {
+              spanResourceMatch: /^bulkWrite test\./,
+              timeoutMs: traceTimeoutMs,
+            })
           })
 
           it('should tag the bulkWrite span when the operation fails', async () => {
@@ -273,7 +281,10 @@ describe('Plugin', () => {
                 // The bulkWrite span has finished by the time the callback runs, so a span
                 // started there must nest under the original parent, not the bulkWrite span.
                 assert.strictEqual(child.parent_id.toString(), parentSpan.context().toSpanId())
-              }, { spanResourceMatch: /^bulkWrite test\./ })
+              }, {
+                spanResourceMatch: /^bulkWrite test\./,
+                timeoutMs: traceTimeoutMs,
+              })
 
               tracer.scope().activate(parentSpan, () => {
                 collection.bulkWrite([{ insertOne: { document: { a: 1 } } }], {}, () => {
@@ -623,7 +634,7 @@ describe('Plugin', () => {
             .assertSomeTraces(traces => {
               assert.strictEqual(traces[0][0].name, expectedSchema.outbound.opName)
               assert.strictEqual(traces[0][0].service, 'custom')
-            })
+            }, { timeoutMs: traceTimeoutMs })
             .then(done)
             .catch(done)
 

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -25,8 +25,7 @@ describe('esm', () => {
       bindingName: 'mongoose',
       packageName: 'mongoose',
       defaultExport: true,
-      namedExports: ['Schema', 'model', 'connect', 'disconnect'],
-      namedExportBinding: 'namespace',
+      namedExports: [],
     })
 
     beforeEach(async () => {

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -16,14 +16,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('mongoose', ['mongoose'], '>=4', version => {
     useSandbox([`'mongoose@${version}'`], false, [
       './packages/datadog-plugin-mongoose/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'mongoose')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'mongoose',
+      packageName: 'mongoose',
+      defaultExport: true,
+      namedExports: ['Schema', 'model', 'connect', 'disconnect'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -34,7 +37,7 @@ describe('esm', () => {
       await stopProc(proc)
       await agent.stop()
     })
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-multer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-multer/test/integration-test/client.spec.js
@@ -14,13 +14,16 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('multer', 'multer', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'multer@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-multer/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'multer')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'multer',
+      packageName: 'multer',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -32,7 +35,7 @@ withVersions('multer', 'multer', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await axios.post(`${proc.url}/upload`, { key: 'value' })

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -17,14 +17,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('mysql', 'mysql', version => {
     useSandbox([`'mysql@${version}'`], false, [
       './packages/datadog-plugin-mysql/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'mysql', 'createConnection')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'mysql',
+      packageName: 'mysql',
+      defaultExport: true,
+      namedExports: ['createConnection'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('mysql2', 'mysql2', version => {
     useSandbox([`'mysql2@${version}'`], false, [
@@ -27,8 +26,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'mysql', 'createConnection', 'mysql2')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'mysql',
+      packageName: 'mysql2',
+      defaultExport: true,
+      namedExports: ['createConnection'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-net/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-net/test/integration-test/client.spec.js
@@ -15,13 +15,16 @@ const {
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   useSandbox(['net'], false, [
     './packages/datadog-plugin-net/test/integration-test/*'])
 
-  before(async function () {
-    variants = varySandbox('server.mjs', 'net', 'createConnection')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'net',
+    packageName: 'net',
+    defaultExport: true,
+    namedExports: ['createConnection'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -34,7 +37,7 @@ describe('esm', () => {
   })
 
   context('net', () => {
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -27,7 +27,6 @@ const min = NODE_MAJOR >= 25 ? '>=13' : '>=11.1'
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // These next versions have a dependency which uses a deprecated node buffer and match versions tested with unit tests
   withVersions('next', 'next', min, (version, _, realVersion) => {
@@ -48,7 +47,13 @@ describe('esm', () => {
           NODE_OPTIONS: legacyOpenssl.trim(),
         },
       })
-      variants = varySandbox('server.mjs', 'next')
+    })
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'next',
+      packageName: 'next',
+      defaultExport: true,
+      namedExports: [],
     })
 
     beforeEach(async () => {
@@ -60,7 +65,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port, {
           NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init${legacyOpenssl}`,

--- a/packages/datadog-plugin-node-serialize/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-node-serialize/test/integration-test/client.spec.js
@@ -14,13 +14,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('node-serialize', 'node-serialize', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'node-serialize@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-node-serialize/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'lib', 'unserialize, serialize', 'node-serialize')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'lib',
+      packageName: 'node-serialize',
+      defaultExport: true,
+      namedExports: ['unserialize', 'serialize'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -32,7 +36,7 @@ withVersions('node-serialize', 'node-serialize', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // limit v4 tests while the IITM issue is resolved or a workaround is introduced
   // this is only relevant for `openai` >=4.0 <=4.1
@@ -37,8 +36,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'OpenAI', undefined, 'openai')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'OpenAI',
+      packageName: 'openai',
+      defaultExport: true,
+      namedExports: ['OpenAI'],
+      namedExportBinding: 'direct',
     })
 
     afterEach(async () => {
@@ -46,7 +49,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
 
+const semver = require('semver')
+
 const {
   FakeAgent,
   sandboxCwd,
@@ -20,7 +22,7 @@ describe('esm', () => {
   // limit v4 tests while the IITM issue is resolved or a workaround is introduced
   // this is only relevant for `openai` >=4.0 <=4.1
   // issue link: https://github.com/DataDog/import-in-the-middle/issues/60
-  withVersions('openai', 'openai', '>=3 <4.0.0 || >4.1.0', (version) => {
+  withVersions('openai', 'openai', '>=3 <4.0.0 || >4.1.0', (version, _, realVersion) => {
     useSandbox(
       [
         `'openai@${version}'`,
@@ -36,12 +38,14 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
+    const hasNamedExport = semver.satisfies(realVersion, '>=4')
+
     const variants = varySandbox('server.mjs', {
       bindingName: 'OpenAI',
       packageName: 'openai',
       defaultExport: true,
-      namedExports: ['OpenAI'],
-      namedExportBinding: 'direct',
+      namedExports: hasNamedExport ? ['OpenAI'] : [],
+      namedExportBinding: hasNamedExport ? 'direct' : undefined,
     })
 
     afterEach(async () => {

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('opensearch', '@opensearch-project/opensearch', version => {
     useSandbox([`'@opensearch-project/opensearch@${version}'`], false, [
@@ -26,8 +25,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'opensearch', 'Client', '@opensearch-project/opensearch')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'opensearch',
+      packageName: '@opensearch-project/opensearch',
+      defaultExport: true,
+      namedExports: ['Client'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -35,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('oracledb', 'oracledb', version => {
     useSandbox([`'oracledb@${version}'`], false, [
@@ -27,8 +26,11 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'oracledb', undefined)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'oracledb',
+      packageName: 'oracledb',
+      defaultExport: true,
+      namedExports: [],
     })
 
     afterEach(async () => {
@@ -36,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-passport-http/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-passport-http/test/integration-test/client.spec.js
@@ -14,13 +14,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('passport-http', 'passport-http', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox(['passport', `passport-http@${version}`, 'express'], false,
       ['./packages/datadog-plugin-passport-http/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'passportHttp', 'BasicStrategy', 'passport-http')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'passportHttp',
+      packageName: 'passport-http',
+      defaultExport: true,
+      namedExports: ['BasicStrategy'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -32,7 +36,7 @@ withVersions('passport-http', 'passport-http', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -18,22 +18,19 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('pg', 'pg', (version, _, realVersion) => {
     useSandbox([`'pg@${version}'`], false, [
       './packages/datadog-plugin-pg/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', {
-        default: 'import pg from \'pg\'',
-        star: semver.satisfies(realVersion, '<8.15.0')
-          ? 'import * as mod from \'pg\'; const pg = { Client: mod.Client || mod.default.Client }'
-          : 'import * as pg from \'pg\';',
-        destructure: semver.satisfies(realVersion, '<8.15.0')
-          ? 'import { default as pg } from \'pg\';'
-          : 'import { Client } from \'pg\'; const pg = { Client }',
-      })
+    const hasNamedExport = semver.satisfies(realVersion, '>=8.15.0')
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'pg',
+      packageName: 'pg',
+      defaultExport: true,
+      namedExports: hasNamedExport ? ['Client'] : [],
+      namedExportBinding: hasNamedExport ? 'namespace' : undefined,
     })
 
     beforeEach(async () => {
@@ -45,7 +42,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -2,6 +2,9 @@
 
 const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
+
+const semver = require('semver')
+
 const {
   FakeAgent,
   spawnPluginIntegrationTestProcAndExpectExit,
@@ -15,14 +18,19 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
-  withVersions('pino', 'pino', version => {
+  withVersions('pino', 'pino', (version, _, realVersion) => {
     useSandbox([`'pino@${version}'`],
       false, ['./packages/datadog-plugin-pino/test/integration-test/*'])
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'pino')
+    const hasNamedExport = semver.satisfies(realVersion, '>=6.8.0')
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'pino',
+      packageName: 'pino',
+      defaultExport: true,
+      namedExports: hasNamedExport ? ['pino'] : [],
+      namedExportBinding: hasNamedExport ? 'direct' : undefined,
     })
 
     beforeEach(async () => {
@@ -34,7 +42,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProcAndExpectExit(
           sandboxCwd(),

--- a/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
@@ -63,7 +63,6 @@ const prismaClientConfigs = [{
   schema: `./packages/datadog-plugin-prisma/test/${SCHEMA_FIXTURES.clientJs}`,
   serverFile: 'server.mjs',
   importPath: '@prisma/client',
-  variant: 'default',
   env: {
     PRISMA_TEST_DATABASE_URL: TEST_DATABASE_URL,
   },
@@ -74,7 +73,6 @@ const prismaClientConfigs = [{
   importPath: './generated/prisma/index.js',
   schema: `./packages/datadog-plugin-prisma/test/${SCHEMA_FIXTURES.clientOutputJs}`,
   env: { PRISMA_CLIENT_OUTPUT: './generated/prisma', PRISMA_TEST_DATABASE_URL: TEST_DATABASE_URL },
-  variant: 'star',
 },
 {
   name: 'prisma-generator v6 postgres',
@@ -86,7 +84,6 @@ const prismaClientConfigs = [{
     DATABASE_URL: TEST_DATABASE_URL,
   },
   ts: true,
-  variant: 'star',
 },
 {
   name: 'prisma-generator v7 pg adapter (url)',
@@ -99,7 +96,6 @@ const prismaClientConfigs = [{
     DATABASE_URL: TEST_DATABASE_URL,
   },
   ts: true,
-  variant: 'destructure',
 },
 {
   name: 'prisma-generator v7 pg adapter (fields)',
@@ -113,7 +109,6 @@ const prismaClientConfigs = [{
     PRISMA_PG_ADAPTER_CONFIG: 'fields',
   },
   ts: true,
-  variant: 'star',
 },
 {
   name: 'prisma-generator v6 mongodb',
@@ -127,7 +122,6 @@ const prismaClientConfigs = [{
   ts: true,
   waitForService: waitForMongoReplicaSet,
   skipMigrateReset: true,
-  variant: 'destructure',
   // mongodb@7.2 dropped Node 18 (crypto.getRandomValues is not a global there).
   skip: () => !semifies(semver.clean(process.version), '>=20.19.0'),
   dbSpan: {
@@ -151,7 +145,6 @@ const prismaClientConfigs = [{
     DATABASE_URL: TEST_MARIADB_DATABASE_URL,
   },
   ts: true,
-  variant: 'star',
   dbSpan: {
     name: 'mariadb.query',
     meta: {
@@ -173,7 +166,6 @@ const prismaClientConfigs = [{
   },
   ts: true,
   waitForService: waitForMssql,
-  variant: 'destructure',
   dbSpan: {
     name: 'tedious.request',
     meta: {
@@ -196,7 +188,6 @@ const prismaClientConfigs = [{
   },
   ts: true,
   waitForService: waitForMssql,
-  variant: 'star',
   dbSpan: {
     name: 'tedious.request',
     meta: {
@@ -260,7 +251,6 @@ describe('esm', () => {
 
       withVersions('prisma', '@prisma/client', supportedRange, version => {
         if (config.ts && version === '6.1.0') return
-        let variants
         const paths = ['./packages/datadog-plugin-prisma/test/integration-test/*', config.schema]
 
         if (isPrismaV7) paths.push(config.configFile)
@@ -277,15 +267,15 @@ describe('esm', () => {
 
         useSandbox(deps, false, paths)
 
-        if (!config.customTest) {
-          before(function () {
-            variants = varySandbox(config.serverFile, config.ts ? 'PrismaClient' : 'prismaLib',
-              config.ts ? 'PrismaClient' : undefined, config.importPath, config.ts)
-            if (!variants[config.variant]) {
-              throw new Error(`Unknown variant ${config.variant} for ${config.name}`)
-            }
+        const variants = config.customTest
+          ? undefined
+          : varySandbox(config.serverFile, {
+            bindingName: config.ts ? 'PrismaClient' : 'prismaLib',
+            packageName: config.importPath,
+            defaultExport: !config.ts,
+            namedExports: config.ts ? ['PrismaClient'] : [],
+            namedExportBinding: config.ts ? 'direct' : undefined,
           })
-        }
 
         before(function () {
           this.timeout(60000)
@@ -356,41 +346,39 @@ describe('esm', () => {
             proc = await config.customTest.run({ agent, config })
           })
         } else {
-          const variant = config.variant
-          it(`is instrumented with ${variant} import`, async function () {
-            this.timeout(60000)
-            const dbSpanExpectation = config.dbSpan || {
-              name: config.configFile ? 'pg.query' : 'prisma.engine',
-              service: config.configFile ? 'node-postgres' : 'node-prisma',
-              meta: {
-                'db.user': 'postgres',
-                'db.name': 'postgres',
-                'db.type': 'postgres',
-              },
-            }
-            const res = agent.assertMessageReceived(({ headers, payload }) => {
-              assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
-              assertObjectContains(payload, [[{
-                name: 'prisma.client',
-                resource: 'User.create',
-                service: 'node-prisma',
-              }], [dbSpanExpectation]])
+          for (const variant of Object.keys(variants)) {
+            it(`is instrumented with ${variant} import`, async function () {
+              this.timeout(60000)
+              const dbSpanExpectation = config.dbSpan || {
+                name: config.configFile ? 'pg.query' : 'prisma.engine',
+                service: config.configFile ? 'node-postgres' : 'node-prisma',
+                meta: {
+                  'db.user': 'postgres',
+                  'db.name': 'postgres',
+                  'db.type': 'postgres',
+                },
+              }
+              const res = agent.assertMessageReceived(({ headers, payload }) => {
+                assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
+                assertObjectContains(payload, [[{
+                  name: 'prisma.client',
+                  resource: 'User.create',
+                  service: 'node-prisma',
+                }], [dbSpanExpectation]])
+              })
+
+              const [childProcess] = await Promise.all([
+                spawnPluginIntegrationTestProcAndExpectExit(
+                  sandboxCwd(),
+                  variants[variant],
+                  agent.port,
+                  { DD_TRACE_FLUSH_INTERVAL: '2000', ...config.env }
+                ),
+                res,
+              ])
+              proc = childProcess
             })
-
-            const procPromise = spawnPluginIntegrationTestProcAndExpectExit(
-              sandboxCwd(),
-              variants[variant],
-              agent.port,
-              { DD_TRACE_FLUSH_INTERVAL: '2000', ...config.env }
-            )
-
-            await Promise.all([
-              procPromise.then((res) => {
-                proc = res
-              }),
-              res,
-            ])
-          })
+          }
         }
       })
     })

--- a/packages/datadog-plugin-process/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-process/test/integration-test/client.spec.js
@@ -12,13 +12,17 @@ const {
 } = require('../../../../integration-tests/helpers')
 
 describe('ESM', () => {
-  let variants, proc, agent
+  let proc, agent
 
   useSandbox(['process', 'express'], false,
     ['./packages/datadog-plugin-process/test/integration-test/*'])
 
-  before(function () {
-    variants = varySandbox('server.mjs', 'process', undefined, 'node:process')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'process',
+    packageName: 'node:process',
+    defaultExport: true,
+    namedExports: ['setUncaughtExceptionCaptureCallback'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -30,7 +34,7 @@ describe('ESM', () => {
     await agent.stop()
   })
 
-  for (const variant of varySandbox.VARIANTS) {
+  for (const variant of Object.keys(variants)) {
     it(`is instrumented loaded with ${variant}`, async () => {
       proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
       const response = await curl(proc)

--- a/packages/datadog-plugin-process/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-process/test/integration-test/server.mjs
@@ -19,5 +19,5 @@ app.get('/', (req, res) => {
 
 const server = app.listen(0, () => {
   const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-  process.send({ port })
+  globalThis.process.send({ port })
 })

--- a/packages/datadog-plugin-pug/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pug/test/integration-test/client.spec.js
@@ -14,13 +14,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('pug', 'pug', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'pug@${version}'`, 'express'], false,
       ['./packages/datadog-plugin-pug/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'pug')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'pug',
+      packageName: 'pug',
+      defaultExport: true,
+      namedExports: ['compile'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -32,7 +36,7 @@ withVersions('pug', 'pug', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -17,7 +17,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   // test against later versions because server.mjs uses newer package syntax
   withVersions('redis', 'redis', '>=4', version => {
     useSandbox([`'redis@${version}'`], false, [
@@ -27,8 +26,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'redis', 'createClient')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'redis',
+      packageName: 'redis',
+      defaultExport: true,
+      namedExports: ['createClient'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -36,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -18,7 +18,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // restify 7.x-9.x crash on load on this job's Node >=18 matrix: they assign the now getter-only
   // `IncomingMessage#closed` (`TypeError: Cannot set property closed`). 4.x-6.x predate that assignment
@@ -32,8 +31,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'restify', 'createServer')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'restify',
+      packageName: 'restify',
+      defaultExport: true,
+      namedExports: ['createServer'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -41,7 +44,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('rhea', 'rhea', version => {
     useSandbox([`'rhea@${version}'`], false, [
@@ -26,8 +25,11 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'container', undefined, 'rhea')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'container',
+      packageName: 'rhea',
+      defaultExport: true,
+      namedExports: [],
     })
 
     afterEach(async () => {
@@ -35,7 +37,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -18,7 +18,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   withVersions('router', 'router', version => {
     useSandbox([`'router@${version}'`]
@@ -28,8 +27,11 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'router', undefined)
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'router',
+      packageName: 'router',
+      defaultExport: true,
+      namedExports: [],
     })
 
     afterEach(async () => {
@@ -37,7 +39,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
 

--- a/packages/datadog-plugin-sequelize/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sequelize/test/integration-test/client.spec.js
@@ -14,13 +14,17 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 
 withVersions('sequelize', 'sequelize', version => {
   describe('ESM', () => {
-    let variants, proc, agent
+    let proc, agent
 
     useSandbox([`'sequelize@${version}'`, 'sqlite3', 'express'], false,
       ['./packages/datadog-plugin-sequelize/test/integration-test/*'])
 
-    before(function () {
-      variants = varySandbox('server.mjs', 'sequelizeLib', 'Sequelize', 'sequelize')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'sequelizeLib',
+      packageName: 'sequelize',
+      defaultExport: true,
+      namedExports: ['Sequelize'],
+      namedExportBinding: 'namespace',
     })
 
     beforeEach(async () => {
@@ -32,7 +36,7 @@ withVersions('sequelize', 'sequelize', version => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
         const response = await curl(proc)

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -16,7 +16,6 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
   // test against later versions because server.mjs uses newer package syntax
   withVersions('sharedb', 'sharedb', '>=3', version => {
     useSandbox([`'sharedb@${version}'`], false, [
@@ -26,8 +25,11 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'ShareDB', undefined, 'sharedb')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'ShareDB',
+      packageName: 'sharedb',
+      defaultExport: true,
+      namedExports: [],
     })
 
     afterEach(async () => {
@@ -35,7 +37,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -23,7 +23,6 @@ const describe = version.NODE_MAJOR >= 20
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
   withVersions('tedious', 'tedious', '>=16.0.0', version => {
@@ -34,8 +33,12 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'tds', 'Connection, Request', 'tedious')
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'tds',
+      packageName: 'tedious',
+      defaultExport: true,
+      namedExports: ['Connection', 'Request'],
+      namedExportBinding: 'namespace',
     })
 
     afterEach(async () => {
@@ -43,7 +46,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-url/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-url/test/integration-test/client.spec.js
@@ -12,13 +12,17 @@ const {
 } = require('../../../../integration-tests/helpers')
 
 describe('ESM', () => {
-  let variants, proc, agent
+  let proc, agent
 
   useSandbox(['url', 'express'], false,
     ['./packages/datadog-plugin-url/test/integration-test/*'])
 
-  before(function () {
-    variants = varySandbox('server.mjs', 'urlLib', 'URL', 'node:url')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'urlLib',
+    packageName: 'node:url',
+    defaultExport: true,
+    namedExports: ['URL'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -30,7 +34,7 @@ describe('ESM', () => {
     await agent.stop()
   })
 
-  for (const variant of varySandbox.VARIANTS) {
+  for (const variant of Object.keys(variants)) {
     it(`is instrumented loaded with ${variant}`, async () => {
       proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
       const response = await curl(proc)

--- a/packages/datadog-plugin-vm/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-vm/test/integration-test/client.spec.js
@@ -12,13 +12,17 @@ const {
 } = require('../../../../integration-tests/helpers')
 
 describe('ESM', () => {
-  let variants, proc, agent
+  let proc, agent
 
   useSandbox(['vm', 'express'], false,
     ['./packages/datadog-plugin-vm/test/integration-test/*'])
 
-  before(function () {
-    variants = varySandbox('server.mjs', 'vmLib', 'runInThisContext', 'node:vm')
+  const variants = varySandbox('server.mjs', {
+    bindingName: 'vmLib',
+    packageName: 'node:vm',
+    defaultExport: true,
+    namedExports: ['runInThisContext'],
+    namedExportBinding: 'namespace',
   })
 
   beforeEach(async () => {
@@ -30,7 +34,7 @@ describe('ESM', () => {
     await agent.stop()
   })
 
-  for (const variant of varySandbox.VARIANTS) {
+  for (const variant of Object.keys(variants)) {
     it(`is instrumented loaded with ${variant}`, async () => {
       proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
       const response = await curl(proc)

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -2,6 +2,9 @@
 
 const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
+
+const semver = require('semver')
+
 const {
   FakeAgent,
   sandboxCwd,
@@ -15,10 +18,9 @@ const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 describe('esm', () => {
   let agent
   let proc
-  let variants
 
   // test against later versions because server.mjs uses newer package syntax
-  withVersions('winston', 'winston', '>=3', version => {
+  withVersions('winston', 'winston', '>=3', (version, _, realVersion) => {
     useSandbox([`'winston@${version}'`]
       , false, ['./packages/datadog-plugin-winston/test/integration-test/*'])
 
@@ -26,8 +28,14 @@ describe('esm', () => {
       agent = await new FakeAgent().start()
     })
 
-    before(async function () {
-      variants = varySandbox('server.mjs', 'winston', undefined)
+    const hasNamedExports = semver.satisfies(realVersion, '>=3.4.0')
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'winston',
+      packageName: 'winston',
+      defaultExport: true,
+      namedExports: hasNamedExports ? ['createLogger', 'format', 'transports'] : [],
+      namedExportBinding: hasNamedExports ? 'namespace' : undefined,
     })
 
     afterEach(async () => {
@@ -35,7 +43,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.VARIANTS) {
+    for (const variant of Object.keys(variants)) {
       it(`is instrumented ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProcAndExpectExit(
           sandboxCwd(),


### PR DESCRIPTION
Named ESM imports could retain the original function because IITM only replaced the default binding after instrumentation. Preserve aliases that reference the original default export and synchronize patched builtin exports so every supported import form observes instrumentation.

Fixes: https://github.com/DataDog/dd-trace-js/issues/9421