### PR TITLE
test(appsec): fix express ssrf flaky test

### DIFF
--- a/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
@@ -81,12 +81,13 @@ describe('RASP - ssrf', () => {
             const module = require(protocol)
 
             app = (req, res) => {
-              const clientRequest = module.get(`${protocol}://${req.query.host}`, function (incomingResponse) {
-                incomingResponse.resume()
+              const clientRequest = module.get(`${protocol}://${req.query.host}`)
+
+              clientRequest.on('error', noop)
+              setImmediate(() => {
+                clientRequest.destroy()
                 res.end('end')
               })
-
-              clientRequest.on('error', () => res.end('end'))
             }
 
             await Promise.all([
@@ -148,9 +149,14 @@ describe('RASP - ssrf', () => {
 
           it('Should not detect threat', async () => {
             app = (req, res) => {
-              axiosToTest.get(`https://${req.query.host}`, { proxy: false })
+              const abortController = new AbortController()
+              axiosToTest.get(`https://${req.query.host}`, { proxy: false, signal: abortController.signal })
                 .catch(noop) // swallow network error
-                .then(() => res.end('end'))
+
+              setImmediate(() => {
+                abortController.abort()
+                res.end('end')
+              })
             }
 
             await Promise.all([
@@ -202,9 +208,13 @@ describe('RASP - ssrf', () => {
 
           it('Should not detect threat', async () => {
             app = (req, res) => {
-              requestToTest.get(`https://${req.query.host}`, { proxy: false })
-                .on('response', () => res.end('end'))
-                .on('error', () => res.end('end'))
+              const clientRequest = requestToTest.get(`https://${req.query.host}`, { proxy: false })
+              clientRequest.on('error', noop)
+
+              setImmediate(() => {
+                clientRequest.abort()
+                res.end('end')
+              })
             }
 
             await Promise.all([

--- a/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
@@ -15,7 +15,7 @@ const { checkRaspExecutedAndNotThreat, checkRaspExecutedAndHasThreat } = require
 
 function noop () {}
 
-const UNRESOLVABLE_HOST = 'not-a-threat.invalid'
+const NON_ROUTABLE_HOST = '192.0.2.1'
 
 describe('RASP - ssrf', () => {
   withVersions('express', 'express', expressVersion => {
@@ -92,7 +92,7 @@ describe('RASP - ssrf', () => {
 
             await Promise.all([
               checkRaspExecutedAndNotThreat(agent),
-              axios.get(`/?host=${UNRESOLVABLE_HOST}`),
+              axios.get(`/?host=${NON_ROUTABLE_HOST}`),
             ])
           })
 
@@ -160,7 +160,7 @@ describe('RASP - ssrf', () => {
             }
 
             await Promise.all([
-              axios.get(`/?host=${UNRESOLVABLE_HOST}`),
+              axios.get(`/?host=${NON_ROUTABLE_HOST}`),
               checkRaspExecutedAndNotThreat(agent),
             ])
           })
@@ -218,7 +218,7 @@ describe('RASP - ssrf', () => {
             }
 
             await Promise.all([
-              axios.get(`/?host=${UNRESOLVABLE_HOST}`),
+              axios.get(`/?host=${NON_ROUTABLE_HOST}`),
               checkRaspExecutedAndNotThreat(agent),
             ])
           })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
### What does this PR do?
Makes the RASP SSRF “Should not detect threat” tests independent of external DNS resolution.

### Motivation

The tests used `not-a-threat.invalid` and waited for its DNS lookup to fail before ending the Express response.
Cancelling the outbound request after its instrumentation has run removes DNS timing from the test while preserving the behavior under test.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


