### PR TITLE
ci(release): exclude release proposal branches from license auto-commit

### DIFF
--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       needs_update: ${{ steps.check.outputs.needs_update }}
       is_bot_same_repo: ${{ steps.check.outputs.is_bot_same_repo }}
+      is_release_proposal: ${{ steps.check.outputs.is_release_proposal }}
       head_oid: ${{ steps.check.outputs.head_oid }}
     env:
       REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -85,6 +86,7 @@ jobs:
           PR_USER_TYPE: ${{ github.event.pull_request.user.type }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -e
 
@@ -104,8 +106,23 @@ jobs:
             echo "is_bot_same_repo=false" >> $GITHUB_OUTPUT
           fi
 
+          # Release proposal branches are built by cherry-picking master onto a release
+          # line and carry their own version-bump bookkeeping (scripts/release/proposal.js
+          # assumes HEAD is always that bump commit). A commit landed here by this workflow
+          # breaks that assumption, so these branches are excluded from auto-commit and
+          # fail loudly instead — the license CSV is already correct on master and should
+          # never need attribution work done directly on a proposal branch.
+          if [[ "$HEAD_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-proposal$ ]]; then
+            echo "is_release_proposal=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release_proposal=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload updated LICENSE-3rdparty.csv
-        if: steps.check.outputs.needs_update == 'true' && steps.check.outputs.is_bot_same_repo == 'true'
+        if: >-
+          steps.check.outputs.needs_update == 'true' &&
+          steps.check.outputs.is_bot_same_repo == 'true' &&
+          steps.check.outputs.is_release_proposal != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: license-csv
@@ -113,7 +130,9 @@ jobs:
           if-no-files-found: error
 
       - name: Fail for PRs with outdated licenses
-        if: steps.check.outputs.needs_update == 'true' && steps.check.outputs.is_bot_same_repo != 'true'
+        if: >-
+          steps.check.outputs.needs_update == 'true' &&
+          (steps.check.outputs.is_bot_same_repo != 'true' || steps.check.outputs.is_release_proposal == 'true')
         run: |
           echo "❌ The LICENSE-3rdparty.csv file needs to be updated!"
           echo ""
@@ -137,7 +156,10 @@ jobs:
 
   auto-commit-licenses:
     needs: check-licenses
-    if: needs.check-licenses.outputs.needs_update == 'true' && needs.check-licenses.outputs.is_bot_same_repo == 'true'
+    if: >-
+      needs.check-licenses.outputs.needs_update == 'true' &&
+      needs.check-licenses.outputs.is_bot_same_repo == 'true' &&
+      needs.check-licenses.outputs.is_release_proposal != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Excludes release-proposal branches (`v<version>-proposal`) from `update-3rdparty-licenses.yml`'s auto-commit behavior. Instead of silently pushing an `Update LICENSE-3rdparty.csv` commit onto these branches, the check now fails loudly if the license file is stale.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


