### PR TITLE
ci: skip redundant datadog-ci git metadata uploads

### DIFF
--- a/.github/actions/datadog-ci/package.json
+++ b/.github/actions/datadog-ci/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@datadog/datadog-ci": "5.17.0"
+    "@datadog/datadog-ci": "5.21.2"
   }
 }

--- a/.github/actions/datadog-ci/yarn.lock
+++ b/.github/actions/datadog-ci/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@datadog/datadog-ci@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.npmjs.org/@datadog/datadog-ci/-/datadog-ci-5.17.0.tgz#88f68eff837d9988564592e0c52a859cd9de7836"
-  integrity sha512-Orwju9h/kLQnuNr7VoHW/JABbKsK8/Lhh8zDacjR1CqwJBmgwejgmcL3ut9/Vbi6hC5KYlgXybeeMpsdJEWvQQ==
+"@datadog/datadog-ci@5.21.2":
+  version "5.21.2"
+  resolved "https://registry.npmjs.org/@datadog/datadog-ci/-/datadog-ci-5.21.2.tgz#0fd6391405e3612a3fea2e3265e3b417f7952619"
+  integrity sha512-DNSveS6vV6UWAL5BQbbFtQQnLvJlrTQnc0k7EonpJR9AA8RgTB3f9LYyXo1Qch8Z2IJK/+WrLPcK29Z94j/Waw==

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -52,7 +52,9 @@ jobs:
       - if: "!cancelled()"
         uses: ./.github/actions/datadog-ci
       - if: "!cancelled()"
-        run: datadog-ci junit upload --service dd-trace-js-tests --auto-discovery junit-results
+        run: >-
+          datadog-ci junit upload --service dd-trace-js-tests --auto-discovery
+          --skip-git-metadata-upload junit-results
         env:
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       # One Datadog upload per integration, flagged with the integration name so coverage is
@@ -64,7 +66,8 @@ jobs:
           shopt -s nullglob
           # shellcheck disable=SC2016 # the inner shell must expand "$1", not the template.
           printf '%s\0' coverage-upload/*/lcov/ | xargs -0 -r -P 20 -I {} \
-            bash -c 'datadog-ci coverage upload "$1" --flags "$(basename "$(dirname "$1")")"' _ {}
+            bash -c 'datadog-ci coverage upload "$1" --flags "$(basename "$(dirname "$1")")" \
+              --skip-git-metadata-upload' _ {}
         env:
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       # One Codecov upload per integration via the CLI directly — the codecov-action would re-validate


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bumps `@datadog/datadog-ci` from 5.17.0 to 5.21.2 and disables Git metadata uploads for the All Green JUnit and coverage report commands.

### Motivation
<!-- What inspired you to submit this pull request? -->

The referenced All Green job started 104 separately flagged coverage uploads and one JUnit upload. Every command redundantly synchronized the same Git metadata, producing 105 unnecessary sync operations. Skipping those uploads removes that repeated network work while preserving the Git identity attached to the reports.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The 104 coverage uploads remain separate because each carries its integration-specific flag. The JUnit command already uploads all reports concurrently in one process.

Validation:

- `npm run test:scripts` (36 passing)
- `yarn install --frozen-lockfile --offline` in `.github/actions/datadog-ci`
- Datadog CI coverage and JUnit dry runs with `--skip-git-metadata-upload`
- Workflow YAML parse and `git diff --check`
