### PR TITLE
test(config): assert DD_APPSEC_AGENTIC_ONBOARDING in v5 appsec config

### DIFF
--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -2804,6 +2804,7 @@ describe('Config', () => {
       },
       rateLimit: 42,
       rules: RULES_JSON_PATH,
+      DD_APPSEC_AGENTIC_ONBOARDING: '',
       DD_APPSEC_SCA_ENABLED: undefined,
       stackTrace: {
         enabled: true,


### PR DESCRIPTION
APPSEC-69230

## What

Adds `DD_APPSEC_AGENTIC_ONBOARDING: ''` to the expected `config.appsec` object in the v5-only `should give priority to non-experimental options` test.

## Why

After #9486 merged, the v5 release pipeline started failing (e.g. [this run](https://github.com/DataDog/dd-trace-js/actions/runs/29930822072/job/88960951679)):

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+   DD_APPSEC_AGENTIC_ONBOARDING: '',
  at packages/dd-trace/test/config/index.spec.js:2779
```

#9486 registered `DD_APPSEC_AGENTIC_ONBOARDING` as a `namespace: "appsec"` entry in `supported-configurations.json` with `default: ""`. That mechanism populates `config.appsec[NAME]` for **all** major versions, so the key is now always present.

The PR updated the dedicated test and the two `assertObjectContains` (partial-match) tests, but missed this test, which does a strict `assert.deepStrictEqual(config.appsec, {…})`.

### Why PR CI didn't catch it

The test is gated:

```js
;(DD_MAJOR < 6 ? it : it.skip)('should give priority to non-experimental options', …)
```

It only runs under **v5**. #9486 merged on `master` (v6+), where the test is `it.skip`'d, so the assertion never ran. It only surfaces in the v5 release/backport pipeline.

## Testing

Temporarily forced the gate open locally to confirm the assertion now passes; reverted the override before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)