### PR TITLE
test(aws-sdk): disable clock skew correction in the Lambda spec

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -18,18 +18,17 @@ const createClientContext = data => Buffer.from(JSON.stringify(data)).toString('
 
 /**
  * `@aws-sdk/core` 3.977.0 rewrote the clock-skew helper and dropped the guard that ignored an
- * unparsable server `Date`. Older clients, and every v2 client, resolve no `@aws-sdk/core` at all.
+ * unparsable server `Date`. Resolution reaches that copy through the hoisted tree even from clients
+ * that predate `@aws-sdk/core`, so only the declared dependency separates the two.
  *
  * @param {string} version Suffix of the `versions/@aws-sdk/client-lambda@<version>` entry.
- * @returns {boolean}
  */
 function hasUnguardedClockSkewCorrection (version) {
-  try {
-    const versionEntry = require(`../../../versions/@aws-sdk/client-lambda@${version}`)
-    return semifies(require(versionEntry.pkgJsonPath('@aws-sdk/core')).version, '>=3.977.0')
-  } catch {
-    return false
-  }
+  const versionEntry = require(`../../../versions/@aws-sdk/client-lambda@${version}`)
+  const { dependencies } = require(versionEntry.pkgJsonPath())
+
+  return dependencies?.['@aws-sdk/core'] !== undefined &&
+    semifies(require(versionEntry.pkgJsonPath('@aws-sdk/core')).version, '>=3.977.0')
 }
 
 describe('Plugin', () => {

--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 
 const JSZip = require('jszip')
 const { after, before, describe, it } = require('mocha')
+const semifies = require('semifies')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
@@ -14,6 +15,22 @@ const { setup, withAwsSdkVersions } = require('./spec_helpers')
 const zip = new JSZip()
 
 const createClientContext = data => Buffer.from(JSON.stringify(data)).toString('base64')
+
+/**
+ * `@aws-sdk/core` 3.977.0 rewrote the clock-skew helper and dropped the guard that ignored an
+ * unparsable server `Date`. Older clients, and every v2 client, resolve no `@aws-sdk/core` at all.
+ *
+ * @param {string} version Suffix of the `versions/@aws-sdk/client-lambda@<version>` entry.
+ * @returns {boolean}
+ */
+function hasUnguardedClockSkewCorrection (version) {
+  try {
+    const versionEntry = require(`../../../versions/@aws-sdk/client-lambda@${version}`)
+    return semifies(require(versionEntry.pkgJsonPath('@aws-sdk/core')).version, '>=3.977.0')
+  } catch {
+    return false
+  }
+}
 
 describe('Plugin', () => {
   describe('aws-sdk (lambda)', function () {
@@ -34,6 +51,24 @@ describe('Plugin', () => {
         return JSON.parse(payload)
       }
 
+      if (lambdaClientName === '@aws-sdk/client-lambda' && hasUnguardedClockSkewCorrection(version)) {
+        describe('clock skew correction against the legacy LocalStack', () => {
+          // A failure here means `@aws-sdk/core` guards the unparsable `Date` again, which is the
+          // signal to drop this block together with the `disableClockSkewCorrection` option below.
+          it('poisons the signature of every request after the first', async () => {
+            const { Lambda } = require(`../../../versions/${lambdaClientName}@${version}`).get()
+            const skewCorrected = new Lambda({ endpoint: 'http://127.0.0.1:4567', region: 'us-east-1' })
+
+            await skewCorrected.listFunctions({})
+
+            await assert.rejects(
+              () => skewCorrected.listFunctions({}),
+              { name: 'RangeError', message: 'Invalid time value' }
+            )
+          })
+        })
+      }
+
       describe('with the new trace context propagation', () => {
         let ZipFile
 
@@ -47,7 +82,13 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/${lambdaClientName}@${version}`).get()
 
-          lambda = new AWS.Lambda({ endpoint: 'http://127.0.0.1:4567', region: 'us-east-1' })
+          // The pinned legacy LocalStack answers with two `Date` headers, which `@aws-sdk/core`
+          // >= 3.977.0 parses to `NaN` and keeps as the skew offset, breaking every later signature.
+          lambda = new AWS.Lambda({
+            endpoint: 'http://127.0.0.1:4567',
+            region: 'us-east-1',
+            disableClockSkewCorrection: true,
+          })
           lambda.createFunction({
             FunctionName: 'ironmaiden',
             Code: { ZipFile },


### PR DESCRIPTION
## Summary

The pinned legacy LocalStack Lambda endpoint emits duplicate `Date` headers. Node combines them into an unparsable value, and `@aws-sdk/core` 3.977.0 stores `NaN` as the clock-skew offset, causing subsequent signed requests to fail with `RangeError: Invalid time value`.

The workaround is scoped to the affected test client, with a version-gated regression test that preserves the failure signal until the SDK handles the response correctly.

## Why

Modern LocalStack cannot replace the legacy container because these tests depend on `ClientContext` propagation.

Refs: https://github.com/localstack/localstack/issues/11053