### PR TITLE
feat(core): add public tracer.flush() API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -286,6 +286,26 @@ function handle (a, b, c, callback) {
 const handleWithTrace = tracer.wrap('web.request', handle)
 ```
 
+<h3 id="tracer-flush">tracer.flush()</h3>
+
+This method flushes any buffered/pending spans immediately, without waiting for the usual flush interval, and returns a promise that resolves once the resulting export completes. It resolves immediately (without exporting anything) if there is nothing to flush, for example before `init()` is called or when tracing is disabled, and it never rejects.
+
+This is useful in serverless and isolate runtimes, where the process can freeze or exit before the tracer's normal timer-based flush has a chance to run. For example, in a Cloudflare Worker:
+
+```javascript
+export default {
+  async fetch (request, env, ctx) {
+    const response = await tracer.trace('handle.request', () => handleRequest(request))
+
+    ctx.waitUntil(tracer.flush())
+
+    return response
+  }
+}
+```
+
+`tracer.flush()` only waits on the trace exporter. If a separate exporter is active for another signal (for example the OTel span-stats exporter enabled via `OTEL_TRACES_SPAN_METRICS_ENABLED`), `tracer.flush()` does not currently wait on it.
+
 <h3 id="scope-manager">tracer.scope()</h3>
 
 In order to provide context propagation, this library includes a scope manager available with `tracer.scope()`. A scope is basically a wrapper around a span that can cross both synchronous and asynchronous contexts.

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -454,6 +454,8 @@ tracer.wrap('test', (foo: string) => 'test')
 
 promise = tracer.wrap('test', () => Promise.resolve())()
 
+promise = tracer.flush()
+
 const carrier = {}
 
 tracer.inject(span, HTTP_HEADERS, carrier);

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,20 @@ interface Tracer extends opentracing.Tracer {
   setUrl (url: string): this;
 
   /**
+   * Flushes any buffered/pending spans immediately, without waiting for the
+   * usual flush interval, and resolves once the resulting export completes.
+   *
+   * Resolves immediately (without exporting anything) if there is nothing to
+   * flush, e.g. before `init()` is called or when tracing is disabled. Never
+   * rejects.
+   *
+   * Useful in serverless/isolate runtimes (e.g. `ctx.waitUntil(tracer.flush())`
+   * in Cloudflare Workers, or as part of a Lambda/graceful shutdown handler) to
+   * ensure spans are sent before the runtime freezes or exits.
+   */
+  flush (): Promise<void>;
+
+  /**
    * Enable and optionally configure a plugin.
    * @param plugin The name of a built-in plugin.
    * @param config Configuration options. Can also be `false` to disable the plugin.

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -67,6 +67,20 @@ interface Tracer extends opentracing.Tracer {
   setUrl (url: string): this;
 
   /**
+   * Flushes any buffered/pending spans immediately, without waiting for the
+   * usual flush interval, and resolves once the resulting export completes.
+   *
+   * Resolves immediately (without exporting anything) if there is nothing to
+   * flush, e.g. before `init()` is called or when tracing is disabled. Never
+   * rejects.
+   *
+   * Useful in serverless/isolate runtimes (e.g. `ctx.waitUntil(tracer.flush())`
+   * in Cloudflare Workers, or as part of a Lambda/graceful shutdown handler) to
+   * ensure spans are sent before the runtime freezes or exits.
+   */
+  flush (): Promise<void>;
+
+  /**
    * Enable and optionally configure a plugin.
    * @param plugin The name of a built-in plugin.
    * @param config Configuration options. Can also be `false` to disable the plugin.

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -4,6 +4,7 @@ const { features } = require('../feature-registry')
 const NoopAppsecSdk = require('../appsec/sdk/noop')
 const NoopLLMObsSDK = require('../llmobs/noop')
 const NoopAIGuardSDK = require('../aiguard/noop')
+const log = require('../log')
 const NoopDogStatsDClient = require('./dogstatsd')
 const NoopTracer = require('./tracer')
 
@@ -76,6 +77,21 @@ class NoopProxy {
   setUrl () {
     this._tracer.setUrl.apply(this._tracer, arguments)
     return this
+  }
+
+  // Public flush(); see Tracer#flush in index.d.ts for the contract.
+  /**
+   * @returns {Promise<void>}
+   */
+  flush () {
+    return new Promise((resolve) => {
+      try {
+        this._tracer.flush(() => resolve())
+      } catch (error) {
+        log.error('Error flushing tracer:', error)
+        resolve()
+      }
+    })
   }
 
   startSpan () {

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -29,6 +29,14 @@ class NoopTracer {
 
   setUrl () {}
 
+  /**
+   * @param {Function} [done] - Callback invoked immediately, since there is nothing to flush.
+   * @returns {void}
+   */
+  flush (done = () => {}) {
+    done()
+  }
+
   startSpan (name, options) {
     return this._span
   }

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -20,6 +20,8 @@ const legacyStorage = storage('legacy')
  */
 class OtlpHttpExporterBase {
   #transport = https
+  #pendingRequests = 0
+  #flushCallbacks = []
 
   /**
    * Creates a new OtlpHttpExporterBase instance.
@@ -88,6 +90,17 @@ class OtlpHttpExporterBase {
       },
     }
 
+    this.#pendingRequests++
+    let settled = false
+    const onResult = (result) => {
+      // destroy() on timeout can still trigger a later 'error' for the same request; guard against double-counting.
+      if (settled) return
+      settled = true
+      this.#pendingRequests--
+      resultCallback(result)
+      this.#notifyFlushWaiters()
+    }
+
     legacyStorage.run({ noop: true }, () => {
       const req = this.#transport.request(options, (res) => {
         let data = ''
@@ -99,28 +112,54 @@ class OtlpHttpExporterBase {
         res.once('end', () => {
           // @ts-expect-error - res.statusCode can be undefined
           if (res.statusCode >= 200 && res.statusCode < 300) {
-            resultCallback({ code: 0 })
+            onResult({ code: 0 })
           } else {
             const error = new Error(`HTTP ${res.statusCode}: ${data}`)
-            resultCallback({ code: 1, error })
+            onResult({ code: 1, error })
           }
         })
       })
 
       req.on('error', (error) => {
         log.error('Error sending OTLP %s:', this.signalType, error)
-        resultCallback({ code: 1, error })
+        onResult({ code: 1, error })
       })
 
       req.once('timeout', () => {
         req.destroy()
         const error = new Error('Request timeout')
-        resultCallback({ code: 1, error })
+        onResult({ code: 1, error })
       })
 
       req.write(payload)
       req.end()
     })
+  }
+
+  /**
+   * Resolves any callbacks registered through {@link flush} once every in-flight export
+   * request for this exporter has completed.
+   */
+  #notifyFlushWaiters () {
+    if (this.#pendingRequests !== 0 || this.#flushCallbacks.length === 0) return
+
+    const callbacks = this.#flushCallbacks
+    this.#flushCallbacks = []
+    for (const callback of callbacks) callback()
+  }
+
+  /**
+   * export() sends immediately, so flush() waits for in-flight requests rather than triggering a send.
+   *
+   * @param {Function} [done] - Callback invoked once all in-flight exports for this signal complete.
+   * @returns {void}
+   */
+  flush (done = () => {}) {
+    if (this.#pendingRequests === 0) {
+      done()
+    } else {
+      this.#flushCallbacks.push(done)
+    }
   }
 
   /**

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -132,6 +132,23 @@ class DatadogTracer {
       return null
     }
   }
+
+  /**
+   * @param {Function} [done]
+   * @returns {void}
+   */
+  flush (done = () => {}) {
+    try {
+      if (typeof this._exporter.flush === 'function') {
+        this._exporter.flush(done)
+      } else {
+        done()
+      }
+    } catch (error) {
+      log.error('Error flushing exporter:', error)
+      done()
+    }
+  }
 }
 
 /**

--- a/packages/dd-trace/test/noop.spec.js
+++ b/packages/dd-trace/test/noop.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 
 const { describe, it, beforeEach } = require('mocha')
+const sinon = require('sinon')
 
 require('./setup/core')
 const Span = require('../src/noop/span')
@@ -48,6 +49,20 @@ describe('NoopTracer', () => {
       assert.match(span.context().toTraceId(), /^\d+$/)
       assert.strictEqual(typeof span.context().toSpanId, 'function')
       assert.match(span.context().toSpanId(), /^\d+$/)
+    })
+  })
+
+  describe('flush', () => {
+    it('should call the done callback synchronously', () => {
+      const done = sinon.spy()
+
+      tracer.flush(done)
+
+      sinon.assert.calledOnce(done)
+    })
+
+    it('should not throw when called without a callback', () => {
+      tracer.flush()
     })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/otlp/otlp_http_exporter_base.spec.js
+++ b/packages/dd-trace/test/opentelemetry/otlp/otlp_http_exporter_base.spec.js
@@ -1,0 +1,169 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const http = require('node:http')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+require('../../setup/core')
+
+const OtlpHttpExporterBase = require('../../../src/opentelemetry/otlp/otlp_http_exporter_base')
+
+function respondWith (callback, statusCode = 200) {
+  const res = {
+    statusCode,
+    on: (event, handler) => { if (event === 'data') handler('') },
+    once: (event, handler) => { if (event === 'end') handler() },
+  }
+  callback(res)
+}
+
+// Captures the handlers `sendPayload` registers via `req.on`/`req.once` so tests can
+// fire them directly (e.g. to simulate the timeout -> destroy() -> error sequence).
+function createMockReq () {
+  const handlers = {}
+  const registerHandler = (event, handler) => { handlers[event] = handler }
+
+  return {
+    write: sinon.stub(),
+    end: sinon.stub(),
+    destroy: sinon.stub(),
+    on: sinon.stub().callsFake(registerHandler),
+    once: sinon.stub().callsFake(registerHandler),
+    handlers,
+  }
+}
+
+describe('OtlpHttpExporterBase', () => {
+  let httpStub
+  let pendingCallbacks
+  let pendingReqs
+
+  beforeEach(() => {
+    pendingCallbacks = []
+    pendingReqs = []
+
+    httpStub = sinon.stub(http, 'request').callsFake((options, callback) => {
+      pendingCallbacks.push(callback)
+      const req = createMockReq()
+      pendingReqs.push(req)
+      return req
+    })
+  })
+
+  afterEach(() => {
+    httpStub.restore()
+  })
+
+  describe('flush', () => {
+    it('calls done synchronously when there are no in-flight requests', () => {
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+      const done = sinon.spy()
+
+      exporter.flush(done)
+
+      sinon.assert.calledOnce(done)
+    })
+
+    it('waits for an in-flight request to complete before calling done', () => {
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+      const resultCallback = sinon.spy()
+
+      exporter.sendPayload(Buffer.from('{}'), resultCallback)
+
+      const done = sinon.spy()
+      exporter.flush(done)
+
+      sinon.assert.notCalled(done)
+
+      respondWith(pendingCallbacks[0])
+
+      sinon.assert.calledOnceWithExactly(resultCallback, { code: 0 })
+      sinon.assert.calledOnce(done)
+    })
+
+    it('waits for every in-flight request before calling done', () => {
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+
+      exporter.sendPayload(Buffer.from('{}'), sinon.spy())
+      exporter.sendPayload(Buffer.from('{}'), sinon.spy())
+
+      const done = sinon.spy()
+      exporter.flush(done)
+
+      respondWith(pendingCallbacks[0])
+      sinon.assert.notCalled(done)
+
+      respondWith(pendingCallbacks[1])
+      sinon.assert.calledOnce(done)
+    })
+
+    it('resolves callbacks for a failed request instead of hanging', () => {
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+      const resultCallback = sinon.spy()
+
+      exporter.sendPayload(Buffer.from('{}'), resultCallback)
+
+      const done = sinon.spy()
+      exporter.flush(done)
+
+      respondWith(pendingCallbacks[0], 500)
+
+      sinon.assert.calledOnce(resultCallback)
+      assert.strictEqual(resultCallback.firstCall.args[0].code, 1)
+      sinon.assert.calledOnce(done)
+    })
+
+    it('resolves every registered flush callback once pending requests reach zero', () => {
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+
+      exporter.sendPayload(Buffer.from('{}'), sinon.spy())
+
+      const first = sinon.spy()
+      const second = sinon.spy()
+      exporter.flush(first)
+      exporter.flush(second)
+
+      respondWith(pendingCallbacks[0])
+
+      sinon.assert.calledOnce(first)
+      sinon.assert.calledOnce(second)
+    })
+
+    it('does not require a done callback', () => {
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+
+      exporter.flush()
+    })
+
+    it('does not resolve flush early when a timed-out request also emits a subsequent error', () => {
+      // Simulates destroy()'s "socket hang up" firing after the timeout handler already ran.
+      const exporter = new OtlpHttpExporterBase('http://localhost:4318/v1/traces', {}, 1000, 'http/json', 'traces')
+      const resultCallbackA = sinon.spy()
+      const resultCallbackB = sinon.spy()
+
+      exporter.sendPayload(Buffer.from('{}'), resultCallbackA)
+      exporter.sendPayload(Buffer.from('{}'), resultCallbackB)
+
+      const done = sinon.spy()
+      exporter.flush(done)
+
+      pendingReqs[0].handlers.timeout()
+
+      sinon.assert.calledOnce(pendingReqs[0].destroy)
+      sinon.assert.calledOnce(resultCallbackA)
+      sinon.assert.notCalled(done)
+
+      pendingReqs[0].handlers.error(new Error('socket hang up'))
+
+      sinon.assert.calledOnce(resultCallbackA)
+      sinon.assert.notCalled(done)
+
+      respondWith(pendingCallbacks[1])
+
+      sinon.assert.calledOnce(resultCallbackB)
+      sinon.assert.calledOnce(done)
+    })
+  })
+})

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -58,6 +58,7 @@ describe('Tracer', () => {
 
     agentExporter = {
       export: sinon.spy(),
+      flush: sinon.stub().callsArg(0),
     }
     AgentExporter = sinon.stub().returns(agentExporter)
 
@@ -437,6 +438,45 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
 
       tracer.extract()
+    })
+  })
+
+  describe('flush', () => {
+    it('should delegate to the exporter and forward the done callback', () => {
+      tracer = new Tracer(config)
+      const done = sinon.spy()
+
+      tracer.flush(done)
+
+      sinon.assert.calledWith(agentExporter.flush, done)
+      sinon.assert.calledOnce(done)
+    })
+
+    it('should call done synchronously when the exporter has no flush method', () => {
+      delete agentExporter.flush
+      tracer = new Tracer(config)
+      const done = sinon.spy()
+
+      tracer.flush(done)
+
+      sinon.assert.calledOnce(done)
+    })
+
+    it('should not throw when called without a callback', () => {
+      tracer = new Tracer(config)
+
+      tracer.flush()
+    })
+
+    it('should call done and log instead of throwing when the exporter flush throws synchronously', () => {
+      agentExporter.flush = sinon.stub().throws(new Error('boom'))
+      tracer = new Tracer(config)
+      const done = sinon.spy()
+
+      tracer.flush(done)
+
+      sinon.assert.calledOnce(done)
+      sinon.assert.calledOnce(log.error)
     })
   })
 })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -73,6 +73,7 @@ describe('TracerProxy', () => {
       inject: sinon.stub().returns('tracer'),
       extract: sinon.stub().returns('spanContext'),
       setUrl: sinon.stub(),
+      flush: sinon.stub().callsArg(0),
       configure: sinon.spy(),
     }
 
@@ -84,6 +85,7 @@ describe('TracerProxy', () => {
       inject: sinon.stub().returns('noop'),
       extract: sinon.stub().returns('spanContext'),
       setUrl: sinon.stub(),
+      flush: sinon.stub().callsArg(0),
       configure: sinon.spy(),
     }
 
@@ -243,6 +245,7 @@ describe('TracerProxy', () => {
       '../aiguard/noop': NoopAIGuardSdk,
       '../appsec/sdk/noop': NoopAppsecSdk,
       './dogstatsd': NoopDogStatsDClient,
+      '../log': log,
     })
 
     ProxyClass = proxyquire('../src/proxy', {
@@ -790,6 +793,25 @@ describe('TracerProxy', () => {
       })
     })
 
+    describe('flush', () => {
+      it('should resolve once the underlying NoopTracer flush completes', async () => {
+        const returnValue = proxy.flush()
+
+        assert.strictEqual(typeof returnValue.then, 'function')
+        sinon.assert.called(noop.flush)
+        await returnValue
+      })
+
+      it('should resolve instead of rejecting when the underlying flush throws synchronously', async () => {
+        noop.flush = sinon.stub().throws(new Error('boom'))
+
+        const returnValue = proxy.flush()
+
+        await returnValue
+        sinon.assert.calledOnce(log.error)
+      })
+    })
+
     describe('baggage', () => {
       afterEach(() => {
         proxy.removeAllBaggageItems()
@@ -1028,6 +1050,41 @@ describe('TracerProxy', () => {
 
         sinon.assert.calledWith(tracer.setUrl, 'http://example.com')
         assert.strictEqual(returnValue, proxy)
+      })
+    })
+
+    describe('flush', () => {
+      it('should resolve once the underlying DatadogTracer flush completes', async () => {
+        const returnValue = proxy.flush()
+
+        assert.strictEqual(typeof returnValue.then, 'function')
+        sinon.assert.called(tracer.flush)
+        await returnValue
+      })
+
+      it('should only resolve after the flush callback is invoked', async () => {
+        let flushDone
+        tracer.flush = sinon.stub().callsFake((done) => { flushDone = done })
+
+        let resolved = false
+        const returnValue = proxy.flush().then(() => { resolved = true })
+
+        // Give any (incorrect) synchronous resolution a chance to happen before asserting.
+        await Promise.resolve()
+        assert.strictEqual(resolved, false)
+
+        flushDone()
+        await returnValue
+        assert.strictEqual(resolved, true)
+      })
+
+      it('should resolve instead of rejecting when the underlying flush throws synchronously', async () => {
+        tracer.flush = sinon.stub().throws(new Error('boom'))
+
+        const returnValue = proxy.flush()
+
+        await returnValue
+        sinon.assert.calledOnce(log.error)
       })
     })
 


### PR DESCRIPTION
### What does this PR do?

Adds a public, promise-returning **`tracer.flush(): Promise<void>`** that flushes buffered/pending spans and resolves once the resulting export completes. This gives serverless/isolate runtimes a way to guarantee spans are sent before the runtime freezes or the process exits:

```js
export default {
  async fetch (req, env, ctx) {
    const span = tracer.startSpan('handler'); /* ... */ span.finish()
    ctx.waitUntil(tracer.flush()) // spans leave before the isolate freezes
    return new Response('ok')
  }
}
```

- Reuses the existing `Writer.flush(done)` / `AgentExporter.flush(done)` plumbing for the agent/agentless path.
- Adds a pending-request-counter flush to the OTLP exporter (`OtlpHttpExporterBase`) so `flush()` resolves when in-flight OTLP requests complete — the Cloudflare Workers path.
- Resolves on the noop/disabled path immediately; **never rejects** (logs on failure) so a `ctx.waitUntil(tracer.flush())` can't error the caller.
- No `async`/`await` in production code — the Promise is constructed only at the public boundary; internals stay callback-based.

### Motivation

Serverless/isolate runtimes (Cloudflare Workers via `ctx.waitUntil`, AWS Lambda, graceful shutdown) freeze or exit as soon as the handler returns, dropping any not-yet-exported spans. dd-trace previously only flushed on an interval and on `beforeExit` (which Workers never fires). A promise-returning `flush()` lets callers await export completion. Complements the Cloudflare Workers support effort (#1892).

### Additional Notes

- **`semver-minor`** — new public API. Added to both `index.d.ts` and `index.d.v5.ts`, documented in `docs/API.md`.
- Independent of the Workers PR stack; mergeable on its own.
- OTLP `flush()` waits on already-in-flight requests (doesn't trigger a new send). It does not currently wait on the separate OTel span-stats exporter — noted in `docs/API.md`.
- Fixed a correctness bug found in review: the OTLP pending-request counter could double-decrement on a request timeout (`timeout`→`destroy()`→`error`), which would let `flush()` resolve while an export was still in flight; guarded with a per-request `settled` flag + a regression test.
