### PR TITLE
fix(core): guard FinalizationRegistry/WeakRef for runtimes that lack them

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
@@ -4,6 +4,7 @@ const { getMessageSize } = require('../../dd-trace/src/datastreams')
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
 const SpanContext = require('../../dd-trace/src/opentracing/span_context')
 const id = require('../../dd-trace/src/id')
+const { createFinalizationRegistry, createWeakRef } = require('../../dd-trace/src/util')
 const { storage } = require('../../datadog-core')
 
 /**
@@ -19,7 +20,7 @@ const { storage } = require('../../datadog-core')
 const messageToContext = new WeakMap() // Message -> context (auto-cleanup on GC)
 const ackIdToMessage = new Map() // ackId -> WeakRef<Message> (needs cleanup)
 
-const ackMapCleanup = new FinalizationRegistry((ackId) => {
+const ackMapCleanup = createFinalizationRegistry((ackId) => {
   ackIdToMessage.delete(ackId) // Remove orphaned ackId when Message is GC'd
 })
 
@@ -41,7 +42,7 @@ class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
 
       if (currentStore) {
         messageToContext.set(message, currentStore)
-        ackIdToMessage.set(ackId, new WeakRef(message))
+        ackIdToMessage.set(ackId, createWeakRef(message))
         ackMapCleanup.register(message, ackId, message)
       }
     })

--- a/packages/datadog-plugin-google-cloud-pubsub/test/consumer.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/consumer.spec.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
+
+describe('google-cloud-pubsub consumer', () => {
+  describe('when FinalizationRegistry is unavailable', () => {
+    let realFinalizationRegistry
+
+    afterEach(() => {
+      globalThis.FinalizationRegistry = realFinalizationRegistry
+    })
+
+    it('should not throw when the module is loaded', () => {
+      realFinalizationRegistry = globalThis.FinalizationRegistry
+      delete globalThis.FinalizationRegistry
+
+      let caught
+      try {
+        proxyquire('../src/consumer', {})
+      } catch (e) {
+        caught = e
+      }
+
+      assert.strictEqual(caught, undefined)
+    })
+  })
+})

--- a/packages/dd-trace/src/appsec/store.js
+++ b/packages/dd-trace/src/appsec/store.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { storage } = require('../../../datadog-core')
+const { createWeakRef } = require('../util')
 
 const legacyStorage = storage('legacy')
 
@@ -19,7 +20,7 @@ const kReq = Symbol('dd-trace.appsec.req')
  * @returns {object}
  */
 function withRequest (store, req) {
-  return { ...store, [kReq]: new WeakRef(req) }
+  return { ...store, [kReq]: createWeakRef(req) }
 }
 
 /**

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -9,6 +9,7 @@ const id = require('../id')
 const tagger = require('../tagger')
 const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
+const { createFinalizationRegistry } = require('../util')
 const { storage } = require('../../../datadog-core')
 const { resolveServiceSource } = require('../service-naming/source-resolver')
 const telemetryMetrics = require('../telemetry/metrics')
@@ -458,7 +459,7 @@ class DatadogSpan {
 }
 
 function createRegistry (type) {
-  return new global.FinalizationRegistry(name => {
+  return createFinalizationRegistry(name => {
     runtimeMetrics.decrement(`runtime.node.spans.${type}`)
     runtimeMetrics.decrement(`runtime.node.spans.${type}.by.name`, [`span_name:${name}`])
   })

--- a/packages/dd-trace/src/spanleak.js
+++ b/packages/dd-trace/src/spanleak.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-console */
 
 const SortedSet = require('../../../vendor/dist/tlhunter-sorted-set')
+const { createWeakRef } = require('./util')
 
 const INTERVAL = 1000 // look for expired spans every 1s
 const LIFETIME = 60 * 1000 // all spans have a max lifetime of 1m
@@ -83,7 +84,7 @@ module.exports.addSpan = function (span) {
 
   const now = Date.now()
   const expiration = now + LIFETIME
-  const wrapped = new WeakRef(span)
+  const wrapped = createWeakRef(span) // without WeakRef, this pins the span until the scrubber's interval clears it
   spans.add(wrapped, expiration)
 }
 

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -32,6 +32,27 @@ function isError (value) {
   return Boolean(value?.message || value instanceof Error)
 }
 
+// Returns a real FinalizationRegistry, or a no-op stand-in on runtimes without it.
+/**
+ * @param {(heldValue: unknown) => void} callback
+ * @returns {FinalizationRegistry<unknown>|object}
+ */
+function createFinalizationRegistry (callback) {
+  return typeof FinalizationRegistry === 'function'
+    ? new FinalizationRegistry(callback)
+    : { register () {}, unregister () {} }
+}
+
+// Returns a real WeakRef, or a strong-reference stand-in with the same deref() shape.
+/**
+ * @template T
+ * @param {T} target
+ * @returns {WeakRef<T>|{ deref: () => T }}
+ */
+function createWeakRef (target) {
+  return typeof WeakRef === 'function' ? new WeakRef(target) : { deref: () => target }
+}
+
 // Matches a glob pattern to a given subject string
 function globMatch (pattern, subject) {
   if (typeof pattern === 'string') pattern = pattern.toLowerCase()
@@ -109,6 +130,8 @@ module.exports = {
   isTrue,
   isFalse,
   isError,
+  createFinalizationRegistry,
+  createWeakRef,
   globMatch,
   ddBasePath: globalThis.__DD_ESBUILD_BASEPATH || calculateDDBasePath(__dirname),
   normalizePluginEnvName,

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -679,4 +679,51 @@ describe('Span', () => {
       })
     })
   })
