### PR TITLE
fix(core): tolerate partial AsyncLocalStorage at load for restricted runtimes

### DIFF
--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -46,10 +46,17 @@ class DatadogStorage extends AsyncLocalStorage {
 // `enterWith`, without ACF `run` does not.
 const isACFActive = (() => {
   let active = false
-  const als = new AsyncLocalStorage()
-  als.enterWith = () => { active = true }
-  als.run(1, () => {})
-  als.disable()
+  try {
+    const als = new AsyncLocalStorage()
+    als.enterWith = () => { active = true }
+    als.run(1, () => {})
+    als.disable()
+  } catch {
+    // Runtimes with a partial ALS (e.g. Cloudflare Workers: enterWith/disable
+    // unimplemented) behave like ACF — the value lives in the context frame,
+    // not the resource — so use native run/getStore and skip the pre-ACF path.
+    return true
+  }
   return active
 })()
 

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const { executionAsyncResource } = require('async_hooks')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
 
 require('../../dd-trace/test/setup/core')
 const { storage } = require('../src/storage')
@@ -85,6 +86,63 @@ describe('storage', () => {
   it('should report no store once entered with undefined', () => {
     testStorage.enterWith({ span: 'x' })
     testStorage.enterWith(undefined)
+
+    assert.strictEqual(testStorage.getStore(), undefined)
+  })
+})
+
+describe('storage with a partial AsyncLocalStorage (e.g. Cloudflare Workers)', () => {
+  // Mirrors workerd: `run()`/`getStore()` are implemented natively, but
+  // `enterWith()`/`disable()` throw, which crashes the module-load ACF probe.
+  class PartialAsyncLocalStorage {
+    #store
+
+    run (store, fn, ...args) {
+      const prior = this.#store
+      this.#store = store
+      try {
+        return fn(...args)
+      } finally {
+        this.#store = prior
+      }
+    }
+
+    getStore () {
+      return this.#store
+    }
+
+    enterWith () {
+      throw new Error('not implemented')
+    }
+
+    disable () {
+      throw new Error('not implemented')
+    }
+  }
+
+  const requireStorage = () => proxyquire.noPreserveCache()('../src/storage', {
+    async_hooks: { AsyncLocalStorage: PartialAsyncLocalStorage },
+  })
+
+  it('should not throw when required', () => {
+    requireStorage()
+  })
+
+  it('should treat the runtime as ACF-active', () => {
+    const { isACFActive } = requireStorage()
+
+    assert.strictEqual(isACFActive, true)
+  })
+
+  it('should run and get a store via the native path, without the WeakMap fallback', () => {
+    // Would throw here if the pre-ACF fallback drove enterWith() manually.
+    const { storage: partialStorage } = requireStorage()
+    const testStorage = partialStorage('partial')
+    const store = { span: 'native' }
+
+    testStorage.run(store, () => {
+      assert.strictEqual(testStorage.getStore(), store)
+    })
 
     assert.strictEqual(testStorage.getStore(), undefined)
   })


### PR DESCRIPTION
### What does this PR do?

Third in a stack making dd-trace-js loadable in Cloudflare Workers (`workerd`). It makes `datadog-core`'s AsyncContextFrame-detection probe tolerate a runtime whose `AsyncLocalStorage` implements `run()`/`getStore()` natively but throws on `disable()`/`enterWith()` (workerd). The module-scope probe is now wrapped so such a runtime is treated as **ACF-active**: dd-trace uses the native `run`/`getStore` and skips the pre-ACF WeakMap fallback (which would call the unimplemented native `enterWith`). Previously the probe called `AsyncLocalStorage.prototype.disable()` at module load and crashed `require('dd-trace')`.

Behavior on Node is **exactly unchanged** — `disable()` succeeds on Node, so the probe returns the identical value as before for both ACF and pre-ACF backends (the added `catch` is unreachable there).

**Scope:** this makes load + init + a **flat span** work in workerd. It does **not** provide a working `enterWith`, so span parenting via `scope.activate()` remains unsupported on partial-ALS runtimes — a tracked follow-up.

### Motivation

Stacked on #9440 (and #9437). `require('dd-trace')` threw at module load in `workerd` because the ACF probe calls `AsyncLocalStorage.prototype.disable()`, which workerd doesn't implement. Part of exploring Cloudflare Workers support (#1892).

### Additional Notes

- **Stacked PR** — base branch is `brian.marks/cf-bundler-globals` (#9440), not `master`. Single commit.
- `semver-patch`, behavior-preserving on Node, backportable. Node non-regression verified across the datadog-core storage, scope, and tracer specs.
- New unit test stubs a partial `AsyncLocalStorage` (native `run`/`getStore`, throwing `enterWith`/`disable`) and asserts: module load doesn't throw, the probe resolves ACF-active, and native `run`/`getStore` are used with no WeakMap fallback installed.
