### PR TITLE
fix(test-optimization): hide WebdriverIO worker messages

### DIFF
--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -314,6 +314,8 @@ for (const version of versions) {
       }
 
       assert.strictEqual(exitCode, expectedExitCode, testOutput)
+      assert.doesNotMatch(testOutput, /dd:test-optimization:webdriverio:/)
+      assert.doesNotMatch(testOutput, /\bundefined undefined undefined\b/)
       assert.strictEqual(
         webDriver.getSessionCount() - initialWebDriverSessionCount,
         expectedWebDriverSessions

--- a/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
+++ b/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
@@ -1,9 +1,19 @@
 'use strict'
 
+const {
+  createWebdriverioWorkerMessage,
+  WEBDRIVERIO_WORKER_ENV,
+  WEBDRIVERIO_WORKER_EVENT,
+  WEBDRIVERIO_WORKER_ORIGIN,
+} = require('../../../dd-trace/src/ci-visibility/exporters/test-worker/webdriverio')
+
 module.exports = {
   CONFIGURATION_REQUEST: 'dd:test-optimization:webdriverio:configuration:request',
   CONFIGURATION_RESPONSE: 'dd:test-optimization:webdriverio:configuration:response',
+  createWebdriverioWorkerMessage,
   SUITE_FINISH: 'dd:test-optimization:webdriverio:test-suite:finish',
   WORKER_READY: 'dd:test-optimization:webdriverio:worker:ready',
-  WEBDRIVERIO_WORKER_ENV: '_DD_TEST_OPTIMIZATION_WEBDRIVERIO_WORKER',
+  WEBDRIVERIO_WORKER_ENV,
+  WEBDRIVERIO_WORKER_EVENT,
+  WEBDRIVERIO_WORKER_ORIGIN,
 }

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -20,6 +20,7 @@ const {
 const {
   CONFIGURATION_REQUEST,
   CONFIGURATION_RESPONSE,
+  createWebdriverioWorkerMessage,
   SUITE_FINISH,
   WEBDRIVERIO_WORKER_ENV,
   WORKER_READY,
@@ -49,7 +50,7 @@ function sendWebdriverioMessage (message, onError) {
     return
   }
 
-  process.send(message, (error) => {
+  process.send(createWebdriverioWorkerMessage(message), (error) => {
     if (!error) {
       return
     }

--- a/packages/datadog-instrumentations/src/webdriverio.js
+++ b/packages/datadog-instrumentations/src/webdriverio.js
@@ -15,6 +15,8 @@ const {
   CONFIGURATION_RESPONSE,
   SUITE_FINISH,
   WEBDRIVERIO_WORKER_ENV,
+  WEBDRIVERIO_WORKER_EVENT,
+  WEBDRIVERIO_WORKER_ORIGIN,
   WORKER_READY,
 } = require('./mocha/webdriverio-protocol')
 
@@ -447,6 +449,10 @@ function handleSuiteResults (workerRecord, message) {
  * @returns {void}
  */
 function handleWorkerMessage (state, workerRecord, message) {
+  if (message?.origin === WEBDRIVERIO_WORKER_ORIGIN && message.name === WEBDRIVERIO_WORKER_EVENT) {
+    message = message.args
+  }
+
   if (Array.isArray(message)) {
     const [messageCode, payload] = message
     if (messageCode === MOCHA_WORKER_TRACE_PAYLOAD_CODE) {
@@ -455,6 +461,10 @@ function handleWorkerMessage (state, workerRecord, message) {
         [TEST_SUITE_EXECUTION_ID]: workerRecord.testSuiteExecutionId,
       })
     }
+    return
+  }
+
+  if (!message || typeof message !== 'object') {
     return
   }
 

--- a/packages/datadog-instrumentations/test/fixtures/webdriverio-disconnected-worker.js
+++ b/packages/datadog-instrumentations/test/fixtures/webdriverio-disconnected-worker.js
@@ -9,6 +9,8 @@ const {
   CONFIGURATION_REQUEST,
   CONFIGURATION_RESPONSE,
   WEBDRIVERIO_WORKER_ENV,
+  WEBDRIVERIO_WORKER_EVENT,
+  WEBDRIVERIO_WORKER_ORIGIN,
 } = require('../../src/mocha/webdriverio-protocol')
 
 process.env[WEBDRIVERIO_WORKER_ENV] = 'true'
@@ -93,7 +95,9 @@ assert.strictEqual(sendCalls, 0)
 process.connected = true
 process.send = (message, onDone) => {
   sendCalls++
-  assert.ok(message)
+  assert.strictEqual(message.origin, WEBDRIVERIO_WORKER_ORIGIN)
+  assert.strictEqual(message.name, WEBDRIVERIO_WORKER_EVENT)
+  assert.ok(message.args)
   assert.strictEqual(typeof onDone, 'function')
   onDone(new Error('IPC channel closed during send'))
 }
@@ -103,14 +107,16 @@ assert.strictEqual(sendCalls, 3)
 
 process.send = (message, onDone) => {
   sendCalls++
-  assert.ok(message)
+  assert.strictEqual(message.origin, WEBDRIVERIO_WORKER_ORIGIN)
+  assert.strictEqual(message.name, WEBDRIVERIO_WORKER_EVENT)
+  assert.ok(message.args)
   assert.strictEqual(typeof onDone, 'function')
   onDone()
-  if (message.name === CONFIGURATION_REQUEST) {
+  if (message.args.name === CONFIGURATION_REQUEST) {
     process.emit('message', {
       name: CONFIGURATION_RESPONSE,
       content: {
-        requestId: message.content.requestId,
+        requestId: message.args.content.requestId,
       },
     })
   }

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -263,12 +263,20 @@ describe('webdriverio instrumentation', () => {
       })
 
       firstWorker.emit('message', {
-        name: WORKER_READY,
-        content: { frameworkVersion: '10.8.2' },
+        origin: 'datadog',
+        name: 'workerEvent',
+        args: {
+          name: WORKER_READY,
+          content: { frameworkVersion: '10.8.2' },
+        },
       })
       secondWorker.emit('message', {
-        name: WORKER_READY,
-        content: { frameworkVersion: '10.8.2' },
+        origin: 'datadog',
+        name: 'workerEvent',
+        args: {
+          name: WORKER_READY,
+          content: { frameworkVersion: '10.8.2' },
+        },
       })
       await new Promise(setImmediate)
 
@@ -276,8 +284,16 @@ describe('webdriverio instrumentation', () => {
       requestConfiguration(secondWorker, secondFile, 'second-request')
       await new Promise(setImmediate)
 
-      firstWorker.emit('message', [MOCHA_WORKER_TRACE_PAYLOAD_CODE, 'first-trace'])
-      secondWorker.emit('message', [MOCHA_WORKER_TRACE_PAYLOAD_CODE, 'second-trace'])
+      firstWorker.emit('message', {
+        origin: 'datadog',
+        name: 'workerEvent',
+        args: [MOCHA_WORKER_TRACE_PAYLOAD_CODE, 'first-trace'],
+      })
+      secondWorker.emit('message', {
+        origin: 'datadog',
+        name: 'workerEvent',
+        args: [MOCHA_WORKER_TRACE_PAYLOAD_CODE, 'second-trace'],
+      })
 
       assert.strictEqual(firstWorker.sentMessages[0].name, CONFIGURATION_RESPONSE)
       assert.strictEqual(firstWorker.sentMessages[0].content.requestId, 'first-request')
@@ -723,11 +739,15 @@ function finishLocalRunner (localRunner, error) {
  */
 function requestConfiguration (worker, file, requestId) {
   worker.emit('message', {
-    name: CONFIGURATION_REQUEST,
-    content: {
-      files: [file],
-      frameworkVersion: '10.8.2',
-      requestId,
+    origin: 'datadog',
+    name: 'workerEvent',
+    args: {
+      name: CONFIGURATION_REQUEST,
+      content: {
+        files: [file],
+        frameworkVersion: '10.8.2',
+        requestId,
+      },
     },
   })
 }
@@ -742,9 +762,13 @@ function requestConfiguration (worker, file, requestId) {
  */
 function reportSuiteFinish (worker, file, status = 'pass') {
   worker.emit('message', {
-    name: SUITE_FINISH,
-    content: {
-      results: [{ file, status }],
+    origin: 'datadog',
+    name: 'workerEvent',
+    args: {
+      name: SUITE_FINISH,
+      content: {
+        results: [{ file, status }],
+      },
     },
   })
 }

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/webdriverio.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/webdriverio.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const WEBDRIVERIO_WORKER_ENV = '_DD_TEST_OPTIMIZATION_WEBDRIVERIO_WORKER'
+const WEBDRIVERIO_WORKER_EVENT = 'workerEvent'
+const WEBDRIVERIO_WORKER_ORIGIN = 'datadog'
+
+/**
+ * Wraps an internal worker payload in the event WebdriverIO reserves for worker messages.
+ *
+ * @param {unknown} args
+ * @returns {{args: unknown, name: string, origin: string}}
+ */
+function createWebdriverioWorkerMessage (args) {
+  return {
+    origin: WEBDRIVERIO_WORKER_ORIGIN,
+    name: WEBDRIVERIO_WORKER_EVENT,
+    args,
+  }
+}
+
+module.exports = {
+  createWebdriverioWorkerMessage,
+  WEBDRIVERIO_WORKER_ENV,
+  WEBDRIVERIO_WORKER_EVENT,
+  WEBDRIVERIO_WORKER_ORIGIN,
+}

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
@@ -2,6 +2,10 @@
 const { JSONEncoder } = require('../../encode/json-encoder')
 const { getEnvironmentVariable } = require('../../../config/helper')
 const log = require('../../../log')
+const {
+  createWebdriverioWorkerMessage,
+  WEBDRIVERIO_WORKER_ENV,
+} = require('./webdriverio')
 
 function getVitestWorkerPort () {
   const port = globalThis.__vitest_worker__?.ctx?.port
@@ -13,6 +17,7 @@ class Writer {
     this._encoder = new JSONEncoder()
     // Code used to identify the type of payload being sent to the main process
     this._interprocessCode = interprocessCode
+    this._isWebdriverioWorker = !!getEnvironmentVariable(WEBDRIVERIO_WORKER_ENV)
   }
 
   /**
@@ -43,9 +48,12 @@ class Writer {
     // Old because vitest@>=4 uses `DD_VITEST_WORKER` and reports arrays just like other frameworks
     // Before vitest@>=4, we need the `__tinypool_worker_message__` property, or tinypool will crash
     const isVitestWorkerOld = !!getEnvironmentVariable('TINYPOOL_WORKER_ID')
-    const payload = isVitestWorkerOld
+    let payload = isVitestWorkerOld
       ? { __tinypool_worker_message__: true, interprocessCode: this._interprocessCode, data }
       : [this._interprocessCode, data]
+    if (this._isWebdriverioWorker) {
+      payload = createWebdriverioWorkerMessage(payload)
+    }
 
     const vitestWorkerPort = getVitestWorkerPort()
     if (vitestWorkerPort) {

--- a/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
@@ -190,6 +190,27 @@ describe('CI Visibility Test Worker Exporter', () => {
     })
   })
 
+  context('when writing from a WebdriverIO worker', () => {
+    it('wraps traces in a filtered WebdriverIO worker event', () => {
+      const trace = [{ type: 'test' }]
+      const WebdriverioWriter = proxyquire('../../../../src/ci-visibility/exporters/test-worker/writer', {
+        '../../../config/helper': {
+          getEnvironmentVariable: name =>
+            name === '_DD_TEST_OPTIMIZATION_WEBDRIVERIO_WORKER' ? 'true' : undefined,
+        },
+      })
+      const writer = new WebdriverioWriter(MOCHA_WORKER_TRACE_PAYLOAD_CODE)
+      writer.append(trace)
+      writer.flush()
+
+      sinon.assert.calledWith(send, {
+        origin: 'datadog',
+        name: 'workerEvent',
+        args: [MOCHA_WORKER_TRACE_PAYLOAD_CODE, JSON.stringify([trace])],
+      })
+    })
+  })
+
   context('when the process is a playwright worker', () => {
     beforeEach(() => {
       process.env.DD_PLAYWRIGHT_WORKER = '1'


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Wraps Datadog worker-to-launcher IPC in WebdriverIO's filtered `workerEvent` envelope. The coordinator unwraps the envelope before processing the existing internal protocol.

### Motivation
<!-- What inspired you to submit this pull request? -->

WebdriverIO logs unrecognized worker messages. Datadog's custom messages and raw Mocha trace payloads therefore appeared in normal test output, including `undefined undefined undefined` lines.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verified with:

- Test-worker exporter and WebdriverIO instrumentation unit suites
- The parallel-worker integration scenario on WebdriverIO 9.0.0 and latest
- Targeted ESLint