+
+  describe('when FinalizationRegistry is unavailable', () => {
+    let realFinalizationRegistry
+
+    beforeEach(() => {
+      realFinalizationRegistry = global.FinalizationRegistry
+      delete global.FinalizationRegistry
+    })
+
+    afterEach(() => {
+      global.FinalizationRegistry = realFinalizationRegistry
+    })
+
+    it('should not throw when the module is loaded', () => {
+      let caught
+      try {
+        proxyquire('../../src/opentracing/span', {
+          perf_hooks: { performance: { now } },
+          '../id': id,
+          '../tagger': tagger,
+        })
+      } catch (e) {
+        caught = e
+      }
+      assert.strictEqual(caught, undefined)
+    })
+
+    it('should fall back to a no-op registry so span counts do not throw', () => {
+      const NoRegistrySpan = proxyquire('../../src/opentracing/span', {
+        perf_hooks: { performance: { now } },
+        '../id': id,
+        '../tagger': tagger,
+      })
+      const spanCountsTracer = { _config: { ...getConfig(), DD_TRACE_EXPERIMENTAL_SPAN_COUNTS: true } }
+      const noRegistrySpan = new NoRegistrySpan(spanCountsTracer, processor, prioritySampler, {
+        operationName: 'operation',
+      })
+
+      let caught
+      try {
+        noRegistrySpan.finish()
+      } catch (e) {
+        caught = e
+      }
+      assert.strictEqual(caught, undefined)
+    })
+  })
 })

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 
 require('./setup/core')
-const { isEmpty, isTrue, isFalse, globMatch } = require('../src/util')
+const { isEmpty, isTrue, isFalse, globMatch, createFinalizationRegistry, createWeakRef } = require('../src/util')
 
 const TRUES = [
   1,
@@ -78,5 +78,54 @@ describe('util', () => {
     assert.strictEqual(isEmpty(Object.assign(Object.create({ inherited: 1 }), { own: 2 })), false)
     // `for-in` walks inherited enumerable keys, so a prototype-only object counts as non-empty.
     assert.strictEqual(isEmpty(Object.create({ inherited: 1 })), false)
+  })
+
+  describe('createFinalizationRegistry', () => {
+    it('returns a real FinalizationRegistry when the global is available', () => {
+      const registry = createFinalizationRegistry(() => {})
+
+      assert.ok(registry instanceof FinalizationRegistry)
+    })
+
+    it('falls back to a no-op registry when the global is unavailable', () => {
+      const real = globalThis.FinalizationRegistry
+      delete globalThis.FinalizationRegistry
+      let registry
+      try {
+        registry = createFinalizationRegistry(() => {})
+      } finally {
+        globalThis.FinalizationRegistry = real
+      }
+
+      assert.strictEqual(typeof registry.register, 'function')
+      assert.strictEqual(typeof registry.unregister, 'function')
+      registry.register({}, 'heldValue')
+      registry.unregister({})
+    })
+  })
+
+  describe('createWeakRef', () => {
+    it('returns a real WeakRef when the global is available', () => {
+      const target = {}
+      const ref = createWeakRef(target)
+
+      assert.ok(ref instanceof WeakRef)
+      assert.strictEqual(ref.deref(), target)
+    })
+
+    it('falls back to a strong-reference stand-in when the global is unavailable', () => {
+      const real = globalThis.WeakRef
+      delete globalThis.WeakRef
+      const target = {}
+      let ref
+      try {
+        ref = createWeakRef(target)
+      } finally {
+        globalThis.WeakRef = real
+      }
+
+      assert.strictEqual(typeof ref.deref, 'function')
+      assert.strictEqual(ref.deref(), target)
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Guards dd-trace's use of `FinalizationRegistry` and `WeakRef` so `require('dd-trace')` doesn't crash in runtimes that don't expose those globals. When either global is absent, dd-trace falls back to a no-op stand-in (same shape) instead of throwing at module load:

- `packages/dd-trace/src/opentracing/span.js` — the `createRegistry()` calls (this was a hard crash-at-`require` in such runtimes).
- `packages/datadog-plugin-google-cloud-pubsub/src/consumer.js`, `packages/dd-trace/src/appsec/store.js`, `packages/dd-trace/src/spanleak.js` — the same pattern.
- Shared `createFinalizationRegistry` / `createWeakRef` helpers added to `packages/dd-trace/src/util.js`.

The fallback only degrades a GC-cleanup optimization (memory-only; `spanleak`'s opt-in debug tracker pins spans until its scrubber interval when `WeakRef` is absent). **Behavior on Node is exactly unchanged** — the feature-detect resolves to the real globals, evaluated once at registry creation (no per-span overhead).

### Motivation

`FinalizationRegistry`/`WeakRef` aren't universally available: Cloudflare Workers (`workerd`) omits them below a certain `compatibility_date`, and hardened/bundled/snapshot runtimes may too. In those environments `new FinalizationRegistry(...)` at module scope throws `TypeError: ... is not a constructor`, crashing `require('dd-trace')` before any user code runs. Standalone robustness fix; also complements the Cloudflare Workers support effort (#1892).

### Additional Notes

- `semver-patch`, behavior-preserving on Node, backportable. No new public API.
- Independent of the Workers PR stack (touches different code); mergeable on its own.
- Unit tests set `globalThis.FinalizationRegistry`/`WeakRef` to `undefined`, require fresh, and assert no throw + working no-op; the normal (global-present) path is unchanged.
