### PR TITLE
test(config): update v5 agentic onboarding expectation

### DIFF
--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -2804,6 +2804,7 @@ describe('Config', () => {
       },
       rateLimit: 42,
       rules: RULES_JSON_PATH,
+      DD_APPSEC_AGENTIC_ONBOARDING: '',
       DD_APPSEC_SCA_ENABLED: undefined,
       stackTrace: {
         enabled: true,


### PR DESCRIPTION
## Motivation

`DD_APPSEC_AGENTIC_ONBOARDING` now defaults to an empty string and is included in the AppSec config object. The v5-only exact config expectation omitted that field, causing the v5 release proposal checks in #9415 to fail.

## Changes

- Add `DD_APPSEC_AGENTIC_ONBOARDING: ''` to the v5 AppSec config expectation.

## Decisions

- Keep the production default and telemetry behavior unchanged.
- Fix the expectation on `master` so the correction can be included in the v5 release proposal.

## Validation

- Full `packages/dd-trace/test/config/index.spec.js` with `DD_MAJOR` simulated as 5: passed.
- `npm run test:trace:core`: 4,029 passed; one unrelated failure because `process-tags.spec.js` expects the checkout basename to be exactly `dd-trace-js`, while the isolated worktree uses `dd-trace-js-fix-v5-agentic-onboarding-expectation`.
