### PR TITLE
test(iast): drop redundant yarn install from sourcemap test

### DIFF
--- a/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
+++ b/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
@@ -17,7 +17,6 @@ describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
 
     appDir = path.join(cwd, 'appsec', 'iast-stack-traces-ts-with-sourcemaps')
 
-    childProcess.execSync('yarn || yarn', { cwd })
     childProcess.execSync('npx tsc', {
       cwd: appDir,
     })


### PR DESCRIPTION
## Summary

The IAST sourcemap integration spec re-resolved dependencies with Yarn after the sandbox had already installed them. Registry latency could block the synchronous setup hook past Mocha's timeout, so this removes the redundant install while retaining the TypeScript compilation and integration coverage.