### PR TITLE
fix(cucumber): support version 13.2

### DIFF
--- a/packages/datadog-instrumentations/src/cucumber-worker-threads.js
+++ b/packages/datadog-instrumentations/src/cucumber-worker-threads.js
@@ -9,11 +9,17 @@ const appRequire = createRequire(path.join(process.cwd(), 'package.json'))
 
 try {
   // Cucumber v13 parallel workers start from an ESM worker.mjs entrypoint, which
-  // statically imports the internal runtime Worker before it runs support-code
+  // statically imports the internal runtime Worker/Executor before it runs support-code
   // requireModules. The regular module hook does not patch that internal worker
-  // import, so this preload is injected into requireModules to patch the cached Worker
+  // import, so this preload is injected into requireModules to patch the cached class
   // prototype before Cucumber constructs the worker instance.
-  patchCucumberWorkerRunTestCase(appRequire('@cucumber/cucumber/lib/runtime/worker'), true)
+  let runtimeExecutorPackage
+  try {
+    runtimeExecutorPackage = appRequire('@cucumber/cucumber/lib/runtime/executor')
+  } catch {
+    runtimeExecutorPackage = appRequire('@cucumber/cucumber/lib/runtime/worker')
+  }
+  patchCucumberWorkerRunTestCase(runtimeExecutorPackage, true)
 } catch {
   // Ignore preload failures so cucumber can keep running if its internals change.
 }

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -1036,7 +1036,9 @@ function testCaseHook (TestCaseRunner, version) {
 // Valid for old and new cucumber versions
 function getCucumberOptions (adapterOrCoordinator) {
   if (adapterOrCoordinator.adapter) {
-    return adapterOrCoordinator.adapter.worker?.options || adapterOrCoordinator.adapter.options
+    return adapterOrCoordinator.adapter.worker?.options ||
+      adapterOrCoordinator.adapter.executor?.options ||
+      adapterOrCoordinator.adapter.options
   }
   return adapterOrCoordinator.options
 }
@@ -1434,13 +1436,14 @@ function getWrappedRunTestCase (runTestCaseFunction, isNewerCucumberVersion = fa
   }
 }
 
-function patchCucumberWorkerRunTestCase (workerPackage, isWorker) {
-  const workerPrototype = workerPackage?.Worker?.prototype
-  if (!workerPrototype || patchedCucumberWorkers.has(workerPrototype)) return
+function patchCucumberWorkerRunTestCase (runtimeExecutorPackage, isWorker) {
+  const runtimeExecutorPrototype =
+    runtimeExecutorPackage?.Worker?.prototype || runtimeExecutorPackage?.Executor?.prototype
+  if (!runtimeExecutorPrototype || patchedCucumberWorkers.has(runtimeExecutorPrototype)) return
 
-  patchedCucumberWorkers.add(workerPrototype)
+  patchedCucumberWorkers.add(runtimeExecutorPrototype)
   shimmer.wrap(
-    workerPrototype,
+    runtimeExecutorPrototype,
     'runTestCase',
     runTestCase => getWrappedRunTestCase(runTestCase, true, isWorker)
   )
@@ -1572,13 +1575,23 @@ addHook({
 // `getWrappedRunTestCase` does two things:
 // - generates suite start and finish events in the main process,
 // - handles EFD in both the main process and the worker process.
+// Shimmer is required because this wrapper may invoke the original test case multiple times and mutate runtime options.
 addHook({
   name: '@cucumber/cucumber',
-  versions: ['>=11.0.0'],
+  versions: ['>=11.0.0 <13.2.0'],
   file: 'lib/runtime/worker.js',
 }, (workerPackage) => {
   patchCucumberWorkerRunTestCase(workerPackage, !!getEnvironmentVariable('CUCUMBER_WORKER_ID'))
   return workerPackage
+})
+
+addHook({
+  name: '@cucumber/cucumber',
+  versions: ['>=13.2.0'],
+  file: 'lib/runtime/executor.js',
+}, (executorPackage) => {
+  patchCucumberWorkerRunTestCase(executorPackage, !!getEnvironmentVariable('CUCUMBER_WORKER_ID'))
+  return executorPackage
 })
 
 // `getWrappedStart` generates session start and finish events

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "7.29.0",
     "@babel/preset-typescript": "7.28.5",
     "@confluentinc/kafka-javascript": "1.10.0",
-    "@cucumber/cucumber": "13.1.0",
+    "@cucumber/cucumber": "13.2.0",
     "@datadog/openfeature-node-server": "2.0.0",
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/transport": "9.3.5",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the latest Cucumber test version to 13.2.0 and preserves Test Optimization instrumentation across its runtime rename.

- Hooks the new `runtime/executor` module while retaining the older `runtime/worker` hook.
- Supports both `Executor` and `Worker` exports in the shared test-case wrapper.
- Updates the parallel worker preload and serial runtime option lookup for the renamed executor.

### Motivation
<!-- What inspired you to submit this pull request? -->

Cucumber 13.2 renamed its internal `Worker` class and `runtime/worker` module to `Executor` and `runtime/executor`. The existing hooks therefore stopped creating test events, propagating parallel EFD state, and applying API-driven retry settings.

This restores serial and parallel instrumentation without changing behavior for earlier supported Cucumber versions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- `DD_GIT_REPOSITORY_URL=git@github.com:DataDog/dd-trace-js.git npm run test:integration:cucumber -- --bail` — 132 passing.
- Targeted Cucumber integration coverage for serial execution, parallel EFD, and flaky retries — 5 passing with the changed paths covered.
- `./node_modules/.bin/mocha packages/dd-trace/test/plugins/versions.spec.js` — 28 passing.
- Targeted ESLint and `git diff --check` — passing.
