### PR TITLE
test(test-optimization): pin compatible dependency axes

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -299,6 +299,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/plugins/test
 
+  dependency-helpers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/node
+      - uses: ./.github/actions/install
+      - run: npm run test:integration:test-optimization:helpers
+
   integration-cucumber:
     strategy:
       fail-fast: false

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -56,7 +56,11 @@ jobs:
       - name: Get Playwright version from versions package.json
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(node -p "require('./packages/dd-trace/test/plugins/versions/package.json').dependencies['@playwright/test']")
+          PLAYWRIGHT_VERSION=$(node -p \
+            "const versions = require('./integration-tests/playwright/versions'); \
+            versions.getLatestPlaywrightSpecifier() === 'latest' \
+              ? versions.latest \
+              : versions.latestSupportedByNode18")
           echo "version=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
           echo "Playwright version: $PLAYWRIGHT_VERSION"
       - name: Cache Playwright browsers
@@ -73,14 +77,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        playwright-version: [oldest, latest]
+        playwright-version: [oldest, latest, latest-node18]
     name: Ensure Playwright Docker image (${{ matrix.playwright-version }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
-      # Both matrix jobs set this to the same value, so the last-writer-wins
+      # All matrix jobs set this to the same value, so the last-writer-wins
       # behaviour of matrix outputs is safe here.
       images: ${{ steps.versions.outputs.images }}
     steps:
@@ -89,14 +93,30 @@ jobs:
         id: versions
         run: |
           LATEST=$(node -p "require('./integration-tests/playwright/versions').latest")
+          LATEST_NODE18=$(node -p "require('./integration-tests/playwright/versions').latestSupportedByNode18")
           OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
           DOCKER_HASH=$(sha256sum .github/playwright/Dockerfile | cut -c1-8)
           LATEST_TAG="${LATEST}-${DOCKER_HASH}"
+          LATEST_NODE18_TAG="${LATEST_NODE18}-${DOCKER_HASH}"
           OLDEST_TAG="${OLDEST}-${DOCKER_HASH}"
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
-          IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST_TAG" "$BASE" "$OLDEST_TAG")
-          PW_VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST" || echo "$OLDEST")
-          IMAGE_TAG=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST_TAG" || echo "$OLDEST_TAG")
+          IMAGES=$(printf \
+            '{"latest-latest":"%s:%s","latest-oldest":"%s:%s","oldest-latest":"%s:%s","oldest-oldest":"%s:%s"}' \
+            "$BASE" "$LATEST_TAG" "$BASE" "$LATEST_NODE18_TAG" "$BASE" "$OLDEST_TAG" "$BASE" "$OLDEST_TAG")
+          case "${{ matrix.playwright-version }}" in
+            latest)
+              PW_VERSION="$LATEST"
+              IMAGE_TAG="$LATEST_TAG"
+              ;;
+            latest-node18)
+              PW_VERSION="$LATEST_NODE18"
+              IMAGE_TAG="$LATEST_NODE18_TAG"
+              ;;
+            *)
+              PW_VERSION="$OLDEST"
+              IMAGE_TAG="$OLDEST_TAG"
+              ;;
+          esac
           echo "images=$IMAGES" >> $GITHUB_OUTPUT
           echo "pw-version=$PW_VERSION" >> $GITHUB_OUTPUT
           echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
@@ -140,7 +160,9 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ${{ fromJson(needs.playwright-image.outputs.images)[matrix.playwright-version] }}
+      image: >-
+        ${{ fromJson(needs.playwright-image.outputs.images)
+          [format('{0}-{1}', matrix.playwright-version, matrix.node-version)] }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -101,8 +101,8 @@ jobs:
           OLDEST_TAG="${OLDEST}-${DOCKER_HASH}"
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
           IMAGES=$(printf \
-            '{"latest-latest":"%s:%s","latest-oldest":"%s:%s","oldest-latest":"%s:%s","oldest-oldest":"%s:%s"}' \
-            "$BASE" "$LATEST_TAG" "$BASE" "$LATEST_NODE18_TAG" "$BASE" "$OLDEST_TAG" "$BASE" "$OLDEST_TAG")
+            '{"latest":{"latest":"%s:%s","oldest":"%s:%s"},"oldest":{"latest":"%s:%s","oldest":"%s:%s"}}' \
+            "$BASE" "$LATEST_TAG" "$BASE" "$OLDEST_TAG" "$BASE" "$LATEST_NODE18_TAG" "$BASE" "$OLDEST_TAG")
           case "${{ matrix.playwright-version }}" in
             latest)
               PW_VERSION="$LATEST"
