### PR TITLE
fix(standalone): stamp _dd.apm.enabled on every span

### DIFF
--- a/integration-tests/appsec/standalone-asm.spec.js
+++ b/integration-tests/appsec/standalone-asm.spec.js
@@ -121,11 +121,16 @@ describe('Standalone ASM', () => {
       assert.ok(groups.indexOf(rootGroup) < groups.indexOf(outboundGroup))
       assert.strictEqual(String(outboundSpan.parent_id), String(rootSpan.span_id))
 
-      // Load-bearing: the delayed child chunk must carry the billing marker,
-      // even though its parent is a local (non-remote) span.
-      assert.strictEqual(rootSpan.metrics['_dd.apm.enabled'], 0)
-      assert.strictEqual(outboundGroup[0], outboundSpan)
-      assert.strictEqual(outboundSpan.metrics['_dd.apm.enabled'], 0)
+      // Load-bearing: every span in every chunk must carry the billing marker,
+      // including the delayed child whose parent is a local (non-remote) span.
+      for (const group of groups) {
+        for (const span of group) {
+          assert.strictEqual(
+            span.metrics['_dd.apm.enabled'], 0,
+            `span ${span.name}/${span.resource} missing _dd.apm.enabled:0`
+          )
+        }
+      }
     })
 
     it('should keep fifth req because RateLimiter allows 1 req/min', async () => {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -62,7 +62,7 @@ class SpanProcessor {
           active.push(span)
         } else {
           const formattedSpan = spanFormat(span, isFirstSpanInChunk, this._processTags)
-          if (isFirstSpanInChunk && stampApmDisabled) {
+          if (stampApmDisabled) {
             formattedSpan.metrics[APM_TRACING_ENABLED_KEY] = 0
           }
           isFirstSpanInChunk = false

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -235,7 +235,7 @@ describe('SpanProcessor', () => {
     sinon.assert.calledWith(spanFormat.getCall(3), finishedSpan, false, processor._processTags)
   })
 
-  it('should add APM disabled marker to first span in a chunk when APM tracing is disabled', () => {
+  it('should add APM disabled marker to every span in a chunk when APM tracing is disabled', () => {
     config.apmTracingEnabled = false
     config.flushMinSpans = 2
     const processor = new SpanProcessor(exporter, prioritySampler, config)
@@ -249,7 +249,7 @@ describe('SpanProcessor', () => {
     processor.process(finishedSpan)
 
     assert.strictEqual(firstFormatted.metrics[APM_TRACING_ENABLED_KEY], 0)
-    assert.ok(!Object.hasOwn(secondFormatted.metrics, APM_TRACING_ENABLED_KEY))
+    assert.strictEqual(secondFormatted.metrics[APM_TRACING_ENABLED_KEY], 0)
     sinon.assert.calledWith(exporter.export, [firstFormatted, secondFormatted])
   })
 


### PR DESCRIPTION
### What does this PR do?

Stamp every span with `_dd.apm.enabled:0` on standalone mode.


System-test: https://github.com/DataDog/system-tests/pull/7359

### Additional Notes
<!-- Anything else we should know when reviewing? -->


