### PR TITLE
feat(serverless): add event invocation foundation

### DIFF
--- a/packages/dd-trace/src/serverless/channels.js
+++ b/packages/dd-trace/src/serverless/channels.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { createLifecycleChannels } = require('../events/lifecycle')
+
+const invocation = createLifecycleChannels('tracing:datadog:serverless:invocation', [
+  'start',
+  'finish',
+  'error',
+  'timeout',
+])
+const flush = createLifecycleChannels('tracing:datadog:serverless:flush', [
+  'start',
+  'handed_off',
+  'timed_out',
+  'failed',
+  'disabled',
+  'empty',
+])
+
+module.exports = {
+  invocationStart: invocation.start,
+  invocationFinish: invocation.finish,
+  invocationError: invocation.error,
+  invocationTimeout: invocation.timeout,
+  flushStart: flush.start,
+  flushHandedOff: flush.handed_off,
+  flushTimedOut: flush.timed_out,
+  flushFailed: flush.failed,
+  flushDisabled: flush.disabled,
+  flushEmpty: flush.empty,
+}

--- a/packages/dd-trace/src/serverless/flush-coordinator.js
+++ b/packages/dd-trace/src/serverless/flush-coordinator.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const channels = require('./channels')
+
+const OUTCOME_DISABLED = 'disabled'
+const OUTCOME_HANDED_OFF = 'handed_off'
+const OUTCOME_EMPTY = 'empty'
+const OUTCOME_FAILED = 'failed'
+const OUTCOME_TIMED_OUT = 'timed_out'
+
+function noop () {}
+
+class FlushCoordinator {
+  /**
+   * @param {object} tracer Internal tracer instance.
+   * @param {object} [options]
+   * @param {Function} [options.isEmpty] Returns true when there is no buffered trace work to flush.
+   */
+  constructor (tracer, options = {}) {
+    this._tracer = tracer
+    this._isEmpty = options.isEmpty
+  }
+
+  /**
+   * Flush pending trace data and report a truthful handoff outcome.
+   *
+   * Exporter completion means the trace was handed to its configured transport.
+   * It does not prove that a local agent delivered the trace to Datadog.
+   *
+   * @param {object} options
+   * @param {number} [options.deadlineMs] Absolute timestamp by which flushing should finish.
+   * @param {string} [options.reason] Invocation phase that requested the flush.
+   * @param {unknown} [options.token] Opaque invocation token.
+   * @param {object} [options.source] Source metadata for the platform adapter.
+   * @param {Function} [done] Callback invoked with the flush result.
+   * @returns {void}
+   */
+  flush (options = {}, done = noop) {
+    const resultBase = {
+      reason: options.reason,
+      token: options.token,
+      source: options.source,
+    }
+
+    channels.flushStart.publish(resultBase)
+
+    if (this._isEmpty && this._isEmpty()) {
+      return this._finish(OUTCOME_EMPTY, resultBase, done)
+    }
+
+    const exporter = this._tracer?._exporter
+    if (!exporter || typeof exporter.flush !== 'function') {
+      return this._finish(OUTCOME_DISABLED, resultBase, done)
+    }
+
+    let settled = false
+    let timer
+
+    const timeoutMs = getTimeoutMs(options.deadlineMs)
+    if (timeoutMs !== undefined) {
+      if (timeoutMs <= 0) {
+        return this._finish(OUTCOME_TIMED_OUT, resultBase, done)
+      }
+
+      timer = setTimeout(() => {
+        finish(OUTCOME_TIMED_OUT)
+      }, timeoutMs)
+      timer.unref?.()
+    }
+
+    const finish = (outcome, error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      this._finish(outcome, resultBase, done, error)
+    }
+
+    try {
+      exporter.flush(error => {
+        finish(error ? OUTCOME_FAILED : OUTCOME_HANDED_OFF, error)
+      })
+    } catch (error) {
+      finish(OUTCOME_FAILED, error)
+    }
+  }
+
+  /**
+   * Publish the terminal flush outcome and notify the caller.
+   *
+   * @param {string} outcome Flush outcome.
+   * @param {object} resultBase Shared result fields.
+   * @param {Function} done Completion callback.
+   * @param {Error} [error] Flush failure.
+   * @returns {void}
+   */
+  _finish (outcome, resultBase, done, error) {
+    const result = {
+      ...resultBase,
+      outcome,
+      error,
+    }
+
+    getOutcomeChannel(outcome).publish(result)
+    done(result)
+  }
+}
+
+function getTimeoutMs (deadlineMs) {
+  if (typeof deadlineMs === 'number') return deadlineMs - Date.now()
+}
+
+function getOutcomeChannel (outcome) {
+  switch (outcome) {
+    case OUTCOME_HANDED_OFF:
+      return channels.flushHandedOff
+    case OUTCOME_EMPTY:
+      return channels.flushEmpty
+    case OUTCOME_FAILED:
+      return channels.flushFailed
+    case OUTCOME_TIMED_OUT:
+      return channels.flushTimedOut
+    default:
+      return channels.flushDisabled
+  }
+}
+
+module.exports = {
+  FlushCoordinator,
+  OUTCOME_DISABLED,
+  OUTCOME_HANDED_OFF,
+  OUTCOME_EMPTY,
+  OUTCOME_FAILED,
+  OUTCOME_TIMED_OUT,
+}

