### PR TITLE
chore(eslint): enable rules that are clean or trivially fixable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -247,6 +247,7 @@
 /packages/dd-trace/test/telemetry/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/config/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/log/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/opentelemetry/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/opentelemetry/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/opentracing/ @DataDog/apm-sdk-capabilities-js

--- a/benchmark/sirun/appsec-iast/common.js
+++ b/benchmark/sirun/appsec-iast/common.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  port: 3331 + parseInt(process.env.CPU_AFFINITY || '0'),
+  port: 3331 + parseInt(process.env.CPU_AFFINITY || '0', 10),
   // Env-tunable like the other live benches. Local tuning (keep-alive, higher
   // counts) did not reduce the run-to-run jitter -- it is express/IAST scheduling
   // noise that CI core-pinning addresses, not connection churn -- so this is left

--- a/benchmark/sirun/appsec/common.js
+++ b/benchmark/sirun/appsec/common.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  port: 3231 + parseInt(process.env.CPU_AFFINITY || '0'),
+  port: 3231 + parseInt(process.env.CPU_AFFINITY || '0', 10),
   // Requests per iteration, sized per variant in meta.json (REQS). A higher count
   // dilutes the fixed startup (node boot + tracer/AppSec init), which is otherwise
   // a large, run-to-run-variable share of a short run and dominates stddev (control

--- a/benchmark/sirun/diff-recent.js
+++ b/benchmark/sirun/diff-recent.js
@@ -23,7 +23,7 @@ function getReadmes () {
         const name = require(path.join(__dirname, dirent.name, 'meta.json')).name
         const value = fs.readFileSync(path.join(__dirname, dirent.name, 'README.md'), 'utf8')
         readmes[name] = value
-      } catch (e) {
+      } catch {
         // just keep going
       }
     }

--- a/benchmark/sirun/diffserver.js
+++ b/benchmark/sirun/diffserver.js
@@ -35,7 +35,7 @@ function getMetas () {
       try {
         const meta = require(path.join(__dirname, dirent.name, 'meta.json'))
         metas[meta.name] = meta
-      } catch (e) {
+      } catch {
         // just keep going
       }
     }

--- a/benchmark/sirun/plugin-http/common.js
+++ b/benchmark/sirun/plugin-http/common.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  port: 3031 + parseInt(process.env.CPU_AFFINITY || '0'),
+  port: 3031 + parseInt(process.env.CPU_AFFINITY || '0', 10),
   // A large request count keeps the per-iteration node/tracer startup a small
   // fraction of the run so the measurement is dominated by the HTTP round-trips.
   // Safe to be large because the client reuses one keep-alive connection.

--- a/benchmark/sirun/plugin-net/common.js
+++ b/benchmark/sirun/plugin-net/common.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  port: 3131 + parseInt(process.env.CPU_AFFINITY || '0'),
+  port: 3131 + parseInt(process.env.CPU_AFFINITY || '0', 10),
   // A larger request count keeps the per-iteration tracer load a small fraction
   // of the run so the measurement is dominated by the TCP round-trips. Kept
   // conservative: the echo server counts raw connections, so an over-high count

--- a/benchmark/sirun/run-all-variants.js
+++ b/benchmark/sirun/run-all-variants.js
@@ -26,7 +26,7 @@ const env = { ...process.env, DD_TRACE_STARTUP_LOGS: 'false' }
 
   try {
     fs.unlinkSync(path.join(process.cwd(), 'meta-temp.json'))
-  } catch (e) {
+  } catch {
     // it's ok if we can't delete a temp file
   }
 })()

--- a/benchmark/sirun/run-util.js
+++ b/benchmark/sirun/run-util.js
@@ -26,7 +26,7 @@ function streamAddVersion (input) {
       json.nodeVersion = process.versions.node
       // eslint-disable-next-line no-console
       console.log(JSON.stringify(json))
-    } catch (e) {
+    } catch {
       // eslint-disable-next-line no-console
       console.log(line)
     }

