### PR TITLE
chore(eslint): enable JSDoc parameter and type checks

### DIFF
--- a/ci/diagnose.js
+++ b/ci/diagnose.js
@@ -224,7 +224,7 @@ const UNSUPPORTED_FRAMEWORKS = [
  *
  * @param {object} [options] diagnosis options
  * @param {string} [options.root] repository path to inspect
- * @param {NodeJS.ProcessEnv} [options.env] environment to inspect
+ * @param {typeof process.env} [options.env] environment to inspect
  * @param {Function} [options.execFile] command runner used for git checks
  * @param {string} [options.gitExecutable] trusted git executable used for git checks
  * @param {number} [options.maxFiles] maximum number of text files to scan
@@ -542,7 +542,7 @@ function checkUnsupportedFrameworks (results, unsupported, supported) {
  * @param {Array<object>} results mutable result list
  * @param {Array<object>} frameworks detected supported frameworks
  * @param {object} evidence repository evidence
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  */
 function checkInitialization (results, frameworks, evidence, env) {
   if (!frameworks.length) return
@@ -770,7 +770,7 @@ function checkCypressConfiguration (results, evidence) {
  * @param {Array<object>} results mutable result list
  * @param {Array<object>} workflowFiles scanned CI workflow files
  * @param {object} evidence repository evidence
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  */
 function checkCiConfiguration (results, workflowFiles, evidence, env) {
   if (!workflowFiles.length) {
@@ -876,7 +876,7 @@ function checkCiConfiguration (results, workflowFiles, evidence, env) {
  *
  * @param {Array<object>} results mutable result list
  * @param {string} root repository root
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  * @param {Function} execFile command runner
  * @param {string|undefined} gitExecutable trusted git executable
  */
@@ -959,7 +959,7 @@ function checkGit (results, root, env, execFile, gitExecutable) {
  * Checks current environment variables relevant to Test Optimization.
  *
  * @param {Array<object>} results mutable result list
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  * @param {object} evidence repository evidence
  */
 function checkCurrentEnvironment (results, env, evidence) {
@@ -1039,7 +1039,7 @@ function checkCurrentEnvironment (results, env, evidence) {
  * Checks current CI provider metadata.
  *
  * @param {Array<object>} results mutable result list
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  */
 function checkCurrentCiMetadata (results, env) {
   const providerDetected = CURRENT_ENV_PROVIDER_KEYS.some(key => env[key])
@@ -1372,7 +1372,7 @@ function detectUnsupportedFrameworks (definitions, manifests, scripts) {
  * Collects useful boolean evidence from scanned files and environment.
  *
  * @param {Array<object>} textFiles scanned text files
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  * @returns {object} evidence object
  */
 function collectEvidence (textFiles, env) {
@@ -1888,7 +1888,7 @@ function isTestSetupOrCiFile (file) {
  * @param {Function} execFile command runner
  * @param {string} root repository root
  * @param {string|undefined} gitExecutable trusted git executable
- * @param {NodeJS.ProcessEnv} env credential-free git environment
+ * @param {typeof process.env} env credential-free git environment
  * @returns {boolean} true if git runs
  */
 function canRunGit (execFile, root, gitExecutable, env) {
@@ -1908,7 +1908,7 @@ function canRunGit (execFile, root, gitExecutable, env) {
  * @param {Function} execFile command runner
  * @param {string} root repository root
  * @param {string} gitExecutable trusted git executable
- * @param {NodeJS.ProcessEnv} env credential-free git environment
+ * @param {typeof process.env} env credential-free git environment
  * @param {string[]} args git arguments
  * @returns {string} command output
  */
@@ -1952,8 +1952,8 @@ function findTrustedGitExecutable () {
  * Creates the minimal environment needed by read-only local git metadata commands.
  *
  * @param {string|undefined} gitExecutable trusted git executable
- * @param {NodeJS.ProcessEnv} sourceEnv source environment
- * @returns {NodeJS.ProcessEnv} credential-free git environment
+ * @param {typeof process.env} sourceEnv source environment
+ * @returns {typeof process.env} credential-free git environment
  */
 function getGitEnvironment (gitExecutable, sourceEnv) {
   const env = {
@@ -2065,7 +2065,7 @@ function hasRegisterInNodeOptions (nodeOptions) {
 /**
  * Checks whether environment contains branch or tag metadata.
  *
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  * @returns {boolean} true if branch metadata exists
  */
 function hasBranchMetadata (env) {
@@ -2089,7 +2089,7 @@ function hasBranchMetadata (env) {
 /**
  * Checks whether environment contains commit SHA metadata.
  *
- * @param {NodeJS.ProcessEnv} env environment
+ * @param {typeof process.env} env environment
  * @returns {boolean} true if SHA metadata exists
  */
 function hasShaMetadata (env) {

--- a/ci/test-optimization-validation/cli.js
+++ b/ci/test-optimization-validation/cli.js
@@ -898,6 +898,7 @@ function getStaticFailure (framework, blocker, reportPath) {
  * @param {object} framework framework entry
  * @param {string} diagnosis blocker diagnosis
  * @param {string} reasonCode blocker id
+ * @param {string | undefined} blockerCategory blocker category
  * @returns {object} result
  */
 function getBasicNotReached (framework, diagnosis, reasonCode, blockerCategory) {

--- a/ci/test-optimization-validation/command-runner.js
+++ b/ci/test-optimization-validation/command-runner.js
@@ -522,7 +522,7 @@ function buildOfflineCaptureEnv ({ fixture, outputRoot }) {
  * @param {object} input offline validation inputs
  * @param {{manifestPath: string}} input.fixture authoritative cache fixture
  * @param {string} input.outputRoot pre-created payload output root
- * @returns {NodeJS.ProcessEnv} validation transport environment
+ * @returns {typeof process.env} validation transport environment
  */
 function buildOfflineValidationEnv ({ fixture, outputRoot }) {
   return {
@@ -551,7 +551,7 @@ function buildOfflineValidationEnv ({ fixture, outputRoot }) {
  * Rejects command-local assignments that can bypass validator-controlled offline routing.
  *
  * @param {object} command command to execute
- * @param {NodeJS.ProcessEnv} env validator environment overrides
+ * @param {typeof process.env} env validator environment overrides
  */
 function assertNoInlineValidationEnvOverrides (command, env) {
   if (!env[VALIDATION_MODE_ENV]) return

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -152,6 +152,7 @@ function getGeneratedStepsPath (testDirectory) {
  * Returns Cucumber arguments that select one existing feature.
  *
  * @param {string} filename selected Cucumber feature
+ * @param {string} cwd project working directory
  * @returns {string[]} focused Cucumber arguments
  */
 function getFocusedTestArgs (filename, cwd) {
@@ -163,6 +164,7 @@ function getFocusedTestArgs (filename, cwd) {
  *
  * @param {string} filename generated Cucumber feature
  * @param {string} stepsFile generated Cucumber step definitions
+ * @param {string} cwd project working directory
  * @returns {string[]} generated scenario arguments
  */
 function getGeneratedTestArgs (filename, stepsFile, cwd) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -293,11 +293,11 @@ export default [
       'jsdoc/no-blank-blocks': 'error',
       // TODO: Enable the rules that we want to use.
       'jsdoc/no-defaults': 'error',
-      'jsdoc/no-undefined-types': 'off',
+      'jsdoc/no-undefined-types': 'error',
       'jsdoc/reject-function-type': 'off',
       'jsdoc/require-jsdoc': 'off',
       'jsdoc/require-param-description': 'off', // Having a description is not crucial for now.
-      'jsdoc/require-param': 'off',
+      'jsdoc/require-param': 'error',
       'jsdoc/require-property-description': 'off',
       'jsdoc/require-returns-check': 'error',
       'jsdoc/require-returns-description': 'off',

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -462,7 +462,7 @@ class FakeCiVisIntake extends FakeAgent {
   // drain. `hardTimeout` is a backstop for a genuinely hung child — bump it per-call
   // only when a workload's child runtime is provably above the default.
   /**
-   * @param {import('child_process').ChildProcess | NodeJS.EventEmitter} childProcess
+   * @param {import('child_process').ChildProcess | import('node:events').EventEmitter} childProcess
    *   Source of the `'exit'` event. `exitCode` / `signalCode` are read synchronously
    *   so a child that has already exited is handled correctly.
    * @param {(message: object) => boolean} [payloadMatch] Per-message filter; falsy

--- a/integration-tests/coverage-child-process.spec.js
+++ b/integration-tests/coverage-child-process.spec.js
@@ -393,7 +393,7 @@ w.once('exit', code => process.exit(code))
       `  v8Dir: process.env.${V8_COVERAGE_ENV} || '',\n` +
       '}))\n')
 
-    /** @type {NodeJS.ProcessEnv} */
+    /** @type {typeof process.env} */
     const env = { ...process.env, [DISABLE_ENV]: '1' }
 
     await new Promise(/** @type {(resolve: (value?: void) => void, reject: (reason?: Error) => void) => void} */

--- a/integration-tests/coverage/runtime.js
+++ b/integration-tests/coverage/runtime.js
@@ -41,7 +41,7 @@ function canonicalizePath (value) {
 }
 
 /**
- * @param {NodeJS.ProcessEnv} [env]
+ * @param {typeof process.env} [env]
  * @returns {boolean}
  */
 function isCoverageActive (env = process.env) {
@@ -65,7 +65,7 @@ function labelSuffix () {
 }
 
 /**
- * @param {NodeJS.ProcessEnv} [env]
+ * @param {typeof process.env} [env]
  * @returns {string}
  */
 function getCollectorRoot (env = process.env) {
@@ -242,11 +242,11 @@ function prependBootstrapRequire (nodeOptions) {
  * copies the parent's value to a child even when a custom env omits it, so omitting is not enough),
  * while a foreign directory the child set itself is preserved.
  *
- * @param {NodeJS.ProcessEnv | undefined} env
+ * @param {typeof process.env | undefined} env
  * @param {object} [options]
  * @param {string} [options.cwd]
  * @param {string | URL} [options.scriptPath]
- * @returns {NodeJS.ProcessEnv | undefined}
+ * @returns {typeof process.env | undefined}
  */
 function applyCoverageEnv (env, options = {}) {
   if (!isCoverageActive()) return env

--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -1586,7 +1586,7 @@ if (requestedVersion === 'latest' &&
      * @param {string} code filesystem error code
      * @param {string} filePath affected path
      * @param {string} [syscall] failed system call
-     * @returns {NodeJS.ErrnoException} filesystem error
+     * @returns {Error & { code: string, path: string, syscall: string }} filesystem error
      */
     function createFileError (code, filePath, syscall = 'open') {
       return Object.assign(new Error(`${code}: ${syscall} ${filePath}`), {

--- a/integration-tests/debugger/target-app/time-budget.js
+++ b/integration-tests/debugger/target-app/time-budget.js
@@ -63,6 +63,10 @@ const complexTypes = ['object', 'array', 'map', 'set']
 
 /**
  * Generate a complex nested object that requires a lot of async CDP calls to traverse
+ *
+ * @param {number} depth
+ * @param {number} breath
+ * @returns {Record<string, unknown>}
  */
 function generateObject (depth, breath) {
   const obj = {}

--- a/integration-tests/helpers/bun.js
+++ b/integration-tests/helpers/bun.js
@@ -7,8 +7,8 @@ const BUN_INSTALL = join(PROJECT_ROOT, 'node_modules', '.cache', 'bun')
 const BUN = join(PROJECT_ROOT, 'node_modules', '.bin', 'bun')
 
 /**
- * @param {NodeJS.ProcessEnv} [env]
- * @returns {NodeJS.ProcessEnv & { BUN_INSTALL: string }}
+ * @param {typeof process.env} [env]
+ * @returns {typeof process.env & { BUN_INSTALL: string }}
  */
 function withBun (env = process.env) {
   return { ...env, BUN_INSTALL }

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -519,7 +519,7 @@ function buildExpressServer (agent) {
     } else {
       agent.emit('debugger-diagnostics', {
         headers: req.headers,
-        payload: JSON.parse((/** @type {Express.Multer.File[]} */ (req.files))[0].buffer.toString()),
+        payload: JSON.parse((/** @type {Array<{ buffer: Buffer }>} */ (req.files))[0].buffer.toString()),
       })
     }
   })

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -182,8 +182,8 @@ function assertTelemetryPoints (pid, msgs, expectedTelemetryPoints) {
 /**
  * @typedef {childProcess.ChildProcess & {
  *   url: string,
- *   stdout: NodeJS.ReadableStream,
- *   stderr: NodeJS.ReadableStream
+ *   stdout: import('node:stream').Readable,
+ *   stderr: import('node:stream').Readable
  * }} SpawnedProcess
  */
 
@@ -277,7 +277,8 @@ function spawnProcAndExpectExit (filename, options = {}, stdioHandler, stderrHan
  *
  * @param {childProcess.ChildProcess|undefined} proc - Process to stop.
  * @param {object} [options] - Stop options.
- * @param {NodeJS.Signals} [options.signal] - Signal to send before escalating. Defaults to `SIGTERM`.
+ * @param {keyof import('node:os').SignalConstants} [options.signal] - Signal to send before escalating.
+ *   Defaults to `SIGTERM`.
  * @param {number} [options.timeoutMs] - Max wait per signal in milliseconds. Defaults to the stop-proc timeout.
  * @returns {Promise<void>}
  */
@@ -456,7 +457,7 @@ async function execHelperAsync (command, options) {
 
 /**
  * @param {string} tarballPath
- * @param {NodeJS.ProcessEnv} env
+ * @param {typeof process.env} env
  * @returns {Promise<void>}
  */
 async function packTarball (tarballPath, env) {
@@ -485,7 +486,7 @@ async function copyIntegrationTests (integrationTestsPaths, folder) {
  * Only one worker will pack the tarball, others will wait for it to be ready.
  *
  * @param {string} tarballPath - The path where the tarball should be created
- * @param {NodeJS.ProcessEnv} env - The environment to use for the pack command
+ * @param {typeof process.env} env - The environment to use for the pack command
  * @returns {Promise<void>}
  */
 async function packTarballWithLock (tarballPath, env) {
@@ -881,7 +882,7 @@ async function curlAndAssertMessage (agent, procOrUrl, fn, timeout, expectedMess
 
 /**
  * @param {number} port
- * @returns {NodeJS.ProcessEnv}
+ * @returns {typeof process.env}
  */
 function getCiVisAgentlessConfig (port) {
   // We remove GITHUB_WORKSPACE so the repository root is not assigned to dd-trace-js
@@ -899,7 +900,7 @@ function getCiVisAgentlessConfig (port) {
 
 /**
  * @param {number} port
- * @returns {NodeJS.ProcessEnv}
+ * @returns {typeof process.env}
  */
 function getCiVisEvpProxyConfig (port) {
   // We remove GITHUB_WORKSPACE so the repository root is not assigned to dd-trace-js

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -2823,7 +2823,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         })
 
     /**
-     * @param {Mocha.Done} done
+     * @param {(error?: Error) => void} done
      * @param {object} options
      * @param {boolean} options.isModified
      * @param {boolean} [options.isEfd]

--- a/integration-tests/mocha-parallel-files.spec.js
+++ b/integration-tests/mocha-parallel-files.spec.js
@@ -13,11 +13,11 @@ const fixturesDir = path.join(__dirname, 'mocha-parallel-files-fixtures')
  *   stdout: string,
  *   stderr: string,
  *   code: number|null,
- *   signal: NodeJS.Signals|null
+ *   signal: keyof import('node:os').SignalConstants|null
  * }} ChildResult
  *
  * @typedef {{
- *   killSignal?: NodeJS.Signals,
+ *   killSignal?: keyof import('node:os').SignalConstants,
  *   killOnFirstStdout?: boolean,
  *   timeoutMs?: number
  * }} RunOpts

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -368,7 +368,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
   const nonLegacyReportingOptions = ['evp proxy', 'agentless']
 
   nonLegacyReportingOptions.forEach((reportingOption) => {
-    let envVars = /** @type {NodeJS.ProcessEnv} */ ({})
+    let envVars = /** @type {typeof process.env} */ ({})
     context(`(${reportingOption}) can run and report`, () => {
       beforeEach(() => {
         if (reportingOption === 'agentless') {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -470,7 +470,7 @@ versions.forEach((version) => {
     /**
      * Runs Vitest typechecking with TIA settings and gathers all TIA payloads.
      *
-     * @param {{ suitesToSkip: string[], testFilter?: string, env?: NodeJS.ProcessEnv }} options
+     * @param {{ suitesToSkip: string[], testFilter?: string, env?: typeof process.env }} options
      * @param {(payloads: object[]) => void} assertPayloads
      * @returns {Promise<void>}
      */

--- a/packages/datadog-esbuild/src/utils.js
+++ b/packages/datadog-esbuild/src/utils.js
@@ -86,9 +86,24 @@ function getSource (url, { format }) {
 }
 
 /**
+ * @typedef {[typeof LOAD_OPERATION, URL, object] | [typeof RESOLVE_OPERATION, string, object]} GetExportsOperation
+ */
+
+/**
+ * @typedef {{ done: false, value: GetExportsOperation } | { done: true, value: Set<string> }} GetExportsResult
+ */
+
+/**
+ * @typedef {{
+ *   next: (value?: unknown) => GetExportsResult,
+ *   throw: (error?: unknown) => GetExportsResult,
+ * }} GetExportsGenerator
+ */
+
+/**
  * Drives the generator returned by import-in-the-middle >=3.1.0 export discovery.
  *
- * @param {Generator<Array, Set<string>>} exportsGenerator Generator returned by getExports
+ * @param {GetExportsGenerator} exportsGenerator Generator returned by getExports
  * @param {(url: URL, context: object) => { source: string, format: string }} getSource
  * Function that loads module source
  * @returns {Set<string>}

--- a/packages/datadog-instrumentations/src/claude-agent-sdk.js
+++ b/packages/datadog-instrumentations/src/claude-agent-sdk.js
@@ -13,6 +13,66 @@ const LOCAL_LIFECYCLE_LOOKAHEAD = 4
 
 const chunkEmitTimes = new WeakMap()
 
+/**
+ * @typedef {{ session_id?: string } & Record<string, unknown>} Chunk
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   name?: string,
+ *   input?: unknown,
+ *   output?: unknown,
+ *   error?: unknown,
+ *   isInterrupt?: boolean,
+ *   sessionId?: string,
+ *   hookStartTime?: number,
+ *   hookFinishTime?: number,
+ * }} ToolState
+ */
+
+/**
+ * @typedef {{ taskStartedChunk?: Chunk, toolResultIndex?: number }} ToolLifecycle
+ */
+
+/**
+ * @typedef {(startIndex: number, toolUseId: string) => ToolLifecycle} GetLifecycle
+ */
+
+/**
+ * @typedef {{
+ *   tools: Map<string, ToolState>,
+ *   subagents: Map<string, Record<string, unknown>>,
+ *   prompt?: string,
+ *   model?: string,
+ *   resume?: string,
+ *   maxTurns?: number,
+ *   permissionMode?: string,
+ *   sessionId?: string,
+ *   source?: string,
+ *   cwd?: string,
+ *   transcriptPath?: string,
+ *   agentType?: string,
+ *   endReason?: string,
+ *   stopReason?: string,
+ *   lastAssistantMessage?: string,
+ * }} SessionContext
+ */
+
+/**
+ * @typedef {{
+ *   stepIndex: number,
+ *   startTime?: number,
+ *   finishTime?: number,
+ *   parentToolUseId?: string,
+ *   sessionId?: string,
+ *   chunks?: Chunk[],
+ *   llmStartIdx?: number,
+ *   llmEndIdx?: number,
+ *   toolOutputs?: unknown[],
+ * }} StepContext
+ */
+
 function hasDownstreamSubscribers () {
   return queryChannel.asyncEnd.hasSubscribers ||
     queryChannel.error.hasSubscribers ||
@@ -287,10 +347,12 @@ function getToolResultContent (chunk, toolUseId) {
 }
 
 /**
- *
- * @param {Array<Record<string, unknown>>} chunks
+ * @param {Chunk[]} chunks
  * @param {number} startIndex
  * @param {string} toolUseId
+ * @param {SessionContext | null | undefined} sessionCtx
+ * @param {GetLifecycle} getLifecycle
+ * @param {ToolLifecycle} lifecycle
  * @returns {number} index in chunks where the next step should start iteration
  */
 function processTool (chunks, startIndex, toolUseId, sessionCtx, getLifecycle, lifecycle) {
@@ -342,9 +404,14 @@ function processTool (chunks, startIndex, toolUseId, sessionCtx, getLifecycle, l
 }
 
 /**
- *
- * @param {Array<Record<string, unknown>>} chunks
+ * @param {Chunk[]} chunks
  * @param {number} startIndex
+ * @param {number | undefined} stepStartTime
+ * @param {string | null | undefined} parentToolUseId
+ * @param {string | undefined} initialPrompt
+ * @param {StepContext | null | undefined} stepCtx
+ * @param {SessionContext | null | undefined} sessionCtx
+ * @param {GetLifecycle} getLifecycle
  * @returns {number} index in chunks where the next step should start iteration
  */
 function processStep (
@@ -447,7 +514,16 @@ function processStep (
 }
 
 /**
- * @param {Array<Record<string, unknown>>} chunks
+ * @param {Chunk[]} chunks
+ * @param {{
+ *   sessionCtx?: SessionContext,
+ *   session_id?: string,
+ *   cwd?: string,
+ *   permissionMode?: string,
+ *   output?: unknown,
+ *   arguments?: Array<{ prompt?: string }>,
+ *   runInContext?: (fn: () => number) => number,
+ * }} agentCtx
  */
 function processChunks (chunks, agentCtx) {
   let chunkIndex = 0

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -25,6 +25,8 @@ const bodyPublished = new WeakSet()
 let lastPublishedError
 let lastPublishedReq
 
+/** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
+
 function wrapFastify (fastify, hasParsingEvents) {
   if (typeof fastify !== 'function') return fastify
 
@@ -81,7 +83,7 @@ function wrapAddHook (addHook) {
  * @param {string} name Lifecycle phase the hook was registered against.
  * @param {Function} fn User-supplied hook.
  * @param {unknown} thisArg `this` Fastify passes to the hook.
- * @param {ArrayLike<unknown>} args Fastify's positional args; the dispatcher always
+ * @param {ArgumentsLike} args Fastify's positional args; the dispatcher always
  *   places `done` as the trailing positional (see fastify/lib/hooks.js hookIterator,
  *   onSendHookRunner, preParsingHookRunner, onRequestAbortHookRunner).
  */

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -13,6 +13,8 @@ const errorChannel = channel('apm:grpc:client:request:error')
 const finishChannel = channel('apm:grpc:client:request:finish')
 const emitChannel = channel('apm:grpc:client:request:emit')
 
+/** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
+
 function createWrapMakeRequest (type, hasPeer = false) {
   const metadataIndex = type === types.client_stream || type === types.bidi ? 3 : 4
 
@@ -186,9 +188,9 @@ function callMethod (client, method, args, path, metadata, type, hasPeer = false
  * one at `index` when the user did not pass their own.
  *
  * @param {object} client
- * @param {ArrayLike<unknown>} args
+ * @param {ArgumentsLike} args
  * @param {number} index
- * @returns {{ metadata: object | undefined, args: ArrayLike<unknown> }}
+ * @returns {{ metadata: object | undefined, args: ArgumentsLike }}
  */
 function resolveMetadata (client, args, index) {
   const grpc = client && getGrpc(client)

--- a/packages/datadog-instrumentations/src/helpers/callback-instrumentor.js
+++ b/packages/datadog-instrumentations/src/helpers/callback-instrumentor.js
@@ -3,6 +3,8 @@
 const shimmer = require('../../../datadog-shimmer')
 const { channel } = require('./instrument')
 
+/** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
+
 /**
  * Create a shimmer-compatible instrumentor for callback-style APIs whose work is offloaded to the
  * libuv worker thread pool (e.g. zlib.gzip, crypto.pbkdf2, dns.lookup). Builds a set of three
@@ -22,7 +24,7 @@ const { channel } = require('./instrument')
  * @param {boolean} [options.captureResult] set `ctx.result` to the callback's first
  *   non-error argument before publishing `:finish`. Plugins that tag spans from the call's
  *   return value (e.g. the DNS lookup plugin) rely on this.
- * @returns {(buildContext: (thisArg: unknown, args: IArguments) => object | undefined) =>
+ * @returns {(buildContext: (thisArg: unknown, args: ArgumentsLike) => object | undefined) =>
  *   (fn: Function) => Function}
  */
 function createCallbackInstrumentor (prefix, { captureResult = false } = {}) {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -87,10 +87,12 @@ function rewrite (content, filename, format, target) {
   return content
 }
 
+/** @typedef {{ buffer: ArrayBuffer | SharedArrayBuffer, byteLength: number, byteOffset: number }} BufferView */
+
 /**
  * Convert the source representations accepted by Node.js loader hooks to text.
  *
- * @param {string | ArrayBuffer | ArrayBufferView} source
+ * @param {string | ArrayBuffer | BufferView} source
  * @returns {string}
  */
 function getSourceText (source) {

--- a/packages/datadog-instrumentations/src/helpers/router-helper.js
+++ b/packages/datadog-instrumentations/src/helpers/router-helper.js
@@ -23,6 +23,10 @@ const METHODS = [...require('http').METHODS.map(v => v.toLowerCase()), 'all']
 const routeAddedChannel = channel('apm:express:route:added')
 
 /**
+ * @typedef {{ stack?: Array<{ route?: unknown, handle?: ExpressRouter }> }} ExpressRouter
+ */
+
+/**
  * Joins two URL path segments into a single path
  *
  * @param {string} base - The base path
@@ -177,6 +181,8 @@ function isAppMounted (router) {
  * Express accepts strings, regex, arrays (possibly nested), or
  * no mount path at all; this helper returns the flattened set of paths along
  * with the index where actual middleware arguments start.
+ *
+ * @param {unknown} path First `use()` argument, which may be a mount path or already a middleware.
  */
 function extractMountPaths (path) {
   const hasMount = typeof path === 'string' || path instanceof RegExp || Array.isArray(path)
@@ -194,6 +200,9 @@ function extractMountPaths (path) {
 
 /**
  * Detect cycle router graphs.
+ *
+ * @param {ExpressRouter | undefined} router
+ * @param {Set<ExpressRouter>} [stack]
  */
 function hasRouterCycle (router, stack = new Set()) {
   if (!router?.stack?.length) return false

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -31,6 +31,8 @@ const isModifiedCh = channel('ci:mocha:test:is-modified')
 // suite channels
 const testSuiteErrorCh = channel('ci:mocha:test-suite:error')
 
+/** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
+
 const testToContext = new WeakMap()
 const originalFns = new WeakMap()
 const testToStartLine = new WeakMap()
@@ -818,7 +820,7 @@ function finishDeferredHookEnd (test) {
  * @param {object} test - Mocha test currently owning the hook.
  * @param {Promise<void>|undefined} failedTestReplayPromise - Pending Failed Test Replay wait, if any.
  * @param {unknown} hookThis - Callback receiver.
- * @param {IArguments} args - Arguments passed by Mocha.
+ * @param {ArgumentsLike} args - Arguments passed by Mocha.
  * @returns {unknown}
  */
 function runFailedTestReplayHookUpCallback (fn, test, failedTestReplayPromise, hookThis, args) {

--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -211,9 +211,23 @@ addHook({ name: 'openai', file: 'dist/api.js', versions: ['>=3.0.0 <4'] }, expor
 })
 
 /**
+ * @typedef {{
+ *   methodName: string,
+ *   args: unknown[],
+ *   basePath?: string,
+ *   result?: Record<string, unknown>,
+ *   error?: unknown,
+ * }} OpenAiContext
+ */
+
+/**
  * For streamed responses, we need to accumulate all of the content in
  * the chunks, and let the combined content be the final response.
  * This way, spans look the same as when not streamed.
+ *
+ * @param {{ headers: unknown, url: string }} response
+ * @param {{ method: string }} options
+ * @param {OpenAiContext} ctx
  */
 function wrapStreamIterator (response, options, ctx) {
   return function (itr) {

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -281,6 +281,7 @@ const finish = (ctx) => {
  *   error?: unknown,
  *   poolWaitTime?: number
  * }} AcquireContext
+ * @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike
  */
 
 // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
@@ -312,7 +313,7 @@ function latestPoolConnectionParameters (pool) {
 /**
  * @param {Function} connect
  * @param {InstrumentedPool} pool
- * @param {IArguments} args
+ * @param {ArgumentsLike} args
  * @param {AcquireContext} acquireCtx
  * @param {number | undefined} start
  */

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1638,6 +1638,30 @@ addHook({
 })
 
 /**
+ * @typedef {Record<string, unknown>} PlaywrightTest
+ */
+
+/**
+ * @typedef {Record<string, unknown>} PlaywrightSuite
+ */
+
+/**
+ * @typedef {{ _fullProject: unknown, _addSuite: (suite: unknown) => void }} PlaywrightProjectSuite
+ */
+
+/**
+ * @typedef {(
+ *   copiedTest: PlaywrightTest, originalTest: PlaywrightTest, repeatEachIndex: number
+ * ) => void} ConfigureCopiedTest
+ */
+
+/**
+ * @typedef {(
+ *   fileSuite: PlaywrightSuite, projectSuite: PlaywrightProjectSuite, repeatEachIndex: number, numRetries: number
+ * ) => number} GetRetryRepeatEachIndex
+ */
+
+/**
  * We could repeat the logic of `applyRepeatEachIndex` here, but it'd be more risky
  * as playwright could change it at any time.
  *
@@ -1650,6 +1674,13 @@ addHook({
  * - we clone each of these file suites for each repeat index
  * - we execute `applyRepeatEachIndex` for each of these cloned file suites
  * - we add the cloned file suites to the project suite
+ *
+ * @param {Map<PlaywrightSuite, PlaywrightProjectSuite>} fileSuitesWithTestsToRetry
+ * @param {(test: PlaywrightTest) => unknown} filterTest
+ * @param {Array<string | ((test: PlaywrightTest) => unknown)>} tagsToApply
+ * @param {number} numRetries
+ * @param {ConfigureCopiedTest} [configureCopiedTest]
+ * @param {GetRetryRepeatEachIndex} [getRetryRepeatEachIndex]
  */
 function applyRetriesToTests (
   fileSuitesWithTestsToRetry,

--- a/packages/datadog-instrumentations/src/webdriverio.js
+++ b/packages/datadog-instrumentations/src/webdriverio.js
@@ -78,7 +78,7 @@ addHook({
  * @typedef {object} WebdriverioRunnerConfig
  * @property {string} framework
  * @property {string|undefined} rootDir
- * @property {NodeJS.ProcessEnv|undefined} runnerEnv
+ * @property {typeof process.env|undefined} runnerEnv
  */
 
 /**

--- a/packages/datadog-instrumentations/src/ws.js
+++ b/packages/datadog-instrumentations/src/ws.js
@@ -49,7 +49,11 @@ const setSocketCh = channel('tracing:ws:server:connect:setSocket')
  */
 
 /**
- * @typedef {string | Buffer | ArrayBuffer | ArrayBufferView | Blob | Buffer[]} WebSocketMessageData
+ * @typedef {{ buffer: ArrayBuffer | SharedArrayBuffer, byteLength: number, byteOffset: number }} BufferView
+ */
+
+/**
+ * @typedef {string | Buffer | ArrayBuffer | BufferView | Blob | Buffer[]} WebSocketMessageData
  */
 
 /**

--- a/packages/datadog-plugin-azure-durable-functions/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-durable-functions/test/integration-test/client.spec.js
@@ -99,6 +99,8 @@ describe('esm', () => {
  * - spawns process for azure func start commands
  * - connects to azurite (running in container)
  *    then runs the durable function locally
+ *
+ * @param {number} agentPort port the fake agent listens on
  */
 async function spawnPluginIntegrationTestProc (agentPort) {
   const cwd = sandboxCwd()

--- a/packages/datadog-plugin-elasticsearch/test/meta-tags.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/meta-tags.spec.js
@@ -13,6 +13,7 @@ const OpenSearchPlugin = require('../../datadog-plugin-opensearch/src')
  * four logical permutations of the params gate can be pinned in isolation.
  *
  * @param {typeof ElasticsearchPlugin} PluginCtor
+ * @param {{ path?: string, method?: string, querystring?: object, query?: object }} params
  */
 function captureMeta (PluginCtor, params) {
   const plugin = new PluginCtor({}, {})

--- a/packages/datadog-plugin-graphql/test/tools/signature.spec.js
+++ b/packages/datadog-plugin-graphql/test/tools/signature.spec.js
@@ -260,8 +260,8 @@ describe('extractErrorIntoSpanEvent stack handling', () => {
    *
    * @param {{
    *   message?: string,
-   *   locations?: ReadonlyArray<{ line: number, column: number }>,
-   *   path?: ReadonlyArray<string | number>,
+   *   locations?: Readonly<Array<{ line: number, column: number }>>,
+   *   path?: Readonly<Array<string | number>>,
    *   originalError?: { stack?: string },
    * }} [shape]
    * @returns {{ error: object, getStackReads: () => number }}

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -15,6 +15,8 @@ const log = require('../../dd-trace/src/log')
  * [[1, 2, 3], [2, 3, 5]]
  * 2. An array of objects, e.g.
  * [{ a: 1, b: 2, expected: 3 }, { a: 2, b: 3, expected: 5}]
+ *
+ * @param {unknown[]} testParameters `test.each` arguments
  */
 function getFormattedJestTestParameters (testParameters) {
   if (!testParameters || !testParameters.length) {

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -29,12 +29,13 @@ class KafkajsProducerPlugin extends ProducerPlugin {
   /**
    *
    * @typedef {object} ProducerResponseItem
-   * @property {string} topic
+   * @property {string} topicName
    * @property {number} partition
    * @property {import('kafkajs/utils/long').Long} [offset]
    * @property {import('kafkajs/utils/long').Long} [baseOffset]
    *
    * @param {ProducerResponseItem} response
+   * @param {string} [clusterId]
    * @returns {ProducerBacklog}
    */
   transformProduceResponse (response, clusterId) {

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -627,6 +627,10 @@ function lookupOperationEndpoint (operationId, methodName, url) {
  * This function essentially normalizes the OpenAI method interface. Many methods accept
  * a single object argument. The remaining ones take individual arguments. This function
  * turns the individual arguments into an object to make extracting properties consistent.
+ *
+ * @param {string} methodName SDK method name, e.g. `createChatCompletion` or `chat.completions.create`
+ * @param {unknown[]} args arguments the SDK method was called with
+ * @returns {Record<string, unknown>}
  */
 function normalizeRequestPayload (methodName, args) {
   switch (methodName) {

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -15,6 +15,10 @@ const skipMethodSize = skipMethods.size
 
 const nonConfigurableModuleExports = new WeakMap()
 
+/**
+ * @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} Descriptor
+ */
+
 // Reused descriptor scratch space for the `name` and `length` slots that
 // `copyProperties` and `wrapCallback` rewrite per wrap. `Object.defineProperty`
 // reads the descriptor's slots synchronously and does not retain the object,
@@ -46,7 +50,7 @@ function copyProperties (original, wrapped) {
   if (ownKeys.length !== 2) {
     for (const key of ownKeys) {
       if (skipMethods.has(key)) continue
-      const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(original, key))
+      const descriptor = /** @type {Descriptor} */ (Object.getOwnPropertyDescriptor(original, key))
       if (descriptor.writable && descriptor.enumerable && descriptor.configurable) {
         wrapped[key] = original[key]
       } else if (descriptor.writable || descriptor.configurable || !Object.hasOwn(wrapped, key)) {
@@ -65,7 +69,7 @@ function copyObjectProperties (original, wrapped, skipKey) {
   const ownKeys = Reflect.ownKeys(original)
   for (const key of ownKeys) {
     if (key === skipKey) continue
-    const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(original, key))
+    const descriptor = /** @type {Descriptor} */ (Object.getOwnPropertyDescriptor(original, key))
     if (descriptor.writable && descriptor.enumerable && descriptor.configurable) {
       wrapped[key] = original[key]
     } else if (descriptor.writable || descriptor.configurable || !Object.hasOwn(wrapped, key)) {

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -121,6 +121,9 @@ class AIGuard extends NoopAIGuard {
    *
    * - Clones each message so callers cannot mutate the data set in the meta struct.
    * - Truncates the list of messages and `content` fields emitting metrics accordingly.
+   *
+   * @param {import('../../../../index').aiguard.Message[]} messages
+   * @param {{ source: string, integration: string }} telemetryTags
    */
   #buildMessagesForMetaStruct (messages, telemetryTags) {
     const size = Math.min(messages.length, this.#maxMessagesLength)

--- a/packages/dd-trace/src/appsec/sdk/track_event.js
+++ b/packages/dd-trace/src/appsec/sdk/track_event.js
@@ -11,6 +11,10 @@ const { getRootSpan } = require('./utils')
 
 /**
  * @deprecated in favor of trackUserLoginSuccessV2
+ * @param {import('../../tracer')} tracer
+ * @param {import('../../../../../index').User} user
+ * @param {Record<string, string>} [metadata]
+ * @returns {void}
  */
 function trackUserLoginSuccessEvent (tracer, user, metadata) {
   // TODO: better user check here and in _setUser() ?
@@ -40,6 +44,11 @@ function trackUserLoginSuccessEvent (tracer, user, metadata) {
 
 /**
  * @deprecated in favor of trackUserLoginFailureV2
+ * @param {import('../../tracer')} tracer
+ * @param {string} userId
+ * @param {boolean} exists
+ * @param {Record<string, string>} [metadata]
+ * @returns {void}
  */
 function trackUserLoginFailureEvent (tracer, userId, exists, metadata) {
   if (!userId || typeof userId !== 'string') {

--- a/packages/dd-trace/src/ci-visibility/efd-retry-policy.js
+++ b/packages/dd-trace/src/ci-visibility/efd-retry-policy.js
@@ -19,7 +19,7 @@ const EARLY_FLAKE_DETECTION_RETRY_BUCKETS =
 
 /**
  * @typedef {object} EfdRetryPolicy
- * @property {ReadonlyArray<EfdDurationRetryCount>} durationRetryCounts
+ * @property {readonly EfdDurationRetryCount[]} durationRetryCounts
  * @property {number} schedulingRetryCount
  */
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -24,6 +24,18 @@ const { sendGitMetadata: sendGitMetadataRequest } = require('./git/git_metadata'
 const hostname = getHostname()
 const EMPTY_SETTINGS = Object.freeze({})
 
+/**
+ * Test session identity sent with every request. Fields are optional because the CI provider,
+ * the git repository or the runtime may not expose them.
+ *
+ * @typedef {{
+ *   repositoryUrl?: string, sha?: string, branch?: string, tag?: string, testLevel?: string,
+ *   osVersion?: string, osPlatform?: string, osArchitecture?: string,
+ *   runtimeName?: string, runtimeVersion?: string, commitMessage?: string,
+ *   pullRequestBaseSha?: string, commitHeadSha?: string, commitHeadMessage?: string,
+ * }} TestConfiguration
+ */
+
 function getTestConfigurationTags (tags) {
   if (!tags) {
     return {}
@@ -239,6 +251,10 @@ class CiVisibilityExporter extends BufferingExporter {
   /**
    * We can't request library configuration until we know whether we can use the
    * CI Visibility Protocol, hence the this._canUseCiVisProtocol promise.
+   *
+   * @param {TestConfiguration} testConfiguration
+   * @param {(error: Error | null, libraryConfig?: Readonly<Record<string, unknown>>) => void} callback
+   * @returns {void}
    */
   getLibraryConfiguration (testConfiguration, callback) {
     const { repositoryUrl } = testConfiguration

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -32,6 +32,9 @@ const {
   TELEMETRY_GIT_REQUESTS_OBJECT_PACKFILES_BYTES,
 } = require('../../../ci-visibility/telemetry')
 
+/** @typedef {{ isEvpProxy: boolean, evpProxyPrefix: string }} EvpProxyConfiguration */
+/** @typedef {EvpProxyConfiguration & { url: URL, repositoryUrl: string }} GitUploadTarget */
+
 const isValidSha1 = (sha) => /^[0-9a-f]{40}$/.test(sha)
 const isValidSha256 = (sha) => /^[0-9a-f]{64}$/.test(sha)
 
@@ -62,6 +65,10 @@ function getCommonRequestOptions (url) {
  * This function posts the SHAs of the commits of the last month
  * The response are the commits for which the backend already has information
  * This response is used to know which commits can be ignored from there on
+ *
+ * @param {GitUploadTarget & { latestCommits: string[] }} options
+ * @param {(error: Error | null, commitsToUpload?: string[]) => void} callback
+ * @returns {void}
  */
 function getCommitsToUpload ({ url, repositoryUrl, latestCommits, isEvpProxy, evpProxyPrefix }, callback) {
   const commonOptions = getCommonRequestOptions(url)
@@ -127,6 +134,10 @@ function getCommitsToUpload ({ url, repositoryUrl, latestCommits, isEvpProxy, ev
 
 /**
  * This function uploads a git packfile
+ *
+ * @param {GitUploadTarget & { packFileToUpload: string, headCommit: string }} options
+ * @param {(error: Error | null, uploadSize?: number) => void} callback
+ * @returns {void}
  */
 function uploadPackFile ({ url, isEvpProxy, evpProxyPrefix, packFileToUpload, repositoryUrl, headCommit }, callback) {
   const form = new FormData()
@@ -245,6 +256,12 @@ function generateAndUploadPackFiles ({
 
 /**
  * This function uploads git metadata to CI Visibility's backend.
+ *
+ * @param {URL} url
+ * @param {EvpProxyConfiguration} evpProxyConfiguration
+ * @param {string | undefined} configRepositoryUrl repository URL from the configuration, if set
+ * @param {(error?: Error | null) => void} callback
+ * @returns {void}
  */
 function sendGitMetadata (url, { isEvpProxy, evpProxyPrefix }, configRepositoryUrl, callback) {
   if (!isGitAvailable()) {

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -307,6 +307,8 @@ module.exports = {
    *
    * This should only be called once in config.js to avoid copying the object frequently.
    *
+   * @param {typeof process.env} [source] The environment to read from
+   * @param {boolean} [internalOnly] Only return configurations marked as internal
    * @returns {TracerEnv} The environment variables
    */
   getEnvironmentVariables (source = process.env, internalOnly = false) {

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -88,6 +88,9 @@ class BaseLLMObsWriter {
   }
 
   /**
+   * @param {Record<string, unknown>} event
+   * @param {{ apiKey?: string, site?: string }} [routing]
+   * @param {number} [byteLength]
    * @returns {boolean} `true` if the event was buffered, `false` if it was dropped
    * (e.g. the per-routing buffer was full). Callers that depend on the event
    * actually being submitted should check this value.

--- a/packages/dd-trace/src/llmobs/writers/util.js
+++ b/packages/dd-trace/src/llmobs/writers/util.js
@@ -7,6 +7,8 @@ const { fetchAgentInfo } = require('../../agent/info')
 
 /**
  * @param {import('../../config/config-base')} config
+ * @param {(agentless: boolean) => void} setWritersAgentlessValue
+ * @returns {void}
  */
 function setAgentStrategy (config, setWritersAgentlessValue) {
   const agentlessEnabled = config.llmobs.agentlessEnabled

--- a/packages/dd-trace/src/opentelemetry/logs/batch_log_processor.js
+++ b/packages/dd-trace/src/opentelemetry/logs/batch_log_processor.js
@@ -22,7 +22,7 @@ class BatchLogRecordProcessor {
   /**
    * Creates a new BatchLogRecordProcessor instance.
    *
-   * @param {OtlpHttpLogExporter} exporter - Log processor for exporting batches to Datadog Agent
+   * @param {import('./otlp_http_log_exporter')} exporter - Log processor for exporting batches to Datadog Agent
    * @param {number} batchTimeout - Timeout in milliseconds for batch processing
    * @param {number} maxExportBatchSize - Maximum number of log records per batch
    */

--- a/packages/dd-trace/src/opentelemetry/metrics/meter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/meter.js
@@ -9,6 +9,8 @@ const { METRIC_TYPES } = require('./constants')
 /**
  * @typedef {import('@opentelemetry/api').MetricOptions} MetricOptions
  * @typedef {import('@opentelemetry/core').InstrumentationScope} InstrumentationScope
+ * @typedef {Counter | UpDownCounter | Histogram | Gauge |
+ *   ObservableGauge | ObservableCounter | ObservableUpDownCounter} Instrument
  */
 
 /**
@@ -25,7 +27,7 @@ class Meter {
   /**
    * Creates a new Meter instance.
    *
-   * @param {MeterProvider} meterProvider - Parent meter provider
+   * @param {import('./meter_provider')} meterProvider - Parent meter provider
    * @param {InstrumentationScope} instrumentationScope - Instrumentation scope information
    * @param {string} [instrumentationScope.name] - Meter name (defaults to 'dd-trace-js')
    * @param {string} [instrumentationScope.version] - Meter version (defaults to tracer version)
@@ -50,11 +52,13 @@ class Meter {
    * Instruments are cached by type and normalized (lowercase) name.
    *
    *
+   * @template {Instrument} T
    * @param {string} name - Instrument name (will be normalized to lowercase)
    * @param {string} type - Instrument type (e.g., 'counter', 'histogram', 'gauge')
-   * @param {Function} InstrumentClass - Constructor for the instrument type
-   * @param {MetricOptions} [options] - Instrument options (description, unit, etc.)
-   * @returns {Instrument} The instrument instance (new or cached)
+   * @param {new (name: string, options: object, instrumentationScope: InstrumentationScope,
+   *   reader: object) => T} InstrumentClass - Constructor for the instrument type
+   * @param {MetricOptions} options - Instrument options (description, unit, etc.)
+   * @returns {T} The instrument instance (new or cached)
    */
   #getOrCreateInstrument (name, type, InstrumentClass, options) {
     const normalizedName = name.toLowerCase()

--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -109,7 +109,7 @@ class PeriodicMetricReader {
   /**
    * Creates a new PeriodicMetricReader instance.
    *
-   * @param {OtlpHttpMetricExporter} exporter - Metric exporter for sending to Datadog Agent
+   * @param {import('./otlp_http_metric_exporter')} exporter - Metric exporter for sending to Datadog Agent
    * @param {number} exportInterval - Export interval in milliseconds
    * @param {string} temporalityPreference - Temporality preference: DELTA, CUMULATIVE, or LOWMEMORY
    * @param {number} maxBatchedQueueSize - Maximum number of measurements to queue before dropping

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -38,6 +38,10 @@ function hrTimeToMilliseconds (hrTime) {
 /**
  * Several of these attributes are not yet supported by the Node.js OTel API.
  * We check for old equivalents where we can, but not all had equivalents.
+ *
+ * @param {string | undefined} spanName
+ * @param {import('@opentelemetry/api').SpanKind} kind
+ * @param {import('@opentelemetry/api').Attributes} attributes
  */
 function spanNameMapper (spanName, kind, attributes) {
   if (spanName) return spanName

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -114,6 +114,9 @@ const uniq = (items) => [...new Set(items)]
  *
  * This is much more robust than relying on hardcoded paths, especially on self-hosted runners
  * and GHES environments where the runner may be installed under arbitrary directories/users.
+ *
+ * @param {string | undefined} runnerTemp value of the `RUNNER_TEMP` environment variable
+ * @returns {string[]}
  */
 function getGithubDiagnosticDirsFromEnv (runnerTemp) {
   const dirs = []
@@ -182,6 +185,9 @@ function expandGlobPattern (pattern) {
 /**
  * Expands a mixed list of literal directories and glob patterns into concrete
  * directories. Literals pass through unchanged (existence is checked later).
+ *
+ * @param {string[]} candidates
+ * @returns {string[]}
  */
 function expandDiagnosticDirCandidates (candidates) {
   const expanded = []

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -38,6 +38,8 @@ const {
 const { filterSensitiveInfoFromRepository } = require('./url')
 const { cachedExec } = require('./git-cache')
 
+/** @typedef {NonNullable<ReturnType<string['match']>>} RegExpMatch */
+
 const legacyStorage = storage('legacy')
 
 const GIT_REV_LIST_MAX_BUFFER = 12 * 1024 * 1024 // 12MB
@@ -116,7 +118,7 @@ function isShallowRepository () {
 
 function getGitVersion () {
   const gitVersionString = sanitizedExec('git', ['version'])
-  const gitVersionMatches = /** @type {RegExpMatchArray} */ (gitVersionString.match(/git version (\d+)\.(\d+)\.(\d+)/))
+  const gitVersionMatches = /** @type {RegExpMatch} */ (gitVersionString.match(/git version (\d+)\.(\d+)\.(\d+)/))
   try {
     return {
       major: Number.parseInt(gitVersionMatches[1], 10),

--- a/packages/dd-trace/src/plugins/util/stacktrace.js
+++ b/packages/dd-trace/src/plugins/util/stacktrace.js
@@ -184,6 +184,9 @@ function isDDInstrumentationFile (fileName) {
  * This function extracts the `myscript.js:10:3` part, passes it, returns the file name, line number, and column
  * number and sets the `index` to the start of the whole location string.
  *
+ * @param {string} stack the stack trace, or the nested location string when recursing
+ * @param {number} start index of the first character of the frame in `stack`
+ * @param {number} index index to start parsing backwards from
  * @returns {[string, string, string, number]|undefined}
  */
 function parseLocation (stack, start, index) {

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -736,6 +736,7 @@ function checkShaDiscrepancies (ciMetadata, userProvidedGitMetadata) {
  *
  * @param {string=} testFramework
  * @param {TestEnvironmentConfig=} config
+ * @param {boolean=} shouldSkipGitMetadataExtraction
  * @returns {TestEnvironmentMetadata}
  */
 function getTestEnvironmentMetadata (testFramework, config, shouldSkipGitMetadataExtraction = false) {
@@ -916,6 +917,10 @@ function getTestCommonTags (name, suite, version, testFramework) {
 /**
  * We want to make sure that test suites are reported the same way for
  * every OS, so we replace `path.sep` by `/`
+ *
+ * @param {string | undefined} testSuiteAbsolutePath
+ * @param {string} sourceRoot
+ * @returns {string}
  */
 function getTestSuitePath (testSuiteAbsolutePath, sourceRoot) {
   if (!testSuiteAbsolutePath) {

--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -20,7 +20,7 @@ module.exports = {
 
   /**
    * Declares the set of custom label keys that will be used with
-   * {@link runWithLabels}.
+   * `runWithLabels`.
    *
    * @param {Iterable<string>} keys - Custom label key names
    */

--- a/packages/dd-trace/src/profiling/exporters/event_serializer.js
+++ b/packages/dd-trace/src/profiling/exporters/event_serializer.js
@@ -43,7 +43,7 @@ class EventSerializer {
 
   /**
    * Returns the destination URL for the near-OOM export subprocess, or nothing when this exporter
-   * does not support OOM export. Overridden by {@link AgentExporter} and {@link FileExporter}.
+   * does not support OOM export. Overridden by `AgentExporter` and `FileExporter`.
    *
    * @returns {URL | undefined}
    */

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -49,6 +49,7 @@ class LazyModule {
 
   /**
    * @param {import('./config/config-base')} config - Tracer configuration
+   * @param {...unknown} args - Extra arguments forwarded to the lazily loaded module
    */
   enable (config, ...args) {
     this.module = this.provider()

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -37,6 +37,11 @@ const moduleLoadEndChannel = dc.channel('dd-trace:moduleLoadEnd')
  * @param {string[]} modules list of modules to hook into
  * @param {Function} onrequire callback to be executed upon encountering module
  */
+/**
+ * @param {string[]} modules list of modules to hook into
+ * @param {object | Function} [options] hook options, or the `onrequire` callback
+ * @param {Function} [onrequire] callback to be executed upon encountering module
+ */
 function Hook (modules, options, onrequire) {
   if (!(this instanceof Hook)) return new Hook(modules, options, onrequire)
   if (typeof options === 'function') {

--- a/packages/dd-trace/src/telemetry/logs/index.js
+++ b/packages/dd-trace/src/telemetry/logs/index.js
@@ -13,6 +13,9 @@ let enabled = false
  * Telemetry logs api defines only ERROR, WARN and DEBUG levels:
  * - WARN level is enabled by default
  * - DEBUG level will be possible to activate with an env var or telemetry config property
+ *
+ * @param {string | undefined} level
+ * @returns {boolean}
  */
 function isLevelEnabled (level) {
   return isValidLevel(level)

--- a/packages/dd-trace/test/appsec/index.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.express.plugin.spec.js
@@ -25,9 +25,11 @@ withVersions('express', 'express', version => {
   }
 
   describe('Suspicious request blocking - path parameters', () => {
-    let axios /** @type {AxiosInstance} */
+    /** @type {import('axios').AxiosInstance} */
+    let axios
     let server
-    let paramCallbackSpy /** @type {SinonSpy} */
+    /** @type {import('sinon').SinonSpy} */
+    let paramCallbackSpy
 
     before(() => {
       return agent.load(['express', 'http'], { client: false }, { appsec: { enabled: true } })

--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -804,7 +804,7 @@ function overloadPropertyWithGetter (obj, propName) {
  *
  * @template T extends object
  * @param {T} obj
- * @param {PropertyKey} methodName
+ * @param {string | number | symbol} methodName
  * @returns {T}
  */
 function overloadMethod (obj, methodName) {
@@ -817,43 +817,43 @@ function overloadMethod (obj, methodName) {
  * in the prototype chain to throw, and return a further subclass constructor.
  *
  * @overload
- * @param {StringConstructor} Builtin
- * @param {PropertyKey} propName
- * @returns {StringConstructor}
+ * @param {typeof globalThis.String} Builtin
+ * @param {string | number | symbol} propName
+ * @returns {typeof globalThis.String}
  */
 /**
  * @overload
- * @param {ArrayConstructor} Builtin
- * @param {PropertyKey} propName
- * @returns {ArrayConstructor}
+ * @param {typeof Array} Builtin
+ * @param {string | number | symbol} propName
+ * @returns {typeof Array}
  */
 /**
  * @overload
- * @param {Int16ArrayConstructor} Builtin
- * @param {PropertyKey} propName
- * @returns {Int16ArrayConstructor}
+ * @param {typeof Int16Array} Builtin
+ * @param {string | number | symbol} propName
+ * @returns {typeof Int16Array}
  */
 /**
  * @overload
- * @param {Int32ArrayConstructor} Builtin
- * @param {PropertyKey} propName
- * @returns {Int32ArrayConstructor}
+ * @param {typeof Int32Array} Builtin
+ * @param {string | number | symbol} propName
+ * @returns {typeof Int32Array}
  */
 /**
  * @overload
- * @param {SetConstructor} Builtin
- * @param {PropertyKey} propName
- * @returns {SetConstructor}
+ * @param {typeof Set} Builtin
+ * @param {string | number | symbol} propName
+ * @returns {typeof Set}
  */
 /**
  * @overload
- * @param {MapConstructor} Builtin
- * @param {PropertyKey} propName
- * @returns {MapConstructor}
+ * @param {typeof Map} Builtin
+ * @param {string | number | symbol} propName
+ * @returns {typeof Map}
  */
 /**
  * @param {new (...args: unknown[]) => object} Builtin
- * @param {PropertyKey} propName
+ * @param {string | number | symbol} propName
  * @returns {new (...args: unknown[]) => object}
  */
 function createClassWithOverloadedMethodInPrototypeChain (Builtin, propName) {

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/complex-types.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/complex-types.js
@@ -60,7 +60,7 @@ function get () {
     yield 1
     yield 2
   }
-  /** @type {Generator<1 | 2, void, unknown> & { foo?: number }} */
+  /** @type {ReturnType<typeof makeIterator> & { foo?: number }} */
   const gen = makeIterator()
   gen.foo = 42
 

--- a/packages/dd-trace/test/debugger/devtools_client/utils.js
+++ b/packages/dd-trace/test/debugger/devtools_client/utils.js
@@ -81,7 +81,7 @@ function generateProbeConfig (breakpoint, overrides = {}) {
 /**
  * Get the request options from a request spy call
  *
- * @param {sinon.SinonSpy} request - The request spy to get the options from.
+ * @param {import('sinon').SinonSpy} request - The request spy to get the options from.
  * @returns {RequestOptions} - The 2nd argument to the `request` function (i.e. the request options).
  */
 function getRequestOptions (request) {

--- a/packages/dd-trace/test/lambda/fixtures/handler.js
+++ b/packages/dd-trace/test/lambda/fixtures/handler.js
@@ -62,6 +62,8 @@ const errorHandler = async (_event, _context) => {
 /**
  * Lambda Authorizer handler - only receives event, no context.
  * This is the signature used by API Gateway Lambda Authorizers.
+ *
+ * @param {import('aws-lambda').APIGatewayAuthorizerEvent} event
  */
 const authorizerHandler = async (event) => {
   // Simulate a simple authorizer that returns an IAM policy
@@ -71,6 +73,8 @@ const authorizerHandler = async (event) => {
 
 /**
  * Synchronous Lambda Authorizer handler - only receives event, no context.
+ *
+ * @param {import('aws-lambda').APIGatewayAuthorizerEvent} event
  */
 const authorizerHandlerSync = (event) => {
   return {
@@ -90,6 +94,8 @@ const authorizerHandlerSync = (event) => {
 
 /**
  * Lambda Authorizer handler that throws an error.
+ *
+ * @param {import('aws-lambda').APIGatewayAuthorizerEvent} event
  */
 const authorizerErrorHandler = async (event) => {
   class AuthorizationError extends Error {

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -398,7 +398,17 @@ describe('mocha hooks setup', () => {
 })
 
 /**
+ * Subset of Mocha's JSON reporter output that these assertions read.
+ *
+ * @typedef {{
+ *   failures: Array<{ title: string, err: { message: string } }>,
+ *   passes: Array<{ title: string }>,
+ * }} MochaJsonResult
+ */
+
+/**
  * @param {string} body
+ * @param {string[]} [args]
  * @returns {Promise<MochaJsonResult>}
  */
 async function runFixture (body, args = []) {

--- a/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
@@ -24,6 +24,8 @@ const {
 /**
  * Lightweight DatadogSpan-shaped fixture. Just enough to exercise each helper's
  * contract; no DD-tracer wiring or scope-manager interaction.
+ *
+ * @param {{ ended?: boolean }} [options]
  */
 function createMockDdSpan ({ ended = false } = {}) {
   const tags = {}

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -126,7 +126,7 @@ process.on('warning', (warning) => {
  * same emitter for event `error`. Once the upstream fix ships the duplicates
  * disappear and this returns false again, so real leaks resume throwing.
  *
- * @param {Error & { emitter?: NodeJS.EventEmitter, type?: string }} warning
+ * @param {Error & { emitter?: import('node:events').EventEmitter, type?: string }} warning
  * @returns {boolean}
  */
 function isNodeHttpSocketLeak (warning) {

--- a/packages/dd-trace/test/setup/operation.js
+++ b/packages/dd-trace/test/setup/operation.js
@@ -18,7 +18,11 @@ class RetryOperation extends BaseRetryOperation {
     super(timeouts, { service })
   }
 
-  /** @this {{ _options: { service?: string } }} */
+  /**
+   * @this {{ _options: { service?: string } }}
+   * @param {Error} error
+   * @returns {boolean}
+   */
   retry (error) {
     const shouldRetry = super.retry(error)
 

--- a/packages/dd-trace/test/setup/services/mongo-replica-set.js
+++ b/packages/dd-trace/test/setup/services/mongo-replica-set.js
@@ -45,6 +45,7 @@ function commandMongoCore (server, command) {
 }
 
 /**
+ * @param {boolean} isSandbox load `mongodb-core` from the sandbox instead of the version folder
  * @returns {Promise<void>}
  */
 function waitForMongoReplicaSet (isSandbox) {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -108,12 +108,13 @@ describe('telemetry', () => {
       bar2: { _enabled: false },
     }
     /**
-     * @type {object} CircularObject
-     * @property {string} field
-     * @property {object} child
-     * @property {string} child.field
-     * @property {CircularObject | null} child.parent
+     * @typedef {{
+     *   field: string,
+     *   child: { field: string, parent: CircularObject | null },
+     * }} CircularObject
      */
+
+    /** @type {CircularObject} */
     const circularObject = {
       child: { parent: null, field: 'child_value' },
       field: 'parent_value',

--- a/packages/dd-trace/test/telemetry/session-propagation.spec.js
+++ b/packages/dd-trace/test/telemetry/session-propagation.spec.js
@@ -60,7 +60,7 @@ describe('session-propagation', () => {
 
   /**
    * @param {Record<string, string>} additions
-   * @returns {NodeJS.ProcessEnv}
+   * @returns {typeof process.env}
    */
   function createExpectedEnv (additions) {
     return {

--- a/scripts/helpers/test-file-index.js
+++ b/scripts/helpers/test-file-index.js
@@ -120,7 +120,7 @@ class TestFileIndex {
   /** @type {boolean} */
   #nocase
 
-  /** @type {NodeJS.Platform} */
+  /** @type {typeof process.platform} */
   #platform
 
   /** @type {Map<string, InstanceType<typeof Minimatch>>} */
@@ -137,7 +137,7 @@ class TestFileIndex {
 
   /**
    * @param {string[]} files Sorted repository-relative POSIX paths.
-   * @param {{ nocase: boolean, platform: NodeJS.Platform }} options
+   * @param {{ nocase: boolean, platform: typeof process.platform }} options
    */
   constructor (files, { nocase, platform }) {
     this.files = files

--- a/scripts/mocha-parallel-files.js
+++ b/scripts/mocha-parallel-files.js
@@ -99,7 +99,7 @@ function splitLines (carry, chunk) {
  *   stdoutEnded: boolean,
  *   stderrEnded: boolean,
  *   code: number|null,
- *   signal: NodeJS.Signals|null,
+ *   signal: keyof import('node:os').SignalConstants|null,
  *   outBuf: {stream: 'stdout'|'stderr', text: string}[],
  *   stderrErrBuf: string[],
  *   failureBuf: string[],
@@ -262,7 +262,7 @@ async function main () {
   let interrupted = false
 
   /**
-   * @param {NodeJS.ErrnoException} error
+   * @param {Error & { code?: string }} error
    */
   const onPipeError = (error) => {
     if (!error || error.code !== 'EPIPE') return
@@ -277,7 +277,7 @@ async function main () {
   process.stderr.on('error', onPipeError)
 
   /**
-   * @param {NodeJS.Signals} signal
+   * @param {keyof import('node:os').SignalConstants} signal
    */
   const onSignal = (signal) => {
     if (interrupted) return
@@ -351,7 +351,7 @@ async function main () {
   let idx = 0
   let running = 0
   let failures = 0
-  /** @type {{file: string, code: number|null, signal: NodeJS.Signals|null}[]} */
+  /** @type {{file: string, code: number|null, signal: keyof import('node:os').SignalConstants|null}[]} */
   const failed = []
 
   /** @type {Entry[]} */

--- a/version.js
+++ b/version.js
@@ -1,10 +1,12 @@
 'use strict'
 
+/** @typedef {NonNullable<ReturnType<string['match']>>} RegExpMatch */
+
 var version = require('./package.json').version
 // @ts-expect-error
-var /** @type {RegExpMatchArray} */ ddMatches = version.match(/^(\d+)\.(\d+)\.(\d+)/)
+var /** @type {RegExpMatch} */ ddMatches = version.match(/^(\d+)\.(\d+)\.(\d+)/)
 // @ts-expect-error
-var /** @type {RegExpMatchArray} */ nodeMatches = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/)
+var /** @type {RegExpMatch} */ nodeMatches = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/)
 
 module.exports = {
   VERSION: version,


### PR DESCRIPTION
## Summary

Complete missing JSDoc parameter declarations and replace unresolved type names across instrumentation, Test Optimization, tracer, integration, and helper code. Enable `jsdoc/require-param` and `jsdoc/no-undefined-types`.

## Why

The rules were disabled behind a backlog of violations. Resolving it turns these contracts into a lint gate instead of allowing further drift.