### PR TITLE
test(couchbase,kafkajs): wait for client readiness

### DIFF
--- a/packages/datadog-plugin-couchbase/test/index.spec.js
+++ b/packages/datadog-plugin-couchbase/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { setTimeout } = require('node:timers/promises')
 const { inspect } = require('node:util')
 
 const { after, afterEach, beforeEach, describe, it } = require('mocha')
@@ -32,6 +33,9 @@ describe('Plugin', () => {
             password: 'password',
           })
           bucket = cluster.bucket('datadog-test')
+          if (semver.gte(version, '4.0.0')) {
+            await waitForBucketConnection(cluster, couchbase)
+          }
           collection = bucket.defaultCollection()
         })
 
@@ -181,3 +185,26 @@ describe('Plugin', () => {
     })
   })
 })
+
+/**
+ * Couchbase 4.x resolves connect before bucket() finishes opening its KV connection.
+ *
+ * @param {{
+ *   ping(options: { serviceTypes: string[] }): Promise<{ services: Record<string, Array<{ state: number }>> }>
+ * }} cluster
+ * @param {{ ServiceType: { KeyValue: string }, PingState: { Ok: number } }} couchbase
+ */
+async function waitForBucketConnection (cluster, couchbase) {
+  const deadline = Date.now() + 8_000
+  while (Date.now() < deadline) {
+    const { services } = await cluster.ping({
+      serviceTypes: [couchbase.ServiceType.KeyValue],
+    })
+    const endpoints = services[couchbase.ServiceType.KeyValue] ?? []
+    for (const { state } of endpoints) {
+      if (state === couchbase.PingState.Ok) return
+    }
+    await setTimeout(10)
+  }
+  throw new Error('Couchbase KV connection did not become ready')
+}

