### PR TITLE
fix(loader): defer instrumentation graph during preload

### DIFF
--- a/initialize.mjs
+++ b/initialize.mjs
@@ -22,7 +22,7 @@ import {
   iitmExclusionRegExp,
   load as hookLoad,
   resolve as hookResolve,
-} from './loader-hook.mjs'
+} from './loader-hook.mjs?initialize'
 
 let hasInsertedInit = false
 const initJsUrl = new URL('init.js', import.meta.url).href

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -41,7 +41,7 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
   context('preferring app-dir dd-trace', () => {
     context('when dd-trace is not in the app dir', () => {
       const NODE_OPTIONS = `--no-warnings --${arg} ${path.join(__dirname, '..', filename)}`
-      useEnv({ NODE_OPTIONS })
+      useEnv({ DD_TEST_TRACER_ROOT: path.join(__dirname, '..'), NODE_OPTIONS })
 
       if (currentVersionIsSupported) {
         context('without DD_INJECTION_ENABLED', () => {
@@ -62,6 +62,11 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
         it('should not initialize instrumentation', () => testFile(instrFile, 'false\n', [], ''))
 
         it('should not initialize ESM instrumentation', () => testFile('init/instrument.mjs', 'false\n', [], ''))
+
+        if (arg === 'import') {
+          it('does not load loader internals after deferring to the app copy', () =>
+            testFile('init/loader-hook-loaded.js', 'false\n', [], ''))
+        }
       })
     })
 
@@ -93,8 +98,7 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
 }
 
 function testRuntimeVersionChecks (arg, filename) {
-  const skipRuntimeVersionChecks = filename === 'initialize.mjs' &&
-    ['22.0.0', '24.0.0'].includes(process.versions.node)
+  const skipRuntimeVersionChecks = filename === 'initialize.mjs' && process.versions.node === '24.0.0'
   const runtimeVersionContext = skipRuntimeVersionChecks ? context.skip : context
 
   runtimeVersionContext('runtime version check', () => {

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -98,10 +98,7 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
 }
 
 function testRuntimeVersionChecks (arg, filename) {
-  const skipRuntimeVersionChecks = filename === 'initialize.mjs' && process.versions.node === '24.0.0'
-  const runtimeVersionContext = skipRuntimeVersionChecks ? context.skip : context
-
-  runtimeVersionContext('runtime version check', () => {
+  context('runtime version check', () => {
     const NODE_OPTIONS = `--${arg} dd-trace/${filename}`
     const entryFile = arg === 'loader' ? 'init/trace.mjs' : 'init/trace.js'
     const doTest = (expectedOut, expectedTelemetryPoints, expectedSource) =>

--- a/integration-tests/init/loader-hook-loaded.js
+++ b/integration-tests/init/loader-hook-loaded.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const path = require('node:path')
+
+const hooksPath = require.resolve(path.join(
+  process.env.DD_TEST_TRACER_ROOT,
+  'packages/datadog-instrumentations/src/helpers/hooks.js'
+))
+
+// eslint-disable-next-line no-console
+console.log(require.cache[hooksPath] !== undefined)

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -2,24 +2,22 @@
 
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
+import { isMainThread } from 'node:worker_threads'
 
 import { createHook, supportsSyncHooks } from 'import-in-the-middle/create-hook.mjs'
 import { initialize as origInitialize, load as origLoad, resolve } from 'import-in-the-middle/hook.mjs'
-import regexpEscapeModule from './vendor/dist/escape-string-regexp/index.js'
-import hooks from './packages/datadog-instrumentations/src/helpers/hooks.js'
-import configHelper from './packages/dd-trace/src/config/helper.js'
 import * as rewriterLoader from './packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs'
-import { isRelativeRequire } from './packages/datadog-instrumentations/src/helpers/shared-utils.js'
 
 // This file must support Node.js 12.0.0 syntax
 
 const { builtinModules } = Module
-const regexpEscape = regexpEscapeModule.default
 const require = Module.createRequire(import.meta.url)
+// The query marks initialize.mjs's application-thread preload; loader workers use the full graph.
+const isInitializeMainThread = isMainThread && import.meta.url.endsWith('?initialize')
 let syncImportInTheMiddleHook
 
-// The config helper's named exports aren't visible to ESM; destructure the default.
-const { getValueFromEnvSources } = configHelper
+let getValueFromEnvSources
+let regexpEscape
 
 // Substrings of resolved URLs that import-in-the-middle must never wrap: re-export
 // shims and internal helper graphs that break when proxied, plus iitm's own files
@@ -32,15 +30,26 @@ export const iitmExclusionRegExp = /middle|langsmith|openai\/_shims|openai\/reso
 // against a regex metacharacter entering a package name.
 const includeModuleNames = new Set()
 let moduleNameAlternation = ''
-for (const moduleName of Object.keys(hooks)) {
-  // Relative hooks resolve outside node_modules and are not instrumented here.
-  if (isRelativeRequire(moduleName)) continue
-  includeModuleNames.add(moduleName)
-  // iitm matches a built-in by its node: specifier too, so mirror that and
-  // wrap `import 'node:crypto'` as well as `import 'crypto'`.
-  if (builtinModules.includes(moduleName)) includeModuleNames.add(`node:${moduleName}`)
-  if (moduleNameAlternation !== '') moduleNameAlternation += '|'
-  moduleNameAlternation += regexpEscape(moduleName)
+
+if (!isInitializeMainThread) {
+  const regexpEscapeModule = require('./vendor/dist/escape-string-regexp/index.js')
+  const hooks = require('./packages/datadog-instrumentations/src/helpers/hooks.js')
+  const configHelper = require('./packages/dd-trace/src/config/helper.js')
+  const { isRelativeRequire } = require('./packages/datadog-instrumentations/src/helpers/shared-utils.js')
+
+  regexpEscape = regexpEscapeModule.default
+  getValueFromEnvSources = configHelper.getValueFromEnvSources
+
+  for (const moduleName of Object.keys(hooks)) {
+    // Relative hooks resolve outside node_modules and are not instrumented here.
+    if (isRelativeRequire(moduleName)) continue
+    includeModuleNames.add(moduleName)
+    // iitm matches a built-in by its node: specifier too, so mirror that and
+    // wrap `import 'node:crypto'` as well as `import 'crypto'`.
+    if (builtinModules.includes(moduleName)) includeModuleNames.add(`node:${moduleName}`)
+    if (moduleNameAlternation !== '') moduleNameAlternation += '|'
+    moduleNameAlternation += regexpEscape(moduleName)
+  }
 }
 
 const nodeModulesIncludeSource = `node_modules/(?:${moduleNameAlternation})/(?!node_modules).+`


### PR DESCRIPTION
## Summary
Node.js can hang when initialize.mjs eagerly loads the instrumentation graph before the app-dir bailout. Marking the preload import lets the application thread avoid that graph while loader workers retain the full instrumentation hooks, preserving bailout behavior and re-enabling the runtime checks.

## Why
The static import initialized the instrumentation dependency graph before the bailout path could defer to the app copy, exposing a Node.js 24 loader shutdown hang. The query-marked preload keeps the main-thread path lightweight without changing the worker-side instrumentation path.
