### PR TITLE
fix(core): support manual span parenting on runtimes without native enterWith

### DIFF
--- a/integration-tests/cloudflare-workers/cloudflare-workers.spec.js
+++ b/integration-tests/cloudflare-workers/cloudflare-workers.spec.js
@@ -77,4 +77,25 @@ describe('Cloudflare Workers (workerd) acceptance test', function () {
     const span = resourceSpan.scopeSpans[0].spans.find((candidate) => candidate.name === 'cf.worker.test')
     assert.ok(span, 'expected an OTLP span named "cf.worker.test"')
   })
+
+  it('parents a manually-created child span under its parent from inside real workerd', async () => {
+    // Proves scope.js's storage.run()-based fallback (see datadog-core/src/storage.js): workerd
+    // has no imperative AsyncLocalStorage.prototype.enterWith(), so tracer.trace() nesting only
+    // works if activate() correctly propagates the parent span through run()'s bounding callback.
+    const tracesPromise = waitForOtlpTraces(agent, 15_000)
+
+    const response = await worker.fetch('/parented')
+    assert.strictEqual(response.status, 200)
+
+    const { payload } = await tracesPromise
+
+    const spans = payload.resourceSpans[0].scopeSpans[0].spans
+    const parent = spans.find((candidate) => candidate.name === 'cf.parent')
+    const child = spans.find((candidate) => candidate.name === 'cf.child')
+
+    assert.ok(parent, 'expected an OTLP span named "cf.parent"')
+    assert.ok(child, 'expected an OTLP span named "cf.child"')
+    assert.strictEqual(child.traceId, parent.traceId)
+    assert.strictEqual(child.parentSpanId, parent.spanId)
+  })
 })

--- a/integration-tests/cloudflare-workers/fixtures/worker.mjs
+++ b/integration-tests/cloudflare-workers/fixtures/worker.mjs
@@ -15,11 +15,24 @@ export default {
       initialized = true
     }
 
-    // A flat span: scope.activate()/parenting is not supported in workerd yet.
-    const span = tracer.startSpan('cf.worker.test')
-    span.setTag('http.method', request.method)
-    span.setTag('deploy.target', 'cloudflare-workers')
-    span.finish()
+    const { pathname } = new URL(request.url)
+
+    if (pathname === '/parented') {
+      // Manual parenting via tracer.trace(): scope.js falls back to a storage.run()-scoped
+      // activation on workerd, since workerd's AsyncLocalStorage has no imperative enterWith()
+      // (see datadog-core/src/storage.js and scope.js). The child span is created while the
+      // parent is the active span, so it must come back with the parent as its parent.
+      tracer.trace('cf.parent', () => {
+        tracer.trace('cf.child', () => {})
+      })
+    } else {
+      // A flat span: automatic plugin instrumentation is unsupported in workerd (it imperatively
+      // calls enterWith() with no bounding callback, which scope.js's fallback can't emulate).
+      const span = tracer.startSpan('cf.worker.test')
+      span.setTag('http.method', request.method)
+      span.setTag('deploy.target', 'cloudflare-workers')
+      span.finish()
+    }
 
     // span.finish() fires the OTLP export as fire-and-forget async I/O (an
     // http.request() call), and dd-trace exposes no awaitable flush yet, so

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -60,6 +60,19 @@ const isACFActive = (() => {
   return active
 })()
 
