### PR TITLE
fix(webpack): opt out of typescript auto resolve

### DIFF
--- a/integration-tests/webpack/build-and-test-git-tags.js
+++ b/integration-tests/webpack/build-and-test-git-tags.js
@@ -9,6 +9,7 @@ const { spawnSync } = require('child_process')
 const assert = require('assert')
 const webpack = require('webpack')
 const DatadogWebpackPlugin = require('../../webpack') // dd-trace/webpack
+const experiments = require('./webpack-experiments')
 
 const OUTFILE = path.join(__dirname, 'git-tags-out.js')
 
@@ -17,6 +18,7 @@ const compiler = webpack({
   entry: path.join(__dirname, 'basic-test.js'),
   target: 'node',
   externalsType: 'commonjs',
+  ...(experiments && { experiments }),
   output: {
     filename: 'git-tags-out.js',
     path: __dirname,

--- a/integration-tests/webpack/build-and-test-minify.js
+++ b/integration-tests/webpack/build-and-test-minify.js
@@ -8,6 +8,7 @@ const path = require('path')
 const assert = require('assert')
 const webpack = require('webpack')
 const DatadogWebpackPlugin = require('../../webpack') // dd-trace/webpack
+const experiments = require('./webpack-experiments')
 
 const OUTFILE = path.join(__dirname, 'minify-out.js')
 
@@ -17,6 +18,7 @@ try {
     // optimization.minimize is enabled by default in production mode
     entry: path.join(__dirname, 'basic-test.js'),
     target: 'node',
+    ...(experiments && { experiments }),
     output: {
       filename: 'minify-out.js',
       path: __dirname,

--- a/integration-tests/webpack/build-and-test-openfeature.js
+++ b/integration-tests/webpack/build-and-test-openfeature.js
@@ -23,6 +23,7 @@ const assert = require('assert')
 const { execFileSync } = require('child_process')
 const webpack = require('webpack')
 const DatadogWebpackPlugin = require('../../webpack') // dd-trace/webpack
+const experiments = require('./webpack-experiments')
 
 const ENTRY = path.join(__dirname, 'openfeature-app.js')
 const FLAGGING_PROVIDER = path.join('openfeature', 'flagging_provider')
@@ -49,6 +50,7 @@ function build (outfile, plugins) {
       entry: ENTRY,
       target: 'node',
       externalsType: 'commonjs',
+      ...(experiments && { experiments }),
       output: { filename: path.basename(outfile), path: path.dirname(outfile), hashFunction: 'sha256' },
       externals: EXTERNALS,
       plugins,

--- a/integration-tests/webpack/build-and-test-skip-external.js
+++ b/integration-tests/webpack/build-and-test-skip-external.js
@@ -8,6 +8,7 @@ const path = require('path')
 const assert = require('assert')
 const webpack = require('webpack')
 const DatadogWebpackPlugin = require('../../webpack') // dd-trace/webpack
+const experiments = require('./webpack-experiments')
 
 const OUTFILE = path.join(__dirname, 'skip-external-out.js')
 
@@ -16,6 +17,7 @@ const compiler = webpack({
   entry: path.join(__dirname, 'skip-external.js'),
   target: 'node',
   externalsType: 'commonjs',
+  ...(experiments && { experiments }),
   output: {
     filename: 'skip-external-out.js',
     path: __dirname,

--- a/integration-tests/webpack/build.js
+++ b/integration-tests/webpack/build.js
@@ -6,12 +6,14 @@
 const path = require('path')
 const webpack = require('webpack')
 const DatadogWebpackPlugin = require('../../webpack') // dd-trace/webpack
+const experiments = require('./webpack-experiments')
 
 const compiler = webpack({
   mode: 'development',
   entry: path.join(__dirname, 'basic-test.js'),
   target: 'node',
   externalsType: 'commonjs',
+  ...(experiments && { experiments }),
   output: {
     filename: 'out.js',
     path: __dirname,

--- a/integration-tests/webpack/webpack-experiments.js
+++ b/integration-tests/webpack/webpack-experiments.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const webpackPkg = require('webpack/package.json')
+
+// webpack 5.107.0 introduced `experiments.typescript` (opt-in), and 5.109.0 defaults it to
+// "auto". On Node.js >= 22.6 (where `module.stripTypeScriptTypes` exists), "auto" turns the
+// experiment on and sets `resolve.tsconfig = true`, making enhanced-resolve walk up to each
+// resolved package's own tsconfig.json. Some published packages (e.g. `side-channel`) ship a
+// tsconfig.json that `extends` a devDependency-only config package (`@ljharb/tsconfig`) that
+// isn't installed, so resolution fails with a "Module not found" error unrelated to
+// TypeScript. Explicitly disable the experiment where the option exists; older webpack
+// versions don't recognize the key at all, so it must not be set for those.
+const [major, minor] = webpackPkg.version.split('.').map(Number)
+const supportsTypescriptExperiment = major > 5 || (major === 5 && minor >= 107)
+
+module.exports = supportsTypescriptExperiment ? { typescript: false } : undefined


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
 
 Webpack 5.109.0 defaults `experiments.typescript` to `"auto"`, which auto-enables on Node.js ≥22.6. This turns on `resolve.tsconfig`, causing enhanced-resolve to walk up to each resolved package's own `tsconfig.json` — including packages like `side-channel` whose `tsconfig.json` extends a devDependency-only config (`@ljharb/tsconfig`) that isn't installed. This broke `test:integration:webpack` on newer Node/webpack versions with spurious "Module not found" errors unrelated to TypeScript.
 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


