### PR TITLE
feat(appsec): report DD_APPSEC_AGENTIC_ONBOARDING in config telemetry

### DIFF
--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -6,7 +6,6 @@ export interface GeneratedConfig {
   _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL: number;
   apmTracingEnabled: boolean;
   appsec: {
-    agenticOnboarding: string;
     blockedTemplateGraphql: string | undefined;
     blockedTemplateHtml: string | undefined;
     blockedTemplateJson: string | undefined;
@@ -17,6 +16,7 @@ export interface GeneratedConfig {
     DD_API_SECURITY_MAX_DOWNSTREAM_BODY_BYTES: number;
     DD_API_SECURITY_MAX_DOWNSTREAM_REQUEST_BODY_ANALYSIS: number;
     DD_API_SECURITY_SAMPLE_DELAY: number;
+    DD_APPSEC_AGENTIC_ONBOARDING: string;
     DD_APPSEC_SCA_ENABLED: boolean | undefined;
     enabled: boolean | undefined;
     eventTracking: {

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -6,6 +6,7 @@ export interface GeneratedConfig {
   _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL: number;
   apmTracingEnabled: boolean;
   appsec: {
+    agenticOnboarding: string;
     blockedTemplateGraphql: string | undefined;
     blockedTemplateHtml: string | undefined;
     blockedTemplateJson: string | undefined;
@@ -620,6 +621,7 @@ export interface GeneratedEnvVarConfig {
   DD_APM_FLUSH_DEADLINE_MILLISECONDS: number;
   DD_APM_TRACING_ENABLED: boolean;
   DD_APP_KEY: string | undefined;
+  DD_APPSEC_AGENTIC_ONBOARDING: string;
   DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE: string;
   DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING: string;
   DD_APPSEC_COLLECT_ALL_HEADERS: boolean;

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -206,6 +206,17 @@
         ]
       }
     ],
+    "DD_APPSEC_AGENTIC_ONBOARDING": [
+      {
+        "implementation": "A",
+        "type": "string",
+        "configurationNames": [
+          "appsec.agenticOnboarding"
+        ],
+        "default": "",
+        "description": "Set automatically by Datadog's agentic onboarding solution when it configures App & API Protection for a service. Reported verbatim in configuration telemetry only; it has no effect on tracer behavior."
+      }
+    ],
     "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE": [
       {
         "implementation": "E",

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -210,10 +210,8 @@
       {
         "implementation": "A",
         "type": "string",
-        "configurationNames": [
-          "appsec.agenticOnboarding"
-        ],
         "default": "",
+        "namespace": "appsec",
         "description": "Set automatically by Datadog's agentic onboarding solution when it configures App & API Protection for a service. Reported verbatim in configuration telemetry only; it has no effect on tracer behavior."
       }
     ],

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -621,7 +621,7 @@ describe('Config', () => {
     it('should default to an empty string and report it with origin=default when unset', () => {
       const config = getConfig()
 
-      assert.strictEqual(config.appsec.agenticOnboarding, '')
+      assert.strictEqual(config.appsec.DD_APPSEC_AGENTIC_ONBOARDING, '')
       assertConfigUpdateContains(updateConfig.getCall(0).args[0], [
         { name: 'DD_APPSEC_AGENTIC_ONBOARDING', value: '', origin: 'default' },
       ])
@@ -632,7 +632,7 @@ describe('Config', () => {
 
       const config = getConfig()
 
-      assert.strictEqual(config.appsec.agenticOnboarding, 'true')
+      assert.strictEqual(config.appsec.DD_APPSEC_AGENTIC_ONBOARDING, 'true')
       assertConfigUpdateContains(updateConfig.getCall(0).args[0], [
         { name: 'DD_APPSEC_AGENTIC_ONBOARDING', value: 'true', origin: 'env_var' },
       ])
@@ -643,7 +643,7 @@ describe('Config', () => {
 
       const config = getConfig()
 
-      assert.strictEqual(config.appsec.agenticOnboarding, 'false')
+      assert.strictEqual(config.appsec.DD_APPSEC_AGENTIC_ONBOARDING, 'false')
       assertConfigUpdateContains(updateConfig.getCall(0).args[0], [
         { name: 'DD_APPSEC_AGENTIC_ONBOARDING', value: 'false', origin: 'env_var' },
       ])

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -615,6 +615,41 @@ describe('Config', () => {
     })
   })
 
+  describe('DD_APPSEC_AGENTIC_ONBOARDING', () => {
+    // RFC-1113: reported verbatim in configuration telemetry, always emitted
+    // (empty value with origin=default when unset). No effect on tracer behavior.
+    it('should default to an empty string and report it with origin=default when unset', () => {
+      const config = getConfig()
+
+      assert.strictEqual(config.appsec.agenticOnboarding, '')
+      assertConfigUpdateContains(updateConfig.getCall(0).args[0], [
+        { name: 'DD_APPSEC_AGENTIC_ONBOARDING', value: '', origin: 'default' },
+      ])
+    })
+
+    it('should report the value verbatim with origin=env_var when set to true', () => {
+      process.env.DD_APPSEC_AGENTIC_ONBOARDING = 'true'
+
+      const config = getConfig()
+
+      assert.strictEqual(config.appsec.agenticOnboarding, 'true')
+      assertConfigUpdateContains(updateConfig.getCall(0).args[0], [
+        { name: 'DD_APPSEC_AGENTIC_ONBOARDING', value: 'true', origin: 'env_var' },
+      ])
+    })
+
+    it('should report an arbitrary value verbatim rather than collapsing to a boolean', () => {
+      process.env.DD_APPSEC_AGENTIC_ONBOARDING = 'false'
+
+      const config = getConfig()
+
+      assert.strictEqual(config.appsec.agenticOnboarding, 'false')
+      assertConfigUpdateContains(updateConfig.getCall(0).args[0], [
+        { name: 'DD_APPSEC_AGENTIC_ONBOARDING', value: 'false', origin: 'env_var' },
+      ])
+    })
+  })
+
   it('should correctly map OTEL_RESOURCE_ATTRIBUTES', () => {
     process.env.OTEL_RESOURCE_ATTRIBUTES =
       'deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1'


### PR DESCRIPTION
APPSEC-69230

Implements [RFC-1113]: register `DD_APPSEC_AGENTIC_ONBOARDING` as a string configuration reported verbatim in configuration telemetry. Always emitted — empty value with `origin=default` when unset. No derived boolean and no AppSec-state logic; activation analysis is done downstream in Metabase.

Same change on other tracers: [java](https://github.com/DataDog/dd-trace-java/pull/11983), [dotnet](https://github.com/DataDog/dd-trace-dotnet/pull/8920), [go](https://github.com/DataDog/dd-trace-go/pull/5055), [rb](https://github.com/DataDog/dd-trace-rb/pull/6079).

🤖 Generated with [Claude Code](https://claude.com/claude-code)