### PR TITLE
fix(next): use matrix Node version in CI

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1009,7 +1009,18 @@ jobs:
       PACKAGE_VERSION_RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
+      - name: Verify Node.js matrix version
+        shell: bash
+        run: |
+          MAJOR=$(node -p 'process.versions.node.split(".")[0]')
+          if [ "${{ matrix.version }}" = "18" ]; then
+            test "$MAJOR" = "18"
+          else
+            test "$MAJOR" != "18"
+          fi
       - uses: ./.github/actions/install
       - run: npm run test:plugins:ci
       - uses: ./.github/actions/coverage


### PR DESCRIPTION
Ensures the Next integration test matrix passes its declared Node version to the existing setup action and verifies the Node 18 and latest lanes are distinct.

Validation: workflow YAML parsing, local matrix assertion checks, git diff --check, signed commit. GitHub Actions is required to verify both live matrix lanes.