@@ -160,9 +160,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: >-
-        ${{ fromJson(needs.playwright-image.outputs.images)
-          [format('{0}-{1}', matrix.playwright-version, matrix.node-version)] }}
+      image: ${{ fromJson(needs.playwright-image.outputs.images)[matrix.node-version][matrix.playwright-version] }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -14,11 +14,11 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { NODE_MAJOR } = require('../../version')
+const { getLatestPlaywrightSpecifier } = require('../playwright/versions')
 const webAppServer = require('./web-app-server')
 
 const isLatestCucumberSupported = NODE_MAJOR === 22 || NODE_MAJOR === 24 || NODE_MAJOR >= 26
-// Playwright 1.62 drops Node 18 support.
-const playwrightDependency = NODE_MAJOR < 20 ? '@playwright/test@1.61.0' : '@playwright/test'
+const playwrightDependency = `@playwright/test@${getLatestPlaywrightSpecifier()}`
 
 describe('test optimization automatic log submission', () => {
   let cwd, receiver, childProcess, webAppPort

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -17,6 +17,8 @@ const { NODE_MAJOR } = require('../../version')
 const webAppServer = require('./web-app-server')
 
 const isLatestCucumberSupported = NODE_MAJOR === 22 || NODE_MAJOR === 24 || NODE_MAJOR >= 26
+// Playwright 1.62 drops Node 18 support.
+const playwrightDependency = NODE_MAJOR < 20 ? '@playwright/test@1.61.0' : '@playwright/test'
 
 describe('test optimization automatic log submission', () => {
   let cwd, receiver, childProcess, webAppPort
@@ -27,7 +29,7 @@ describe('test optimization automatic log submission', () => {
     ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
     'jest',
     'winston',
-    '@playwright/test',
+    playwrightDependency,
   ], true)
 
   before(async () => {

--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -31,6 +31,7 @@ const {
   TEST_HAS_DYNAMIC_NAME,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -97,9 +98,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       this.timeout(180_000)

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -28,6 +28,7 @@ const {
   TEST_FINAL_STATUS,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -95,9 +96,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       this.timeout(180_000)

--- a/integration-tests/cypress/cypress-final-status-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-final-status-impacted-tests.spec.js
@@ -43,6 +43,7 @@ const {
   TEST_IS_MODIFIED,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -110,9 +111,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       this.timeout(180_000)

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -28,6 +28,7 @@ const {
   TEST_ITR_FORCED_RUN,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -111,9 +112,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       this.timeout(180_000)

--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -45,6 +45,7 @@ const {
   resolveOriginalSourceFile,
   resolveSourceLineForTest,
 } = require('../../packages/datadog-plugin-cypress/src/source-map-utils')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -165,9 +166,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    const sandboxDependencies = [`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript']
+    const sandboxDependencies = getCypressDependencies(version)
     if (type === 'commonJS' && version === 'latest') {
       // These dependencies are only needed by the component/Vite regression test below.
       sandboxDependencies.push(

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -34,6 +34,7 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE, ERROR_TYPE, COMPONENT } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -102,9 +103,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       this.timeout(180_000)

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -33,6 +33,7 @@ const {
   TEST_RETRY_REASON_TYPES,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -100,9 +101,7 @@ moduleTypes.forEach(({
     this.timeout(80_000)
     let cwd, receiver, childProcess, webAppBaseUrl, webAppServer, secondWebAppBaseUrl, secondWebAppServer
 
-    // cypress-fail-fast is required as an incompatible plugin.
-    // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       this.timeout(180_000)

--- a/integration-tests/cypress/cypress-tia-code-coverage.spec.js
+++ b/integration-tests/cypress/cypress-tia-code-coverage.spec.js
@@ -24,6 +24,7 @@ const {
   getLineCoverageBitmap,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getCypressDependencies } = require('./dependencies')
 
 const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
@@ -122,7 +123,7 @@ moduleTypes.forEach(({
 
     let cwd, childProcess, webAppBaseUrl, webAppServer
 
-    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+    useSandbox(getCypressDependencies(version), true)
 
     before(async function () {
       cwd = sandboxCwd()

--- a/integration-tests/cypress/dependencies.js
+++ b/integration-tests/cypress/dependencies.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const BABEL_7_PRESET_TYPESCRIPT_VERSION = '7.28.5'
+const TYPESCRIPT_6_VERSION = '6.0.3'
+
+/**
+ * @param {string} cypressVersion
+ * @returns {string[]}
+ */
+function getCypressDependencies (cypressVersion) {
+  const dependencies = [
+    `cypress@${cypressVersion}`,
+    'cypress-fail-fast@7.1.0',
+    `typescript@${TYPESCRIPT_6_VERSION}`,
+  ]
+
+  if (cypressVersion === 'latest') {
+    dependencies.push(`@babel/preset-typescript@${BABEL_7_PRESET_TYPESCRIPT_VERSION}`)
+  }
+
+  return dependencies
+}
+
+module.exports = { getCypressDependencies }

--- a/integration-tests/cypress/dependencies.spec.js
+++ b/integration-tests/cypress/dependencies.spec.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { getCypressDependencies } = require('./dependencies')
+
+const sharedDependencies = [
+  'cypress-fail-fast@7.1.0',
+  'typescript@6.0.3',
+]
+
+describe('getCypressDependencies', () => {
+  it('pins TypeScript 6 for Cypress versions using the bundled TypeScript loader', () => {
+    assert.deepStrictEqual(getCypressDependencies('12.0.0'), [
+      'cypress@12.0.0',
+      ...sharedDependencies,
+    ])
+  })
+
+  it('installs the Babel TypeScript preset required by latest Cypress', () => {
+    assert.deepStrictEqual(getCypressDependencies('latest'), [
+      'cypress@latest',
+      ...sharedDependencies,
+      '@babel/preset-typescript@7.28.5',
+    ])
+  })
+})

--- a/integration-tests/jest/babel-dependencies.js
+++ b/integration-tests/jest/babel-dependencies.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { satisfies } = require('semver')
+
+const { NODE_VERSION } = require('../../version')
+
+const BABEL_7_CORE_VERSION = '7.29.0'
+const BABEL_7_PRESET_TYPESCRIPT_VERSION = '7.28.5'
+const BABEL_8_NODE_RANGE = '^22.18.0 || >=24.11.0'
+
+/**
+ * @param {string} jestVersion
+ * @param {string} [nodeVersion]
+ * @returns {string[]}
+ */
+function getBabelDependencies (jestVersion, nodeVersion = NODE_VERSION) {
+  if (jestVersion === 'latest' && satisfies(nodeVersion, BABEL_8_NODE_RANGE)) {
+    return [
+      '@babel/core',
+      '@babel/preset-typescript',
+    ]
+  }
+
+  return [
+    `@babel/core@${BABEL_7_CORE_VERSION}`,
+    `@babel/preset-typescript@${BABEL_7_PRESET_TYPESCRIPT_VERSION}`,
+  ]
+}
+
+module.exports = { getBabelDependencies }

--- a/integration-tests/jest/jest.babel-dependencies.spec.js
+++ b/integration-tests/jest/jest.babel-dependencies.spec.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const { getBabelDependencies } = require('./babel-dependencies')
+
+const babel7Dependencies = [
+  '@babel/core@7.29.0',
+  '@babel/preset-typescript@7.28.5',
+]
+
+describe('getBabelDependencies', () => {
+  it('uses Babel 7 pins when Node.js does not support Babel 8', () => {
+    assert.deepStrictEqual(getBabelDependencies('latest', '18.20.8'), babel7Dependencies)
+  })
+
+  it('uses Babel 7 pins when Jest is not latest', () => {
+    assert.deepStrictEqual(getBabelDependencies('28.0.0', '22.22.3'), babel7Dependencies)
+  })
+
+  it('uses Babel 7 pins before the Node.js 24 version supported by Babel 8', () => {
+    assert.deepStrictEqual(getBabelDependencies('latest', '24.10.0'), babel7Dependencies)
+  })
+
+  it('uses the unversioned Babel entries when Node.js and Jest support Babel 8', () => {
+    assert.deepStrictEqual(getBabelDependencies('latest', '22.22.3'), [
+      '@babel/core',
+      '@babel/preset-typescript',
+    ])
+  })
+})

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -56,6 +56,7 @@ const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/
 const { ERROR_MESSAGE, ERROR_TYPE, ORIGIN_KEY, COMPONENT } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR } = require('../../version')
 const { version: ddTraceVersion } = require('../../package.json')
+const { getBabelDependencies } = require('./babel-dependencies')
 
 const testFile = 'ci-visibility/run-jest.js'
 const expectedStdout = 'Test Suites: 2 passed'
@@ -83,8 +84,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     shouldInstallJestEnvironmentJsdom ? `jest-environment-jsdom@${JEST_VERSION}` : '',
     // jest-circus is not included in older versions of jest
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
-    '@babel/core',
-    '@babel/preset-typescript',
+    ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
     'office-addin-mock',
     'winston',

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -53,6 +53,7 @@ const {
 const { TELEMETRY_COVERAGE_UPLOAD } = require('../../packages/dd-trace/src/ci-visibility/telemetry')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR } = require('../../version')
+const { getBabelDependencies } = require('./babel-dependencies')
 
 const runTestsCommand = 'node ./ci-visibility/run-jest.js'
 
@@ -75,8 +76,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     shouldInstallJestEnvironmentJsdom ? `jest-environment-jsdom@${JEST_VERSION}` : '',
     // jest-circus is not included in older versions of jest
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
-    '@babel/core',
-    '@babel/preset-typescript',
+    ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
     'office-addin-mock',
     'winston',

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -51,6 +51,7 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+const { getBabelDependencies } = require('./babel-dependencies')
 
 const testFile = 'ci-visibility/run-jest.js'
 const expectedCoverageFiles = [
@@ -98,8 +99,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     shouldInstallJestEnvironmentJsdom ? `jest-environment-jsdom@${JEST_VERSION}` : '',
     // jest-circus is not included in older versions of jest
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
-    '@babel/core',
-    '@babel/preset-typescript',
+    ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
     'office-addin-mock',
     'winston',

--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -33,8 +33,8 @@ const { PLAYWRIGHT_VERSION } = process.env
 
 const NUM_RETRIES_EFD = 3
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-atr.spec.js
+++ b/integration-tests/playwright/playwright-atr.spec.js
@@ -23,8 +23,8 @@ const {
 
 const { PLAYWRIGHT_VERSION } = process.env
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-efd.spec.js
+++ b/integration-tests/playwright/playwright-efd.spec.js
@@ -31,8 +31,8 @@ const { PLAYWRIGHT_VERSION } = process.env
 const NUM_RETRIES_EFD = 3
 const PLAYWRIGHT_EFD_GATHER_TIMEOUT = 60000
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -27,8 +27,8 @@ const { PLAYWRIGHT_VERSION } = process.env
 const NUM_RETRIES_EFD = 3
 const RETRY_FINAL_STATUS_TIMEOUT = 60000
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-impacted-tests.spec.js
+++ b/integration-tests/playwright/playwright-impacted-tests.spec.js
@@ -30,8 +30,8 @@ const { PLAYWRIGHT_VERSION } = process.env
 
 const NUM_RETRIES_EFD = 3
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 
 const DEFAULT_IMPACTED_KNOWN_TESTS = {

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -48,8 +48,8 @@ const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 const REQUEST_ERROR_TAG_TEST_DIR = './ci-visibility/playwright-tests-request-error-tag'
 const SCREENSHOT_CAPTURE_DISABLED_WARNING =

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -36,8 +36,8 @@ const { PLAYWRIGHT_VERSION } = process.env
 
 const PLAYWRIGHT_TEST_MANAGEMENT_GATHER_TIMEOUT = 60000
 
-const latest = 'latest'
-const { oldest } = require('./versions')
+const { getLatestPlaywrightSpecifier, oldest } = require('./versions')
+const latest = getLatestPlaywrightSpecifier()
 const versions = [oldest, latest]
 
 const ATF_MANAGEMENT_TESTS = {

--- a/integration-tests/playwright/versions.js
+++ b/integration-tests/playwright/versions.js
@@ -1,9 +1,23 @@
 'use strict'
 
-const { DD_MAJOR } = require('../../version')
+const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
 const latest = require('../../packages/dd-trace/test/plugins/versions/package.json')
   .dependencies['@playwright/test']
+const latestSupportedByNode18 = '1.61.0'
 
-module.exports = { oldest, latest }
+/**
+ * @param {number} [nodeMajor]
+ * @returns {string}
+ */
+function getLatestPlaywrightSpecifier (nodeMajor = NODE_MAJOR) {
+  return nodeMajor < 20 ? latestSupportedByNode18 : 'latest'
+}
+
+module.exports = {
+  getLatestPlaywrightSpecifier,
+  latest,
+  latestSupportedByNode18,
+  oldest,
+}

--- a/integration-tests/playwright/versions.spec.js
+++ b/integration-tests/playwright/versions.spec.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const {
+  getLatestPlaywrightSpecifier,
+  latestSupportedByNode18,
+} = require('./versions')
+
+describe('getLatestPlaywrightSpecifier', () => {
+  it('uses the last Playwright version supporting Node.js 18', () => {
+    assert.strictEqual(getLatestPlaywrightSpecifier(18), latestSupportedByNode18)
+  })
+
+  it('uses latest Playwright on supported Node.js versions', () => {
+    assert.strictEqual(getLatestPlaywrightSpecifier(20), 'latest')
+  })
+})

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -114,7 +114,6 @@ versions.forEach((version) => {
     let cwd, receiver, childProcess, testOutput
     const newerVitestIt = version === '1.6.0' ? it.skip : it
     const typecheckIt = version === '1.6.0' ? it.skip : it
-    const typescriptDependency = version === 'latest' ? 'typescript' : 'typescript@6.0.3'
 
     useSandbox([
       `vitest@${version}`,
@@ -122,7 +121,7 @@ versions.forEach((version) => {
       `@vitest/coverage-v8@${version}`,
       '@types/node',
       'tinypool',
-      typescriptDependency,
+      'typescript@6.0.3',
     ], true)
 
     before(function () {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -114,6 +114,7 @@ versions.forEach((version) => {
     let cwd, receiver, childProcess, testOutput
     const newerVitestIt = version === '1.6.0' ? it.skip : it
     const typecheckIt = version === '1.6.0' ? it.skip : it
+    const typescriptDependency = version === 'latest' ? 'typescript' : 'typescript@6.0.3'
 
     useSandbox([
       `vitest@${version}`,
@@ -121,7 +122,7 @@ versions.forEach((version) => {
       `@vitest/coverage-v8@${version}`,
       '@types/node',
       'tinypool',
-      'typescript',
+      typescriptDependency,
     ], true)
 
     before(function () {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "test:integration:playwright:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/playwright/${SPEC:-playwright-*}.spec.js\"",
     "test:integration:selenium": "mocha --timeout 60000 \"integration-tests/selenium/*.spec.js\"",
     "test:integration:selenium:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/selenium/*.spec.js\"",
+    "test:integration:test-optimization:helpers": "mocha \"integration-tests/cypress/*dependencies.spec.js\" \"integration-tests/jest/*dependencies.spec.js\" \"integration-tests/playwright/version*.spec.js\"",
     "test:integration:webdriverio": "mocha --timeout 60000 \"integration-tests/webdriverio/*.spec.js\"",
     "test:integration:webdriverio:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/webdriverio/*.spec.js\"",
     "test:integration:vitest": "mocha --timeout 60000 \"integration-tests/vitest/${SPEC:-vitest*}.spec.js\"",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Keeps the Test Optimization dependency matrix compatible with its supported Node.js and test-framework axes:

- uses Babel 7 for Jest or Node.js combinations that Babel 8 does not support;
- pins TypeScript 6 for Cypress and Vitest typechecking;
- installs the Babel TypeScript preset required by the latest Cypress preprocessor;
- uses Playwright 1.61 on Node.js 18 while retaining the latest Playwright on supported runtimes;
- selects a matching Playwright Docker image for each Node.js/Playwright combination; and
- runs the dependency-selection helper specs in Test Optimization CI.

### Motivation
<!-- What inspired you to submit this pull request? -->

#9514 updates several test/build dependencies to versions whose runtime requirements exceed parts of the Test
Optimization matrix. Babel was one cause, matching the unmerged fix in #9132, but it was not the only one:
Playwright 1.62 requires Node.js 20, while TypeScript 7 is incompatible with the tested Cypress loaders and Vitest
typecheck behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Stacked on #9514, so GitHub tests this PR together with that dependency bump. The remaining red checks do not
require changes in this PR:

- all four `AppSec / integration` axes also fail on #9514 because `npx tsc` fails in
  `iast-stack-traces-with-sourcemaps.spec.js` after its TypeScript 7 update;
- `Audit / dependencies` reports advisories from the dependency set inherited from #9514; this PR does not change
  the root lockfile relative to its base; and
- `All Green / all-green` only reflects those failures.

An earlier `tracing-windows` failure in the unchanged `ci-validation.spec.js` passed in the fresh run and was
classified as flaky; no change is needed for it.

Validation:

- Test Optimization GitHub Actions: 161/161 jobs passed
- Project GitHub Actions: 11/11 jobs passed
- Tracing GitHub Actions: 6/6 jobs passed
- focused Vitest latest typecheck cases on Node.js 24: 2 passing
- representative Jest, Cypress, and Playwright compatibility cases on their affected axes
- dependency-selector unit tests: 8 passing
- exercised-test verifier unit suite: 27 passing
- ESLint on all changed JavaScript files
- workflow YAML parsing and `git diff --check`
