### PR TITLE
test(tracing): bind peer-service checks to generated spans

### DIFF
--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -107,7 +107,11 @@ describe('Plugin', () => {
             'mongodb-core',
             (done) => collection.insertOne({ a: 1 }, {}, done),
             'test',
-            'peer.service'
+            'peer.service',
+            {
+              component: 'mongodb',
+              resource: () => `insert test.${collectionName}`,
+            }
           )
 
           // The bulkWrite span is opened with `db.name` set, so it flows through the same
@@ -118,7 +122,11 @@ describe('Plugin', () => {
             () => collection.bulkWrite([{ insertOne: { document: { a: 1 } } }]),
             'test',
             'peer.service',
-            { desc: 'with bulkWrite' }
+            {
+              component: 'mongodb',
+              desc: 'with bulkWrite',
+              resource: () => `bulkWrite test.${collectionName}`,
+            }
           )
 
           it('should do automatic instrumentation', done => {

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -73,7 +73,11 @@ describe('Plugin', () => {
           return new PeerCat({ name: 'PeerCat' }).save()
         },
         () => dbName,
-        'peer.service')
+        'peer.service',
+        {
+          component: 'mongodb',
+          resource: () => `insert ${dbName}.peercats`,
+        })
 
       it('should propagate context with write operations', () => {
         const Cat = mongoose.model('Cat1', { name: String })

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -182,6 +182,14 @@ function withNamingSchema (
   })
 }
 
+/**
+ * @param {() => import('../../src/proxy')} tracer
+ * @param {string} pluginName
+ * @param {((callback: (error?: Error) => void) => unknown) | (() => Promise<unknown>)} spanGenerationFn
+ * @param {string | (() => string)} service
+ * @param {string} serviceSource
+ * @param {{ component?: string, desc?: string, resource?: string | (() => string) }} [opts]
+ */
 function withPeerService (tracer, pluginName, spanGenerationFn, service, serviceSource, opts = {}) {
   describe('peer service computation' + (opts.desc ? ` ${opts.desc}` : ''), function () {
     this.timeout(10000)
@@ -199,7 +207,53 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
     })
 
     it('should compute peer service', async () => {
+      const currentTracer = global._ddtrace
+      const parentSpan = currentTracer.startSpan('peer-service.test')
+      const traceId = BigInt(parentSpan.context().toTraceId())
+      const component = opts.component ?? pluginName
+      const expectedResource = typeof opts.resource === 'function' ? opts.resource() : opts.resource
+      const expectedService = typeof service === 'function' ? service() : service
+
+      /**
+       * @param {Array<Array<{ trace_id: bigint, resource: string, meta: Record<string, string> }>>} traces
+       */
+      function assertPeerServiceSpan (traces) {
+        for (const trace of traces) {
+          for (const span of trace) {
+            if (
+              span.trace_id !== traceId ||
+              span.meta.component !== component ||
+              (expectedResource !== undefined && span.resource !== expectedResource)
+            ) {
+              continue
+            }
+
+            assert.strictEqual(span.meta['peer.service'], expectedService)
+            assert.strictEqual(span.meta['_dd.peer.service.source'], serviceSource)
+            return
+          }
+        }
+
+        assert.fail(
+          `No ${component} span in trace ${traceId} matched resource ${expectedResource}.\n\n` +
+          `Candidate Traces:\n${util.inspect(traces, { depth: null })}`
+        )
+      }
+
+      const traceAssertion = getAgent().assertSomeTraces(assertPeerServiceSpan)
       const useCallback = spanGenerationFn.length === 1
+      spanGenerationFn = currentTracer.scope().bind(spanGenerationFn, parentSpan)
+
+      async function generateSpanWithPromise () {
+        const result = spanGenerationFn()
+        assert.strictEqual(
+          typeof result?.then, 'function',
+          'spanGenerationFn should return a promise in case no callback is defined. Received: ' +
+            util.inspect(result, { depth: 1 }),
+        )
+        return result
+      }
+
       const spanGenerationPromise = useCallback
         ? new Promise(/** @type {() => void} */ (resolve, reject) => {
           const result = spanGenerationFn((err) => err ? reject(err) : resolve())
@@ -209,22 +263,18 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
             result.then?.(resolve, reject)
           }
         })
-        : spanGenerationFn()
+        : generateSpanWithPromise()
+      parentSpan.finish()
 
-      assert.strictEqual(
-        typeof spanGenerationPromise?.then, 'function',
-        'spanGenerationFn should return a promise in case no callback is defined. Received: ' +
-          util.inspect(spanGenerationPromise, { depth: 1 }),
-      )
-
-      await Promise.all([
-        getAgent().assertSomeTraces(traces => {
-          const span = traces[0][0]
-          assert.strictEqual(span.meta['peer.service'], typeof service === 'function' ? service() : service)
-          assert.strictEqual(span.meta['_dd.peer.service.source'], serviceSource)
-        }),
-        spanGenerationPromise,
-      ])
+      try {
+        await Promise.all([
+          traceAssertion,
+          spanGenerationPromise,
+        ])
+      } finally {
+        parentSpan.finish()
+        traceAssertion?.cancel()
+      }
     })
   })
 }


### PR DESCRIPTION
## Summary
Peer-service checks started each operation before arming the fake-agent expectation and only inspected the first span in each payload. Delayed MongoDB setup traffic could therefore hide the generated operation and leave the Mongoose check to time out. The helper now correlates the generated trace, integration component, and operation resource before checking peer-service tags, and cancels the expectation for every generator outcome.