### PR TITLE
test(aws-sdk): pin core before clock skew regression

### DIFF
--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "license": "BSD-3-Clause",
   "private": true,
+  "resolutions": {
+    "@aws-sdk/core": "3.975.3"
+  },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "5.0.24",
     "@ai-sdk/anthropic": "4.0.16",

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -12,7 +12,7 @@ const semver = require('semver')
 const externals = require('../packages/dd-trace/test/plugins/externals')
 const { getInstrumentation } = require('../packages/dd-trace/test/setup/helpers/load-inst')
 const { getCappedRange, resolvePluginVersions } = require('../packages/dd-trace/test/plugins/versions')
-const latests = require('../packages/dd-trace/test/plugins/versions/package.json').dependencies
+const { dependencies: latests, resolutions } = require('../packages/dd-trace/test/plugins/versions/package.json')
 const { isRelativeRequire } = require('../packages/datadog-instrumentations/src/helpers/shared-utils')
 const exec = require('./helpers/exec')
 const mapWithConcurrency = require('./helpers/concurrency')
@@ -354,6 +354,7 @@ async function assertWorkspaces () {
     version: '1.0.0',
     license: 'BSD-3-Clause',
     private: true,
+    resolutions,
     workspaces: {
       packages: [...workspaces].sort(),
     },


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Propagates selective dependency resolutions to generated plugin-test workspaces and temporarily pins `@aws-sdk/core` to `3.975.3`.

### Motivation
<!-- What inspired you to submit this pull request? -->

`@aws-sdk/core@3.977.0` introduced a clock-skew regression in [aws/aws-sdk-js-v3#8189](https://github.com/aws/aws-sdk-js-v3/pull/8189). When legacy LocalStack omits the response `Date` header, the SDK stores `NaN` as its system clock offset. The next Lambda request then fails during signing with `RangeError: Invalid time value`.

Because the plugin-test workspaces are installed without a lockfile, every branch started resolving the regressed transitive version. This caused the [`aws-sdk (latest, lambda)` Serverless job](https://github.com/DataDog/dd-trace-js/actions/runs/30245822530/job/89913548118?pr=9431) to fail independently of branch changes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is a temporary compatibility pin and should be removed after AWS publishes a release that preserves the existing clock offset when the response date is missing or invalid.

Validation:
- `PLUGINS=aws-sdk yarn services` (confirmed generated resolution and `@aws-sdk/core@3.975.3`)
- Two consecutive Lambda requests against a headerless local HTTP endpoint
- `./node_modules/.bin/mocha packages/dd-trace/test/plugins/versions.spec.js` (28 passing)
- `./node_modules/.bin/eslint scripts/install_plugin_modules.js`
- `git diff --check`

The full LocalStack Lambda spec was not run locally because Docker is not installed in this environment; the draft PR CI will exercise it.
