### PR TITLE
fix(next): extract context from Fetch headers

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -18,7 +18,7 @@ class NextPlugin extends ServerPlugin {
 
   bindStart ({ req, res }) {
     const store = storage('legacy').getStore()
-    const childOf = store ? store.span : store
+    const childOf = store?.span || web.extractIncomingServerContext(this.tracer, req.headers)
     const { name: schemaServiceName, source: schemaServiceSource } = this.serviceName()
     const serviceName = this.config.service || schemaServiceName
     let serviceSource = this.config.service ? 'opt.plugin' : schemaServiceSource

--- a/packages/datadog-plugin-next/test/plugin.spec.js
+++ b/packages/datadog-plugin-next/test/plugin.spec.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { afterEach, describe, it } = require('mocha')
+
+const { storage } = require('../../datadog-core')
+
+const legacyStorage = storage('legacy')
+
+describe('next plugin', () => {
+  afterEach(() => {
+    legacyStorage.enterWith(undefined)
+    assert.strictEqual(legacyStorage.getStore(), undefined)
+  })
+
+  it('emits a Next request span with the extracted Fetch Headers context', () => {
+    const tracer = require('../../dd-trace').init({ plugins: false })
+    const NextPlugin = require('../src')
+    const plugin = new NextPlugin(tracer, {})
+    const headers = new Headers({
+      'X-Datadog-Trace-Id': '123',
+      'X-Datadog-Parent-Id': '456',
+    })
+
+    const { span } = plugin.bindStart({ req: { method: 'GET', headers }, res: {} })
+
+    assert.strictEqual(span.context().toTraceId(), '123')
+    assert.strictEqual(span.context()._parentId.toString(), '00000000000001c8')
+  })
+
+  it('keeps the active local span over conflicting Fetch Headers context', () => {
+    const tracer = require('../../dd-trace').init({ plugins: false })
+    const NextPlugin = require('../src')
+    const plugin = new NextPlugin(tracer, {})
+    const localSpan = tracer.startSpan('local.request')
+    const headers = new Headers({
+      'X-Datadog-Trace-Id': '123',
+      'X-Datadog-Parent-Id': '456',
+    })
+
+    legacyStorage.run({ span: localSpan }, () => {
+      const { span } = plugin.bindStart({ req: { method: 'GET', headers }, res: {} })
+
+      assert.strictEqual(span.context().toTraceId(), localSpan.context().toTraceId())
+      assert.strictEqual(span.context()._parentId.toString(), localSpan.context()._spanId.toString())
+    })
+  })
+})

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -219,7 +219,7 @@ const web = {
     const store = legacyStorage.getStore()
     const pubsubSpan = store?.span?._name === 'pubsub.push.receive' ? store.span : null
 
-    let childOf = pubsubSpan || tracer.extract(FORMAT_HTTP_HEADERS, headers)
+    let childOf = pubsubSpan || this.extractIncomingServerContext(tracer, headers)
 
     // we may have headers signaling a router proxy span should be created (such as for AWS API Gateway)
     if (tracer._config?.inferredProxyServicesEnabled) {
@@ -230,6 +230,10 @@ const web = {
     }
 
     return startSpanHelper(tracer, name, { childOf }, traceCtx, config)
+  },
+
+  extractIncomingServerContext (tracer, headers) {
+    return tracer.extract(FORMAT_HTTP_HEADERS, normalizeHeadersCarrier(headers))
   },
 
   // Validate a request's status code and then add error tags if necessary
@@ -343,6 +347,18 @@ const web = {
 
     applyRouteOrEndpointTag(context)
   },
+}
+
+function normalizeHeadersCarrier (headers) {
+  if (!headers || typeof headers.get !== 'function' || typeof headers[Symbol.iterator] !== 'function') {
+    return headers
+  }
+
+  const carrier = {}
+  for (const [key, value] of headers) {
+    carrier[String(key).toLowerCase()] = value
+  }
+  return carrier
 }
 
 function addAllowHeaders (req, res, headers) {


### PR DESCRIPTION
Normalizes iterable Fetch Headers for incoming context extraction while preserving ordinary Node header objects and active local-parent precedence.

Validation: focused Mocha coverage, targeted ESLint, git diff --check, signed commit, and clean stack application with the CI slice. Exact packaged Vercel validation remains required.