### PR TITLE
fix(instrumentation): avoid duplicate URL ESM wrapping

### DIFF
--- a/packages/datadog-instrumentations/src/url.js
+++ b/packages/datadog-instrumentations/src/url.js
@@ -6,7 +6,12 @@ const parseFinishedChannel = channel('datadog:url:parse:finish')
 const urlGetterChannel = channel('datadog:url:getter:finish')
 const instrumentedGetters = ['host', 'origin', 'hostname']
 
+// CommonJS and ESM expose the same URL constructor through different module objects.
+const instrumentedUrlConstructors = new WeakSet()
+
 addHook({ name: 'url' }, function (url) {
+  if (instrumentedUrlConstructors.has(url.URL)) return url
+
   shimmer.wrap(url, 'parse', (parse) => {
     return function wrappedParse (input) {
       const parsedValue = parse.apply(this, arguments)
@@ -75,4 +80,8 @@ addHook({ name: 'url' }, function (url) {
       }
     })
   }
+
+  instrumentedUrlConstructors.add(url.URL)
+
+  return url
 })

--- a/packages/datadog-instrumentations/test/url.spec.js
+++ b/packages/datadog-instrumentations/test/url.spec.js
@@ -1,12 +1,54 @@
 'use strict'
 
-const assert = require('node:assert')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
+
 const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { channel } = require('../src/helpers/instrument')
 const names = ['url', 'node:url']
+
+describe('url ESM loading', () => {
+  it('does not instrument the same URL implementation twice', () => {
+    const repositoryRoot = path.resolve(__dirname, '../../..')
+    const script = [
+      "const dc = require('dc-polyfill')",
+      'let parseCount = 0',
+      'let getterCount = 0',
+      "dc.subscribe('datadog:url:parse:finish', () => parseCount++)",
+      "dc.subscribe('datadog:url:getter:finish', () => getterCount++)",
+      "require('node:url')",
+      "import('node:url').then(({ URL }) => {",
+      '  const parseCountBefore = parseCount',
+      "  const parsed = new URL('https://www.datadoghq.com/path')",
+      '  const getterCountBefore = getterCount',
+      '  parsed.host',
+      '  console.log("URL_COUNTS " + (parseCount - parseCountBefore) + " " + ' +
+        '(getterCount - getterCountBefore))',
+      '})',
+    ].join('\n')
+    const result = spawnSync(process.execPath, ['-e', script], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DD_INSTRUMENTATION_TELEMETRY_ENABLED: '0',
+        DD_REMOTE_CONFIG_ENABLED: '0',
+        DD_TRACE_AGENT_URL: 'http://127.0.0.1:9',
+        DD_TRACE_DEBUG: '1',
+        NODE_OPTIONS: `-r ${path.join(repositoryRoot, 'init.js')} ` +
+          `--loader ${path.join(repositoryRoot, 'loader-hook.mjs')}`,
+      },
+    })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.doesNotMatch(`${result.stdout}${result.stderr}`, /Error during ddtrace instrumentation/)
+    assert.match(result.stdout, /URL_COUNTS 1 1/)
+  })
+})
 
 names.forEach(name => {
   describe(name, () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Makes the built-in `url` instrumentation idempotent when CommonJS and ESM expose the same `URL` constructor through different module objects.

### Motivation
<!-- What inspired you to submit this pull request? -->

Loading `url` through CommonJS and then `node:url` through ESM re-applied the getter wrappers to the already wrapped `URL` subclass. The second wrap invoked Node's native `host` getter with the prototype as `this`, producing:

```text
Error during ddtrace instrumentation of application, aborting.
TypeError: Cannot read private member #context from an object whose class did not declare it
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- The regression test fails with the error above when the idempotency guard is removed.
- `PLUGINS=url npm run test:instrumentations`
- URL instrumentation suite on Node.js 22.23.1 and 24.14.0
- Targeted ESLint
