### PR TITLE
test(mocha): prevent test swallowing errors

### DIFF
--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -345,6 +345,19 @@ describe('mocha hooks setup', () => {
     )
   })
 
+  it('does not swallow errors thrown after a hook completes with allow uncaught enabled', () => {
+    const failure = new Error('test failed')
+    const hook = new Hook('before each', () => {})
+
+    hook.allowUncaught = true
+
+    assert.throws(() => {
+      hook.run(() => {
+        throw failure
+      })
+    }, error => error === failure)
+  })
+
   it('does not let a suppressed after each error change bail behavior', async () => {
     const result = await runFixture(`
       describe('suite', () => {

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -358,6 +358,23 @@ describe('mocha hooks setup', () => {
     }, error => error === failure)
   })
 
+  it('does not swallow test errors after a promise hook completes with allow uncaught enabled', async () => {
+    await assert.rejects(runFixtureProcess(`
+      describe('suite', () => {
+        beforeEach(async () => {})
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+      })
+    `, ['--allow-uncaught']), (error) => {
+      assert.strictEqual(typeof error.code, 'number')
+      assert.notStrictEqual(error.code, 0)
+      assert.match(error.stderr, /test failed/)
+      return true
+    })
+  })
+
   it('does not let a suppressed after each error change bail behavior', async () => {
     const result = await runFixture(`
       describe('suite', () => {
@@ -385,6 +402,21 @@ describe('mocha hooks setup', () => {
  * @returns {Promise<MochaJsonResult>}
  */
 async function runFixture (body, args = []) {
+  try {
+    const { stdout } = await runFixtureProcess(body, args)
+    return JSON.parse(stdout)
+  } catch (err) {
+    if (!err || typeof err !== 'object' || !('stdout' in err) || typeof err.stdout !== 'string') throw err
+    return JSON.parse(err.stdout)
+  }
+}
+
+/**
+ * @param {string} body
+ * @param {string[]} [args]
+ * @returns {Promise<{ stdout: string, stderr: string }>}
+ */
+async function runFixtureProcess (body, args = []) {
   const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-trace-mocha-hooks-'))
   const fixture = path.join(tmpdir, 'fixture.spec.js')
   fs.writeFileSync(fixture, `'use strict'
@@ -395,8 +427,7 @@ ${body}
 `)
 
   try {
-    const { stdout } = await execFileMocha(fixture, args)
-    return JSON.parse(stdout)
+    return await execFileMocha(fixture, args)
   } finally {
     fs.rmSync(tmpdir, { force: true, recursive: true })
   }
@@ -413,12 +444,7 @@ async function execFileMocha (fixture, args) {
   // plain Mocha behavior with JSON emitted on stdout.
   const mochaArgs = [mochaBin, '--no-config', '--reporter', 'json', ...args, fixture]
 
-  try {
-    return await execFileAsync(process.execPath, mochaArgs)
-  } catch (err) {
-    if (!err || typeof err !== 'object' || !('stdout' in err) || typeof err.stdout !== 'string') throw err
-    return { stdout: err.stdout }
-  }
+  return execFileAsync(process.execPath, mochaArgs)
 }
 
 /**

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -47,12 +47,20 @@ if (!patched.has(Runner.prototype)) {
    */
   Hook.prototype.run = function patchedRunHook (fn) {
     let hookCompleted = false
+    let hookRunReturned = false
 
     try {
-      return runHook.call(this, (err) => {
+      const result = runHook.call(this, (err) => {
         hookCompleted = true
-        return fn(err && shouldSuppress(this) ? undefined : err)
+        try {
+          return fn(err && shouldSuppress(this) ? undefined : err)
+        } catch (err) {
+          if (!hookRunReturned) throw err
+          process.nextTick(() => { throw err })
+        }
       })
+      hookRunReturned = true
+      return result
     } catch (err) {
       if (hookCompleted) throw err
       return this.callback(shouldSuppress(this) ? undefined : Runnable.toValueOrError(err))

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -46,11 +46,15 @@ if (!patched.has(Runner.prototype)) {
    * @param {(err?: Error) => void} fn
    */
   Hook.prototype.run = function patchedRunHook (fn) {
+    let hookCompleted = false
+
     try {
       return runHook.call(this, (err) => {
+        hookCompleted = true
         return fn(err && shouldSuppress(this) ? undefined : err)
       })
     } catch (err) {
+      if (hookCompleted) throw err
       return this.callback(shouldSuppress(this) ? undefined : Runnable.toValueOrError(err))
     }
   }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Prevent the custom Mocha hook wrapper from swallowing test errors when `allowUncaught` is enabled. Errors thrown after a hook completes are now rethrown and reported correctly.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