--- a/packages/dd-trace/src/serverless/index.js
+++ b/packages/dd-trace/src/serverless/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  channels: require('./channels'),
+  ...require('./flush-coordinator'),
+  ...require('./invocation-processor'),
+}

--- a/packages/dd-trace/src/serverless/invocation-processor.js
+++ b/packages/dd-trace/src/serverless/invocation-processor.js
@@ -1,0 +1,226 @@
+'use strict'
+
+const { storage } = require('../../../datadog-core')
+const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../constants')
+const { isError } = require('../util')
+const { FlushCoordinator } = require('./flush-coordinator')
+const channels = require('./channels')
+
+const legacyStorage = storage('legacy')
+
+class ServerlessInvocationProcessor {
+  /**
+   * @param {object} tracer Internal tracer instance.
+   * @param {object} [options]
+   * @param {FlushCoordinator} [options.flushCoordinator] Coordinator used to drain trace data.
+   */
+  constructor (tracer, options = {}) {
+    this._tracer = tracer
+    this._flushCoordinator = options.flushCoordinator || new FlushCoordinator(tracer)
+    this._invocations = new WeakMap()
+    this._enabled = false
+
+    this._onStart = this._onStart.bind(this)
+    this._onFinish = this._onFinish.bind(this)
+    this._onError = this._onError.bind(this)
+    this._onTimeout = this._onTimeout.bind(this)
+  }
+
+  /**
+   * Subscribe to normalized serverless invocation events.
+   *
+   * @returns {void}
+   */
+  enable () {
+    if (this._enabled) return
+    this._enabled = true
+    channels.invocationStart.bindStore(legacyStorage, this._onStart)
+    channels.invocationFinish.subscribe(this._onFinish)
+    channels.invocationError.subscribe(this._onError)
+    channels.invocationTimeout.subscribe(this._onTimeout)
+  }
+
+  /**
+   * Unsubscribe from normalized serverless invocation events.
+   *
+   * @returns {void}
+   */
+  disable () {
+    if (!this._enabled) return
+    this._enabled = false
+    channels.invocationStart.unbindStore(legacyStorage)
+    channels.invocationFinish.unsubscribe(this._onFinish)
+    channels.invocationError.unsubscribe(this._onError)
+    channels.invocationTimeout.unsubscribe(this._onTimeout)
+    this._invocations = new WeakMap()
+  }
+
+  /**
+   * Start the root invocation span and bind it into legacy storage for user code.
+   *
+   * @param {object} event Normalized serverless invocation event.
+   * @returns {object|undefined} Store to enter while the platform invokes user code.
+   */
+  _onStart (event) {
+    if (!isInvocationEvent(event) || !isObjectToken(event.token)) return legacyStorage.getStore()
+
+    const token = event.token
+    const activeInvocation = this._invocations.get(token)
+    if (activeInvocation) return activeInvocation.currentStore
+
+    const data = event.data || {}
+    const source = event.source || {}
+    const parentStore = legacyStorage.getStore()
+    const span = this._tracer.startSpan(getOperationName(event), {
+      childOf: getParentContext(this._tracer, event),
+      startTime: data.startTime,
+      tags: getSpanTags(event),
+      integrationName: source.integration || source.platform || 'serverless',
+    })
+    const currentStore = { ...parentStore, span }
+
+    event.context = {
+      ...event.context,
+      parentStore,
+      currentStore,
+      span,
+    }
+
+    const state = {
+      span,
+      source,
+      currentStore,
+      deadlineMs: data.deadlineMs,
+    }
+    this._invocations.set(token, state)
+    event.context.operationState = state
+
+    return currentStore
+  }
+
+  /**
+   * Finish a successful invocation.
+   *
+   * @param {object} event Normalized serverless invocation event.
+   * @returns {void}
+   */
+  _onFinish (event) {
+    this._complete(event, 'finish')
+  }
+
+  /**
+   * Finish an invocation that failed with an error.
+   *
+   * @param {object} event Normalized serverless invocation event.
+   * @returns {void}
+   */
+  _onError (event) {
+    this._complete(event, 'error', getEventError(event))
+  }
+
+  /**
+   * Mark an invocation as timed out, finish unfinished work, and flush.
+   *
+   * @param {object} event Normalized serverless invocation event.
+   * @returns {void}
+   */
+  _onTimeout (event) {
+    const error = getEventError(event) || new Error('Serverless invocation timed out')
+    this._complete(event, 'timeout', error)
+  }
+
+  /**
+   * Finish a root invocation span once and hand off to the flush coordinator.
+   *
+   * @param {object} event Normalized serverless invocation event.
+   * @param {string} reason Completion reason.
+   * @param {unknown} [error] Optional invocation error.
+   * @returns {void}
+   */
+  _complete (event, reason, error) {
+    const state = this._invocations.get(event?.token)
+    if (!state) return
+
+    this._invocations.delete(event.token)
+
+    if (error) {
+      addError(state.span, error)
+    }
+
+    state.span.finish(event?.data?.finishTime)
+
+    this._flushCoordinator.flush({
+      reason,
+      token: event.token,
+      source: event.source || state.source,
+      deadlineMs: event?.data?.deadlineMs ?? state.deadlineMs,
+    }, getDoneCallback(event))
+  }
+}
+
+function isInvocationEvent (event) {
+  return event?.kind === 'serverless' && event.operation === 'invocation'
+}
+
+function isObjectToken (token) {
+  return (typeof token === 'object' && token !== null) || typeof token === 'function'
+}
+
+function getParentContext (tracer, event) {
+  const data = event.data || {}
+  if (data.childOf !== undefined) return data.childOf
+  const carrier = data.carrier || data.headers
+  return carrier && typeof tracer.extract === 'function'
+    ? tracer.extract('text_map', carrier) || null
+    : null
+}
+
+function getOperationName (event) {
+  const data = event.data || {}
+  return data.operationName || `${event.source?.platform || 'serverless'}.invocation`
+}
+
+function getSpanTags (event) {
+  const data = event.data || {}
+  const source = event.source || {}
+  const tags = {
+    component: source.integration || source.platform || 'serverless',
+    'span.kind': 'server',
+    'span.type': 'serverless',
+    'resource.name': data.resourceName || data.handlerName || data.functionName,
+    ...data.tags,
+  }
+
+  if (source.platform !== undefined) tags['serverless.platform'] = source.platform
+  if (data.functionName !== undefined) tags['serverless.function.name'] = data.functionName
+  if (data.handlerName !== undefined) tags['serverless.handler'] = data.handlerName
+  if (data.triggerType !== undefined) tags['serverless.trigger'] = data.triggerType
+  if (data.route !== undefined) tags['http.route'] = data.route
+
+  return tags
+}
+
+function getEventError (event) {
+  return event?.error || event?.data?.error
+}
+
+function addError (span, error) {
+  if (isError(error)) {
+    span.addTags({
+      [ERROR_TYPE]: error.name,
+      [ERROR_MESSAGE]: error.message,
+      [ERROR_STACK]: error.stack,
+    })
+    return
+  }
+
+  span.setTag('error', error)
+}
+
+function getDoneCallback (event) {
+  return event?.done || event?.context?.done
+}
+
+module.exports = {
+  ServerlessInvocationProcessor,
+}

