### PR TITLE
bench(native): add native spans microbenchmarks

### DIFF
--- a/benchmark/sirun/native-span-drain.js
+++ b/benchmark/sirun/native-span-drain.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const DEFAULT_DRAIN_THRESHOLD = 5000
+
+function createNativeSpanDrain (tracer, threshold = DEFAULT_DRAIN_THRESHOLD) {
+  const nativeSpans = tracer._tracer._nativeSpans
+  const pendingSpanIds = nativeSpans ? [] : null
+
+  function add (span) {
+    if (pendingSpanIds) {
+      pendingSpanIds.push(span.context()._nativeSpanId)
+    }
+  }
+
+  function addAll (spans) {
+    if (!pendingSpanIds) return
+
+    for (const span of spans) {
+      pendingSpanIds.push(span.context()._nativeSpanId)
+    }
+  }
+
+  async function drain () {
+    if (!pendingSpanIds || pendingSpanIds.length === 0) return
+
+    nativeSpans.flushChangeQueue()
+
+    const spanIds = Buffer.allocUnsafe(pendingSpanIds.length * 8)
+    let offset = 0
+    for (const spanId of pendingSpanIds) {
+      spanIds.set(spanId, offset)
+      offset += 8
+    }
+
+    nativeSpans._state.prepareChunk(pendingSpanIds.length, false, spanIds)
+    await nativeSpans._state.sendPreparedChunk().catch(() => {})
+    pendingSpanIds.length = 0
+  }
+
+  function needsDrain () {
+    return pendingSpanIds && pendingSpanIds.length >= threshold
+  }
+
+  return { add, addAll, drain, needsDrain }
+}
+
+module.exports = { createNativeSpanDrain }

--- a/benchmark/sirun/native-spans/creation.js
+++ b/benchmark/sirun/native-spans/creation.js
@@ -1,0 +1,72 @@
+'use strict'
+
+// Span creation benchmark.
+//
+// Measures the full create-to-finish cycle with varying tag counts.
+// The processor is short-circuited so export cost is excluded. Spans are
+// periodically drained from native storage only to keep the WASM span map
+// (and the staged-chunk buffer) bounded over the run — see drainNative.
+//
+// Variants:
+//   SCENARIO=bare      — create + finish, no tags
+//   SCENARIO=10tags    — create with 10 realistic tags + finish
+
+const nock = require('nock')
+
+const { createNativeSpanDrain } = require('../native-span-drain')
+
+// Mock the agent so the periodic drain's send resolves instantly and never
+// touches the network (the drain exists only to bound memory, not to measure
+// export).
+nock.disableNetConnect()
+nock('http://127.0.0.1:8126')
+  .persist()
+  .get('/info')
+  .reply(200, { endpoints: ['/v0.4/traces', '/v0.5/traces'] })
+  .put(/.*/)
+  .reply(200, '{}')
+  .post(/.*/)
+  .reply(200, '{}')
+
+const tracer = require('../../..').init({ hostname: '127.0.0.1', port: 8126 })
+
+const nativeSpanDrain = createNativeSpanDrain(tracer)
+
+tracer._tracer._processor.process = function (span) {
+  nativeSpanDrain.add(span)
+  this._erase(span.context()._trace, [])
+}
+
+const OPERATIONS = Number(process.env.OPERATIONS) || 100_000
+const scenario = process.env.SCENARIO || 'bare'
+
+async function main () {
+  if (scenario === 'bare') {
+    for (let i = 0; i < OPERATIONS; i++) {
+      tracer.startSpan('bench.create.bare').finish()
+      if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+    }
+  } else if (scenario === '10tags') {
+    for (let i = 0; i < OPERATIONS; i++) {
+      const span = tracer.startSpan('bench.create.10tags', {
+        tags: {
+          'service.name': 'my-service',
+          'resource.name': 'GET /users/123',
+          'span.type': 'web',
+          'http.method': 'GET',
+          'http.url': 'https://api.example.com/users/123',
+          'http.status_code': 200,
+          component: 'express',
+          'custom.tag1': 'some-value',
+          'custom.tag2': 42,
+          'custom.tag3': 3.14159,
+        },
+      })
+      span.finish()
+      if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+    }
+  }
+  await nativeSpanDrain.drain()
+}
+
+main()

