### PR TITLE
chore(tsconfig): drop deprecated alwaysStrict and baseUrl options

### DIFF
--- a/packages/dd-trace/src/plugins/util/llm.js
+++ b/packages/dd-trace/src/plugins/util/llm.js
@@ -28,7 +28,7 @@ function normalize (text, limit = 128) {
  * Determines whether a prompt completion should be sampled based on the configured sampling rate.
  *
  * @param {Sampler} sampler
- * @param {import('index').Span|import('index').SpanContext} span
+ * @param {import('../../../../..').Span|import('../../../../..').SpanContext} span
  * @returns {boolean} `true` if the prompt completion should be sampled, otherwise `false`.
  */
 function isPromptCompletionSampled (sampler, span) {
@@ -51,7 +51,7 @@ module.exports = function makeUtilities (integrationName, tracerConfig) {
     /**
      * Determines whether a prompt completion should be sampled based on the configured sampling rate.
      *
-     * @param {import('index').Span|import('index').SpanContext} span
+     * @param {import('../../../../..').Span|import('../../../../..').SpanContext} span
      * @returns {boolean} `true` if the prompt completion should be sampled, otherwise `false`.
      */
     isPromptCompletionSampled: (span) => isPromptCompletionSampled(sampler, span),

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -10,7 +10,6 @@
     "strictBuiltinIteratorReturn": true,
     "strictFunctionTypes": true,
 
-    "alwaysStrict": false,
     "exactOptionalPropertyTypes": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
@@ -28,7 +27,6 @@
     "moduleDetection": "force",
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
-    "baseUrl": ".",
 
     "types": ["node"],
     "typeRoots": ["./types", "./node_modules/@types"],


### PR DESCRIPTION
## Summary

`npm run type:check` has not type-checked anything since the TypeScript 6 bump: `tsc` treats `alwaysStrict=false` (TS5107) and `baseUrl` (TS5101) as errors and exits 2 before it reads a source file. Both options are removed rather than silenced with `ignoreDeprecations`:

1. `alwaysStrict: false` only relaxes strict-mode syntax diagnostics (`with` statements, duplicate parameter names). Nothing in the checked set uses that syntax, so dropping it changes no diagnostic.
2. `baseUrl` resolved exactly one specifier in the repo: `import('index')` in `packages/dd-trace/src/plugins/util/llm.js`. It now points at the package root, the form `packages/dd-trace/src/sampler.js` already uses for the same `Span|SpanContext` union. There was no `paths` mapping to rewrite.

Compared against `master` with `ignoreDeprecations: "6.0"` added, `tsc` emits a byte-identical diagnostic set, so the invocation is restored without changing what gets checked.

## Why

No CI job runs `type:check`, so the TypeScript 6 bump broke it silently. `tsc` runs again now, but still exits 2 on pre-existing errors, so the command is usable locally and in editors while remaining unfit as a CI gate until those are addressed.

Pre-existing errors, identical before and after this change (TypeScript 6.0.3, checkout with `vendor/dist` built): 7276 across 1075 files.

- `packages/**` non-test sources: 2718 errors in 482 files
- tests, `integration-tests/`, `ci/`: 3582 errors in 573 files
- `vendor/dist/**` bundles reached through the require graph: 976 errors in 20 files

Leading diagnostics: TS2339 (2096), TS2345 (1304), TS2322 (791), TS18046 (733), TS18048 (347), TS2554 (279), TS2307 (186). Without `vendor/dist` present the same run reports 6338, so the total moves with how the checkout is provisioned.

Excluding the generated `vendor/dist` bundles from the program, and wiring `type:check` into CI, both warrant their own changes.