--- a/packages/dd-trace/test/serverless/flush-coordinator.spec.js
+++ b/packages/dd-trace/test/serverless/flush-coordinator.spec.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+const {
+  FlushCoordinator,
+  OUTCOME_DISABLED,
+  OUTCOME_HANDED_OFF,
+  OUTCOME_EMPTY,
+  OUTCOME_FAILED,
+  OUTCOME_TIMED_OUT,
+  channels,
+} = require('../../src/serverless/index')
+
+describe('serverless FlushCoordinator', () => {
+  const subscriptions = []
+
+  afterEach(() => {
+    for (const { channel, handler } of subscriptions.splice(0)) {
+      channel.unsubscribe(handler)
+    }
+    sinon.restore()
+  })
+
+  it('reports handed off when the exporter flush callback succeeds', () => {
+    const starts = []
+    const handedOff = []
+    record(channels.flushStart, starts)
+    record(channels.flushHandedOff, handedOff)
+
+    const exporter = { flush: sinon.stub().callsArg(0) }
+    const coordinator = new FlushCoordinator({ _exporter: exporter })
+    let result
+
+    coordinator.flush({ reason: 'finish', token: 'abc' }, value => {
+      result = value
+    })
+
+    sinon.assert.calledOnce(exporter.flush)
+    assert.strictEqual(result.outcome, OUTCOME_HANDED_OFF)
+    assert.strictEqual(handedOff[0].outcome, OUTCOME_HANDED_OFF)
+    assert.deepStrictEqual(starts[0], { reason: 'finish', token: 'abc', source: undefined })
+  })
+
+  it('reports disabled when no exporter flush is available', () => {
+    const disabled = []
+    record(channels.flushDisabled, disabled)
+
+    const coordinator = new FlushCoordinator({})
+    let result
+
+    coordinator.flush({}, value => {
+      result = value
+    })
+
+    assert.strictEqual(result.outcome, OUTCOME_DISABLED)
+    assert.strictEqual(disabled[0].outcome, OUTCOME_DISABLED)
+  })
+
+  it('reports empty without calling exporter flush when the buffer is empty', () => {
+    const empty = []
+    record(channels.flushEmpty, empty)
+
+    const exporter = { flush: sinon.stub() }
+    const coordinator = new FlushCoordinator({ _exporter: exporter }, { isEmpty: () => true })
+    let result
+
+    coordinator.flush({}, value => {
+      result = value
+    })
+
+    sinon.assert.notCalled(exporter.flush)
+    assert.strictEqual(result.outcome, OUTCOME_EMPTY)
+    assert.strictEqual(empty[0].outcome, OUTCOME_EMPTY)
+  })
+
+  it('reports timed out when the exporter does not complete before the deadline', () => {
+    const clock = sinon.useFakeTimers()
+    const timeouts = []
+    record(channels.flushTimedOut, timeouts)
+
+    const exporter = { flush: sinon.stub() }
+    const coordinator = new FlushCoordinator({ _exporter: exporter })
+    let result
+
+    coordinator.flush({ deadlineMs: Date.now() + 10 }, value => {
+      result = value
+    })
+    clock.tick(10)
+
+    assert.strictEqual(result.outcome, OUTCOME_TIMED_OUT)
+    assert.strictEqual(timeouts[0].outcome, OUTCOME_TIMED_OUT)
+  })
+
+  it('reports timed out immediately when the deadline has expired', () => {
+    const clock = sinon.useFakeTimers({ now: 100 })
+    const exporter = { flush: sinon.stub() }
+    const coordinator = new FlushCoordinator({ _exporter: exporter })
+    let result
+
+    coordinator.flush({ deadlineMs: 100 }, value => {
+      result = value
+    })
+
+    sinon.assert.notCalled(exporter.flush)
+    assert.strictEqual(result.outcome, OUTCOME_TIMED_OUT)
+    clock.restore()
+  })
+
+  it('ignores exporter completion after the deadline outcome', () => {
+    const clock = sinon.useFakeTimers()
+    const exporter = { flush: sinon.stub() }
+    const coordinator = new FlushCoordinator({ _exporter: exporter })
+    const done = sinon.spy()
+
+    coordinator.flush({ deadlineMs: Date.now() + 10 }, done)
+    clock.tick(10)
+    exporter.flush.firstCall.args[0]()
+
+    sinon.assert.calledOnce(done)
+    assert.strictEqual(done.firstCall.args[0].outcome, OUTCOME_TIMED_OUT)
+  })
+
+  it('reports failed when exporter flush throws', () => {
+    const errors = []
+    record(channels.flushFailed, errors)
+
+    const error = new Error('flush failed')
+    const exporter = {
+      flush: sinon.stub().throws(error),
+    }
+    const coordinator = new FlushCoordinator({ _exporter: exporter })
+    let result
+
+    coordinator.flush({}, value => {
+      result = value
+    })
+
+    assert.strictEqual(result.outcome, OUTCOME_FAILED)
+    assert.strictEqual(result.error, error)
+    assert.strictEqual(errors[0].error, error)
+  })
+
+  it('reports failed when the exporter callback receives an error', () => {
+    const error = new Error('flush failed')
+    const exporter = { flush: sinon.stub().callsArgWith(0, error) }
+    const coordinator = new FlushCoordinator({ _exporter: exporter })
+    let result
+
+    coordinator.flush({}, value => {
+      result = value
+    })
+
+    assert.strictEqual(result.outcome, OUTCOME_FAILED)
+    assert.strictEqual(result.error, error)
+  })
+
+  function record (channel, events) {
+    const handler = event => events.push(event)
+    subscriptions.push({ channel, handler })
+    channel.subscribe(handler)
+  }
+})