--- a/packages/datadog-plugin-couchbase/test/index.spec.js
+++ b/packages/datadog-plugin-couchbase/test/index.spec.js
@@ -22,19 +22,24 @@ describe('Plugin', () => {
     let tracer
     let collection
 
-    withVersions('couchbase', 'couchbase', '>=3.0.0', version => {
+    /**
+     * @param {string} versionKey
+     * @param {string} _moduleName
+     * @param {string} resolvedVersion
+     */
+    function registerVersionTests (versionKey, _moduleName, resolvedVersion) {
       describe('without configuration', () => {
         beforeEach(async function () {
           this.timeout(10_000)
           tracer = global.tracer = await agent.load('couchbase')
-          couchbase = proxyquire(`../../../versions/couchbase@${version}`, {}).get()
+          couchbase = proxyquire(`../../../versions/couchbase@${versionKey}`, {}).get()
           cluster = await couchbase.connect('couchbase://localhost', {
             username: 'Administrator',
             password: 'password',
           })
           bucket = cluster.bucket('datadog-test')
-          if (semver.gte(version, '4.0.0')) {
-            await waitForBucketConnection(cluster, couchbase)
+          if (semver.gte(resolvedVersion, '4.0.0')) {
+            await waitForBucketConnection(bucket, couchbase)
           }
           collection = bucket.defaultCollection()
         })
@@ -165,7 +170,7 @@ describe('Plugin', () => {
             })
 
             // due to bug in couchbase for these versions (see JSCBC-945)
-            if (!semver.intersects('3.2.0 - 3.2.1', version)) {
+            if (!semver.satisfies(resolvedVersion, '3.2.0 - 3.2.1')) {
               it('should catch errors in callback and report error in trace', done => {
                 const invalidQuery = 'SELECT'
                 const cb = sinon.spy()
@@ -182,7 +187,9 @@ describe('Plugin', () => {
           })
         })
       })
-    })
+    }
+
+    withVersions('couchbase', 'couchbase', '>=3.0.0', registerVersionTests)
   })
 })
 
@@ -191,13 +198,13 @@ describe('Plugin', () => {
  *
  * @param {{
  *   ping(options: { serviceTypes: string[] }): Promise<{ services: Record<string, Array<{ state: number }>> }>
- * }} cluster
+ * }} bucket
  * @param {{ ServiceType: { KeyValue: string }, PingState: { Ok: number } }} couchbase
  */
-async function waitForBucketConnection (cluster, couchbase) {
+async function waitForBucketConnection (bucket, couchbase) {
   const deadline = Date.now() + 8_000
   while (Date.now() < deadline) {
-    const { services } = await cluster.ping({
+    const { services } = await bucket.ping({
       serviceTypes: [couchbase.ServiceType.KeyValue],
     })
     const endpoints = services[couchbase.ServiceType.KeyValue] ?? []

--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { randomUUID } = require('crypto')
+const { randomUUID } = require('node:crypto')
+const { EventEmitter, once } = require('node:events')
 const { inspect } = require('node:util')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const semver = require('semver')
@@ -176,16 +177,33 @@ describe('Plugin', () => {
               DataStreamsProcessor.prototype.recordCheckpoint.restore()
             }
             const recordCheckpointSpy = sinon.spy(DataStreamsProcessor.prototype, 'recordCheckpoint')
-            await sendMessages(kafka, testTopic, messages)
-            await consumer.run({
-              eachMessage: async () => {
-                assert.ok(
-                  Object.hasOwn(recordCheckpointSpy.args[0][0], 'payloadSize'),
-                  `Available keys: ${inspect(Object.keys(recordCheckpointSpy.args[0][0]))}`
-                )
-                recordCheckpointSpy.restore()
-              },
-            })
+            const consumption = new EventEmitter()
+            try {
+              await consumer.run({
+                eachMessage: async () => {
+                  try {
+                    const checkpoint = recordCheckpointSpy.lastCall.args[0]
+                    assert.ok(
+                      checkpoint.edgeTags.includes('direction:in'),
+                      `Available tags: ${inspect(checkpoint.edgeTags)}`
+                    )
+                    assert.ok(
+                      Object.hasOwn(checkpoint, 'payloadSize'),
+                      `Available keys: ${inspect(Object.keys(checkpoint))}`
+                    )
+                    consumption.emit('complete')
+                  } catch (error) {
+                    consumption.emit('error', error)
+                  }
+                },
+              })
+              await Promise.all([
+                once(consumption, 'complete'),
+                sendMessages(kafka, testTopic, messages),
+              ])
+            } finally {
+              recordCheckpointSpy.restore()
+            }
           })
         })
 

--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -180,27 +180,21 @@ describe('Plugin', () => {
             const consumption = new EventEmitter()
             try {
               await consumer.run({
-                eachMessage: async () => {
-                  try {
-                    const checkpoint = recordCheckpointSpy.lastCall.args[0]
-                    assert.ok(
-                      checkpoint.edgeTags.includes('direction:in'),
-                      `Available tags: ${inspect(checkpoint.edgeTags)}`
-                    )
-                    assert.ok(
-                      Object.hasOwn(checkpoint, 'payloadSize'),
-                      `Available keys: ${inspect(Object.keys(checkpoint))}`
-                    )
-                    consumption.emit('complete')
-                  } catch (error) {
-                    consumption.emit('error', error)
-                  }
-                },
+                eachMessage: async () => consumption.emit('complete', recordCheckpointSpy.lastCall?.args[0]),
               })
-              await Promise.all([
+              const [[checkpoint]] = await Promise.all([
                 once(consumption, 'complete'),
                 sendMessages(kafka, testTopic, messages),
               ])
+              assert.ok(checkpoint, 'Expected a consume checkpoint')
+              assert.ok(
+                checkpoint.edgeTags.includes('direction:in'),
+                `Available tags: ${inspect(checkpoint.edgeTags)}`
+              )
+              assert.ok(
+                Object.hasOwn(checkpoint, 'payloadSize'),
+                `Available keys: ${inspect(Object.keys(checkpoint))}`
+              )
             } finally {
               recordCheckpointSpy.restore()
             }


### PR DESCRIPTION
## Summary
Couchbase 4.x can resolve cluster connect before its bucket KV endpoint is ready, so the first collection call races the SDK's ambiguous timeout. The setup now waits for the public KV ping signal.

The KafkaJS payload-size test previously finished when `consumer.run()` started, before `eachMessage` asserted the consumer checkpoint. Waiting for that callback prevents stale group members from making later version cases rebalance indefinitely.