--- a/benchmark/sirun/native-spans/get-tag.js
+++ b/benchmark/sirun/native-spans/get-tag.js
@@ -1,0 +1,70 @@
+'use strict'
+
+// Tag read benchmark.
+//
+// Measures the cost of reading tags back from a span. For JS spans this
+// is a direct property lookup on a plain object. For native spans,
+// getTag() reads from a JS-side cache (no WASM call), but getTags()
+// returns a copy. This matters for instrumentation code that reads
+// tags to make routing decisions.
+
+const nock = require('nock')
+
+const { createNativeSpanDrain } = require('../native-span-drain')
+
+nock.disableNetConnect()
+nock('http://127.0.0.1:8126')
+  .persist()
+  .get('/info')
+  .reply(200, { endpoints: ['/v0.4/traces', '/v0.5/traces'] })
+  .put(/.*/)
+  .reply(200, '{}')
+  .post(/.*/)
+  .reply(200, '{}')
+
+const tracer = require('../../..').init({ hostname: '127.0.0.1', port: 8126 })
+
+const nativeSpanDrain = createNativeSpanDrain(tracer)
+
+tracer._tracer._processor.process = function (span) {
+  nativeSpanDrain.add(span)
+  this._erase(span.context()._trace, [])
+}
+
+const ITERATIONS = 1_000_000
+
+async function main () {
+  // Pre-create spans with tags, then measure read cost in a separate loop
+  // to isolate reads from writes.
+  const spans = new Array(1000)
+  for (let i = 0; i < spans.length; i++) {
+    spans[i] = tracer.startSpan('bench.gettag', {
+      tags: {
+        'http.method': 'GET',
+        'http.url': 'https://api.example.com/users/123',
+        'http.status_code': 200,
+        'service.name': 'my-service',
+        'resource.name': 'GET /users/:id',
+      },
+    })
+  }
+
+  // Read tags in a tight loop across the pre-created spans
+  for (let i = 0; i < ITERATIONS; i++) {
+    const span = spans[i % spans.length]
+    const ctx = span.context()
+
+    // Individual reads (common in plugin code)
+    ctx.getTag('http.method')
+    ctx.getTag('http.status_code')
+    ctx.getTag('resource.name')
+  }
+
+  // Clean up
+  for (const span of spans) {
+    span.finish()
+  }
+  await nativeSpanDrain.drain()
+}
+
+main()

--- a/benchmark/sirun/native-spans/meta.json
+++ b/benchmark/sirun/native-spans/meta.json
@@ -1,0 +1,54 @@
+{
+  "name": "native-spans",
+  "setup": "bash -c \"node verify.js 1>&2\"",
+  "setup_with_affinity": "bash -c \"node verify.js 1>&2\"",
+  "cachegrind": false,
+  "iterations": 2,
+  "instructions": true,
+  "variants": {
+    "creation-bare": {
+      "run": "node creation.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node creation.js\"",
+      "env": { "SCENARIO": "bare", "DD_TRACE_SCOPE": "noop", "OPERATIONS": "100000" }
+    },
+    "creation-10tags": {
+      "run": "node creation.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node creation.js\"",
+      "env": { "SCENARIO": "10tags", "DD_TRACE_SCOPE": "noop", "OPERATIONS": "50000" }
+    },
+
+    "tagging-settag": {
+      "run": "node tagging.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node tagging.js\"",
+      "env": { "SCENARIO": "settag", "DD_TRACE_SCOPE": "noop", "OPERATIONS": "100000" }
+    },
+    "tagging-addtags": {
+      "run": "node tagging.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node tagging.js\"",
+      "env": { "SCENARIO": "addtags", "DD_TRACE_SCOPE": "noop", "OPERATIONS": "100000" }
+    },
+
+    "parent-child-3deep": {
+      "run": "node parent-child.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node parent-child.js\"",
+      "env": { "DEPTH": "3", "DD_TRACE_SCOPE": "noop", "OPERATIONS": "50000" }
+    },
+    "parent-child-10deep": {
+      "run": "node parent-child.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node parent-child.js\"",
+      "env": { "DEPTH": "10", "DD_TRACE_SCOPE": "noop", "OPERATIONS": "20000" }
+    },
+
+    "pipeline": {
+      "run": "node pipeline.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node pipeline.js\"",
+      "env": { "DD_TRACE_SCOPE": "noop", "OPERATIONS": "50000" }
+    },
+
+    "getTag": {
+      "run": "node get-tag.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node get-tag.js\"",
+      "env": { "DD_TRACE_SCOPE": "noop" }
+    }
+  }
+}