--- a/packages/dd-trace/test/serverless/invocation-processor.spec.js
+++ b/packages/dd-trace/test/serverless/invocation-processor.spec.js
@@ -1,0 +1,252 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+const { storage } = require('../../../datadog-core')
+const {
+  ServerlessInvocationProcessor,
+  channels,
+} = require('../../src/serverless/index')
+
+const legacyStorage = storage('legacy')
+
+describe('serverless ServerlessInvocationProcessor', () => {
+  let tracer
+  let flushCoordinator
+  let processor
+  let spans
+
+  beforeEach(() => {
+    spans = []
+    tracer = {
+      startSpan: sinon.stub().callsFake((name, options) => {
+        const span = createSpan(name, options)
+        spans.push(span)
+        return span
+      }),
+      extract: sinon.stub(),
+    }
+    flushCoordinator = {
+      flush: sinon.stub().callsFake((_options, done) => {
+        if (done) done({ outcome: 'drained' })
+      }),
+    }
+    processor = new ServerlessInvocationProcessor(tracer, { flushCoordinator })
+    processor.enable()
+  })
+
+  afterEach(() => {
+    processor.disable()
+    legacyStorage.enterWith(undefined)
+    sinon.restore()
+  })
+
+  it('starts a serverless root span and activates it for user code', () => {
+    const token = {}
+    const parentContext = { traceId: 'parent' }
+    tracer.extract.returns(parentContext)
+
+    const event = startEvent(token, {
+      carrier: { 'x-datadog-trace-id': '1' },
+      functionName: 'handler',
+      handlerName: 'api/users',
+      operationName: 'vercel.invoke',
+      route: '/users',
+      tags: {
+        'vercel.region': 'iad1',
+      },
+    })
+
+    let activeSpan
+    channels.invocationStart.runStores(event, () => {
+      activeSpan = legacyStorage.getStore().span
+    })
+
+    const span = spans[0]
+    assert.strictEqual(activeSpan, span)
+    assert.strictEqual(event.context.span, span)
+    sinon.assert.calledWith(tracer.extract, 'text_map', { 'x-datadog-trace-id': '1' })
+    sinon.assert.calledWith(tracer.startSpan, 'vercel.invoke', sinon.match({
+      childOf: parentContext,
+      tags: sinon.match({
+        component: 'vercel',
+        'span.kind': 'server',
+        'span.type': 'serverless',
+        'resource.name': 'api/users',
+        'serverless.platform': 'vercel',
+        'serverless.function.name': 'handler',
+        'serverless.handler': 'api/users',
+        'http.route': '/users',
+        'vercel.region': 'iad1',
+      }),
+      integrationName: 'vercel',
+    }))
+  })
+
+  it('finishes the root span and flushes before invoking the done callback', () => {
+    const token = {}
+    const done = sinon.spy()
+    const event = startEvent(token, { deadlineMs: 1234 })
+
+    channels.invocationStart.runStores(event, () => {})
+    channels.invocationFinish.publish({
+      kind: 'serverless',
+      operation: 'invocation',
+      token,
+      source: event.source,
+      context: { done },
+      data: { finishTime: 42 },
+    })
+
+    assert.strictEqual(spans[0].finished, true)
+    assert.strictEqual(spans[0].finishTime, 42)
+    sinon.assert.calledWith(flushCoordinator.flush, sinon.match({
+      reason: 'finish',
+      token,
+      deadlineMs: 1234,
+      source: event.source,
+    }), sinon.match.func)
+    sinon.assert.calledOnce(done)
+  })
+
+  it('tags errors before finishing and flushing the root span', () => {
+    const token = {}
+    const error = new Error('boom')
+
+    channels.invocationStart.runStores(startEvent(token), () => {})
+    channels.invocationError.publish({
+      kind: 'serverless',
+      operation: 'invocation',
+      token,
+      error,
+    })
+
+    assert.strictEqual(spans[0].tags['error.type'], 'Error')
+    assert.strictEqual(spans[0].tags['error.message'], 'boom')
+    assert.strictEqual(spans[0].finished, true)
+    sinon.assert.calledWith(flushCoordinator.flush, sinon.match({ reason: 'error' }), undefined)
+  })
+
+  it('finishes the selected invocation on timeout', () => {
+    const token = {}
+    const deadlineMs = Date.now() + 5
+
+    channels.invocationStart.runStores(startEvent(token, { deadlineMs }), () => {})
+    channels.invocationTimeout.publish({
+      kind: 'serverless',
+      operation: 'invocation',
+      token,
+    })
+
+    assert.strictEqual(spans[0].tags['error.type'], 'Error')
+    assert.strictEqual(spans[0].tags['error.message'], 'Serverless invocation timed out')
+    assert.strictEqual(spans[0].finished, true)
+    sinon.assert.calledWith(flushCoordinator.flush, sinon.match({
+      reason: 'timeout',
+      deadlineMs,
+    }), undefined)
+  })
+
+  it('ignores duplicate completion events for the same token', () => {
+    const token = {}
+
+    channels.invocationStart.runStores(startEvent(token), () => {})
+    channels.invocationFinish.publish({
+      kind: 'serverless',
+      operation: 'invocation',
+      token,
+    })
+    channels.invocationError.publish({
+      kind: 'serverless',
+      operation: 'invocation',
+      token,
+      error: new Error('late error'),
+    })
+
+    assert.strictEqual(spans[0].finishCount, 1)
+    sinon.assert.calledOnce(flushCoordinator.flush)
+  })
+
+  it('does not start an invocation without an opaque object token', () => {
+    channels.invocationStart.runStores(startEvent(undefined), () => {})
+    channels.invocationStart.runStores(startEvent('request-id'), () => {})
+
+    sinon.assert.notCalled(tracer.startSpan)
+  })
+
+  it('reuses the active invocation when a token is started twice', () => {
+    const token = {}
+    const first = startEvent(token)
+    const duplicate = startEvent(token)
+    let firstStore
+    let duplicateStore
+
+    channels.invocationStart.runStores(first, () => {
+      firstStore = legacyStorage.getStore()
+    })
+    channels.invocationStart.runStores(duplicate, () => {
+      duplicateStore = legacyStorage.getStore()
+    })
+
+    sinon.assert.calledOnce(tracer.startSpan)
+    assert.strictEqual(duplicateStore, firstStore)
+    assert.strictEqual(first.context.operationState.currentStore, firstStore)
+  })
+
+  it('times out only the selected concurrent invocation', () => {
+    const firstToken = {}
+    const secondToken = {}
+
+    channels.invocationStart.runStores(startEvent(firstToken), () => {})
+    channels.invocationStart.runStores(startEvent(secondToken), () => {})
+    channels.invocationTimeout.publish({
+      kind: 'serverless',
+      operation: 'invocation',
+      token: firstToken,
+    })
+
+    assert.strictEqual(spans[0].finished, true)
+    assert.strictEqual(spans[1].finished, false)
+  })
+})
+
+function startEvent (token, data = {}) {
+  return {
+    v: 1,
+    kind: 'serverless',
+    operation: 'invocation',
+    phase: 'start',
+    token,
+    source: {
+      platform: 'vercel',
+      integration: 'vercel',
+    },
+    data,
+  }
+}
+
+function createSpan (name, options) {
+  return {
+    name,
+    options,
+    tags: { ...options.tags },
+    finished: false,
+    finishCount: 0,
+    addTags (tags) {
+      Object.assign(this.tags, tags)
+    },
+    setTag (key, value) {
+      this.tags[key] = value
+    },
+    finish (time) {
+      this.finished = true
+      this.finishTime = time
+      this.finishCount++
+    },
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds the serverless-specific event foundation on top of #9404:

- normalized invocation lifecycle channels for `start`, `finish`, `error`, and `timeout`;
- flush lifecycle channels with explicit `handed_off`, `timed_out`, `failed`, `disabled`, and `empty` outcomes;
- `ServerlessInvocationProcessor`, which creates and activates one root serverless span per invocation token;
- distributed-context extraction and normalized platform/function/trigger tags;
- exactly-once invocation completion, error tagging, and timeout handling;
- `FlushCoordinator`, which finishes through a deadline-aware callback barrier before platform code resumes.

### Motivation

Serverless platform integrations own an invocation boundary rather than an ordinary package call. Each platform adapter must preserve context around user code, finish the root span exactly once, and delay the platform return until trace handoff finishes or the safe deadline expires.

Keeping that telemetry policy in a shared processor lets platform-specific instrumentation remain thin: it captures platform facts and publishes lifecycle events instead of creating spans or implementing its own flush policy.

### Architecture

```text
platform-specific wrapper / source adapter
  -> tracing:datadog:serverless:invocation lifecycle
  -> shared ServerlessInvocationProcessor
  -> root span finish
  -> deadline-aware FlushCoordinator
  -> completion callback releases the platform return
```

### Stack

- #9404: package-agnostic event registries and semantic lifecycle bridge
- This PR: shared serverless invocation and flush foundation
- Follow-up: concrete platform adapter and Orchestrion configuration, starting with the selected Vercel boundary

### Draft scope and remaining work

This PR is intentionally a foundation and does not yet add a complete platform integration.

Before a platform integration is production-ready, follow-up work must add:

- a stable platform entrypoint and package-scoped Orchestrion source adapter;
- registration/lease wiring through the shared event-domain model;
- serialization or coalescing for concurrent flush requests;
- cancellation-aware exporter and transport draining;
- explicit agent-backed versus agentless delivery semantics;
- double-instrumentation protection;
- deployed normal, error, timeout, long-running, burst, and delivery probes.

### Verification

- Event foundation and serverless lifecycle tests: 42 passing
- Targeted ESLint for all six serverless source/test files
- `git diff --check`
- Rebase intent audit confirmed the serverless patch remained equivalent when restacked onto the current #9404 head