+// workerd lacks a working `enterWith()` despite passing the `isACFActive` probe above, so this
+// is a separate check. Checked once at load, not per call.
+const hasNativeEnterWith = (() => {
+  try {
+    const als = new AsyncLocalStorage()
+    als.enterWith()
+    als.disable()
+    return true
+  } catch {
+    return false
+  }
+})()
+
 if (!isACFActive) {
   const superGetStore = AsyncLocalStorage.prototype.getStore
   const superEnterWith = AsyncLocalStorage.prototype.enterWith
@@ -135,4 +148,4 @@ function storage (namespace) {
   return storages[namespace]
 }
 
-module.exports = { storage, isACFActive }
+module.exports = { storage, isACFActive, hasNativeEnterWith }

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -7,7 +7,7 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const proxyquire = require('proxyquire')
 
 require('../../dd-trace/test/setup/core')
-const { storage } = require('../src/storage')
+const { storage, hasNativeEnterWith } = require('../src/storage')
 
 describe('storage', () => {
   let testStorage
@@ -89,6 +89,10 @@ describe('storage', () => {
 
     assert.strictEqual(testStorage.getStore(), undefined)
   })
+
+  it('should report native enterWith() support', () => {
+    assert.strictEqual(hasNativeEnterWith, true)
+  })
 })
 
 describe('storage with a partial AsyncLocalStorage (e.g. Cloudflare Workers)', () => {
@@ -132,6 +136,12 @@ describe('storage with a partial AsyncLocalStorage (e.g. Cloudflare Workers)', (
     const { isACFActive } = requireStorage()
 
     assert.strictEqual(isACFActive, true)
+  })
+
+  it('should report no native enterWith() support', () => {
+    const { hasNativeEnterWith } = requireStorage()
+
+    assert.strictEqual(hasNativeEnterWith, false)
   })
 
   it('should run and get a store via the native path, without the WeakMap fallback', () => {

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -1,8 +1,70 @@
 'use strict'
 
 const { storage } = require('../../datadog-core')
+const { hasNativeEnterWith } = require('../../datadog-core/src/storage')
 
 const legacyStorage = storage('legacy')
+
+/**
+ * Shared by both `activate()` strategies below so error-tagging stays identical between them.
+ *
+ * @param {import('opentracing').Span | undefined} span
+ * @param {Error} error
+ */
+function setErrorTag (span, error) {
+  if (span && typeof span.setTag === 'function') {
+    span.setTag('error', error)
+  }
+}
+
+/**
+ * Selected when the runtime supports `enterWith()` (every Node release).
+ *
+ * @param {Record<string, unknown>} newStore
+ * @param {Record<string, unknown> | undefined} oldStore
+ * @param {import('opentracing').Span | undefined} span
+ * @param {() => unknown} callback
+ * @returns {unknown}
+ */
+function activateWithEnterWith (newStore, oldStore, span, callback) {
+  legacyStorage.enterWith(newStore)
+
+  try {
+    return callback()
+  } catch (e) {
+    setErrorTag(span, e)
+
+    throw e
+  } finally {
+    legacyStorage.enterWith(oldStore)
+  }
+}
+
+/**
+ * The store reverts automatically to whatever was active before this call once `callback`
+ * settles, including across `await`/timers inside it. Selected when the runtime has no native
+ * `enterWith()` (e.g. workerd).
+ *
+ * @param {Record<string, unknown>} newStore
+ * @param {Record<string, unknown> | undefined} oldStore
+ * @param {import('opentracing').Span | undefined} span
+ * @param {() => unknown} callback
+ * @returns {unknown}
+ */
+function activateWithRun (newStore, oldStore, span, callback) {
+  return legacyStorage.run(newStore, () => {
+    try {
+      return callback()
+    } catch (e) {
+      setErrorTag(span, e)
+
+      throw e
+    }
+  })
+}
+
+// Decided once at module load, not per `activate()` call, so the hot path never feature-detects.
+const activateStore = hasNativeEnterWith ? activateWithEnterWith : activateWithRun
 
 // TODO: refactor bind to use shimmer once the new internal tracer lands
 class Scope {
@@ -18,19 +80,7 @@ class Scope {
     const oldStore = legacyStorage.getStore()
     const newStore = span ? legacyStorage.getStore(span._store) : oldStore
 
-    legacyStorage.enterWith({ ...newStore, span })
-
-    try {
-      return callback()
-    } catch (e) {
-      if (span && typeof span.setTag === 'function') {
-        span.setTag('error', e)
-      }
-
-      throw e
-    } finally {
-      legacyStorage.enterWith(oldStore)
-    }
+    return activateStore({ ...newStore, span }, oldStore, span, callback)
   }
 
   bind (fn, span) {

--- a/packages/dd-trace/test/scope.spec.js
+++ b/packages/dd-trace/test/scope.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 
 const { describe, it, beforeEach } = require('mocha')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 const { Span } = require('opentracing')
@@ -168,6 +169,85 @@ describe('Scope', () => {
       it('should return the target', () => {
         assert.strictEqual(scope.bind('test', span), 'test')
       })
+    })
+  })
+})
+
+describe('Scope without a native enterWith() (e.g. Cloudflare Workers)', () => {
+  // `hasNativeEnterWith: false` forces scope.js onto the `run()` fallback (workerd's path).
+  // `storage` itself is untouched, so `activate()` still runs against a real ALS store.
+  const ScopeWithoutNativeEnterWith = proxyquire('../src/scope', {
+    '../../datadog-core/src/storage': { hasNativeEnterWith: false },
+  })
+
+  let scope
+  let span
+
+  beforeEach(() => {
+    scope = new ScopeWithoutNativeEnterWith()
+    span = new Span()
+  })
+
+  describe('activate()', () => {
+    it('should return the value returned by the callback', () => {
+      assert.strictEqual(scope.activate(span, () => 'test'), 'test')
+    })
+
+    it('should activate the span on the current scope and restore the prior scope after', () => {
+      assert.strictEqual(scope.active(), null)
+
+      scope.activate(span, () => {
+        assert.strictEqual(scope.active(), span)
+      })
+
+      assert.strictEqual(scope.active(), null)
+    })
+
+    it('should persist through an await within the callback', async () => {
+      await scope.activate(span, async () => {
+        assert.strictEqual(scope.active(), span)
+        await Promise.resolve()
+        assert.strictEqual(scope.active(), span)
+      })
+
+      assert.strictEqual(scope.active(), null)
+    })
+
+    it('should persist through setTimeout within the callback', done => {
+      scope.activate(span, () => {
+        setTimeout(() => {
+          assert.strictEqual(scope.active(), span)
+          done()
+        }, 0)
+      })
+    })
+
+    it('should restore the previously active span after nested activation', () => {
+      const outer = new Span()
+
+      scope.activate(outer, () => {
+        assert.strictEqual(scope.active(), outer)
+
+        scope.activate(span, () => {
+          assert.strictEqual(scope.active(), span)
+        })
+
+        assert.strictEqual(scope.active(), outer)
+      })
+    })
+
+    it('should handle errors', () => {
+      const error = new Error('boom')
+
+      sinon.spy(span, 'setTag')
+
+      assert.throws(() => {
+        scope.activate(span, () => {
+          throw error
+        })
+      }, error)
+
+      sinon.assert.calledWith(span.setTag, 'error', error)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Enables **manual span parenting** on runtimes that lack native `AsyncLocalStorage.prototype.enterWith` (Cloudflare Workers / workerd). `Scope.activate()` (used by `tracer.trace()`/`tracer.wrap()` and nested manual spans) previously set context via `enterWith()`, which workerd doesn't implement — so only flat, non-activated spans worked there. Since every `scope.js` `activate`/`bind` call site has a bounding callback, the fallback uses the scoped `legacyStorage.run(store, callback)` instead:

- `datadog-core` gains a `hasNativeEnterWith` capability probe (feature-detected **once** at module load).
- `scope.js` selects the activation strategy **once** at load — the existing `enterWith`+`finally` path when native `enterWith` is present (Node: **byte-identical behavior**), the `run()`-based path when it's absent (workerd). No per-`activate()` feature-detect on the hot path.
- The Cloudflare Workers acceptance test now asserts a real **parent/child trace** (`child.parentSpanId === parent.spanId`, same `traceId`), verified in real workerd.

### Motivation

Flat spans already worked in workerd (prior PRs in this effort); this makes *nested manual tracing* — `tracer.trace('parent', () => tracer.trace('child', ...))` — work too, which is how a Workers app instruments itself. Part of the Cloudflare Workers support effort (#1892).

### Additional Notes

- **Stacked PR** — base branch is `brian.marks/cf-wrangler-ci` (#9442). Review the 2 commits unique to this branch.
- `semver-patch` — no public API change; **Node context propagation is unchanged** (the `run()` path is taken only when native `enterWith` is absent; the `hasNativeEnterWith === true` case is directly asserted in `storage.spec.js` as a regression tripwire).
- **Known limitation (out of scope, blocked upstream):** *automatic* plugin instrumentation parenting still doesn't work in workerd — the plugin layer sets context via `enterWith` with no bounding callback, which can't be expressed via `run()`. workerd omits `enterWith` deliberately/permanently (workerd PR #208); the eventual fix is TC39 `AsyncContext`, not yet shipped. This PR covers manual instrumentation only.
