### PR TITLE
ci(scripts): speed up verify-exercised-tests and close detection gaps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -280,6 +280,7 @@
 /scripts/generate-config-types.js @DataDog/apm-sdk-capabilities-js
 /scripts/generate-supported-integrations.js @DataDog/apm-sdk-capabilities-js
 /scripts/verify-exercised-tests.js @DataDog/apm-sdk-capabilities-js
+/scripts/verify-exercised-tests.spec.mjs @DataDog/apm-sdk-capabilities-js
 /supported_versions_output.json @DataDog/apm-sdk-capabilities-js
 /supported_versions_table.csv @DataDog/apm-sdk-capabilities-js
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -279,6 +279,8 @@
 
 /scripts/generate-config-types.js @DataDog/apm-sdk-capabilities-js
 /scripts/generate-supported-integrations.js @DataDog/apm-sdk-capabilities-js
+/scripts/helpers/test-file-index.js @DataDog/apm-sdk-capabilities-js
+/scripts/helpers/test-file-index.spec.js @DataDog/apm-sdk-capabilities-js
 /scripts/verify-exercised-tests.js @DataDog/apm-sdk-capabilities-js
 /scripts/verify-exercised-tests.spec.mjs @DataDog/apm-sdk-capabilities-js
 /supported_versions_output.json @DataDog/apm-sdk-capabilities-js

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -52,6 +52,7 @@ jobs:
         spec:
           - client
           - aws-sdk
+          - base-inject-field
           - bedrockruntime
           - dynamodb
           - eventbridge

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.2",
     "jszip": "^3.10.1",
+    "minimatch": "^10.2.5",
     "mocha": "^11.7.6",
     "mocha-junit-reporter": "^2.2.1",
     "mocha-multi-reporters": "^1.5.1",

--- a/scripts/helpers/test-file-index.js
+++ b/scripts/helpers/test-file-index.js
@@ -1,0 +1,288 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { Glob } = require('glob')
+const { Minimatch } = require('minimatch')
+
+const TEST_FILE_GLOB = '**/*.@(spec|test).@(js|mjs|cjs)'
+
+// Case-insensitive because `glob` matches case-insensitively on darwin and win32. Indexing a
+// `FOO.SPEC.JS` that a case-sensitive platform would reject is harmless: the pattern matcher
+// applies that platform's own rules and drops it again.
+const TEST_FILE_NAME = /\.(?:spec|test)\.(?:js|mjs|cjs)$/i
+
+// Any character that can start a wildcard, brace, class, or extglob. Over-reporting only shortens
+// the literal prefix, which widens the candidate set and can never drop a match.
+const PATTERN_MAGIC = /[*?[\]{}()!+@\\]/
+
+// `glob` walks `..` on the real filesystem before matching. The index has no tree to walk, so it
+// would answer such a pattern with too few files and report exercised specs as unexercised.
+const PARENT_SEGMENT = /(?:^|\/)\.\.(?:\/|$)/
+
+/**
+ * @param {string} repoRoot
+ * @returns {string[]}
+ */
+function walkTestFiles (repoRoot) {
+  /** @type {string[]} */
+  const found = []
+  /** @type {string[]} */
+  const pending = ['']
+
+  while (pending.length) {
+    const relativeDir = pending.pop()
+
+    /** @type {import('node:fs').Dirent[]} */
+    let entries
+    try {
+      entries = fs.readdirSync(path.join(repoRoot, relativeDir), { withFileTypes: true })
+    } catch (error) {
+      // `glob` skips unreadable directories without a word. Staying silent here would shrink the
+      // index instead, and an unexercised spec below that directory would pass the check unseen.
+      process.stderr.write(`test-file-index: skipped unreadable ${relativeDir || '.'} (${error.code})\n`)
+      continue
+    }
+
+    for (const entry of entries) {
+      const { name } = entry
+
+      // `glob` runs with `dot: false`, so a dot entry can never satisfy TEST_FILE_GLOB. Every
+      // consumer of this index also ignores `node_modules`, so descending into it is dead work.
+      if (name.startsWith('.') || name === 'node_modules') continue
+
+      const relativePath = relativeDir ? `${relativeDir}/${name}` : name
+
+      if (entry.isDirectory()) {
+        pending.push(relativePath)
+      } else if (TEST_FILE_NAME.test(name)) {
+        // Symlinks are kept: `nodir: true` filters directories, not links to files.
+        found.push(relativePath)
+      }
+    }
+  }
+
+  return found
+}
+
+/**
+ * Drops `.` and empty path segments the way `glob` does while building its pattern. `minimatch`
+ * on a bare string keeps them and would then compare one segment too many.
+ *
+ * @param {string} pattern
+ * @returns {string}
+ */
+function normalizePattern (pattern) {
+  if (!pattern.includes('./') && !pattern.includes('//')) return pattern
+
+  const segments = pattern.split('/')
+  const kept = []
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    // A leading empty segment marks an absolute pattern and a trailing one a directory-only
+    // pattern; both change what matches, so only interior blanks are collapsed.
+    if (segment === '.' || (segment === '' && i !== 0 && i !== segments.length - 1)) continue
+    kept.push(segment)
+  }
+
+  return kept.join('/')
+}
+
+/**
+ * Longest leading directory path of `pattern` that contains no wildcard.
+ *
+ * @param {string} pattern
+ * @returns {string}
+ */
+function literalPrefix (pattern) {
+  const magic = pattern.search(PATTERN_MAGIC)
+  const literal = magic === -1 ? pattern : pattern.slice(0, magic)
+  const lastSlash = literal.lastIndexOf('/')
+  return lastSlash === -1 ? '' : literal.slice(0, lastSlash + 1)
+}
+
+/**
+ * In-memory stand-in for repeated `globSync` walks over the repository's test files.
+ *
+ * The repository is traversed once; every later pattern is answered from the resulting list. Only
+ * paths named like a test file are indexed, so a pattern that also selects non-test files reports
+ * just the test-file subset.
+ *
+ * Results have to stay identical to the `globSync` walk they replace; `test-file-index.spec.js`
+ * pins that against `glob` itself, including the repository's own pattern corpus.
+ */
+class TestFileIndex {
+  /** @type {string[]} */
+  files
+
+  /** @type {boolean} */
+  #nocase
+
+  /** @type {NodeJS.Platform} */
+  #platform
+
+  /** @type {Map<string, InstanceType<typeof Minimatch>>} */
+  #matchers = new Map()
+
+  /** @type {Map<string, InstanceType<typeof Minimatch>>} */
+  #ignoreMatchers = new Map()
+
+  /** @type {Map<string, { files: string[], folded: string[] }>} */
+  #scopes = new Map()
+
+  /** @type {Map<string, string[]>} */
+  #candidates = new Map()
+
+  /**
+   * @param {string[]} files Sorted repository-relative POSIX paths.
+   * @param {{ nocase: boolean, platform: NodeJS.Platform }} options
+   */
+  constructor (files, { nocase, platform }) {
+    this.files = files
+    this.#nocase = nocase
+    this.#platform = platform
+  }
+
+  /**
+   * A literal path segment is compared case-sensitively on every platform, which is what `glob`
+   * does on Linux. On a case-insensitive filesystem `glob` instead resolves `foo/BAR.spec.js` to
+   * the differently-spelled file on disk; reproducing that would make the result depend on the
+   * developer's machine, so the index keeps the Linux rule everywhere.
+   *
+   * @param {string} pattern
+   * @param {string[]} [ignoreGlobs]
+   * @throws {Error} If `pattern` contains a `..` segment, which the index cannot resolve.
+   * @returns {string[]} Matching paths, in the index's sort order.
+   */
+  match (pattern, ignoreGlobs = []) {
+    if (PARENT_SEGMENT.test(pattern)) {
+      throw new Error(`test-file-index cannot resolve the '..' segment in pattern '${pattern}'`)
+    }
+
+    const normalized = normalizePattern(pattern)
+    const scope = this.#scope(ignoreGlobs)
+    const matcher = this.#matcher(normalized)
+
+    /** @type {string[]} */
+    const matched = []
+    for (const file of this.#candidatesFor(scope, ignoreGlobs, normalized)) {
+      // eslint-disable-next-line unicorn/prefer-regexp-test -- Minimatch#match, not String#match.
+      if (matcher.match(file)) matched.push(file)
+    }
+
+    return matched
+  }
+
+  /**
+   * @param {string[]} ignoreGlobs
+   * @returns {{ files: string[], folded: string[] }}
+   */
+  #scope (ignoreGlobs) {
+    const key = ignoreGlobs.join('\0')
+
+    let scope = this.#scopes.get(key)
+    if (scope === undefined) {
+      const matchers = ignoreGlobs.map(glob => this.#ignoreMatcher(glob))
+      const files = matchers.length === 0
+        ? this.files
+        : this.files.filter(file => !matchers.some(matcher => matcher.match(file) || matcher.match(`${file}/`)))
+
+      scope = { files, folded: this.#nocase ? files.map(file => file.toLowerCase()) : files }
+      this.#scopes.set(key, scope)
+    }
+
+    return scope
+  }
+
+  /**
+   * @param {{ files: string[], folded: string[] }} scope
+   * @param {string[]} ignoreGlobs
+   * @param {string} pattern
+   * @returns {string[]}
+   */
+  #candidatesFor (scope, ignoreGlobs, pattern) {
+    const prefix = literalPrefix(pattern)
+    if (prefix === '') return scope.files
+
+    const key = `${ignoreGlobs.join('\0')}\0${prefix}`
+
+    let candidates = this.#candidates.get(key)
+    if (candidates === undefined) {
+      const wanted = this.#nocase ? prefix.toLowerCase() : prefix
+
+      candidates = []
+      for (let i = 0; i < scope.files.length; i++) {
+        if (scope.folded[i].startsWith(wanted)) candidates.push(scope.files[i])
+      }
+
+      this.#candidates.set(key, candidates)
+    }
+
+    return candidates
+  }
+
+  /**
+   * @param {string} pattern
+   * @returns {InstanceType<typeof Minimatch>}
+   */
+  #matcher (pattern) {
+    let matcher = this.#matchers.get(pattern)
+    if (matcher === undefined) {
+      matcher = new Minimatch(pattern, {
+        dot: false,
+        nocase: this.#nocase,
+        nocaseMagicOnly: this.#platform === 'darwin' || this.#platform === 'win32',
+        nocomment: true,
+        nonegate: true,
+        optimizationLevel: 2,
+        platform: this.#platform,
+        windowsPathsNoEscape: true,
+      })
+      this.#matchers.set(pattern, matcher)
+    }
+
+    return matcher
+  }
+
+  /**
+   * @param {string} glob
+   * @returns {InstanceType<typeof Minimatch>}
+   */
+  #ignoreMatcher (glob) {
+    let matcher = this.#ignoreMatchers.get(glob)
+    if (matcher === undefined) {
+      // Mirrors the options `glob`'s Ignore class builds; notably `dot: true`, so `**/.git/**`
+      // still matches paths that the main pattern would skip.
+      matcher = new Minimatch(glob, {
+        dot: true,
+        nocase: this.#nocase,
+        nocomment: true,
+        nonegate: true,
+        optimizationLevel: 2,
+        platform: this.#platform,
+      })
+      this.#ignoreMatchers.set(glob, matcher)
+    }
+
+    return matcher
+  }
+}
+
+/**
+ * @param {string} repoRoot
+ * @returns {TestFileIndex}
+ */
+function createTestFileIndex (repoRoot) {
+  // `glob` decides case sensitivity from the platform's filesystem; read it back rather than
+  // re-deriving it here, so the index cannot drift from the walker it replaces.
+  const probe = new Glob(TEST_FILE_GLOB, { cwd: repoRoot, windowsPathsNoEscape: true })
+
+  const files = walkTestFiles(repoRoot)
+  files.sort((a, b) => a.localeCompare(b, 'en'))
+
+  return new TestFileIndex(files, { nocase: probe.nocase, platform: probe.platform })
+}
+
+module.exports = { TEST_FILE_GLOB, TestFileIndex, createTestFileIndex }

