### PR TITLE
docs(llmobs): correct both agent skills against the codebase

### DIFF
--- a/.agents/skills/llmobs-integration/SKILL.md
+++ b/.agents/skills/llmobs-integration/SKILL.md
@@ -12,11 +12,18 @@ description: |
 
 # LLM Observability Integration Skill
 
-This skill covers creating LLMObs plugins that instrument LLM library operations and emit span events. Supported operations: chat completions (streaming and non-streaming), embeddings, agent runs, orchestration (workflows / graphs), tool calls, retrieval (RAG / vector DB).
+This skill covers creating LLMObs plugins that instrument LLM library operations and emit span events. Supported
+operations: chat completions (streaming and non-streaming), embeddings, agent runs, orchestration (workflows /
+graphs), tool calls, retrieval (RAG / vector DB).
 
 ## Read Upstream Source First
 
-LLM libraries iterate fast — six-month-old assumptions about an SDK's response shape, streaming contract, or tool-call format are usually wrong. Before category detection or any plugin work, read the upstream library's source for the installed version (`versions/<lib>@<range>/node_modules/<lib>`). The category decision tree below depends on facts the source carries (does this package make HTTP calls? does it orchestrate? does it support multiple providers?). See [apm-integrations § Read Upstream Source First](../apm-integrations/SKILL.md#read-upstream-source-first) for the shallow-clone / `npm pack` shapes.
+LLM libraries iterate fast — six-month-old assumptions about an SDK's response shape, streaming contract, or tool-call
+format are usually wrong. Before category detection or any plugin work, read the upstream library's source for the
+installed version (`versions/<lib>@<range>/node_modules/<lib>`). The category decision tree below depends on facts the
+source carries (does this package make HTTP calls? does it orchestrate? does it support multiple providers?). See
+[apm-integrations § Read Upstream Source First](../apm-integrations/SKILL.md#read-upstream-source-first) for the
+shallow-clone / `npm pack` shapes.
 
 ## Core Concepts
 
@@ -27,26 +34,39 @@ All LLMObs plugins extend `LLMObsPlugin`. Two methods must be implemented:
 - `getLLMObsSpanRegisterOptions(ctx)` — returns `{ modelProvider, modelName, kind, name }`.
 - `setLLMObsTags(ctx)` — extracts and tags input / output messages, token metrics, and model metadata.
 
-Lifecycle: `start(ctx)` registers the span and captures context; the wrapped operation runs; `asyncEnd(ctx)` calls `setLLMObsTags()`; `end(ctx)` restores the parent.
+Lifecycle: `start(ctx)` registers the span and captures context; the wrapped operation runs; `asyncEnd(ctx)` calls
+`setLLMObsTags()`; `end(ctx)` restores the parent.
 
 See [references/plugin-architecture.md](references/plugin-architecture.md) for the full implementation surface.
 
 ### 2. Package Shape
 
-**Settle the library's shape before writing anything** — it decides which methods to hook and how the plugin can be tested. These are working categories for reasoning about a package; none of them exists as a constant in the codebase, so classify by reading the source rather than looking for an enum.
+**Settle the library's shape before writing anything** — it decides which methods to hook and how the plugin can be
+tested. These are working categories for reasoning about a package; none of them exists as a constant in the codebase,
+so classify by reading the source rather than looking for an enum.
 
-- **LLM client** — calls provider endpoints itself and needs API keys (openai, anthropic, genai). Hook the chat / completion methods.
-- **Multi-provider** — exposes several providers behind one surface, wrapping the clients above (ai, langchain). Hook the provider abstraction layer.
-- **Orchestration** — runs a graph or workflow and holds state, with no provider HTTP of its own (langgraph). Hook the workflow lifecycle (invoke, stream, run).
-- **Infrastructure** — implements a protocol across a client / server split (modelcontextprotocol-sdk). Hook the protocol handlers.
+- **LLM client** — calls provider endpoints itself and needs API keys (openai, anthropic, genai). Hook the chat /
+  completion methods.
+- **Multi-provider** — exposes several providers behind one surface, wrapping the clients above (ai, langchain). Hook
+  the provider abstraction layer.
+- **Orchestration** — runs a graph or workflow and holds state, with no provider HTTP of its own (langgraph). Hook the
+  workflow lifecycle (invoke, stream, run).
+- **Infrastructure** — implements a protocol across a client / server split (modelcontextprotocol-sdk). Hook the
+  protocol handlers.
 
-The distinctions that decide it: does the package talk to a provider endpoint itself, does it front more than one provider, and does it carry graph state. Test strategy per shape lives in [llmobs-testing](../llmobs-testing/SKILL.md) — including that an orchestration spec drives its nodes with plain return values, not a real model.
+The distinctions that decide it: does the package talk to a provider endpoint itself, does it front more than
+one provider, and does it carry graph state. Test strategy per shape lives in
+[llmobs-testing](../llmobs-testing/SKILL.md) — including that an orchestration spec drives its nodes with
+plain return values, not a real model.
 
 See [references/category-detection.md](references/category-detection.md) for heuristics and worked examples.
 
 ### 3. LLM Span Kinds
 
-`SPAN_KINDS` in [`packages/dd-trace/src/llmobs/constants/tags.js`](../../../packages/dd-trace/src/llmobs/constants/tags.js) is the source of truth: `llm`, `agent`, `workflow`, `task`, `tool`, `embedding`, `retrieval`. Chat completions and text generation are `llm`; graph or chain execution is `workflow`; agent runs are `agent`; vector-DB and RAG lookups are `retrieval`.
+`SPAN_KINDS` in [`packages/dd-trace/src/llmobs/constants/tags.js`](../../../packages/dd-trace/src/llmobs/constants/tags.js)
+is the source of truth: `llm`, `agent`, `workflow`, `task`, `tool`, `embedding`, `retrieval`. Chat completions and
+text generation are `llm`; graph or chain execution is `workflow`; agent runs are `agent`; vector-DB and RAG lookups
+are `retrieval`.
 
 ### 4. Message Extraction
 
@@ -102,13 +122,16 @@ All plugins must export an array:
 **Static properties required:**
 - `integration` - Integration name (e.g., 'openai')
 - `id` - Unique plugin ID (e.g., 'llmobs_openai')
-- `prefix` - Channel prefix (e.g., 'tracing:apm:openai:chat')
+- `prefix` - Channel prefix (e.g., 'tracing:apm:openai:request')
 
 ## References
 
 For detailed information, see:
 
-- [references/plugin-architecture.md](references/plugin-architecture.md) - Complete plugin structure, implementation steps, helper methods
-- [references/category-detection.md](references/category-detection.md) - Package classification heuristics and detection process
+- [references/plugin-architecture.md](references/plugin-architecture.md) - Complete plugin structure, implementation
+  steps, helper methods
+- [references/category-detection.md](references/category-detection.md) - Package classification heuristics and
+  detection process
 - [references/message-extraction.md](references/message-extraction.md) - Provider-specific message format patterns
-- [references/reference-implementations.md](references/reference-implementations.md) - Working plugin examples (Anthropic, Google GenAI)
+- [references/reference-implementations.md](references/reference-implementations.md) - Working plugin examples
+  (Anthropic, Google GenAI)

--- a/.agents/skills/llmobs-integration/SKILL.md
+++ b/.agents/skills/llmobs-integration/SKILL.md
@@ -29,53 +29,53 @@ shallow-clone / `npm pack` shapes.
 
 ### 1. LLMObsPlugin Base Class
 
-All LLMObs plugins extend `LLMObsPlugin`. Two methods must be implemented:
+Leaf plugins extend `LLMObsPlugin` and implement two methods:
 
-- `getLLMObsSpanRegisterOptions(ctx)` — returns `{ modelProvider, modelName, kind, name }`.
-- `setLLMObsTags(ctx)` — extracts and tags input / output messages, token metrics, and model metadata.
+- `getLLMObsSpanRegisterOptions(ctx)` — returns a required `kind` plus any available name, model and session fields.
+- `setLLMObsTags(ctx)` — tags the operation's input, output, metrics, and metadata.
 
-Lifecycle: `start(ctx)` registers the span and captures context; the wrapped operation runs; `asyncEnd(ctx)` calls
-`setLLMObsTags()`; `end(ctx)` restores the parent.
+A composite root such as `ai/index.js` extends `CompositePlugin` and selects leaf plugins.
+
+On the usual promise-backed channel, `start(ctx)` registers the span and captures context, `end(ctx)` restores the
+parent after the wrapped call returns, and `asyncEnd(ctx)` calls `setLLMObsTags()` after the operation settles.
 
 See [references/plugin-architecture.md](references/plugin-architecture.md) for the full implementation surface.
 
 ### 2. Package Shape
 
-**Settle the library's shape before writing anything** — it decides which methods to hook and how the plugin can be
-tested. These are working categories for reasoning about a package; none of them exists as a constant in the codebase,
-so classify by reading the source rather than looking for an enum.
+**Settle each instrumented surface's shape before writing anything** — it decides which methods to hook and how the
+operation gets its response. These are working categories for reasoning, not constants in the codebase, so classify
+by reading the source rather than looking for an enum.
 
-- **LLM client** — calls provider endpoints itself and needs API keys (openai, anthropic, genai). Hook the chat /
-  completion methods.
-- **Multi-provider** — exposes several providers behind one surface, wrapping the clients above (ai, langchain). Hook
-  the provider abstraction layer.
+- **LLM client** — owns the provider endpoint, transport and authentication (openai, anthropic, genai). Hook the
+  chat / completion methods.
+- **Multi-provider** — accepts provider implementations behind one surface (ai, langchain). The providers may live
+  in separate packages. Hook the provider abstraction layer.
 - **Orchestration** — runs a graph or workflow and holds state, with no provider HTTP of its own (langgraph). Hook the
   workflow lifecycle (invoke, stream, run).
 - **Infrastructure** — implements a protocol across a client / server split (modelcontextprotocol-sdk). Hook the
   protocol handlers.
 
-The distinctions that decide it: does the package talk to a provider endpoint itself, does it front more than
-one provider, and does it carry graph state. Test strategy per shape lives in
-[llmobs-testing](../llmobs-testing/SKILL.md) — including that an orchestration spec drives its nodes with
-plain return values, not a real model.
+The shape decides the response source and test harness. The instrumented operation decides its span kind and fields.
+Hybrid packages such as `ai` and LangChain must be classified per operation. Test strategy per shape lives in
+[llmobs-testing](../llmobs-testing/SKILL.md).
 
 See [references/category-detection.md](references/category-detection.md) for heuristics and worked examples.
 
 ### 3. LLM Span Kinds
 
-`SPAN_KINDS` in [`packages/dd-trace/src/llmobs/constants/tags.js`](../../../packages/dd-trace/src/llmobs/constants/tags.js)
-lists `llm`, `agent`, `workflow`, `task`, `tool`, `embedding`, `retrieval`. Chat completions and text generation are
-`llm`; graph or chain execution is `workflow`; agent runs are `agent`; vector-DB and RAG lookups are `retrieval`.
-Only the public SDK validates against that list, so a plugin may register a kind outside it — `ai` v7 and
-claude-agent-sdk both use `step`.
+`SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js` lists `llm`, `agent`, `workflow`, `task`, `tool`,
+`embedding`, `retrieval`. Chat completions and text generation are `llm`; graph or chain execution is `workflow`;
+agent runs are `agent`; vector-DB and RAG lookups are `retrieval`. Only the public SDK validates against that list,
+so a plugin may register a kind outside it — `ai` v7 and claude-agent-sdk both use `step`.
 
 ### 4. Message Extraction
 
-All plugins must convert provider-specific message formats to the standard format:
+`llm` operations convert provider-specific messages to the tagger's message shape:
 
-**Standard format:** `[{content: string, role: string}]`
+**Common shape:** `[{ content?: string, role: string, toolCalls?: object[], toolResults?: object[] }]`
 
-**Common roles:** `'user'`, `'assistant'`, `'system'`, `'tool'`
+`role` defaults to an empty string. Tool-call or tool-result-only messages may omit `content`.
 
 **Provider-specific handling:**
 - OpenAI: Direct format match, handle `function_call` and `tool_calls`
@@ -87,14 +87,14 @@ See [references/message-extraction.md](references/message-extraction.md) for pro
 
 ## Implementation Steps
 
-1. **Settle the shape first**, from the upstream source rather than the package name.
-2. **Create `packages/dd-trace/src/llmobs/plugins/{integration}/index.js`** extending `LLMObsPlugin`.
-3. **Implement `getLLMObsSpanRegisterOptions(ctx)`** — model provider, model name, span kind, span name.
-4. **Implement `setLLMObsTags(ctx)`** — input from `ctx.arguments`, output from `ctx.result`, token metrics and
-  model metadata, tagged through `this._tagger`.
-5. **Cover the edges**: streaming, errors (output messages come out empty), non-standard formats, absent metadata.
+1. **Map each surface's response source and operation kind**, from the upstream source rather than the package name.
+2. **Create leaf plugins under `packages/dd-trace/src/llmobs/plugins/{integration}/`** extending `LLMObsPlugin`.
+3. **Implement `getLLMObsSpanRegisterOptions(ctx)`** — span kind plus any available name, model and session fields.
+4. **Implement `setLLMObsTags(ctx)`** — input, output, metrics and metadata from the fields the instrumentation
+  publishes on `ctx`, tagged through `this._tagger`.
+5. **Cover the edges**: streaming, kind-specific error output, non-standard formats, absent metadata.
 
 Export the class itself when the package needs one plugin (openai, anthropic, genai), or an array when several
-operations each need their own (langchain, langgraph, modelcontextprotocol-sdk, claude-agent-sdk). The required
-static fields and the rest of the surface are in
-[references/plugin-architecture.md](references/plugin-architecture.md).
+operations each need their own (langchain, langgraph, modelcontextprotocol-sdk, claude-agent-sdk). Use a
+`CompositePlugin` root when one integration selects between child implementations, as `ai` does. The required static
+fields and the rest of the surface are in [references/plugin-architecture.md](references/plugin-architecture.md).

--- a/.agents/skills/llmobs-integration/SKILL.md
+++ b/.agents/skills/llmobs-integration/SKILL.md
@@ -20,7 +20,7 @@ graphs), tool calls, retrieval (RAG / vector DB).
 
 LLM libraries iterate fast — six-month-old assumptions about an SDK's response shape, streaming contract, or tool-call
 format are usually wrong. Before category detection or any plugin work, read the upstream library's source for the
-installed version (`versions/<lib>@<range>/node_modules/<lib>`). The category decision tree below depends on facts the
+installed version (`versions/<lib>@<range>/node_modules/<lib>`). The shape checklist below depends on facts the
 source carries (does this package make HTTP calls? does it orchestrate? does it support multiple providers?). See
 [apm-integrations § Read Upstream Source First](../apm-integrations/SKILL.md#read-upstream-source-first) for the
 shallow-clone / `npm pack` shapes.
@@ -64,9 +64,10 @@ See [references/category-detection.md](references/category-detection.md) for heu
 ### 3. LLM Span Kinds
 
 `SPAN_KINDS` in [`packages/dd-trace/src/llmobs/constants/tags.js`](../../../packages/dd-trace/src/llmobs/constants/tags.js)
-is the source of truth: `llm`, `agent`, `workflow`, `task`, `tool`, `embedding`, `retrieval`. Chat completions and
-text generation are `llm`; graph or chain execution is `workflow`; agent runs are `agent`; vector-DB and RAG lookups
-are `retrieval`.
+lists `llm`, `agent`, `workflow`, `task`, `tool`, `embedding`, `retrieval`. Chat completions and text generation are
+`llm`; graph or chain execution is `workflow`; agent runs are `agent`; vector-DB and RAG lookups are `retrieval`.
+Only the public SDK validates against that list, so a plugin may register a kind outside it — `ai` v7 and
+claude-agent-sdk both use `step`.
 
 ### 4. Message Extraction
 
@@ -86,52 +87,14 @@ See [references/message-extraction.md](references/message-extraction.md) for pro
 
 ## Implementation Steps
 
-1. **Detect package category** (REQUIRED FIRST STEP)
-  - Follow decision tree above
-  - Output: category, confidence, reasoning
+1. **Settle the shape first**, from the upstream source rather than the package name.
+2. **Create `packages/dd-trace/src/llmobs/plugins/{integration}/index.js`** extending `LLMObsPlugin`.
+3. **Implement `getLLMObsSpanRegisterOptions(ctx)`** — model provider, model name, span kind, span name.
+4. **Implement `setLLMObsTags(ctx)`** — input from `ctx.arguments`, output from `ctx.result`, token metrics and
+  model metadata, tagged through `this._tagger`.
+5. **Cover the edges**: streaming, errors (output messages come out empty), non-standard formats, absent metadata.
 
-2. **Create plugin file**
-  - Location: `packages/dd-trace/src/llmobs/plugins/{integration}/index.js`
-  - Extend: `LLMObsPlugin` base class
-  - Implement: Required methods per plugin architecture
-
-3. **Implement `getLLMObsSpanRegisterOptions(ctx)`**
-  - Extract model provider and name from context
-  - Determine span kind (usually `'llm'`)
-  - Return registration options object
-
-4. **Implement `setLLMObsTags(ctx)`**
-  - Extract input messages from `ctx.arguments`
-  - Extract output messages from `ctx.result`
-  - Extract token metrics (input_tokens, output_tokens, total_tokens)
-  - Extract metadata (temperature, max_tokens, etc.)
-  - Tag span using `this._tagger` methods
-
-5. **Handle edge cases**
-  - Streaming responses (if applicable)
-  - Error cases (empty output messages)
-  - Non-standard message formats
-  - Missing metadata
-
-See [references/plugin-architecture.md](references/plugin-architecture.md) for step-by-step implementation guide.
-
-## Plugin Registration
-
-All plugins must export an array:
-
-**Static properties required:**
-- `integration` - Integration name (e.g., 'openai')
-- `id` - Unique plugin ID (e.g., 'llmobs_openai')
-- `prefix` - Channel prefix (e.g., 'tracing:apm:openai:request')
-
-## References
-
-For detailed information, see:
-
-- [references/plugin-architecture.md](references/plugin-architecture.md) - Complete plugin structure, implementation
-  steps, helper methods
-- [references/category-detection.md](references/category-detection.md) - Package classification heuristics and
-  detection process
-- [references/message-extraction.md](references/message-extraction.md) - Provider-specific message format patterns
-- [references/reference-implementations.md](references/reference-implementations.md) - Working plugin examples
-  (Anthropic, Google GenAI)
+Export the class itself when the package needs one plugin (openai, anthropic, genai), or an array when several
+operations each need their own (langchain, langgraph, modelcontextprotocol-sdk, claude-agent-sdk). The required
+static fields and the rest of the surface are in
+[references/plugin-architecture.md](references/plugin-architecture.md).

--- a/.agents/skills/llmobs-integration/SKILL.md
+++ b/.agents/skills/llmobs-integration/SKILL.md
@@ -5,9 +5,9 @@ description: |
   in dd-trace-js. Triggers: "add LLMObs support", "instrument chat
   completions / streaming / embeddings / agent runs / orchestration / tool
   calls / retrieval", "LLMObsPlugin", "getLLMObsSpanRegisterOptions",
-  "setLLMObsTags", "LlmObsCategory", "LlmObsSpanKind", any provider tag
+  "setLLMObsTags", "SPAN_KINDS", "span kind", any provider tag
   ("openai" / "anthropic" / "genai" / "google" / "langchain" / "langgraph" /
-  "ai-sdk" llmobs), "VCR cassettes".
+  "ai" llmobs), "VCR cassettes".
 ---
 
 # LLM Observability Integration Skill
@@ -31,63 +31,22 @@ Lifecycle: `start(ctx)` registers the span and captures context; the wrapped ope
 
 See [references/plugin-architecture.md](references/plugin-architecture.md) for the full implementation surface.
 
-### 2. Package Category System
+### 2. Package Shape
 
-**CRITICAL:** Every integration must be classified into one category using the `LlmObsCategory` enum. This determines test strategy and implementation approach.
+**Settle the library's shape before writing anything** — it decides which methods to hook and how the plugin can be tested. These are working categories for reasoning about a package; none of them exists as a constant in the codebase, so classify by reading the source rather than looking for an enum.
 
-#### LlmObsCategory Enum Values
+- **LLM client** — calls provider endpoints itself and needs API keys (openai, anthropic, genai). Hook the chat / completion methods.
+- **Multi-provider** — exposes several providers behind one surface, wrapping the clients above (ai, langchain). Hook the provider abstraction layer.
+- **Orchestration** — runs a graph or workflow and holds state, with no provider HTTP of its own (langgraph). Hook the workflow lifecycle (invoke, stream, run).
+- **Infrastructure** — implements a protocol across a client / server split (modelcontextprotocol-sdk). Hook the protocol handlers.
 
-- **`LlmObsCategory.LLM_CLIENT`** - Direct API wrappers (openai, anthropic, genai)
-  - Signs: Makes HTTP calls to LLM provider endpoints, requires API keys
-  - Test strategy: VCR with real API calls via proxy
-  - Instrumentation: Hook chat/completion methods
+The distinctions that decide it: does the package talk to a provider endpoint itself, does it front more than one provider, and does it carry graph state. Test strategy per shape lives in [llmobs-testing](../llmobs-testing/SKILL.md) — including that an orchestration spec drives its nodes with plain return values, not a real model.
 
-- **`LlmObsCategory.MULTI_PROVIDER`** - Multi-provider frameworks (ai-sdk, langchain)
-  - Signs: Supports multiple LLM providers via configuration, wraps LLM_CLIENT libraries
-  - Test strategy: VCR with real API calls via proxy
-  - Instrumentation: Hook provider abstraction layer
-
-- **`LlmObsCategory.ORCHESTRATION`** - Workflow managers (langgraph)
-  - Signs: Graph/workflow execution, state management, NO direct HTTP to LLM providers
-  - Test strategy: Pure function tests, NO VCR, NO real API calls
-  - Instrumentation: Hook workflow lifecycle (invoke, stream, run)
-  - **Special:** Tests should use actual LLM as orchestration node (not mock responses)
-
-- **`LlmObsCategory.INFRASTRUCTURE`** - Protocols/servers (MCP)
-  - Signs: Protocol implementation, server/client architecture, transport layers
-  - Test strategy: Mock server tests
-  - Instrumentation: Hook protocol handlers
-
-#### Decision Tree
-
-Answer these questions by reading the code:
-
-1. **Does the package make direct HTTP calls to LLM provider endpoints?**
-  - YES → Go to question 2
-  - NO → Go to question 3
-
-2. **Does it support multiple LLM providers via configuration?**
-  - YES → **`LlmObsCategory.MULTI_PROVIDER`**
-  - NO → **`LlmObsCategory.LLM_CLIENT`**
-
-3. **Does it implement workflow/graph orchestration with state management?**
-  - YES → **`LlmObsCategory.ORCHESTRATION`**
-  - NO → **`LlmObsCategory.INFRASTRUCTURE`**
-
-See [references/category-detection.md](references/category-detection.md) for detailed heuristics and examples.
+See [references/category-detection.md](references/category-detection.md) for heuristics and worked examples.
 
 ### 3. LLM Span Kinds
 
-Use the `LlmObsSpanKind` enum:
-
-- **`LlmObsSpanKind.LLM`** - Chat completions, text generation
-- **`LlmObsSpanKind.WORKFLOW`** - Graph/chain execution
-- **`LlmObsSpanKind.AGENT`** - Agent runs
-- **`LlmObsSpanKind.TOOL`** - Tool/function calls
-- **`LlmObsSpanKind.EMBEDDING`** - Embedding generation
-- **`LlmObsSpanKind.RETRIEVAL`** - Vector DB/RAG retrieval
-
-**Most common:** Use `'llm'` for chat completions/text generation in LLM_CLIENT and MULTI_PROVIDER categories.
+`SPAN_KINDS` in [`packages/dd-trace/src/llmobs/constants/tags.js`](../../../packages/dd-trace/src/llmobs/constants/tags.js) is the source of truth: `llm`, `agent`, `workflow`, `task`, `tool`, `embedding`, `retrieval`. Chat completions and text generation are `llm`; graph or chain execution is `workflow`; agent runs are `agent`; vector-DB and RAG lookups are `retrieval`.
 
 ### 4. Message Extraction
 

--- a/.agents/skills/llmobs-integration/references/category-detection.md
+++ b/.agents/skills/llmobs-integration/references/category-detection.md
@@ -10,7 +10,7 @@ for reasoning about a package, not constants in the codebase.
 **Definition:** Direct wrappers around LLM provider APIs.
 
 **Examples:**
-- `@google/generative-ai` - Google GenAI client (recommended reference implementation)
+- `@google/genai` - Google GenAI client (recommended reference implementation)
 - `@anthropic-ai/sdk` - Anthropic Claude client (recommended reference implementation)
 - `openai` - OpenAI API client
 
@@ -141,13 +141,15 @@ Check for:
 
 **Package:** `@anthropic-ai/sdk` — see `packages/datadog-plugin-anthropic/`
 
-**Category:** LLM client — name contains "anthropic", direct HTTP calls to Claude API, requires API key, methods are `messages.create`
+**Category:** LLM client — name contains "anthropic", direct HTTP calls to Claude API, requires API key, methods are
+`messages.create`
 
 ### Example 2: Google GenAI (LLM client)
 
-**Package:** `@google/generative-ai` — see `packages/datadog-plugin-google-genai/`
+**Package:** `@google/genai` — see `packages/datadog-plugin-google-genai/`
 
-**Category:** LLM client — name contains "genai", direct HTTP calls to Gemini API, complex nested message format (contents/parts)
+**Category:** LLM client — name contains "genai", direct HTTP calls to Gemini API, complex nested message format
+(contents/parts)
 
 ### Example 3: Vercel AI SDK (multi-provider)
 
@@ -163,11 +165,14 @@ Check for:
 
 **Package:** `@langchain/langgraph` — see `packages/dd-trace/src/llmobs/plugins/langgraph/`
 
-**Category:** orchestration — name indicates graph orchestration, depends on `@langchain/core`, methods manage workflow state (`StateGraph.invoke`, `Pregel.stream`), no direct LLM HTTP calls
+**Category:** orchestration — name indicates graph orchestration, depends on `@langchain/core`, methods manage
+workflow state (`StateGraph.invoke`, `Pregel.stream`), no direct LLM HTTP calls
 
 ## Edge Cases
 
-When signals conflict or are weak, choose the category with the most evidence and prefer the category that matches test strategy needs: if the package makes HTTP calls it needs VCR (LLM client/multi-provider); if it doesn't, use pure functions (orchestration) or mock servers (infrastructure).
+When signals conflict or are weak, choose the category with the most evidence and prefer the category that matches
+test strategy needs: if the package makes HTTP calls it needs VCR (LLM client/multi-provider); if it doesn't, use pure
+functions (orchestration) or mock servers (infrastructure).
 
 Some packages don't fit cleanly:
 - Utilities/helpers → Check what they instrument

--- a/.agents/skills/llmobs-integration/references/category-detection.md
+++ b/.agents/skills/llmobs-integration/references/category-detection.md
@@ -1,10 +1,11 @@
 # Package Category Detection Reference
 
-Detailed guide for classifying LLM packages into `LlmObsCategory` enum values.
+Detailed guide for classifying an LLM package into one of the four shapes. These are working categories
+for reasoning about a package, not constants in the codebase.
 
 ## Categories Explained
 
-### LlmObsCategory.LLM_CLIENT
+### LLM client
 
 **Definition:** Direct wrappers around LLM provider APIs.
 
@@ -23,28 +24,24 @@ Detailed guide for classifying LLM packages into `LlmObsCategory` enum values.
 
 **Test strategy:** VCR with real API calls via proxy
 
-**Enum value:** `LlmObsCategory.LLM_CLIENT`
-
-### LlmObsCategory.MULTI_PROVIDER
+### Multi-provider
 
 **Definition:** Unified interfaces that abstract multiple LLM providers.
 
 **Examples:**
-- `@ai-sdk/vercel` - Vercel AI SDK
+- `ai` - Vercel AI SDK
 - `langchain` - LangChain framework
 
 **Observable signs:**
-- Package name suggests multi-provider (ai-sdk, langchain)
+- Package name suggests multi-provider (ai, langchain)
 - Provider configuration and switching support
-- Wraps multiple Category 1 libraries
+- Wraps multiple LLM client libraries
 - Dependencies include 2+ LLM provider SDKs
 - Has abstraction layers over providers
 
 **Test strategy:** VCR with real API calls via proxy
 
-**Enum value:** `LlmObsCategory.MULTI_PROVIDER`
-
-### LlmObsCategory.ORCHESTRATION
+### Orchestration
 
 **Definition:** Workflow/graph managers that coordinate LLM calls but don't make them directly.
 
@@ -61,9 +58,7 @@ Detailed guide for classifying LLM packages into `LlmObsCategory` enum values.
 
 **Test strategy:** Pure function tests, NO VCR, NO real API calls
 
-**Enum value:** `LlmObsCategory.ORCHESTRATION`
-
-### LlmObsCategory.INFRASTRUCTURE
+### Infrastructure
 
 **Definition:** Communication protocols, server frameworks, infrastructure layers.
 
@@ -79,8 +74,6 @@ Detailed guide for classifying LLM packages into `LlmObsCategory` enum values.
 
 **Test strategy:** Mock server tests
 
-**Enum value:** `LlmObsCategory.INFRASTRUCTURE`
-
 ## Decision Tree
 
 Follow this tree to determine category:
@@ -91,12 +84,12 @@ Follow this tree to determine category:
     └─ NO  → Go to question 3
 
 2. Does it support multiple LLM providers via configuration?
-    ├─ YES → LlmObsCategory.MULTI_PROVIDER
-    └─ NO  → LlmObsCategory.LLM_CLIENT
+    ├─ YES → multi-provider
+    └─ NO  → LLM client
 
 3. Does it implement workflow/graph orchestration with state management?
-    ├─ YES → LlmObsCategory.ORCHESTRATION
-    └─ NO  → LlmObsCategory.INFRASTRUCTURE
+    ├─ YES → orchestration
+    └─ NO  → infrastructure
 ```
 
 ## Detection Process
@@ -104,10 +97,12 @@ Follow this tree to determine category:
 ### Step 1: Read Package Name
 
 Analyze package name for patterns:
-- Contains "openai", "anthropic", "genai" → Likely `LlmObsCategory.LLM_CLIENT`
-- Contains "langchain", "llamaindex", "ai-sdk" → Likely `LlmObsCategory.MULTI_PROVIDER`
-- Contains "langgraph", "crew", "workflow" → Likely `LlmObsCategory.ORCHESTRATION`
-- Contains "mcp", "protocol", "server" → Likely `LlmObsCategory.INFRASTRUCTURE`
+- Contains "openai", "anthropic", "genai" → Likely LLM client
+- Named `ai`, or contains "langchain" or "llamaindex" → Likely multi-provider
+- Contains "langgraph", "crew", "workflow" → Likely orchestration
+- Contains "mcp", "protocol", "server" → Likely infrastructure
+
+"ai" only counts as an exact package name. Every provider client contains it as a substring.
 
 ### Step 2: Check package.json Dependencies
 
@@ -116,10 +111,10 @@ cat node_modules/{{package}}/package.json
 ```
 
 Look for:
-- HTTP clients (axios, fetch, got) → `LlmObsCategory.LLM_CLIENT`
-- Multiple LLM SDKs (openai + anthropic + cohere) → `LlmObsCategory.MULTI_PROVIDER`
-- LangChain/orchestration libs → `LlmObsCategory.ORCHESTRATION`
-- Protocol/transport libs → `LlmObsCategory.INFRASTRUCTURE`
+- HTTP clients (axios, fetch, got) → LLM client
+- Multiple LLM SDKs (openai + anthropic + cohere) → multi-provider
+- LangChain/orchestration libs → orchestration
+- Protocol/transport libs → infrastructure
 
 ### Step 3: Check Exported Methods
 
@@ -128,51 +123,51 @@ node -e "console.log(Object.keys(require('{{package}}')))"
 ```
 
 Method patterns:
-- `chat()`, `complete()`, `embed()` → `LlmObsCategory.LLM_CLIENT` or `MULTI_PROVIDER`
-- `invoke()`, `stream()`, `graph()`, `workflow()` → `LlmObsCategory.ORCHESTRATION`
-- `connect()`, `listen()`, `handle()` → `LlmObsCategory.INFRASTRUCTURE`
+- `chat()`, `complete()`, `embed()` → LLM client or multi-provider
+- `invoke()`, `stream()`, `graph()`, `workflow()` → orchestration
+- `connect()`, `listen()`, `handle()` → infrastructure
 
 ### Step 4: Analyze Source Code
 
 Check for:
-- HTTP request patterns (`http.request`, `.post(`, `fetch(`) → `LlmObsCategory.LLM_CLIENT`
-- Provider switching logic → `LlmObsCategory.MULTI_PROVIDER`
-- State management, graph execution → `LlmObsCategory.ORCHESTRATION`
-- Protocol implementation → `LlmObsCategory.INFRASTRUCTURE`
+- HTTP request patterns (`http.request`, `.post(`, `fetch(`) → LLM client
+- Provider switching logic → multi-provider
+- State management, graph execution → orchestration
+- Protocol implementation → infrastructure
 
 ## Real-World Examples
 
-### Example 1: Anthropic (LLM_CLIENT)
+### Example 1: Anthropic (LLM client)
 
 **Package:** `@anthropic-ai/sdk` — see `packages/datadog-plugin-anthropic/`
 
-**Category:** `LlmObsCategory.LLM_CLIENT` — name contains "anthropic", direct HTTP calls to Claude API, requires API key, methods are `messages.create`
+**Category:** LLM client — name contains "anthropic", direct HTTP calls to Claude API, requires API key, methods are `messages.create`
 
-### Example 2: Google GenAI (LLM_CLIENT)
+### Example 2: Google GenAI (LLM client)
 
 **Package:** `@google/generative-ai` — see `packages/datadog-plugin-google-genai/`
 
-**Category:** `LlmObsCategory.LLM_CLIENT` — name contains "genai", direct HTTP calls to Gemini API, complex nested message format (contents/parts)
+**Category:** LLM client — name contains "genai", direct HTTP calls to Gemini API, complex nested message format (contents/parts)
 
-### Example 3: Vercel AI SDK (MULTI_PROVIDER)
+### Example 3: Vercel AI SDK (multi-provider)
 
 **Package:** `ai` (Vercel AI SDK)
 
-- Name contains "ai-sdk" → multi_provider
+- Named `ai`, not a provider name
 - Depends on openai + anthropic SDKs (multiple LLM providers)
 - Methods include provider-agnostic chat interface
 
-**Category:** `LlmObsCategory.MULTI_PROVIDER`
+**Category:** multi-provider
 
-### Example 4: LangGraph (ORCHESTRATION)
+### Example 4: LangGraph (orchestration)
 
 **Package:** `@langchain/langgraph` — see `packages/dd-trace/src/llmobs/plugins/langgraph/`
 
-**Category:** `LlmObsCategory.ORCHESTRATION` — name indicates graph orchestration, depends on `@langchain/core`, methods manage workflow state (`StateGraph.invoke`, `Pregel.stream`), no direct LLM HTTP calls
+**Category:** orchestration — name indicates graph orchestration, depends on `@langchain/core`, methods manage workflow state (`StateGraph.invoke`, `Pregel.stream`), no direct LLM HTTP calls
 
 ## Edge Cases
 
-When signals conflict or are weak, choose the category with the most evidence and prefer the category that matches test strategy needs: if the package makes HTTP calls it needs VCR (LLM_CLIENT/MULTI_PROVIDER); if it doesn't, use pure functions (ORCHESTRATION) or mock servers (INFRASTRUCTURE).
+When signals conflict or are weak, choose the category with the most evidence and prefer the category that matches test strategy needs: if the package makes HTTP calls it needs VCR (LLM client/multi-provider); if it doesn't, use pure functions (orchestration) or mock servers (infrastructure).
 
 Some packages don't fit cleanly:
 - Utilities/helpers → Check what they instrument

--- a/.agents/skills/llmobs-integration/references/category-detection.md
+++ b/.agents/skills/llmobs-integration/references/category-detection.md
@@ -72,27 +72,13 @@ for reasoning about a package, not constants in the codebase.
 - Implements protocols or server/client architecture
 - Transport layer code
 
-**Test strategy:** Mock server tests
-
-## Decision Tree
-
-Follow this tree to determine category:
-
-```
-1. Does the package make direct HTTP calls to LLM provider endpoints?
-    ├─ YES → Go to question 2
-    └─ NO  → Go to question 3
-
-2. Does it support multiple LLM providers via configuration?
-    ├─ YES → multi-provider
-    └─ NO  → LLM client
-
-3. Does it implement workflow/graph orchestration with state management?
-    ├─ YES → orchestration
-    └─ NO  → infrastructure
-```
+**Test strategy:** the SDK's own server and client over its in-memory transport
 
 ## Detection Process
+
+Direct HTTP calls to provider endpoints mean LLM client, or multi-provider when the provider is
+configurable. Without them, graph or workflow execution means orchestration and a protocol
+implementation means infrastructure.
 
 ### Step 1: Read Package Name
 
@@ -135,44 +121,20 @@ Check for:
 - State management, graph execution → orchestration
 - Protocol implementation → infrastructure
 
-## Real-World Examples
+## Worked Examples
 
-### Example 1: Anthropic (LLM client)
-
-**Package:** `@anthropic-ai/sdk` — see `packages/datadog-plugin-anthropic/`
-
-**Category:** LLM client — name contains "anthropic", direct HTTP calls to Claude API, requires API key, methods are
-`messages.create`
-
-### Example 2: Google GenAI (LLM client)
-
-**Package:** `@google/genai` — see `packages/datadog-plugin-google-genai/`
-
-**Category:** LLM client — name contains "genai", direct HTTP calls to Gemini API, complex nested message format
-(contents/parts)
-
-### Example 3: Vercel AI SDK (multi-provider)
-
-**Package:** `ai` (Vercel AI SDK)
-
-- Named `ai`, not a provider name
-- Depends on openai + anthropic SDKs (multiple LLM providers)
-- Methods include provider-agnostic chat interface
-
-**Category:** multi-provider
-
-### Example 4: LangGraph (orchestration)
-
-**Package:** `@langchain/langgraph` — see `packages/dd-trace/src/llmobs/plugins/langgraph/`
-
-**Category:** orchestration — name indicates graph orchestration, depends on `@langchain/core`, methods manage
-workflow state (`StateGraph.invoke`, `Pregel.stream`), no direct LLM HTTP calls
+| Package | Category | Deciding signal |
+|---------|----------|-----------------|
+| `@anthropic-ai/sdk` | LLM client | `messages.create` calls the Claude API directly, needs a key |
+| `@google/genai` | LLM client | calls the Gemini API directly, nested `contents` / `parts` format |
+| `ai` | multi-provider | not a provider name, and depends on the openai and anthropic SDKs |
+| `@langchain/langgraph` | orchestration | `StateGraph.invoke` / `Pregel.stream` manage state, no provider calls |
 
 ## Edge Cases
 
 When signals conflict or are weak, choose the category with the most evidence and prefer the category that matches
 test strategy needs: if the package makes HTTP calls it needs VCR (LLM client/multi-provider); if it doesn't, use pure
-functions (orchestration) or mock servers (infrastructure).
+functions (orchestration) or the SDK's in-memory transport (infrastructure).
 
 Some packages don't fit cleanly:
 - Utilities/helpers → Check what they instrument

--- a/.agents/skills/llmobs-integration/references/category-detection.md
+++ b/.agents/skills/llmobs-integration/references/category-detection.md
@@ -1,7 +1,7 @@
-# Package Category Detection Reference
+# Instrumented Surface Detection Reference
 
-Detailed guide for classifying an LLM package into one of the four shapes. These are working categories
-for reasoning about a package, not constants in the codebase.
+Detailed guide for classifying an instrumented surface by how it gets responses. These are working categories,
+not constants in the codebase. The operation itself determines its span kind and fields.
 
 ## Categories Explained
 
@@ -15,14 +15,12 @@ for reasoning about a package, not constants in the codebase.
 - `openai` - OpenAI API client
 
 **Observable signs:**
-- Package name contains provider name (openai, anthropic, genai, etc.)
 - Has chat/completion/embedding methods (`chat.completions.create`, `messages.create`)
 - Makes HTTP calls directly to LLM provider endpoints
-- Requires API keys for authentication
-- Has HTTP client dependencies (axios, fetch, request)
-- Code contains HTTP request patterns
+- Owns provider authentication and endpoint configuration
+- Uses an HTTP client or the runtime's `fetch`
 
-**Test strategy:** VCR with real API calls via proxy
+**Test strategy:** exercise the real client through VCR or a canned `fetch`
 
 ### Multi-provider
 
@@ -33,13 +31,12 @@ for reasoning about a package, not constants in the codebase.
 - `langchain` - LangChain framework
 
 **Observable signs:**
-- Package name suggests multi-provider (ai, langchain)
 - Provider configuration and switching support
 - Wraps multiple LLM client libraries
-- Dependencies include 2+ LLM provider SDKs
+- Accepts provider adapters or SDK instances, often from separate packages
 - Has abstraction layers over providers
 
-**Test strategy:** VCR with real API calls via proxy
+**Test strategy:** exercise the real provider path through VCR or an injected `fetch`
 
 ### Orchestration
 
@@ -50,7 +47,6 @@ for reasoning about a package, not constants in the codebase.
 - Workflow engines, agent coordinators
 
 **Observable signs:**
-- Package name suggests orchestration (langgraph, crew, workflow, graph)
 - Has graph/workflow/chain execution methods (`invoke`, `stream`, `run`)
 - Manages state and control flow between nodes/agents
 - Dependencies include orchestration libraries (e.g., @langchain/core)
@@ -68,7 +64,6 @@ for reasoning about a package, not constants in the codebase.
 - Transport layers
 
 **Observable signs:**
-- Package name suggests infrastructure (mcp, protocol, server, transport)
 - Implements protocols or server/client architecture
 - Transport layer code
 
@@ -76,50 +71,34 @@ for reasoning about a package, not constants in the codebase.
 
 ## Detection Process
 
-Direct HTTP calls to provider endpoints mean LLM client, or multi-provider when the provider is
-configurable. Without them, graph or workflow execution means orchestration and a protocol
-implementation means infrastructure.
+The component that performs provider HTTP determines the response strategy. A configurable provider surface is
+multi-provider even when the caller supplies the provider from another package. Without provider traffic, graph or
+workflow execution means orchestration and a protocol implementation means infrastructure.
 
-### Step 1: Read Package Name
+### Step 1: Read the Installed Source
 
-Analyze package name for patterns:
-- Contains "openai", "anthropic", "genai" → Likely LLM client
-- Named `ai`, or contains "langchain" or "llamaindex" → Likely multi-provider
-- Contains "langgraph", "crew", "workflow" → Likely orchestration
-- Contains "mcp", "protocol", "server" → Likely infrastructure
+Inspect `versions/<package>@<range>/node_modules/<package>/` and find the exported operation being instrumented.
+Follow that operation through wrappers and adapters to the code that produces its result.
 
-"ai" only counts as an exact package name. Every provider client contains it as a substring.
+### Step 2: Find the Response Owner
 
-### Step 2: Check package.json Dependencies
+- Direct provider HTTP from the package → LLM client
+- A caller-supplied provider adapter or model implementation → multi-provider
+- Node/state execution with no provider transport → orchestration
+- Client/server protocol handlers over a transport → infrastructure
 
-```bash
-cat node_modules/{{package}}/package.json
-```
+### Step 3: Check Configuration and Dependencies
 
-Look for:
-- HTTP clients (axios, fetch, got) → LLM client
-- Multiple LLM SDKs (openai + anthropic + cohere) → multi-provider
-- LangChain/orchestration libs → orchestration
-- Protocol/transport libs → infrastructure
+Use `package.json` and constructor options to confirm the source trace:
+- Provider credentials, endpoints and HTTP clients support an LLM-client classification
+- Provider adapter interfaces or separate provider packages support multi-provider
+- State/graph dependencies support orchestration
+- Protocol and transport dependencies support infrastructure
 
-### Step 3: Check Exported Methods
+### Step 4: Use the Name Only as a Weak Signal
 
-```bash
-node -e "console.log(Object.keys(require('{{package}}')))"
-```
-
-Method patterns:
-- `chat()`, `complete()`, `embed()` → LLM client or multi-provider
-- `invoke()`, `stream()`, `graph()`, `workflow()` → orchestration
-- `connect()`, `listen()`, `handle()` → infrastructure
-
-### Step 4: Analyze Source Code
-
-Check for:
-- HTTP request patterns (`http.request`, `.post(`, `fetch(`) → LLM client
-- Provider switching logic → multi-provider
-- State management, graph execution → orchestration
-- Protocol implementation → infrastructure
+Names such as `openai`, `langgraph`, or `mcp` are useful search hints, not classifications. Hybrid packages and
+provider adapters are classified per instrumented operation, regardless of package name.
 
 ## Worked Examples
 
@@ -127,16 +106,16 @@ Check for:
 |---------|----------|-----------------|
 | `@anthropic-ai/sdk` | LLM client | `messages.create` calls the Claude API directly, needs a key |
 | `@google/genai` | LLM client | calls the Gemini API directly, nested `contents` / `parts` format |
-| `ai` | multi-provider | not a provider name, and depends on the openai and anthropic SDKs |
+| `ai` | multi-provider | accepts separately installed provider implementations behind one API |
 | `@langchain/langgraph` | orchestration | `StateGraph.invoke` / `Pregel.stream` manage state, no provider calls |
 
 ## Edge Cases
 
-When signals conflict or are weak, choose the category with the most evidence and prefer the category that matches
-test strategy needs: if the package makes HTTP calls it needs VCR (LLM client/multi-provider); if it doesn't, use pure
-functions (orchestration) or the SDK's in-memory transport (infrastructure).
+When signals conflict or are weak, classify each instrumented surface by its response source. Provider-backed calls
+use VCR or an injected `fetch`; orchestration uses plain node responses; infrastructure uses the SDK's in-memory
+transport.
 
 Some packages don't fit cleanly:
 - Utilities/helpers → Check what they instrument
 - Plugins/extensions → Follow parent library category
-- Hybrid packages → Categorize by primary function
+- Hybrid packages → Classify each instrumented operation separately

--- a/.agents/skills/llmobs-integration/references/message-extraction.md
+++ b/.agents/skills/llmobs-integration/references/message-extraction.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Every LLM provider uses a different message format. Before implementing message extraction, you **must** read the provider's actual source code and existing plugin implementation to understand its specific format.
+Every LLM provider uses a different message format. Before implementing message extraction, you **must** read the
+provider's actual source code and existing plugin implementation to understand its specific format.
 
 All plugins must normalize messages to the standard LLMObs format: `[{ content: string, role: string }]`
 
@@ -23,12 +24,14 @@ Common variations include:
 - **Simple array** — messages are already `[{role, content}]` (e.g. OpenAI)
 - **Nested content blocks** — content is an array of typed objects (e.g. Anthropic `[{type: 'text', text: '...'}]`)
 - **Parts format** — messages use a `parts` array inside a `contents` array (e.g. Google GenAI)
-- **Role normalization** — provider uses different role names that must be mapped (e.g. Google's `'model'` → `'assistant'`)
+- **Role normalization** — provider uses different role names that must be mapped (e.g. Google's `'model'` →
+  `'assistant'`)
 - **Streaming** — content arrives as deltas that must be accumulated across chunks
 
 ## How to Research a New Provider
 
-1. Read the existing tracing plugin for the package (`packages/datadog-plugin-<name>/src/index.js`) to understand what arguments and results look like
+1. Read the existing tracing plugin for the package (`packages/datadog-plugin-<name>/src/index.js`) to understand what
+   arguments and results look like
 2. Look at the provider's SDK source or API docs to understand response shapes
 3. Check an existing LLMObs plugin for a similar provider as a reference
 
@@ -42,6 +45,7 @@ The best examples of message extraction for the providers we support:
 
 - Always handle null/undefined with fallback defaults (`|| ''` and `|| []`)
 - Normalize `'model'` role to `'assistant'` for consistency (preserve `'system'`, `'tool'`, `'function'`)
-- For array content parts, the separator is the provider's, not a default: `genai/util.js` joins text parts with `'\n'`, `anthropic/util.js` with `','`
+- For array content parts, the separator is the provider's, not a default: `genai/util.js` joins text parts with
+  `'\n'`, `anthropic/util.js` with `','`
 - For streaming, accumulate delta content across chunks before tagging
 - Always return `[{ content: '', role: '' }]` on error (never omit output messages)

--- a/.agents/skills/llmobs-integration/references/message-extraction.md
+++ b/.agents/skills/llmobs-integration/references/message-extraction.md
@@ -5,7 +5,9 @@
 Every LLM provider uses a different message format. Before implementing message extraction, you **must** read the
 provider's actual source code and existing plugin implementation to understand its specific format.
 
-All plugins must normalize messages to the standard LLMObs format: `[{ content: string, role: string }]`
+`llm` operations pass message objects to `tagLLMIO`. The tagger defaults a missing role to `''` and supports
+content, tool-call, tool-result and audio fields; a tool-only message need not carry content.
+Embedding, retrieval, workflow, agent, task, step, and tool operations use documents or text values instead.
 
 Common roles: `'user'`, `'assistant'`, `'system'`, `'tool'`
 
@@ -37,14 +39,16 @@ Common variations include:
 ## Reference Implementations
 
 The best examples of message extraction for the providers we support:
-- Anthropic: [`packages/dd-trace/src/llmobs/plugins/anthropic/util.js`](../../../../packages/dd-trace/src/llmobs/plugins/anthropic/util.js)
-- Google GenAI: [`packages/dd-trace/src/llmobs/plugins/genai/util.js`](../../../../packages/dd-trace/src/llmobs/plugins/genai/util.js)
+- Anthropic: `packages/dd-trace/src/llmobs/plugins/anthropic/util.js`
+- Google GenAI: `packages/dd-trace/src/llmobs/plugins/genai/util.js`
 
 ## Key Implementation Notes
 
-- Always handle null/undefined with fallback defaults (`|| ''` and `|| []`)
+- Preserve valid falsy values. Use nullish defaults such as `?? ''` or `?? []` when only `null` / `undefined` mean
+  absent, and follow the provider's semantics when an empty value also means absent
 - Normalize `'model'` role to `'assistant'` for consistency (preserve `'system'`, `'tool'`, `'function'`)
 - For array content parts, the separator is the provider's, not a default: `genai/util.js` joins text parts with
   `'\n'`, `anthropic/util.js` with `','`
 - For streaming, accumulate delta content across chunks before tagging
-- Always return `[{ content: '', role: '' }]` on error (never omit output messages)
+- Error output follows the integration contract: OpenAI and GenAI emit an empty message, while Anthropic omits
+  output when there is no result

--- a/.agents/skills/llmobs-integration/references/message-extraction.md
+++ b/.agents/skills/llmobs-integration/references/message-extraction.md
@@ -30,8 +30,7 @@ Common variations include:
 
 ## How to Research a New Provider
 
-1. Read the existing tracing plugin for the package (`packages/datadog-plugin-<name>/src/index.js`) to understand what
-   arguments and results look like
+1. Read the package's tracing plugin (`packages/datadog-plugin-<name>/src/index.js`) for argument and result shapes
 2. Look at the provider's SDK source or API docs to understand response shapes
 3. Check an existing LLMObs plugin for a similar provider as a reference
 

--- a/.agents/skills/llmobs-integration/references/message-extraction.md
+++ b/.agents/skills/llmobs-integration/references/message-extraction.md
@@ -42,6 +42,6 @@ The best examples of message extraction for the providers we support:
 
 - Always handle null/undefined with fallback defaults (`|| ''` and `|| []`)
 - Normalize `'model'` role to `'assistant'` for consistency (preserve `'system'`, `'tool'`, `'function'`)
-- For array content parts (Anthropic, Google), join text parts with `''`
+- For array content parts, the separator is the provider's, not a default: `genai/util.js` joins text parts with `'\n'`, `anthropic/util.js` with `','`
 - For streaming, accumulate delta content across chunks before tagging
 - Always return `[{ content: '', role: '' }]` on error (never omit output messages)

--- a/.agents/skills/llmobs-integration/references/message-extraction.md
+++ b/.agents/skills/llmobs-integration/references/message-extraction.md
@@ -35,8 +35,8 @@ Common variations include:
 ## Reference Implementations
 
 The best examples of message extraction for the providers we support:
-- Anthropic: [`packages/datadog-plugin-anthropic/src/llmobs.js`](../../../../../packages/datadog-plugin-anthropic/src/llmobs.js)
-- Google GenAI: [`packages/datadog-plugin-google-genai/src/llmobs.js`](../../../../../packages/datadog-plugin-google-genai/src/llmobs.js)
+- Anthropic: [`packages/dd-trace/src/llmobs/plugins/anthropic/util.js`](../../../../packages/dd-trace/src/llmobs/plugins/anthropic/util.js)
+- Google GenAI: [`packages/dd-trace/src/llmobs/plugins/genai/util.js`](../../../../packages/dd-trace/src/llmobs/plugins/genai/util.js)
 
 ## Key Implementation Notes
 

--- a/.agents/skills/llmobs-integration/references/plugin-architecture.md
+++ b/.agents/skills/llmobs-integration/references/plugin-architecture.md
@@ -4,9 +4,10 @@ Guide to implementing LLMObs plugins in dd-trace-js.
 
 ## Base Class
 
-All LLMObs plugins extend `LLMObsPlugin` at `packages/dd-trace/src/llmobs/plugins/base.js`.
+Leaf plugins extend `LLMObsPlugin` at `packages/dd-trace/src/llmobs/plugins/base.js`. A composite root can extend
+`CompositePlugin` and select among leaf implementations, as `ai/index.js` does.
 
-The base class handles span registration, context management, and lifecycle hooks. Plugins only need to implement two
+The LLMObs base class handles span registration, context management, and lifecycle hooks. Leaf plugins implement two
 methods.
 
 ## Required Methods
@@ -16,11 +17,13 @@ methods.
 Defines span metadata for registration with LLMObs. Called at span start.
 
 **Returns** an object with:
-- `kind` (string) — span type, from `SPAN_KINDS`: `'llm'`, `'agent'`, `'workflow'`, `'task'`, `'tool'`, `'embedding'`,
-  `'retrieval'`
-- `name` (string) — operation name (e.g. `'openai.chat.completions'`)
+- `kind` (string) — span type. `SPAN_KINDS` lists `'llm'`, `'agent'`, `'workflow'`, `'task'`, `'tool'`, `'embedding'`,
+  and `'retrieval'`; plugin extensions such as `'step'` also exist
+- `name` (string, optional) — operation name (e.g. `'openai.chat.completions'`); the event falls back to the APM
+  span name when omitted
 - `modelProvider` (string, optional) — provider name (e.g. `'openai'`, `'anthropic'`, `'google'`)
 - `modelName` (string, optional) — model identifier (e.g. `'gpt-4'`, `'claude-3-sonnet'`)
+- `sessionId` (string, optional) — session identifier when the integration supplies one
 
 **Return nothing** to skip recording an LLMObs span for a given `ctx` entirely — `base.js` only tests the
 result for truthiness, and the plugins use a bare `return` (`openai/index.js` does this for the methods it
@@ -31,39 +34,40 @@ does not trace).
 Extracts and tags LLM-specific data after the operation completes. Called in `asyncEnd`.
 
 Responsibilities:
-1. Extract input messages/data from `ctx.arguments`
-2. Extract output messages/data from `ctx.result`
-3. Extract token usage metrics
-4. Extract model parameters (metadata)
+1. Extract the kind-specific input from the channel's `ctx` fields
+2. Extract the kind-specific output from the channel's `ctx` fields
+3. Extract token usage metrics when available
+4. Extract model parameters when available
 5. Tag all data via `this._tagger` methods (see below)
 
-Always tag inputs. On error, tag empty outputs. On success, tag outputs, metrics, and metadata.
+Tag the input when the channel provides it. Error output is integration-specific: OpenAI and GenAI use an empty
+message, while integrations without a result omit output. Pin that contract in the integration's spec.
 
 ## Plugin Lifecycle
 
-1. `start(ctx)` — registers the LLMObs span, captures parent context
-2. Operation executes
-3. `asyncEnd(ctx)` — calls `setLLMObsTags()` to extract and tag data
-4. `end(ctx)` — restores parent context
+1. `start(ctx)` — registers the LLMObs span and captures parent context
+2. The wrapped operation is invoked
+3. `end(ctx)` — restores parent context after the wrapped call returns
+4. `asyncEnd(ctx)` — calls `setLLMObsTags()` after a promise-backed operation settles
 
 ## Tagger Methods
 
 Tag data using `this._tagger`, which provides:
 
 - `tagLLMIO(span, inputMessages, outputMessages)` — for `llm` spans
-- `tagEmbeddingIO(span, inputDocuments, outputDocuments)` — for `embedding` spans
-- `tagRetrievalIO(span, inputDocuments, outputDocuments)` — for `retrieval` spans
-- `tagTextIO(span, inputValue, outputValue)` — for `workflow`, `agent`, `tool` spans
+- `tagEmbeddingIO(span, inputDocuments, outputValue)` — for `embedding` spans
+- `tagRetrievalIO(span, inputValue, outputDocuments)` — for `retrieval` spans
+- `tagTextIO(span, inputValue, outputValue)` — for `workflow`, `agent`, `task`, `step`, and `tool` spans
 - `tagMetadata(span, metadata)` — model parameters (temperature, max_tokens, etc.)
 - `tagMetrics(span, metrics)` — token usage (`input_tokens`, `output_tokens`, `total_tokens`)
 - `tagSpanTags(span, tags)` — arbitrary key/value span tags
-- `tagPrompt(span, prompt)` — prompt tracking metadata
+- `tagPrompt(span, prompt, strictValidation = false)` — prompt tracking metadata
 - `tagToolDefinitions(span, toolDefinitions)` — the tools a request declared, for tool-calling integrations
 - `tagModelName(span, modelName)` — a model name discovered after registration
 
 ## Static Properties
 
-Each plugin class needs:
+Each leaf plugin class needs:
 - `static integration` — integration name for LLMObs telemetry (`'openai'`, `'google_genai'`)
 - `static id` — unique plugin ID. Often the same string as the integration (`'openai'`), but not
   necessarily: genai pairs `id = 'google-genai'` with `integration = 'google_genai'`. A package that hooks
@@ -72,19 +76,22 @@ Each plugin class needs:
 
 ## Error Handling
 
-Always tag empty outputs on error to ensure consistent span structure:
+OpenAI and GenAI tag an empty output message on error:
 
 ```javascript
 if (ctx.error) {
-  this._tagger.tagLLMIO(span, inputMessages, [{ content: '', role: '' }])
+  this._tagger.tagLLMIO(span, inputMessages, [{ content: '' }])
   return
 }
 ```
+
+That is not a base-class invariant. Anthropic omits output when no result exists, and non-`llm` integrations follow
+their own kind-specific contract.
 
 ## Reference Implementations
 
 See existing plugins for complete working examples:
 - `packages/dd-trace/src/llmobs/plugins/openai/index.js` — simple messages array, standard token usage
-- `packages/dd-trace/src/llmobs/plugins/anthropic/util.js` — nested content arrays, different token field names
+- `packages/dd-trace/src/llmobs/plugins/anthropic/` — nested content in `util.js`, usage extraction in `index.js`
 - `packages/dd-trace/src/llmobs/plugins/genai/util.js` — contents/parts format, role normalization
 - `packages/dd-trace/src/llmobs/plugins/langgraph/index.js` — orchestration, `workflow` span kind, no messages

--- a/.agents/skills/llmobs-integration/references/plugin-architecture.md
+++ b/.agents/skills/llmobs-integration/references/plugin-architecture.md
@@ -6,7 +6,8 @@ Guide to implementing LLMObs plugins in dd-trace-js.
 
 All LLMObs plugins extend `LLMObsPlugin` at `packages/dd-trace/src/llmobs/plugins/base.js`.
 
-The base class handles span registration, context management, and lifecycle hooks. Plugins only need to implement two methods.
+The base class handles span registration, context management, and lifecycle hooks. Plugins only need to implement two
+methods.
 
 ## Required Methods
 
@@ -15,7 +16,8 @@ The base class handles span registration, context management, and lifecycle hook
 Defines span metadata for registration with LLMObs. Called at span start.
 
 **Returns** an object with:
-- `kind` (string) — span type, from `SPAN_KINDS`: `'llm'`, `'agent'`, `'workflow'`, `'task'`, `'tool'`, `'embedding'`, `'retrieval'`
+- `kind` (string) — span type, from `SPAN_KINDS`: `'llm'`, `'agent'`, `'workflow'`, `'task'`, `'tool'`, `'embedding'`,
+  `'retrieval'`
 - `name` (string) — operation name (e.g. `'openai.chat.completions'`)
 - `modelProvider` (string, optional) — provider name (e.g. `'openai'`, `'anthropic'`, `'google'`)
 - `modelName` (string, optional) — model identifier (e.g. `'gpt-4'`, `'claude-3-sonnet'`)
@@ -57,16 +59,16 @@ Tag data using `this._tagger`, which provides:
 - `tagSpanTags(span, tags)` — arbitrary key/value span tags
 - `tagPrompt(span, prompt)` — prompt tracking metadata
 - `tagToolDefinitions(span, toolDefinitions)` — the tools a request declared, for tool-calling integrations
-- `tagCostTags(span, costTags, source)` — provider-reported cost
 - `tagModelName(span, modelName)` — a model name discovered after registration
 
 ## Static Properties
 
 Each plugin class needs:
-- `static integration` — integration name (e.g. `'openai'`)
-- `static id` — unique plugin ID, matching the integration for a single-plugin package (`'openai'`) and
-  qualified per hooked operation when a package needs several (`'llmobs_langgraph_pregel_stream'`)
-- `static prefix` — diagnostic channel prefix (e.g. `'tracing:apm:openai:chat'`)
+- `static integration` — integration name for LLMObs telemetry (`'openai'`, `'google_genai'`)
+- `static id` — unique plugin ID. Often the same string as the integration (`'openai'`), but not
+  necessarily: genai pairs `id = 'google-genai'` with `integration = 'google_genai'`. A package that hooks
+  several operations qualifies it per operation (`'llmobs_langgraph_pregel_stream'`)
+- `static prefix` — diagnostic channel prefix (e.g. `'tracing:apm:openai:request'`)
 
 ## Error Handling
 

--- a/.agents/skills/llmobs-integration/references/plugin-architecture.md
+++ b/.agents/skills/llmobs-integration/references/plugin-architecture.md
@@ -15,12 +15,14 @@ The base class handles span registration, context management, and lifecycle hook
 Defines span metadata for registration with LLMObs. Called at span start.
 
 **Returns** an object with:
-- `kind` (string) — span type: `'llm'`, `'embedding'`, `'workflow'`, `'agent'`, `'tool'`, `'retrieval'`
+- `kind` (string) — span type, from `SPAN_KINDS`: `'llm'`, `'agent'`, `'workflow'`, `'task'`, `'tool'`, `'embedding'`, `'retrieval'`
 - `name` (string) — operation name (e.g. `'openai.chat.completions'`)
 - `modelProvider` (string, optional) — provider name (e.g. `'openai'`, `'anthropic'`, `'google'`)
 - `modelName` (string, optional) — model identifier (e.g. `'gpt-4'`, `'claude-3-sonnet'`)
 
-**Return `null`** to skip recording an LLMObs span for a given `ctx` entirely.
+**Return nothing** to skip recording an LLMObs span for a given `ctx` entirely — `base.js` only tests the
+result for truthiness, and the plugins use a bare `return` (`openai/index.js` does this for the methods it
+does not trace).
 
 ### setLLMObsTags(ctx)
 
@@ -54,12 +56,16 @@ Tag data using `this._tagger`, which provides:
 - `tagMetrics(span, metrics)` — token usage (`input_tokens`, `output_tokens`, `total_tokens`)
 - `tagSpanTags(span, tags)` — arbitrary key/value span tags
 - `tagPrompt(span, prompt)` — prompt tracking metadata
+- `tagToolDefinitions(span, toolDefinitions)` — the tools a request declared, for tool-calling integrations
+- `tagCostTags(span, costTags, source)` — provider-reported cost
+- `tagModelName(span, modelName)` — a model name discovered after registration
 
 ## Static Properties
 
 Each plugin class needs:
 - `static integration` — integration name (e.g. `'openai'`)
-- `static id` — unique plugin ID (e.g. `'llmobs_openai'`)
+- `static id` — unique plugin ID, matching the integration for a single-plugin package (`'openai'`) and
+  qualified per hooked operation when a package needs several (`'llmobs_langgraph_pregel_stream'`)
 - `static prefix` — diagnostic channel prefix (e.g. `'tracing:apm:openai:chat'`)
 
 ## Error Handling

--- a/.agents/skills/llmobs-integration/references/plugin-architecture.md
+++ b/.agents/skills/llmobs-integration/references/plugin-architecture.md
@@ -77,6 +77,6 @@ if (ctx.error) {
 
 See existing plugins for complete working examples:
 - `packages/dd-trace/src/llmobs/plugins/openai/index.js` — simple messages array, standard token usage
-- `packages/datadog-plugin-anthropic/src/llmobs.js` — nested content arrays, different token field names
-- `packages/datadog-plugin-google-genai/src/llmobs.js` — contents/parts format, role normalization
+- `packages/dd-trace/src/llmobs/plugins/anthropic/util.js` — nested content arrays, different token field names
+- `packages/dd-trace/src/llmobs/plugins/genai/util.js` — contents/parts format, role normalization
 - `packages/dd-trace/src/llmobs/plugins/langgraph/index.js` — orchestration, `workflow` span kind, no messages

--- a/.agents/skills/llmobs-integration/references/reference-implementations.md
+++ b/.agents/skills/llmobs-integration/references/reference-implementations.md
@@ -36,7 +36,7 @@ The abstract base class all plugins extend.
 
 ### Anthropic Plugin
 
-**Location:** `packages/datadog-plugin-anthropic/src/llmobs.js`
+**Location:** `packages/dd-trace/src/llmobs/plugins/anthropic/` (`index.js` + `util.js`)
 
 **Category:** LLM API Client
 
@@ -49,7 +49,7 @@ The abstract base class all plugins extend.
 
 ### Google GenAI Plugin
 
-**Location:** `packages/datadog-plugin-google-genai/src/llmobs.js`
+**Location:** `packages/dd-trace/src/llmobs/plugins/genai/` (`index.js` + `util.js`)
 
 **Category:** LLM API Client
 
@@ -64,7 +64,7 @@ The abstract base class all plugins extend.
 
 ### Vercel AI SDK
 
-**Location:** `packages/datadog-plugin-ai-sdk/src/llmobs.js`
+**Location:** `packages/dd-trace/src/llmobs/plugins/ai/` (`ddTelemetry.js` + `vercelTelemetry.js` behind a `CompositePlugin`)
 
 **Category:** Multi-Provider Framework
 
@@ -79,7 +79,7 @@ The abstract base class all plugins extend.
 
 ### LangChain LangGraph
 
-**Location:** `packages/datadog-plugin-langchain-langgraph/src/llmobs.js`
+**Location:** `packages/dd-trace/src/llmobs/plugins/langchain/` and `.../langgraph/` (separate plugins)
 
 **Category:** Pure Orchestration
 
@@ -179,10 +179,10 @@ See `packages/datadog-plugin-google-genai/src/index.js` for a reference implemen
 Test files demonstrate expected span structure and assertions:
 
 **Locations:**
-- `packages/dd-trace/test/llmobs/plugins/openai/index.spec.js`
+- `packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js`
 - `packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js`
 - `packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js`
-- `packages/dd-trace/test/llmobs/plugins/langchain-langgraph/index.spec.js`
+- `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js`
 
 ## How to Use References
 

--- a/.agents/skills/llmobs-integration/references/reference-implementations.md
+++ b/.agents/skills/llmobs-integration/references/reference-implementations.md
@@ -106,55 +106,8 @@ proxy.
 | Vercel AI SDK | Multi-Provider | Medium | Provider abstraction |
 | LangGraph | Orchestration | Simple | Workflow spans, state management |
 
-## Key Patterns by Provider
-
-### OpenAI Pattern
-```javascript
-// Messages: Simple array
-inputs.messages → [{role, content}]
-
-// Response: choices array
-results.choices[0].message → {role, content}
-
-// Tokens: Standard names
-usage.prompt_tokens, usage.completion_tokens
-```
-
-### Anthropic Pattern
-```javascript
-// Messages: Content blocks
-msg.content[0].text → Extract text from blocks
-
-// Response: Content array
-results.content.filter(c => c.type === 'text')
-
-// Tokens: Different names
-usage.input_tokens, usage.output_tokens
-```
-
-### Google Pattern
-```javascript
-// Messages: Parts format
-contents → [{role, parts: [{text}]}]
-
-// Response: Candidates
-candidates[0].content.parts → Join text
-
-// Tokens: Mixed names
-usageMetadata.promptTokenCount, candidatesTokenCount
-```
-
-### LangGraph Pattern
-```javascript
-// Input: State objects
-StateGraph state → Extract relevant fields
-
-// Output: State changes
-Track state transitions, not LLM responses
-
-// Span kind: 'workflow' not 'llm'
-kind: 'workflow' for graph execution
-```
+Per-provider request, response and token-field shapes live in
+[message-extraction.md](message-extraction.md).
 
 ## Streaming Implementations
 
@@ -190,38 +143,5 @@ Test files demonstrate expected span structure and assertions:
 - `packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js`
 - `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js`
 
-## How to Use References
-
-### Starting Point
-
-1. Read `base.js` to understand abstract methods
-2. Study OpenAI plugin for simplest example
-3. Look at Anthropic/Google for complex formats
-
-### Finding Similar Patterns
-
-1. Check message format in provider docs
-2. Find reference plugin with similar format
-3. Adapt extraction logic
-
-### Debugging
-
-1. Compare your plugin with reference
-2. Check test files for expected structure
-3. Verify message format matches standard
-
-## Quick Reference Guide
-
-**Simple formats (messages array):** Use OpenAI pattern
-
-**Nested content:** Use Anthropic pattern
-
-**Multi-level nesting:** Use Google pattern
-
-**Multiple providers:** Use Vercel AI SDK pattern
-
-**Orchestration/workflows:** Use LangGraph pattern
-
-**Streaming:** Check OpenAI streaming implementation
-
-**CompositePlugin:** Check Anthropic integration
+Start from `base.js` for the abstract methods, then the plugin above whose message format is closest to the
+one you are adding.

--- a/.agents/skills/llmobs-integration/references/reference-implementations.md
+++ b/.agents/skills/llmobs-integration/references/reference-implementations.md
@@ -64,7 +64,8 @@ The abstract base class all plugins extend.
 
 ### Vercel AI SDK
 
-**Location:** `packages/dd-trace/src/llmobs/plugins/ai/` (`ddTelemetry.js` + `vercelTelemetry.js` behind a `CompositePlugin`)
+**Location:** `packages/dd-trace/src/llmobs/plugins/ai/` (`ddTelemetry.js` + `vercelTelemetry.js` behind a
+`CompositePlugin`)
 
 **Category:** Multi-Provider Framework
 
@@ -77,9 +78,9 @@ The abstract base class all plugins extend.
 
 ## Orchestration Examples
 
-### LangChain LangGraph
+### LangGraph
 
-**Location:** `packages/dd-trace/src/llmobs/plugins/langchain/` and `.../langgraph/` (separate plugins)
+**Location:** `packages/dd-trace/src/llmobs/plugins/langgraph/`
 
 **Category:** Pure Orchestration
 
@@ -88,6 +89,10 @@ The abstract base class all plugins extend.
 - State management tracking
 - Uses 'workflow' span kind instead of 'llm'
 - No direct LLM API calls
+
+LangChain is a separate plugin (`packages/dd-trace/src/llmobs/plugins/langchain/`) and is not
+orchestration: it returns `llm`, `embedding`, `tool` and `retrieval` kinds and its spec runs over the VCR
+proxy.
 
 **Good for:** Workflow instrumentation, non-LLM span kinds
 
@@ -170,7 +175,8 @@ kind: 'workflow' for graph execution
 
 ## CompositePlugin Integration
 
-Some plugins integrate LLMObs with tracing plugins using `CompositePlugin`. The plugin class declares a `static plugins` field mapping keys to plugin classes.
+Some plugins integrate LLMObs with tracing plugins using `CompositePlugin`. The plugin class declares a
+`static plugins` field mapping keys to plugin classes.
 
 See `packages/datadog-plugin-google-genai/src/index.js` for a reference implementation.
 

--- a/.agents/skills/llmobs-integration/references/reference-implementations.md
+++ b/.agents/skills/llmobs-integration/references/reference-implementations.md
@@ -6,18 +6,19 @@ Working examples of LLMObs plugins in dd-trace-js.
 
 **Location:** `packages/dd-trace/src/llmobs/plugins/base.js`
 
-The abstract base class all plugins extend.
+The abstract base class leaf plugins extend. Composite roots such as `ai/index.js` extend `CompositePlugin`
+instead.
 
 **Key methods:**
 - `start(ctx)` - Registers span, captures context
 - `getLLMObsSpanRegisterOptions(ctx)` - Abstract, must implement
 - `setLLMObsTags(ctx)` - Abstract, must implement
-- `asyncEnd(ctx)` - Calls setLLMObsTags
-- `end(ctx)` - Restores context
+- `end(ctx)` - Restores context after the wrapped call returns
+- `asyncEnd(ctx)` - Calls setLLMObsTags after the operation settles
 
 **Tagger methods** (accessed via `this._tagger`):
 - `tagLLMIO`, `tagEmbeddingIO`, `tagRetrievalIO`, `tagTextIO`
-- `tagMetadata`, `tagMetrics`, `tagSpanTags`, `tagPrompt`
+- `tagMetadata`, `tagMetrics`, `tagSpanTags`, `tagPrompt`, `tagToolDefinitions`, `tagModelName`
 
 ## Simple LLM Client Examples
 
@@ -90,9 +91,8 @@ The abstract base class all plugins extend.
 - Uses 'workflow' span kind instead of 'llm'
 - No direct LLM API calls
 
-LangChain is a separate plugin (`packages/dd-trace/src/llmobs/plugins/langchain/`) and is not
-orchestration: it returns `llm`, `embedding`, `tool` and `retrieval` kinds and its spec runs over the VCR
-proxy.
+LangChain is a separate hybrid plugin (`packages/dd-trace/src/llmobs/plugins/langchain/`). It emits `workflow`,
+`llm`, `embedding`, `tool`, and `retrieval` spans. Provider-backed cases run over the VCR proxy.
 
 **Good for:** Workflow instrumentation, non-LLM span kinds
 
@@ -121,15 +121,14 @@ Per-provider request, response and token-field shapes live in
 
 ### General Streaming Approach
 
-1. Maintain buffer keyed by request/span ID
-2. On each chunk, extract delta and append to buffer
-3. On completion, tag accumulated content
-4. Clear buffer for that request
+Use the contract the instrumentation already publishes. Anthropic and GenAI append chunks to the operation's `ctx`
+and build `ctx.result` when the chunk channel reports `done`; OpenAI's instrumentation builds the result before
+publishing `asyncEnd`. The plugin tags that final result instead of maintaining a second request-keyed buffer.
 
 ## CompositePlugin Integration
 
-Some plugins integrate LLMObs with tracing plugins using `CompositePlugin`. The plugin class declares a
-`static plugins` field mapping keys to plugin classes.
+Some plugins integrate LLMObs with tracing plugins using `CompositePlugin`. The plugin class exposes a
+`static plugins` mapping, either as a field or a getter.
 
 See `packages/datadog-plugin-google-genai/src/index.js` for a reference implementation.
 

--- a/.agents/skills/llmobs-testing/SKILL.md
+++ b/.agents/skills/llmobs-testing/SKILL.md
@@ -5,23 +5,22 @@ description: |
   dd-trace-js. Triggers: "write LLMObs tests", "test an LLMObs plugin",
   "assertLlmObsSpanEvent", "useLlmObs", "getEvents", any MOCK_* matcher
   ("MOCK_STRING" / "MOCK_NOT_NULLISH" / "MOCK_NUMBER" / "MOCK_OBJECT"),
-  "VCR cassette", "vcr proxy", "127.0.0.1:9126", any LlmObsCategory test
-  ("LLM_CLIENT" / "MULTI_PROVIDER" / "ORCHESTRATION" / "INFRASTRUCTURE").
+  "VCR cassette", "vcr proxy", "127.0.0.1:9126", "record a cassette",
+  "test:llmobs:plugins".
 ---
 
 # LLM Observability Testing Skill
 
-## Determine the package category first
+## Decide how the package gets its responses first
 
-**Before writing any test, determine the package's `LlmObsCategory`.** Category picks the test strategy (VCR or not), the span kind, and the test structure. The wrong category produces tests that pass against the wrong contract — VCR cassettes for a workflow library produce empty recordings; pure-function tests for an HTTP-call wrapper miss the network surface entirely.
+**That choice picks the test strategy, the span kind, and the test structure, and the wrong one tests the wrong contract** — cassettes for a workflow library record nothing, while pure-function tests for an HTTP wrapper miss the network surface entirely. These are working categories for reasoning about a package; none of them exists as a constant in the codebase.
 
-Quick check:
+- **LLM client / multi-provider** — talks provider HTTP itself (openai, anthropic, genai, ai, langchain): VCR cassettes.
+- **Orchestration** — carries workflow or graph state and makes no provider calls of its own (langgraph): no VCR; drive nodes with plain return values.
+- **Infrastructure** — implements a protocol or server (modelcontextprotocol-sdk): mock the server.
+- **SDKs that call through global `fetch`** (google-cloud-vertexai) cannot be intercepted by `nock`, so their specs replace `global.fetch` for the duration of the test instead of recording a cassette.
 
-- Direct HTTP calls to an LLM provider? → `LLM_CLIENT` or `MULTI_PROVIDER` — VCR.
-- Workflow / graph orchestration with state? → `ORCHESTRATION` — no VCR, pure functions, real LLM as the orchestration node.
-- Protocol / server implementation? → `INFRASTRUCTURE` — mock server.
-
-See [references/category-strategies.md](references/category-strategies.md) for the FORBIDDEN-vs-REQUIRED matrix per category.
+See [references/category-strategies.md](references/category-strategies.md) for the forbidden-vs-required matrix per strategy.
 
 ## Core Testing Concepts
 
@@ -44,38 +43,28 @@ See [references/test-structure.md](references/test-structure.md) for complete te
 
 ### 2. VCR Cassettes
 
-VCR records real API calls and replays them in tests for deterministic testing without external dependencies.
+Provider traffic is recorded once and replayed afterwards. Clients reach the proxy at
+`http://127.0.0.1:9126/vcr/{provider}`; the category block above decides which categories use it at all.
 
-**Purpose:**
-- Record real LLM API responses once
-- Replay deterministically in CI without API keys
-- No external dependencies after recording
+Two facts block every first run:
 
-**How it works:**
-1. Configure proxy baseURL: `http://127.0.0.1:9126/vcr/{provider}`
-2. Run tests with real API keys (first time only)
-3. VCR proxy records requests/responses to cassette files
-4. Subsequent test runs replay from cassettes (no API keys needed)
+- **The proxy is the test-agent container**, not a script in this repo — `docker compose up -d testagent`.
+  Without it every call fails with `ECONNREFUSED 127.0.0.1:9126`, which reads like a provider outage.
+- **Cassettes live in one shared tree** under `packages/dd-trace/test/llmobs/cassettes/{provider}/`, with
+  generated names, rather than beside the spec.
 
-**Cassette location:** `test/llmobs/plugins/{integration}/cassettes/`
+See [references/vcr-cassettes.md](references/vcr-cassettes.md) for recording, provider mapping, body
+normalizers, and the commands to run a single integration.
 
-**When to use VCR:**
-- ✅ `LlmObsCategory.LLM_CLIENT` (Direct API wrappers)
-- ✅ `LlmObsCategory.MULTI_PROVIDER` (Multi-provider frameworks)
-- ❌ `LlmObsCategory.ORCHESTRATION` (Pure functions, no API calls)
-- ❌ `LlmObsCategory.INFRASTRUCTURE` (Mock servers instead)
+### 3. Strategy Per Package Shape
 
-See [references/vcr-cassettes.md](references/vcr-cassettes.md) for recording process and troubleshooting.
+The block at the top maps shape to strategy. The non-obvious bits:
 
-### 3. Category-Specific Test Strategies
+- **LLM client / multi-provider**: proxy baseURL `http://127.0.0.1:9126/vcr/{provider}`, span kind `'llm'`. Cassettes are recorded once with real keys and replayed everywhere after.
+- **Orchestration**: span kind `'workflow'` or `'agent'`, never `'llm'` — the orchestrator coordinates libraries that call providers rather than calling them itself. Nodes return plain values, so the test exercises graph execution instead of a provider API.
+- **Infrastructure**: mock server, protocol-specific validation, no VCR.
 
-The category-determination block at the top maps category to strategy. Non-obvious bits per category:
-
-- **LLM_CLIENT / MULTI_PROVIDER**: VCR proxy baseURL is `http://127.0.0.1:9126/vcr/{provider}`. Span kind: `'llm'`. Cassettes record once with real API keys; CI replays them.
-- **ORCHESTRATION**: Span kind: `'workflow'` or `'agent'`, never `'llm'`. No VCR, no real API calls — the orchestrator itself doesn't make HTTP calls, it coordinates libraries that do. Mock LLM responses as plain return values from the node so the test exercises the workflow execution, not the provider API.
-- **INFRASTRUCTURE**: Mock server, protocol-specific validation, no VCR.
-
-See [references/category-strategies.md](references/category-strategies.md) for per-category patterns.
+See [references/category-strategies.md](references/category-strategies.md) for the patterns per shape.
 
 ### 4. Assertion Patterns
 
@@ -87,10 +76,10 @@ Validates span structure with flexible matchers for non-deterministic values.
 - `MOCK_STRING` - Matches any non-empty string (use for output text)
 - `MOCK_NOT_NULLISH` - Matches any truthy value (use for token counts)
 - `MOCK_NUMBER` - Matches any number
-- `MOCK_OBJECT` - Matches any object (use for errors)
+- `MOCK_OBJECT` - Matches any object (use for opaque `schema` / `metadata` payloads, never for `error`)
 
 **Assertable fields:**
-- `spanKind` (required) - Span type from `LlmObsSpanKind` enum
+- `spanKind` (required) - one of `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js`
 - `name` - Operation name
 - `modelName` - Model identifier (for LLM spans)
 - `modelProvider` - Provider name (for LLM spans)
@@ -106,7 +95,9 @@ See [references/assertion-helpers.md](references/assertion-helpers.md) for compl
 
 ## Test File Organization
 
-**Location:** `test/llmobs/plugins/{integration}/index.spec.js`
+**Location:** `packages/dd-trace/test/llmobs/plugins/{integration}/index.spec.js`. One file per
+major-version surface when the SDK's shape changed across majors, named after it rather than kept in
+one file — `openaiv3.spec.js` / `openaiv4.spec.js`, `index.spec.js` / `index.v7.spec.js`.
 
 **Structure:**
 1. Import helpers from `'../../util'`
@@ -125,33 +116,36 @@ See [references/test-structure.md](references/test-structure.md) for complete te
 
 ## Key Testing Points
 
-### Coverage Requirements
+### What Every Span Assertion Pins
 
-Test all instrumented methods with:
-- ✅ Basic operation (single message/call)
-- ✅ Multi-turn conversations (if applicable)
-- ✅ Error cases
-- ✅ All required span fields (spanKind, name, modelName, modelProvider)
-- ✅ Message format validation (`{content, role}` structure)
-- ✅ Metrics validation (token counts exist and are truthy)
-- ✅ Metadata validation (parameters passed through)
+Beyond covering each instrumented method, once with a single message and once with a multi-turn
+conversation where the surface takes one: `spanKind`, `name`, `modelName` and `modelProvider` on every
+span; messages as `{ content, role }`; token counts truthy in `metrics`; and the parameters the caller
+passed reflected in `metadata`.
 
 ### Span Kind Validation
 
-Match span kind to operation type using `LlmObsSpanKind` enum:
+Span kinds come from `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js`:
 - Chat/completions → `'llm'`
 - Workflow execution → `'workflow'`
 - Agent runs → `'agent'`
+- Discrete unit of work inside a workflow → `'task'`
 - Tool calls → `'tool'`
 - Embeddings → `'embedding'`
 - Retrieval → `'retrieval'`
 
 ### Error Handling
 
-On errors, validate:
-- Empty output messages: `[{content: '', role: ''}]`
-- Error object exists: `error: MOCK_OBJECT`
-- Span still created (not dropped)
+On errors the span is still submitted, with `outputMessages: [{ content: '', role: '' }]`. Every LLMObs
+spec pins all three error fields against the error the call threw, so `error: MOCK_OBJECT` would accept a
+span that failed for the wrong reason:
+
+```javascript
+error: { type: 'Error', message: error.message, stack: error.stack },
+```
+
+Reach for a per-field matcher only where the value genuinely varies, as langchain does with
+`message: MOCK_STRING` and `stack: MOCK_NOT_NULLISH`.
 
 ## References
 
@@ -160,4 +154,4 @@ For detailed information, see:
 - [references/test-structure.md](references/test-structure.md) - Complete test file templates and organization
 - [references/vcr-cassettes.md](references/vcr-cassettes.md) - VCR recording process, cassette management, troubleshooting
 - [references/assertion-helpers.md](references/assertion-helpers.md) - Complete assertLlmObsSpanEvent API, matchers, patterns
-- [references/category-strategies.md](references/category-strategies.md) - Detailed test strategies for each LlmObsCategory
+- [references/category-strategies.md](references/category-strategies.md) - Detailed test strategy per package shape

--- a/.agents/skills/llmobs-testing/SKILL.md
+++ b/.agents/skills/llmobs-testing/SKILL.md
@@ -92,20 +92,10 @@ Validates span structure with flexible matchers for non-deterministic values.
 - `MOCK_OBJECT` - anything with `typeof 'object'`, `null` included (opaque `schema` / `metadata` payloads, or
   a whole output message whose shape varies, as the `ai` specs do)
 
-**Assertable fields:**
-- `spanKind` (required) - one of `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js`
-- `name` - Operation name
-- `modelName` - Model identifier (for LLM spans)
-- `modelProvider` - Provider name (for LLM spans)
-- `inputMessages` - Input messages in `[{content, role}]` format
-- `outputMessages` - Output messages in `[{content, role}]` format
-- `metrics` - Token usage (`input_tokens`, `output_tokens`, `total_tokens`)
-- `metadata` - Model parameters (`temperature`, `max_tokens`, etc.)
-- `error` - Error object (if operation failed)
-
-**Partial validation:** Only specified fields are checked, others ignored.
-
-See [references/assertion-helpers.md](references/assertion-helpers.md) for complete API and patterns.
+**Assertable fields:** `span`, `parentId`, `spanKind` (required), `name`, `modelName`, `modelProvider`,
+`inputMessages`, `outputMessages`, `inputDocuments`, `outputDocuments`, `inputValue`, `outputValue`, `metrics`,
+`metadata`, `error`, `tags`. Only the fields you pass are checked, and which ones a span carries depends on its
+kind. See [references/assertion-helpers.md](references/assertion-helpers.md) for the patterns.
 
 ## Test File Organization
 
@@ -128,27 +118,24 @@ useLlmObs, assertLlmObsSpanEvent, MOCK_STRING, MOCK_NOT_NULLISH, MOCK_NUMBER, MO
 
 See [references/test-structure.md](references/test-structure.md) for complete template.
 
-## Key Testing Points
+## Span Kinds And The Fields They Carry
 
-### What Every Span Assertion Pins
+`SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js` is the list the public SDK validates against:
+`llm` (chat / completions), `workflow`, `agent`, `task` (a unit of work inside a workflow), `tool`, `embedding`,
+`retrieval`. Plugins set the kind directly and skip that validation, so kinds outside the list exist — `ai` v7
+and claude-agent-sdk both emit `step`.
 
-Beyond covering each instrumented method, once with a single message and once with a multi-turn
-conversation where the surface takes one: `spanKind`, `name`, `modelName` and `modelProvider` on every
-span; messages as `{ content, role }`; token counts truthy in `metrics`; and the parameters the caller
-passed reflected in `metadata`.
+Pinning a field the kind never emits asserts metadata production does not produce:
 
-### Span Kind Validation
+- `llm` — `modelName`, `modelProvider`, `inputMessages` / `outputMessages`, token `metrics`, `metadata`
+- `embedding` — `modelName`, `modelProvider`, `inputDocuments`, `outputValue`, sometimes `metrics`
+- `retrieval` — `inputValue`, `outputDocuments`
+- `workflow` / `agent` / `task` / `step` / `tool` — `name` plus `inputValue` / `outputValue`, no model fields
+  and no token metrics
 
-Span kinds come from `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js`:
-- Chat/completions → `'llm'`
-- Workflow execution → `'workflow'`
-- Agent runs → `'agent'`
-- Discrete unit of work inside a workflow → `'task'`
-- Tool calls → `'tool'`
-- Embeddings → `'embedding'`
-- Retrieval → `'retrieval'`
+Cover every instrumented method, and a multi-turn conversation where the surface takes one.
 
-### Error Handling
+## Error Handling
 
 On errors the span is still submitted, with `outputMessages: [{ content: '', role: '' }]`. The specs that assert
 an error pass all three fields, reaching for a matcher where the value varies (`type: MOCK_STRING` in the MCP
@@ -165,14 +152,3 @@ throw without asserting it. Pin the identity of the error on the APM span the LL
 ```javascript
 assert.strictEqual(apmSpans[0].meta['error.message'], error.message)
 ```
-
-## References
-
-For detailed information, see:
-
-- [references/test-structure.md](references/test-structure.md) - Complete test file templates and organization
-- [references/vcr-cassettes.md](references/vcr-cassettes.md) - VCR recording process, cassette management,
-  troubleshooting
-- [references/assertion-helpers.md](references/assertion-helpers.md) - Complete assertLlmObsSpanEvent API, matchers,
-  patterns
-- [references/category-strategies.md](references/category-strategies.md) - Detailed test strategy per package shape

--- a/.agents/skills/llmobs-testing/SKILL.md
+++ b/.agents/skills/llmobs-testing/SKILL.md
@@ -11,15 +11,14 @@ description: |
 
 # LLM Observability Testing Skill
 
-## Decide how the package gets its responses first
+## Decide how each instrumented surface gets its responses first
 
-**That choice picks the test strategy, the span kind, and the test structure, and the wrong one tests the wrong
-contract** — cassettes for a workflow library record nothing, while pure-function tests for an HTTP wrapper miss the
-network surface entirely. These are working categories for reasoning about a package; none of them exists as a
-constant in the codebase.
+**That choice picks the response source and test setup** — cassettes for a workflow record nothing, while
+pure-function tests for a provider-backed call miss the network surface entirely. The operation independently
+determines its span kind and fields. These are working categories for reasoning; none exists as a code constant.
 
-- **LLM client / multi-provider** — talks provider HTTP itself (openai, anthropic, genai, ai, langchain): VCR
-  cassettes.
+- **LLM client / multi-provider** — reaches provider HTTP directly or through a supplied provider package (openai,
+  anthropic, genai, ai, langchain): VCR cassettes or a canned `fetch`.
 - **Orchestration** — carries workflow or graph state and makes no provider calls of its own (langgraph): no VCR;
   drive nodes with plain return values.
 - **Infrastructure** — implements a protocol or server (modelcontextprotocol-sdk): run the SDK's own server
@@ -65,12 +64,13 @@ Two facts block every first run:
 See [references/vcr-cassettes.md](references/vcr-cassettes.md) for recording, provider mapping, body
 normalizers, and the commands to run a single integration.
 
-### 3. Strategy Per Package Shape
+### 3. Response Strategy And Operation Kind
 
-The block at the top maps shape to strategy. The non-obvious bits:
+The block at the top maps response source to test strategy. The operation maps independently to a span kind:
 
-- **LLM client / multi-provider**: proxy baseURL `http://127.0.0.1:9126/vcr/{provider}`, span kind `'llm'`. Cassettes
-  are recorded once with real keys and replayed everywhere after.
+- **Provider-backed LLM client / multi-provider operations**: use the proxy baseURL
+  `http://127.0.0.1:9126/vcr/{provider}` or a canned `fetch`. Chat and generation emit `llm`; LangChain and `ai`
+  also expose operations with other kinds.
 - **Orchestration**: span kind `'workflow'` or `'agent'`, never `'llm'` — the orchestrator coordinates libraries that
   call providers rather than calling them itself. Nodes return plain values, so the test exercises graph execution
   instead of a provider API.
@@ -92,10 +92,16 @@ Validates span structure with flexible matchers for non-deterministic values.
 - `MOCK_OBJECT` - anything with `typeof 'object'`, `null` included (opaque `schema` / `metadata` payloads, or
   a whole output message whose shape varies, as the `ai` specs do)
 
-**Assertable fields:** `span`, `parentId`, `spanKind` (required), `name`, `modelName`, `modelProvider`,
-`inputMessages`, `outputMessages`, `inputDocuments`, `outputDocuments`, `inputValue`, `outputValue`, `metrics`,
-`metadata`, `error`, `tags`. Only the fields you pass are checked, and which ones a span carries depends on its
-kind. See [references/assertion-helpers.md](references/assertion-helpers.md) for the patterns.
+**Required fields:** `span`, `spanKind`, `name`, `tags`. A missing `tags` throws
+`TypeError: Cannot read properties of undefined (reading 'ml_app')` instead of failing an assertion, and every
+plugin span carries at least `{ ml_app: 'test', integration: '<integration>' }`.
+
+**Optional fields:** `modelName`, `modelProvider`, `inputMessages`, `outputMessages`, `inputDocuments`,
+`outputDocuments`, `inputValue`, `outputValue`, `metrics`, `metadata`, `toolDefinitions`, `error`, `parentId`,
+`sessionId`, `traceId`. Omitting a field asserts its absence rather than ignoring it: no model fields, no input, no
+output, no metadata, no tool definitions, `metrics` of `{}`, `status: 'ok'`, and the root parent id. `traceId` is
+the exception: omission defaults to `MOCK_STRING` because every event has one. See
+[references/assertion-helpers.md](references/assertion-helpers.md) for the patterns.
 
 ## Test File Organization
 
@@ -106,7 +112,7 @@ one file — `openaiv3.spec.js` / `openaiv4.spec.js`, `index.spec.js` / `index.v
 **Structure:**
 1. Import helpers from `'../../util'`
 2. Initialize LLMObs test environment
-3. Load modules in `beforeEach()` for fresh state
+3. Load modules after `useLlmObs()` installs the tracer, then recreate mutable clients per test
 4. Group tests by method (`describe('chat completions', ...)`)
 5. Cover all instrumented methods
 6. Test error cases
@@ -127,27 +133,30 @@ and claude-agent-sdk both emit `step`.
 
 Pinning a field the kind never emits asserts metadata production does not produce:
 
-- `llm` — `modelName`, `modelProvider`, `inputMessages` / `outputMessages`, token `metrics`, `metadata`
+- `llm` — `modelName`, `modelProvider`, `inputMessages` / `outputMessages`, and any emitted token `metrics` /
+  `metadata`
 - `embedding` — `modelName`, `modelProvider`, `inputDocuments`, `outputValue`, sometimes `metrics`
 - `retrieval` — `inputValue`, `outputDocuments`
-- `workflow` / `agent` / `task` / `step` / `tool` — `name` plus `inputValue` / `outputValue`, no model fields
-  and no token metrics
+- `workflow` / `agent` / `task` / `step` / `tool` — kind-specific `inputValue` / `outputValue`, sometimes
+  `metadata`, never
+  model fields or token metrics
 
 Cover every instrumented method, and a multi-turn conversation where the surface takes one.
 
 ## Error Handling
 
-On errors the span is still submitted, with `outputMessages: [{ content: '', role: '' }]`. The specs that assert
-an error pass all three fields, reaching for a matcher where the value varies (`type: MOCK_STRING` in the MCP
-spec, `message: MOCK_STRING` in langchain):
+On errors the span is still submitted. Match the plugin's output contract: OpenAI and GenAI carry
+`outputMessages: [{ content: '', role: '' }]`, while Anthropic and non-`llm` integrations may omit output.
+Pass a truthy marker to expect an error:
 
 ```javascript
-error: { type: 'Error', message: error.message, stack: error.stack },
+error: {},
 ```
 
 The option decides only whether the expected event carries `status: 'error'` — `assertLlmObsSpanEvent`
-copies the three error fields out of the span it is checking, so the values written here document the
-throw without asserting it. Pin the identity of the error on the APM span the LLMObs span was built from:
+copies the three error fields out of the span it is checking, so the marker does not pin the throw.
+A call that resolves still fails on that status. Pin which error was thrown on the APM span the LLMObs
+span was built from:
 
 ```javascript
 assert.strictEqual(apmSpans[0].meta['error.message'], error.message)

--- a/.agents/skills/llmobs-testing/SKILL.md
+++ b/.agents/skills/llmobs-testing/SKILL.md
@@ -13,14 +13,23 @@ description: |
 
 ## Decide how the package gets its responses first
 
-**That choice picks the test strategy, the span kind, and the test structure, and the wrong one tests the wrong contract** — cassettes for a workflow library record nothing, while pure-function tests for an HTTP wrapper miss the network surface entirely. These are working categories for reasoning about a package; none of them exists as a constant in the codebase.
+**That choice picks the test strategy, the span kind, and the test structure, and the wrong one tests the wrong
+contract** — cassettes for a workflow library record nothing, while pure-function tests for an HTTP wrapper miss the
+network surface entirely. These are working categories for reasoning about a package; none of them exists as a
+constant in the codebase.
 
-- **LLM client / multi-provider** — talks provider HTTP itself (openai, anthropic, genai, ai, langchain): VCR cassettes.
-- **Orchestration** — carries workflow or graph state and makes no provider calls of its own (langgraph): no VCR; drive nodes with plain return values.
-- **Infrastructure** — implements a protocol or server (modelcontextprotocol-sdk): mock the server.
-- **SDKs that call through global `fetch`** (google-cloud-vertexai) cannot be intercepted by `nock`, so their specs replace `global.fetch` for the duration of the test instead of recording a cassette.
+- **LLM client / multi-provider** — talks provider HTTP itself (openai, anthropic, genai, ai, langchain): VCR
+  cassettes.
+- **Orchestration** — carries workflow or graph state and makes no provider calls of its own (langgraph): no VCR;
+  drive nodes with plain return values.
+- **Infrastructure** — implements a protocol or server (modelcontextprotocol-sdk): run the SDK's own server
+  and client over its in-memory transport.
+- **Canned `fetch` instead of a cassette** — where the spec supplies the responses itself: google-cloud-vertexai
+  swaps `global.fetch` per test and stubs Google auth, openai-agents and some `ai` providers pass a `fetch` option
+  to the client they construct.
 
-See [references/category-strategies.md](references/category-strategies.md) for the forbidden-vs-required matrix per strategy.
+See [references/category-strategies.md](references/category-strategies.md) for the forbidden-vs-required matrix per
+strategy.
 
 ## Core Testing Concepts
 
@@ -60,9 +69,13 @@ normalizers, and the commands to run a single integration.
 
 The block at the top maps shape to strategy. The non-obvious bits:
 
-- **LLM client / multi-provider**: proxy baseURL `http://127.0.0.1:9126/vcr/{provider}`, span kind `'llm'`. Cassettes are recorded once with real keys and replayed everywhere after.
-- **Orchestration**: span kind `'workflow'` or `'agent'`, never `'llm'` — the orchestrator coordinates libraries that call providers rather than calling them itself. Nodes return plain values, so the test exercises graph execution instead of a provider API.
-- **Infrastructure**: mock server, protocol-specific validation, no VCR.
+- **LLM client / multi-provider**: proxy baseURL `http://127.0.0.1:9126/vcr/{provider}`, span kind `'llm'`. Cassettes
+  are recorded once with real keys and replayed everywhere after.
+- **Orchestration**: span kind `'workflow'` or `'agent'`, never `'llm'` — the orchestrator coordinates libraries that
+  call providers rather than calling them itself. Nodes return plain values, so the test exercises graph execution
+  instead of a provider API.
+- **Infrastructure**: the SDK's own server and client over its in-memory transport, protocol-specific
+  validation, no VCR.
 
 See [references/category-strategies.md](references/category-strategies.md) for the patterns per shape.
 
@@ -72,11 +85,12 @@ See [references/category-strategies.md](references/category-strategies.md) for t
 
 Validates span structure with flexible matchers for non-deterministic values.
 
-**Available matchers:**
-- `MOCK_STRING` - Matches any non-empty string (use for output text)
-- `MOCK_NOT_NULLISH` - Matches any truthy value (use for token counts)
-- `MOCK_NUMBER` - Matches any number
-- `MOCK_OBJECT` - Matches any object (use for opaque `schema` / `metadata` payloads, never for `error`)
+**Available matchers:** each one is a `typeof` or nullish check, not a value check.
+- `MOCK_STRING` - any string, `''` included (use for output text)
+- `MOCK_NOT_NULLISH` - anything but `null` / `undefined`, so `0` and `''` pass (use for token counts)
+- `MOCK_NUMBER` - any number
+- `MOCK_OBJECT` - anything with `typeof 'object'`, `null` included (opaque `schema` / `metadata` payloads, or
+  a whole output message whose shape varies, as the `ai` specs do)
 
 **Assertable fields:**
 - `spanKind` (required) - one of `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js`
@@ -136,22 +150,29 @@ Span kinds come from `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tag
 
 ### Error Handling
 
-On errors the span is still submitted, with `outputMessages: [{ content: '', role: '' }]`. Every LLMObs
-spec pins all three error fields against the error the call threw, so `error: MOCK_OBJECT` would accept a
-span that failed for the wrong reason:
+On errors the span is still submitted, with `outputMessages: [{ content: '', role: '' }]`. The specs that assert
+an error pass all three fields, reaching for a matcher where the value varies (`type: MOCK_STRING` in the MCP
+spec, `message: MOCK_STRING` in langchain):
 
 ```javascript
 error: { type: 'Error', message: error.message, stack: error.stack },
 ```
 
-Reach for a per-field matcher only where the value genuinely varies, as langchain does with
-`message: MOCK_STRING` and `stack: MOCK_NOT_NULLISH`.
+The option decides only whether the expected event carries `status: 'error'` — `assertLlmObsSpanEvent`
+copies the three error fields out of the span it is checking, so the values written here document the
+throw without asserting it. Pin the identity of the error on the APM span the LLMObs span was built from:
+
+```javascript
+assert.strictEqual(apmSpans[0].meta['error.message'], error.message)
+```
 
 ## References
 
 For detailed information, see:
 
 - [references/test-structure.md](references/test-structure.md) - Complete test file templates and organization
-- [references/vcr-cassettes.md](references/vcr-cassettes.md) - VCR recording process, cassette management, troubleshooting
-- [references/assertion-helpers.md](references/assertion-helpers.md) - Complete assertLlmObsSpanEvent API, matchers, patterns
+- [references/vcr-cassettes.md](references/vcr-cassettes.md) - VCR recording process, cassette management,
+  troubleshooting
+- [references/assertion-helpers.md](references/assertion-helpers.md) - Complete assertLlmObsSpanEvent API, matchers,
+  patterns
 - [references/category-strategies.md](references/category-strategies.md) - Detailed test strategy per package shape

--- a/.agents/skills/llmobs-testing/references/assertion-helpers.md
+++ b/.agents/skills/llmobs-testing/references/assertion-helpers.md
@@ -35,7 +35,10 @@ assertLlmObsSpanEvent(span, {
 ### 1. Basic Chat Completion
 
 ```javascript
-assertLlmObsSpanEvent(events[0], {
+const { apmSpans, llmobsSpans } = await getEvents()
+
+assertLlmObsSpanEvent(llmobsSpans[0], {
+  span: apmSpans[0],
   spanKind: 'llm',
   name: 'openai.chat.completions',
   modelName: 'gpt-4',
@@ -51,34 +54,20 @@ assertLlmObsSpanEvent(events[0], {
 })
 ```
 
-### 2. Multi-Turn Conversation
+### 2. Workflow/Orchestration Span
 
 ```javascript
-assertLlmObsSpanEvent(events[0], {
-  spanKind: 'llm',
-  inputMessages: [
-    { content: 'Hello', role: 'user' },
-    { content: 'Hi!', role: 'assistant' },
-    { content: 'How are you?', role: 'user' }
-  ],
-  outputMessages: [{ content: MOCK_STRING, role: 'assistant' }]
-})
-```
-
-### 3. Workflow/Orchestration Span
-
-```javascript
-assertLlmObsSpanEvent(events[0], {
+assertLlmObsSpanEvent(llmobsSpans[0], {
   spanKind: 'workflow',  // Not 'llm'!
   name: 'langgraph.graph.invoke'
   // Workflows may not have inputMessages/outputMessages
 })
 ```
 
-### 4. Error Case
+### 3. Error Case
 
 ```javascript
-assertLlmObsSpanEvent(events[0], {
+assertLlmObsSpanEvent(llmobsSpans[0], {
   spanKind: 'llm',
   outputMessages: [{ content: '', role: '' }],  // Empty on error
   error: { type: 'Error', message: error.message, stack: error.stack }
@@ -91,49 +80,8 @@ The helper fills `error.message`, `error.type` and `error.stack` from the span i
 `error` option decides `status: 'error'` and nothing else. The fields written into it document the throw;
 the assertion on the APM span is what pins which error was thrown.
 
-### 5. Partial Validation
-
-Only specified fields are checked (others ignored):
-
-```javascript
-assertLlmObsSpanEvent(events[0], {
-  spanKind: 'llm',
-  modelName: 'gpt-4'
-  // inputMessages, outputMessages, metrics, metadata not validated
-})
-```
-
-## Best Practices
-
-1. **Use MOCK_* for non-deterministic values:**
-    - Output text: `MOCK_STRING` (real responses vary)
-    - Token counts: `MOCK_NOT_NULLISH` (counts vary but should exist)
-    - Error message and stack: `MOCK_STRING` / `MOCK_NOT_NULLISH` per field, keeping `type` exact
-
-2. **Use exact values for inputs:**
-    - Input messages: You control these in tests
-    - Model parameters: You set these (temperature, max_tokens)
-    - Model name: You specify this
-
-3. **Always validate core fields:**
-    - `spanKind` (required for every span)
-    - `name` (operation identifier)
-    - `modelName` and `modelProvider` (for LLM spans)
-
-4. **Validate message format:**
-    - Ensure `{content: string, role: string}` structure
-    - Check role values: `'user'`, `'assistant'`, `'system'`, `'tool'`
-
-5. **Test error paths:**
-    - Verify empty `outputMessages: [{content: '', role: ''}]` on errors
-    - Pass `error` as `{ type, message, stack }`, and assert the thrown error on the APM span
-
-6. **Match span kind to operation:**
-    - Chat/completions → `spanKind: 'llm'`
-    - Workflow execution → `spanKind: 'workflow'`
-    - Agent runs → `spanKind: 'agent'`
-    - Tool calls → `spanKind: 'tool'`
-    - Embeddings → `spanKind: 'embedding'`
+Values you control in the spec — input messages, model name, model parameters — are pinned exactly; only
+what the provider decides gets a matcher.
 
 ## Reference Test Implementation
 
@@ -145,25 +93,13 @@ For a complete, real-world example of how tests using these helpers are structur
 - [`packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js)
   (orchestration pattern)
 
-## Field Reference Quick Lookup
+## Fields Per Span Kind
 
-**Required:**
-- `spanKind` - Always required
+`spanKind` and `name` are on every span. The rest follow the kind, and a field the kind never emits fails:
 
-**LLM Spans:**
-- `name`, `modelName`, `modelProvider`, `inputMessages`, `outputMessages`, `metrics`, `metadata`
-
-**Workflow Spans:**
-- `name` (may not have messages/metrics)
-
-**Agent Spans:**
-- `name` (may have messages for agent I/O)
-
-**Tool Spans:**
-- `name` (may have input/output for tool calls)
-
-**Embedding Spans:**
-- `name`, `modelName`, `modelProvider`, `metrics` (input/output token counts)
-
-**Retrieval Spans:**
-- `name`, `metadata` (query, results count, etc.)
+| Kind | Fields |
+|------|--------|
+| `llm` | `modelName`, `modelProvider`, `inputMessages`, `outputMessages`, `metrics`, `metadata` |
+| `embedding` | `modelName`, `modelProvider`, `inputDocuments`, `outputValue`, sometimes `metrics` |
+| `retrieval` | `inputValue`, `outputDocuments` |
+| `workflow`, `agent`, `task`, `step`, `tool` | `inputValue`, `outputValue`, `metadata` |

--- a/.agents/skills/llmobs-testing/references/assertion-helpers.md
+++ b/.agents/skills/llmobs-testing/references/assertion-helpers.md
@@ -4,10 +4,16 @@ Complete guide to `assertLlmObsSpanEvent()` and mock matchers for validating LLM
 
 ## assertLlmObsSpanEvent
 
-Main assertion function for validating LLMObs span structure. Only the fields you specify are checked — unspecified
-fields are ignored.
+Main assertion function for validating LLMObs span structure. `span`, `spanKind`, `name` and `tags` are required —
+`span` and `tags` are dereferenced, so leaving either out throws a `TypeError` instead of failing an assertion.
 
-See the docstring in `packages/dd-trace/test/llmobs/util.js` for the full type signature and parameter details.
+Every other field asserts its own absence when omitted, so an expectation lists exactly what the span carries and
+nothing more. `metrics` defaults to `{}` and `parentId` to the root parent id. `traceId` is the exception: it
+defaults to `MOCK_STRING`.
+
+See the `ExpectedLLMObsSpanEvent` typedef in `packages/dd-trace/test/llmobs/util.js` for the full signature.
+The helper removes fields from the actual event while comparing them, so make raw-event assertions first and call
+it only once per event.
 
 ## Mock Matchers
 
@@ -20,82 +26,148 @@ Use these for non-deterministic values (output text, token counts, errors).
 | `MOCK_NUMBER` | Any number | Specific numeric metrics |
 | `MOCK_OBJECT` | Anything with `typeof 'object'`, `null` included | Opaque `schema` / `metadata`, whole messages |
 
-**Usage:**
-```javascript
-const { MOCK_STRING, MOCK_NOT_NULLISH, MOCK_NUMBER, MOCK_OBJECT } = require('../../util')
+Import them alongside the helpers and use them inside the expected object:
 
-assertLlmObsSpanEvent(span, {
-  outputMessages: [{ content: MOCK_STRING, role: 'assistant' }],
-  metrics: { input_tokens: MOCK_NOT_NULLISH }
-})
+```javascript
+const { useLlmObs, assertLlmObsSpanEvent, MOCK_STRING, MOCK_NUMBER } = require('../../util')
 ```
 
 ## Common Patterns
 
 ### 1. Basic Chat Completion
 
+`name` is the event name the plugin reports, or the APM span name when the plugin omits it; it is not a string the
+spec chooses. `metadata` carries every request parameter the plugin tagged:
+
 ```javascript
+await client.chat.completions.create({
+  model: 'gpt-3.5-turbo',
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Hello, OpenAI!' },
+  ],
+  max_tokens: 100,
+  n: 1,
+  stream: false,
+  temperature: 0.5,
+  user: 'dd-trace-test',
+})
+
 const { apmSpans, llmobsSpans } = await getEvents()
 
 assertLlmObsSpanEvent(llmobsSpans[0], {
   span: apmSpans[0],
   spanKind: 'llm',
-  name: 'openai.chat.completions',
-  modelName: 'gpt-4',
+  name: 'OpenAI.createChatCompletion',
+  modelName: 'gpt-3.5-turbo-0125',
   modelProvider: 'openai',
-  inputMessages: [{ content: 'Hello', role: 'user' }],
+  inputMessages: [
+    { content: 'You are a helpful assistant.', role: 'system' },
+    { content: 'Hello, OpenAI!', role: 'user' },
+  ],
   outputMessages: [{ content: MOCK_STRING, role: 'assistant' }],
   metrics: {
-    input_tokens: MOCK_NOT_NULLISH,
-    output_tokens: MOCK_NOT_NULLISH,
-    total_tokens: MOCK_NOT_NULLISH
+    cache_read_input_tokens: 0,
+    input_tokens: MOCK_NUMBER,
+    output_tokens: MOCK_NUMBER,
+    reasoning_output_tokens: 0,
+    total_tokens: MOCK_NUMBER,
   },
-  metadata: { temperature: 0.7 }
+  metadata: {
+    max_tokens: 100,
+    n: 1,
+    stream: false,
+    temperature: 0.5,
+    user: 'dd-trace-test',
+  },
+  tags: { ml_app: 'test', integration: 'openai' },
 })
 ```
 
+Objects are compared key for key, so a `metadata` or `metrics` literal that misses one entry fails on length.
+Reach for `MOCK_NOT_NULLISH` on the whole object when the set varies across versions, as the LangChain specs do.
+
 ### 2. Workflow/Orchestration Span
+
+The name is the graph's own name, and the input is the object the spec passed to `invoke`, JSON-stringified
+the way the tagger stores it:
 
 ```javascript
 assertLlmObsSpanEvent(llmobsSpans[0], {
-  spanKind: 'workflow',  // Not 'llm'!
-  name: 'langgraph.graph.invoke'
-  // Workflows may not have inputMessages/outputMessages
+  span: apmSpans[0],
+  spanKind: 'workflow',
+  name: 'my-graph',
+  inputValue: JSON.stringify({ messages: [{ role: 'user', content: 'Test' }] }),
+  outputValue: MOCK_STRING,
+  tags: { ml_app: 'test', integration: 'langgraph' }
 })
 ```
 
 ### 3. Error Case
 
 ```javascript
+let requestError
+await assert.rejects(
+  () => client.chat.completions.create({
+    model: 'gpt-3.5-turbo-instruct',
+    messages: [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'Hello, OpenAI!' },
+    ],
+    max_tokens: 100,
+    n: 1,
+    stream: false,
+    temperature: 0.5,
+    user: 'dd-trace-test',
+  }),
+  (error) => {
+    requestError = error
+    return true
+  }
+)
+
+const { apmSpans, llmobsSpans } = await getEvents()
+
 assertLlmObsSpanEvent(llmobsSpans[0], {
+  span: apmSpans[0],
   spanKind: 'llm',
-  outputMessages: [{ content: '', role: '' }],  // Empty on error
-  error: { type: 'Error', message: error.message, stack: error.stack }
+  name: 'OpenAI.createChatCompletion',
+  modelName: 'gpt-3.5-turbo-instruct',
+  modelProvider: 'openai',
+  inputMessages: [
+    { content: 'You are a helpful assistant.', role: 'system' },
+    { content: 'Hello, OpenAI!', role: 'user' },
+  ],
+  outputMessages: [{ content: '', role: '' }],
+  metadata: { max_tokens: 100, temperature: 0.5, n: 1, stream: false, user: 'dd-trace-test' },
+  tags: { ml_app: 'test', integration: 'openai' },
+  error: {}
 })
 
-assert.strictEqual(apmSpans[0].meta['error.message'], error.message)
+assert.strictEqual(apmSpans[0].meta['error.message'], requestError.message)
 ```
 
-The helper fills `error.message`, `error.type` and `error.stack` from the span it is checking, so the
-`error` option decides `status: 'error'` and nothing else. The fields written into it document the throw;
-the assertion on the APM span is what pins which error was thrown.
+The failed call tags no token metrics, so `metrics` stays out and the helper asserts `{}`.
 
-Values you control in the spec — input messages, model name, model parameters — are pinned exactly; only
-what the provider decides gets a matcher.
+The helper fills `error.message`, `error.type` and `error.stack` from the span it is checking, so the
+`error` option is only a truthy marker that forces `status: 'error'`. A call that resolves instead of throwing
+still fails on that status, and the assertion on the APM span pins which error was thrown.
+
+Values you control in the spec — input messages, model name, model parameters, the invoke payload — are
+pinned exactly; only what the provider decides gets a matcher.
 
 ## Reference Test Implementation
 
 For a complete, real-world example of how tests using these helpers are structured, see:
-- [`packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js)
-  (LLM client / multi-provider pattern)
-- [`packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js)
-  (LLM client pattern)
-- [`packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js)
-  (orchestration pattern)
+- `packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js` (LLM client pattern)
+- `packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js` (LLM client pattern)
+- `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js` (orchestration pattern)
 
 ## Fields Per Span Kind
 
-`spanKind` and `name` are on every span. The rest follow the kind, and a field the kind never emits fails:
+`span`, `spanKind`, `name` and `tags` are on every span. The table lists possible fields; include only what the
+event carries. The helper rejects an input or output field that contradicts the kind — `inputMessages` demands
+`llm`, `inputDocuments` demands `embedding`, `outputDocuments` demands `retrieval`:
 
 | Kind | Fields |
 |------|--------|

--- a/.agents/skills/llmobs-testing/references/assertion-helpers.md
+++ b/.agents/skills/llmobs-testing/references/assertion-helpers.md
@@ -17,7 +17,7 @@ Use these for non-deterministic values (output text, token counts, errors).
 | `MOCK_STRING` | Any non-empty string | Output message content (varies per run) |
 | `MOCK_NOT_NULLISH` | Any truthy value | Token counts (exist but vary) |
 | `MOCK_NUMBER` | Any number | Specific numeric metrics |
-| `MOCK_OBJECT` | Any object | Error objects |
+| `MOCK_OBJECT` | Any object | Opaque `schema` / `metadata` payloads. Never `error` |
 
 **Usage:**
 ```javascript
@@ -80,9 +80,12 @@ assertLlmObsSpanEvent(events[0], {
 assertLlmObsSpanEvent(events[0], {
   spanKind: 'llm',
   outputMessages: [{ content: '', role: '' }],  // Empty on error
-  error: MOCK_OBJECT
+  error: { type: 'Error', message: error.message, stack: error.stack }
 })
 ```
+
+All three error fields are pinned against the error the call threw. `error: MOCK_OBJECT` would accept a
+span that failed for the wrong reason.
 
 ### 5. Partial Validation
 
@@ -101,7 +104,7 @@ assertLlmObsSpanEvent(events[0], {
 1. **Use MOCK_* for non-deterministic values:**
     - Output text: `MOCK_STRING` (real responses vary)
     - Token counts: `MOCK_NOT_NULLISH` (counts vary but should exist)
-    - Error objects: `MOCK_OBJECT` (error details vary)
+    - Error message and stack: `MOCK_STRING` / `MOCK_NOT_NULLISH` per field, keeping `type` exact
 
 2. **Use exact values for inputs:**
     - Input messages: You control these in tests
@@ -119,7 +122,7 @@ assertLlmObsSpanEvent(events[0], {
 
 5. **Test error paths:**
     - Verify empty `outputMessages: [{content: '', role: ''}]` on errors
-    - Assert `error` field exists with `MOCK_OBJECT`
+    - Assert `error` as `{ type, message, stack }`, not as a whole-object matcher
 
 6. **Match span kind to operation:**
     - Chat/completions → `spanKind: 'llm'`
@@ -131,9 +134,9 @@ assertLlmObsSpanEvent(events[0], {
 ## Reference Test Implementation
 
 For a complete, real-world example of how tests using these helpers are structured, see:
-- [`packages/datadog-plugin-anthropic/test/llmobs.spec.js`](../../../../../packages/datadog-plugin-anthropic/test/llmobs.spec.js) (LLM_CLIENT / MULTI_PROVIDER pattern)
-- [`packages/datadog-plugin-google-genai/test/llmobs.spec.js`](../../../../../packages/datadog-plugin-google-genai/test/llmobs.spec.js) (LLM_CLIENT pattern)
-- `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js` (ORCHESTRATION pattern)
+- [`packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js) (LLM client / multi-provider pattern)
+- [`packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js) (LLM client pattern)
+- `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js` (orchestration pattern)
 
 ## Field Reference Quick Lookup
 

--- a/.agents/skills/llmobs-testing/references/assertion-helpers.md
+++ b/.agents/skills/llmobs-testing/references/assertion-helpers.md
@@ -4,7 +4,8 @@ Complete guide to `assertLlmObsSpanEvent()` and mock matchers for validating LLM
 
 ## assertLlmObsSpanEvent
 
-Main assertion function for validating LLMObs span structure. Only the fields you specify are checked — unspecified fields are ignored.
+Main assertion function for validating LLMObs span structure. Only the fields you specify are checked — unspecified
+fields are ignored.
 
 See the docstring in `packages/dd-trace/test/llmobs/util.js` for the full type signature and parameter details.
 
@@ -14,10 +15,10 @@ Use these for non-deterministic values (output text, token counts, errors).
 
 | Matcher | Matches | Example Use Case |
 |---------|---------|------------------|
-| `MOCK_STRING` | Any non-empty string | Output message content (varies per run) |
-| `MOCK_NOT_NULLISH` | Any truthy value | Token counts (exist but vary) |
+| `MOCK_STRING` | Any string, `''` included | Output message content (varies per run) |
+| `MOCK_NOT_NULLISH` | Anything but `null` / `undefined` | Token counts (exist but vary) |
 | `MOCK_NUMBER` | Any number | Specific numeric metrics |
-| `MOCK_OBJECT` | Any object | Opaque `schema` / `metadata` payloads. Never `error` |
+| `MOCK_OBJECT` | Anything with `typeof 'object'`, `null` included | Opaque `schema` / `metadata`, whole messages |
 
 **Usage:**
 ```javascript
@@ -82,10 +83,13 @@ assertLlmObsSpanEvent(events[0], {
   outputMessages: [{ content: '', role: '' }],  // Empty on error
   error: { type: 'Error', message: error.message, stack: error.stack }
 })
+
+assert.strictEqual(apmSpans[0].meta['error.message'], error.message)
 ```
 
-All three error fields are pinned against the error the call threw. `error: MOCK_OBJECT` would accept a
-span that failed for the wrong reason.
+The helper fills `error.message`, `error.type` and `error.stack` from the span it is checking, so the
+`error` option decides `status: 'error'` and nothing else. The fields written into it document the throw;
+the assertion on the APM span is what pins which error was thrown.
 
 ### 5. Partial Validation
 
@@ -122,7 +126,7 @@ assertLlmObsSpanEvent(events[0], {
 
 5. **Test error paths:**
     - Verify empty `outputMessages: [{content: '', role: ''}]` on errors
-    - Assert `error` as `{ type, message, stack }`, not as a whole-object matcher
+    - Pass `error` as `{ type, message, stack }`, and assert the thrown error on the APM span
 
 6. **Match span kind to operation:**
     - Chat/completions → `spanKind: 'llm'`
@@ -134,9 +138,12 @@ assertLlmObsSpanEvent(events[0], {
 ## Reference Test Implementation
 
 For a complete, real-world example of how tests using these helpers are structured, see:
-- [`packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js) (LLM client / multi-provider pattern)
-- [`packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js) (LLM client pattern)
-- `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js` (orchestration pattern)
+- [`packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js)
+  (LLM client / multi-provider pattern)
+- [`packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js)
+  (LLM client pattern)
+- [`packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js`](../../../../packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js)
+  (orchestration pattern)
 
 ## Field Reference Quick Lookup
 

--- a/.agents/skills/llmobs-testing/references/category-strategies.md
+++ b/.agents/skills/llmobs-testing/references/category-strategies.md
@@ -82,9 +82,10 @@ it('instruments chat completion', async () => {
     model: 'gpt-4'
   })
 
-  const events = getEvents()
+  const { apmSpans, llmobsSpans } = await getEvents()
 
-  assertLlmObsSpanEvent(events[0], {
+  assertLlmObsSpanEvent(llmobsSpans[0], {
+    span: apmSpans[0],
     spanKind: 'llm',
     modelName: 'gpt-4',
     inputMessages: [{ content: 'Hello', role: 'user' }],
@@ -94,20 +95,12 @@ it('instruments chat completion', async () => {
 })
 ```
 
-### Key Points
-
-- ✅ Use VCR proxy URL
-- ✅ Make real API calls
-- ✅ Test actual LLM responses
-- ✅ Validate token counts from real usage
-- ✅ Test provider-specific features
-- ✅ Commit cassettes to repo
-
 ### ⚠️ Require The SDK Inside `before()`
 
-RITM patches a module the first time it is loaded, and it cannot patch one already in the require cache.
-`useLlmObs()` loads the tracer from its own `before()` hook, so a `require` at file scope runs first and stays
-uninstrumented. Load the version fixtures from `before()`:
+A module is instrumented by the `require` that runs after the hooks are installed: RITM's patched require pulls
+the exports (from Node's cache if they are already there) and hands them to every registered hook.
+`useLlmObs()` loads the tracer from its own `before()` hook, so a file-scope `require` returns the exports as
+they were before any hook existed. Load the version fixtures from `before()`:
 
 ```javascript
 withVersions('openai-agents', '@openai/agents', (version) => {
@@ -165,9 +158,10 @@ it('instruments graph invoke', async () => {
     messages: [{ role: 'user', content: 'Test' }]
   })
 
-  const events = getEvents()
+  const { apmSpans, llmobsSpans } = await getEvents()
 
-  assertLlmObsSpanEvent(events[0], {
+  assertLlmObsSpanEvent(llmobsSpans[0], {
+    span: apmSpans[0],
     spanKind: 'workflow',  // Not 'llm'!
     name: 'langgraph.graph.invoke'
   })
@@ -235,72 +229,12 @@ it('creates a tool span for a basic tool call', async () => {
 - ✅ Protocol-specific tags (`mcp_tool_kind`, `mcp_server_name`, `mcp_server_version`)
 - ✅ `inputValue` / `outputValue` carry the JSON-stringified protocol payloads
 
-## Decision Matrix
+## Which Row Applies
 
-Use this to choose strategy:
-
-### Does package make HTTP calls to LLM APIs?
-
-**YES** → Use VCR (LLM client or multi-provider)
-- Configure baseURL to VCR proxy
-- Make real API calls
-- Validate real responses
-
-**NO** → Check next question
-
-### Does it orchestrate workflows/graphs?
-
-**YES** → Pure functions (orchestration)
-- No VCR proxy
-- Mock LLM responses
-- Test state management
-
-**NO** → Infrastructure
-- Run the SDK's own server and client over its in-memory transport
-- Test protocol/transport
-
-## Common Mistakes
-
-### Mistake 1: Using VCR for Orchestration
-
-```javascript
-// ❌ WRONG - LangGraph with VCR
-const client = new StateGraph({
-  baseURL: 'http://127.0.0.1:9126/vcr/langgraph'
-})
-```
-
-**Why wrong:** LangGraph doesn't make HTTP calls itself.
-
-**Fix:** Use pure functions with mock responses.
-
-### Mistake 2: Not Using VCR for API Clients
-
-```javascript
-// ❌ WRONG - OpenAI without VCR
-const client = new OpenAI({
-  apiKey: 'real-key',
-  baseURL: 'https://api.openai.com'  // Direct to API
-})
-```
-
-**Why wrong:** Tests will fail without API key, hit rate limits, be non-deterministic.
-
-**Fix:** Use VCR proxy URL.
-
-### Mistake 3: Making Real API Calls in Orchestration Tests
-
-```javascript
-// ❌ WRONG - Real OpenAI in LangGraph test
-graph.addNode('agent', async (state) => {
-  const openai = new OpenAI({ apiKey: 'real-key' })
-  return await openai.chat.completions.create({ ... })
-})
-```
-
-**Why wrong:** Orchestration tests should be pure functions.
-
-**Fix:** Mock LLM responses directly.
+The question that picks the row is whether the package itself speaks HTTP to a provider. Pointing an
+orchestrator at a proxy baseURL, or letting a node inside a graph construct a real client, tests the provider
+instead of the graph; letting a client reach `https://api.openai.com` needs a key and stops being
+deterministic.
 
 ## Examples by Shape
 
@@ -341,12 +275,3 @@ await server.connect(serverTransport)
 await client.connect(clientTransport)
 await client.callTool({ name: 'test-tool', arguments: {} })
 ```
-
-## Summary
-
-- **API clients**: Use VCR, test real APIs
-- **Multi-provider**: Use VCR, test provider switching
-- **Orchestration**: Pure functions, mock responses
-- **Infrastructure**: SDK server over in-memory transport, test protocols
-
-Choose strategy based on what the package does, not what it's called.

--- a/.agents/skills/llmobs-testing/references/category-strategies.md
+++ b/.agents/skills/llmobs-testing/references/category-strategies.md
@@ -24,23 +24,22 @@ wrong one fails on contract rather than on behaviour.
 ### LLM client (openai, anthropic, genai)
 
 **FORBIDDEN:**
-- ❌ Pure function tests without VCR
+- ❌ Tests that skip the SDK and tag spans by hand
 - ❌ spanKind: 'workflow' (use 'llm' instead)
 
 **REQUIRED:**
-- ✅ VCR cassettes with proxy baseURL
-- ✅ Real API calls (recorded once)
+- ✅ Calls through the real client, answered by a cassette on the proxy baseURL or by a canned `fetch`
 - ✅ spanKind: 'llm'
 - ✅ modelName, modelProvider fields
 
 ### Multi-provider (ai, langchain)
 
-Same as LLM client.
+Same as LLM client. `ai` records cassettes for some providers and hands a canned `fetch` to others.
 
 ### Infrastructure (modelcontextprotocol-sdk)
 
 **REQUIRED:**
-- ✅ Mock server tests
+- ✅ The SDK's real server and client over its in-memory transport
 - ❌ NO VCR
 
 ---
@@ -54,7 +53,11 @@ Test strategy depends on package category:
 | LLM client | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
 | Multi-provider | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
 | Orchestration | ❌ No | ❌ No | ✅ Yes | Pure functions, mock responses |
-| Infrastructure | ❌ No | ❌ No | ✅ Yes | Mock servers |
+| Infrastructure | ❌ No | ❌ No | ✅ Yes | SDK server over in-memory transport |
+
+A cassette is the default source of responses for the first two rows. Where the client takes a `fetch` option
+(openai-agents, some `ai` providers) or only reaches for `global.fetch` (google-cloud-vertexai), the spec answers the
+call itself instead.
 
 ## LLM client & multi-provider
 
@@ -100,25 +103,28 @@ it('instruments chat completion', async () => {
 - ✅ Test provider-specific features
 - ✅ Commit cassettes to repo
 
-### ⚠️ Transitive Dependency Require Order
+### ⚠️ Require The SDK Inside `before()`
 
-If the instrumented methods live in a **sub-package** that is a dependency of the package you load (e.g. `@openai/agents-openai` is a dep of `@openai/agents-core`), you must **require the sub-package first**.
-
-RITM patches modules on their first `require()`. If the parent package loads the sub-package transitively before your `before()` hook requires it, the module is already cached and RITM never fires — instrumentation silently does nothing.
+RITM patches a module the first time it is loaded, and it cannot patch one already in the require cache.
+`useLlmObs()` loads the tracer from its own `before()` hook, so a `require` at file scope runs first and stays
+uninstrumented. Load the version fixtures from `before()`:
 
 ```javascript
-before(() => {
-  // ✅ CORRECT: require the instrumented sub-package first
-  const { OpenAIResponsesModel } = require('@openai/agents-openai')
-  const agentsCore = require('@openai/agents-core')
-
-  // ❌ WRONG: parent loads sub-package transitively, caching it before RITM patches it
-  // const agentsCore = require('@openai/agents-core')        // caches @openai/agents-openai
-  // const { OpenAIResponsesModel } = require('@openai/agents-openai')  // already cached, not patched
+withVersions('openai-agents', '@openai/agents', (version) => {
+  before(() => {
+    agentsCore = require(`../../../../../../versions/@openai/agents@${version}`).get()
+    const { OpenAIResponsesModel } =
+      require(`../../../../../../versions/@openai/agents-openai@${version}`).get()
+  })
 })
 ```
 
-**Symptom when wrong:** tests time out — `getEvents()` never resolves, no APM traces arrive, only the SDK's own internal tracing output appears.
+Order between the two does not matter here: `packages/datadog-instrumentations/src/openai-agents.js` hooks both
+`@openai/agents` and `@openai/agents-openai`. Where a spec's comment does ask for an order — the MCP spec requires
+its client entry before the server — keep it.
+
+**Symptom when wrong:** tests time out — `getEvents()` never resolves, no APM traces arrive, only the SDK's own
+internal tracing output appears.
 
 ## Orchestration
 
@@ -182,46 +188,52 @@ it('instruments graph invoke', async () => {
 
 ### Why No VCR?
 
-Orchestration tools don't make HTTP calls themselves - they coordinate other libraries that do. Testing them requires testing the orchestration logic, not API interactions.
+Orchestration tools don't make HTTP calls themselves - they coordinate other libraries that do. Testing them requires
+testing the orchestration logic, not API interactions.
 
 ## Infrastructure
 
-**Strategy:** Mock server tests
+**Strategy:** the SDK's own server and client, wired over its in-memory transport
 
 ### Setup
 
 ```javascript
-const mockServer = new MockMCPServer()
-await mockServer.start()
+const server = new McpServer({ name: 'test-server', version: '1.0.0' })
+server.registerTool('test-tool', { description: 'A test tool', inputSchema: {} }, async () => ({
+  content: [{ type: 'text', text: 'Result from test-tool' }],
+}))
+
+const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+await server.connect(serverTransport)
+
+client = new Client({ name: 'test-client', version: '1.0.0' })
+await client.connect(clientTransport)
 ```
 
 ### Test Pattern
 
 ```javascript
-it('instruments MCP protocol', async () => {
-  const client = new MCPClient({
-    serverUrl: mockServer.url
-  })
+it('creates a tool span for a basic tool call', async () => {
+  const result = await client.callTool({ name: 'test-tool', arguments: {} })
 
-  await client.connect()
-  const response = await client.call('method', params)
+  const { apmSpans, llmobsSpans } = await getEvents()
 
-  const events = getEvents()
-
-  assertLlmObsSpanEvent(events[0], {
-    spanKind: 'task',  // Or appropriate kind
-    name: 'mcp.call'
+  assertLlmObsSpanEvent(llmobsSpans[0], {
+    span: apmSpans[0],
+    spanKind: 'tool',
+    name: 'MCP Client Tool Call: test-tool',
+    inputValue: JSON.stringify({ name: 'test-tool', arguments: {} }),
+    tags: { ml_app: 'test', integration: 'modelcontextprotocol-sdk', mcp_tool_kind: 'client' },
   })
 })
 ```
 
 ### Key Points
 
-- ❌ NO VCR
-- ✅ Mock server instances
-- ✅ Test protocol compliance
-- ✅ Test message passing
-- ✅ Validate transport behavior
+- ❌ NO VCR, and no hand-rolled fake server — the tool handlers you register are the canned responses
+- ✅ Span kinds `'tool'` for tool calls and `'task'` for the rest of the protocol
+- ✅ Protocol-specific tags (`mcp_tool_kind`, `mcp_server_name`, `mcp_server_version`)
+- ✅ `inputValue` / `outputValue` carry the JSON-stringified protocol payloads
 
 ## Decision Matrix
 
@@ -243,8 +255,8 @@ Use this to choose strategy:
 - Mock LLM responses
 - Test state management
 
-**NO** → Mock servers (infrastructure)
-- Create mock server
+**NO** → Infrastructure
+- Run the SDK's own server and client over its in-memory transport
 - Test protocol/transport
 
 ## Common Mistakes
@@ -321,12 +333,13 @@ graph.addNode('agent', async (state) => ({
 await graph.invoke({ ... })
 ```
 
-### Infrastructure: MCP (Mock Server)
+### Infrastructure: MCP
 
 ```javascript
-const mockServer = new MockServer()
-const client = new MCPClient({ url: mockServer.url })
-await client.call('method', {})
+const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+await server.connect(serverTransport)
+await client.connect(clientTransport)
+await client.callTool({ name: 'test-tool', arguments: {} })
 ```
 
 ## Summary
@@ -334,6 +347,6 @@ await client.call('method', {})
 - **API clients**: Use VCR, test real APIs
 - **Multi-provider**: Use VCR, test provider switching
 - **Orchestration**: Pure functions, mock responses
-- **Infrastructure**: Mock servers, test protocols
+- **Infrastructure**: SDK server over in-memory transport, test protocols
 
 Choose strategy based on what the package does, not what it's called.

--- a/.agents/skills/llmobs-testing/references/category-strategies.md
+++ b/.agents/skills/llmobs-testing/references/category-strategies.md
@@ -1,7 +1,7 @@
-# Test Strategy Per Package Shape
+# Test Strategy Per Instrumented Surface
 
-The strategies do not mix: each shape forbids what another requires, so a spec written against the
-wrong one fails on contract rather than on behaviour.
+A package may expose several kinds of surface. Choose the response source and expected span fields for each
+instrumented operation.
 
 ## Quick Reference: What's FORBIDDEN vs REQUIRED
 
@@ -21,20 +21,22 @@ wrong one fails on contract rather than on behaviour.
 - ✅ spanKind: 'workflow' or 'agent'
 - ✅ Test orchestration logic, not API calls
 
-### LLM client (openai, anthropic, genai)
+### Provider-backed LLM operation (openai, anthropic, genai)
 
 **FORBIDDEN:**
 - ❌ Tests that skip the SDK and tag spans by hand
-- ❌ spanKind: 'workflow' (use 'llm' instead)
+- ❌ `spanKind: 'workflow'` for chat or generation
 
 **REQUIRED:**
-- ✅ Calls through the real client, answered by a cassette on the proxy baseURL or by a canned `fetch`
-- ✅ spanKind: 'llm'
-- ✅ modelName, modelProvider fields
+- ✅ Calls through the real client, answered by a cassette on the proxy baseURL or a canned `fetch`
+- ✅ `spanKind: 'llm'`
+- ✅ `modelName` and `modelProvider`
 
 ### Multi-provider (ai, langchain)
 
-Same as LLM client. `ai` records cassettes for some providers and hands a canned `fetch` to others.
+Exercise the real abstraction and provider path. `ai` records cassettes for some providers and hands a canned
+`fetch` to others. Do not assign one kind to the package: `ai` and LangChain emit kinds such as `llm`, `workflow`,
+`embedding`, `retrieval`, and `tool` according to the operation.
 
 ### Infrastructure (modelcontextprotocol-sdk)
 
@@ -46,29 +48,28 @@ Same as LLM client. `ai` records cassettes for some providers and hands a canned
 
 ## Overview
 
-Test strategy depends on package category:
+Response strategy depends on the surface under test:
 
-| Package shape | VCR | Real APIs | Mock LLMs | Strategy |
-|----------------|-----|-----------|-----------|----------|
-| LLM client | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
-| Multi-provider | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
-| Orchestration | ❌ No | ❌ No | ✅ Yes | Pure functions, mock responses |
-| Infrastructure | ❌ No | ❌ No | ✅ Yes | SDK server over in-memory transport |
+| Surface | Response source | Harness |
+|---------|-----------------|---------|
+| LLM client | Provider response | Real client through VCR or a canned `fetch` |
+| Multi-provider | Provider response | Real abstraction and provider through VCR or a canned `fetch` |
+| Orchestration | Plain node response | Native graph/workflow APIs |
+| Infrastructure | Protocol handler response | SDK server and client over in-memory transport |
 
-A cassette is the default source of responses for the first two rows. Where the client takes a `fetch` option
-(openai-agents, some `ai` providers) or only reaches for `global.fetch` (google-cloud-vertexai), the spec answers the
-call itself instead.
+A cassette is the default provider response. Where the client takes a `fetch` option (openai-agents, some `ai`
+providers) or only reaches for `global.fetch` (google-cloud-vertexai), the spec answers the call itself instead.
 
-## LLM client & multi-provider
+## Provider-backed operations
 
-**Strategy:** VCR with real API calls through proxy
+**Strategy:** the real SDK path through VCR or a canned `fetch`
 
 ### Setup
 
 ```javascript
 const client = new MyLLMClient({
   apiKey: 'test-key',
-  baseURL: 'http://127.0.0.1:9126/vcr/provider'  // VCR proxy
+  baseURL: 'http://127.0.0.1:9126/vcr/provider'
 })
 ```
 
@@ -76,8 +77,7 @@ const client = new MyLLMClient({
 
 ```javascript
 it('instruments chat completion', async () => {
-  // Real API call (first run records, subsequent replays)
-  const response = await client.chat.completions.create({
+  await client.chat.completions.create({
     messages: [{ role: 'user', content: 'Hello' }],
     model: 'gpt-4'
   })
@@ -87,15 +87,25 @@ it('instruments chat completion', async () => {
   assertLlmObsSpanEvent(llmobsSpans[0], {
     span: apmSpans[0],
     spanKind: 'llm',
-    modelName: 'gpt-4',
+    name: 'MyLLMClient.createChatCompletion',
+    modelName: 'my-model',
+    modelProvider: 'my-provider',
     inputMessages: [{ content: 'Hello', role: 'user' }],
     outputMessages: [{ content: MOCK_STRING, role: 'assistant' }],
-    metrics: { input_tokens: MOCK_NOT_NULLISH }
+    metrics: {
+      input_tokens: MOCK_NOT_NULLISH,
+      output_tokens: MOCK_NOT_NULLISH,
+      total_tokens: MOCK_NOT_NULLISH
+    },
+    tags: { ml_app: 'test', integration: 'my-integration' }
   })
 })
 ```
 
-### ⚠️ Require The SDK Inside `before()`
+`name` and `modelProvider` are whatever the plugin reports, not strings the spec picks, and `tags` is required —
+see [assertion-helpers.md](assertion-helpers.md) for the openai shape and the required-field list.
+
+### Require The SDK Inside `before()`
 
 A module is instrumented by the `require` that runs after the hooks are installed: RITM's patched require pulls
 the exports (from Node's cache if they are already there) and hands them to every registered hook.
@@ -112,9 +122,12 @@ withVersions('openai-agents', '@openai/agents', (version) => {
 })
 ```
 
-Order between the two does not matter here: `packages/datadog-instrumentations/src/openai-agents.js` hooks both
-`@openai/agents` and `@openai/agents-openai`. Where a spec's comment does ask for an order — the MCP spec requires
-its client entry before the server — keep it.
+`beforeEach()` works the same way and is what the openai and langgraph specs use; the requirement is any hook
+rather than file scope.
+
+Order between the two requires does not matter here: `packages/datadog-instrumentations/src/openai-agents.js` hooks
+both `@openai/agents` and `@openai/agents-openai`. Where a spec's comment does ask for an order — the MCP spec
+requires its client entry before the server — keep it.
 
 **Symptom when wrong:** tests time out — `getEvents()` never resolves, no APM traces arrive, only the SDK's own
 internal tracing output appears.
@@ -125,48 +138,60 @@ internal tracing output appears.
 
 ### Setup
 
+No proxy and no client — the graph is built from the library's own exports, required from the version fixture in a
+hook so the tracer is already installed:
+
 ```javascript
-// No VCR proxy - use library directly
-const { StateGraph, Annotation } = require('@langchain/langgraph')
+let StateGraph
+let Annotation
+
+beforeEach(() => {
+  const langgraph = require(`../../../../../../versions/@langchain/langgraph@${version}`).get()
+  StateGraph = langgraph.StateGraph
+  Annotation = langgraph.Annotation
+})
 ```
 
 ### Test Pattern
 
 ```javascript
-it('instruments graph invoke', async () => {
-  // Create graph with mock LLM responses
-  const graph = new StateGraph({
-    channels: {
-      messages: Annotation.Root({
-        reducer: (x, y) => x.concat(y)
-      })
-    }
+it('creates a workflow span for streaming execution', async () => {
+  const StateAnnotation = Annotation.Root({
+    messages: Annotation({
+      reducer: (existingMessages, newMessages) => existingMessages.concat(newMessages),
+      default: () => [],
+    }),
   })
 
-  // Add node with mock LLM response (no real API call)
-  graph.addNode('agent', async (state) => ({
-    messages: [{ role: 'assistant', content: 'Mock LLM response' }]
-  }))
+  const workflow = new StateGraph(StateAnnotation)
+    .addNode('chat', () => ({ messages: [{ role: 'assistant', content: 'Streaming response' }] }))
+    .addEdge('__start__', 'chat')
+    .addEdge('chat', '__end__')
 
-  graph.addEdge(START, 'agent')
-  graph.addEdge('agent', END)
+  const app = workflow.compile({ name: 'my-graph' })
 
-  const compiled = graph.compile()
-
-  // Invoke with mock data
-  const result = await compiled.invoke({
-    messages: [{ role: 'user', content: 'Test' }]
-  })
+  const chunks = []
+  for await (const chunk of await app.stream({ messages: [{ role: 'user', content: 'Test' }] })) {
+    chunks.push(chunk)
+  }
+  assert.ok(chunks.length > 0, `Expected ${chunks.length} > 0`)
 
   const { apmSpans, llmobsSpans } = await getEvents()
 
   assertLlmObsSpanEvent(llmobsSpans[0], {
     span: apmSpans[0],
-    spanKind: 'workflow',  // Not 'llm'!
-    name: 'langgraph.graph.invoke'
+    spanKind: 'workflow',
+    name: 'my-graph',
+    inputValue: JSON.stringify({ messages: [{ role: 'user', content: 'Test' }] }),
+    outputValue: MOCK_STRING,
+    tags: { ml_app: 'test', integration: 'langgraph' },
   })
 })
 ```
+
+The instrumented entry point is `Pregel.stream`, so the span closes when the iterator is drained, and `name` is
+whatever `compile({ name })` was given. The graph's state shape comes from `Annotation.Root`, and the terminal
+nodes are the `'__start__'` / `'__end__'` literals the spec uses.
 
 ### Key Points
 
@@ -178,12 +203,12 @@ it('instruments graph invoke', async () => {
 - ✅ Use pure functions returning mock data
 - ✅ Test workflow/graph state transitions
 - ✅ Mock LLM responses as simple objects
-- ✅ Load modules in `beforeEach()` for fresh state
+- ✅ Load modules after `useLlmObs()` installs the tracer
 
 ### Why No VCR?
 
-Orchestration tools don't make HTTP calls themselves - they coordinate other libraries that do. Testing them requires
-testing the orchestration logic, not API interactions.
+Pure orchestration operations do not make provider HTTP calls. Their tests exercise graph state and execution rather
+than a provider API.
 
 ## Infrastructure
 
@@ -208,7 +233,7 @@ await client.connect(clientTransport)
 
 ```javascript
 it('creates a tool span for a basic tool call', async () => {
-  const result = await client.callTool({ name: 'test-tool', arguments: {} })
+  await client.callTool({ name: 'test-tool', arguments: {} })
 
   const { apmSpans, llmobsSpans } = await getEvents()
 
@@ -217,7 +242,17 @@ it('creates a tool span for a basic tool call', async () => {
     spanKind: 'tool',
     name: 'MCP Client Tool Call: test-tool',
     inputValue: JSON.stringify({ name: 'test-tool', arguments: {} }),
-    tags: { ml_app: 'test', integration: 'modelcontextprotocol-sdk', mcp_tool_kind: 'client' },
+    outputValue: JSON.stringify({
+      content: [{ type: 'text', text: 'Result from test-tool', annotations: {}, meta: {} }],
+      isError: false,
+    }),
+    tags: {
+      ml_app: 'test',
+      integration: 'modelcontextprotocol-sdk',
+      mcp_tool_kind: 'client',
+      mcp_server_name: 'test-server',
+      mcp_server_version: '1.0.0',
+    },
   })
 })
 ```
@@ -225,16 +260,15 @@ it('creates a tool span for a basic tool call', async () => {
 ### Key Points
 
 - ❌ NO VCR, and no hand-rolled fake server — the tool handlers you register are the canned responses
-- ✅ Span kinds `'tool'` for tool calls and `'task'` for the rest of the protocol
+- ✅ Span kind `'tool'` for tool calls and `'task'` for list-tools
 - ✅ Protocol-specific tags (`mcp_tool_kind`, `mcp_server_name`, `mcp_server_version`)
 - ✅ `inputValue` / `outputValue` carry the JSON-stringified protocol payloads
 
 ## Which Row Applies
 
-The question that picks the row is whether the package itself speaks HTTP to a provider. Pointing an
-orchestrator at a proxy baseURL, or letting a node inside a graph construct a real client, tests the provider
-instead of the graph; letting a client reach `https://api.openai.com` needs a key and stops being
-deterministic.
+The question that picks the response source is whether the instrumented operation reaches a provider. Pointing an
+orchestrator at a proxy baseURL, or letting a node construct a real client, tests the provider instead of the graph;
+letting a client reach `https://api.openai.com` needs a key and stops being deterministic.
 
 ## Examples by Shape
 
@@ -261,10 +295,13 @@ await generateText({ model, prompt: '...' })
 ### Orchestration: LangGraph (Pure Functions)
 
 ```javascript
-graph.addNode('agent', async (state) => ({
-  messages: [{ role: 'assistant', content: 'Mock' }]
-}))
-await graph.invoke({ ... })
+const workflow = new StateGraph(StateAnnotation)
+  .addNode('chat', () => ({ messages: [{ role: 'assistant', content: 'Mock' }] }))
+  .addEdge('__start__', 'chat')
+  .addEdge('chat', '__end__')
+
+const app = workflow.compile({ name: 'my-graph' })
+for await (const chunk of await app.stream({ messages: [] })) { /* drain to close the span */ }
 ```
 
 ### Infrastructure: MCP

--- a/.agents/skills/llmobs-testing/references/category-strategies.md
+++ b/.agents/skills/llmobs-testing/references/category-strategies.md
@@ -1,16 +1,11 @@
-# Category-Specific Test Strategies
+# Test Strategy Per Package Shape
 
-## ⚠️ CRITICAL: Categories Are Mutually Exclusive ⚠️
-
-**YOU CANNOT MIX STRATEGIES BETWEEN CATEGORIES.**
-
-**Each category has FORBIDDEN and REQUIRED patterns. Violating these will cause test failure.**
-
----
+The strategies do not mix: each shape forbids what another requires, so a spec written against the
+wrong one fails on contract rather than on behaviour.
 
 ## Quick Reference: What's FORBIDDEN vs REQUIRED
 
-### ORCHESTRATION (langgraph, crewai, autogen)
+### Orchestration (langgraph)
 
 **FORBIDDEN:**
 - ❌ VCR cassettes or VCR proxy URLs
@@ -26,7 +21,7 @@
 - ✅ spanKind: 'workflow' or 'agent'
 - ✅ Test orchestration logic, not API calls
 
-### LLM_CLIENT (openai, anthropic, google-genai)
+### LLM client (openai, anthropic, genai)
 
 **FORBIDDEN:**
 - ❌ Pure function tests without VCR
@@ -38,11 +33,11 @@
 - ✅ spanKind: 'llm'
 - ✅ modelName, modelProvider fields
 
-### MULTI_PROVIDER (ai-sdk, langchain)
+### Multi-provider (ai, langchain)
 
-Same as LLM_CLIENT.
+Same as LLM client.
 
-### INFRASTRUCTURE (MCP)
+### Infrastructure (modelcontextprotocol-sdk)
 
 **REQUIRED:**
 - ✅ Mock server tests
@@ -54,18 +49,14 @@ Same as LLM_CLIENT.
 
 Test strategy depends on package category:
 
-| LlmObsCategory | VCR | Real APIs | Mock LLMs | Strategy |
+| Package shape | VCR | Real APIs | Mock LLMs | Strategy |
 |----------------|-----|-----------|-----------|----------|
-| LLM_CLIENT | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
-| MULTI_PROVIDER | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
-| ORCHESTRATION | ❌ No | ❌ No | ✅ Yes | Pure functions, mock responses |
-| INFRASTRUCTURE | ❌ No | ❌ No | ✅ Yes | Mock servers |
+| LLM client | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
+| Multi-provider | ✅ Yes | ✅ Yes | ❌ No | VCR with real API calls |
+| Orchestration | ❌ No | ❌ No | ✅ Yes | Pure functions, mock responses |
+| Infrastructure | ❌ No | ❌ No | ✅ Yes | Mock servers |
 
-**Enum location:** `anubis_apm/workflows/analyze/models.py`
-
-**IF YOU USE THE WRONG STRATEGY, THE TEST WILL FAIL. ALWAYS CHECK THE CATEGORY FIRST.**
-
-## LlmObsCategory.LLM_CLIENT & LlmObsCategory.MULTI_PROVIDER
+## LLM client & multi-provider
 
 **Strategy:** VCR with real API calls through proxy
 
@@ -129,7 +120,7 @@ before(() => {
 
 **Symptom when wrong:** tests time out — `getEvents()` never resolves, no APM traces arrive, only the SDK's own internal tracing output appears.
 
-## LlmObsCategory.ORCHESTRATION
+## Orchestration
 
 **Strategy:** Pure function tests, NO VCR, NO real API calls
 
@@ -193,7 +184,7 @@ it('instruments graph invoke', async () => {
 
 Orchestration tools don't make HTTP calls themselves - they coordinate other libraries that do. Testing them requires testing the orchestration logic, not API interactions.
 
-## Category 4: Infrastructure
+## Infrastructure
 
 **Strategy:** Mock server tests
 
@@ -238,7 +229,7 @@ Use this to choose strategy:
 
 ### Does package make HTTP calls to LLM APIs?
 
-**YES** → Use VCR (Category 1 or 2)
+**YES** → Use VCR (LLM client or multi-provider)
 - Configure baseURL to VCR proxy
 - Make real API calls
 - Validate real responses
@@ -247,12 +238,12 @@ Use this to choose strategy:
 
 ### Does it orchestrate workflows/graphs?
 
-**YES** → Pure functions (Category 3)
+**YES** → Pure functions (orchestration)
 - No VCR proxy
 - Mock LLM responses
 - Test state management
 
-**NO** → Mock servers (Category 4)
+**NO** → Mock servers (infrastructure)
 - Create mock server
 - Test protocol/transport
 
@@ -299,9 +290,9 @@ graph.addNode('agent', async (state) => {
 
 **Fix:** Mock LLM responses directly.
 
-## Examples by Category
+## Examples by Shape
 
-### Category 1: OpenAI (VCR)
+### LLM client: OpenAI (VCR)
 
 ```javascript
 const openai = new OpenAI({
@@ -311,7 +302,7 @@ const openai = new OpenAI({
 await openai.chat.completions.create({ ... })
 ```
 
-### Category 2: Vercel AI SDK (VCR)
+### Multi-provider: Vercel AI SDK (VCR)
 
 ```javascript
 const model = createOpenAI({
@@ -321,7 +312,7 @@ const model = createOpenAI({
 await generateText({ model, prompt: '...' })
 ```
 
-### Category 3: LangGraph (Pure Functions)
+### Orchestration: LangGraph (Pure Functions)
 
 ```javascript
 graph.addNode('agent', async (state) => ({
@@ -330,7 +321,7 @@ graph.addNode('agent', async (state) => ({
 await graph.invoke({ ... })
 ```
 
-### Category 4: MCP (Mock Server)
+### Infrastructure: MCP (Mock Server)
 
 ```javascript
 const mockServer = new MockServer()

--- a/.agents/skills/llmobs-testing/references/test-structure.md
+++ b/.agents/skills/llmobs-testing/references/test-structure.md
@@ -7,6 +7,8 @@ Complete guide to organizing LLMObs test files.
 ```javascript
 'use strict'
 
+const assert = require('node:assert/strict')
+
 const { useLlmObs, assertLlmObsSpanEvent, MOCK_STRING, MOCK_NOT_NULLISH } = require('../../util')
 
 describe('my-integration LLMObs', () => {
@@ -15,24 +17,20 @@ describe('my-integration LLMObs', () => {
   let MyClient
   let client
 
-  beforeEach(() => {
-    // Load module fresh for each test
+  before(() => {
     MyClient = require('my-integration')
+  })
 
-    // Initialize client with VCR proxy (if using VCR)
+  beforeEach(() => {
     client = new MyClient({
       apiKey: 'test-api-key',
       baseURL: 'http://127.0.0.1:9126/vcr/my-integration'
     })
   })
 
-  afterEach(() => {
-    // Cleanup if needed
-  })
-
   describe('chat completions', () => {
     it('instruments basic chat', async () => {
-      const result = await client.chat({
+      await client.chat({
         messages: [{ role: 'user', content: 'Hello' }],
         model: 'test-model',
         temperature: 0.7
@@ -53,23 +51,40 @@ describe('my-integration LLMObs', () => {
           output_tokens: MOCK_NOT_NULLISH,
           total_tokens: MOCK_NOT_NULLISH
         },
-        metadata: {
-          temperature: 0.7
-        }
+        metadata: { temperature: 0.7 },
+        tags: { ml_app: 'test', integration: 'my-integration' }
       })
     })
 
     it('handles errors', async () => {
-      const error = await client.chat({ messages: [], model: 'invalid' }).catch(error => error)
+      let requestError
+      await assert.rejects(
+        () => client.chat({
+          messages: [{ role: 'user', content: 'Hello' }],
+          model: 'invalid',
+          temperature: 0.7
+        }),
+        (error) => {
+          requestError = error
+          return true
+        }
+      )
 
       const { apmSpans, llmobsSpans } = await getEvents()
 
       assertLlmObsSpanEvent(llmobsSpans[0], {
         span: apmSpans[0],
         spanKind: 'llm',
+        name: 'my-integration.chat',
+        modelName: 'invalid',
+        modelProvider: 'my-integration',
+        inputMessages: [{ content: 'Hello', role: 'user' }],
         outputMessages: [{ content: '', role: '' }],
-        error: { type: 'Error', message: error.message, stack: error.stack }
+        metadata: { temperature: 0.7 },
+        tags: { ml_app: 'test', integration: 'my-integration' },
+        error: {}
       })
+      assert.strictEqual(apmSpans[0].meta['error.message'], requestError.message)
     })
   })
 })
@@ -92,22 +107,24 @@ const { apmSpans, llmobsSpans } = await getEvents(2)
 
 ## Module Loading Pattern
 
-**Critical for state isolation:**
+**Critical for instrumentation order:**
 
 ```javascript
 let MyLib
 let client
 
-beforeEach(() => {
-  // Fresh require each test
+before(() => {
   MyLib = require('my-lib')
+})
+
+beforeEach(() => {
   client = new MyLib()
 })
 ```
 
-A require at file scope is shared by every test and runs before the tracer exists, so the exports it captures
-are never instrumented. See
-[category-strategies.md](category-strategies.md) for the fixture form and why the hook matters.
+A file-scope require runs before `useLlmObs()` installs the tracer. Register `useLlmObs()` first, require the SDK
+from a `before()` or `beforeEach()` hook, and recreate mutable clients in `beforeEach()` when tests need isolation.
+See [category-strategies.md](category-strategies.md) for the version-fixture form.
 
 ## Test Organization
 
@@ -116,13 +133,17 @@ Group by method (`describe('chat completions')`, `describe('embeddings')`) or by
 
 ## Assertions
 
-```javascript
-const { useLlmObs, assertLlmObsSpanEvent, MOCK_STRING, MOCK_NOT_NULLISH } = require('../../util')
+Pin the number of events before asserting them, so an extra or missing span fails here rather than inside the
+event comparison:
 
+```javascript
 const { apmSpans, llmobsSpans } = await getEvents()
 assert.strictEqual(llmobsSpans.length, 1)
-assertLlmObsSpanEvent(llmobsSpans[0], { span: apmSpans[0], spanKind: 'llm' })
 ```
+
+Then assert each event as the template above does. `span`, `spanKind`, `name` and `tags` are required — leaving
+`span` or `tags` out throws a `TypeError` rather than failing an assertion — and omitted fields assert their
+absence. `traceId` is the exception: it defaults to `MOCK_STRING`.
 
 Per-shape patterns, including the orchestration spec that answers its own nodes rather than recording
 cassettes, live in [category-strategies.md](category-strategies.md).

--- a/.agents/skills/llmobs-testing/references/test-structure.md
+++ b/.agents/skills/llmobs-testing/references/test-structure.md
@@ -38,10 +38,10 @@ describe('my-integration LLMObs', () => {
         temperature: 0.7
       })
 
-      const events = getEvents()
-      expect(events).to.have.lengthOf(1)
+      const { apmSpans, llmobsSpans } = await getEvents()
 
-      assertLlmObsSpanEvent(events[0], {
+      assertLlmObsSpanEvent(llmobsSpans[0], {
+        span: apmSpans[0],
         spanKind: 'llm',
         name: 'my-integration.chat',
         modelName: 'test-model',
@@ -60,52 +60,35 @@ describe('my-integration LLMObs', () => {
     })
 
     it('handles errors', async () => {
-      try {
-        await client.chat({ messages: [], model: 'invalid' })
-      } catch (err) {
-        // Expected error
-      }
+      const error = await client.chat({ messages: [], model: 'invalid' }).catch(error => error)
 
-      const events = getEvents()
+      const { apmSpans, llmobsSpans } = await getEvents()
 
-      assertLlmObsSpanEvent(events[0], {
+      assertLlmObsSpanEvent(llmobsSpans[0], {
+        span: apmSpans[0],
         spanKind: 'llm',
         outputMessages: [{ content: '', role: '' }],
-        error: MOCK_NOT_NULLISH
+        error: { type: 'Error', message: error.message, stack: error.stack }
       })
     })
   })
 })
 ```
 
-## useLlmObs Configuration
+## useLlmObs And getEvents
 
 ```javascript
-const { getEvents } = useLlmObs({ plugin: 'integration-name' })
+const { getEvents, assertNoLlmObsSpans, getEvaluationMetrics } =
+  useLlmObs({ plugin: 'integration-name', tracerConfigOptions: {} })
 ```
 
-**Parameters:**
-- `plugin` (string): Plugin name to test
-
-**Returns:**
-- `getEvents()` function that returns captured span events
-
-**Usage:**
-Call `useLlmObs()` once at describe block level, then call `getEvents()` in each test.
-
-## getEvents() Usage
+Call `useLlmObs()` once per `describe`; it installs its own `before` / `after` hooks. `getEvents(count = 1)` is
+async and resolves `{ apmSpans, llmobsSpans }` once that many LLMObs span events have arrived, in creation
+order, so a spec that asks for the wrong count times out rather than failing an assertion:
 
 ```javascript
-const events = getEvents()
+const { apmSpans, llmobsSpans } = await getEvents(2)
 ```
-
-**Returns:** Array of captured LLMObs span events
-
-**Usage:**
-- Call after instrumented operation completes
-- Returns spans in creation order
-- Use `events[0]` for first/only span
-- Use `events.length` to assert count
 
 ## Module Loading Pattern
 
@@ -122,130 +105,27 @@ beforeEach(() => {
 })
 ```
 
-**Why this matters:**
-- Ensures clean state between tests
-- Prevents test pollution
-- Especially important for orchestration packages with state management
-- Allows each test to start fresh
-
-**Bad pattern (don't do this):**
-```javascript
-// At top of file
-const MyLib = require('my-lib')  // ❌ Shared across all tests
-
-describe('tests', () => {
-  it('test 1', () => { ... })  // May affect test 2
-  it('test 2', () => { ... })  // May be affected by test 1
-})
-```
+A require at file scope is shared by every test and runs before the tracer exists, so the exports it captures
+are never instrumented. See
+[category-strategies.md](category-strategies.md) for the fixture form and why the hook matters.
 
 ## Test Organization
 
 Group by method (`describe('chat completions')`, `describe('embeddings')`) or by scenario (`describe('basic usage')`,
 `describe('error handling')`).
 
-## beforeEach / afterEach
-
-Standard: Load module in `beforeEach`, cleanup in `afterEach` if needed.
-Async: Use `async beforeEach/afterEach` if initialization/cleanup is async.
-
-## Imports
-
-```javascript
-const { useLlmObs, assertLlmObsSpanEvent, MOCK_STRING, MOCK_NOT_NULLISH } = require('../../util')
-```
-
 ## Assertions
 
 ```javascript
-const events = getEvents()
-expect(events).to.have.lengthOf(1)
-assertLlmObsSpanEvent(events[0], { spanKind: 'llm', ... })
+const { useLlmObs, assertLlmObsSpanEvent, MOCK_STRING, MOCK_NOT_NULLISH } = require('../../util')
+
+const { apmSpans, llmobsSpans } = await getEvents()
+assert.strictEqual(llmobsSpans.length, 1)
+assertLlmObsSpanEvent(llmobsSpans[0], { span: apmSpans[0], spanKind: 'llm' })
 ```
 
-## Testing Orchestration
-
-**No VCR, pure functions:**
-
-```javascript
-describe('langgraph', () => {
-  const { getEvents } = useLlmObs({ plugin: 'langgraph' })
-
-  let StateGraph, Annotation
-
-  beforeEach(() => {
-    // Fresh import
-    const langgraph = require('@langchain/langgraph')
-    StateGraph = langgraph.StateGraph
-    Annotation = langgraph.Annotation
-  })
-
-  it('instruments graph invoke', async () => {
-    const graph = new StateGraph({
-      channels: {
-        messages: Annotation.Root({ ... })
-      }
-    })
-
-    graph.addNode('agent', async (state) => ({
-      messages: [{ role: 'assistant', content: 'Mock response' }]
-    }))
-
-    const result = await graph.invoke({ messages: [...] })
-
-    assertLlmObsSpanEvent(events[0], {
-      spanKind: 'workflow',  // Not 'llm'
-      name: 'langgraph.graph.invoke'
-    })
-  })
-})
-```
-
-## Common Pitfalls
-
-### Pitfall 1: Forgetting to call getEvents()
-
-```javascript
-// ❌ Bad
-it('test', async () => {
-  await client.chat({ ... })
-  // Missing: const events = getEvents()
-  assertLlmObsSpanEvent(undefined, { ... })  // Error!
-})
-
-// ✅ Good
-it('test', async () => {
-  await client.chat({ ... })
-  const events = getEvents()
-  assertLlmObsSpanEvent(events[0], { ... })
-})
-```
-
-### Pitfall 2: Using VCR for orchestration
-
-```javascript
-// ❌ Bad (orchestration with VCR)
-const client = new LangGraph({
-  baseURL: 'http://127.0.0.1:9126/vcr/langgraph'  // Wrong!
-})
-
-// ✅ Good (orchestration without VCR)
-const graph = new StateGraph({ ... })  // Pure functions
-```
-
-### Pitfall 3: Not isolating module state
-
-```javascript
-// ❌ Bad (shared state)
-const MyLib = require('my-lib')  // Once at top
-it('test 1', () => { ... })  // Modifies MyLib state
-it('test 2', () => { ... })  // Affected by test 1
-
-// ✅ Good (isolated)
-beforeEach(() => {
-  MyLib = require('my-lib')  // Fresh each test
-})
-```
+Per-shape patterns, including the orchestration spec that answers its own nodes rather than recording
+cassettes, live in [category-strategies.md](category-strategies.md).
 
 ## Working Examples
 

--- a/.agents/skills/llmobs-testing/references/test-structure.md
+++ b/.agents/skills/llmobs-testing/references/test-structure.md
@@ -141,7 +141,8 @@ describe('tests', () => {
 
 ## Test Organization
 
-Group by method (`describe('chat completions')`, `describe('embeddings')`) or by scenario (`describe('basic usage')`, `describe('error handling')`).
+Group by method (`describe('chat completions')`, `describe('embeddings')`) or by scenario (`describe('basic usage')`,
+`describe('error handling')`).
 
 ## beforeEach / afterEach
 

--- a/.agents/skills/llmobs-testing/references/test-structure.md
+++ b/.agents/skills/llmobs-testing/references/test-structure.md
@@ -162,7 +162,7 @@ expect(events).to.have.lengthOf(1)
 assertLlmObsSpanEvent(events[0], { spanKind: 'llm', ... })
 ```
 
-## Testing Orchestration (Category 3)
+## Testing Orchestration
 
 **No VCR, pure functions:**
 
@@ -250,7 +250,7 @@ beforeEach(() => {
 
 Study these test files as templates:
 
-- `packages/dd-trace/test/llmobs/plugins/openai/index.spec.js` - Simple format
+- `packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js` - Simple format
 - `packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js` - Complex format
 - `packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js` - Nested format
-- `packages/dd-trace/test/llmobs/plugins/langchain-langgraph/index.spec.js` - Orchestration
+- `packages/dd-trace/test/llmobs/plugins/langgraph/index.spec.js` - Orchestration

--- a/.agents/skills/llmobs-testing/references/vcr-cassettes.md
+++ b/.agents/skills/llmobs-testing/references/vcr-cassettes.md
@@ -39,14 +39,12 @@ new OpenAI({
 
 Names are generated as `{provider}_{path}_{method}_{hash}`, so you never choose or rename one. The
 hash covers the request, which means editing a prompt in a spec orphans its cassette and requires a
-new recording. Both `.json` and `.yaml` files are in the tree and both replay, so take whichever
-format a recording produces; each request is stored once, in one format, so a cassette never has a
-twin in the other. Binary and multipart bodies live inside JSON cassettes, base64-encoded behind a
-`base64:` prefix.
+new recording. Both `.json` and `.yaml` files replay, so keep the format a recording produces. Binary and
+multipart bodies may be base64-encoded behind a `base64:` prefix.
 
-Only one of the seven cassette directories has an entry in `VCR_PROVIDER_MAP` in `docker-compose.yml`:
-`claude-agent-sdk=https://api.anthropic.com`. The other six (openai, anthropic, genai, azure-openai,
-deepseek, bedrock-runtime) are names the testagent resolves on its own. Add a map entry when it cannot.
+`VCR_PROVIDER_MAP` in `docker-compose.yml` lists only provider aliases the testagent cannot resolve itself.
+Read the current mapping before adding another, and add one only when the testagent cannot infer the upstream
+provider.
 
 ## Recording
 
@@ -54,7 +52,9 @@ deepseek, bedrock-runtime) are names the testagent resolves on its own. Add a ma
   uncomment `AWS_SECRET_ACCESS_KEY` in the testagent service and restart it.
 2. Run the spec. A request with no cassette is recorded; one with a cassette is replayed, so
   re-recording means deleting exactly the cassette in question — never the provider directory.
-3. Commit the new files with the spec that produced them.
+3. Inspect every new cassette, including decoded `base64:` bodies, for credentials and sensitive prompt or response
+  data. Remove the value at the source or add a normalizer and re-record; do not hand-edit only the cassette.
+4. Commit the new files with the spec that produced them.
 
 ## Non-deterministic fields break replay — normalize, never loosen the assertion
 
@@ -65,7 +65,7 @@ match on replay. Strip it in `docker-compose.yml`, where the other normalizers a
 - `VCR_BODY_REGEX_NORMALIZERS` — regexes, for values embedded in prose bodies (agent ids,
   `<usage>` blocks, tool descriptions, client version markers).
 
-A cassette that replays locally but fails in CI is almost always a field that needs one of these.
+When replay differs across environments, inspect the request diff for a field that needs one of these.
 
 ## Running the specs
 

--- a/.agents/skills/llmobs-testing/references/vcr-cassettes.md
+++ b/.agents/skills/llmobs-testing/references/vcr-cassettes.md
@@ -44,10 +44,9 @@ format a recording produces; each request is stored once, in one format, so a ca
 twin in the other. Binary and multipart bodies live inside JSON cassettes, base64-encoded behind a
 `base64:` prefix.
 
-Six providers record without any configuration (openai, anthropic, genai, azure-openai, deepseek,
-bedrock-runtime), which is every cassette directory except one. A provider the agent cannot resolve
-from its name needs an entry in `VCR_PROVIDER_MAP` in `docker-compose.yml`, and the seventh directory
-is that worked example: `claude-agent-sdk=https://api.anthropic.com`.
+Only one of the seven cassette directories has an entry in `VCR_PROVIDER_MAP` in `docker-compose.yml`:
+`claude-agent-sdk=https://api.anthropic.com`. The other six (openai, anthropic, genai, azure-openai,
+deepseek, bedrock-runtime) are names the testagent resolves on its own. Add a map entry when it cannot.
 
 ## Recording
 
@@ -79,6 +78,8 @@ npm run test:llmobs:sdk                      # everything except the plugin spec
 `PLUGINS` is matched as a glob alternation against
 `packages/dd-trace/test/llmobs/plugins/@(${PLUGINS})/*.spec.js`.
 
-`Cannot find module '…/versions/<pkg>@<version>'` is a missing version fixture, not a broken spec:
-`PLUGINS=<pkg> yarn services` installs it. The fixtures live in a gitignored `versions/` directory at
-the repo root, so a fresh worktree has none of them.
+`Cannot find module '…/versions/<package>@<version>'` is a missing version fixture, not a broken spec:
+`PLUGINS=<integration> yarn services` installs it. The error names the npm package while `PLUGINS` takes
+the integration key, which is the file name under `packages/datadog-instrumentations/src/` — so
+`@anthropic-ai/sdk` is `anthropic` and `@google/genai` is `google-genai`. The fixtures live in a gitignored
+`versions/` directory at the repo root, so a fresh worktree has none of them.

--- a/.agents/skills/llmobs-testing/references/vcr-cassettes.md
+++ b/.agents/skills/llmobs-testing/references/vcr-cassettes.md
@@ -1,223 +1,83 @@
-# VCR Cassettes Guide
+# VCR cassettes
 
-Using VCR for recording and replaying API calls in LLMObs tests.
+The VCR proxy records provider HTTP traffic once and replays it afterwards, so specs run
+deterministically without credentials.
 
-## What is VCR?
+## The proxy is the test-agent container
 
-VCR (Video Cassette Recorder) records real HTTP requests/responses and replays them in tests.
+There is no VCR script in this repo. Start the container from the repo root before running any
+cassette-backed spec:
 
-**Benefits:**
-- Tests use real API responses (authentic data)
-- No API keys needed in CI
-- Deterministic test execution
-- No external dependencies after recording
+```bash
+docker compose up -d testagent
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9126/info   # 200 once ready
+```
 
-## How VCR Works
+Skip this and every call fails as `ECONNREFUSED 127.0.0.1:9126`. SDKs that retry report their own
+wrapper error instead, which reads like a provider outage rather than missing infrastructure. CI starts
+the same container and waits on the same `/info` endpoint via `.github/actions/testagent/start`.
 
-1. **Recording:** First test run makes real API calls through VCR proxy
-2. **Proxy captures:** HTTP requests/responses saved to cassette files (YAML)
-3. **Playback:** Subsequent runs replay from cassettes (no real API calls)
+## Point the client at the proxy
 
-## VCR Configuration
+One path segment per provider: `http://127.0.0.1:9126/vcr/{provider}`. The option name is the
+SDK's, not ours — `baseURL` for openai, `endpoint` for azure-openai, `endpoint: { url }` for
+bedrock through aws-sdk, `httpOptions.baseUrl` for google-genai.
 
-Configure client to use VCR proxy:
+Keep the key falling back to a placeholder so replay works without credentials:
 
 ```javascript
-const client = new MyLLMClient({
-  apiKey: process.env.PROVIDER_API_KEY ?? 'test-api-key',  // Real key needed for first recording; replays work without one
-  baseURL: 'http://127.0.0.1:9126/vcr/{provider-name}'  // VCR proxy URL
+new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY ?? 'test-api-key',
+  baseURL: 'http://127.0.0.1:9126/vcr/openai',
 })
 ```
 
-**URL Format:** `http://127.0.0.1:9126/vcr/{provider-name}`
+## Cassettes live in one shared tree
 
-**Examples:**
-- OpenAI: `http://127.0.0.1:9126/vcr/openai`
-- Anthropic: `http://127.0.0.1:9126/vcr/anthropic`
-- Google: `http://127.0.0.1:9126/vcr/google-genai`
+`packages/dd-trace/test/llmobs/cassettes/{provider}/` — not beside the spec.
+`docker-compose.yml` mounts that directory at the container's `VCR_CASSETTES_DIRECTORY`.
 
-## Recording Process
+Names are generated as `{provider}_{path}_{method}_{hash}`, so you never choose or rename one. The
+hash covers the request, which means editing a prompt in a spec orphans its cassette and requires a
+new recording. Both `.json` and `.yaml` files are in the tree and both replay, so take whichever
+format a recording produces. Binary and multipart bodies live inside JSON cassettes, base64-encoded
+behind a `base64:` prefix.
 
-### Step 1: Set Real API Key
+Six providers record without any configuration (openai, anthropic, genai, azure-openai, deepseek,
+bedrock-runtime), which is every cassette directory except one. A provider the agent cannot resolve
+from its name needs an entry in `VCR_PROVIDER_MAP` in `docker-compose.yml`, and the seventh directory
+is that worked example: `claude-agent-sdk=https://api.anthropic.com`.
 
-```bash
-export OPENAI_API_KEY="your-real-key"
-export ANTHROPIC_API_KEY="your-real-key"
-```
+## Recording
 
-### Step 2: Run Tests
+1. Export the real provider key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …). For aws-sdk providers,
+  uncomment `AWS_SECRET_ACCESS_KEY` in the testagent service and restart it.
+2. Run the spec. A request with no cassette is recorded; one with a cassette is replayed, so
+  re-recording means deleting exactly the cassette in question — never the provider directory.
+3. Commit the new files with the spec that produced them.
 
-```bash
-npm test packages/dd-trace/test/llmobs/plugins/my-provider/
-```
+## Non-deterministic fields break replay — normalize, never loosen the assertion
 
-### Step 3: VCR Auto-Generates Cassettes
+A body that carries a request id, a timestamp, a version string, or generated agent text will not
+match on replay. Strip it in `docker-compose.yml`, where the other normalizers already live:
 
-Cassettes saved to: `test/llmobs/plugins/{provider}/cassettes/`
+- `VCR_JSON_BODY_NORMALIZERS` — JSON paths, e.g. `metadata.user_id`.
+- `VCR_BODY_REGEX_NORMALIZERS` — regexes, for values embedded in prose bodies (agent ids,
+  `<usage>` blocks, tool descriptions, client version markers).
 
-### Step 4: Commit Cassettes
+A cassette that replays locally but fails in CI is almost always a field that needs one of these.
 
-```bash
-git add packages/dd-trace/test/llmobs/plugins/my-provider/cassettes/
-git commit -m "Add VCR cassettes for my-provider"
-```
-
-## Cassette Directory Structure
-
-```
-packages/dd-trace/test/llmobs/plugins/
-├── openai/
-│   ├── index.spec.js
-│   └── cassettes/
-│       ├── chat-completion.yaml
-│       ├── chat-streaming.yaml
-│       └── embeddings.yaml
-├── anthropic/
-│   ├── index.spec.js
-│   └── cassettes/
-│       ├── messages-create.yaml
-│       └── messages-streaming.yaml
-└── google-genai/
-    ├── index.spec.js
-    └── cassettes/
-        └── generate-content.yaml
-```
-
-## Cassette Format
-
-Cassettes are YAML files with request/response data:
-
-```yaml
-interactions:
-  - request:
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-      body:
-        messages:
-          - role: user
-            content: Hello
-    response:
-      status: 200
-      body:
-        choices:
-          - message:
-              role: assistant
-              content: Hi there!
-```
-
-## Re-Recording Cassettes
-
-When to re-record:
-- API response format changed
-- Need to test new features
-- Cassettes are outdated
-
-**Process:**
-1. Delete the specific cassette file that needs re-recording (visible in the git diff of the PR being worked on — don't delete the whole folder)
-2. Set API key: `export PROVIDER_API_KEY="..."`
-3. Run tests: `npm test ...`
-4. Commit the updated cassette
-
-## Playback Mode
-
-Once cassettes exist, tests replay automatically:
-
-- No API keys needed
-- No network calls
-- Fast, deterministic execution
-- Works in CI without credentials
-
-## When to Use VCR
-
-**Use VCR for:**
-- ✅ Category 1: LLM API Clients (openai, anthropic, genai)
-- ✅ Category 2: Multi-Provider Frameworks (ai-sdk, langchain)
-
-**Don't use VCR for:**
-- ❌ Category 3: Pure Orchestration (langgraph, crewai)
-- ❌ Category 4: Infrastructure (MCP)
-
-## VCR Proxy Setup
-
-VCR proxy typically runs as part of test infrastructure:
+## Running the specs
 
 ```bash
-# Start VCR proxy (usually handled by test framework)
-node test/vcr-proxy.js
+unset OTEL_TRACES_EXPORTER OTEL_LOGS_EXPORTER OTEL_METRICS_EXPORTER
+PLUGINS=openai npm run test:llmobs:plugins   # one integration; alternation: "openai|anthropic"
+npm run test:llmobs:sdk                      # everything except the plugin specs
 ```
 
-Proxy listens on `http://127.0.0.1:9126` and routes to real APIs.
+`PLUGINS` is matched as a glob alternation against
+`packages/dd-trace/test/llmobs/plugins/@(${PLUGINS})/*.spec.js`.
 
-## Troubleshooting
-
-### Problem: Cassettes Not Generated
-
-**Solution:** Ensure VCR proxy is running and API key is set.
-
-### Problem: Playback Fails
-
-**Solution:** Check cassette format matches expected response structure.
-
-### Problem: Tests Fail After Re-Recording
-
-**Solution:** Response format may have changed. Update assertions to match new format.
-
-### Problem: Missing Cassettes in CI
-
-**Solution:** Ensure cassettes are committed to git.
-
-## Best Practices
-
-1. **Commit cassettes:** Always commit cassettes to version control
-2. **Use descriptive names:** Name cassettes after test cases
-3. **Review cassettes:** Check cassette content before committing
-4. **Update when needed:** Re-record when API changes
-5. **Test both modes:** Test with and without cassettes locally
-6. **Clean sensitive data:** Ensure no real API keys in cassettes
-
-## Example Test with VCR
-
-```javascript
-describe('openai LLMObs', () => {
-  const { getEvents } = useLlmObs({ plugin: 'openai' })
-
-  let openai
-
-  beforeEach(() => {
-    const OpenAI = require('openai')
-    openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY ?? 'test-api-key',
-      baseURL: 'http://127.0.0.1:9126/vcr/openai'  // VCR proxy
-    })
-  })
-
-  it('instruments chat (uses VCR)', async () => {
-    // First run: Records to cassette
-    // Subsequent runs: Replays from cassette
-    const response = await openai.chat.completions.create({
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'Hello' }]
-    })
-
-    const events = getEvents()
-    assertLlmObsSpanEvent(events[0], {
-      spanKind: 'llm',
-      modelName: 'gpt-4',
-      // Response data comes from cassette
-      outputMessages: [{ content: MOCK_STRING, role: 'assistant' }]
-    })
-  })
-})
-```
-
-## VCR vs Mock Comparison
-
-| Aspect | VCR | Manual Mocks |
-|--------|-----|--------------|
-| Authenticity | Real API responses | Synthetic data |
-| Setup | Minimal | Requires mock implementation |
-| Maintenance | Re-record when API changes | Update mock code |
-| Coverage | Full response structure | Only mocked fields |
-| Performance | Fast (playback) | Fast |
-
-**Recommendation:** Use VCR for API clients (Categories 1 & 2), manual mocks for orchestration (Category 3).
+`Cannot find module '…/versions/<pkg>@<version>'` is a missing version fixture, not a broken spec:
+`PLUGINS=<pkg> yarn services` installs it. The fixtures live in a gitignored `versions/` directory at
+the repo root, so a fresh worktree has none of them.

--- a/.agents/skills/llmobs-testing/references/vcr-cassettes.md
+++ b/.agents/skills/llmobs-testing/references/vcr-cassettes.md
@@ -40,8 +40,9 @@ new OpenAI({
 Names are generated as `{provider}_{path}_{method}_{hash}`, so you never choose or rename one. The
 hash covers the request, which means editing a prompt in a spec orphans its cassette and requires a
 new recording. Both `.json` and `.yaml` files are in the tree and both replay, so take whichever
-format a recording produces. Binary and multipart bodies live inside JSON cassettes, base64-encoded
-behind a `base64:` prefix.
+format a recording produces; each request is stored once, in one format, so a cassette never has a
+twin in the other. Binary and multipart bodies live inside JSON cassettes, base64-encoded behind a
+`base64:` prefix.
 
 Six providers record without any configuration (openai, anthropic, genai, azure-openai, deepseek,
 bedrock-runtime), which is every cassette directory except one. A provider the agent cannot resolve

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -16,25 +16,31 @@ const MOCK_OBJECT = Symbol('object')
 const MOCK_NOT_NULLISH = Symbol('not-nullish')
 
 /**
+ * @typedef {typeof MOCK_STRING | typeof MOCK_NUMBER | typeof MOCK_OBJECT | typeof MOCK_NOT_NULLISH} MockValue
+ */
+
+/**
+ * Optional fields assert their own absence when omitted, except `traceId`, which defaults to `MOCK_STRING`.
  * @typedef {{
- *   spanKind: 'llm' | 'embedding' | 'agent' | 'workflow' | 'task' | 'tool' | 'retrieval',
+ *   spanKind: 'llm' | 'embedding' | 'agent' | 'workflow' | 'task' | 'step' | 'tool' | 'retrieval',
  *   name: string,
- *   inputMessages: Record<string, unknown>,
- *   outputMessages: Record<string, unknown>,
- *   inputDocuments: Record<string, unknown>,
- *   outputDocuments: Record<string, unknown>,
- *   inputValue: Record<string, unknown>,
- *   outputValue: Record<string, unknown>,
- *   metrics: { [key: string]: number },
- *   metadata: Record<string, unknown>,
+ *   inputMessages?: Array<Record<string, unknown> | MockValue> | MockValue,
+ *   outputMessages?: Array<Record<string, unknown> | MockValue> | MockValue,
+ *   inputDocuments?: Array<Record<string, unknown> | MockValue> | MockValue,
+ *   outputDocuments?: Array<Record<string, unknown> | MockValue> | MockValue,
+ *   inputValue?: string | MockValue,
+ *   outputValue?: string | MockValue,
+ *   metrics?: Record<string, number | MockValue> | MockValue,
+ *   metadata?: Record<string, unknown> | MockValue,
+ *   toolDefinitions?: Array<Record<string, unknown> | MockValue> | MockValue,
  *   modelName?: string,
  *   modelProvider?: string,
  *   parentId?: string,
- *   error?: { message: string, type: string, stack: string },
- *   span: unknown,
+ *   error?: object,
+ *   span: object,
  *   sessionId?: string,
- *   tags: Record<string, unknown>,
- *   traceId?: string,
+ *   tags: Record<string, string>,
+ *   traceId?: string | MockValue,
  * }} ExpectedLLMObsSpanEvent
  */
 
@@ -58,7 +64,7 @@ const MOCK_NOT_NULLISH = Symbol('not-nullish')
 /**
  *
  * @param {object} actual
- * @param {ExpectedLLMObsSpanEvent} expected
+ * @param {object | MockValue | string | number | boolean | null | undefined} expected
  * @param {string} key name to associate with the assertion
  */
 function assertWithMockValues (actual, expected, key) {


### PR DESCRIPTION
## Summary

Both LLMObs agent skills described a repository that does not exist, so an agent following them writes against the wrong contract before reading any source.

1. The VCR reference described a `node test/vcr-proxy.js` script and per-spec cassette folders, neither of which exists, and said nothing about the `docker-compose.yml` normalizers that keep replay deterministic. It now covers starting the test-agent container, the shared cassette tree, the provider map, and the commands to run one integration.
2. Plugin pointers aimed at `packages/datadog-plugin-<name>/src/llmobs.js`, a path this repo never had, rather than `packages/dd-trace/src/llmobs/plugins/<name>/`.
3. `LlmObsCategory` and `LlmObsSpanKind` exist nowhere in the repository. The four package shapes stay as prose, and span kinds now cite `SPAN_KINDS` in `packages/dd-trace/src/llmobs/constants/tags.js`, which restores the missing `task` kind.
4. The two skills disagreed on orchestration tests, and the langgraph spec settles it against the integration skill: `chatNode` returns a fixed message and the directory reads no cassette.
5. `nock` cannot intercept an SDK that calls through global `fetch`. google-cloud-vertexai's spec swaps `global.fetch` for the duration of the test, while the newer `ai` specs pass a `fetch` option to each provider factory, which also sidesteps when `globalThis.fetch` is captured.
6. `assertLlmObsSpanEvent` reads `error` for truthiness only and copies `error.type` / `message` / `stack` off the span it is checking, so no assertion form pins which error was thrown. Both skills claimed the pinned shape does.
7. LangChain was filed as pure orchestration with no direct LLM API calls, though its plugin returns `llm` / `embedding` / `tool` / `retrieval` kinds and its spec records over VCR.
8. `tagCostTags` was listed as a plugin tagger for provider-reported cost. It takes an array of tag keys from `annotate`, and no plugin calls it.
9. The infrastructure strategy said to mock the server, while the MCP spec runs the SDK's own `McpServer` over `InMemoryTransport.createLinkedPair()`.

## Why

A skill that documents a path, a constant, or a start command that does not exist is worse than no skill, because an agent trusts it instead of reading the source. Every concrete claim here is now taken from the tree: paths and relative links resolve on disk, the proxy start and cassette layout come from `docker-compose.yml` and `.github/actions/testagent/start`, and the assertion shapes come from the specs. Anything I could not support from this repository was dropped rather than kept.