--- a/benchmark/sirun/startup-guard.js
+++ b/benchmark/sirun/startup-guard.js
@@ -26,7 +26,7 @@ let statsd
 function loopStart () {
   loopStartedAt = process.hrtime.bigint()
   if (process.env.SIRUN_READY_FD) {
-    require('fs').writeSync(parseInt(process.env.SIRUN_READY_FD), 'x')
+    require('fs').writeSync(parseInt(process.env.SIRUN_READY_FD, 10), 'x')
   } else {
     process.stderr.write('startup-guard: SIRUN_READY_FD is not set, startup time will be included in measurements\n')
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -536,6 +536,7 @@ export default [
       'sonarjs/no-duplicated-branches': 'error',
       'sonarjs/no-empty-collection': 'error',
       'sonarjs/no-extra-arguments': 'error',
+      'sonarjs/no-globals-shadowing': 'error',
       'sonarjs/no-gratuitous-expressions': 'error',
       'sonarjs/no-identical-functions': 'error',
       'sonarjs/no-ignored-exceptions': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -361,7 +361,9 @@ export default [
       'preserve-caught-error': 'off',
       'promise/no-new-statics': 'error',
       'promise/no-return-in-finally': 'error',
+      'promise/no-return-wrap': 'error',
       'promise/param-names': 'error',
+      'promise/valid-params': 'error',
       'symbol-description': 'error',
       'unicode-bom': ['error', 'never'],
       'use-isnan': [ // override config from @eslint/js/recommended
@@ -468,6 +470,9 @@ export default [
       }],
       'eslint-rules/eslint-require-export-exists': 'error',
       'import/no-extraneous-dependencies': 'error',
+      // 72 errors. Instrumentation has to publish its finish event after invoking the wrapped
+      // callback, so returning the callback call would drop the event.
+      'n/callback-return': 'off',
       'n/hashbang': 'error',
       'n/no-extraneous-require': ['error', {
         allowModules: Object.keys(dependencies),
@@ -490,6 +495,9 @@ export default [
       }],
       'no-console': 'error',
       'no-implicit-coercion': ['error', { boolean: true, number: true, string: true, allow: ['!!'] }],
+      // 107 errors, all of them the `new Promise(resolve => setTimeout(resolve, ms))` shape.
+      // `no-async-promise-executor` already covers the executor footgun that loses errors.
+      'no-promise-executor-return': 'off',
       'no-prototype-builtins': 'off', // Override (turned on by @eslint/js/recommended)
       'no-useless-assignment': 'error',
       'no-var': 'error',
@@ -498,6 +506,9 @@ export default [
       'prefer-exponentiation-operator': 'error',
       'prefer-object-has-own': 'error',
       'prefer-object-spread': 'error',
+      // 49 errors, all in single-flow init or test scaffolding. The one site with real
+      // concurrency (the debugger's breakpoint bookkeeping) already runs behind a lock.
+      'require-atomic-updates': 'off',
       'require-await': 'error',
       strict: 'error',
     },
@@ -539,6 +550,9 @@ export default [
 
       // --- Rules to check later ------------------
       'sonarjs/no-element-overwrite': 'off', // 3 errors (false positives)
+      // 37 errors, all false positives: those suites are built by shared helper factories
+      // (`assertPromise`, `prepareTestServerForIast`) instead of literal `it()` calls.
+      'sonarjs/no-empty-test-file': 'off',
       'sonarjs/todo-tag': 'off', // 434 errors. We use TODO/FIXME as tracked markers by policy.
     },
   },
@@ -589,7 +603,9 @@ export default [
 
       ...eslintPluginUnicorn.configs.recommended.rules,
 
-      'unicorn/no-unsafe-dom-html': 'error', // Not in `recommended`; guards the innerHTML sink class.
+      // Not in `recommended`: the innerHTML sink class and unread object properties.
+      'unicorn/no-unsafe-dom-html': 'error',
+      'unicorn/no-unused-properties': 'error',
 
       // Overriding recommended unicorn rules.
       // Rules not listed here are left at the `recommended` default. The entries below
@@ -685,7 +701,6 @@ export default [
       'unicorn/no-confusing-array-splice': 'off', // few
       'unicorn/no-for-each': 'off', // many | we already prefer for-of in production
       'unicorn/no-unnecessary-global-this': 'off', // few | explicit globals are clearer
-      'unicorn/no-useless-continue': 'off', // few | the one site guards third-party parser output
       'unicorn/prefer-array-from-map': 'off', // few | loops avoid callback allocation
       'unicorn/prefer-continue': 'off', // many
       'unicorn/prefer-ternary': 'off', // many
@@ -986,6 +1001,21 @@ export default [
     rules: {
       'import/no-extraneous-dependencies': 'off',
       'n/no-extraneous-require': 'off',
+    },
+  },
+  {
+    name: 'dd-trace/openfeature',
+    plugins: {
+      promise: eslintPluginPromise,
+    },
+    files: [
+      'packages/dd-trace/src/openfeature/**/*.js',
+      'packages/dd-trace/test/openfeature/**/*.js',
+    ],
+    rules: {
+      // The OpenFeature hook API defines `finally(hookContext, evalDetails)`, which the rule
+      // reads as `Promise.prototype.finally`.
+      'promise/valid-params': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -517,6 +517,7 @@ export default [
       'sonarjs/no-extra-arguments': 'error',
       'sonarjs/no-gratuitous-expressions': 'error',
       'sonarjs/no-identical-functions': 'error',
+      'sonarjs/no-ignored-exceptions': 'error',
       'sonarjs/no-invariant-returns': 'error',
       'sonarjs/no-nested-assignment': 'error',
       'sonarjs/no-parameter-reassignment': 'error',
@@ -691,6 +692,17 @@ export default [
     },
   },
   {
+    name: 'dd-trace/unicorn/all',
+    // Unicorn is otherwise limited to production code, and `sonarjs/no-ignored-exceptions`
+    // reports only a subset of the unused catch bindings in tests and fixtures.
+    plugins: {
+      unicorn: eslintPluginUnicorn,
+    },
+    rules: {
+      'unicorn/prefer-optional-catch-binding': 'error',
+    },
+  },
+  {
     name: 'dd-trace/config-sync',
     files: [
       'eslint.config.mjs',
@@ -781,6 +793,8 @@ export default [
       }],
       'no-var': 'off', // Only supported in Node.js 6+
       'object-shorthand': 'off', // Only supported in Node.js 4+
+      // The binding cannot be dropped without optional catch binding (Node.js 10+).
+      'sonarjs/no-ignored-exceptions': 'off',
       'unicorn/prefer-includes': 'off', // Only supported in Node.js 6+
       'unicorn/prefer-number-properties': 'off', // Only supported in Node.js 0.12+
       'unicorn/prefer-optional-catch-binding': 'off', // Only supported in Node.js 10+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -261,6 +261,8 @@ export default [
       'import/no-absolute-path': ['error', { esmodule: true, commonjs: true, amd: false }],
       'import/no-cycle': 'error',
       'import/no-duplicates': 'error',
+      'import/no-empty-named-blocks': 'error',
+      'import/no-mutable-exports': 'error',
       'import/no-named-default': 'error',
       'import/no-self-import': 'error',
       'import/order': ['error', {
@@ -280,6 +282,8 @@ export default [
       'import/no-webpack-loader-syntax': 'error',
       'jsdoc/check-param-names': ['error', { disableMissingParamChecks: true }],
       'jsdoc/check-tag-names': ['error', { definedTags: ['datadog'] }],
+      'jsdoc/no-bad-blocks': 'error',
+      'jsdoc/no-blank-blocks': 'error',
       // TODO: Enable the rules that we want to use.
       'jsdoc/no-defaults': 'error',
       'jsdoc/no-undefined-types': 'off',
@@ -289,7 +293,6 @@ export default [
       'jsdoc/require-param': 'off',
       'jsdoc/require-property-description': 'off',
       'jsdoc/require-returns-description': 'off',
-      'jsdoc/require-returns-type': 'off',
       'jsdoc/require-returns': 'off',
       'jsdoc/tag-lines': 'off', // Alignment is not important for us.
       'n/handle-callback-err': ['error', '^(err|error)$'],
@@ -303,6 +306,7 @@ export default [
       'no-array-constructor': 'error',
       'no-caller': 'error',
       'no-constant-condition': ['error', { checkLoops: false }], // override config from @eslint/js/recommended
+      'no-constructor-return': 'error',
       'no-empty': ['error', { allowEmptyCatch: true }], // override config from @eslint/js/recommended
       'no-eval': 'error',
       'no-extend-native': 'error',
@@ -324,9 +328,6 @@ export default [
       'no-sequences': 'error',
       'no-template-curly-in-string': 'error',
       'no-throw-literal': 'error',
-      // Surfaces pre-existing latent bugs (always-undefined vars in tests/intake helpers)
-      // unrelated to this tooling bump; worth a focused follow-up.
-      'no-unassigned-vars': 'off',
       'no-undef-init': 'error',
       'no-unmodified-loop-condition': 'error',
       'no-unneeded-ternary': ['error', { defaultAssignment: false }],
@@ -356,8 +357,10 @@ export default [
       'prefer-const': ['error', { destructuring: 'all' }],
       'prefer-promise-reject-errors': 'error',
       'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
-      // Newly enabled by the ESLint 10 bump; deferred with no-unassigned-vars above.
+      // 6 errors. Attaching `cause` changes error output, so it needs its own change.
       'preserve-caught-error': 'off',
+      'promise/no-new-statics': 'error',
+      'promise/no-return-in-finally': 'error',
       'promise/param-names': 'error',
       'symbol-description': 'error',
       'unicode-bom': ['error', 'never'],
@@ -446,7 +449,6 @@ export default [
           'packages/dd-trace/src/llmobs/span_processor.js',
           // Test specs that intentionally mock the `_tags` field shape on a
           // fake span context (their `getTag`/`getTags` mocks read `this._tags`).
-          'packages/dd-trace/test/opentracing/span_context.spec.js',
           'packages/dd-trace/test/priority_sampler.spec.js',
           'packages/dd-trace/test/sampling_rule.spec.js',
           'packages/dd-trace/test/span_sampler.spec.js',
@@ -461,7 +463,6 @@ export default [
           'packages/dd-trace/test/profiling/profilers/wall.spec.js',
           // Benchmark stubs that mock the `_tags` field shape on a fake span
           // context (their `getTag`/`getTags` mocks read from `_tags`).
-          'benchmark/stubs/span.js',
           'benchmark/sirun/exporting-pipeline/index.js',
         ],
       }],
@@ -522,19 +523,21 @@ export default [
       'sonarjs/no-redundant-assignments': 'error',
       'sonarjs/no-redundant-jump': 'error',
       'sonarjs/no-small-switch': 'error',
+      'sonarjs/no-unthrown-error': 'error',
       'sonarjs/no-unused-collection': 'error',
       'sonarjs/no-use-of-empty-return-value': 'error',
+      'sonarjs/non-existent-operator': 'error',
       'sonarjs/prefer-immediate-return': 'error',
       'sonarjs/prefer-single-boolean-return': 'error',
       'sonarjs/single-char-in-character-classes': 'error',
       'sonarjs/single-character-alternation': 'error',
+      'sonarjs/slow-regex': 'error',
       'sonarjs/stable-tests': 'error',
       'sonarjs/test-check-exception': 'error',
       'sonarjs/updated-loop-counter': 'error',
 
       // --- Rules to check later ------------------
       'sonarjs/no-element-overwrite': 'off', // 3 errors (false positives)
-      'sonarjs/slow-regex': 'off', // 30 errors. Valuable ReDoS signal; needs audit.
       'sonarjs/todo-tag': 'off', // 434 errors. We use TODO/FIXME as tracked markers by policy.
     },
   },
@@ -585,12 +588,13 @@ export default [
 
       ...eslintPluginUnicorn.configs.recommended.rules,
 
+      'unicorn/no-unsafe-dom-html': 'error', // Not in `recommended`; guards the innerHTML sink class.
+
       // Overriding recommended unicorn rules.
       // Rules not listed here are left at the `recommended` default. The entries below
       // document deliberate exceptions. Volume markers stay coarse so they do not drift:
       // `few` is under ten sites, `many` is tens, `lots` is hundreds or more.
       'unicorn/catch-error-name': ['off', { name: 'err' }], // lots
-      'unicorn/expiring-todo-comments': 'off',
       'unicorn/filename-case': ['off', { case: 'kebabCase' }], // lots
       'unicorn/name-replacements': 'off', // lots | naming churn (split out of prevent-abbreviations)
       'unicorn/prevent-abbreviations': 'off', // Its replacements moved to name-replacements
@@ -613,7 +617,7 @@ export default [
       // These rules could potentially be evaluated again at a much later point
       'unicorn/class-reference-in-static-methods': 'off', // few
       'unicorn/consistent-class-member-order': 'off', // many | ordering churn
-      'unicorn/consistent-conditional-object-spread': 'off', // few
+      'unicorn/consistent-conditional-object-spread': 'off', // many
       'unicorn/explicit-length-check': 'off', // Not a big advantage
       'unicorn/explicit-timer-delay': 'off', // Covered by our own timer lint rules
       'unicorn/no-array-callback-reference': 'off',
@@ -680,7 +684,7 @@ export default [
       'unicorn/no-confusing-array-splice': 'off', // few
       'unicorn/no-for-each': 'off', // many | we already prefer for-of in production
       'unicorn/no-unnecessary-global-this': 'off', // few | explicit globals are clearer
-      'unicorn/no-useless-continue': 'off', // few
+      'unicorn/no-useless-continue': 'off', // few | the one site guards third-party parser output
       'unicorn/prefer-array-from-map': 'off', // few | loops avoid callback allocation
       'unicorn/prefer-continue': 'off', // many
       'unicorn/prefer-ternary': 'off', // many
@@ -913,7 +917,6 @@ export default [
       },
     },
     rules: {
-      'mocha/max-top-level-suites': 'off',
       'mocha/no-pending-tests': 'off',
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -199,6 +199,7 @@ export default [
       '@stylistic/yield-star-spacing': ['error', 'both'],
       'accessor-pairs': ['error', { setWithoutGet: true, enforceForClassMembers: true }],
       'array-callback-return': ['error', { allowImplicit: false, checkForEach: false }],
+      'block-scoped-var': 'error',
       'brace-style': [ // TODO: Deprecated, use @stylistic/brace-style instead
         'error',
         '1tbs',
@@ -218,6 +219,7 @@ export default [
       'dot-notation': ['error', { allowKeywords: true }],
       eqeqeq: ['error', 'always', { null: 'ignore' }],
       'func-call-spacing': ['error', 'never'], // TODO: Deprecated, use @stylistic/func-call-spacing instead
+      'grouped-accessor-pairs': ['error', 'getBeforeSet'],
       indent: [ // TODO: Deprecated, use @stylistic/indent instead
         'error',
         2,
@@ -259,9 +261,11 @@ export default [
       'import/export': 'error',
       'import/first': 'error',
       'import/no-absolute-path': ['error', { esmodule: true, commonjs: true, amd: false }],
+      'import/no-amd': 'error',
       'import/no-cycle': 'error',
       'import/no-duplicates': 'error',
       'import/no-empty-named-blocks': 'error',
+      'import/no-import-module-exports': 'error',
       'import/no-mutable-exports': 'error',
       'import/no-named-default': 'error',
       'import/no-self-import': 'error',
@@ -283,6 +287,7 @@ export default [
       // The option keeps `@overload` blocks that document fewer params than the implementation.
       'jsdoc/check-param-names': ['error', { disableMissingParamChecks: true }],
       'jsdoc/check-tag-names': ['error', { definedTags: ['datadog'] }],
+      'jsdoc/check-template-names': 'error',
       'jsdoc/check-types': 'error',
       'jsdoc/no-bad-blocks': 'error',
       'jsdoc/no-blank-blocks': 'error',
@@ -297,6 +302,9 @@ export default [
       'jsdoc/require-returns-check': 'error',
       'jsdoc/require-returns-description': 'off',
       'jsdoc/require-returns': 'off',
+      'jsdoc/require-template': 'error',
+      'jsdoc/require-throws-description': 'error',
+      'jsdoc/require-yields-description': 'error',
       'jsdoc/tag-lines': 'off', // Alignment is not important for us.
       'n/handle-callback-err': ['error', '^(err|error)$'],
       'n/no-callback-literal': 'error',
@@ -358,6 +366,7 @@ export default [
       'object-shorthand': ['warn', 'properties'],
       'one-var': ['error', { initialized: 'never' }],
       'prefer-const': ['error', { destructuring: 'all' }],
+      'prefer-numeric-literals': 'error',
       'prefer-promise-reject-errors': 'error',
       'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
       // 6 errors. Attaching `cause` changes error output, so it needs its own change.
@@ -366,6 +375,7 @@ export default [
       'promise/no-return-in-finally': 'error',
       'promise/no-return-wrap': 'error',
       'promise/param-names': 'error',
+      'promise/spec-only': 'error',
       'promise/valid-params': 'error',
       'symbol-description': 'error',
       'unicode-bom': ['error', 'never'],
@@ -529,18 +539,30 @@ export default [
       sonarjs: eslintPluginSonar,
     },
     rules: {
+      'sonarjs/anchor-precedence': 'error',
+      'sonarjs/arguments-order': 'error',
+      'sonarjs/comma-or-logical-or-case': 'error',
       'sonarjs/duplicates-in-character-class': 'error',
+      'sonarjs/empty-string-repetition': 'error',
+      'sonarjs/inverted-assertion-arguments': 'error',
       'sonarjs/no-all-duplicated-branches': 'error',
+      'sonarjs/no-case-label-in-switch': 'error',
       'sonarjs/no-code-after-done': 'error',
+      'sonarjs/no-collection-size-mischeck': 'error',
       'sonarjs/no-commented-code': 'error',
       'sonarjs/no-duplicated-branches': 'error',
+      'sonarjs/no-empty-after-reluctant': 'error',
       'sonarjs/no-empty-collection': 'error',
+      'sonarjs/no-empty-group': 'error',
+      'sonarjs/no-equals-in-for-termination': 'error',
       'sonarjs/no-extra-arguments': 'error',
       'sonarjs/no-globals-shadowing': 'error',
       'sonarjs/no-gratuitous-expressions': 'error',
+      'sonarjs/no-identical-conditions': 'error',
       'sonarjs/no-identical-functions': 'error',
       'sonarjs/no-ignored-exceptions': 'error',
       'sonarjs/no-invariant-returns': 'error',
+      'sonarjs/no-mixed-completion-style': 'error',
       'sonarjs/no-nested-assignment': 'error',
       'sonarjs/no-parameter-reassignment': 'error',
       'sonarjs/no-redundant-assignments': 'error',
@@ -549,17 +571,25 @@ export default [
       'sonarjs/no-unthrown-error': 'error',
       'sonarjs/no-unused-collection': 'error',
       'sonarjs/no-use-of-empty-return-value': 'error',
+      'sonarjs/no-variable-usage-before-declaration': 'error',
       'sonarjs/non-existent-operator': 'error',
       'sonarjs/prefer-immediate-return': 'error',
+      'sonarjs/prefer-promise-shorthand': 'error',
       'sonarjs/prefer-single-boolean-return': 'error',
+      'sonarjs/prefer-while': 'error',
+      'sonarjs/reduce-initial-value': 'error',
       'sonarjs/single-char-in-character-classes': 'error',
       'sonarjs/single-character-alternation': 'error',
       'sonarjs/slow-regex': 'error',
       'sonarjs/stable-tests': 'error',
+      'sonarjs/synchronous-suite-callback': 'error',
       'sonarjs/test-check-exception': 'error',
+      'sonarjs/unicode-aware-regex': 'error',
       'sonarjs/updated-loop-counter': 'error',
 
       // --- Rules to check later ------------------
+      // SonarJS rules marked `requiresTypeChecking` report nothing without a TypeScript program, so they
+      // read as clean while catching nothing. Enabling them needs typescript-eslint wired up first.
       'sonarjs/no-element-overwrite': 'off', // 3 errors (false positives)
       // 37 errors, all false positives: those suites are built by shared helper factories
       // (`assertPromise`, `prepareTestServerForIast`) instead of literal `it()` calls.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -280,8 +280,10 @@ export default [
       }],
       'import/no-useless-path-segments': 'error',
       'import/no-webpack-loader-syntax': 'error',
+      // The option keeps `@overload` blocks that document fewer params than the implementation.
       'jsdoc/check-param-names': ['error', { disableMissingParamChecks: true }],
       'jsdoc/check-tag-names': ['error', { definedTags: ['datadog'] }],
+      'jsdoc/check-types': 'error',
       'jsdoc/no-bad-blocks': 'error',
       'jsdoc/no-blank-blocks': 'error',
       // TODO: Enable the rules that we want to use.
@@ -292,6 +294,7 @@ export default [
       'jsdoc/require-param-description': 'off', // Having a description is not crucial for now.
       'jsdoc/require-param': 'off',
       'jsdoc/require-property-description': 'off',
+      'jsdoc/require-returns-check': 'error',
       'jsdoc/require-returns-description': 'off',
       'jsdoc/require-returns': 'off',
       'jsdoc/tag-lines': 'off', // Alignment is not important for us.
@@ -477,6 +480,7 @@ export default [
       'n/no-extraneous-require': ['error', {
         allowModules: Object.keys(dependencies),
       }],
+      'n/no-mixed-requires': 'error',
       'n/no-process-exit': 'error',
       'n/no-restricted-require': ['error', GLOBAL_RESTRICTED_REQUIRES],
       'n/no-unpublished-require': ['error', {
@@ -499,6 +503,10 @@ export default [
       // `no-async-promise-executor` already covers the executor footgun that loses errors.
       'no-promise-executor-return': 'off',
       'no-prototype-builtins': 'off', // Override (turned on by @eslint/js/recommended)
+      'no-return-assign': 'error',
+      'no-template-curly-in-string': 'error',
+      'no-unmodified-loop-condition': 'error',
+      'no-unreachable-loop': 'error',
       'no-useless-assignment': 'error',
       'no-var': 'error',
       'no-void': ['error', { allowAsStatement: true }],
@@ -506,6 +514,7 @@ export default [
       'prefer-exponentiation-operator': 'error',
       'prefer-object-has-own': 'error',
       'prefer-object-spread': 'error',
+      radix: 'error',
       // 49 errors, all in single-flow init or test scaffolding. The one site with real
       // concurrency (the debugger's breakpoint bookkeeping) already runs behind a lock.
       'require-atomic-updates': 'off',
@@ -525,6 +534,7 @@ export default [
       'sonarjs/no-code-after-done': 'error',
       'sonarjs/no-commented-code': 'error',
       'sonarjs/no-duplicated-branches': 'error',
+      'sonarjs/no-empty-collection': 'error',
       'sonarjs/no-extra-arguments': 'error',
       'sonarjs/no-gratuitous-expressions': 'error',
       'sonarjs/no-identical-functions': 'error',
@@ -714,6 +724,7 @@ export default [
       unicorn: eslintPluginUnicorn,
     },
     rules: {
+      'unicorn/consistent-date-clone': 'error',
       'unicorn/prefer-optional-catch-binding': 'error',
     },
   },
@@ -777,6 +788,7 @@ export default [
     files: [
       'init.js',
       'packages/dd-trace/src/guardrails/**/*',
+      'packages/dd-trace/src/log/levels.js', // Required by the guardrails logger.
       'version.js',
     ],
     settings: {

--- a/integration-tests/appsec/esm-security-controls/index.mjs
+++ b/integration-tests/appsec/esm-security-controls/index.mjs
@@ -10,7 +10,7 @@ app.get('/cmdi-s-secure', (req, res) => {
   const command = sanitize(req.query.command)
   try {
     childProcess.execSync(command)
-  } catch (e) {
+  } catch {
     // ignore
   }
 
@@ -21,13 +21,13 @@ app.get('/cmdi-s-secure-comparison', (req, res) => {
   const command = sanitize(req.query.command)
   try {
     childProcess.execSync(command)
-  } catch (e) {
+  } catch {
     // ignore
   }
 
   try {
     childProcess.execSync(req.query.command)
-  } catch (e) {
+  } catch {
     // ignore
   }
 
@@ -38,7 +38,7 @@ app.get('/cmdi-s-secure-default', (req, res) => {
   const command = sanitizeDefault(req.query.command)
   try {
     childProcess.execSync(command)
-  } catch (e) {
+  } catch {
     // ignore
   }
 

--- a/integration-tests/appsec/index.spec.js
+++ b/integration-tests/appsec/index.spec.js
@@ -148,7 +148,7 @@ describe('RASP', () => {
 
       try {
         await axios.get('/crash')
-      } catch (e) {
+      } catch {
         return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
           setTimeout(() => {
             if (hasOutput) {
@@ -176,7 +176,7 @@ describe('RASP', () => {
 
         try {
           await axios.get('/crash-and-recovery-A')
-        } catch (e) {
+        } catch {
           return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
             setTimeout(() => {
               if (hasOutput) {
@@ -199,7 +199,7 @@ describe('RASP', () => {
 
         try {
           await axios.get('/crash-and-recovery-B')
-        } catch (e) {
+        } catch {
           return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
             setTimeout(() => {
               if (hasOutput) {
@@ -251,7 +251,7 @@ describe('RASP', () => {
       it('should crash as expected after block in domain request', async () => {
         try {
           await axios.get('/ssrf/http/should-block-in-domain?host=localhost/ifconfig.pro')
-        } catch (e) {
+        } catch {
           return await testAppCrashesAsExpected()
         }
 
@@ -276,7 +276,7 @@ describe('RASP', () => {
       it('should crash as expected after a requiest block when error is unhandled', async () => {
         try {
           await axios.get('/ssrf/http/unhandled-error?host=localhost/ifconfig.pro')
-        } catch (e) {
+        } catch {
           return await testAppCrashesAsExpected()
         }
 

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -547,7 +547,7 @@ class FakeCiVisIntake extends FakeAgent {
             clearTimeout(timeoutId)
             this.off('message', messageHandler)
             resolve()
-          } catch (e) {
+          } catch {
             // Assertion not yet satisfied — we'll try again when a new payload arrives.
             // The timeout handler will re-run onPayload and reject with the actual error.
           }

--- a/integration-tests/ci-visibility/vitest-tests-programmatic-api/run-programmatic-api.mjs
+++ b/integration-tests/ci-visibility/vitest-tests-programmatic-api/run-programmatic-api.mjs
@@ -12,6 +12,8 @@ async function runProgrammaticTests () {
 
     await vitest.close()
   } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error)
     process.exit(1)
   }
 }

--- a/integration-tests/electron/app/preload.js
+++ b/integration-tests/electron/app/preload.js
@@ -15,7 +15,7 @@ ipcRenderer.on('check-bridge', () => {
   try {
     bridge.send('test-payload')
     sendSuccess = true
-  } catch (_e) {
+  } catch {
     // sendSuccess stays false
   }
 

--- a/integration-tests/package-guardrails/index.js
+++ b/integration-tests/package-guardrails/index.js
@@ -7,7 +7,7 @@ try {
 
   // eslint-disable-next-line no-console
   console.log(isWrapped)
-} catch (e) {
+} catch {
   const fastify = require('fastify')
 
   // eslint-disable-next-line no-console

--- a/integration-tests/profiler/allocation.js
+++ b/integration-tests/profiler/allocation.js
@@ -2,7 +2,7 @@
 
 require('dd-trace').init({ profiling: true })
 
-const durationMs = Number.parseInt(process.env.TEST_DURATION_MS ?? '5000')
+const durationMs = Number.parseInt(process.env.TEST_DURATION_MS ?? '5000', 10)
 
 function runAllocations (ms) {
   return new Promise(resolve => {

--- a/integration-tests/profiler/index.js
+++ b/integration-tests/profiler/index.js
@@ -22,5 +22,5 @@ function busyWait (ms) {
 }
 
 const tracer = require('dd-trace')
-const durationMs = Number.parseInt(process.env.TEST_DURATION_MS ?? '500')
+const durationMs = Number.parseInt(process.env.TEST_DURATION_MS ?? '500', 10)
 setImmediate(() => tracer.trace('test-operation', () => busyWait(durationMs)))

--- a/packages/datadog-core/src/utils/src/parse-tags.js
+++ b/packages/datadog-core/src/utils/src/parse-tags.js
@@ -9,7 +9,6 @@ const digitRegex = /^\d+$/
  *   { 'a.0.b': 'value' } -> { a: [{ b: 'value' }] }
  *
  * @param {object} tags - Key/value pairs of tags
- * @returns Object - Parsed tags
  */
 module.exports = function parseTags (tags) {
   const parsedTags = {}

--- a/packages/datadog-instrumentations/src/bluebird.js
+++ b/packages/datadog-instrumentations/src/bluebird.js
@@ -15,12 +15,12 @@ function createGetNewLibraryCopyWrap (originalLib) {
   }
 }
 
-addHook({ name: 'bluebird', versions: ['>=2.0.2'] }, Promise => {
-  shimmer.wrap(Promise.prototype, '_then', wrapThen)
-  return Promise
+addHook({ name: 'bluebird', versions: ['>=2.0.2'] }, LibraryPromise => {
+  shimmer.wrap(LibraryPromise.prototype, '_then', wrapThen)
+  return LibraryPromise
 })
 
-addHook({ name: 'bluebird', versions: ['^2.11.0', '^3.4.1'] }, Promise => {
-  shimmer.wrap(Promise, 'getNewLibraryCopy', createGetNewLibraryCopyWrap(Promise))
-  return Promise
+addHook({ name: 'bluebird', versions: ['^2.11.0', '^3.4.1'] }, LibraryPromise => {
+  shimmer.wrap(LibraryPromise, 'getNewLibraryCopy', createGetNewLibraryCopyWrap(LibraryPromise))
+  return LibraryPromise
 })

--- a/packages/datadog-instrumentations/src/electron.js
+++ b/packages/datadog-instrumentations/src/electron.js
@@ -149,6 +149,7 @@ function wrapBrowserWindow (electron) {
 
       // BrowserWindow doesn't support subclassing because it's all native code
       // so we return an instance of it instead of the subclass.
+      // eslint-disable-next-line no-constructor-return
       return win
     }
   }

--- a/packages/datadog-instrumentations/src/promise-js.js
+++ b/packages/datadog-instrumentations/src/promise-js.js
@@ -7,9 +7,9 @@ const { wrapThen } = require('./helpers/promise')
 addHook({
   name: 'promise-js',
   versions: ['>=0.0.3'],
-}, Promise => {
-  if (Promise !== global.Promise) {
-    shimmer.wrap(Promise.prototype, 'then', wrapThen)
+}, LibraryPromise => {
+  if (LibraryPromise !== global.Promise) {
+    shimmer.wrap(LibraryPromise.prototype, 'then', wrapThen)
   }
-  return Promise
+  return LibraryPromise
 })

--- a/packages/datadog-instrumentations/src/promise.js
+++ b/packages/datadog-instrumentations/src/promise.js
@@ -8,7 +8,7 @@ addHook({
   name: 'promise',
   file: 'lib/core.js',
   versions: ['>=7'],
-}, Promise => {
-  shimmer.wrap(Promise.prototype, 'then', wrapThen)
-  return Promise
+}, LibraryPromise => {
+  shimmer.wrap(LibraryPromise.prototype, 'then', wrapThen)
+  return LibraryPromise
 })

--- a/packages/datadog-instrumentations/src/when.js
+++ b/packages/datadog-instrumentations/src/when.js
@@ -8,7 +8,7 @@ addHook({
   name: 'when',
   file: 'lib/Promise.js',
   versions: ['>=3'],
-}, Promise => {
-  shimmer.wrap(Promise.prototype, 'then', wrapThen)
-  return Promise
+}, LibraryPromise => {
+  shimmer.wrap(LibraryPromise.prototype, 'then', wrapThen)
+  return LibraryPromise
 })

--- a/packages/datadog-instrumentations/test/child_process.spec.js
+++ b/packages/datadog-instrumentations/test/child_process.spec.js
@@ -190,7 +190,7 @@ describe('child process', () => {
                 it('should execute error callback', async () => {
                   try {
                     await promisify(childProcess[methodName])('invalid_command_test')
-                  } catch (e) {
+                  } catch {
                     sinon.assert.calledOnce(start)
                     assertObjectContains(start.firstCall.firstArg, { command: 'invalid_command_test', shell: false })
 
@@ -220,7 +220,7 @@ describe('child process', () => {
 
                   try {
                     await promisify(childProcess[methodName])('node -e "process.exit(1)"', { shell: true })
-                  } catch (e) {
+                  } catch {
                     sinon.assert.calledOnce(start)
                     assertObjectContains(start.firstCall.firstArg, {
                       command: 'node -e "process.exit(1)"',
@@ -342,7 +342,7 @@ describe('child process', () => {
                 try {
                   await promisify(childProcess[methodName])('invalid_command_test')
                   return Promise.reject(new Error('Command expected to fail'))
-                } catch (e) {
+                } catch {
                   sinon.assert.calledOnce(start)
                   sinon.assert.calledWithMatch(start, {
                     command: 'invalid_command_test',
@@ -359,7 +359,7 @@ describe('child process', () => {
                 try {
                   await promisify(childProcess[methodName])('node -e "process.exit(1)"')
                   return Promise.reject(new Error('Command expected to fail'))
-                } catch (e) {
+                } catch {
                   sinon.assert.calledOnce(start)
                   sinon.assert.calledWithMatch(start, {
                     command: 'node -e "process.exit(1)"',
@@ -713,7 +713,7 @@ describe('child process', () => {
         })
 
         after(() => {
-          try { fs.unlinkSync(tmpScript) } catch (e) { /* ignore */ }
+          try { fs.unlinkSync(tmpScript) } catch { /* ignore */ }
         })
 
         it('should execute success callbacks', (done) => {

--- a/packages/datadog-instrumentations/test/helpers/promise.js
+++ b/packages/datadog-instrumentations/test/helpers/promise.js
@@ -9,7 +9,7 @@ const agent = require('../../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
 module.exports = (name, factory, versionRange) => {
   describe('Instrumentation', () => {
-    let Promise
+    let LibraryPromise
 
     describe(name, () => {
       withVersions(name, name, version => {
@@ -26,13 +26,13 @@ module.exports = (name, factory, versionRange) => {
         beforeEach(() => {
           const moduleExports = require(`../../../../versions/${name}@${version}`, {}).get()
 
-          Promise = factory ? factory(moduleExports) : moduleExports
+          LibraryPromise = factory ? factory(moduleExports) : moduleExports
         })
 
         it('should run the then() callbacks in the context where then() was called', () => {
           const store = 'store'
 
-          let promise = new Promise((resolve, reject) => {
+          let promise = new LibraryPromise((resolve, reject) => {
             setImmediate(() => {
               storage('legacy').run('promise', () => {
                 resolve()
@@ -58,7 +58,7 @@ module.exports = (name, factory, versionRange) => {
         it('should run the catch() callback in the context where catch() was called', () => {
           const store = storage('legacy').getStore()
 
-          let promise = new Promise((resolve, reject) => {
+          let promise = new LibraryPromise((resolve, reject) => {
             setImmediate(() => {
               storage('legacy').run('promise', () => {
                 reject(new Error())
@@ -81,7 +81,7 @@ module.exports = (name, factory, versionRange) => {
 
         it('should allow to run without a scope if not available when calling then()', () => {
           storage('legacy').run(null, () => {
-            const promise = new Promise((resolve, reject) => {
+            const promise = new LibraryPromise((resolve, reject) => {
               setImmediate(() => {
                 resolve()
               })

--- a/packages/datadog-instrumentations/test/hono.spec.js
+++ b/packages/datadog-instrumentations/test/hono.spec.js
@@ -128,7 +128,7 @@ withVersions('hono', 'hono', version => {
     it('should publish to errorChannel when middleware throws', async () => {
       try {
         await axios.get(`http://localhost:${port}/error`)
-      } catch (e) {
+      } catch {
         // Expected to fail
       }
 

--- a/packages/datadog-instrumentations/test/q.spec.js
+++ b/packages/datadog-instrumentations/test/q.spec.js
@@ -5,7 +5,7 @@ require('../src/q')
 const assertPromise = require('./helpers/promise')
 
 assertPromise('q', Q => {
-  return function Promise (executor) {
+  return function LibraryPromise (executor) {
     const deferred = Q.defer()
 
     executor(deferred.resolve, deferred.reject)

--- a/packages/datadog-instrumentations/test/when.spec.js
+++ b/packages/datadog-instrumentations/test/when.spec.js
@@ -5,7 +5,7 @@ require('../src/when')
 const assertPromise = require('./helpers/promise')
 
 assertPromise('when', when => {
-  return function Promise (executor) {
+  return function LibraryPromise (executor) {
     const deferred = when.defer()
 
     executor(deferred.resolve, deferred.reject)

--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -25,7 +25,7 @@ function getTestData (kinesis, streamName, input, cb) {
 
     try {
       cb(null, JSON.parse(dataBuffer))
-    } catch (e) {
+    } catch {
       cb(null, dataBuffer)
     }
   })

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -230,7 +230,7 @@ describe('Plugin', () => {
             })
 
             total++
-          }).catch(() => {}, { timeoutMs: 100 })
+          }, { timeoutMs: 100 }).catch(() => {})
 
           s3.putObject({
             Bucket: bucketName,

--- a/packages/datadog-plugin-aws-sdk/test/serverless-peer-service.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/serverless-peer-service.spec.js
@@ -53,7 +53,7 @@ describe('Plugin', () => {
           // ignore error if the table already exists
           if (typeof dynamo.createTable === 'function') {
             const createTable = toPromise(dynamo, dynamo.createTable)
-            try { await createTable(getCreateTableParams()) } catch (_) {}
+            try { await createTable(getCreateTableParams()) } catch {}
           }
         })
 

--- a/packages/datadog-plugin-azure-cosmos/test/index.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/index.spec.js
@@ -79,8 +79,8 @@ describe('Plugin', () => {
               })
 
               assert(span.meta['http.useragent'].includes('azure-cosmos-js/'), 'expected http.useragent in span meta')
-              assert(parseInt(span.meta['db.response.status_code']) >= 200 &&
-                parseInt(span.meta['db.response.status_code']) < 300,
+              assert(parseInt(span.meta['db.response.status_code'], 10) >= 200 &&
+                parseInt(span.meta['db.response.status_code'], 10) < 300,
                 `expected 2xx status code, got ${span.meta['db.response.status_code']}`)
 
               validatedResources.add(resource)

--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -55,7 +55,7 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
 
       try {
         await testSetup.queueAddError()
-      } catch (err) {
+      } catch {
         // Expected error
       }
 
@@ -114,7 +114,7 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
 
       try {
         await testSetup.queueAddBulkError()
-      } catch (err) {
+      } catch {
         // Expected error
       }
 
@@ -194,7 +194,7 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
 
       try {
         await testSetup.flowProducerAddError()
-      } catch (err) {
+      } catch {
         // Expected error
       }
 

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -117,7 +117,7 @@ describe('Plugin', () => {
 
           try {
             client.batch(queries, { prepare: true })
-          } catch (e) {
+          } catch {
             // older versions require a callback
           }
         })

--- a/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
+++ b/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
@@ -58,9 +58,7 @@ function scrubChildProcessCmd (expression) {
     for (let index = 0; index < expressionTokens.length; index++) {
       const token = expressionTokens[index]
 
-      if (token === null) {
-        continue
-      } else if (typeof token === 'object') {
+      if (token !== null && typeof token === 'object') {
         if (token.pattern) {
           result.push(token.pattern)
         } else if (token.op) {

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
@@ -426,7 +426,7 @@ describe('Plugin', () => {
               try {
                 // Passing invalid arguments should cause an error
                 nativeProducer.produce()
-              } catch (err) {
+              } catch {
                 // Error is expected
               }
 

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
@@ -210,7 +210,7 @@ describe('Plugin', () => {
                   resource: testTopic,
                 })
 
-                const parentId = parseInt(span.parent_id.toString())
+                const parentId = parseInt(span.parent_id.toString(), 10)
                 assert.ok(parentId > 0, `Expected ${parentId} > 0`)
               }, { timeoutMs: 10000 })
 
@@ -537,7 +537,7 @@ describe('Plugin', () => {
                   resource: testTopic,
                 })
 
-                const parentId = parseInt(span.parent_id.toString())
+                const parentId = parseInt(span.parent_id.toString(), 10)
                 assert.ok(parentId > 0, `Expected ${parentId} > 0`)
               }, { timeoutMs: 10000 })
               nativeConsumer.setDefaultConsumeTimeout(10)

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -825,7 +825,7 @@ describe('Plugin', () => {
             app.use(/\/foo\/(bar|baz|bez)/, (req, res, next) => {
               next()
             })
-          } catch (err) {
+          } catch {
             // eslint-disable-next-line no-console
             console.log('This version of Express (>4.0 <4.6) has broken support for regex routing. Skipping this test.')
             this.skip()
@@ -860,7 +860,7 @@ describe('Plugin', () => {
             app.use(/\/foo\/(bar|baz|bez)/i, (req, res, next) => {
               next()
             })
-          } catch (err) {
+          } catch {
             // eslint-disable-next-line no-console
             console.log('This version of Express (>4.0 <4.6) has broken support for regex routing. Skipping this test.')
             this.skip()
@@ -897,7 +897,7 @@ describe('Plugin', () => {
               next()
             })
             app.use('/foo', router)
-          } catch (err) {
+          } catch {
             // eslint-disable-next-line no-console
             console.log('This version of Express (>4.0 <4.6) has broken support for regex routing. Skipping this test.')
             this.skip()

--- a/packages/datadog-plugin-fastify/test/integration-test/helper.mjs
+++ b/packages/datadog-plugin-fastify/test/integration-test/helper.mjs
@@ -8,7 +8,9 @@ export async function createAndStartServer (app) {
     const address = app.server.address()
     const port = address.port
     process.send({ port })
-  } catch (err) {
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error)
     process.exit(1)
   }
 }

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -307,7 +307,7 @@ describe('Plugin', () => {
           const filename = path.join(__filename, Math.random().toString())
           try {
             fs.openSync(filename, 'r')
-          } catch (err) {
+          } catch {
             expectOneSpan(agent, done, {
               resource: 'openSync',
               error: 0,
@@ -386,7 +386,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(filename)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -425,7 +425,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(filename)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -477,7 +477,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(dest)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1000,7 +1000,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(link)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1025,7 +1025,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(link)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1054,10 +1054,10 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(sourceFile)
-          } catch (e) { /* */ }
+          } catch { /* */ }
           try {
             realFS.unlinkSync(link)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1084,7 +1084,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.rmdirSync(dir)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1112,7 +1112,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.unlinkSync(dest)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1190,7 +1190,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.rmdirSync(dir)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1315,7 +1315,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.rmdirSync(tmpdir)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1347,7 +1347,7 @@ describe('Plugin', () => {
         afterEach(() => {
           try {
             realFS.rmdirSync(tmpdir)
-          } catch (e) { /* */ }
+          } catch { /* */ }
         })
 
         it('should be instrumented', (done) => {
@@ -1647,7 +1647,7 @@ describe('Plugin', () => {
           afterEach(async () => {
             try {
               await filehandle.close()
-            } catch (e) { /* */ }
+            } catch { /* */ }
             await fs.promises.unlink(filename)
           })
 

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -146,7 +146,7 @@ describe('Plugin', () => {
               // This should fail because the topic already exists or similar error
               await publisher.createTopic({ name })
               await publisher.createTopic({ name }) // Try to create twice to force error
-            } catch (e) {
+            } catch {
             // this is just to prevent mocha from crashing
             }
             return expectedSpanPromise

--- a/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
@@ -58,7 +58,7 @@ describe('Plugin (ESM)', () => {
           await axios.post(`${proc.url}/graphql`, {
             query,
           })
-        } catch (error) {
+        } catch {
           // Server might not respond correctly, but we care about tracing
         }
 
@@ -96,7 +96,7 @@ describe('Plugin (ESM)', () => {
             await axios.post(`${proc.url}/graphql`, {
               query,
             })
-          } catch (error) {
+          } catch {
             // Server might not respond correctly, but we care about tracing
           }
 
@@ -131,7 +131,7 @@ describe('Plugin (ESM)', () => {
                 accept: 'text/event-stream',
               },
             })
-          } catch (error) {
+          } catch {
             // Server might not respond correctly, but we care about tracing
           }
 

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -14,7 +14,7 @@ const { withVersions } = require('../../dd-trace/test/setup/mocha')
 // hapi 19.x and 20.x are EOL and hang CI: on error and 404 replies they crash inside their own
 // `Request._finalize` (null `response.statusCode`) and never finish the request, stalling the
 // worker until the job is cancelled. 21.x fixed it, so the matrix covers 16.x and 21+.
-const versionRange = parseInt(process.versions.node.split('.')[0]) > 14
+const versionRange = parseInt(process.versions.node.split('.')[0], 10) > 14
   ? '<17 || >=21'
   : ''
 

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -56,7 +56,7 @@ class HttpClientPlugin extends ClientPlugin {
         'out.host': hostname,
       },
       metrics: {
-        [CLIENT_PORT_KEY]: Number.parseInt(options.port),
+        [CLIENT_PORT_KEY]: Number.parseInt(options.port, 10),
       },
     }, false)
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -17,7 +17,7 @@ const { rawExpectedSchema } = require('./naming')
 
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
-const NODE_MAJOR = parseInt(process.versions.node.split('.')[0])
+const NODE_MAJOR = parseInt(process.versions.node.split('.')[0], 10)
 const SERVICE_NAME = 'test'
 
 describe('Plugin', () => {

--- a/packages/datadog-plugin-http/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http/test/integration-test/server.mjs
@@ -4,7 +4,7 @@ import http from 'http'
 const server = http.createServer(async (req, res) => {
   try {
     res.end('integration test response handler success')
-  } catch (err) {
+  } catch {
     res.statusCode = 500
     res.end('integration test response handler failure')
   }

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -55,7 +55,7 @@ class Http2ClientPlugin extends ClientPlugin {
         'out.host': sessionDetails.host,
       },
       metrics: {
-        [CLIENT_PORT_KEY]: Number.parseInt(sessionDetails.port),
+        [CLIENT_PORT_KEY]: Number.parseInt(sessionDetails.port, 10),
       },
     }, false)
 

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -606,7 +606,7 @@ describe('Plugin', () => {
                 resource: testTopic,
               })
 
-              const parentId = parseInt(span.parent_id.toString())
+              const parentId = parseInt(span.parent_id.toString(), 10)
               assert.ok(parentId > 0, `Expected ${parentId} > 0`)
             })
 

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -114,7 +114,7 @@ describe('Plugin', function () {
         // if there is a way to re-use nodules from somewhere in the versions folder, this `execSync` will be reverted
         try {
           execSync('yarn install', { cwd })
-        } catch (e) { // retry in case of error from registry
+        } catch { // retry in case of error from registry
           execSync('yarn install', { cwd })
         }
 

--- a/packages/datadog-plugin-openai-agents/test/index.spec.js
+++ b/packages/datadog-plugin-openai-agents/test/index.spec.js
@@ -138,7 +138,7 @@ createIntegrationTestSuite('openai-agents', '@openai/agents', {
 
       try {
         await testSetup.runError()
-      } catch (err) {
+      } catch {
         // errorAgent triggers an intentional error from the mocked model
       }
 

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -458,7 +458,7 @@ describe('Plugin', () => {
                 Session.prototype.on_transfer = function onTransferWrapped (...args) {
                   try {
                     return onTransfer.apply(this, args)
-                  } catch (e) {
+                  } catch {
                     // this is just to prevent mocha from crashing
                   }
                 }

--- a/packages/dd-trace/src/appsec/iast/analyzers/hsts-header-missing-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/hsts-header-missing-analyzer.js
@@ -31,7 +31,7 @@ class HstsHeaderMissingAnalyzer extends MissingHeaderAnalyzer {
       semicolonIndex === -1 ? headerValue.length : semicolonIndex
     )
 
-    const timestamp = Number.parseInt(timestampString)
+    const timestamp = Number.parseInt(timestampString, 10)
     // eslint-disable-next-line eqeqeq
     return timestamp > 0 && timestamp == timestampString
   }

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -150,7 +150,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
 
             sensitiveRanges.push({
               start,
-              end: start + Number.parseInt(regexRes[1]),
+              end: start + Number.parseInt(regexRes[1], 10),
             })
             segments.push(value.slice(pos, rangeKeyIndex))
             outputLength += cleanLength

--- a/packages/dd-trace/src/debugger/devtools_client/status.js
+++ b/packages/dd-trace/src/debugger/devtools_client/status.js
@@ -32,7 +32,7 @@ const STATUSES = {
   INSTALLED: 'INSTALLED',
   EMITTING: 'EMITTING',
   ERROR: 'ERROR',
-  BLOCKED: 'BLOCKED', // TODO: Implement once support for allow list, deny list or max probe limit has been added
+  // TODO: Add BLOCKED once support for allow list, deny list or max probe limit has been added
 }
 
 function ackReceived ({ id: probeId, version }) {

--- a/packages/dd-trace/src/encode/coverage-ci-visibility.js
+++ b/packages/dd-trace/src/encode/coverage-ci-visibility.js
@@ -110,7 +110,6 @@ class CoverageCIVisibilityEncoder extends AgentEncoder {
   _encodePayloadStart (bytes) {
     const payload = {
       version: COVERAGE_PAYLOAD_VERSION,
-      coverages: [],
     }
     bytes.writeMapPrefix(COVERAGE_KEYS_LENGTH)
     this._encodeString(bytes, 'version')

--- a/packages/dd-trace/src/guardrails/log.js
+++ b/packages/dd-trace/src/guardrails/log.js
@@ -7,13 +7,9 @@ var isTrue = require('./util').isTrue
 var DD_TRACE_DEBUG = process.env.DD_TRACE_DEBUG
 var DD_TRACE_LOG_LEVEL = process.env.DD_TRACE_LOG_LEVEL
 
+// Numeric severities match the canonical `Level` map in `../log/channels.js`.
 var logLevels = {
-  trace: 20,
   debug: 20,
-  info: 30,
-  warn: 40,
-  error: 50,
-  critical: 50,
   off: 100
 }
 

--- a/packages/dd-trace/src/guardrails/log.js
+++ b/packages/dd-trace/src/guardrails/log.js
@@ -2,16 +2,11 @@
 
 /* eslint-disable no-console */
 
+var logLevels = require('../log/levels')
 var isTrue = require('./util').isTrue
 
 var DD_TRACE_DEBUG = process.env.DD_TRACE_DEBUG
 var DD_TRACE_LOG_LEVEL = process.env.DD_TRACE_LOG_LEVEL
-
-// Numeric severities match the canonical `Level` map in `../log/channels.js`.
-var logLevels = {
-  debug: 20,
-  off: 100
-}
 
 var logLevel = isTrue(DD_TRACE_DEBUG)
   ? Number(DD_TRACE_LOG_LEVEL) || logLevels.debug

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -118,7 +118,7 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
    * @returns {string | undefined}
    */
   findToolName (toolName, toolDescription) {
-    if (Number.isNaN(Number.parseInt(toolName))) return toolName
+    if (Number.isNaN(Number.parseInt(toolName, 10))) return toolName
 
     for (const availableTool of this.#availableTools) {
       const description = availableTool.description

--- a/packages/dd-trace/src/llmobs/plugins/ai/util.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/util.js
@@ -322,7 +322,7 @@ function getToolNameFromTags (tags) {
   const toolName = tags['ai.toolCall.name']
   if (!toolName) return null
 
-  const parsedToolName = Number.parseInt(toolName)
+  const parsedToolName = Number.parseInt(toolName, 10)
   if (!Number.isNaN(parsedToolName)) return null
 
   return toolName

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -72,10 +72,10 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       const cacheWriteTokenCount = headers['x-amzn-bedrock-cache-write-input-token-count']
 
       pendingTokenHeaders.set(requestId, {
-        inputTokensFromHeaders: inputTokenCount && Number.parseInt(inputTokenCount),
-        outputTokensFromHeaders: outputTokenCount && Number.parseInt(outputTokenCount),
-        cacheReadTokensFromHeaders: cacheReadTokenCount && Number.parseInt(cacheReadTokenCount),
-        cacheWriteTokensFromHeaders: cacheWriteTokenCount && Number.parseInt(cacheWriteTokenCount),
+        inputTokensFromHeaders: inputTokenCount && Number.parseInt(inputTokenCount, 10),
+        outputTokensFromHeaders: outputTokenCount && Number.parseInt(outputTokenCount, 10),
+        cacheReadTokensFromHeaders: cacheReadTokenCount && Number.parseInt(cacheReadTokenCount, 10),
+        cacheWriteTokensFromHeaders: cacheWriteTokenCount && Number.parseInt(cacheWriteTokenCount, 10),
       })
     })
 
@@ -138,7 +138,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
   #tagCommon ({ span, requestParams, textAndResponseReason, tokensFromHeaders }) {
     this._tagger.tagMetadata(span, {
       temperature: Number.parseFloat(requestParams.temperature) || 0,
-      max_tokens: Number.parseInt(requestParams.maxTokens) || 0,
+      max_tokens: Number.parseInt(requestParams.maxTokens, 10) || 0,
     })
     this._tagger.tagLLMIO(span, requestParams.prompt, textAndResponseReason.messages)
     this._tagger.tagMetrics(span, extractTokens({

--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -113,7 +113,7 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
     }
 
     if (maxTokens) {
-      metadata.maxTokens = Number.parseInt(maxTokens)
+      metadata.maxTokens = Number.parseInt(maxTokens, 10)
     }
 
     this._tagger.tagMetadata(span, metadata)

--- a/packages/dd-trace/src/log/channels.js
+++ b/packages/dd-trace/src/log/channels.js
@@ -2,15 +2,7 @@
 
 const { channel } = require('dc-polyfill')
 
-const Level = {
-  trace: 10,
-  debug: 20,
-  info: 30,
-  warn: 40,
-  error: 50,
-  critical: 50,
-  off: 100,
-}
+const Level = require('./levels')
 
 const traceChannel = channel('datadog:log:trace')
 const debugChannel = channel('datadog:log:debug')

--- a/packages/dd-trace/src/log/levels.js
+++ b/packages/dd-trace/src/log/levels.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// The guardrails logger requires this file, so it has to parse on Node.js 0.8.
+module.exports = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  critical: 50,
+  off: 100
+}

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -119,9 +119,9 @@ function getGitVersion () {
   const gitVersionMatches = /** @type {RegExpMatchArray} */ (gitVersionString.match(/git version (\d+)\.(\d+)\.(\d+)/))
   try {
     return {
-      major: Number.parseInt(gitVersionMatches[1]),
-      minor: Number.parseInt(gitVersionMatches[2]),
-      patch: Number.parseInt(gitVersionMatches[3]),
+      major: Number.parseInt(gitVersionMatches[1], 10),
+      minor: Number.parseInt(gitVersionMatches[2], 10),
+      patch: Number.parseInt(gitVersionMatches[3], 10),
     }
   } catch {
     return null

--- a/packages/dd-trace/src/plugins/util/http-otel-semantics.js
+++ b/packages/dd-trace/src/plugins/util/http-otel-semantics.js
@@ -71,7 +71,7 @@ function decomposeServerUrl (rawUrl, obfuscatedUrl) {
       address = stripIpv6Brackets(hostname)
     }
     if (parsed.port) {
-      const parsedPort = Number.parseInt(parsed.port)
+      const parsedPort = Number.parseInt(parsed.port, 10)
       if (parsedPort > 0) port = parsedPort
     }
     path = parsed.pathname || '/'
@@ -210,7 +210,7 @@ function applyHttpOtelSemantics (formattedSpan) {
     // metric (the OTLP exporter serializes meta as stringValue but metrics as
     // intValue) — mirroring how server.port is handled below. Guard against a
     // non-numeric status, which would otherwise write a NaN metric.
-    statusCode = Number.parseInt(status)
+    statusCode = Number.parseInt(status, 10)
     if (Number.isFinite(statusCode)) newMetrics[HTTP_RESPONSE_STATUS_CODE] = statusCode
   }
 

--- a/packages/dd-trace/src/plugins/util/ip_extractor.js
+++ b/packages/dd-trace/src/plugins/util/ip_extractor.js
@@ -36,7 +36,7 @@ const privateIPMatcher = new net.BlockList()
 for (const cidr of privateCIDRs) {
   const [address, prefix] = cidr.split('/')
 
-  privateIPMatcher.addSubnet(address, Number.parseInt(prefix), net.isIPv6(address) ? 'ipv6' : 'ipv4')
+  privateIPMatcher.addSubnet(address, Number.parseInt(prefix, 10), net.isIPv6(address) ? 'ipv6' : 'ipv4')
 }
 
 function extractIp (config, req) {

--- a/packages/dd-trace/src/plugins/util/url.js
+++ b/packages/dd-trace/src/plugins/util/url.js
@@ -14,7 +14,7 @@ const INT_SEGMENT = /^[1-9][0-9]+$/ // Integer of size at least 2 (>=10)
 const INT_ID_SEGMENT = /^(?=.*[0-9])[0-9._-]{3,}$/ // Mixed string with digits and delimiters
 const HEX_SEGMENT = /^(?=.*[0-9])[A-Fa-f0-9]{6,}$/ // Hexadecimal digits of size at least 6 with at least one decimal digit
 const HEX_ID_SEGMENT = /^(?=.*[0-9])[A-Fa-f0-9._-]{6,}$/ // Mixed string with hex digits and delimiters
-const STRING_SEGMENT = /^.{20,}|[%&'()*+,:=@]/ // Long string or a string containing special characters
+const STRING_SEGMENT = /(?:^.{20,}|[%&'()*+,:=@])/ // Long string or a string containing special characters
 
 /**
  * Extract full URL from HTTP request

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -2,7 +2,7 @@
 
 const { performance, constants, PerformanceObserver } = require('perf_hooks')
 const {
-  Function,
+  Function: PprofFunction,
   Label,
   Line,
   Location,
@@ -256,7 +256,7 @@ class EventSerializer {
     // A synthetic single-frame location to serve as the location for timeline
     // samples. We need these as the profiling backend (mimicking official pprof
     // tool's behavior) ignores these.
-    const fn = new Function({ id: this.functions.length + 1, name: this.stringTable.dedup('') })
+    const fn = new PprofFunction({ id: this.functions.length + 1, name: this.stringTable.dedup('') })
     this.functions.push(fn)
     const line = new Line({ functionId: fn.id })
     const location = new Location({ id: this.locations.length + 1, line: [line] })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
@@ -97,7 +97,7 @@ withVersions('passport-http', 'passport-http', version => {
             },
           }
         )
-      } catch (e) {}
+      } catch {}
 
       await agent.assertSomeTraces(assertFingerprintInTraces)
     })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
@@ -96,7 +96,7 @@ withVersions('passport-local', 'passport-local', version => {
             password: '1234',
           }
         )
-      } catch (e) {}
+      } catch {}
 
       await agent.assertSomeTraces(assertFingerprintInTraces)
     })

--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.kafkajs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.kafkajs.plugin.spec.js
@@ -42,7 +42,7 @@ describe('command-injection-analyzer with kafkajs', () => {
 
               const command = message.value.toString()
               execSync(command)
-            } catch (e) {
+            } catch {
               // do nothing
             }
           },

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -45,7 +45,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
         tmpFilePath = path.join(os.tmpdir(), vulnerableMethodFilename)
         try {
           fs.unlinkSync(tmpFilePath)
-        } catch (e) {
+        } catch {
           // ignore the error
         }
         fs.copyFileSync(src, tmpFilePath)

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -51,7 +51,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
         tmpFilePath = path.join(os.tmpdir(), vulnerableMethodFilename)
         try {
           fs.unlinkSync(tmpFilePath)
-        } catch (e) {
+        } catch {
           // ignore the error
         }
         fs.copyFileSync(src, tmpFilePath)
@@ -60,7 +60,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
       after(() => {
         try {
           fs.unlinkSync(tmpFilePath)
-        } catch (e) {
+        } catch {
           // ignore the error
         }
 
@@ -183,7 +183,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
                   }).exec(() => {
                     res.end()
                   })
-                } catch (e) {
+                } catch {
                   res.writeHead(500)
                   res.end()
                 }
@@ -201,7 +201,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
                     }).exec(() => {
                       res.end()
                     })
-                  } catch (e) {
+                  } catch {
                     res.writeHead(500)
                     res.end()
                   }
@@ -224,7 +224,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
                     }, () => {
                       res.end()
                     })
-                  } catch (e) {
+                  } catch {
                     res.writeHead(500)
                     res.end()
                   }

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js
@@ -42,7 +42,7 @@ describe('nosql injection detection with mquery', () => {
         tmpFilePath = path.join(os.tmpdir(), vulnerableMethodFilename)
         try {
           fs.unlinkSync(tmpFilePath)
-        } catch (e) {
+        } catch {
           // ignore the error
         }
         fs.copyFileSync(src, tmpFilePath)
@@ -84,7 +84,7 @@ describe('nosql injection detection with mquery', () => {
                   assert.notStrictEqual(result, undefined)
                   assert.strictEqual(result.length, 1)
                   assert.strictEqual(result[0].id, 1)
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
 
@@ -112,7 +112,7 @@ describe('nosql injection detection with mquery', () => {
 
                       res.end()
                     })
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
               },
@@ -128,7 +128,7 @@ describe('nosql injection detection with mquery', () => {
               fn: async (req, res) => {
                 try {
                   await require(tmpFilePath).vulnerableFindExec(collection, { name: req.query.key })
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -145,7 +145,7 @@ describe('nosql injection detection with mquery', () => {
                 try {
                   await require(tmpFilePath)
                     .vulnerableFindWhereExec(collection, { name: req.query.key }, { where: req.query.key2 })
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -164,7 +164,7 @@ describe('nosql injection detection with mquery', () => {
                 try {
                   await require(tmpFilePath)
                     .vulnerableFindWhereExec(collection, { name: req.query.key }, { where: req.query.key2 })
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -182,7 +182,7 @@ describe('nosql injection detection with mquery', () => {
                 try {
                   await require(tmpFilePath)
                     .vulnerableFindWhereExec(collection, { name: req.query.key }, { where: 'not_tainted' })
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -201,7 +201,7 @@ describe('nosql injection detection with mquery', () => {
                   const filter = { name: req.query.key }
                   const where = { key2: req.query.key2 }
                   await require(tmpFilePath).vulnerableFindWhere(collection, filter, where)
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -220,7 +220,7 @@ describe('nosql injection detection with mquery', () => {
                 }
                 try {
                   await require(tmpFilePath).vulnerableFind(collection, filter)
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -246,7 +246,7 @@ describe('nosql injection detection with mquery', () => {
                 }
                 try {
                   await require(tmpFilePath).vulnerableFindOne(collection, filter)
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -272,7 +272,7 @@ describe('nosql injection detection with mquery', () => {
                 try {
                   require(tmpFilePath)
                     .vulnerableFind(collection, { name: req.query.key })
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()
@@ -289,7 +289,7 @@ describe('nosql injection detection with mquery', () => {
                   .find({
                     name: 'test',
                   })
-              } catch (e) {
+              } catch {
                 // do nothing
               }
               res.end()
@@ -299,7 +299,7 @@ describe('nosql injection detection with mquery', () => {
               try {
                 await collection
                   .find()
-              } catch (e) {
+              } catch {
                 // do nothing
               }
               res.end()
@@ -319,7 +319,7 @@ describe('nosql injection detection with mquery', () => {
                 }
                 try {
                   await require(tmpFilePath).vulnerableFindOne(collection, filter)
-                } catch (e) {
+                } catch {
                   // do nothing
                 }
                 res.end()

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-sync-way-method.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-sync-way-method.js
@@ -7,7 +7,7 @@ module.exports = function (methodName, args, cb) {
   try {
     const res = fs[method](...args)
     cb(res)
-  } catch (e) {
+  } catch {
     cb(null)
   }
 }

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/knex-sql-injection-methods.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/knex-sql-injection-methods.js
@@ -43,7 +43,7 @@ async function executeKnexAsyncNestedRawQuery (knex, taintedSql, notTaintedSql) 
 async function executeKnexAsyncNestedRawQueryAsAsyncTryCatch (knex, taintedSql, sqlToFail) {
   try {
     await knex.raw(sqlToFail)
-  } catch (e) {
+  } catch {
     await knex.raw(taintedSql)
   }
 }

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/random-functions.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/random-functions.js
@@ -10,6 +10,8 @@ function safeRandom () {
 }
 
 function customRandom () {
+  // Shadowing is the subject under test: the analyzer must not report a user-defined Math.random.
+  // eslint-disable-next-line sonarjs/no-globals-shadowing
   const Math = {
     random: function () {
       return 4 // chosen by fair dice roll - guaranteed to be random

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
@@ -42,7 +42,7 @@ describe('sql-injection-analyzer with mysql2', () => {
 
           try {
             fs.unlinkSync(tmpFilePath)
-          } catch (e) {
+          } catch {
             // ignore the error
           }
           const src = path.join(__dirname, 'resources', vulnerableMethodFilename)
@@ -53,7 +53,7 @@ describe('sql-injection-analyzer with mysql2', () => {
         afterEach(() => {
           try {
             fs.unlinkSync(tmpFilePath)
-          } catch (e) {
+          } catch {
             // ignore the error
           }
         })

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -479,13 +479,13 @@ describe('Overhead controller', () => {
           agent.subscribe(handler)
           testRequestEventEmitter.on(TEST_REQUEST_STARTED, (url) => {
             if (url === FIRST_REQUEST) {
-              axios.get(`http://localhost:${serverConfig.port}${SECOND_REQUEST}`).then().catch(done)
+              axios.get(`http://localhost:${serverConfig.port}${SECOND_REQUEST}`).catch(done)
             } else if (url === SECOND_REQUEST) {
               requestResolvers[FIRST_REQUEST]()
               requestResolvers[SECOND_REQUEST]()
             }
           })
-          axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).then().catch(done)
+          axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).catch(done)
         })
 
         it('should detect vulnerabilities in both if max concurrent is 2', (done) => {
@@ -523,7 +523,7 @@ describe('Overhead controller', () => {
           agent.subscribe(handler)
           testRequestEventEmitter.on(TEST_REQUEST_STARTED, (url) => {
             if (url === FIRST_REQUEST) {
-              axios.get(`http://localhost:${serverConfig.port}${SECOND_REQUEST}`).then().catch(done)
+              axios.get(`http://localhost:${serverConfig.port}${SECOND_REQUEST}`).catch(done)
             } else if (url === SECOND_REQUEST) {
               setImmediate(() => {
                 requestResolvers[FIRST_REQUEST]()
@@ -537,7 +537,7 @@ describe('Overhead controller', () => {
               })
             }
           })
-          axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).then().catch(done)
+          axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).catch(done)
         })
 
         it('should recovery requests budget', function (done) {
@@ -587,13 +587,13 @@ describe('Overhead controller', () => {
           agent.subscribe(handler)
           testRequestEventEmitter.on(TEST_REQUEST_STARTED, (url) => {
             if (url === FIRST_REQUEST) {
-              axios.get(`http://localhost:${serverConfig.port}${SECOND_REQUEST}`).then().catch(done)
+              axios.get(`http://localhost:${serverConfig.port}${SECOND_REQUEST}`).catch(done)
             } else if (url === SECOND_REQUEST) {
-              axios.get(`http://localhost:${serverConfig.port}${THIRD_REQUEST}`).then().catch(done)
+              axios.get(`http://localhost:${serverConfig.port}${THIRD_REQUEST}`).catch(done)
             } else if (url === THIRD_REQUEST) {
               requestResolvers[FIRST_REQUEST]()
             } else if (url === FOURTH_REQUEST) {
-              axios.get(`http://localhost:${serverConfig.port}${FIFTH_REQUEST}`).then().catch(done)
+              axios.get(`http://localhost:${serverConfig.port}${FIFTH_REQUEST}`).catch(done)
             } else if (url === FIFTH_REQUEST) {
               requestResolvers[SECOND_REQUEST]()
             }
@@ -601,7 +601,7 @@ describe('Overhead controller', () => {
 
           testRequestEventEmitter.on(TEST_REQUEST_FINISHED, (url) => {
             if (url === FIRST_REQUEST) {
-              axios.get(`http://localhost:${serverConfig.port}${FOURTH_REQUEST}`).then().catch(done)
+              axios.get(`http://localhost:${serverConfig.port}${FOURTH_REQUEST}`).catch(done)
             } else if (url === SECOND_REQUEST) {
               requestResolvers[THIRD_REQUEST]()
               requestResolvers[FOURTH_REQUEST]()
@@ -609,7 +609,7 @@ describe('Overhead controller', () => {
             }
           })
 
-          axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).then().catch(done)
+          axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).catch(done)
         })
 
         it('should add _dd.iast.enabled tag even when no vulnerability is detected', (done) => {
@@ -652,7 +652,7 @@ describe('Overhead controller', () => {
               })
             }
           })
-          axios.get(`http://localhost:${serverConfig.port}${SECURE_REQUEST}`).then().catch(done)
+          axios.get(`http://localhost:${serverConfig.port}${SECURE_REQUEST}`).catch(done)
         })
       }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -81,7 +81,7 @@ describe('TaintTracking', () => {
               try {
                 const childProcess = require('child_process')
                 childProcess.execSync(commandResult, { stdio: 'ignore' })
-              } catch (e) {
+              } catch {
                 // do nothing
               }
             }, 'COMMAND_INJECTION')
@@ -120,7 +120,7 @@ describe('TaintTracking', () => {
         try {
           const childProcess = require('child_process')
           childProcess.execSync(result.command, { stdio: 'ignore' })
-        } catch (e) {
+        } catch {
           // do nothing
         }
       }, 'COMMAND_INJECTION')

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -71,7 +71,7 @@ describe('TaintTracking lodash', () => {
               try {
                 const childProcess = require('child_process')
                 childProcess.execSync(commandResult, { stdio: 'ignore' })
-              } catch (e) {
+              } catch {
                 // do nothing
               }
             }, 'COMMAND_INJECTION')

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -403,7 +403,7 @@ function prepareTestServerForIastInExpress (
       try {
         const cookieParser = require('../../../../../versions/cookie-parser').get()
         expressApp.use(cookieParser())
-      } catch (e) {
+      } catch {
         // do nothing, in some scenarios we don't have cookie-parser dependency available, and we don't need
         // it in all the iast tests
       }
@@ -470,7 +470,7 @@ function prepareTestServerForIastInFastify (description, fastifyVersion, tests, 
           } else {
             finish()
           }
-        } catch (e) {
+        } catch {
           if (!headersSent()) {
             reply.code(500).send()
           } else if (reply.raw && typeof reply.raw.end === 'function') {

--- a/packages/dd-trace/test/appsec/next.utils.js
+++ b/packages/dd-trace/test/appsec/next.utils.js
@@ -28,7 +28,7 @@ function initApp (appName, version, realVersion) {
     // if there is a way to re-use nodules from somewhere in the versions folder, this `execSync` will be reverted
     try {
       execSync('yarn install', { cwd })
-    } catch (e) { // retry in case of error from registry
+    } catch { // retry in case of error from registry
       execSync('yarn install', { cwd })
     }
 

--- a/packages/dd-trace/test/appsec/payment_events.stripe.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/payment_events.stripe.plugin.spec.js
@@ -97,7 +97,7 @@ withVersions('stripe', 'stripe', version => {
           amount_discount = subtotal * 0.1
         }
 
-        amount_shipping = parseInt(amount_shipping)
+        amount_shipping = parseInt(amount_shipping, 10)
 
         const amount_total = subtotal - amount_discount + amount_shipping
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
@@ -171,7 +171,7 @@ describe('RASP - lfi', () => {
           args.forEach(arg => {
             try {
               fs.unlinkSync(arg)
-            } catch (e) {
+            } catch {
 
             }
           })
@@ -250,7 +250,7 @@ describe('RASP - lfi', () => {
           afterEach(() => {
             try {
               fs.rmdirSync(dirname)
-            } catch (e) {
+            } catch {
               // some ops are blocked
             }
           })
@@ -264,7 +264,7 @@ describe('RASP - lfi', () => {
             onfinish: (todelete) => {
               try {
                 fs.rmdirSync(todelete)
-              } catch (e) {
+              } catch {
                 // some ops are blocked
               }
             },
@@ -377,7 +377,7 @@ describe('RASP - lfi', () => {
           afterEach(() => {
             try {
               fs.rmdirSync(dirname)
-            } catch (e) {
+            } catch {
             }
           })
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.mysql2.plugin.spec.js
@@ -98,7 +98,7 @@ describe('RASP - sql_injection', () => {
 
               try {
                 await axios.get('/?param=\' OR 1 = 1 --')
-              } catch (e) {
+              } catch {
                 return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
               }
 
@@ -135,7 +135,7 @@ describe('RASP - sql_injection', () => {
 
               try {
                 await axios.get('/?param=\' OR 1 = 1 --')
-              } catch (e) {
+              } catch {
                 return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
               }
 
@@ -180,7 +180,7 @@ describe('RASP - sql_injection', () => {
 
               try {
                 await axios.get('/?param=\' OR 1 = 1 --')
-              } catch (e) {
+              } catch {
                 return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
               }
 
@@ -217,7 +217,7 @@ describe('RASP - sql_injection', () => {
 
               try {
                 await axios.get('/?param=\' OR 1 = 1 --')
-              } catch (e) {
+              } catch {
                 return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
               }
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.pg.plugin.spec.js
@@ -103,7 +103,7 @@ describe('RASP - sql_injection', () => {
 
             try {
               await axios.get('/?param=\' OR 1 = 1 --')
-            } catch (e) {
+            } catch {
               return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
             }
 
@@ -124,7 +124,7 @@ describe('RASP - sql_injection', () => {
 
             try {
               await axios.get('/?param=\' OR 1 = 1 --')
-            } catch (e) {
+            } catch {
               return checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
             }
 
@@ -167,7 +167,7 @@ describe('RASP - sql_injection', () => {
 
             try {
               await axios.get('/?param=\' OR 1 = 1 --')
-            } catch (e) {
+            } catch {
               return checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
             }
 
@@ -188,7 +188,7 @@ describe('RASP - sql_injection', () => {
 
             try {
               await axios.get('/?param=\' OR 1 = 1 --')
-            } catch (e) {
+            } catch {
               return checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
             }
 
@@ -210,7 +210,7 @@ describe('RASP - sql_injection', () => {
             async function runQueryAndIgnoreError (query) {
               try {
                 await pool.query(query)
-              } catch (err) {
+              } catch {
                 // do nothing
               }
             }

--- a/packages/dd-trace/test/appsec/stack_trace.spec.js
+++ b/packages/dd-trace/test/appsec/stack_trace.spec.js
@@ -92,7 +92,7 @@ describe('Stack trace reporter', () => {
       const stackId = 'test_stack_id'
       try {
         reportStackTrace(rootSpan, stackId, callSiteList)
-      } catch (e) {
+      } catch {
         assert.fail()
       }
     })

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -170,7 +170,7 @@ function generateTestCaseName (ast, dataOrSuffix, expected) {
 function serialize (value) {
   try {
     return JSON.stringify(value)
-  } catch (e) {
+  } catch {
     // Some values are not serializable to JSON, so we fall back to stringification
     return String(value)
   }

--- a/packages/dd-trace/test/llmobs/plugins/openai-agents/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai-agents/index.spec.js
@@ -334,7 +334,7 @@ describe('integrations', () => {
           // through the runner.
           try {
             await agentsCore.run(toolErrorAgent, 'What is the sum of 1 and 2?', { maxTurns: 2 })
-          } catch (err) {
+          } catch {
             // Expected: model loops on the failing tool call until maxTurns.
           }
 

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
@@ -721,7 +721,7 @@ describe('integrations', () => {
             n: 1,
             user: 'dd-trace-test',
           })
-        } catch (e) {
+        } catch {
           // expected error
         }
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -742,7 +742,6 @@ module.exports = {
    *
    * @param {RunCallbackAgainstTracesCallback} callback - runs once per agent payload
    * @param {RunCallbackAgainstTracesOptions} [options] - An options object
-   * @returns Promise
    */
   assertSomeTraces (callback, options) {
     return runCallbackAgainstTraces(callback, options, traceHandlers)
@@ -772,7 +771,6 @@ module.exports = {
    *
    * @param {testAssertionSpanCallback|Record<string|symbol, unknown>} callbackOrExpected - runs once per agent payload
    * @param {RunCallbackAgainstTracesOptions} [options] - An options object
-   * @returns Promise
    */
   assertFirstTraceSpan (callbackOrExpected, options) {
     return runCallbackAgainstTraces(function (traces) {
@@ -799,7 +797,6 @@ module.exports = {
    *
    * @param {RunCallbackAgainstTracesCallback} callback - runs once per agent payload
    * @param {RunCallbackAgainstTracesOptions} [options] - An options object
-   * @returns Promise
    */
   expectPipelineStats (callback, options) {
     return runCallbackAgainstTraces(callback, options, statsHandlers)

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -49,14 +49,15 @@ describe('profiler', function () {
     },
   }
 
-  function waitForExport () {
-    return Promise.all([
+  async function waitForExport () {
+    await Promise.all([
       wallProfilePromise,
       spaceProfilePromise,
       exporterPromise,
-    // After all profiles resolve, need to wait another microtask
-    // tick until _collect method calls _submit to begin the export.
-    ]).then(() => Promise.resolve())
+    ])
+    // The profiles resolving is not enough: _collect still has to reach its
+    // _submit call, which happens one microtask tick later.
+    await Promise.resolve()
   }
 
   function setUpProfiler () {

--- a/packages/dd-trace/test/setup/helpers/load-inst.js
+++ b/packages/dd-trace/test/setup/helpers/load-inst.js
@@ -47,10 +47,10 @@ function loadOneInst (name) {
   try {
     loadInstFile(`${name}/server.js`, instrumentations)
     loadInstFile(`${name}/client.js`, instrumentations)
-  } catch (e) {
+  } catch {
     try {
       loadInstFile(`${name}/main.js`, instrumentations)
-    } catch (e) {
+    } catch {
       loadInstFile(`${name}.js`, instrumentations)
     }
   }

--- a/packages/dd-trace/test/setup/services/kafka.js
+++ b/packages/dd-trace/test/setup/services/kafka.js
@@ -32,7 +32,7 @@ function waitForKafka () {
               replicationFactor: 1,
             }],
           })
-        } catch (e) {
+        } catch {
           // Ignore since this will fail when the topic already exists.
         } finally {
           await admin.disconnect()

--- a/version.js
+++ b/version.js
@@ -8,11 +8,11 @@ var /** @type {RegExpMatchArray} */ nodeMatches = process.versions.node.match(/^
 
 module.exports = {
   VERSION: version,
-  DD_MAJOR: parseInt(ddMatches[1]),
-  DD_MINOR: parseInt(ddMatches[2]),
-  DD_PATCH: parseInt(ddMatches[3]),
-  NODE_MAJOR: parseInt(nodeMatches[1]),
-  NODE_MINOR: parseInt(nodeMatches[2]),
-  NODE_PATCH: parseInt(nodeMatches[3]),
+  DD_MAJOR: parseInt(ddMatches[1], 10),
+  DD_MINOR: parseInt(ddMatches[2], 10),
+  DD_PATCH: parseInt(ddMatches[3], 10),
+  NODE_MAJOR: parseInt(nodeMatches[1], 10),
+  NODE_MINOR: parseInt(nodeMatches[2], 10),
+  NODE_PATCH: parseInt(nodeMatches[3], 10),
   NODE_VERSION: nodeMatches[0]
 }


### PR DESCRIPTION
## Summary

Every rule enabled here reports zero violations, or reports only the handful fixed in this change. Several `off` entries were parked on counts that have since drifted to zero: `sonarjs/slow-regex` guards the ReDoS class again, and `no-unassigned-vars` returns to the recommended default.

1. `jsdoc/require-returns-type` had four bare `@returns Promise` / `@returns Object` tags left. Each type is inferable from the body, so the tag goes rather than gaining braces.
2. `no-constructor-return` catches a `return` that silently discards `this`. The one deliberate site returns a native `BrowserWindow` that cannot be subclassed, so it opts out inline.
3. `unicorn/expiring-todo-comments` falls back to the recommended default. Its `checkDates` option stays off, so it enforces package-version and engine conditions only.
4. `unicorn/no-unsafe-dom-html` guards the innerHTML sink class that `recommended` leaves off.
5. Two `eslint-no-private-tags-access` allowlist entries and the relaxed `mocha/max-top-level-suites` exception suppressed nothing and are dropped.

## Why

Each enabled rule was checked against a probe file to confirm it actually reports, so none of them is inert. `unicorn/consistent-function-style` was left out for that reason: every one of its options defaults to `ignore`.

`preserve-caught-error` stays off. Its six sites need `cause` attached, which changes error output and belongs in its own change.

## Drive-by

* `unicorn/consistent-conditional-object-spread` was marked `few` for 15 sites.