--- a/benchmark/sirun/native-spans/parent-child.js
+++ b/benchmark/sirun/native-spans/parent-child.js
@@ -1,0 +1,74 @@
+'use strict'
+
+// Parent-child span chain benchmark.
+//
+// Measures the cost of creating a chain of N nested spans, each with
+// a few tags. This is the pattern seen in real instrumentation: a root
+// web span spawns middleware spans, which spawn DB/HTTP client spans.
+//
+// Variants:
+//   DEPTH=3   — root → parent → child (typical web request)
+//   DEPTH=10  — deep chain (complex orchestration)
+
+const nock = require('nock')
+
+const { createNativeSpanDrain } = require('../native-span-drain')
+
+nock.disableNetConnect()
+nock('http://127.0.0.1:8126')
+  .persist()
+  .get('/info')
+  .reply(200, { endpoints: ['/v0.4/traces', '/v0.5/traces'] })
+  .put(/.*/)
+  .reply(200, '{}')
+  .post(/.*/)
+  .reply(200, '{}')
+
+const tracer = require('../../..').init({ hostname: '127.0.0.1', port: 8126 })
+
+const nativeSpanDrain = createNativeSpanDrain(tracer)
+
+tracer._tracer._processor.process = function (span) {
+  nativeSpanDrain.add(span)
+  this._erase(span.context()._trace, [])
+}
+
+const OPERATIONS = Number(process.env.OPERATIONS) || 50_000
+const depth = Number(process.env.DEPTH) || 3
+
+const tagSets = [
+  { 'span.type': 'web', 'http.method': 'GET', 'http.url': '/api/users' },
+  { 'span.type': 'web', component: 'middleware', 'http.route': '/api/users/:id' },
+  { 'span.type': 'sql', 'db.type': 'postgresql', 'db.statement': 'SELECT * FROM users WHERE id = $1' },
+  { 'span.type': 'http', 'http.method': 'POST', 'http.url': 'https://auth.internal/verify' },
+  { 'span.type': 'cache', 'cache.backend': 'redis', 'cache.command': 'GET' },
+  { 'span.type': 'web', component: 'router', 'http.route': '/api/users/:id/profile' },
+  { 'span.type': 'sql', 'db.type': 'postgresql', 'db.statement': 'SELECT * FROM profiles WHERE user_id = $1' },
+  { 'span.type': 'http', 'http.method': 'GET', 'http.url': 'https://cdn.internal/avatar' },
+  { 'span.type': 'cache', 'cache.backend': 'redis', 'cache.command': 'SET' },
+  { 'span.type': 'web', component: 'serializer', 'content.type': 'application/json' },
+]
+
+async function main () {
+  for (let i = 0; i < OPERATIONS; i++) {
+    const spans = new Array(depth)
+
+    // Create the chain top-down
+    for (let d = 0; d < depth; d++) {
+      const opts = d === 0
+        ? { tags: tagSets[d % tagSets.length] }
+        : { childOf: spans[d - 1], tags: tagSets[d % tagSets.length] }
+      spans[d] = tracer.startSpan(`span.depth.${d}`, opts)
+    }
+
+    // Finish bottom-up (realistic order)
+    for (let d = depth - 1; d >= 0; d--) {
+      spans[d].finish()
+    }
+
+    if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+  }
+  await nativeSpanDrain.drain()
+}
+
+main()

