### PR TITLE
fix(test-optimization): wait for WebDriverIO worker payloads

### DIFF
--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -42,20 +42,22 @@ let configurationRequestId = 0
  *
  * @param {object} message
  * @param {() => void} [onError]
+ * @param {() => void} [onDone]
  * @returns {void}
  */
-function sendWebdriverioMessage (message, onError) {
+function sendWebdriverioMessage (message, onError, onDone) {
   if (!process.send || !process.connected) {
     onError?.()
+    onDone?.()
     return
   }
 
   process.send(createWebdriverioWorkerMessage(message), (error) => {
-    if (!error) {
-      return
+    if (error) {
+      log.error('WebdriverIO Test Optimization IPC error', error)
+      onError?.()
     }
-    log.error('WebdriverIO Test Optimization IPC error', error)
-    onError?.()
+    onDone?.()
   })
 }
 
@@ -266,10 +268,12 @@ function getWebdriverioSuiteResults (runner) {
  * Sends suite results to the WebdriverIO launcher.
  *
  * @param {object} runner
+ * @param {() => void} [onDone]
  * @returns {void}
  */
-function reportWebdriverioSuiteResults (runner) {
+function reportWebdriverioSuiteResults (runner, onDone) {
   if (!isWebdriverioWorker) {
+    onDone?.()
     return
   }
 
@@ -279,7 +283,32 @@ function reportWebdriverioSuiteResults (runner) {
     content: {
       results: getWebdriverioSuiteResults(runner),
     },
-  })
+  }, undefined, onDone)
+}
+
+/**
+ * Flushes worker payloads before reporting suite results and completing Mocha.
+ *
+ * @param {object} runner
+ * @param {() => void} onDone
+ * @returns {void}
+ */
+function finishWebdriverioWorker (runner, onDone) {
+  try {
+    workerFinishCh.publish({
+      onDone: () => {
+        try {
+          reportWebdriverioSuiteResults(runner, onDone)
+        } catch (error) {
+          log.error('WebdriverIO Test Optimization worker completion error', error)
+          onDone()
+        }
+      },
+    })
+  } catch (error) {
+    log.error('WebdriverIO Test Optimization worker completion error', error)
+    onDone()
+  }
 }
 
 function isFailedTestReplayEnabled () {
@@ -376,11 +405,22 @@ addHook({
     if (isFailedTestReplayEnabled()) {
       patchFailedTestReplayHookUp(Runner)
     }
-    // Flush after the worker finishes its Mocha run, including grouped spec files.
-    this.once('end', () => {
-      workerFinishCh.publish()
-      reportWebdriverioSuiteResults(this)
-    })
+    const onRunDone = args[0]
+    if (isWebdriverioWorker && typeof onRunDone === 'function') {
+      args[0] = (...onRunDoneArgs) => {
+        finishWebdriverioWorker(this, () => onRunDone(...onRunDoneArgs))
+      }
+    } else {
+      // Flush after the worker finishes its Mocha run, including grouped spec files.
+      this.once('end', () => {
+        try {
+          workerFinishCh.publish()
+          reportWebdriverioSuiteResults(this)
+        } catch (error) {
+          log.error('WebdriverIO Test Optimization worker completion error', error)
+        }
+      })
+    }
     this.on('test', getOnTestHandler(false))
 
     this.on('test end', getOnTestEndHandler(config))

--- a/packages/datadog-instrumentations/test/fixtures/webdriverio-delayed-worker.js
+++ b/packages/datadog-instrumentations/test/fixtures/webdriverio-delayed-worker.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+
+const { channel } = require('../../src/helpers/instrument')
+const instrumentations = require('../../src/helpers/instrumentations')
+const {
+  SUITE_FINISH,
+  WEBDRIVERIO_WORKER_ENV,
+  WEBDRIVERIO_WORKER_EVENT,
+  WEBDRIVERIO_WORKER_ORIGIN,
+} = require('../../src/mocha/webdriverio-protocol')
+
+process.env[WEBDRIVERIO_WORKER_ENV] = 'true'
+const existingMochaHookCount = instrumentations.mocha?.length || 0
+require('../../src/mocha/worker')
+
+const runnerHook = instrumentations.mocha
+  .slice(existingMochaHookCount)
+  .find(({ file }) => file === 'lib/runner.js')
+
+assert.ok(runnerHook)
+
+const workerFinishCh = channel('ci:mocha:worker:finish')
+let flushDone
+
+function onWorkerFinish ({ onDone }) {
+  flushDone = onDone
+}
+
+workerFinishCh.subscribe(onWorkerFinish)
+
+class FakeRunner extends EventEmitter {
+  constructor () {
+    super()
+    this.failures = 0
+    this.suite = {
+      eachTest () {},
+    }
+  }
+
+  runTests () {}
+
+  run (onDone) {
+    this.emit('end')
+    onDone()
+  }
+}
+
+runnerHook.hook(FakeRunner)
+
+let runDone = false
+let suiteMessageDone
+process.connected = true
+process.send = (message, onDone) => {
+  assert.strictEqual(message.origin, WEBDRIVERIO_WORKER_ORIGIN)
+  assert.strictEqual(message.name, WEBDRIVERIO_WORKER_EVENT)
+  assert.strictEqual(message.args.name, SUITE_FINISH)
+  suiteMessageDone = onDone
+}
+
+new FakeRunner().run(() => {
+  runDone = true
+})
+
+assert.strictEqual(runDone, false)
+assert.strictEqual(typeof flushDone, 'function')
+assert.strictEqual(suiteMessageDone, undefined)
+
+flushDone()
+assert.strictEqual(runDone, false)
+assert.strictEqual(typeof suiteMessageDone, 'function')
+
+suiteMessageDone()
+assert.strictEqual(runDone, true)
+
+runDone = false
+flushDone = undefined
+suiteMessageDone = undefined
+process.connected = false
+
+new FakeRunner().run(() => {
+  runDone = true
+})
+
+assert.strictEqual(runDone, false)
+assert.strictEqual(typeof flushDone, 'function')
+
+flushDone()
+assert.strictEqual(runDone, true)
+assert.strictEqual(suiteMessageDone, undefined)
+
+workerFinishCh.unsubscribe(onWorkerFinish)

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -24,6 +24,7 @@ const {
 } = require('../src/mocha/webdriverio-protocol')
 
 const fixturePath = path.join(__dirname, 'fixtures', 'webdriverio-local-runner.mjs')
+const delayedWorkerFixturePath = path.join(__dirname, 'fixtures', 'webdriverio-delayed-worker.js')
 const disconnectedWorkerFixturePath = path.join(__dirname, 'fixtures', 'webdriverio-disconnected-worker.js')
 const regularMochaWorkerFixturePath = path.join(__dirname, 'fixtures', 'mocha-regular-worker.js')
 const fixtureModulePath = path.join(
@@ -148,6 +149,10 @@ describe('webdriverio instrumentation', () => {
 
   it('does not send Mocha worker messages over disconnected IPC', async () => {
     await execFileAsync(process.execPath, [disconnectedWorkerFixturePath])
+  })
+
+  it('waits for worker payloads before completing Mocha', async () => {
+    await execFileAsync(process.execPath, [delayedWorkerFixturePath])
   })
 
   it('does not track WebdriverIO hook failures in regular Mocha workers', async () => {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -216,8 +216,8 @@ class MochaPlugin extends CiPlugin {
       return ctx.currentStore
     })
 
-    this.addSub('ci:mocha:worker:finish', () => {
-      this.tracer._exporter.flush()
+    this.addSub('ci:mocha:worker:finish', ({ onDone } = {}) => {
+      this.tracer._exporter.flush(onDone)
     })
 
     this.addSub('ci:mocha:test:finish', ({


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Keeps a WebDriverIO Mocha worker alive until its Test Optimization payloads are flushed and its suite-result IPC message is acknowledged. Adds a regression fixture that delays both completion callbacks and covers disconnected IPC.

### Motivation
<!-- What inspired you to submit this pull request? -->

A basic-reporting e2e run completed one WebDriverIO spec successfully but dropped all 133 test events from that worker. Mocha's completion callback previously ran immediately after the `end` event while the exporter used asynchronous `process.send()`, allowing worker teardown to race trace delivery.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This fix is independent of the WebDriverIO optimizations in #9556 and applies to basic reporting already present on `master`.

Validation:

- 13 WebDriverIO instrumentation tests
- 17 test-worker exporter tests
- 14 WebDriverIO latest basic-reporting integration tests
- 14 WebDriverIO 9.0.0 basic-reporting integration tests
- targeted ESLint