--- a/scripts/helpers/test-file-index.spec.js
+++ b/scripts/helpers/test-file-index.spec.js
@@ -1,0 +1,366 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { globSync } = require('glob')
+
+const { TEST_FILE_GLOB, TestFileIndex, createTestFileIndex } = require('./test-file-index')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+
+const DEFAULT_IGNORE_GLOBS = [
+  '**/node_modules/**',
+  '**/coverage/**',
+  '**/.git/**',
+  '**/.nyc_output/**',
+  '**/.junit-tmp/**',
+  'vendor/dist/**',
+]
+const NODE_MODULES_ONLY = ['**/node_modules/**']
+
+const FIXTURE_FILES = [
+  'a.spec.js',
+  'b.test.js',
+  'c.spec.mjs',
+  'd.test.mjs',
+  'e.spec.cjs',
+  'f.test.cjs',
+  'plain.js',
+  'notspec.js',
+  'wrong.spec.jsx',
+  'wrong.spec.ts',
+  '.hidden.spec.js',
+  '.hiddendir/inner.spec.js',
+  'node_modules/pkg/dep.spec.js',
+  'nested/node_modules/deep/dep.spec.js',
+  'packages/alpha/test/one.spec.js',
+  'packages/alpha/test/deep/two.spec.js',
+  'packages/beta/test/three.spec.js',
+  'packages/beta/test/integration-test/four.spec.js',
+  'packages/datadog-plugin-http/test/index.spec.js',
+  'packages/datadog-plugin-redis/test/index.spec.js',
+  'vendor/dist/bundled.spec.js',
+  'coverage/report.spec.js',
+  'sub/dir/with.dots.in.name.spec.js',
+  'sub/dir/UPPER.SPEC.JS',
+  'integration-tests/one.spec.js',
+  'integration-tests/nested/two.spec.js',
+]
+
+const FIXTURE_PATTERNS = [
+  TEST_FILE_GLOB,
+  '**/*.spec.js',
+  '**/*.test.js',
+  '*.spec.js',
+  'packages/*/test/*.spec.js',
+  'packages/*/test/**/*.spec.js',
+  'packages/**/*.spec.js',
+  'packages/alpha/test/one.spec.js',
+  'packages/alpha/test/**/*.@(spec|test).@(js|mjs|cjs)',
+  'packages/datadog-plugin-@(http|redis)/test/**/*.spec.js',
+  'packages/datadog-plugin-@(http)/test/**/*.spec.js',
+  'packages/datadog-plugin-*/test/**/*.spec.js',
+  'packages/{alpha,beta}/test/**/*.spec.js',
+  'packages/{alpha}/test/**/*.spec.js',
+  'integration-tests/*.spec.js',
+  'integration-tests/**/*.spec.js',
+  'sub/dir/*.spec.js',
+  'sub/dir/with.dots.in.name.spec.js',
+  'vendor/dist/*.spec.js',
+  'coverage/*.spec.js',
+  '**/node_modules/**/*.spec.js',
+  '.hiddendir/*.spec.js',
+  'does/not/exist/*.spec.js',
+  'packages/*/test/**/**.spec.js',
+  '**/*.@(spec|test).@(js|mjs|cjs)',
+  '**/*.{spec,test}.js',
+  'packages/?????/test/*.spec.js',
+  'packages/[ab]*/test/*.spec.js',
+  './packages/alpha/test/*.spec.js',
+  './/packages/alpha/test/*.spec.js',
+  '././packages/alpha/test/*.spec.js',
+  'packages/./alpha/test/*.spec.js',
+  'packages/alpha/test/',
+  '',
+]
+
+/**
+ * @param {string} root
+ * @param {string[]} files
+ */
+function writeFixture (root, files) {
+  for (const file of files) {
+    const full = path.join(root, file)
+    fs.mkdirSync(path.dirname(full), { recursive: true })
+    fs.writeFileSync(full, '')
+  }
+}
+
+/**
+ * The index deliberately holds only test-named files outside `node_modules`. Expectations are
+ * intersected with that same set so a pattern selecting other files is compared fairly.
+ *
+ * @param {string} root
+ * @returns {Set<string>}
+ */
+function indexableFiles (root) {
+  return new Set(globSync(TEST_FILE_GLOB, {
+    cwd: root,
+    nodir: true,
+    windowsPathsNoEscape: true,
+    ignore: NODE_MODULES_ONLY,
+  }))
+}
+
+/**
+ * @param {string} root
+ * @param {Set<string>} indexable
+ * @param {string} pattern
+ * @param {string[]} [ignore]
+ * @returns {string[]}
+ */
+function globExpectation (root, indexable, pattern, ignore) {
+  return globSync(pattern, { cwd: root, nodir: true, windowsPathsNoEscape: true, ignore })
+    .filter(file => indexable.has(file))
+    .sort((a, b) => a.localeCompare(b, 'en'))
+}
+
+/**
+ * @param {Record<string, string>} scripts
+ * @returns {string[]}
+ */
+function globTokensFromScripts (scripts) {
+  const tokens = new Set()
+
+  for (const command of Object.values(scripts)) {
+    if (typeof command !== 'string') continue
+
+    for (const raw of command.split(/\s+/)) {
+      const unquoted = raw.replaceAll(/^["']+|["']+$/g, '')
+      if (!unquoted.includes('/') || !/[*?[\]{}()]/.test(unquoted)) continue
+
+      tokens.add(unquoted.replaceAll(/\$\{[^}]+\}/g, '*').replaceAll(/\$[A-Za-z_][A-Za-z0-9_]*/g, '*'))
+    }
+  }
+
+  return [...tokens]
+}
+
+describe('test-file-index', () => {
+  /** @type {string} */
+  let root
+  /** @type {ReturnType<typeof createTestFileIndex>} */
+  let index
+  /** @type {Set<string>} */
+  let indexable
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-test-file-index-'))
+    writeFixture(root, FIXTURE_FILES)
+    fs.symlinkSync(path.join(root, 'packages', 'alpha', 'test'), path.join(root, 'linked-tests'), 'dir')
+
+    index = createTestFileIndex(root)
+    indexable = indexableFiles(root)
+  })
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  describe('inventory', () => {
+    it('indexes every supported test-file extension', () => {
+      assert.deepStrictEqual(
+        index.files.filter(file => !file.includes('/')),
+        ['a.spec.js', 'b.test.js', 'c.spec.mjs', 'd.test.mjs', 'e.spec.cjs', 'f.test.cjs']
+      )
+    })
+
+    it('excludes files that are not named like a test', () => {
+      for (const file of ['plain.js', 'notspec.js', 'wrong.spec.jsx', 'wrong.spec.ts']) {
+        assert.ok(!index.files.includes(file), `${file} should not be indexed`)
+      }
+    })
+
+    it('excludes node_modules at any depth', () => {
+      for (const file of index.files) {
+        assert.ok(!file.includes('node_modules/'), `${file} should not be indexed`)
+      }
+    })
+
+    it('excludes dot files and dot directories', () => {
+      for (const file of index.files) {
+        assert.ok(!file.split('/').some(segment => segment.startsWith('.')), `${file} should not be indexed`)
+      }
+    })
+
+    it('does not descend into symlinked directories', () => {
+      assert.ok(!index.files.some(file => file.startsWith('linked-tests/')))
+    })
+
+    it('returns sorted repository-relative POSIX paths', () => {
+      assert.deepStrictEqual(index.files, [...index.files].sort((a, b) => a.localeCompare(b, 'en')))
+      assert.ok(index.files.every(file => !file.startsWith('/') && !file.includes('\\')))
+    })
+
+    it('indexes an empty directory as no files', () => {
+      const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-test-file-index-empty-'))
+      try {
+        assert.deepStrictEqual(createTestFileIndex(empty).files, [])
+      } finally {
+        fs.rmSync(empty, { recursive: true, force: true })
+      }
+    })
+
+    it('warns instead of silently shrinking the index when a directory cannot be read', () => {
+      const { write } = process.stderr
+      /** @type {string[]} */
+      const warnings = []
+      process.stderr.write = chunk => warnings.push(String(chunk))
+
+      try {
+        assert.deepStrictEqual(createTestFileIndex(path.join(os.tmpdir(), 'dd-test-file-index-missing')).files, [])
+      } finally {
+        process.stderr.write = write
+      }
+
+      assert.deepStrictEqual(warnings, ['test-file-index: skipped unreadable . (ENOENT)\n'])
+    })
+  })
+
+  describe('matching', () => {
+    for (const pattern of FIXTURE_PATTERNS) {
+      it(`matches globSync for ${pattern}`, () => {
+        assert.deepStrictEqual(index.match(pattern), globExpectation(root, indexable, pattern))
+      })
+    }
+
+    for (const pattern of FIXTURE_PATTERNS) {
+      it(`matches globSync for ${pattern} under the default ignore list`, () => {
+        assert.deepStrictEqual(
+          index.match(pattern, DEFAULT_IGNORE_GLOBS),
+          globExpectation(root, indexable, pattern, DEFAULT_IGNORE_GLOBS)
+        )
+      })
+    }
+
+    it('matches globSync for every glob token in the real package.json', () => {
+      const { scripts } = require(path.join(REPO_ROOT, 'package.json'))
+      const repoIndex = createTestFileIndex(REPO_ROOT)
+      const repoIndexable = indexableFiles(REPO_ROOT)
+      const patterns = globTokensFromScripts(scripts)
+
+      assert.ok(patterns.length > 20, `expected a representative corpus, got ${patterns.length}`)
+
+      for (const pattern of patterns) {
+        assert.deepStrictEqual(
+          repoIndex.match(pattern, DEFAULT_IGNORE_GLOBS),
+          globExpectation(REPO_ROOT, repoIndexable, pattern, DEFAULT_IGNORE_GLOBS),
+          `pattern ${pattern} diverged from globSync`
+        )
+      }
+    })
+
+    it('matches globSync for the repository-wide test glob', () => {
+      const repoIndex = createTestFileIndex(REPO_ROOT)
+
+      assert.deepStrictEqual(
+        repoIndex.match(TEST_FILE_GLOB, DEFAULT_IGNORE_GLOBS),
+        globSync(TEST_FILE_GLOB, {
+          cwd: REPO_ROOT,
+          nodir: true,
+          windowsPathsNoEscape: true,
+          ignore: DEFAULT_IGNORE_GLOBS,
+        }).sort((a, b) => a.localeCompare(b, 'en'))
+      )
+    })
+  })
+
+  describe('ignore lists', () => {
+    it('drops paths excluded by the default ignore list', () => {
+      const matched = index.match('**/*.spec.js', DEFAULT_IGNORE_GLOBS)
+
+      assert.ok(!matched.includes('vendor/dist/bundled.spec.js'))
+      assert.ok(!matched.includes('coverage/report.spec.js'))
+      assert.ok(matched.includes('packages/alpha/test/one.spec.js'))
+    })
+
+    it('keeps paths a narrower ignore list allows', () => {
+      const matched = index.match('**/*.spec.js', NODE_MODULES_ONLY)
+
+      assert.ok(matched.includes('vendor/dist/bundled.spec.js'))
+      assert.ok(matched.includes('coverage/report.spec.js'))
+    })
+
+    it('treats an empty ignore list as no filtering', () => {
+      assert.deepStrictEqual(index.match('**/*.spec.js'), index.match('**/*.spec.js', []))
+    })
+
+    it('keeps results for the same pattern independent per ignore list', () => {
+      const wide = index.match('**/*.spec.js', NODE_MODULES_ONLY)
+      const narrow = index.match('**/*.spec.js', DEFAULT_IGNORE_GLOBS)
+
+      assert.ok(wide.length > narrow.length)
+      assert.deepStrictEqual(index.match('**/*.spec.js', NODE_MODULES_ONLY), wide)
+    })
+  })
+
+  describe('platform semantics', () => {
+    // `glob` reads case sensitivity off the filesystem, so a run on one platform never exercises
+    // the other's rules. Both are pinned here, independent of the host this suite runs on.
+    const files = ['sub/dir/lower.spec.js', 'sub/dir/UPPER.SPEC.JS']
+    const platforms = [
+      { platform: 'darwin', nocase: true },
+      { platform: 'win32', nocase: true },
+      { platform: 'linux', nocase: false },
+    ]
+    const caseInsensitivePlatforms = platforms.filter(entry => entry.nocase)
+
+    it('matches a wildcard segment case-insensitively where the filesystem is', () => {
+      for (const { platform } of caseInsensitivePlatforms) {
+        assert.deepStrictEqual(new TestFileIndex(files, { nocase: true, platform }).match('sub/dir/*.spec.js'),
+          files, `platform ${platform}`)
+      }
+    })
+
+    it('matches a wildcard segment case-sensitively on linux', () => {
+      const index = new TestFileIndex(files, { nocase: false, platform: 'linux' })
+      assert.deepStrictEqual(index.match('sub/dir/*.spec.js'), ['sub/dir/lower.spec.js'])
+    })
+
+    it('rejects a literal segment whose case differs, on every platform', () => {
+      for (const { platform, nocase } of platforms) {
+        assert.deepStrictEqual(new TestFileIndex(files, { nocase, platform }).match('sub/dir/upper.spec.js'),
+          [], `platform ${platform}`)
+      }
+    })
+
+    it('throws on a pattern it cannot resolve rather than matching too few files', () => {
+      const index = new TestFileIndex(files, { nocase: false, platform: 'linux' })
+      const expected = { message: /cannot resolve the '\.\.' segment/ }
+
+      assert.throws(() => index.match('packages/../sub/dir/lower.spec.js'), expected)
+      assert.throws(() => index.match('../sub/*.spec.js'), expected)
+      assert.throws(() => index.match('sub/..'), expected)
+      assert.deepStrictEqual(index.match('sub/dir/with..dots.spec.js'), [])
+    })
+  })
+
+  describe('repeated queries', () => {
+    it('returns equal results when a pattern is matched twice', () => {
+      for (const pattern of ['**/*.spec.js', 'packages/*/test/**/*.spec.js', 'does/not/exist/*.spec.js']) {
+        assert.deepStrictEqual(index.match(pattern, DEFAULT_IGNORE_GLOBS), index.match(pattern, DEFAULT_IGNORE_GLOBS))
+      }
+    })
+
+    it('does not leak matches between patterns sharing a literal prefix', () => {
+      const one = index.match('packages/alpha/test/one.spec.js')
+      const deep = index.match('packages/alpha/test/deep/*.spec.js')
+
+      assert.deepStrictEqual(one, ['packages/alpha/test/one.spec.js'])
+      assert.deepStrictEqual(deep, ['packages/alpha/test/deep/two.spec.js'])
+    })
+  })
+})

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -1105,10 +1105,13 @@ function buildLlmobsPluginTestSet (repoRoot) {
   return out
 }
 