--- a/benchmark/sirun/native-spans/pipeline.js
+++ b/benchmark/sirun/native-spans/pipeline.js
@@ -1,0 +1,88 @@
+'use strict'
+
+// Full pipeline benchmark (create → tag → finish → process).
+//
+// Unlike the other benchmarks, the processor is NOT short-circuited here.
+// This measures the cost of SpanProcessor.process() — the critical
+// difference being that JS mode calls spanFormat() for every span while
+// native mode skips it entirely.
+//
+// The exporter's export() is replaced with a collector so we measure the
+// process path without the real send; spans are periodically drained from
+// native storage (extract + mocked-agent send) only to bound memory.
+
+const nock = require('nock')
+
+const { createNativeSpanDrain } = require('../native-span-drain')
+
+nock.disableNetConnect()
+nock('http://127.0.0.1:8126')
+  .persist()
+  .get('/info')
+  .reply(200, { endpoints: ['/v0.4/traces', '/v0.5/traces'] })
+  .put(/.*/)
+  .reply(200, '{}')
+  .post(/.*/)
+  .reply(200, '{}')
+
+const tracer = require('../../..').init({
+  hostname: '127.0.0.1',
+  port: 8126,
+})
+
+const nativeSpanDrain = createNativeSpanDrain(tracer)
+
+// Collect finished span ids; the actual drain happens in the (async) main loop
+// so it can await the staging-clearing send.
+tracer._tracer._exporter.export = function (spans) {
+  nativeSpanDrain.addAll(spans)
+}
+
+const OPERATIONS = Number(process.env.OPERATIONS) || 50_000
+
+async function main () {
+  for (let i = 0; i < OPERATIONS; i++) {
+    const root = tracer.startSpan('web.request', {
+      tags: {
+        'service.name': 'web-app',
+        'resource.name': 'GET /api/users/123',
+        'span.type': 'web',
+        'http.method': 'GET',
+        'http.url': 'https://api.example.com/users/123',
+      },
+    })
+
+    const db = tracer.startSpan('postgresql.query', {
+      childOf: root,
+      tags: {
+        'service.name': 'postgresql',
+        'resource.name': 'SELECT * FROM users WHERE id = $1',
+        'span.type': 'sql',
+        'db.type': 'postgresql',
+        'db.name': 'mydb',
+      },
+    })
+    db.setTag('db.row_count', 1)
+    db.finish()
+
+    const cache = tracer.startSpan('redis.command', {
+      childOf: root,
+      tags: {
+        'service.name': 'redis',
+        'resource.name': 'GET',
+        'span.type': 'cache',
+        'cache.backend': 'redis',
+      },
+    })
+    cache.setTag('cache.hit', true)
+    cache.finish()
+
+    root.setTag('http.status_code', 200)
+    root.finish()
+
+    if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+  }
+  await nativeSpanDrain.drain()
+}
+
+main()

