### PR TITLE
[PR Agent test] fix(instrumentation): wait for asyncEnd on promise settlement

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -5,7 +5,7 @@ const { join } = require('path')
 const { pathToFileURL } = require('url')
 const log = require('../../../../dd-trace/src/log')
 const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
-const { waitForAsyncEnd } = require('./transforms')
+const { waitForAsyncEnd, waitForAsyncEndCallback } = require('./transforms')
 const instrumentations = require('./instrumentations')
 
 // `dc-polyfill` is referenced from injected `require()` (CJS) and `import`
@@ -35,6 +35,7 @@ const matcherEsm = create(instrumentations, dcPolyfillEsm)
 
 for (const matcher of [matcherCjs, matcherEsm]) {
   matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
+  matcher.addTransform('waitForAsyncEndCallback', waitForAsyncEndCallback)
 }
 
 // Keep the marker split: source-map scanners can read a contiguous token in

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -14,7 +14,7 @@ const clone = require('../../../../../vendor/dist/rfdc')({ proto: false, circles
 
 const { parse, query } = require('./compiler')
 
-module.exports = { waitForAsyncEnd }
+module.exports = { waitForAsyncEnd, waitForAsyncEndCallback }
 
 /**
  * Injects a wait for `ctx.asyncEndPromise` into a generated `tracePromise`
@@ -58,4 +58,75 @@ function waitForAsyncEnd (_state, node) {
   onSettled[1].body = clone(returnArgument)
 
   statements.splice(returnIndex, 0, ...waitStatements)
+}
+
+/**
+ * Injects a callback-driven wait into both settlement handlers of a generated
+ * `tracePromise` wrapper.
+ *
+ * @param {object} _state
+ * @param {import('estree').CallExpression} node
+ * @returns {void}
+ */
+function waitForAsyncEndCallback (_state, node) {
+  const onFulfilled = node.arguments[0]
+  const onRejected = node.arguments[1]
+
+  if (!onFulfilled?.body || !onRejected?.body) {
+    return
+  }
+
+  injectAsyncEndCallbackWait(onFulfilled.body, 'ReturnStatement')
+  injectAsyncEndCallbackWait(onRejected.body, 'ThrowStatement')
+}
+
+/**
+ * Injects the callback-driven wait before a fulfillment return or rejection throw.
+ *
+ * @param {import('estree').BlockStatement} body
+ * @param {'ReturnStatement'|'ThrowStatement'} exitType
+ * @returns {void}
+ */
+function injectAsyncEndCallbackWait (body, exitType) {
+  if (query(body, '[id.name=__apm$waitForAsyncEnd]').length > 0) {
+    return
+  }
+
+  const exitIndex = body.body.findIndex(statement =>
+    statement.type === exitType && statement.argument
+  )
+
+  // The generated settlement handlers always end in a return or throw; a miss means the
+  // upstream template changed and the caller's try/catch falls back to the
+  // unwrapped source.
+  assert(exitIndex !== -1, `waitForAsyncEndCallback: no ${exitType} to wait on`)
+
+  const waitStatements = parse(`
+    function wrapper () {
+      const __apm$waitForAsyncEnd = __apm$ctx.waitForAsyncEnd;
+      if (typeof __apm$waitForAsyncEnd === 'function') {
+        return new Promise(__apm$waitForAsyncEnd).then(() => __apm$result, () => __apm$result);
+      }
+    }
+  `).body[0].body.body
+
+  const exitArgument = body.body[exitIndex].argument
+  const { arguments: onSettled } = waitStatements[1].consequent.body[0].argument
+
+  if (exitType === 'ThrowStatement') {
+    for (const handler of onSettled) {
+      handler.body = {
+        type: 'BlockStatement',
+        body: [{
+          type: 'ThrowStatement',
+          argument: clone(exitArgument),
+        }],
+      }
+    }
+  } else {
+    onSettled[0].body = clone(exitArgument)
+    onSettled[1].body = clone(exitArgument)
+  }
+
+  body.body.splice(exitIndex, 0, ...waitStatements)
 }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -295,6 +295,28 @@ describe('check-require-cache', () => {
         },
         {
           module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-promise-async-end-callback.js',
+          },
+          functionQuery: {
+            functionName: 'test',
+            kind: 'Async',
+          },
+          channelName: 'trace_promise_async_end_callback',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-promise-async-end-callback.js',
+          },
+          astQuery: 'ReturnStatement > CallExpression[callee.object.name="promise"][callee.property.name="then"]',
+          channelName: 'trace_promise_async_end_callback',
+          transform: 'waitForAsyncEndCallback',
+        },
+        {
+          module: {
             name: 'test-esm',
             versionRange: '>=0.1',
             filePath: 'pregel-class.js',
@@ -594,6 +616,72 @@ describe('check-require-cache', () => {
 
     assert.equal(result, 'result')
     assert.deepStrictEqual(steps, ['asyncEnd', 'asyncEndPromise', 'resolved'])
+  })
+
+  it('should wait for an asyncEnd callback before resolving', async () => {
+    const { test } = compileFile('trace-promise-async-end-callback')
+    const steps = []
+
+    subs = {
+      asyncEnd (ctx) {
+        steps.push('asyncEnd')
+        ctx.waitForAsyncEnd = onDone => {
+          setImmediate(() => {
+            steps.push('asyncEndCallback')
+            onDone()
+          })
+        }
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_promise_async_end_callback')
+    ch.subscribe(subs)
+
+    const resultPromise = test().then(result => {
+      steps.push('resolved')
+      return result
+    })
+
+    await Promise.resolve()
+
+    assert.deepStrictEqual(steps, ['asyncEnd'])
+
+    const result = await resultPromise
+
+    assert.equal(result, 'result')
+    assert.deepStrictEqual(steps, ['asyncEnd', 'asyncEndCallback', 'resolved'])
+  })
+
+  it('should wait for an asyncEnd callback before preserving a rejection', async () => {
+    const { test } = compileFile('trace-promise-async-end-callback')
+    const error = new Error('test rejection')
+    const steps = []
+
+    subs = {
+      asyncEnd (ctx) {
+        steps.push('asyncEnd')
+        ctx.waitForAsyncEnd = onDone => {
+          setImmediate(() => {
+            steps.push('asyncEndCallback')
+            onDone()
+          })
+        }
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_promise_async_end_callback')
+    ch.subscribe(subs)
+
+    const resultPromise = test(error)
+
+    await Promise.resolve()
+
+    assert.deepStrictEqual(steps, ['asyncEnd'])
+    await assert.rejects(resultPromise, actualError => {
+      steps.push('rejected')
+      return actualError === error
+    })
+    assert.deepStrictEqual(steps, ['asyncEnd', 'asyncEndCallback', 'rejected'])
   })
 
   it('should use import when rewriting esm modules', () => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-promise-async-end-callback.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-promise-async-end-callback.js
@@ -1,0 +1,11 @@
+'use strict'
+
+async function test (error) {
+  if (error) {
+    throw error
+  }
+
+  return 'result'
+}
+
+module.exports = { test }


### PR DESCRIPTION
## Summary

- Draft copy of DataDog/dd-trace-js#9538 at the exact commit analyzed by the PR Agent.
- Preserves commit `a798f7bf9fd2f0295957c87136edb80d20ba46a7` for reproducible testing.

## Context

- Original PR: https://github.com/DataDog/dd-trace-js/pull/9538
- PR Agent session: https://app.datadoghq.com/code/ae804a5c-e1e4-4104-8aee-589b3468da56
- Testing only; do not merge.
