### PR TITLE
fix(core): defer module-load crypto RNG for restricted global scopes (Cloudflare Workers)

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -40,7 +40,15 @@ const {
 const { normalizeService } = require('./normalize-service')
 const { programmaticTypeCoercions, transformers } = require('./parsers')
 
-const RUNTIME_ID = uuid()
+let runtimeId
+
+// Computing this at module load would call crypto RNG in global scope, which Cloudflare Workers forbid.
+function getRuntimeId () {
+  if (runtimeId === undefined) {
+    runtimeId = uuid()
+  }
+  return runtimeId
+}
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
 
@@ -560,7 +568,7 @@ class Config extends ConfigBase {
     if (this.version) {
       this.tags.version = this.version
     }
-    this.tags['runtime-id'] = RUNTIME_ID
+    this.tags['runtime-id'] = getRuntimeId()
 
     if (IS_SERVERLESS) {
       setAndTrack(this, 'telemetry.DD_INSTRUMENTATION_TELEMETRY_ENABLED', false)

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -4,9 +4,16 @@ const Scope = require('../noop/scope')
 const Span = require('./span')
 
 class NoopTracer {
+  #span
+
   constructor (config) {
     this._scope = new Scope()
-    this._span = new Span(this)
+  }
+
+  // Eager construction would call crypto RNG at module load, which Cloudflare Workers forbid in global scope.
+  get _span () {
+    this.#span ??= new Span(this)
+    return this.#span
   }
 
   configure (options) {}

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -4972,3 +4972,21 @@ rules:
     })
   })
 })
+
+describe('RUNTIME_ID lazy init', () => {
+  it('does not call uuid at module load and memoizes on first config build', () => {
+    const uuidStub = sinon.stub().returns('fake-runtime-id')
+    const getConfig = proxyquire('../../src/config', {
+      '../../../../vendor/dist/crypto-randomuuid': uuidStub,
+    })
+
+    assert.ok(uuidStub.notCalled, 'uuid must not be called at module load (global-scope RNG)')
+
+    const config = getConfig({})
+    assert.strictEqual(uuidStub.callCount, 1, 'uuid called once on first config build')
+    assert.strictEqual(config.tags['runtime-id'], 'fake-runtime-id')
+
+    getConfig({})
+    assert.strictEqual(uuidStub.callCount, 1, 'subsequent getConfig() reuses the cached config; uuid not called again')
+  })
+})

--- a/packages/dd-trace/test/noop.spec.js
+++ b/packages/dd-trace/test/noop.spec.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict')
 
 const { describe, it, beforeEach } = require('mocha')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
 
 require('./setup/core')
 const Span = require('../src/noop/span')
@@ -49,5 +51,35 @@ describe('NoopTracer', () => {
       assert.strictEqual(typeof span.context().toSpanId, 'function')
       assert.match(span.context().toSpanId(), /^\d+$/)
     })
+  })
+})
+
+describe('NoopTracer lazy span', () => {
+  let idSpy
+  let LazyNoopTracer
+
+  beforeEach(() => {
+    const realId = require('../src/id')
+    // Named function (not an arrow) so the spy has an own `.prototype` for proxyquire's key-copying.
+    idSpy = sinon.spy(function (...args) { return realId(...args) })
+    const NoopSpan = proxyquire('../src/noop/span', { '../id': idSpy })
+    LazyNoopTracer = proxyquire('../src/noop/tracer', { './span': NoopSpan })
+  })
+
+  it('does not generate a span id when constructed', () => {
+    // eslint-disable-next-line no-new
+    new LazyNoopTracer()
+    assert.ok(idSpy.notCalled, 'id() must not be called at construction (global-scope RNG)')
+  })
+
+  it('generates the span lazily on first use and reuses it', () => {
+    const tracer = new LazyNoopTracer()
+    const first = tracer.startSpan('test')
+    assert.ok(first, 'startSpan returns a span')
+    assert.ok(idSpy.called, 'id() is called on first span use')
+    const callsAfterFirst = idSpy.callCount
+    const second = tracer.startSpan('test')
+    assert.strictEqual(second, first, 'same shared noop span is reused')
+    assert.strictEqual(idSpy.callCount, callsAfterFirst, 'no new id() on reuse')
   })
 })


### PR DESCRIPTION
### What does this PR do?

Makes the two crypto-RNG side effects that run at `require('dd-trace')` time lazy, so importing the tracer performs no randomness at module-load (global) scope:

- **Noop tracer span** — now built on first use via a lazy `#span` getter, instead of in the constructor. The constructor previously created a `NoopSpan`, which generated a span ID via `crypto.randomFillSync` at module load.
- **`RUNTIME_ID`** — now computed by a memoized `getRuntimeId()` read from the `Config` constructor, instead of `const RUNTIME_ID = uuid()` at config module load.

Behavior is unchanged on Node: identical span IDs and a single process-stable `runtime-id`. The per-span hot path (`packages/dd-trace/src/id.js`) is intentionally untouched.

### Motivation

Some JavaScript runtimes forbid randomness, timers, and I/O during top-level (global-scope) module evaluation — most notably **Cloudflare Workers** (`workerd`), and Node's own startup-snapshot builder (`--snapshot-blob`). Today `require('dd-trace')` calls `crypto.randomFillSync` / `randomUUID` at module load (via the eager noop span and `RUNTIME_ID`), which throws in those environments before any user code runs. Deferring both to first use — which happens inside a request/handler context — lets the tracer be imported there.

Part of exploring Cloudflare Workers support (#1892). This change stands on its own as a portability fix for any bundled/snapshotted deployment.

### Additional Notes

- **`semver-patch`** — no public API change; behavior-preserving on Node.
- Both changes are surgical and backportable. `id.js` (per-span hot path) is untouched, so there is no per-span perf impact.
- **Tests**: new coverage asserts `require`-time performs no RNG (`uuid`/`id()` not called until the first `Config`/span is built), the noop span is built lazily and reused, and the `runtime-id` tag is still populated once.