--- a/benchmark/sirun/native-spans/tagging.js
+++ b/benchmark/sirun/native-spans/tagging.js
@@ -1,0 +1,70 @@
+'use strict'
+
+// Span tagging benchmark.
+//
+// Isolates the cost of writing tags to an already-created span.
+// For native spans this exercises queueOp + string table interning.
+// For JS spans this is a plain property write.
+//
+// Variants:
+//   SCENARIO=settag    — individual setTag() calls (string + numeric)
+//   SCENARIO=addtags   — bulk addTags() with 5 tags per call
+
+const nock = require('nock')
+
+const { createNativeSpanDrain } = require('../native-span-drain')
+
+nock.disableNetConnect()
+nock('http://127.0.0.1:8126')
+  .persist()
+  .get('/info')
+  .reply(200, { endpoints: ['/v0.4/traces', '/v0.5/traces'] })
+  .put(/.*/)
+  .reply(200, '{}')
+  .post(/.*/)
+  .reply(200, '{}')
+
+const tracer = require('../../..').init({ hostname: '127.0.0.1', port: 8126 })
+
+const nativeSpanDrain = createNativeSpanDrain(tracer)
+
+tracer._tracer._processor.process = function (span) {
+  nativeSpanDrain.add(span)
+  this._erase(span.context()._trace, [])
+}
+
+const OPERATIONS = Number(process.env.OPERATIONS) || 100_000
+const scenario = process.env.SCENARIO || 'settag'
+
+async function main () {
+  if (scenario === 'settag') {
+    // Measure per-tag cost. Create spans in batches so the processor
+    // doesn't accumulate unbounded traces.
+    for (let i = 0; i < OPERATIONS; i++) {
+      const span = tracer.startSpan('bench.settag')
+      span.setTag('http.method', 'GET')
+      span.setTag('http.url', 'https://api.example.com/users/123')
+      span.setTag('http.status_code', 200)
+      span.setTag('component', 'express')
+      span.setTag('custom.metric', 42.5)
+      span.finish()
+      if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+    }
+  } else if (scenario === 'addtags') {
+    for (let i = 0; i < OPERATIONS; i++) {
+      const span = tracer.startSpan('bench.addtags')
+      span.addTags({
+        'http.method': 'POST',
+        'http.url': 'https://api.example.com/orders',
+        'http.status_code': 201,
+        component: 'express',
+        'custom.metric': 99.9,
+      })
+      span.finish()
+      if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+    }
+  }
+  await nativeSpanDrain.drain()
+}
+
+main()

