### PR TITLE
fix(logs): properly split name and version for scoped names

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -82,7 +82,7 @@ function Hook (modules, hookOptions, onrequire) {
       moduleVersion ||= getVersion(moduleBaseDir)
     } catch (error) {
       log.error('Error getting version for "%s": %s', moduleName, error.message, error)
-      return
+      return moduleExports
     }
 
     if (

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -167,9 +167,9 @@ function logAbortedIntegrations () {
   for (const [nameVersion, success] of instrumentedIntegrationsSuccess) {
     // Only ever log a single version of an integration, even if it is loaded later.
     if (!success && !alreadyLoggedIncompatibleIntegrations.has(nameVersion)) {
-      const parts = nameVersion.split('@')
-      const version = parts.pop()
-      const name = parts.join('@')
+      const lastAtPosition = nameVersion.lastIndexOf('@')
+      const name = nameVersion.slice(0, lastAtPosition)
+      const version = nameVersion.slice(lastAtPosition + 1)
       telemetry('abort.integration', [
         `integration:${name}`,
         `integration_version:${version}`,

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -170,7 +170,6 @@ function logAbortedIntegrations () {
       const parts = nameVersion.split('@')
       const version = parts.pop()
       const name = parts.join('@')
-      nameVersion.split('@')
       telemetry('abort.integration', [
         `integration:${name}`,
         `integration_version:${version}`,

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -167,7 +167,10 @@ function logAbortedIntegrations () {
   for (const [nameVersion, success] of instrumentedIntegrationsSuccess) {
     // Only ever log a single version of an integration, even if it is loaded later.
     if (!success && !alreadyLoggedIncompatibleIntegrations.has(nameVersion)) {
-      const [name, version] = nameVersion.split('@')
+      const parts = nameVersion.split('@')
+      const version = parts.pop()
+      const name = parts.join('@')
+      nameVersion.split('@')
       telemetry('abort.integration', [
         `integration:${name}`,
         `integration_version:${version}`,

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -108,9 +108,9 @@ describe('register', () => {
     const integrationName = '@confluentinc/kafka-javascript'
     const moduleVersion = '0.1.0'
     const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === integrationName)
-    const callback = hookCall.args[2]
+    const hook = hookCall.args[2]
 
-    callback('original', integrationName, '/path/to/module', moduleVersion)
+    hook('original', integrationName, '/path/to/module', moduleVersion)
     channel('dd-trace:exporter:first-flush').publish()
 
     sinon.assert.calledOnceWithExactly(telemetryMock, 'abort.integration', [

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -3,12 +3,14 @@
 const Module = require('module')
 const assert = require('node:assert/strict')
 
+const { channel } = require('dc-polyfill')
 const sinon = require('sinon')
 
 describe('register', () => {
   let hooksMock
   let HookMock
   let originalModuleProtoRequire
+  let telemetryMock
 
   const clearRegisterCache = () => {
     const registerPath = require.resolve('../../src/helpers/register')
@@ -29,6 +31,7 @@ describe('register', () => {
     }
 
     HookMock = sinon.stub()
+    telemetryMock = sinon.stub()
 
     const registerPath = require.resolve('../../src/helpers/register')
     originalModuleProtoRequire = Module.prototype.require
@@ -38,6 +41,7 @@ describe('register', () => {
         const stubs = {
           './hooks': hooksMock,
           './hook': HookMock,
+          '../../../dd-trace/src/guardrails/telemetry': telemetryMock,
         }
         return stubs[request] || originalModuleProtoRequire.call(this, request)
       }
@@ -97,4 +101,25 @@ describe('register', () => {
       assert.deepStrictEqual(registeredNames.sort(), ['@confluentinc/kafka-javascript', 'mongodb-core'])
     })
   }
+
+  it('should report the name and version correctly for scoped integration names', () => {
+    loadRegisterWithEnv()
+
+    const integrationName = '@confluentinc/kafka-javascript'
+    const moduleVersion = '0.1.0'
+    const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === integrationName)
+    const callback = hookCall.args[2]
+
+    callback('original', integrationName, '/path/to/module', moduleVersion)
+    channel('dd-trace:exporter:first-flush').publish()
+
+    sinon.assert.calledOnceWithExactly(telemetryMock, 'abort.integration', [
+      `integration:${integrationName}`,
+      `integration_version:${moduleVersion}`,
+    ], {
+      result: 'abort',
+      result_class: 'incompatible_library',
+      result_reason: `Incompatible integration version: ${integrationName}@${moduleVersion}`,
+    })
+  })
 })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR fixes name and version parsing for scoped integrations in the logAbortedIntegrations function. Before this fix we did a split based on the @ without considering some integrations have names that start with @ which were not accounted for and ended up having an empty name and version set as the name.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