-function main () {
+/**
+ * @param {string} [repoRootArg] Checkout to verify. Defaults to the repository this script lives in.
+ */
+function main (repoRootArg) {
   const startNs = process.hrtime.bigint()
 
-  const repoRoot = path.resolve(__dirname, '..')
+  const repoRoot = repoRootArg ? path.resolve(repoRootArg) : path.resolve(__dirname, '..')
   const packageJsonPath = path.join(repoRoot, 'package.json')
   const pluginsVar = '$' + '{PLUGINS}'
   const bracePluginsVar = '{' + pluginsVar + '}'
@@ -1477,4 +1480,4 @@ function main () {
   process.exit(hasCategoryWarnings ? 1 : 0)
 }
 
-main()
+main(process.argv[2])

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -561,70 +561,75 @@ function isUsesStep (step) {
 }
 
 /**
- * @param {string} repoRoot
- * @param {string} uses
- * @param {Record<string, string|undefined>} env
- * @param {Set<string>} visiting
- * @returns {{ run: string, env: Record<string, string|undefined> }[]}
+ * @typedef {{ kind: 'run', run: string, env: Record<string, string> }
+ *   | { kind: 'upload' }
+ *   | { kind: 'opaque', action: string }} StepEvent
  */
-function expandLocalCompositeActionRuns (repoRoot, uses, env, visiting) {
-  const actionFile = resolveLocalActionFile(repoRoot, uses)
-  if (!actionFile) return []
-  if (visiting.has(actionFile)) return []
-  visiting.add(actionFile)
 
-  const doc = parseYamlFile(repoRoot, actionFile)
-  if (!isPlainObject(doc)) return []
+/**
+ * Ordered events a step contributes, descending into local composite actions.
+ *
+ * Commands and uploads share one timeline because five of this repository's composite actions run a
+ * suite and upload its report, so their relative order exists only inside the action. A second
+ * traversal answering just "does this upload?" drifted from this one and lost the composite guard.
+ *
+ * @param {unknown} stepValue
+ * @param {string} repoRoot
+ * @param {Record<string, string>} env
+ * @param {Set<string>} visiting
+ * @returns {StepEvent[]}
+ */
+function collectStepEvents (stepValue, repoRoot, env, visiting) {
+  if (!isPlainObject(stepValue)) return []
+  const step = stepValue
 
-  const runs = doc.runs
-  if (!isPlainObject(runs) || runs.using !== 'composite') return []
-  const steps = Array.isArray(runs.steps) ? runs.steps : []
-
-  /** @type {{ run: string, env: Record<string, string|undefined> }[]} */
-  const out = []
-
-  for (const s of steps) {
-    if (isRunStep(s)) {
-      /** @type {Record<string, string|undefined>} */
-      const stepEnv = { ...env }
-      if (isPlainObject(s.env)) {
-        for (const [k, v] of Object.entries(s.env)) stepEnv[k] = typeof v === 'string' ? v : String(v)
-      }
-
-      // Inline env in composite run: export and prefix assignments.
-      const exports = parseExportAssignments(s.run)
-      for (const [k, v] of Object.entries(exports)) stepEnv[k] = v
-
-      const idxYarn = s.run.indexOf('yarn ')
-      const idxNpm = s.run.indexOf('npm ')
-      let idx = idxNpm
-      if (idxYarn !== -1) {
-        idx = idxNpm === -1 ? idxYarn : Math.min(idxYarn, idxNpm)
-      }
-      if (idx > 0) {
-        const prefix = s.run.slice(0, idx)
-        const assigns = parseInlineAssignments(prefix)
-        for (const [k, v] of Object.entries(assigns)) stepEnv[k] = v
-      }
-
-      out.push({ run: s.run, env: stepEnv })
-      continue
-    }
-
-    if (isUsesStep(s)) {
-      // Recurse into local composite actions.
-      /** @type {Record<string, string|undefined>} */
-      const nextEnv = { ...env }
-      if (isPlainObject(s.env)) {
-        for (const [k, v] of Object.entries(s.env)) nextEnv[k] = typeof v === 'string' ? v : String(v)
-      }
-      const nested = expandLocalCompositeActionRuns(repoRoot, s.uses, nextEnv, visiting)
-      for (const n of nested) out.push(n)
+  /** @type {Record<string, string>} */
+  const stepEnv = { ...env }
+  if (isPlainObject(step.env)) {
+    for (const [name, value] of Object.entries(step.env)) {
+      stepEnv[name] = typeof value === 'string' ? value : String(value)
     }
   }
 
+  if (isRunStep(step)) {
+    return [{ kind: 'run', run: step.run, env: applyInlineAssignments(step.run, stepEnv) }]
+  }
+
+  if (!isUsesStep(step)) return []
+  if (COVERAGE_ACTIONS.has(step.uses)) return [{ kind: 'upload' }]
+
+  // Third-party retry wrappers run their `with.command` like an inline `run:`. Without unwrapping
+  // it, the joint check below cannot see that `instrumentation-http` exercises
+  // `test:instrumentations:ci` with `PLUGINS=http`.
+  if (/^nick-fields\/retry@/.test(step.uses)) {
+    const command = isPlainObject(step.with) && typeof step.with.command === 'string'
+      ? step.with.command
+      : undefined
+    if (command === undefined) return []
+    return [{ kind: 'run', run: command, env: applyInlineAssignments(command, stepEnv) }]
+  }
+
+  const actionFile = resolveLocalActionFile(repoRoot, step.uses)
+  if (actionFile === null || visiting.has(actionFile)) return []
+
+  const doc = parseYamlFile(repoRoot, actionFile)
+  const runs = isPlainObject(doc) ? doc.runs : undefined
+
+  // A JavaScript or Docker action exposes no steps to read. Reporting it beats letting an upload
+  // hidden inside one read as "this job never uploads".
+  if (!isPlainObject(runs) || runs.using !== 'composite') return [{ kind: 'opaque', action: step.uses }]
+
+  visiting.add(actionFile)
+
+  /** @type {StepEvent[]} */
+  const events = []
+  const steps = Array.isArray(runs.steps) ? runs.steps : []
+  for (const nested of steps) {
+    for (const event of collectStepEvents(nested, repoRoot, stepEnv, visiting)) events.push(event)
+  }
+
   visiting.delete(actionFile)
-  return out
+  return events
 }
 
 /**
@@ -681,34 +686,6 @@ function commandProducesCoverage (command, knownScripts, coverageScripts) {
 }
 
 /**
- * @param {string} repoRoot
- * @param {string} uses
- * @param {Set<string>} visiting
- * @returns {boolean}
- */
-function localActionUploadsCoverage (repoRoot, uses, visiting) {
-  if (COVERAGE_ACTIONS.has(uses)) return true
-
-  const actionFile = resolveLocalActionFile(repoRoot, uses)
-  if (!actionFile || visiting.has(actionFile)) return false
-  visiting.add(actionFile)
-
-  const doc = parseYamlFile(repoRoot, actionFile)
-  const steps = doc.runs.steps
-  let uploadsCoverage = false
-
-  for (const step of steps) {
-    if (isUsesStep(step) && localActionUploadsCoverage(repoRoot, step.uses, visiting)) {
-      uploadsCoverage = true
-      break
-    }
-  }
-
-  visiting.delete(actionFile)
-  return uploadsCoverage
-}
-
-/**
  * Returns all combinations of matrix scalar/array values (ignores include/exclude).
  * @param {Record<string, unknown>} matrix
  * @returns {Record<string, string>[]}
@@ -746,16 +723,64 @@ function expandMatrixExpressions (s, matrixValues) {
 }
 
 /**
+ * Applies the environment a command sets for itself: `export X=1` lines, and `X=1 npm run …`
+ * prefixes.
+ *
+ * @param {string} command
+ * @param {Record<string, string>} env
+ * @returns {Record<string, string>}
+ */
+function applyInlineAssignments (command, env) {
+  const merged = { ...env, ...parseExportAssignments(command) }
+
+  const idxYarn = command.indexOf('yarn ')
+  const idxNpm = command.indexOf('npm ')
+  const idx = idxYarn === -1 ? idxNpm : (idxNpm === -1 ? idxYarn : Math.min(idxYarn, idxNpm))
+  if (idx > 0) Object.assign(merged, parseInlineAssignments(command.slice(0, idx)))
+
+  return merged
+}
+
+/**
+ * @param {Record<string, string>} env
+ * @param {Record<string, string>} matrixValues
+ * @returns {Record<string, string>}
+ */
+function expandMatrixExpressionsInEnv (env, matrixValues) {
+  /** @type {Record<string, string>} */
+  const expanded = {}
+  for (const [name, value] of Object.entries(env)) {
+    expanded[name] = expandMatrixExpressions(value, matrixValues)
+  }
+  return expanded
+}
+
+/**
+ * @typedef {{
+ *   workflowFile: string,
+ *   jobId: string,
+ *   run: string,
+ *   env: Record<string, string>,
+ *   sequence: number
+ * }} WorkflowRun
+ */
+
+/**
  * @param {string} repoRoot
  * @returns {{
- *   runs: { workflowFile: string, jobId: string, run: string, env: Record<string, string|undefined> }[],
- *   coverageUploadJobs: Set<string>
- * }}
+ *   runs: WorkflowRun[],
+ *   coverageUploadSequences: Map<string, number>,
+ *   opaqueActions: Map<string, Set<string>>
+ * }} `coverageUploadSequences` holds each job's last upload position on the same scale as
+ *   `WorkflowRun.sequence`.
  */
 function collectWorkflowRuns (repoRoot) {
-  /** @type {{ workflowFile: string, jobId: string, run: string, env: Record<string, string|undefined> }[]} */
+  /** @type {WorkflowRun[]} */
   const out = []
-  const coverageUploadJobs = new Set()
+  /** @type {Map<string, number>} */
+  const coverageUploadSequences = new Map()
+  /** @type {Map<string, Set<string>>} */
+  const opaqueActions = new Map()
 
   const files = findWorkflowFiles(repoRoot)
   for (const wf of files) {
@@ -775,85 +800,60 @@ function collectWorkflowRuns (repoRoot) {
         : {}
       const matrixCombinations = getMatrixCombinations(matrixData)
 
-      for (const stepVal of steps) {
-        const step = isPlainObject(stepVal) ? stepVal : {}
-        if (
-          typeof step.uses === 'string' &&
-          localActionUploadsCoverage(repoRoot, step.uses, new Set())
-        ) {
-          coverageUploadJobs.add(`${wf}#${jobId}`)
+      // Values can be strings or non-strings; we only keep string-ish.
+      /** @type {Record<string, string>} */
+      const jobEnvironment = {}
+      for (const [k, v] of Object.entries(topEnv)) jobEnvironment[k] = typeof v === 'string' ? v : String(v)
+      for (const [k, v] of Object.entries(jobEnv)) jobEnvironment[k] = typeof v === 'string' ? v : String(v)
+
+      /** @type {StepEvent[]} */
+      const events = []
+      for (const stepValue of steps) {
+        for (const event of collectStepEvents(stepValue, repoRoot, jobEnvironment, new Set())) {
+          events.push(event)
         }
+      }
 
-        // Merge env. Values can be strings or non-strings; we only keep string-ish.
-        /** @type {Record<string, string|undefined>} */
-        const env = {}
-        for (const [k, v] of Object.entries(topEnv)) env[k] = typeof v === 'string' ? v : String(v)
-        for (const [k, v] of Object.entries(jobEnv)) env[k] = typeof v === 'string' ? v : String(v)
-        if (isPlainObject(step.env)) {
-          for (const [k, v] of Object.entries(step.env)) env[k] = typeof v === 'string' ? v : String(v)
-        }
+      const jobKey = `${wf}#${jobId}`
 
-        if (typeof step.run === 'string') {
-          // Expand matrix expressions and emit one entry per combination.
-          const seenRuns = new Set()
-          for (const combo of matrixCombinations) {
-            const run = expandMatrixExpressions(step.run, combo)
-            if (seenRuns.has(run)) continue
-            seenRuns.add(run)
-
-            const stepEnv = { ...env }
-
-            // Inline env in `run:` (export lines and prefix assignments before yarn/npm).
-            const exports = parseExportAssignments(run)
-            for (const [k, v] of Object.entries(exports)) stepEnv[k] = v
-
-            const idxYarn = run.indexOf('yarn ')
-            const idxNpm = run.indexOf('npm ')
-            const idx = idxYarn === -1 ? idxNpm : (idxNpm === -1 ? idxYarn : Math.min(idxYarn, idxNpm))
-            if (idx > 0) {
-              const prefix = run.slice(0, idx)
-              const assigns = parseInlineAssignments(prefix)
-              for (const [k, v] of Object.entries(assigns)) stepEnv[k] = v
-            }
-
-            out.push({ workflowFile: wf, jobId, run, env: stepEnv })
-          }
+      for (const [sequence, event] of events.entries()) {
+        if (event.kind === 'upload') {
+          coverageUploadSequences.set(jobKey, sequence)
           continue
         }
 
-        if (typeof step.uses === 'string' && step.uses.startsWith('./')) {
-          const expanded = expandLocalCompositeActionRuns(repoRoot, step.uses, env, new Set())
-          for (const e of expanded) {
-            out.push({ workflowFile: wf, jobId, run: e.run, env: e.env })
+        if (event.kind === 'opaque') {
+          let actions = opaqueActions.get(jobKey)
+          if (actions === undefined) {
+            actions = new Set()
+            opaqueActions.set(jobKey, actions)
           }
+          actions.add(event.action)
+          continue
         }
 
-        // Third-party retry wrappers run their `with.command` like an inline `run:`.
-        // Without unwrapping it, the joint check below cannot see that `instrumentation-http`
-        // exercises `test:instrumentations:ci` with `PLUGINS=http`.
-        if (typeof step.uses === 'string' && /^nick-fields\/retry@/.test(step.uses)) {
-          const command = isPlainObject(step.with) && typeof step.with.command === 'string'
-            ? step.with.command
-            : null
-          if (command) {
-            const stepEnv = { ...env }
-            const exports = parseExportAssignments(command)
-            for (const [k, v] of Object.entries(exports)) stepEnv[k] = v
-            const idxYarn = command.indexOf('yarn ')
-            const idxNpm = command.indexOf('npm ')
-            const idx = idxYarn === -1 ? idxNpm : (idxNpm === -1 ? idxYarn : Math.min(idxYarn, idxNpm))
-            if (idx > 0) {
-              const assigns = parseInlineAssignments(command.slice(0, idx))
-              for (const [k, v] of Object.entries(assigns)) stepEnv[k] = v
-            }
-            out.push({ workflowFile: wf, jobId, run: command, env: stepEnv })
-          }
+        // Deduplicated per event, not per job: the same command at a later position carries a
+        // later sequence, which is what tells an upload apart from the suites it leaves behind.
+        const seen = new Set()
+
+        for (const combo of matrixCombinations) {
+          // A matrix leg reaches the glob through the environment as often as through the command
+          // (`SPEC: ${{ matrix.spec }}`). Leaving the expression unresolved degrades the pattern to
+          // `*`, and every spec in the directory then looks exercised by every leg.
+          const run = expandMatrixExpressions(event.run, combo)
+          const env = expandMatrixExpressionsInEnv(event.env, combo)
+
+          const key = `${run}\0${JSON.stringify(env)}`
+          if (seen.has(key)) continue
+          seen.add(key)
+
+          out.push({ workflowFile: wf, jobId, run, env, sequence })
         }
       }
     }
   }
 
-  return { runs: out, coverageUploadJobs }
+  return { runs: out, coverageUploadSequences, opaqueActions }
 }
 
 /**
@@ -1108,7 +1108,7 @@ function main (repoRootArg) {
     process.exit(1)
   }
 
-  const { runs: workflowRuns, coverageUploadJobs } = collectWorkflowRuns(repoRoot)
+  const { runs: workflowRuns, coverageUploadSequences, opaqueActions } = collectWorkflowRuns(repoRoot)
 
   /** @type {{ workflowFile: string, jobId: string, script: string, env: Record<string, string|undefined> }[]} */
   const invoked = []
@@ -1124,16 +1124,25 @@ function main (repoRootArg) {
     if (!uniqueErrors.has(msg)) uniqueErrors.add(msg)
   }
 
-  const coverageProducerJobs = new Set()
   const coverageScripts = findCoverageScripts(scripts, knownScripts)
   for (const run of workflowRuns) {
-    if (commandProducesCoverage(run.run, knownScripts, coverageScripts)) {
-      coverageProducerJobs.add(`${run.workflowFile}#${run.jobId}`)
+    if (!commandProducesCoverage(run.run, knownScripts, coverageScripts)) continue
+
+    const job = `${run.workflowFile}#${run.jobId}`
+    const uploadSequence = coverageUploadSequences.get(job)
+
+    if (uploadSequence === undefined) {
+      pushError(`${job}: generates coverage but does not upload it`)
+    } else if (run.sequence > uploadSequence) {
+      // The uploader has already collected the reports it will ever see, so this suite's report
+      // never leaves the runner even though the job looks like it uploads coverage.
+      pushError(`${job}: generates coverage after its last coverage upload`)
     }
   }
-  for (const job of coverageProducerJobs) {
-    if (!coverageUploadJobs.has(job)) {
-      pushError(`${job}: generates coverage but does not upload it`)
+
+  for (const [job, actions] of opaqueActions) {
+    for (const action of actions) {
+      pushError(`${job}: cannot inspect local action "${action}", which is not a composite action`)
     }
   }
 

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -6,20 +6,19 @@ const path = require('node:path')
 const { globSync } = require('glob')
 const YAML = require('yaml')
 
+const { TEST_FILE_GLOB, createTestFileIndex } = require('./helpers/test-file-index')
+
+/** @typedef {import('./helpers/test-file-index').TestFileIndex} TestFileIndex */
+
+const NODE_MODULES_IGNORE_GLOBS = ['**/node_modules/**']
 const DEFAULT_IGNORE_GLOBS = [
-  '**/node_modules/**',
+  ...NODE_MODULES_IGNORE_GLOBS,
   '**/coverage/**',
   '**/.git/**',
   '**/.nyc_output/**',
   '**/.junit-tmp/**',
   'vendor/dist/**',
 ]
-
-const GLOB_CACHE_MAX = 2000
-/** @type {Map<string, string[]>} */
-const globCache = new Map()
-let globCacheHits = 0
-let globCacheMisses = 0
 
 const COVERAGE_ACTIONS = new Set([
   './.github/actions/coverage',
@@ -29,36 +28,6 @@ const COVERAGE_COLLECTORS = new Set([
   'integration-tests/coverage/run-suite.js',
   'scripts/c8-ci.js',
 ])
-
-/**
- * @param {string} pattern
- * @param {{cwd: string, nodir: boolean, windowsPathsNoEscape: boolean, ignore?: string[]}} opts
- * @returns {string[]}
- */
-function globSyncCached (pattern, opts) {
-  const ignoreKey = Array.isArray(opts.ignore) ? opts.ignore.join('\n') : ''
-  const key = `${opts.cwd}\0${pattern}\0${opts.nodir ? 1 : 0}\0${opts.windowsPathsNoEscape ? 1 : 0}\0${ignoreKey}`
-
-  const cached = globCache.get(key)
-  if (cached) {
-    globCacheHits++
-    // Basic LRU: refresh insertion order.
-    globCache.delete(key)
-    globCache.set(key, cached)
-    return cached
-  }
-
-  globCacheMisses++
-  const res = globSync(pattern, opts)
-
-  globCache.set(key, res)
-  if (globCache.size > GLOB_CACHE_MAX) {
-    const first = globCache.keys().next().value
-    if (first !== undefined) globCache.delete(first)
-  }
-
-  return res
-}
 
 /**
  * @param {string} s
@@ -350,30 +319,23 @@ function parseExportAssignments (run) {
 }
 
 /**
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @returns {string[]}
  */
-function findTestFiles (repoRoot) {
-  const commonGlobOpts = { cwd: repoRoot, nodir: true, windowsPathsNoEscape: true, ignore: DEFAULT_IGNORE_GLOBS }
-
+function findTestFiles (index) {
   // Collect every test-file naming convention used in the repo so an unrun spec
   // can never slip through untracked. Kept deliberately wide (js/mjs/cjs) even
   // where no file currently uses an extension, so a future one is caught.
-  const files = globSyncCached('**/*.@(spec|test).@(js|mjs|cjs)', commonGlobOpts)
-
-  files.sort((a, b) => a.localeCompare(b, 'en'))
-  return files
+  return index.match(TEST_FILE_GLOB, DEFAULT_IGNORE_GLOBS)
 }
 
 /**
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @param {Record<string, string>} scripts
  * @param {Record<string, string|undefined>} [env]
  * @returns {{ globs: string[], matchedFiles: Set<string> }}
  */
-function expandScriptGlobs (repoRoot, scripts, env = {}) {
-  const ignore = DEFAULT_IGNORE_GLOBS
-
+function expandScriptGlobs (index, scripts, env = {}) {
   /** @type {string[]} */
   const allGlobs = []
   const matchedFiles = new Set()
@@ -392,7 +354,7 @@ function expandScriptGlobs (repoRoot, scripts, env = {}) {
 
       let expanded
       try {
-        expanded = globSyncCached(normalized, { cwd: repoRoot, nodir: true, windowsPathsNoEscape: true, ignore })
+        expanded = index.match(normalized, DEFAULT_IGNORE_GLOBS)
       } catch {
         // If a pattern can't be parsed by glob, skip expanding it. It still counts as an extracted glob.
         continue
@@ -466,14 +428,14 @@ function extractScriptInvocations (run, knownScripts) {
 
 /**
  * Expand a script and any nested `npm run`/`yarn <script>` calls into matched files.
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @param {Record<string, string>} scripts
  * @param {Set<string>} knownScripts
  * @param {string} scriptName
  * @param {Record<string, string|undefined>} env
  * @returns {{ files: Set<string>, globs: string[], visited: string[] }}
  */
-function expandInvokedScript (repoRoot, scripts, knownScripts, scriptName, env) {
+function expandInvokedScript (index, scripts, knownScripts, scriptName, env) {
   /** @type {string[]} */
   const visited = []
   /** @type {string[]} */
@@ -483,8 +445,6 @@ function expandInvokedScript (repoRoot, scripts, knownScripts, scriptName, env) 
   /** @type {string[]} */
   const queue = [scriptName]
   const seen = new Set()
-
-  const ignore = DEFAULT_IGNORE_GLOBS
 
   while (queue.length) {
     const name = queue.shift()
@@ -503,7 +463,7 @@ function expandInvokedScript (repoRoot, scripts, knownScripts, scriptName, env) 
       allGlobs.push(normalized)
       let expanded
       try {
-        expanded = globSyncCached(normalized, { cwd: repoRoot, nodir: true, windowsPathsNoEscape: true, ignore })
+        expanded = index.match(normalized, DEFAULT_IGNORE_GLOBS)
       } catch {
         continue
       }
@@ -523,7 +483,7 @@ function expandInvokedScript (repoRoot, scripts, knownScripts, scriptName, env) 
  * @returns {string[]}
  */
 function findWorkflowFiles (repoRoot) {
-  const files = globSyncCached('.github/workflows/*.{yml,yaml}', {
+  const files = globSync('.github/workflows/*.{yml,yaml}', {
     cwd: repoRoot,
     nodir: true,
     windowsPathsNoEscape: true,
@@ -901,7 +861,7 @@ function collectWorkflowRuns (repoRoot) {
  * @returns {Set<string>}
  */
 function listPluginPackages (repoRoot) {
-  const entries = globSyncCached('packages/datadog-plugin-*', {
+  const entries = globSync('packages/datadog-plugin-*', {
     cwd: repoRoot,
     nodir: false,
     windowsPathsNoEscape: true,
@@ -989,18 +949,11 @@ function getTraceCoreCategoriesFromScripts (scripts) {
 }
 
 /**
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @returns {Set<string>}
  */
-function findDdTraceTestCategories (repoRoot) {
-  const files = globSyncCached('packages/dd-trace/test/*/**/*.@(spec|test).@(js|mjs|cjs)', {
-    cwd: repoRoot,
-    nodir: true,
-    windowsPathsNoEscape: true,
-    ignore: [
-      '**/node_modules/**',
-    ],
-  })
+function findDdTraceTestCategories (index) {
+  const files = index.match('packages/dd-trace/test/*/**/*.@(spec|test).@(js|mjs|cjs)', NODE_MODULES_IGNORE_GLOBS)
 
   /** @type {Set<string>} */
   const out = new Set()
@@ -1017,21 +970,12 @@ function findDdTraceTestCategories (repoRoot) {
 }
 
 /**
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @param {string} category
  * @returns {string[]}
  */
-function listDdTraceCategorySpecFiles (repoRoot, category) {
-  const files = globSyncCached(`packages/dd-trace/test/${category}/**/*.@(spec|test).@(js|mjs|cjs)`, {
-    cwd: repoRoot,
-    nodir: true,
-    windowsPathsNoEscape: true,
-    ignore: [
-      '**/node_modules/**',
-    ],
-  })
-  files.sort((a, b) => a.localeCompare(b, 'en'))
-  return files
+function listDdTraceCategorySpecFiles (index, category) {
+  return index.match(`packages/dd-trace/test/${category}/**/*.@(spec|test).@(js|mjs|cjs)`, NODE_MODULES_IGNORE_GLOBS)
 }
 
 /**
@@ -1059,16 +1003,14 @@ function isCategoryCoveredByOtherScript (scriptPrefixes, category) {
 }
 
 /**
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @returns {Set<string>}
  */
-function buildAppsecPluginTestSet (repoRoot) {
-  const files = globSyncCached('packages/dd-trace/test/appsec/**/*.plugin.@(spec|test).@(js|mjs|cjs)', {
-    cwd: repoRoot,
-    nodir: true,
-    windowsPathsNoEscape: true,
-    ignore: DEFAULT_IGNORE_GLOBS,
-  })
+function buildAppsecPluginTestSet (index) {
+  const files = index.match(
+    'packages/dd-trace/test/appsec/**/*.plugin.@(spec|test).@(js|mjs|cjs)',
+    DEFAULT_IGNORE_GLOBS
+  )
 
   /** @type {Set<string>} */
   const out = new Set()
@@ -1082,16 +1024,14 @@ function buildAppsecPluginTestSet (repoRoot) {
 }
 
 /**
- * @param {string} repoRoot
+ * @param {TestFileIndex} index
  * @returns {Set<string>}
  */
-function buildLlmobsPluginTestSet (repoRoot) {
-  const files = globSyncCached('packages/dd-trace/test/llmobs/plugins/*/*.@(spec|test).@(js|mjs|cjs)', {
-    cwd: repoRoot,
-    nodir: true,
-    windowsPathsNoEscape: true,
-    ignore: DEFAULT_IGNORE_GLOBS,
-  })
+function buildLlmobsPluginTestSet (index) {
+  const files = index.match(
+    'packages/dd-trace/test/llmobs/plugins/*/*.@(spec|test).@(js|mjs|cjs)',
+    DEFAULT_IGNORE_GLOBS
+  )
 
   /** @type {Set<string>} */
   const out = new Set()
@@ -1148,8 +1088,9 @@ function main (repoRootArg) {
     process.exit(1)
   }
 
-  const testFiles = findTestFiles(repoRoot)
-  const { globs, matchedFiles } = expandScriptGlobs(repoRoot, scripts)
+  const index = createTestFileIndex(repoRoot)
+  const testFiles = findTestFiles(index)
+  const { globs, matchedFiles } = expandScriptGlobs(index, scripts)
 
   /** @type {string[]} */
   const missing = []
@@ -1267,8 +1208,8 @@ function main (repoRootArg) {
   const pluginPkgs = listPluginPackages(repoRoot)
   const versionsDeps = loadUpstreamPluginNames(repoRoot)
   const pluginExternals = loadUpstreamExternals(repoRoot)
-  const appsecPluginTests = buildAppsecPluginTestSet(repoRoot)
-  const llmobsPluginTests = buildLlmobsPluginTestSet(repoRoot)
+  const appsecPluginTests = buildAppsecPluginTestSet(index)
+  const llmobsPluginTests = buildLlmobsPluginTestSet(index)
 
   // Detect CI steps that will match no tests due to env/script mismatches.
   const testFileSet = new Set(testFiles)
@@ -1288,7 +1229,7 @@ function main (repoRootArg) {
     // Only use literal PLUGINS for matching; expressions are unknown.
     if (env.PLUGINS && env.PLUGINS.includes(ghaExprStart)) env.PLUGINS = undefined
 
-    const { files, globs: invokedGlobs } = expandInvokedScript(repoRoot, scripts, knownScripts, i.script, env)
+    const { files, globs: invokedGlobs } = expandInvokedScript(index, scripts, knownScripts, i.script, env)
 
     // Only enforce "matches test files" when the (expanded) script actually contains globs.
     // Some scripts (e.g. `test:plugins:upstream`) run a suite runner and do not directly
@@ -1419,7 +1360,7 @@ function main (repoRootArg) {
   let hasCategoryWarnings = false
   const traceCoreCats = getTraceCoreCategoriesFromScripts(scripts)
   if (traceCoreCats.size) {
-    const ddTraceCats = findDdTraceTestCategories(repoRoot)
+    const ddTraceCats = findDdTraceTestCategories(index)
     /** @type {string[]} */
     const missingFromTraceCore = []
 
@@ -1436,7 +1377,7 @@ function main (repoRootArg) {
       // Only warn when the category is excluded from core AND we can't find any dedicated script
       // that appears to cover it. If it is covered elsewhere, it should not produce warnings.
       if (!covered) {
-        const files = listDdTraceCategorySpecFiles(repoRoot, cat)
+        const files = listDdTraceCategorySpecFiles(index, cat)
         const maxList = 25
         warnLines.push(`test:trace:core excludes "${cat}" (no dedicated test script found; files: ${files.length})`)
         for (let i = 0; i < files.length && i < maxList; i++) {
@@ -1475,7 +1416,6 @@ function main (repoRootArg) {
 
   const durMs = Number(process.hrtime.bigint() - startNs) / 1e6
   process.stdout.write(`Runtime(ms): ${durMs.toFixed(1)}\n`)
-  process.stdout.write(`Glob cache: size=${globCache.size} hits=${globCacheHits} misses=${globCacheMisses}\n`)
 
   process.exit(hasCategoryWarnings ? 1 : 0)
 }

--- a/scripts/verify-exercised-tests.spec.mjs
+++ b/scripts/verify-exercised-tests.spec.mjs
@@ -9,16 +9,25 @@ import { describe, it } from 'mocha'
 
 const SCRIPT = fileURLToPath(new URL('verify-exercised-tests.js', import.meta.url))
 
-// Written split so the linter does not read it as an unintended template literal.
+// Written split so the linter does not read these as unintended template literals.
 const PLUGINS_VAR = '$' + '{PLUGINS}'
+const SPEC_VAR = '$' + '{SPEC:-*}'
+const MATRIX_SPEC = '$' + '{{ matrix.spec }}'
 
 /**
- * @typedef {{ run: string, env?: Record<string, string> }} WorkflowStep
+ * @typedef {{ run: string, env?: Record<string, string> } | { uses: string }} WorkflowStep
+ * @typedef {Array<string|WorkflowStep>} JobSteps
+ * @typedef {JobSteps | {
+ *   steps: JobSteps,
+ *   env?: Record<string, string>,
+ *   matrix?: Record<string, string[]>,
+ * }} WorkflowJob
  * @typedef {{
  *   scripts: Record<string, string>,
- *   workflows: Record<string, Record<string, Array<string|WorkflowStep>>>,
+ *   workflows: Record<string, Record<string, WorkflowJob>|string>,
  *   files: string[],
- * }} Fixture
+ *   actions: Record<string, JobSteps|string>,
+ * }} Fixture Workflows and actions accept raw YAML so malformed shapes stay expressible.
  */
 
 /**
@@ -35,30 +44,95 @@ const PASSING = {
     'test.yml': { unit: ['npm run test:unit:ci'] },
   },
   files: ['packages/alpha/test/one.spec.js'],
+  actions: {},
 }
 
 /**
- * @param {Record<string, Array<string|WorkflowStep>>} jobs
+ * @param {JobSteps} steps
+ * @param {string} indent
+ * @returns {string[]}
+ */
+function stepLines (steps, indent) {
+  const lines = []
+
+  for (const step of steps) {
+    const normalized = typeof step === 'string' ? { run: step } : step
+
+    if ('uses' in normalized) {
+      lines.push(`${indent}- uses: ${normalized.uses}`)
+      continue
+    }
+
+    lines.push(`${indent}- run: ${normalized.run}`)
+    if (normalized.env) {
+      lines.push(`${indent}  env:`)
+      for (const [name, value] of Object.entries(normalized.env)) {
+        lines.push(`${indent}    ${name}: ${value}`)
+      }
+    }
+  }
+
+  return lines
+}
+
+/**
+ * @param {Record<string, WorkflowJob>} jobs
  * @returns {string}
  */
 function workflowYaml (jobs) {
   const lines = ['name: test', 'on: push', 'jobs:']
 
-  for (const [jobId, steps] of Object.entries(jobs)) {
-    lines.push(`  ${jobId}:`, '    runs-on: ubuntu-latest', '    steps:')
+  for (const [jobId, jobValue] of Object.entries(jobs)) {
+    const job = Array.isArray(jobValue) ? { steps: jobValue } : jobValue
+    lines.push(`  ${jobId}:`, '    runs-on: ubuntu-latest')
 
-    for (const step of steps) {
-      const { run, env } = typeof step === 'string' ? { run: step } : step
-      lines.push(`      - run: ${run}`)
-
-      if (env) {
-        lines.push('        env:')
-        for (const [name, value] of Object.entries(env)) lines.push(`          ${name}: ${value}`)
+    if ('matrix' in job && job.matrix) {
+      lines.push('    strategy:', '      matrix:')
+      for (const [name, values] of Object.entries(job.matrix)) {
+        lines.push(`        ${name}:`)
+        for (const value of values) lines.push(`          - ${value}`)
       }
     }
+
+    if ('env' in job && job.env) {
+      lines.push('    env:')
+      for (const [name, value] of Object.entries(job.env)) lines.push(`      ${name}: ${value}`)
+    }
+
+    lines.push('    steps:', ...stepLines(job.steps, ' '.repeat(6)))
   }
 
   return `${lines.join('\n')}\n`
+}
+
+/**
+ * @param {JobSteps|string} action Composite steps, or raw YAML for a non-composite action.
+ * @returns {string}
+ */
+function actionYaml (action) {
+  if (typeof action === 'string') return action
+
+  const lines = ['name: fixture', 'runs:', '  using: composite', '  steps:', ...stepLines(action, ' '.repeat(4))]
+
+  return `${lines.join('\n')}\n`
+}
+
+/**
+ * A single job whose glob narrows per matrix leg through the environment.
+ *
+ * @param {string[]} spec
+ * @returns {Record<string, Record<string, WorkflowJob>>}
+ */
+function matrixWorkflow (spec) {
+  return {
+    'test.yml': {
+      plugins: {
+        matrix: { spec },
+        env: { SPEC: MATRIX_SPEC },
+        steps: ['npm run test:plugins:ci'],
+      },
+    },
+  }
 }
 
 /**
@@ -66,7 +140,7 @@ function workflowYaml (jobs) {
  * @returns {{ status: number|null, stdout: string, stderr: string }}
  */
 function runVerifier (overrides = {}) {
-  const { scripts, workflows, files } = { ...PASSING, ...overrides }
+  const { scripts, workflows, files, actions } = { ...PASSING, ...overrides }
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-verify-exercised-'))
 
   try {
@@ -75,7 +149,13 @@ function runVerifier (overrides = {}) {
     for (const [name, jobs] of Object.entries(workflows)) {
       const file = path.join(root, '.github', 'workflows', name)
       fs.mkdirSync(path.dirname(file), { recursive: true })
-      fs.writeFileSync(file, workflowYaml(jobs))
+      fs.writeFileSync(file, typeof jobs === 'string' ? jobs : workflowYaml(jobs))
+    }
+
+    for (const [directory, action] of Object.entries(actions)) {
+      const file = path.join(root, directory, 'action.yml')
+      fs.mkdirSync(path.dirname(file), { recursive: true })
+      fs.writeFileSync(file, actionYaml(action))
     }
 
     for (const file of files) {
@@ -231,6 +311,150 @@ describe('verify-exercised-tests', () => {
 
     assert.strictEqual(status, 1)
     assert.match(stderr, /generates coverage but does not upload it/)
+  })
+
+  describe('coverage upload ordering', () => {
+    const scripts = { ...PASSING.scripts, 'test:cov:ci': 'node scripts/c8-ci.js test:unit:ci' }
+    const upload = { uses: './.github/actions/coverage' }
+
+    it('accepts a job that uploads after generating coverage', () => {
+      const { status } = runVerifier({
+        scripts,
+        workflows: { 'test.yml': { unit: ['npm run test:cov:ci', upload] } },
+      })
+
+      assert.strictEqual(status, 0)
+    })
+
+    it('reports a job that generates coverage after its last upload', () => {
+      const { status, stderr } = runVerifier({
+        scripts,
+        workflows: { 'test.yml': { unit: [upload, 'npm run test:cov:ci'] } },
+      })
+
+      assert.strictEqual(status, 1)
+      assert.match(stderr, /test\.yml#unit: generates coverage after its last coverage upload/)
+    })
+
+    it('accepts a later upload that still covers an earlier suite', () => {
+      const { status } = runVerifier({
+        scripts,
+        workflows: { 'test.yml': { unit: [upload, 'npm run test:cov:ci', upload] } },
+      })
+
+      assert.strictEqual(status, 0)
+    })
+
+    it('reports a suite repeated after the upload that already covered it', () => {
+      const { status, stderr } = runVerifier({
+        scripts,
+        workflows: { 'test.yml': { unit: ['npm run test:cov:ci', upload, 'npm run test:cov:ci'] } },
+      })
+
+      assert.strictEqual(status, 1)
+      assert.match(stderr, /generates coverage after its last coverage upload/)
+    })
+
+    it('reports the ordering inside a composite action', () => {
+      const { status, stderr } = runVerifier({
+        scripts,
+        actions: { '.github/actions/suite': [upload, { run: 'npm run test:cov:ci' }] },
+        workflows: { 'test.yml': { unit: [{ uses: './.github/actions/suite' }] } },
+      })
+
+      assert.strictEqual(status, 1)
+      assert.match(stderr, /generates coverage after its last coverage upload/)
+    })
+
+    it('accepts a composite action that uploads after its suite', () => {
+      const { status } = runVerifier({
+        scripts,
+        actions: { '.github/actions/suite': [{ run: 'npm run test:cov:ci' }, upload] },
+        workflows: { 'test.yml': { unit: [{ uses: './.github/actions/suite' }] } },
+      })
+
+      assert.strictEqual(status, 0)
+    })
+
+    it('walks past steps that carry neither a command nor an action', () => {
+      const { status } = runVerifier({
+        workflows: {
+          'test.yml': [
+            'name: test',
+            'on: push',
+            'env:',
+            '  DD_ENV: ci',
+            '  DD_TELEMETRY: false',
+            'jobs:',
+            '  unit:',
+            '    runs-on: ubuntu-latest',
+            '    env:',
+            '      DD_TRACE_DEBUG: true',
+            '    steps:',
+            '      -',
+            '      - name: no command here',
+            '      - uses: nick-fields/retry@v3',
+            '      - run: npm run test:unit:ci',
+          ].join('\n') + '\n',
+        },
+      })
+
+      assert.strictEqual(status, 0)
+    })
+
+    it('reports a local action whose steps it cannot read', () => {
+      const { status, stderr } = runVerifier({
+        actions: { '.github/actions/bundled': 'name: fixture\nruns:\n  using: node20\n  main: index.js\n' },
+        workflows: { 'test.yml': { unit: ['npm run test:unit:ci', { uses: './.github/actions/bundled' }] } },
+      })
+
+      assert.strictEqual(status, 1)
+      assert.match(stderr, /cannot inspect local action "\.\/\.github\/actions\/bundled", which is not a composite action/)
+    })
+
+    it('reports an action file it cannot read as a composite action', () => {
+      const { status, stderr } = runVerifier({
+        actions: { '.github/actions/empty': '' },
+        workflows: { 'test.yml': { unit: ['npm run test:unit:ci', { uses: './.github/actions/empty' }] } },
+      })
+
+      assert.strictEqual(status, 1)
+      assert.match(stderr, /cannot inspect local action "\.\/\.github\/actions\/empty"/)
+    })
+
+    it('accepts a composite action that declares no steps', () => {
+      const { status } = runVerifier({
+        actions: { '.github/actions/noop': 'name: fixture\nruns:\n  using: composite\n' },
+        workflows: { 'test.yml': { unit: ['npm run test:unit:ci', { uses: './.github/actions/noop' }] } },
+      })
+
+      assert.strictEqual(status, 0)
+    })
+  })
+
+  describe('matrix legs', () => {
+    // `SPEC` reaches the glob only through the environment, so an unresolved matrix expression
+    // widens the pattern to `*` and hides every spec no leg actually selects.
+    const scripts = {
+      'test:plugins:ci': `mocha "packages/datadog-plugin-alpha/test/**/${SPEC_VAR}*.spec.js"`,
+    }
+    const files = [
+      'packages/datadog-plugin-alpha/test/one.spec.js',
+      'packages/datadog-plugin-alpha/test/two.spec.js',
+    ]
+
+    it('reports a spec that no matrix leg selects', () => {
+      const { status, stderr } = runVerifier({ scripts, files, workflows: matrixWorkflow(['one']) })
+
+      assert.strictEqual(status, 1)
+      assert.match(stderr, /exercise packages\/datadog-plugin-alpha\/test\/two\.spec\.js/)
+    })
+
+    it('accepts specs that the matrix legs cover between them', () => {
+      const { status } = runVerifier({ scripts, files, workflows: matrixWorkflow(['one', 'two']) })
+
+      assert.strictEqual(status, 0)
+    })
   })
 
   it('warns about a dd-trace test category test:trace:core excludes', () => {

--- a/scripts/verify-exercised-tests.spec.mjs
+++ b/scripts/verify-exercised-tests.spec.mjs
@@ -1,0 +1,274 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, it } from 'mocha'
+
+const SCRIPT = fileURLToPath(new URL('verify-exercised-tests.js', import.meta.url))
+
+// Written split so the linter does not read it as an unintended template literal.
+const PLUGINS_VAR = '$' + '{PLUGINS}'
+
+/**
+ * @typedef {{ run: string, env?: Record<string, string> }} WorkflowStep
+ * @typedef {{
+ *   scripts: Record<string, string>,
+ *   workflows: Record<string, Record<string, Array<string|WorkflowStep>>>,
+ *   files: string[],
+ * }} Fixture
+ */
+
+/**
+ * Baseline checkout that satisfies every check. Each case below overrides one part of it, so a
+ * failing assertion points at the single mutation under test rather than at fixture drift.
+ *
+ * @type {Fixture}
+ */
+const PASSING = {
+  scripts: {
+    'test:unit:ci': 'mocha "packages/**/test/**/*.spec.js"',
+  },
+  workflows: {
+    'test.yml': { unit: ['npm run test:unit:ci'] },
+  },
+  files: ['packages/alpha/test/one.spec.js'],
+}
+
+/**
+ * @param {Record<string, Array<string|WorkflowStep>>} jobs
+ * @returns {string}
+ */
+function workflowYaml (jobs) {
+  const lines = ['name: test', 'on: push', 'jobs:']
+
+  for (const [jobId, steps] of Object.entries(jobs)) {
+    lines.push(`  ${jobId}:`, '    runs-on: ubuntu-latest', '    steps:')
+
+    for (const step of steps) {
+      const { run, env } = typeof step === 'string' ? { run: step } : step
+      lines.push(`      - run: ${run}`)
+
+      if (env) {
+        lines.push('        env:')
+        for (const [name, value] of Object.entries(env)) lines.push(`          ${name}: ${value}`)
+      }
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+/**
+ * @param {Partial<Fixture>} overrides
+ * @returns {{ status: number|null, stdout: string, stderr: string }}
+ */
+function runVerifier (overrides = {}) {
+  const { scripts, workflows, files } = { ...PASSING, ...overrides }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-verify-exercised-'))
+
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'fixture', scripts }))
+
+    for (const [name, jobs] of Object.entries(workflows)) {
+      const file = path.join(root, '.github', 'workflows', name)
+      fs.mkdirSync(path.dirname(file), { recursive: true })
+      fs.writeFileSync(file, workflowYaml(jobs))
+    }
+
+    for (const file of files) {
+      const full = path.join(root, file)
+      fs.mkdirSync(path.dirname(full), { recursive: true })
+      fs.writeFileSync(full, '')
+    }
+
+    const { status, stdout, stderr } = spawnSync(process.execPath, [SCRIPT, root], { encoding: 'utf8' })
+    return { status, stdout, stderr }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+describe('verify-exercised-tests', () => {
+  it('verifies its own repository when no root is given', () => {
+    const { status, stdout } = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' })
+
+    assert.strictEqual(status, 0)
+    assert.match(stdout, /All CI workflows reference valid scripts, and plugin setup looks consistent\./)
+  })
+
+  it('accepts a checkout where every test file is exercised', () => {
+    const { status, stdout } = runVerifier()
+
+    assert.strictEqual(status, 0)
+    assert.match(stdout, /All test files are covered by at least one package\.json script glob\./)
+    assert.match(stdout, /^Test files: 1$/m)
+  })
+
+  it('reports a test file no script glob selects', () => {
+    const { status, stderr } = runVerifier({
+      files: ['packages/alpha/test/one.spec.js', 'orphan/lonely.spec.js'],
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /Test files not covered by any package\.json script glob\./)
+    assert.match(stderr, /^- orphan\/lonely\.spec\.js$/m)
+  })
+
+  it('reports every test-file extension the repository allows', () => {
+    const extensions = ['spec.js', 'spec.mjs', 'spec.cjs', 'test.js', 'test.mjs', 'test.cjs']
+    const { status, stderr } = runVerifier({
+      files: extensions.map(extension => `orphan/lonely.${extension}`),
+    })
+
+    assert.strictEqual(status, 1)
+    for (const extension of extensions) {
+      assert.match(stderr, new RegExp(String.raw`^- orphan/lonely\.${extension.replace('.', String.raw`\.`)}$`, 'm'))
+    }
+  })
+
+  it('reports an unquoted globstar that POSIX sh would collapse', () => {
+    const { status, stderr } = runVerifier({
+      scripts: { 'test:unit:ci': 'mocha packages/**/test/**/*.spec.js' },
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /Unquoted `\*\*` globs detected in package\.json scripts/)
+    assert.match(stderr, /script "test:unit:ci" contains an unquoted "\*\*"/)
+  })
+
+  it('reports a :ci script no workflow invokes', () => {
+    const { status, stderr } = runVerifier({
+      scripts: {
+        ...PASSING.scripts,
+        'test:extra:ci': 'mocha "packages/**/test/**/*.spec.js"',
+      },
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /script "test:extra:ci" is not invoked by any GitHub Actions workflow/)
+  })
+
+  it('reports a workflow invoking a script that does not exist', () => {
+    const { status, stderr } = runVerifier({
+      workflows: { 'test.yml': { unit: ['npm run test:unit:ci', 'npm run test:missing'] } },
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /invokes missing script "test:missing"/)
+  })
+
+  it('reports a CI step whose script selects no test file', () => {
+    const { status, stderr } = runVerifier({
+      scripts: {
+        ...PASSING.scripts,
+        'test:empty:ci': 'mocha "nowhere/**/*.spec.js"',
+      },
+      workflows: { 'test.yml': { unit: ['npm run test:unit:ci', 'npm run test:empty:ci'] } },
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /"test:empty:ci" would match 0 test files/)
+  })
+
+  it('reports a test file that a script glob covers but no CI job reaches', () => {
+    const { status, stderr } = runVerifier({
+      scripts: {
+        'test:unit:ci': 'mocha "packages/alpha/test/**/*.spec.js"',
+        'test:beta': 'mocha "packages/beta/test/**/*.spec.js"',
+      },
+      files: ['packages/alpha/test/one.spec.js', 'packages/beta/test/two.spec.js'],
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /No CI workflow invocation expands a glob to exercise packages\/beta\/test\/two\.spec\.js/)
+  })
+
+  it('reports PLUGINS naming a plugin package that does not exist', () => {
+    const { status, stderr } = runVerifier({
+      scripts: {
+        ...PASSING.scripts,
+        'test:plugins:ci': `mocha "packages/datadog-plugin-@(${PLUGINS_VAR})/test/**/*.spec.js"`,
+      },
+      workflows: {
+        'test.yml': {
+          unit: ['npm run test:unit:ci', { run: 'npm run test:plugins:ci', env: { PLUGINS: 'nope' } }],
+        },
+      },
+      files: ['packages/datadog-plugin-http/test/index.spec.js'],
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /PLUGINS includes "nope" but packages\/datadog-plugin-nope does not exist/)
+  })
+
+  it('accepts PLUGINS naming a plugin package that exists', () => {
+    const { status } = runVerifier({
+      scripts: {
+        'test:plugins:ci': `mocha "packages/datadog-plugin-@(${PLUGINS_VAR})/test/**/*.spec.js"`,
+      },
+      workflows: {
+        'test.yml': {
+          plugins: [{ run: 'npm run test:plugins:ci', env: { PLUGINS: 'http' } }],
+        },
+      },
+      files: ['packages/datadog-plugin-http/test/index.spec.js'],
+    })
+
+    assert.strictEqual(status, 0)
+  })
+
+  it('reports a job that generates coverage without uploading it', () => {
+    const { status, stderr } = runVerifier({
+      scripts: {
+        ...PASSING.scripts,
+        'test:cov:ci': 'node scripts/c8-ci.js test:unit:ci',
+      },
+      workflows: { 'test.yml': { unit: ['npm run test:cov:ci'] } },
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stderr, /generates coverage but does not upload it/)
+  })
+
+  it('warns about a dd-trace test category test:trace:core excludes', () => {
+    const { status, stdout } = runVerifier({
+      scripts: {
+        ...PASSING.scripts,
+        'test:trace:core': 'mocha "packages/dd-trace/test/{alpha}/**/*.spec.js"',
+      },
+      files: [
+        'packages/dd-trace/test/alpha/one.spec.js',
+        'packages/dd-trace/test/beta/two.spec.js',
+      ],
+    })
+
+    assert.strictEqual(status, 1)
+    assert.match(stdout, /test:trace:core excludes "beta"/)
+    assert.match(stdout, /^ {2}- packages\/dd-trace\/test\/beta\/two\.spec\.js$/m)
+  })
+
+  it('follows a script into the nested script it invokes', () => {
+    const { status } = runVerifier({
+      scripts: {
+        'test:unit:ci': 'npm run test:unit:inner',
+        'test:unit:inner': 'mocha "packages/**/test/**/*.spec.js"',
+      },
+    })
+
+    assert.strictEqual(status, 0)
+  })
+
+  it('ignores test files under node_modules', () => {
+    const { status } = runVerifier({
+      files: [
+        'packages/alpha/test/one.spec.js',
+        'packages/alpha/test/node_modules/fixture/ignored.spec.js',
+      ],
+    })
+
+    assert.strictEqual(status, 0)
+  })
+})


### PR DESCRIPTION
## Summary

`verify-exercised-tests` runs in the lint gate. It walked the repository once per script glob, and
never modeled a job's steps as an ordered sequence — which cost runtime and hid two classes of
unverified suite.

1. Expanding the script globs took 227 separate `globSync` traversals of the same tree. One walk now
   answers all of them from memory, cutting the run from 312 ms to 178 ms, medians of ten
   interleaved runs on one checkout.
2. A coverage upload placed before the suite it collects passed the check, because uploads were
   tracked as a per-job boolean and position never entered it. Five composite actions run a suite
   and upload its report, so the order that decides whether a report survives usually lives inside
   the action, not in the workflow.
3. `SPEC: ${{ matrix.spec }}` reached the glob unresolved, degrading `${SPEC:-*}` to `*` and making
   every spec in a directory look exercised by every matrix leg. Resolving it per leg surfaces
   `packages/datadog-plugin-aws-sdk/test/base-inject-field.spec.js`, which no leg selects; the
   serverless matrix gains the entry that runs it.

## Why

Matching has to stay identical to the walk it replaces, so the index compiles patterns with the
options `glob` derives internally, and its spec cross-checks every result against `globSync` over
the glob corpus this repository's own package.json produces. Where the index cannot reproduce `glob`
exactly it refuses rather than answering with too few files: an unreadable directory warns, and a
`..` segment throws. Literal path segments are compared case-sensitively on every platform, the rule
`glob` applies on Linux, so a result no longer depends on whether the developer's filesystem folds
case.