--- a/benchmark/sirun/native-spans/verify.js
+++ b/benchmark/sirun/native-spans/verify.js
@@ -1,0 +1,179 @@
+'use strict'
+
+/**
+ * Verification script — proves that the native code paths claimed by the
+ * benchmarks are actually taken.
+ *
+ *   node verify.js
+ *
+ * Exit code 0 = all assertions passed.
+ * Exit code 1 = a code-path assertion failed.
+ *
+ * Native spans are always on when libdatadog is available. If libdatadog
+ * is not loadable on this platform the script exits early.
+ */
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict')
+const nock = require('nock')
+
+nock.disableNetConnect()
+nock('http://127.0.0.1:8126')
+  .persist()
+  .get('/info')
+  .reply(200, { endpoints: ['/v0.4/traces', '/v0.5/traces'] })
+  .put(/.*/)
+  .reply(200, '{}')
+  .post(/.*/)
+  .reply(200, '{}')
+
+const nativeModule = require('../../../packages/dd-trace/src/native')
+
+let NativeSpansInterface
+let WasmSpanState
+try {
+  NativeSpansInterface = nativeModule.NativeSpansInterface
+  WasmSpanState = nativeModule.WasmSpanState
+} catch (err) {
+  console.error('Native pipeline verification failed to load native spans:', err.message)
+  process.exit(1)
+}
+
+if (typeof NativeSpansInterface !== 'function' || typeof WasmSpanState !== 'function') {
+  console.error('Native pipeline verification failed: expected native span exports are unavailable.')
+  process.exit(1)
+}
+
+console.log('\n=== Verifying native span pipeline ===\n')
+
+const tracer = require('../../..').init({
+  hostname: '127.0.0.1',
+  port: 8126,
+})
+
+const internal = tracer._tracer
+let ok = true
+
+function check (label, fn) {
+  try {
+    fn()
+    console.log(`  PASS  ${label}`)
+  } catch (err) {
+    console.log(`  FAIL  ${label}: ${err.message}`)
+    ok = false
+  }
+}
+
+// -------------------------------------------------------------------
+// 1. Tracer-level: correct internal state
+// -------------------------------------------------------------------
+
+check('tracer._nativeSpans is set', () => {
+  assert.notEqual(internal._nativeSpans, null, '_nativeSpans should be set')
+})
+
+// -------------------------------------------------------------------
+// 2. Span-level: correct span and context classes
+// -------------------------------------------------------------------
+
+const span = tracer.startSpan('verify.span', {
+  tags: { 'http.method': 'GET', 'http.url': '/test', 'custom.num': 42 },
+})
+
+check('span uses NativeDatadogSpan class', () => {
+  assert.equal(span.constructor.name, 'NativeDatadogSpan',
+    `expected NativeDatadogSpan, got ${span.constructor.name}`)
+})
+
+check('span context uses NativeSpanContext class', () => {
+  const ctx = span.context()
+  assert.equal(ctx.constructor.name, 'NativeSpanContext',
+    `expected NativeSpanContext, got ${ctx.constructor.name}`)
+})
+
+// -------------------------------------------------------------------
+// 3. Tag accessors work
+// -------------------------------------------------------------------
+
+check('getTag returns correct values', () => {
+  const ctx = span.context()
+  assert.equal(ctx.getTag('http.method'), 'GET')
+  assert.equal(ctx.getTag('http.url'), '/test')
+  assert.equal(ctx.getTag('custom.num'), 42)
+})
+
+check('setTag + getTag roundtrip', () => {
+  span.setTag('roundtrip.key', 'roundtrip.value')
+  assert.equal(span.context().getTag('roundtrip.key'), 'roundtrip.value')
+})
+
+check('getTags returns all tags', () => {
+  const tags = span.context().getTags()
+  assert.equal(tags['http.method'], 'GET')
+  assert.equal(tags['roundtrip.key'], 'roundtrip.value')
+})
+
+// -------------------------------------------------------------------
+// 4. Parent-child relationship works
+// -------------------------------------------------------------------
+
+const child = tracer.startSpan('verify.child', { childOf: span })
+
+check('child has correct parent', () => {
+  const childCtx = child.context()
+  const parentCtx = span.context()
+  assert.equal(
+    childCtx._parentId.toString(),
+    parentCtx._spanId.toString(),
+    'child parentId should match parent spanId',
+  )
+  assert.equal(
+    childCtx._traceId.toString(),
+    parentCtx._traceId.toString(),
+    'child traceId should match parent traceId',
+  )
+})
+
+child.finish()
+span.finish()
+
+// -------------------------------------------------------------------
+// 5. WASM state is alive and functional
+// -------------------------------------------------------------------
+
+check('NativeSpansInterface._state exists', () => {
+  assert.ok(internal._nativeSpans._state, 'WASM state should exist')
+})
+
+check('WASM flushChangeQueue works', () => {
+  internal._nativeSpans.flushChangeQueue()
+})
+
+check('WASM flushStats method exists', () => {
+  assert.equal(typeof internal._nativeSpans._state.flushStats, 'function',
+    'flushStats should be a function on WASM state')
+})
+
+// -------------------------------------------------------------------
+// 6. Pipeline: native exporter is wired up
+// -------------------------------------------------------------------
+
+check('exporter is NativeExporter', () => {
+  const exporter = internal._exporter
+  assert.equal(exporter.constructor.name, 'NativeExporter',
+    `expected NativeExporter, got ${exporter.constructor.name}`)
+})
+
+// -------------------------------------------------------------------
+// Summary
+// -------------------------------------------------------------------
+
+console.log('')
+if (ok) {
+  console.log('All native pipeline checks passed.\n')
+  process.exit(0)
+} else {
+  console.log('Some native pipeline checks FAILED.\n')
+  process.exit(1)
+}


### PR DESCRIPTION
Stacked on #9139 for now.

This moves the native-spans sirun microbenchmarks out of the base native-spans PR so the base PR can run benchmark A/B without the new-benchmark + source-change policy failure.

Changes:
- Add `benchmark/sirun/native-span-drain.js`.
- Add `benchmark/sirun/native-spans/*` variants for creation, tagging, parent/child chains, pipeline, and tag reads.
- Keep `verify.js` diagnostics on stderr during setup so sirun stdout remains JSON-only.
- Mock `/info` in nock so native exporter v0.5 negotiation stays inside the mocked agent.

Verification:
- setup/setup_with_affinity: exit 0, stdoutBytes=0, stderrHasPass=true, stderrHasNockMiss=false.
- All native-spans scripts smoke-run with small operation counts: exit 0, nockMiss=false.
- `npx eslint benchmark/sirun/native-span-drain.js benchmark/sirun/native-spans/*.js`: clean.
- `git diff --cached --check`: clean before commit.
