### PR TITLE
fix(anthropic): complete raw response lifecycle

### DIFF
--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -2,6 +2,7 @@
 
 const { channel, tracingChannel } = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
+const log = require('../../dd-trace/src/log')
 const { addHook } = require('./helpers/instrument')
 
 const anthropicTracingChannel = tracingChannel('apm:anthropic:request')
@@ -84,6 +85,7 @@ function wrapCreate (create) {
       let afterVerdict
       let asResponseResult
       let beforeVerdict
+      let parseLifecycleResult
       let parseResult
 
       function getBeforeVerdict () {
@@ -136,6 +138,11 @@ function wrapCreate (create) {
             throw error
           })
 
+        if (hasLifecycle) {
+          const reuseAfterVerdict = () => afterVerdict
+          parseLifecycleResult = parseResult.then(reuseAfterVerdict, reuseAfterVerdict)
+        }
+
         return parseResult
       })
 
@@ -152,17 +159,16 @@ function wrapCreate (create) {
 
         asResponseResult = gated
           .then(response => {
-            if (!stream && hasLifecycle && (parseResult || messagesAfterChannel.hasSubscribers)) {
-              if (parseResult) {
-                return parseResult.then(() => response)
+            if (!stream && hasLifecycle && (parseLifecycleResult || messagesAfterChannel.hasSubscribers)) {
+              if (parseLifecycleResult) {
+                return parseLifecycleResult.then(() => response)
               }
 
               let bodyPromise
               try {
                 bodyPromise = response.clone().json()
               } catch (error) {
-                finish(ctx, null, error)
-                return response
+                return handleRawResponseEvaluationError(ctx, response, error)
               }
 
               return bodyPromise.then(
@@ -184,10 +190,7 @@ function wrapCreate (create) {
                 /**
                  * @param {Error} error
                  */
-                error => {
-                  finish(ctx, null, error)
-                  return response
-                }
+                error => handleRawResponseEvaluationError(ctx, response, error)
               )
             }
 
@@ -207,6 +210,18 @@ function wrapCreate (create) {
       return apiPromise
     })
   }
+}
+
+/**
+ * @param {object} ctx
+ * @param {object} response
+ * @param {Error} error
+ * @returns {object}
+ */
+function handleRawResponseEvaluationError (ctx, response, error) {
+  log.error('Unable to evaluate Anthropic response body: %s', error.message)
+  finish(ctx)
+  return response
 }
 
 function finish (ctx, result, error) {

--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -83,10 +83,9 @@ function wrapCreate (create) {
       }
 
       let afterVerdict
-      let asResponseResult
       let beforeVerdict
-      let parseLifecycleResult
       let parseResult
+      let rawResponseEvaluation
 
       function getBeforeVerdict () {
         if (!hasLifecycle || beforeVerdict) return beforeVerdict
@@ -138,71 +137,78 @@ function wrapCreate (create) {
             throw error
           })
 
-        if (hasLifecycle) {
-          const reuseAfterVerdict = () => afterVerdict
-          parseLifecycleResult = parseResult.then(reuseAfterVerdict, reuseAfterVerdict)
-        }
-
         return parseResult
       })
 
       // Gate `.asResponse()` callers on the before verdict so raw-response paths still block,
       // and inspect a clone so the caller's response stays unconsumed.
       shimmer.wrap(apiPromise, 'asResponse', origAsResponse => function (...asResponseArgs) {
-        if (asResponseResult) return asResponseResult
-
         const responsePromise = origAsResponse.apply(this, asResponseArgs)
         const verdict = hasLifecycle ? getBeforeVerdict() : undefined
         const gated = verdict
           ? Promise.all([verdict, responsePromise]).then(([, response]) => response)
           : responsePromise
 
-        asResponseResult = gated
+        return gated
           .then(response => {
-            if (!stream && hasLifecycle && (parseLifecycleResult || messagesAfterChannel.hasSubscribers)) {
-              if (parseLifecycleResult) {
-                return parseLifecycleResult.then(() => response)
+            if (!stream && hasLifecycle) {
+              if (afterVerdict) {
+                return afterVerdict.then(() => response)
               }
 
-              let bodyPromise
-              try {
-                bodyPromise = response.clone().json()
-              } catch (error) {
-                return handleRawResponseEvaluationError(ctx, response, error)
+              if (rawResponseEvaluation) {
+                return rawResponseEvaluation
               }
 
-              return bodyPromise.then(
-                /**
-                 * @param {object} body
-                 */
-                body => {
-                  const verdict = getAfterVerdict(body)
-                  if (!verdict) {
-                    finish(ctx, body, null)
+              if (messagesAfterChannel.hasSubscribers) {
+                // node-fetch clones backpressure when the original branch is unread.
+                if (typeof response.body?.pipe === 'function') {
+                  if (!parseResult) finish(ctx)
+                  return response
+                }
+
+                let bodyPromise
+                try {
+                  bodyPromise = response.clone().json()
+                } catch {
+                  handleRawResponseEvaluationError(ctx, !parseResult)
+                  rawResponseEvaluation = Promise.resolve(response)
+                  return rawResponseEvaluation
+                }
+
+                rawResponseEvaluation = bodyPromise.then(
+                  /**
+                   * @param {object} body
+                   */
+                  body => {
+                    const verdict = getAfterVerdict(body)
+                    if (!verdict) {
+                      if (!parseResult) finish(ctx, body, null)
+                      return response
+                    }
+
+                    return verdict.then(() => {
+                      if (!parseResult) finish(ctx, body, null)
+                      return response
+                    })
+                  },
+                  () => {
+                    handleRawResponseEvaluationError(ctx, !parseResult && !afterVerdict)
+                    if (afterVerdict) return afterVerdict.then(() => response)
                     return response
                   }
-
-                  return verdict.then(() => {
-                    finish(ctx, body, null)
-                    return response
-                  })
-                },
-                /**
-                 * @param {Error} error
-                 */
-                error => handleRawResponseEvaluationError(ctx, response, error)
-              )
+                )
+                return rawResponseEvaluation
+              }
             }
 
-            if (!stream && !ctx.finished) finish(ctx, null, null)
+            if (!stream && !ctx.finished && !parseResult) finish(ctx, null, null)
             return response
           })
           .catch(error => {
             if (!ctx.finished) finish(ctx, null, error)
             throw error
           })
-
-        return asResponseResult
       })
 
       anthropicTracingChannel.end.publish(ctx)
@@ -214,14 +220,11 @@ function wrapCreate (create) {
 
 /**
  * @param {object} ctx
- * @param {object} response
- * @param {Error} error
- * @returns {object}
+ * @param {boolean} finishSpan
  */
-function handleRawResponseEvaluationError (ctx, response, error) {
-  log.error('Unable to evaluate Anthropic response body: %s', error.message)
-  finish(ctx)
-  return response
+function handleRawResponseEvaluationError (ctx, finishSpan) {
+  log.error('Unable to evaluate Anthropic response body')
+  if (finishSpan) finish(ctx)
 }
 
 function finish (ctx, result, error) {

--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -85,7 +85,7 @@ function wrapCreate (create) {
       let afterVerdict
       let beforeVerdict
       let parseResult
-      let rawResponseEvaluation
+      let rawResponseRead
 
       function getBeforeVerdict () {
         if (!hasLifecycle || beforeVerdict) return beforeVerdict
@@ -96,7 +96,7 @@ function wrapCreate (create) {
       }
 
       /**
-       * @param {object} body
+       * @param {object|string} body
        */
       function getAfterVerdict (body) {
         if (!hasLifecycle || afterVerdict) return afterVerdict
@@ -156,8 +156,8 @@ function wrapCreate (create) {
                 return afterVerdict.then(() => response)
               }
 
-              if (rawResponseEvaluation) {
-                return rawResponseEvaluation
+              if (rawResponseRead) {
+                return rawResponseRead
               }
 
               if (messagesAfterChannel.hasSubscribers) {
@@ -169,16 +169,16 @@ function wrapCreate (create) {
 
                 let bodyPromise
                 try {
-                  bodyPromise = response.clone().json()
+                  bodyPromise = response.clone().text()
                 } catch {
-                  handleRawResponseEvaluationError(ctx, !parseResult)
-                  rawResponseEvaluation = Promise.resolve(response)
-                  return rawResponseEvaluation
+                  handleRawResponseReadError(ctx, !parseResult)
+                  rawResponseRead = Promise.resolve(response)
+                  return rawResponseRead
                 }
 
-                rawResponseEvaluation = bodyPromise.then(
+                rawResponseRead = bodyPromise.then(
                   /**
-                   * @param {object} body
+                   * @param {string} body
                    */
                   body => {
                     const verdict = getAfterVerdict(body)
@@ -193,12 +193,12 @@ function wrapCreate (create) {
                     })
                   },
                   () => {
-                    handleRawResponseEvaluationError(ctx, !parseResult && !afterVerdict)
+                    handleRawResponseReadError(ctx, !parseResult && !afterVerdict)
                     if (afterVerdict) return afterVerdict.then(() => response)
                     return response
                   }
                 )
-                return rawResponseEvaluation
+                return rawResponseRead
               }
             }
 
@@ -222,9 +222,11 @@ function wrapCreate (create) {
  * @param {object} ctx
  * @param {boolean} finishSpan
  */
-function handleRawResponseEvaluationError (ctx, finishSpan) {
-  log.error('Unable to evaluate Anthropic response body')
-  if (finishSpan) finish(ctx)
+function handleRawResponseReadError (ctx, finishSpan) {
+  if (!finishSpan) return
+
+  log.error('Unable to read Anthropic response body')
+  finish(ctx)
 }
 
 function finish (ctx, result, error) {

--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -152,7 +152,7 @@ function wrapCreate (create) {
 
         asResponseResult = gated
           .then(response => {
-            if (!stream && hasLifecycle && messagesAfterChannel.hasSubscribers) {
+            if (!stream && hasLifecycle && (parseResult || messagesAfterChannel.hasSubscribers)) {
               if (parseResult) {
                 return parseResult.then(() => response)
               }

--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -81,14 +81,28 @@ function wrapCreate (create) {
         throw error
       }
 
+      let afterVerdict
+      let asResponseResult
       let beforeVerdict
       let parseResult
 
       function getBeforeVerdict () {
-        if (!hasLifecycle || !messagesBeforeChannel.hasSubscribers) return
+        if (!hasLifecycle || beforeVerdict) return beforeVerdict
+        if (!messagesBeforeChannel.hasSubscribers) return
 
-        beforeVerdict ??= publishLifecycle(messagesBeforeChannel, { args, parentSpan })
+        beforeVerdict = publishLifecycle(messagesBeforeChannel, { args, parentSpan })
         return beforeVerdict
+      }
+
+      /**
+       * @param {object} body
+       */
+      function getAfterVerdict (body) {
+        if (!hasLifecycle || afterVerdict) return afterVerdict
+        if (!messagesAfterChannel.hasSubscribers) return
+
+        afterVerdict = publishLifecycle(messagesAfterChannel, { args, body, parentSpan })
+        return afterVerdict
       }
 
       shimmer.wrap(apiPromise, 'parse', parse => function (...parseArgs) {
@@ -106,13 +120,14 @@ function wrapCreate (create) {
               shimmer.wrap(response, Symbol.asyncIterator, iterator => wrapStreamIterator(iterator, ctx))
               return response
             }
-            if (!hasLifecycle || !messagesAfterChannel.hasSubscribers) {
+            const verdict = getAfterVerdict(response)
+            if (!verdict) {
               finish(ctx, response, null)
               return response
             }
             // Finish after evaluation so a block propagates the error to anthropic.request
             // and the span wraps its child instead of closing before it.
-            return publishLifecycle(messagesAfterChannel, { args, body: response, parentSpan }).then(() => {
+            return verdict.then(() => {
               finish(ctx, response, null)
               return response
             })
@@ -125,44 +140,55 @@ function wrapCreate (create) {
       })
 
       // Gate `.asResponse()` callers on the before verdict so raw-response paths still block,
-      // and finish the span so it is not leaked when the caller never invokes `.parse()`.
+      // and inspect a clone so the caller's response stays unconsumed.
       shimmer.wrap(apiPromise, 'asResponse', origAsResponse => function (...asResponseArgs) {
+        if (asResponseResult) return asResponseResult
+
         const responsePromise = origAsResponse.apply(this, asResponseArgs)
         const verdict = hasLifecycle ? getBeforeVerdict() : undefined
         const gated = verdict
           ? Promise.all([verdict, responsePromise]).then(([, response]) => response)
           : responsePromise
 
-        return gated
+        asResponseResult = gated
           .then(response => {
             if (!stream && hasLifecycle && messagesAfterChannel.hasSubscribers) {
-              // Defer finish until body is consumed (json/text) so the after-channel sees the content.
-              function wrapBodyConsume (originalMethod) {
-                return function (...methodArgs) {
-                  if (ctx.finished) {
-                    return originalMethod.apply(this, methodArgs)
+              if (parseResult) {
+                return parseResult.then(() => response)
+              }
+
+              let bodyPromise
+              try {
+                bodyPromise = response.clone().json()
+              } catch (error) {
+                finish(ctx, null, error)
+                return response
+              }
+
+              return bodyPromise.then(
+                /**
+                 * @param {object} body
+                 */
+                body => {
+                  const verdict = getAfterVerdict(body)
+                  if (!verdict) {
+                    finish(ctx, body, null)
+                    return response
                   }
 
-                  return originalMethod.apply(this, methodArgs).then(body => {
-                    return publishLifecycle(messagesAfterChannel, { args, body, parentSpan }).then(() => {
-                      finish(ctx, body, null)
-                      return body
-                    })
-                  }).catch(error => {
-                    if (!ctx.finished) finish(ctx, null, error)
-                    throw error
+                  return verdict.then(() => {
+                    finish(ctx, body, null)
+                    return response
                   })
+                },
+                /**
+                 * @param {Error} error
+                 */
+                error => {
+                  finish(ctx, null, error)
+                  return response
                 }
-              }
-              if (typeof response.json === 'function') {
-                shimmer.wrap(response, 'json', wrapBodyConsume)
-              }
-
-              if (typeof response.text === 'function') {
-                shimmer.wrap(response, 'text', wrapBodyConsume)
-              }
-
-              return response
+              )
             }
 
             if (!stream && !ctx.finished) finish(ctx, null, null)
@@ -172,6 +198,8 @@ function wrapCreate (create) {
             if (!ctx.finished) finish(ctx, null, error)
             throw error
           })
+
+        return asResponseResult
       })
 
       anthropicTracingChannel.end.publish(ctx)

--- a/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
+++ b/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
@@ -10,43 +10,18 @@ const { before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const log = require('../../dd-trace/src/log')
+const {
+  FakeAPIPromise,
+  FakeMessages,
+  applyShim,
+  createDeferred,
+  loadAnthropicInstrumentation,
+} = require('./helpers/anthropic-lifecycle')
 
 const messagesBeforeChannel = channel('dd-trace:anthropic:messages:before')
 const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
 const execFileAsync = promisify(execFile)
 const lifecycleRejectionFixture = path.join(__dirname, 'fixtures', 'anthropic-lifecycle-rejections.js')
-
-class FakeAPIPromise {
-  /**
-   * @param {object} body
-   */
-  constructor (body) {
-    this._body = body
-    this._rawResponse = new Response(JSON.stringify(body))
-  }
-
-  parse () {
-    return Promise.resolve(this._body)
-  }
-
-  asResponse () {
-    return Promise.resolve(this._rawResponse)
-  }
-
-  withResponse () {
-    return Promise.all([this.parse(), this.asResponse()]).then(([data, response]) => ({ data, response }))
-  }
-
-  then (onFulfilled, onRejected) {
-    return this.parse().then(onFulfilled, onRejected)
-  }
-}
-
-class FakeMessages {
-  create () {
-    return this._nextApiPromise
-  }
-}
 
 function subscribeAutoResolve (channels) {
   const calls = []
@@ -82,61 +57,9 @@ function lifecycleAbortError (message = 'blocked') {
   return Object.assign(new Error(message), { name: 'AIGuardAbortError' })
 }
 
-function createDeferred () {
-  let resolveDeferred
-  let rejectDeferred
-  const promise = new Promise(
-    /**
-     * @param {(value?: void | PromiseLike<void>) => void} resolve
-     * @param {(reason?: unknown) => void} reject
-     */
-    (resolve, reject) => {
-      resolveDeferred = resolve
-      rejectDeferred = reject
-    }
-  )
-  return { promise, reject: rejectDeferred, resolve: resolveDeferred }
-}
-
 function blockLifecycle (ctx, err) {
   ctx.abortController.abort(err)
   ctx.pending.push(Promise.resolve())
-}
-
-function loadAnthropicInstrumentation () {
-  const instrumentPath = require.resolve('../src/helpers/instrument')
-  const realInstrument = require(instrumentPath)
-  const hookCallbacks = []
-
-  const stub = {
-    ...realInstrument,
-    addHook (spec, cb) {
-      hookCallbacks.push({ spec, cb })
-    },
-  }
-
-  const cache = require.cache[instrumentPath]
-  const prevExports = cache.exports
-  cache.exports = stub
-
-  try {
-    delete require.cache[require.resolve('../src/anthropic')]
-    require('../src/anthropic')
-  } finally {
-    cache.exports = prevExports
-  }
-
-  return hookCallbacks
-}
-
-function applyShim (hookCallbacks, filePath, Messages) {
-  for (const { spec, cb } of hookCallbacks) {
-    if (spec.file === `${filePath}.js`) {
-      cb({ Messages })
-      return
-    }
-  }
-  throw new Error(`No hook registered for ${filePath}.js`)
 }
 
 describe('anthropic lifecycle instrumentation', () => {
@@ -347,7 +270,7 @@ describe('anthropic lifecycle instrumentation', () => {
       const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
 
       assert.strictEqual(calls.length, 2)
-      assert.deepStrictEqual(calls[1].body, body)
+      assert.strictEqual(calls[1].body, JSON.stringify(body))
       assert.ok(asyncEndCtx, 'asyncEnd was not published')
       assert.strictEqual(asyncEndCtx.finished, true)
       assert.strictEqual(response.bodyUsed, false)
@@ -426,7 +349,7 @@ describe('anthropic lifecycle instrumentation', () => {
     const error = new Error('clone failed')
     const cloneFailures = [
       () => { throw error },
-      () => ({ json: () => { throw error } }),
+      () => ({ text: () => { throw error } }),
     ]
 
     try {
@@ -472,7 +395,7 @@ describe('anthropic lifecycle instrumentation', () => {
       for (const rejection of rejections) {
         const messages = new Messages()
         const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
-        apiPromise._rawResponse.clone = () => ({ json: () => Promise.reject(rejection) })
+        apiPromise._rawResponse.clone = () => ({ text: () => Promise.reject(rejection) })
         messages._nextApiPromise = apiPromise
 
         const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
@@ -484,7 +407,7 @@ describe('anthropic lifecycle instrumentation', () => {
       assert.strictEqual(calls.length, 0)
       assert.strictEqual(logError.callCount, rejections.length)
       for (const call of logError.getCalls()) {
-        assert.deepStrictEqual(call.args, ['Unable to evaluate Anthropic response body'])
+        assert.deepStrictEqual(call.args, ['Unable to read Anthropic response body'])
       }
     } finally {
       apmChannel.unsubscribe(apmHandlers)
@@ -493,7 +416,7 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('lets a started parser own the span when raw evaluation fails', async () => {
+  it('lets a started parser own the span when the raw response read fails', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let errorCount = 0
@@ -515,7 +438,7 @@ describe('anthropic lifecycle instrumentation', () => {
         const parseError = new SyntaxError('invalid response')
         apiPromise.parse = () => parseDeferred.promise
         apiPromise._rawResponse.clone = () => ({
-          json: () => {
+          text: () => {
             cloneStarted.resolve()
             return cloneDeferred.promise
           },
@@ -550,7 +473,7 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('honors an after verdict published while raw evaluation is pending', async () => {
+  it('honors an after verdict published while the raw response read is pending', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let errorCount = 0
@@ -578,7 +501,7 @@ describe('anthropic lifecycle instrumentation', () => {
     const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
     apiPromise.parse = () => parseDeferred.promise
     apiPromise._rawResponse.clone = () => ({
-      json: () => {
+      text: () => {
         cloneStarted.resolve()
         return cloneDeferred.promise
       },
@@ -608,7 +531,7 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('honors a resolving after verdict when raw evaluation fails', async () => {
+  it('honors a resolving after verdict when the raw response read fails', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let asyncEndCount = 0
@@ -634,7 +557,7 @@ describe('anthropic lifecycle instrumentation', () => {
     const apiPromise = new FakeAPIPromise(body)
     apiPromise.parse = () => parseDeferred.promise
     apiPromise._rawResponse.clone = () => ({
-      json: () => {
+      text: () => {
         cloneStarted.resolve()
         return cloneDeferred.promise
       },
@@ -674,9 +597,9 @@ describe('anthropic lifecycle instrumentation', () => {
     const messages = new Messages()
     const apiPromise = new FakeAPIPromise(body)
     apiPromise._rawResponse.clone = () => ({
-      json: async () => {
+      text: async () => {
         unsubscribe()
-        return body
+        return JSON.stringify(body)
       },
     })
     messages._nextApiPromise = apiPromise
@@ -847,7 +770,7 @@ describe('anthropic lifecycle instrumentation', () => {
 
       assert.deepStrictEqual(await response.json(), body)
       assert.strictEqual(calls.length, 2)
-      assert.deepStrictEqual(calls[1].body, body)
+      assert.strictEqual(calls[1].body, JSON.stringify(body))
     } finally {
       unsubscribe()
     }
@@ -868,7 +791,7 @@ describe('anthropic lifecycle instrumentation', () => {
 
       assert.strictEqual(raw, JSON.stringify(body))
       assert.strictEqual(calls.length, 2)
-      assert.deepStrictEqual(calls[1].body, body)
+      assert.strictEqual(calls[1].body, JSON.stringify(body))
     } finally {
       unsubscribe()
     }
@@ -1005,7 +928,7 @@ describe('anthropic lifecycle instrumentation', () => {
         lifecycleRejectionFixture,
         'ignored-parse-error',
       ]),
-      { code: 1 }
+      { code: 1, stderr: /SyntaxError: invalid response/ }
     )
   })
 
@@ -1016,7 +939,7 @@ describe('anthropic lifecycle instrumentation', () => {
         lifecycleRejectionFixture,
         'ignored-parse-error-with-raw',
       ]),
-      { code: 1 }
+      { code: 1, stderr: /SyntaxError: invalid response/ }
     )
   })
 
@@ -1027,7 +950,7 @@ describe('anthropic lifecycle instrumentation', () => {
         lifecycleRejectionFixture,
         'ignored-first-raw',
       ]),
-      { code: 1 }
+      { code: 1, stderr: /Error: blocked/ }
     )
   })
 
@@ -1075,12 +998,11 @@ describe('anthropic lifecycle instrumentation', () => {
     const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
 
     try {
-      const [, response] = await Promise.all([
+      await Promise.all([
         apiPromise.parse(),
         apiPromise.asResponse(),
       ])
 
-      assert.deepStrictEqual(await response.json(), { role: 'assistant', content: [] })
       assert.strictEqual(calls.length, 2)
       assert.strictEqual(asyncEndCount, 1)
     } finally {

--- a/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
+++ b/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
@@ -608,6 +608,39 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
+  it('reuses the after verdict when parse() starts before asResponse()', async () => {
+    const error = lifecycleAbortError()
+    let calls = 0
+    const unsubscribe = subscribeWithHandler(
+      [messagesAfterChannel],
+      /**
+       * @param {{ abortController: AbortController, pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        calls++
+        blockLifecycle(ctx, error)
+        unsubscribe()
+      }
+    )
+    const messages = new Messages()
+    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+    const expectedError = { name: error.name, message: error.message }
+
+    try {
+      const parseRejection = assert.rejects(apiPromise.parse(), expectedError)
+      await Promise.resolve()
+      assert.strictEqual(calls, 1)
+
+      await Promise.all([
+        parseRejection,
+        assert.rejects(apiPromise.asResponse(), expectedError),
+      ])
+    } finally {
+      unsubscribe()
+    }
+  })
+
   it('evaluates and finishes exactly once when parse() starts before asResponse()', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }

--- a/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
+++ b/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
@@ -1,12 +1,20 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { execFile } = require('node:child_process')
+const path = require('node:path')
+const { promisify } = require('node:util')
 
 const { channel, tracingChannel } = require('dc-polyfill')
 const { before, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+const log = require('../../dd-trace/src/log')
 
 const messagesBeforeChannel = channel('dd-trace:anthropic:messages:before')
 const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
+const execFileAsync = promisify(execFile)
+const lifecycleRejectionFixture = path.join(__dirname, 'fixtures', 'anthropic-lifecycle-rejections.js')
 
 class FakeAPIPromise {
   /**
@@ -72,6 +80,22 @@ function subscribeWithHandler (channels, handler) {
 
 function lifecycleAbortError (message = 'blocked') {
   return Object.assign(new Error(message), { name: 'AIGuardAbortError' })
+}
+
+function createDeferred () {
+  let resolveDeferred
+  let rejectDeferred
+  const promise = new Promise(
+    /**
+     * @param {(value?: void | PromiseLike<void>) => void} resolve
+     * @param {(reason?: unknown) => void} reject
+     */
+    (resolve, reject) => {
+      resolveDeferred = resolve
+      rejectDeferred = reject
+    }
+  )
+  return { promise, reject: rejectDeferred, resolve: resolveDeferred }
 }
 
 function blockLifecycle (ctx, err) {
@@ -271,6 +295,39 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
+  it('finishes after a resolving before subscriber leaves', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let asyncEndCount = 0
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const unsubscribe = subscribeWithHandler(
+      [messagesBeforeChannel],
+      /**
+       * @param {{ pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        ctx.pending.push(Promise.resolve())
+        unsubscribe()
+      }
+    )
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    messages._nextApiPromise = apiPromise
+
+    try {
+      assert.strictEqual(
+        await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse(),
+        apiPromise._rawResponse
+      )
+      assert.strictEqual(asyncEndCount, 1)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
   it('evaluates and finishes an unconsumed raw response without consuming it', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
@@ -311,10 +368,12 @@ describe('anthropic lifecycle instrumentation', () => {
     const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
 
     try {
-      const [firstResponse, secondResponse] = await Promise.all([
-        apiPromise.asResponse(),
-        apiPromise.asResponse(),
-      ])
+      const firstPromise = apiPromise.asResponse()
+      const secondPromise = apiPromise.asResponse()
+
+      assert.notStrictEqual(firstPromise, secondPromise)
+
+      const [firstResponse, secondResponse] = await Promise.all([firstPromise, secondPromise])
 
       assert.strictEqual(firstResponse, secondResponse)
       assert.strictEqual(calls.length, 2)
@@ -323,7 +382,38 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('finishes without a tracing error when cloning the raw response throws', async () => {
+  it('finishes a raw Node stream response without cloning it', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let asyncEndCount = 0
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const response = {
+      body: { pipe: sinon.spy() },
+      clone: sinon.spy(),
+    }
+    apiPromise._rawResponse = response
+    messages._nextApiPromise = apiPromise
+
+    try {
+      assert.strictEqual(
+        await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse(),
+        response
+      )
+      sinon.assert.notCalled(response.clone)
+      assert.strictEqual(calls.length, 0)
+      assert.strictEqual(asyncEndCount, 1)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
+  it('finishes without a tracing error when cloning or reading the raw response throws', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let errorCount = 0
@@ -333,18 +423,25 @@ describe('anthropic lifecycle instrumentation', () => {
     apmChannel.subscribe(apmHandlers)
 
     const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
-    const messages = new Messages()
-    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
     const error = new Error('clone failed')
-    apiPromise._rawResponse.clone = () => { throw error }
-    messages._nextApiPromise = apiPromise
+    const cloneFailures = [
+      () => { throw error },
+      () => ({ json: () => { throw error } }),
+    ]
 
     try {
-      const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+      for (const clone of cloneFailures) {
+        const messages = new Messages()
+        const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+        apiPromise._rawResponse.clone = clone
+        messages._nextApiPromise = apiPromise
 
-      assert.strictEqual(response, apiPromise._rawResponse)
+        const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+
+        assert.strictEqual(response, apiPromise._rawResponse)
+      }
       assert.strictEqual(errorCount, 0)
-      assert.strictEqual(asyncEndCount, 1)
+      assert.strictEqual(asyncEndCount, cloneFailures.length)
       assert.strictEqual(calls.length, 0)
     } finally {
       apmChannel.unsubscribe(apmHandlers)
@@ -352,7 +449,7 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('finishes without a tracing error when reading the raw response clone rejects', async () => {
+  it('fails open for arbitrary raw response read rejections without logging their values', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let errorCount = 0
@@ -362,19 +459,203 @@ describe('anthropic lifecycle instrumentation', () => {
     apmChannel.subscribe(apmHandlers)
 
     const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
-    const messages = new Messages()
-    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
-    const error = new Error('body failed')
-    apiPromise._rawResponse.clone = () => ({ json: () => Promise.reject(error) })
-    messages._nextApiPromise = apiPromise
+    const logError = sinon.stub(log, 'error')
+    const throwingMessage = {}
+    Object.defineProperty(throwingMessage, 'message', {
+      get () {
+        throw new Error('message getter should not run')
+      },
+    })
+    const rejections = [new Error('body failed'), undefined, null, 'sensitive response body', throwingMessage]
 
     try {
-      const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+      for (const rejection of rejections) {
+        const messages = new Messages()
+        const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+        apiPromise._rawResponse.clone = () => ({ json: () => Promise.reject(rejection) })
+        messages._nextApiPromise = apiPromise
 
-      assert.strictEqual(response, apiPromise._rawResponse)
+        const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+
+        assert.strictEqual(response, apiPromise._rawResponse)
+      }
       assert.strictEqual(errorCount, 0)
-      assert.strictEqual(asyncEndCount, 1)
+      assert.strictEqual(asyncEndCount, rejections.length)
       assert.strictEqual(calls.length, 0)
+      assert.strictEqual(logError.callCount, rejections.length)
+      for (const call of logError.getCalls()) {
+        assert.deepStrictEqual(call.args, ['Unable to evaluate Anthropic response body'])
+      }
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+      logError.restore()
+    }
+  })
+
+  it('lets a started parser own the span when raw evaluation fails', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let errorCount = 0
+    let asyncEndCount = 0
+    apmHandlers.error = () => { errorCount++ }
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const { unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
+    const settlementOrders = ['raw-first', 'parse-first']
+
+    try {
+      for (const settlementOrder of settlementOrders) {
+        const cloneStarted = createDeferred()
+        const cloneDeferred = createDeferred()
+        const parseDeferred = createDeferred()
+        const messages = new Messages()
+        const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+        const parseError = new SyntaxError('invalid response')
+        apiPromise.parse = () => parseDeferred.promise
+        apiPromise._rawResponse.clone = () => ({
+          json: () => {
+            cloneStarted.resolve()
+            return cloneDeferred.promise
+          },
+        })
+        messages._nextApiPromise = apiPromise
+        const instrumentedPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+        const responsePromise = instrumentedPromise.asResponse()
+
+        await cloneStarted.promise
+
+        const parsePromise = instrumentedPromise.parse()
+        const parseRejection = assert.rejects(parsePromise, parseError)
+
+        if (settlementOrder === 'raw-first') {
+          cloneDeferred.reject(new Error('clone failed'))
+          await responsePromise
+          parseDeferred.reject(parseError)
+        } else {
+          parseDeferred.reject(parseError)
+          await parseRejection
+          cloneDeferred.reject(new Error('clone failed'))
+        }
+
+        await Promise.all([responsePromise, parseRejection])
+      }
+
+      assert.strictEqual(errorCount, settlementOrders.length)
+      assert.strictEqual(asyncEndCount, settlementOrders.length)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
+  it('honors an after verdict published while raw evaluation is pending', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let errorCount = 0
+    let asyncEndCount = 0
+    apmHandlers.error = () => { errorCount++ }
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const error = lifecycleAbortError()
+    const afterPublished = createDeferred()
+    const unsubscribe = subscribeWithHandler(
+      [messagesAfterChannel],
+      /**
+       * @param {{ abortController: AbortController, pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        blockLifecycle(ctx, error)
+        afterPublished.resolve()
+      }
+    )
+    const cloneStarted = createDeferred()
+    const cloneDeferred = createDeferred()
+    const parseDeferred = createDeferred()
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    apiPromise.parse = () => parseDeferred.promise
+    apiPromise._rawResponse.clone = () => ({
+      json: () => {
+        cloneStarted.resolve()
+        return cloneDeferred.promise
+      },
+    })
+    messages._nextApiPromise = apiPromise
+    const instrumentedPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+    const responsePromise = instrumentedPromise.asResponse()
+
+    try {
+      await cloneStarted.promise
+
+      const parsePromise = instrumentedPromise.parse()
+      const parseRejection = assert.rejects(parsePromise, error)
+      parseDeferred.resolve(apiPromise._body)
+      await afterPublished.promise
+      cloneDeferred.reject(new Error('clone failed'))
+
+      await Promise.all([
+        parseRejection,
+        assert.rejects(responsePromise, error),
+      ])
+      assert.strictEqual(errorCount, 1)
+      assert.strictEqual(asyncEndCount, 1)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
+  it('honors a resolving after verdict when raw evaluation fails', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let asyncEndCount = 0
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const afterPublished = createDeferred()
+    const unsubscribe = subscribeWithHandler(
+      [messagesAfterChannel],
+      /**
+       * @param {{ pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        ctx.pending.push(Promise.resolve())
+        afterPublished.resolve()
+      }
+    )
+    const cloneStarted = createDeferred()
+    const cloneDeferred = createDeferred()
+    const parseDeferred = createDeferred()
+    const body = { role: 'assistant', content: [] }
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise(body)
+    apiPromise.parse = () => parseDeferred.promise
+    apiPromise._rawResponse.clone = () => ({
+      json: () => {
+        cloneStarted.resolve()
+        return cloneDeferred.promise
+      },
+    })
+    messages._nextApiPromise = apiPromise
+    const instrumentedPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+    const responsePromise = instrumentedPromise.asResponse()
+
+    try {
+      await cloneStarted.promise
+
+      const parsePromise = instrumentedPromise.parse()
+      parseDeferred.resolve(body)
+      await afterPublished.promise
+      cloneDeferred.reject(new Error('clone failed'))
+
+      const [parsed, response] = await Promise.all([parsePromise, responsePromise])
+
+      assert.strictEqual(parsed, body)
+      assert.strictEqual(response, apiPromise._rawResponse)
+      assert.strictEqual(asyncEndCount, 1)
     } finally {
       apmChannel.unsubscribe(apmHandlers)
       unsubscribe()
@@ -479,6 +760,43 @@ describe('anthropic lifecycle instrumentation', () => {
       () => messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).withResponse(),
       e => e === err
     ).finally(unsubscribe)
+  })
+
+  it('propagates after lifecycle rejection through withResponse()', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let afterCalls = 0
+    let asyncEndCount = 0
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const error = lifecycleAbortError()
+    const { unsubscribe: unsubscribeBefore } = subscribeAutoResolve([messagesBeforeChannel])
+    const unsubscribeAfter = subscribeWithHandler(
+      [messagesAfterChannel],
+      /**
+       * @param {{ abortController: AbortController, pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        afterCalls++
+        blockLifecycle(ctx, error)
+      }
+    )
+    const messages = new Messages()
+    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+
+    try {
+      await assert.rejects(
+        messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).withResponse(),
+        error
+      )
+      assert.strictEqual(afterCalls, 1)
+      assert.strictEqual(asyncEndCount, 1)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribeBefore()
+      unsubscribeAfter()
+    }
   })
 
   it('publishes asyncEnd exactly once when withResponse() and parse() are both called', () => {
@@ -637,7 +955,91 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('keeps raw response access independent when parse() rejects before the after lifecycle', async () => {
+  it('waits for a cached after verdict after its subscriber leaves', async () => {
+    const afterPublished = createDeferred()
+    const afterPending = createDeferred()
+    let calls = 0
+    const unsubscribe = subscribeWithHandler(
+      [messagesAfterChannel],
+      /**
+       * @param {{ pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        calls++
+        ctx.pending.push(afterPending.promise)
+        unsubscribe()
+        afterPublished.resolve()
+      }
+    )
+    const messages = new Messages()
+    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+    const parsePromise = apiPromise.parse()
+
+    try {
+      await afterPublished.promise
+      const responsePromise = apiPromise.asResponse()
+      afterPending.resolve()
+
+      const [, response] = await Promise.all([parsePromise, responsePromise])
+
+      assert.strictEqual(response, messages._nextApiPromise._rawResponse)
+      assert.strictEqual(calls, 1)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('does not emit a duplicate unhandled rejection when a parse lifecycle block is caught', async () => {
+    await execFileAsync(process.execPath, [
+      '--unhandled-rejections=strict',
+      lifecycleRejectionFixture,
+      'caught-after-verdict',
+    ])
+  })
+
+  it('preserves an unhandled parse rejection when its result is ignored', async () => {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        '--unhandled-rejections=strict',
+        lifecycleRejectionFixture,
+        'ignored-parse-error',
+      ]),
+      { code: 1 }
+    )
+  })
+
+  it('preserves an unhandled parse rejection when raw response access is handled', async () => {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        '--unhandled-rejections=strict',
+        lifecycleRejectionFixture,
+        'ignored-parse-error-with-raw',
+      ]),
+      { code: 1 }
+    )
+  })
+
+  it('preserves an ignored raw lifecycle rejection across repeated calls', async () => {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        '--unhandled-rejections=strict',
+        lifecycleRejectionFixture,
+        'ignored-first-raw',
+      ]),
+      { code: 1 }
+    )
+  })
+
+  it('does not wait for a pending parser before returning an evaluated raw response', async () => {
+    await execFileAsync(process.execPath, [
+      '--unhandled-rejections=strict',
+      lifecycleRejectionFixture,
+      'raw-with-pending-parse',
+    ])
+  })
+
+  it('evaluates the raw response independently when parse() rejects before the after lifecycle', async () => {
     const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
     const messages = new Messages()
     const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
@@ -653,7 +1055,7 @@ describe('anthropic lifecycle instrumentation', () => {
       ])
 
       assert.strictEqual(response, apiPromise._rawResponse)
-      assert.strictEqual(calls.length, 0)
+      assert.strictEqual(calls.length, 1)
     } finally {
       unsubscribe()
     }

--- a/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
+++ b/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
@@ -323,14 +323,12 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('returns the raw response when cloning it throws', async () => {
+  it('finishes without a tracing error when cloning the raw response throws', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
-    let errorCtx
+    let errorCount = 0
     let asyncEndCount = 0
-    /** @param {{ error: Error }} ctx */
-    const onError = (ctx) => { errorCtx = ctx }
-    apmHandlers.error = onError
+    apmHandlers.error = () => { errorCount++ }
     apmHandlers.asyncEnd = () => { asyncEndCount++ }
     apmChannel.subscribe(apmHandlers)
 
@@ -345,7 +343,7 @@ describe('anthropic lifecycle instrumentation', () => {
       const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
 
       assert.strictEqual(response, apiPromise._rawResponse)
-      assert.strictEqual(errorCtx.error, error)
+      assert.strictEqual(errorCount, 0)
       assert.strictEqual(asyncEndCount, 1)
       assert.strictEqual(calls.length, 0)
     } finally {
@@ -354,14 +352,12 @@ describe('anthropic lifecycle instrumentation', () => {
     }
   })
 
-  it('returns the raw response when reading its clone rejects', async () => {
+  it('finishes without a tracing error when reading the raw response clone rejects', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
-    let errorCtx
+    let errorCount = 0
     let asyncEndCount = 0
-    /** @param {{ error: Error }} ctx */
-    const onError = (ctx) => { errorCtx = ctx }
-    apmHandlers.error = onError
+    apmHandlers.error = () => { errorCount++ }
     apmHandlers.asyncEnd = () => { asyncEndCount++ }
     apmChannel.subscribe(apmHandlers)
 
@@ -376,7 +372,7 @@ describe('anthropic lifecycle instrumentation', () => {
       const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
 
       assert.strictEqual(response, apiPromise._rawResponse)
-      assert.strictEqual(errorCtx.error, error)
+      assert.strictEqual(errorCount, 0)
       assert.strictEqual(asyncEndCount, 1)
       assert.strictEqual(calls.length, 0)
     } finally {
@@ -636,6 +632,28 @@ describe('anthropic lifecycle instrumentation', () => {
         parseRejection,
         assert.rejects(apiPromise.asResponse(), expectedError),
       ])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('keeps raw response access independent when parse() rejects before the after lifecycle', async () => {
+    const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const error = new SyntaxError('invalid response')
+    apiPromise.parse = () => Promise.reject(error)
+    messages._nextApiPromise = apiPromise
+    const instrumentedPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+
+    try {
+      const [, response] = await Promise.all([
+        assert.rejects(instrumentedPromise.parse(), error),
+        instrumentedPromise.asResponse(),
+      ])
+
+      assert.strictEqual(response, apiPromise._rawResponse)
+      assert.strictEqual(calls.length, 0)
     } finally {
       unsubscribe()
     }

--- a/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
+++ b/packages/datadog-instrumentations/test/anthropic-lifecycle.spec.js
@@ -9,13 +9,12 @@ const messagesBeforeChannel = channel('dd-trace:anthropic:messages:before')
 const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
 
 class FakeAPIPromise {
+  /**
+   * @param {object} body
+   */
   constructor (body) {
     this._body = body
-    this._rawResponse = {
-      ok: true,
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(JSON.stringify(body)),
-    }
+    this._rawResponse = new Response(JSON.stringify(body))
   }
 
   parse () {
@@ -246,59 +245,232 @@ describe('anthropic lifecycle instrumentation', () => {
     ).finally(unsubscribe)
   })
 
-  it('publishes asyncEnd when the caller uses asResponse() without parse()', () => {
+  it('reuses the before verdict after its subscriber leaves', async () => {
+    const error = lifecycleAbortError()
+    const unsubscribe = subscribeWithHandler(
+      [messagesBeforeChannel],
+      /**
+       * @param {{ abortController: AbortController, pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        blockLifecycle(ctx, error)
+        unsubscribe()
+      }
+    )
+    const messages = new Messages()
+    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+
+    try {
+      await Promise.all([
+        assert.rejects(apiPromise.parse(), { name: error.name, message: error.message }),
+        assert.rejects(apiPromise.asResponse(), { name: error.name, message: error.message }),
+      ])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('evaluates and finishes an unconsumed raw response without consuming it', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let asyncEndCtx
     apmHandlers.asyncEnd = ctx => { asyncEndCtx = ctx }
     apmChannel.subscribe(apmHandlers)
 
+    const { calls, unsubscribe } = subscribeAutoResolve([
+      messagesBeforeChannel,
+      messagesAfterChannel,
+    ])
+    const body = { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] }
     const messages = new Messages()
-    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    messages._nextApiPromise = new FakeAPIPromise(body)
 
-    return messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
-      .then(() => {
-        assert.ok(asyncEndCtx, 'asyncEnd was not published')
-        assert.strictEqual(asyncEndCtx.finished, true)
-      })
-      .finally(() => apmChannel.unsubscribe(apmHandlers))
+    try {
+      const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+
+      assert.strictEqual(calls.length, 2)
+      assert.deepStrictEqual(calls[1].body, body)
+      assert.ok(asyncEndCtx, 'asyncEnd was not published')
+      assert.strictEqual(asyncEndCtx.finished, true)
+      assert.strictEqual(response.bodyUsed, false)
+      assert.deepStrictEqual(await response.json(), body)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
   })
 
-  it('publishes asyncEnd exactly once when both asResponse() and parse() are called', () => {
+  it('evaluates repeated asResponse() calls once', async () => {
+    const { calls, unsubscribe } = subscribeAutoResolve([
+      messagesBeforeChannel,
+      messagesAfterChannel,
+    ])
+    const messages = new Messages()
+    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+
+    try {
+      const [firstResponse, secondResponse] = await Promise.all([
+        apiPromise.asResponse(),
+        apiPromise.asResponse(),
+      ])
+
+      assert.strictEqual(firstResponse, secondResponse)
+      assert.strictEqual(calls.length, 2)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('returns the raw response when cloning it throws', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let errorCtx
+    let asyncEndCount = 0
+    /** @param {{ error: Error }} ctx */
+    const onError = (ctx) => { errorCtx = ctx }
+    apmHandlers.error = onError
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const error = new Error('clone failed')
+    apiPromise._rawResponse.clone = () => { throw error }
+    messages._nextApiPromise = apiPromise
+
+    try {
+      const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+
+      assert.strictEqual(response, apiPromise._rawResponse)
+      assert.strictEqual(errorCtx.error, error)
+      assert.strictEqual(asyncEndCount, 1)
+      assert.strictEqual(calls.length, 0)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
+  it('returns the raw response when reading its clone rejects', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let errorCtx
+    let asyncEndCount = 0
+    /** @param {{ error: Error }} ctx */
+    const onError = (ctx) => { errorCtx = ctx }
+    apmHandlers.error = onError
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const error = new Error('body failed')
+    apiPromise._rawResponse.clone = () => ({ json: () => Promise.reject(error) })
+    messages._nextApiPromise = apiPromise
+
+    try {
+      const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+
+      assert.strictEqual(response, apiPromise._rawResponse)
+      assert.strictEqual(errorCtx.error, error)
+      assert.strictEqual(asyncEndCount, 1)
+      assert.strictEqual(calls.length, 0)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
+  it('finishes when the after subscriber leaves while the clone is read', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let asyncEndCount = 0
     apmHandlers.asyncEnd = () => { asyncEndCount++ }
     apmChannel.subscribe(apmHandlers)
 
+    const body = { role: 'assistant', content: [] }
+    const { calls, unsubscribe } = subscribeAutoResolve([messagesAfterChannel])
+    const messages = new Messages()
+    const apiPromise = new FakeAPIPromise(body)
+    apiPromise._rawResponse.clone = () => ({
+      json: async () => {
+        unsubscribe()
+        return body
+      },
+    })
+    messages._nextApiPromise = apiPromise
+
+    try {
+      const response = await messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
+
+      assert.strictEqual(response, apiPromise._rawResponse)
+      assert.strictEqual(asyncEndCount, 1)
+      assert.strictEqual(calls.length, 0)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
+  })
+
+  it('evaluates and finishes exactly once when asResponse() starts before parse()', async () => {
+    const apmChannel = tracingChannel('apm:anthropic:request')
+    const apmHandlers = { start () {} }
+    let asyncEndCount = 0
+    apmHandlers.asyncEnd = () => { asyncEndCount++ }
+    apmChannel.subscribe(apmHandlers)
+
+    const { calls, unsubscribe } = subscribeAutoResolve([
+      messagesBeforeChannel,
+      messagesAfterChannel,
+    ])
     const messages = new Messages()
     messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
     const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
 
-    return Promise.all([apiPromise.asResponse(), apiPromise.parse()])
-      .then(() => assert.strictEqual(asyncEndCount, 1))
-      .finally(() => apmChannel.unsubscribe(apmHandlers))
+    try {
+      await Promise.all([apiPromise.asResponse(), apiPromise.parse()])
+
+      assert.strictEqual(calls.length, 2)
+      assert.strictEqual(asyncEndCount, 1)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
   })
 
-  it('publishes asyncEnd when the caller uses withResponse() without parse()', () => {
+  it('evaluates and finishes when the caller uses withResponse()', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let asyncEndCtx
     apmHandlers.asyncEnd = ctx => { asyncEndCtx = ctx }
     apmChannel.subscribe(apmHandlers)
 
+    const { calls, unsubscribe } = subscribeAutoResolve([
+      messagesBeforeChannel,
+      messagesAfterChannel,
+    ])
     const body = { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] }
     const messages = new Messages()
     messages._nextApiPromise = new FakeAPIPromise(body)
 
-    return messages.create({ messages: [{ role: 'user', content: 'Hello' }] }).withResponse()
-      .then(({ data, response }) => {
-        assert.strictEqual(data, body)
-        assert.ok(response.ok)
-        assert.ok(asyncEndCtx, 'asyncEnd was not published')
-        assert.strictEqual(asyncEndCtx.finished, true)
-      })
-      .finally(() => apmChannel.unsubscribe(apmHandlers))
+    try {
+      const { data, response } = await messages.create({
+        messages: [{ role: 'user', content: 'Hello' }],
+      }).withResponse()
+
+      assert.strictEqual(data, body)
+      assert.ok(response.ok)
+      assert.strictEqual(calls.length, 2)
+      assert.ok(asyncEndCtx, 'asyncEnd was not published')
+      assert.strictEqual(asyncEndCtx.finished, true)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
   })
 
   it('propagates before lifecycle rejection through withResponse()', () => {
@@ -346,7 +518,7 @@ describe('anthropic lifecycle instrumentation', () => {
       .finally(unsubscribe)
   })
 
-  it('publishes after lifecycle when asResponse() body is consumed via response.json()', () => {
+  it('leaves the evaluated raw response available through response.json()', async () => {
     const body = { role: 'assistant', content: [{ type: 'text', text: 'Hello!' }] }
     const { calls, unsubscribe } = subscribeAutoResolve([
       messagesBeforeChannel,
@@ -356,17 +528,18 @@ describe('anthropic lifecycle instrumentation', () => {
     messages._nextApiPromise = new FakeAPIPromise(body)
 
     const args = [{ messages: [{ role: 'user', content: 'Hi' }] }]
-    return messages.create(...args).asResponse()
-      .then(response => response.json())
-      .then(data => {
-        assert.strictEqual(data, body)
-        assert.strictEqual(calls.length, 2)
-        assert.deepStrictEqual(calls[1].body, body)
-      })
-      .finally(unsubscribe)
+    try {
+      const response = await messages.create(...args).asResponse()
+
+      assert.deepStrictEqual(await response.json(), body)
+      assert.strictEqual(calls.length, 2)
+      assert.deepStrictEqual(calls[1].body, body)
+    } finally {
+      unsubscribe()
+    }
   })
 
-  it('publishes after lifecycle when asResponse() body is consumed via response.text()', () => {
+  it('leaves the evaluated raw response available through response.text()', async () => {
     const body = { role: 'assistant', content: [{ type: 'text', text: 'Hello!' }] }
     const { calls, unsubscribe } = subscribeAutoResolve([
       messagesBeforeChannel,
@@ -375,18 +548,19 @@ describe('anthropic lifecycle instrumentation', () => {
     const messages = new Messages()
     messages._nextApiPromise = new FakeAPIPromise(body)
 
-    return messages.create([{ messages: [{ role: 'user', content: 'Hi' }] }]).asResponse()
-      .then(response => response.text())
-      .then(raw => {
-        assert.strictEqual(typeof raw, 'string')
-        assert.strictEqual(calls.length, 2)
-        // after-channel receives the raw string; the subscriber is responsible for parsing
-        assert.strictEqual(calls[1].body, raw)
-      })
-      .finally(unsubscribe)
+    try {
+      const response = await messages.create([{ messages: [{ role: 'user', content: 'Hi' }] }]).asResponse()
+      const raw = await response.text()
+
+      assert.strictEqual(raw, JSON.stringify(body))
+      assert.strictEqual(calls.length, 2)
+      assert.deepStrictEqual(calls[1].body, body)
+    } finally {
+      unsubscribe()
+    }
   })
 
-  it('propagates after lifecycle rejection through asResponse().json()', () => {
+  it('rejects asResponse() when the after lifecycle denies', async () => {
     const err = lifecycleAbortError()
     const unsubscribeAfter = subscribeWithHandler([messagesAfterChannel], ctx => blockLifecycle(ctx, err))
     const unsubscribeBefore = subscribeWithHandler([messagesBeforeChannel], ctx => {
@@ -395,37 +569,70 @@ describe('anthropic lifecycle instrumentation', () => {
     const messages = new Messages()
     messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
 
-    return assert.rejects(
-      () => messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse()
-        .then(response => response.json()),
-      e => e === err
-    ).finally(() => {
+    try {
+      await assert.rejects(
+        () => messages.create({ messages: [{ role: 'user', content: 'Hi' }] }).asResponse(),
+        /** @param {Error} error */
+        error => error === err
+      )
+    } finally {
       unsubscribeAfter()
       unsubscribeBefore()
-    })
+    }
   })
 
-  it('publishes asyncEnd exactly once when both parse() and asResponse().json() are called', () => {
+  it('reuses the after verdict after its subscriber leaves', async () => {
+    const error = lifecycleAbortError()
+    let calls = 0
+    const unsubscribe = subscribeWithHandler(
+      [messagesAfterChannel],
+      /**
+       * @param {{ abortController: AbortController, pending: Promise<void>[] }} ctx
+       */
+      ctx => {
+        calls++
+        blockLifecycle(ctx, error)
+        unsubscribe()
+      }
+    )
+    const messages = new Messages()
+    messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+    const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
+
+    try {
+      await assert.rejects(apiPromise.asResponse(), { name: error.name, message: error.message })
+      await assert.rejects(apiPromise.parse(), { name: error.name, message: error.message })
+      assert.strictEqual(calls, 1)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('evaluates and finishes exactly once when parse() starts before asResponse()', async () => {
     const apmChannel = tracingChannel('apm:anthropic:request')
     const apmHandlers = { start () {} }
     let asyncEndCount = 0
     apmHandlers.asyncEnd = () => { asyncEndCount++ }
     apmChannel.subscribe(apmHandlers)
 
-    const { unsubscribe } = subscribeAutoResolve([messagesBeforeChannel, messagesAfterChannel])
+    const { calls, unsubscribe } = subscribeAutoResolve([messagesBeforeChannel, messagesAfterChannel])
 
     const messages = new Messages()
     messages._nextApiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
     const apiPromise = messages.create({ messages: [{ role: 'user', content: 'Hi' }] })
 
-    return Promise.all([
-      apiPromise.parse(),
-      apiPromise.asResponse().then(response => response.json()),
-    ])
-      .then(() => assert.strictEqual(asyncEndCount, 1))
-      .finally(() => {
-        apmChannel.unsubscribe(apmHandlers)
-        unsubscribe()
-      })
+    try {
+      const [, response] = await Promise.all([
+        apiPromise.parse(),
+        apiPromise.asResponse(),
+      ])
+
+      assert.deepStrictEqual(await response.json(), { role: 'assistant', content: [] })
+      assert.strictEqual(calls.length, 2)
+      assert.strictEqual(asyncEndCount, 1)
+    } finally {
+      apmChannel.unsubscribe(apmHandlers)
+      unsubscribe()
+    }
   })
 })

--- a/packages/datadog-instrumentations/test/fixtures/anthropic-lifecycle-rejections.js
+++ b/packages/datadog-instrumentations/test/fixtures/anthropic-lifecycle-rejections.js
@@ -5,93 +5,24 @@ const { setImmediate } = require('node:timers/promises')
 
 const { channel } = require('dc-polyfill')
 
+const {
+  FakeAPIPromise,
+  FakeMessages,
+  applyShim,
+  createDeferred,
+  loadAnthropicInstrumentation,
+} = require('../helpers/anthropic-lifecycle')
+
 const mode = process.argv[2]
 const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
 
-class FakeAPIPromise {
-  /**
-   * @param {object} body
-   */
-  constructor (body) {
-    this.body = body
-    this.response = new Response(JSON.stringify(body))
-  }
-
-  parse () {
-    return Promise.resolve(this.body)
-  }
-
-  asResponse () {
-    return Promise.resolve(this.response)
-  }
-}
-
-class Messages {
-  create () {
-    return this.apiPromise
-  }
-}
-
-function loadAnthropicInstrumentation () {
-  const instrumentPath = require.resolve('../../src/helpers/instrument')
-  const realInstrument = require(instrumentPath)
-  const hookCallbacks = []
-  const cache = require.cache[instrumentPath]
-  const previousExports = cache.exports
-
-  cache.exports = {
-    ...realInstrument,
-    /**
-     * @param {object} spec
-     * @param {Function} callback
-     */
-    addHook (spec, callback) {
-      hookCallbacks.push({ spec, callback })
-    },
-  }
-
-  try {
-    delete require.cache[require.resolve('../../src/anthropic')]
-    require('../../src/anthropic')
-  } finally {
-    cache.exports = previousExports
-  }
-
-  return hookCallbacks
-}
-
-/**
- * @param {Array<{ spec: object, callback: Function }>} hookCallbacks
- */
-function applyShim (hookCallbacks) {
-  for (const { spec, callback } of hookCallbacks) {
-    if (spec.file === 'resources/messages/messages.js') {
-      callback({ Messages })
-      return
-    }
-  }
-  throw new Error('Anthropic messages hook not registered')
-}
-
-function createDeferred () {
-  let resolveDeferred
-  const promise = new Promise(
-    /**
-     * @param {(value: object) => void} resolve
-     */
-    resolve => {
-      resolveDeferred = resolve
-    }
-  )
-  return { promise, resolve: resolveDeferred }
-}
-
 async function run () {
-  applyShim(loadAnthropicInstrumentation())
+  const Messages = class extends FakeMessages {}
+  applyShim(loadAnthropicInstrumentation(), 'resources/messages/messages', Messages)
 
   const messages = new Messages()
   const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
-  messages.apiPromise = apiPromise
+  messages._nextApiPromise = apiPromise
 
   if (mode === 'caught-after-verdict') {
     const error = new Error('blocked')
@@ -179,9 +110,9 @@ async function run () {
         }
       )
       await setImmediate()
-      assert.strictEqual(rawResponse, apiPromise.response)
+      assert.strictEqual(rawResponse, apiPromise._rawResponse)
 
-      parseDeferred.resolve(apiPromise.body)
+      parseDeferred.resolve(apiPromise._body)
       await parsePromise
     } finally {
       messagesAfterChannel.unsubscribe(subscriber)

--- a/packages/datadog-instrumentations/test/fixtures/anthropic-lifecycle-rejections.js
+++ b/packages/datadog-instrumentations/test/fixtures/anthropic-lifecycle-rejections.js
@@ -1,0 +1,195 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { setImmediate } = require('node:timers/promises')
+
+const { channel } = require('dc-polyfill')
+
+const mode = process.argv[2]
+const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
+
+class FakeAPIPromise {
+  /**
+   * @param {object} body
+   */
+  constructor (body) {
+    this.body = body
+    this.response = new Response(JSON.stringify(body))
+  }
+
+  parse () {
+    return Promise.resolve(this.body)
+  }
+
+  asResponse () {
+    return Promise.resolve(this.response)
+  }
+}
+
+class Messages {
+  create () {
+    return this.apiPromise
+  }
+}
+
+function loadAnthropicInstrumentation () {
+  const instrumentPath = require.resolve('../../src/helpers/instrument')
+  const realInstrument = require(instrumentPath)
+  const hookCallbacks = []
+  const cache = require.cache[instrumentPath]
+  const previousExports = cache.exports
+
+  cache.exports = {
+    ...realInstrument,
+    /**
+     * @param {object} spec
+     * @param {Function} callback
+     */
+    addHook (spec, callback) {
+      hookCallbacks.push({ spec, callback })
+    },
+  }
+
+  try {
+    delete require.cache[require.resolve('../../src/anthropic')]
+    require('../../src/anthropic')
+  } finally {
+    cache.exports = previousExports
+  }
+
+  return hookCallbacks
+}
+
+/**
+ * @param {Array<{ spec: object, callback: Function }>} hookCallbacks
+ */
+function applyShim (hookCallbacks) {
+  for (const { spec, callback } of hookCallbacks) {
+    if (spec.file === 'resources/messages/messages.js') {
+      callback({ Messages })
+      return
+    }
+  }
+  throw new Error('Anthropic messages hook not registered')
+}
+
+function createDeferred () {
+  let resolveDeferred
+  const promise = new Promise(
+    /**
+     * @param {(value: object) => void} resolve
+     */
+    resolve => {
+      resolveDeferred = resolve
+    }
+  )
+  return { promise, resolve: resolveDeferred }
+}
+
+async function run () {
+  applyShim(loadAnthropicInstrumentation())
+
+  const messages = new Messages()
+  const apiPromise = new FakeAPIPromise({ role: 'assistant', content: [] })
+  messages.apiPromise = apiPromise
+
+  if (mode === 'caught-after-verdict') {
+    const error = new Error('blocked')
+    /**
+     * @param {{ abortController: AbortController, pending: Promise<void>[] }} context
+     */
+    const blockingSubscriber = context => {
+      context.abortController.abort(error)
+      context.pending.push(Promise.resolve())
+    }
+    messagesAfterChannel.subscribe(blockingSubscriber)
+
+    try {
+      await assert.rejects(messages.create({ messages: [] }).parse(), error)
+    } finally {
+      messagesAfterChannel.unsubscribe(blockingSubscriber)
+    }
+    return
+  }
+
+  if (mode === 'ignored-parse-error' || mode === 'ignored-parse-error-with-raw') {
+    /**
+     * @param {{ pending: Promise<void>[] }} context
+     */
+    const subscriber = context => {
+      context.pending.push(Promise.resolve())
+    }
+    messagesAfterChannel.subscribe(subscriber)
+    apiPromise.parse = () => Promise.reject(new SyntaxError('invalid response'))
+    const instrumentedPromise = messages.create({ messages: [] })
+    instrumentedPromise.parse()
+
+    if (mode === 'ignored-parse-error-with-raw') {
+      await instrumentedPromise.asResponse()
+    }
+
+    await setImmediate()
+    messagesAfterChannel.unsubscribe(subscriber)
+    return
+  }
+
+  if (mode === 'ignored-first-raw') {
+    const error = new Error('blocked')
+    /**
+     * @param {{ abortController: AbortController, pending: Promise<void>[] }} context
+     */
+    const subscriber = context => {
+      context.abortController.abort(error)
+      context.pending.push(Promise.resolve())
+    }
+    messagesAfterChannel.subscribe(subscriber)
+    const instrumentedPromise = messages.create({ messages: [] })
+    instrumentedPromise.asResponse()
+
+    try {
+      await assert.rejects(instrumentedPromise.asResponse(), error)
+      await setImmediate()
+    } finally {
+      messagesAfterChannel.unsubscribe(subscriber)
+    }
+    return
+  }
+
+  if (mode === 'raw-with-pending-parse') {
+    const parseDeferred = createDeferred()
+    /**
+     * @param {{ pending: Promise<void>[] }} context
+     */
+    const subscriber = context => {
+      context.pending.push(Promise.resolve())
+    }
+    messagesAfterChannel.subscribe(subscriber)
+    apiPromise.parse = () => parseDeferred.promise
+    const instrumentedPromise = messages.create({ messages: [] })
+    const parsePromise = instrumentedPromise.parse()
+    let rawResponse
+
+    try {
+      instrumentedPromise.asResponse().then(
+        /**
+         * @param {object} response
+         */
+        response => {
+          rawResponse = response
+        }
+      )
+      await setImmediate()
+      assert.strictEqual(rawResponse, apiPromise.response)
+
+      parseDeferred.resolve(apiPromise.body)
+      await parsePromise
+    } finally {
+      messagesAfterChannel.unsubscribe(subscriber)
+    }
+    return
+  }
+
+  throw new Error(`Unknown mode: ${mode}`)
+}
+
+run()

--- a/packages/datadog-instrumentations/test/helpers/anthropic-lifecycle.js
+++ b/packages/datadog-instrumentations/test/helpers/anthropic-lifecycle.js
@@ -1,0 +1,122 @@
+'use strict'
+
+class FakeAPIPromise {
+  /**
+   * @param {object} body
+   */
+  constructor (body) {
+    this._body = body
+    this._rawResponse = new Response(JSON.stringify(body))
+  }
+
+  /**
+   * @returns {Promise<object>}
+   */
+  parse () {
+    return Promise.resolve(this._body)
+  }
+
+  /**
+   * @returns {Promise<Response>}
+   */
+  asResponse () {
+    return Promise.resolve(this._rawResponse)
+  }
+
+  /**
+   * @returns {Promise<{ data: object, response: Response }>}
+   */
+  withResponse () {
+    return Promise.all([this.parse(), this.asResponse()]).then(([data, response]) => ({ data, response }))
+  }
+
+  /**
+   * @param {(value: object) => unknown} [onFulfilled]
+   * @param {(reason: unknown) => unknown} [onRejected]
+   * @returns {Promise<unknown>}
+   */
+  then (onFulfilled, onRejected) {
+    return this.parse().then(onFulfilled, onRejected)
+  }
+}
+
+class FakeMessages {
+  /**
+   * @returns {FakeAPIPromise}
+   */
+  create () {
+    return this._nextApiPromise
+  }
+}
+
+/**
+ * @template T
+ * @returns {{
+ *   promise: Promise<T | undefined>,
+ *   reject: (reason?: unknown) => void,
+ *   resolve: (value?: T | PromiseLike<T>) => void
+ * }}
+ */
+function createDeferred () {
+  let rejectDeferred
+  let resolveDeferred
+  const promise = new Promise((resolve, reject) => {
+    rejectDeferred = reject
+    resolveDeferred = resolve
+  })
+  return { promise, reject: rejectDeferred, resolve: resolveDeferred }
+}
+
+/**
+ * @returns {Array<{ spec: { file: string }, callback: (exports: object) => object }>}
+ */
+function loadAnthropicInstrumentation () {
+  const instrumentPath = require.resolve('../../src/helpers/instrument')
+  const realInstrument = require(instrumentPath)
+  const hookCallbacks = []
+  const cache = require.cache[instrumentPath]
+  const previousExports = cache.exports
+
+  cache.exports = {
+    ...realInstrument,
+    /**
+     * @param {{ file: string }} spec
+     * @param {(exports: object) => object} callback
+     */
+    addHook (spec, callback) {
+      hookCallbacks.push({ spec, callback })
+    },
+  }
+
+  try {
+    delete require.cache[require.resolve('../../src/anthropic')]
+    require('../../src/anthropic')
+  } finally {
+    cache.exports = previousExports
+  }
+
+  return hookCallbacks
+}
+
+/**
+ * @param {Array<{ spec: { file: string }, callback: (exports: object) => object }>} hookCallbacks
+ * @param {string} filePath
+ * @param {typeof FakeMessages} Messages
+ */
+function applyShim (hookCallbacks, filePath, Messages) {
+  for (const { spec, callback } of hookCallbacks) {
+    if (spec.file === `${filePath}.js`) {
+      callback({ Messages })
+      return
+    }
+  }
+  throw new Error(`No hook registered for ${filePath}.js`)
+}
+
+module.exports = {
+  FakeAPIPromise,
+  FakeMessages,
+  applyShim,
+  createDeferred,
+  loadAnthropicInstrumentation,
+}

--- a/packages/datadog-plugin-anthropic/test/index.spec.js
+++ b/packages/datadog-plugin-anthropic/test/index.spec.js
@@ -17,12 +17,19 @@ describe('Plugin', () => {
 
   withVersions('anthropic', '@anthropic-ai/sdk', (version) => {
     let client
+    let malformedResponseClient
 
     before(async () => {
       await agent.load('anthropic')
 
       const { Anthropic } = require(`../../../versions/@anthropic-ai/sdk@${version}`).get()
       client = new Anthropic({ baseURL: 'http://127.0.0.1:9126/vcr/anthropic' })
+      malformedResponseClient = new Anthropic({
+        fetch: async () => new Response('not json', {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }),
+      })
     })
 
     after(() => agent.close())
@@ -87,6 +94,67 @@ describe('Plugin', () => {
           assert.strictEqual(lifecycleCalls.length, 1)
           assert.strictEqual(response.bodyUsed, false)
           assert.ok(await response.json())
+        } finally {
+          messagesAfterChannel.unsubscribe(onMessagesAfter)
+        }
+      })
+
+      it('keeps raw response access independent from parsing failures', async () => {
+        /** @param {{ pending: Promise<void>[] }} ctx */
+        const onMessagesAfter = (ctx) => {
+          ctx.pending.push(Promise.resolve())
+        }
+        messagesAfterChannel.subscribe(onMessagesAfter)
+
+        const tracesPromise = agent.assertSomeTraces(traces => {
+          const span = traces[0][0]
+
+          assert.strictEqual(span.error, 1)
+        })
+        const apiPromise = malformedResponseClient.messages.create({
+          model: 'claude-3-7-sonnet-20250219',
+          messages: [{ role: 'user', content: 'Hello, world!' }],
+          max_tokens: 100,
+        })
+
+        try {
+          const [response] = await Promise.all([
+            (async () => {
+              await assert.rejects(apiPromise, SyntaxError)
+              return apiPromise.asResponse()
+            })(),
+            tracesPromise,
+          ])
+
+          assert.strictEqual(response.status, 200)
+        } finally {
+          messagesAfterChannel.unsubscribe(onMessagesAfter)
+        }
+      })
+
+      it('does not report lifecycle clone failures as request errors', async () => {
+        /** @param {{ pending: Promise<void>[] }} ctx */
+        const onMessagesAfter = (ctx) => {
+          ctx.pending.push(Promise.resolve())
+        }
+        messagesAfterChannel.subscribe(onMessagesAfter)
+
+        const tracesPromise = agent.assertSomeTraces(traces => {
+          const span = traces[0][0]
+
+          assert.strictEqual(span.error, 0)
+        })
+
+        try {
+          const responsePromise = malformedResponseClient.messages.create({
+            model: 'claude-3-7-sonnet-20250219',
+            messages: [{ role: 'user', content: 'Hello, world!' }],
+            max_tokens: 100,
+          }).asResponse()
+          const [response] = await Promise.all([responsePromise, tracesPromise])
+
+          assert.strictEqual(response.bodyUsed, false)
+          assert.strictEqual(await response.text(), 'not json')
         } finally {
           messagesAfterChannel.unsubscribe(onMessagesAfter)
         }

--- a/packages/datadog-plugin-anthropic/test/index.spec.js
+++ b/packages/datadog-plugin-anthropic/test/index.spec.js
@@ -7,6 +7,10 @@ const { promisify } = require('node:util')
 
 const { channel } = require('dc-polyfill')
 const { describe, before, after, it } = require('mocha')
+const sinon = require('sinon')
+
+const { anthropic: anthropicIntegration } = require('../../dd-trace/src/aiguard/integrations')
+const log = require('../../dd-trace/src/log')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { useEnv } = require('../../../integration-tests/helpers')
@@ -66,14 +70,9 @@ describe('Plugin', () => {
         await tracesPromise
       })
 
-      it('finishes a raw response before its body is consumed', async () => {
-        const lifecycleCalls = []
-        /** @param {{ pending: Promise<void>[] }} ctx */
-        const onMessagesAfter = (ctx) => {
-          lifecycleCalls.push(ctx)
-          ctx.pending.push(Promise.resolve())
-        }
-        messagesAfterChannel.subscribe(onMessagesAfter)
+      it('finishes a raw response through the AI Guard lifecycle before its body is consumed', async () => {
+        const evaluate = sinon.stub().resolves()
+        anthropicIntegration.enable({ evaluate }, true)
 
         const tracesPromise = agent.assertSomeTraces(
           /**
@@ -95,11 +94,46 @@ describe('Plugin', () => {
           }).asResponse()
           const [response] = await Promise.all([responsePromise, tracesPromise])
 
-          assert.strictEqual(lifecycleCalls.length, typeof response.body?.pipe === 'function' ? 0 : 1)
+          const expectedEvaluationCount = typeof response.body?.pipe === 'function' ? 1 : 2
+          assert.strictEqual(evaluate.callCount, expectedEvaluationCount)
+          assert.deepStrictEqual(evaluate.firstCall.args[0], [{ role: 'user', content: 'Hello, world!' }])
+          if (expectedEvaluationCount === 2) {
+            const outputMessages = evaluate.secondCall.args[0]
+            assert.strictEqual(outputMessages[0].role, 'user')
+            assert.strictEqual(outputMessages[1].role, 'assistant')
+          }
           assert.strictEqual(response.bodyUsed, false)
           assert.ok(await response.json())
         } finally {
-          messagesAfterChannel.unsubscribe(onMessagesAfter)
+          anthropicIntegration.disable()
+        }
+      })
+
+      it('does not report the parser-owned raw response read as an instrumentation error', async () => {
+        const evaluate = sinon.stub().resolves()
+        const logError = sinon.stub(log, 'error')
+        anthropicIntegration.enable({ evaluate }, true)
+
+        const tracesPromise = agent.assertSomeTraces(traces => {
+          assert.strictEqual(traces[0][0].name, 'anthropic.request')
+        })
+
+        try {
+          const resultPromise = client.messages.create({
+            model: 'claude-3-7-sonnet-20250219',
+            messages: [{ role: 'user', content: 'Hello, world!' }],
+            max_tokens: 100,
+            temperature: 0.5,
+          }).withResponse()
+          const [result] = await Promise.all([resultPromise, tracesPromise])
+
+          assert.strictEqual(result.data.role, 'assistant')
+          assert.strictEqual(result.response.bodyUsed, true)
+          sinon.assert.calledTwice(evaluate)
+          sinon.assert.notCalled(logError)
+        } finally {
+          anthropicIntegration.disable()
+          logError.restore()
         }
       })
 
@@ -136,12 +170,9 @@ describe('Plugin', () => {
         }
       })
 
-      it('does not report lifecycle clone failures as request errors', async () => {
-        /** @param {{ pending: Promise<void>[] }} ctx */
-        const onMessagesAfter = (ctx) => {
-          ctx.pending.push(Promise.resolve())
-        }
-        messagesAfterChannel.subscribe(onMessagesAfter)
+      it('keeps a completed raw response span successful when parsing starts later', async () => {
+        const evaluate = sinon.stub().resolves()
+        anthropicIntegration.enable({ evaluate }, true)
 
         const tracesPromise = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
@@ -150,17 +181,20 @@ describe('Plugin', () => {
         })
 
         try {
-          const responsePromise = malformedResponseClient.messages.create({
+          const apiPromise = malformedResponseClient.messages.create({
             model: 'claude-3-7-sonnet-20250219',
             messages: [{ role: 'user', content: 'Hello, world!' }],
             max_tokens: 100,
-          }).asResponse()
+          })
+          const responsePromise = apiPromise.asResponse()
           const [response] = await Promise.all([responsePromise, tracesPromise])
 
+          sinon.assert.calledOnce(evaluate)
           assert.strictEqual(response.bodyUsed, false)
-          assert.strictEqual(await response.text(), 'not json')
+          assert.strictEqual(await response.clone().text(), 'not json')
+          await assert.rejects(apiPromise, SyntaxError)
         } finally {
-          messagesAfterChannel.unsubscribe(onMessagesAfter)
+          anthropicIntegration.disable()
         }
       })
 

--- a/packages/datadog-plugin-anthropic/test/index.spec.js
+++ b/packages/datadog-plugin-anthropic/test/index.spec.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { once } = require('node:events')
+const http = require('node:http')
+const { promisify } = require('node:util')
 
 const { channel } = require('dc-polyfill')
 const { describe, before, after, it } = require('mocha')
@@ -16,13 +19,14 @@ describe('Plugin', () => {
   })
 
   withVersions('anthropic', '@anthropic-ai/sdk', (version) => {
+    let Anthropic
     let client
     let malformedResponseClient
 
     before(async () => {
       await agent.load('anthropic')
 
-      const { Anthropic } = require(`../../../versions/@anthropic-ai/sdk@${version}`).get()
+      Anthropic = require(`../../../versions/@anthropic-ai/sdk@${version}`).get().Anthropic
       client = new Anthropic({ baseURL: 'http://127.0.0.1:9126/vcr/anthropic' })
       malformedResponseClient = new Anthropic({
         fetch: async () => new Response('not json', {
@@ -91,7 +95,7 @@ describe('Plugin', () => {
           }).asResponse()
           const [response] = await Promise.all([responsePromise, tracesPromise])
 
-          assert.strictEqual(lifecycleCalls.length, 1)
+          assert.strictEqual(lifecycleCalls.length, typeof response.body?.pipe === 'function' ? 0 : 1)
           assert.strictEqual(response.bodyUsed, false)
           assert.ok(await response.json())
         } finally {
@@ -159,6 +163,75 @@ describe('Plugin', () => {
           messagesAfterChannel.unsubscribe(onMessagesAfter)
         }
       })
+
+      if (version === '0.14.0') {
+        it('fails open for node-fetch raw responses without consuming a clone', async () => {
+          const text = 'x'.repeat(256 * 1024)
+          const body = JSON.stringify({
+            id: 'msg_test',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text }],
+            model: 'claude-3-7-sonnet-20250219',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          })
+          const server = http.createServer(
+            /**
+             * @param {import('node:http').IncomingMessage} _request
+             * @param {import('node:http').ServerResponse} response
+             */
+            (_request, response) => {
+              response.writeHead(200, {
+                'content-length': Buffer.byteLength(body),
+                'content-type': 'application/json',
+              })
+              response.end(body)
+            }
+          )
+          server.listen(0, '127.0.0.1')
+          await once(server, 'listening')
+
+          const address = server.address()
+          const localClient = new Anthropic({
+            apiKey: '<not-a-real-key>',
+            baseURL: `http://127.0.0.1:${address.port}`,
+          })
+          let lifecycleCalls = 0
+          /** @param {{ pending: Promise<void>[] }} ctx */
+          const onMessagesAfter = (ctx) => {
+            lifecycleCalls++
+            ctx.pending.push(Promise.resolve())
+          }
+          messagesAfterChannel.subscribe(onMessagesAfter)
+
+          const tracesPromise = agent.assertSomeTraces(
+            /**
+             * @param {Array<Array<{ name: string }>>} traces
+             */
+            traces => {
+              assert.strictEqual(traces[0][0].name, 'anthropic.request')
+            }
+          )
+
+          try {
+            const responsePromise = localClient.messages.create({
+              model: 'claude-3-7-sonnet-20250219',
+              messages: [{ role: 'user', content: 'Hello, world!' }],
+              max_tokens: 100,
+            }).asResponse()
+            const [response] = await Promise.all([responsePromise, tracesPromise])
+
+            assert.strictEqual(response.bodyUsed, false)
+            assert.strictEqual(lifecycleCalls, 0)
+            assert.strictEqual((await response.json()).content[0].text.length, text.length)
+          } finally {
+            messagesAfterChannel.unsubscribe(onMessagesAfter)
+            await promisify(server.close.bind(server))()
+          }
+        })
+      }
 
       describe('stream', () => {
         it('creates a span', async () => {

--- a/packages/datadog-plugin-anthropic/test/index.spec.js
+++ b/packages/datadog-plugin-anthropic/test/index.spec.js
@@ -1,10 +1,14 @@
 'use strict'
 
-const assert = require('node:assert')
+const assert = require('node:assert/strict')
+
+const { channel } = require('dc-polyfill')
 const { describe, before, after, it } = require('mocha')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { useEnv } = require('../../../integration-tests/helpers')
+
+const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
 
 describe('Plugin', () => {
   useEnv({
@@ -49,6 +53,43 @@ describe('Plugin', () => {
         assert.ok(result)
 
         await tracesPromise
+      })
+
+      it('finishes a raw response before its body is consumed', async () => {
+        const lifecycleCalls = []
+        /** @param {{ pending: Promise<void>[] }} ctx */
+        const onMessagesAfter = (ctx) => {
+          lifecycleCalls.push(ctx)
+          ctx.pending.push(Promise.resolve())
+        }
+        messagesAfterChannel.subscribe(onMessagesAfter)
+
+        const tracesPromise = agent.assertSomeTraces(
+          /**
+           * @param {Array<Array<{ name: string }>>} traces
+           */
+          traces => {
+            const span = traces[0][0]
+
+            assert.equal(span.name, 'anthropic.request')
+          }
+        )
+
+        try {
+          const responsePromise = client.messages.create({
+            model: 'claude-3-7-sonnet-20250219',
+            messages: [{ role: 'user', content: 'Hello, world!' }],
+            max_tokens: 100,
+            temperature: 0.5,
+          }).asResponse()
+          const [response] = await Promise.all([responsePromise, tracesPromise])
+
+          assert.strictEqual(lifecycleCalls.length, 1)
+          assert.strictEqual(response.bodyUsed, false)
+          assert.ok(await response.json())
+        } finally {
+          messagesAfterChannel.unsubscribe(onMessagesAfter)
+        }
       })
 
       describe('stream', () => {

--- a/packages/dd-trace/src/aiguard/integrations/anthropic.js
+++ b/packages/dd-trace/src/aiguard/integrations/anthropic.js
@@ -2,6 +2,7 @@
 
 const { channel } = require('dc-polyfill')
 
+const log = require('../../log')
 const { getMessagesInputMessages, getMessagesOutputMessages } = require('../messages/anthropic')
 const { SOURCE_AUTO } = require('../tags')
 const { pushEvaluation } = require('./evaluate')
@@ -55,6 +56,7 @@ function onMessagesAfter (ctx) {
     try {
       body = JSON.parse(body)
     } catch {
+      log.error('AIGuard: unable to decode Anthropic response body')
       return
     }
   }

--- a/packages/dd-trace/test/aiguard/integrations/anthropic.spec.js
+++ b/packages/dd-trace/test/aiguard/integrations/anthropic.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 
 const { anthropic: anthropicIntegration } = require('../../../src/aiguard/integrations')
 const { SOURCE_AUTO } = require('../../../src/aiguard/tags')
+const log = require('../../../src/log')
 
 const messagesBeforeChannel = channel('dd-trace:anthropic:messages:before')
 const messagesAfterChannel = channel('dd-trace:anthropic:messages:after')
@@ -179,12 +180,14 @@ describe('AIGuard Anthropic integration', () => {
     })
   })
 
-  it('declines after-payloads where body is an invalid JSON string', () => {
+  it('fails open when an after-payload body is an invalid JSON string', () => {
     const args = [{ messages: [{ role: 'user', content: 'Hello' }] }]
+    const logError = sinon.stub(log, 'error')
     const ctx = publish(messagesAfterChannel, { args, body: 'not-json' })
 
     assert.strictEqual(ctx.pending.length, 0)
     sinon.assert.notCalled(evaluate)
+    sinon.assert.calledOnceWithExactly(logError, 'AIGuard: unable to decode Anthropic response body')
   })
 
   it('aborts with the original AIGuardAbortError', async () => {


### PR DESCRIPTION
## Summary
Calling `messages.create(...).asResponse()` without reading the body left `anthropic.request` open and skipped the after-model AI Guard evaluation because lifecycle completion was attached to body reads. Raw access now completes before resolving, evaluates native Web Responses through one shared clone, and keeps caller-visible parser and raw promises independent so concurrent consumers preserve Anthropic's rejection and promise-identity semantics.

## Why
node-fetch backpressures cloned streams while the original body is unread, which can hang large responses indefinitely. Raw Node stream responses therefore finish fail open without output evaluation; parsed paths continue through the after-model lifecycle. Hidden clone and JSON failures also log fixed text so response content cannot leak through parser errors.
