### PR TITLE
fix(llmobs): refresh experiments facade on config changes

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -39,6 +39,7 @@ class LLMObs extends NoopLLMObs {
    * @type {import('./experiments').Experiments | undefined}
    */
   #experiments
+  #experimentsCacheKey
 
   /**
    * @param {import('../tracer')} tracer - Tracer instance
@@ -65,7 +66,21 @@ class LLMObs extends NoopLLMObs {
    * a clear message on use.
    */
   get experiments () {
-    this.#experiments ??= createExperiments(this._config)
+    const llmobsConfig = this._config.llmobs
+    const cacheKey = JSON.stringify([
+      llmobsConfig?.DD_LLMOBS_ENABLED,
+      llmobsConfig?.mlApp,
+      this._config.DD_API_KEY,
+      this._config.DD_APP_KEY,
+      this._config.service,
+      this._config.site,
+    ])
+
+    if (this.#experiments === undefined || this.#experimentsCacheKey !== cacheKey) {
+      this.#experiments = createExperiments(this._config)
+      this.#experimentsCacheKey = cacheKey
+    }
+
     return this.#experiments
   }
 

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -113,6 +113,29 @@ describe('sdk', () => {
       disabledLLMObs.disable() // unsubscribe
     })
 
+    it('recreates experiments after enabling llmobs', () => {
+      const config = getConfigFresh({})
+      config.DD_API_KEY = 'api-key'
+      config.DD_APP_KEY = 'app-key'
+      config.service = 'service'
+      const llmobsModule = {
+        enable: sinon.stub(),
+        disable () {},
+      }
+
+      const disabledLLMObs = new LLMObsSDK(tracer._tracer, llmobsModule, config)
+
+      assert.throws(() => disabledLLMObs.experiments.createDataset('d'), /LLM Observability is not enabled/)
+
+      disabledLLMObs.enable({
+        mlApp: 'mlApp',
+      })
+
+      assert.strictEqual(typeof disabledLLMObs.experiments.createDataset('d').addRecord, 'function')
+
+      disabledLLMObs.disable() // unsubscribe
+    })
+
     it('does not enable llmobs if it is already enabled', () => {
       sinon.spy(llmobs._llmobsModule, 'enable')
       llmobs.enable({})
@@ -158,6 +181,31 @@ describe('sdk', () => {
       enabledLLMObs.disable()
 
       assert.strictEqual(enabledLLMObs.enabled, false)
+      sinon.assert.called(llmobsModule.disable)
+    })
+
+    it('recreates experiments after disabling llmobs', () => {
+      const llmobsModule = {
+        disable: sinon.stub(),
+      }
+
+      const config = getConfigFresh({
+        llmobs: {
+          agentlessEnabled: false,
+          mlApp: 'mlApp',
+        },
+      })
+      config.DD_API_KEY = 'api-key'
+      config.DD_APP_KEY = 'app-key'
+      config.service = 'service'
+
+      const enabledLLMObs = new LLMObsSDK(tracer._tracer, llmobsModule, config)
+
+      assert.strictEqual(typeof enabledLLMObs.experiments.createDataset('d').addRecord, 'function')
+
+      enabledLLMObs.disable()
+
+      assert.throws(() => enabledLLMObs.experiments.createDataset('d'), /LLM Observability is not enabled/)
       sinon.assert.called(llmobsModule.disable)
     })
 


### PR DESCRIPTION
## Summary

Addresses review feedback from https://github.com/DataDog/dd-trace-js/pull/9415#discussion_r3623534383.

- Invalidate the lazily cached LLMObs experiments facade when `llmobs.enable()` or `llmobs.disable()` changes availability config.
- Add coverage for disabled -> enabled and enabled -> disabled transitions so a cached no-op or real facade is not reused after config changes.

## Testing

- `./node_modules/.bin/mocha packages/dd-trace/test/llmobs/sdk/index.spec.js` → 102 passing
- `./node_modules/.bin/eslint packages/dd-trace/src/llmobs/sdk.js packages/dd-trace/test/llmobs/sdk/index.spec.js` → passed
