### PR TITLE
refactor: guard traversals instead of defaulting to an empty object or array

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,6 +80,37 @@ const GLOBAL_RESTRICTED_REQUIRES = [
   },
 ]
 
+const SRC_RESTRICTED_SYNTAX = [
+  {
+    // Inline `.evaluate(<fn>)` callbacks (Playwright/Puppeteer) are serialized with
+    // `toString()` and run in chromium — coverage counters inside would ReferenceError.
+    selector:
+      "CallExpression[callee.property.name='evaluate']" +
+      ":matches([arguments.0.type='ArrowFunctionExpression'], [arguments.0.type='FunctionExpression'])",
+    message:
+      'Move the inline `.evaluate(...)` callback into a `*-browser-scripts.js` file ' +
+      '(NYC-excluded in nyc.config.js) and import it here.',
+  },
+  {
+    // Static-analysis bundlers (esbuild, webpack, rollup) only see literals as require
+    // arguments; once any transform (e.g. NYC) wraps them, this shape breaks bundling.
+    selector: "CallExpression[callee.name='require'][arguments.0.type='ConditionalExpression']",
+    message: 'Use `cond ? require(\'a\') : require(\'b\')` instead of `require(cond ? \'a\' : \'b\')`.',
+  },
+]
+
+// Matches only probe positions; a genuine count (`writeMapPrefix(Object.keys(x).length)`) must stay allowed.
+const OBJECT_KEYS_LENGTH_PROBE = {
+  selector:
+    ':matches(BinaryExpression[right.value=0], BinaryExpression[left.value=0], UnaryExpression[operator="!"],' +
+    ' IfStatement, ConditionalExpression, LogicalExpression, WhileStatement, DoWhileStatement)' +
+    " > MemberExpression[property.name='length']" +
+    " > CallExpression[callee.object.name='Object'][callee.property.name='keys']",
+  message: 'Do not probe emptiness with `Object.keys(obj).length`; the keys array is allocated on every call. ' +
+    'Track presence with a boolean at the assignment site, probe a known key (`obj.field !== undefined`), or ' +
+    'return `undefined` when there is nothing to report instead of an empty object.',
+}
+
 export default [
   {
     name: 'dd-trace/global-ignore',
@@ -552,21 +583,7 @@ export default [
       'eslint-rules/eslint-prefer-set-service-name': 'error',
       'eslint-rules/eslint-timer-unref': 'error',
 
-      'no-restricted-syntax': ['error', {
-        // Inline `.evaluate(<fn>)` callbacks (Playwright/Puppeteer) are serialized with
-        // `toString()` and run in chromium — coverage counters inside would ReferenceError.
-        selector:
-          "CallExpression[callee.property.name='evaluate']" +
-          ":matches([arguments.0.type='ArrowFunctionExpression'], [arguments.0.type='FunctionExpression'])",
-        message:
-          'Move the inline `.evaluate(...)` callback into a `*-browser-scripts.js` file ' +
-          '(NYC-excluded in nyc.config.js) and import it here.',
-      }, {
-        // Static-analysis bundlers (esbuild, webpack, rollup) only see literals as require
-        // arguments; once any transform (e.g. NYC) wraps them, this shape breaks bundling.
-        selector: "CallExpression[callee.name='require'][arguments.0.type='ConditionalExpression']",
-        message: 'Use `cond ? require(\'a\') : require(\'b\')` instead of `require(cond ? \'a\' : \'b\')`.',
-      }],
+      'no-restricted-syntax': ['error', ...SRC_RESTRICTED_SYNTAX],
 
       'n/no-restricted-require': ['error', [
         ...GLOBAL_RESTRICTED_REQUIRES,
@@ -684,6 +701,16 @@ export default [
       'unicorn/prefer-array-from-map': 'off', // few | loops avoid callback allocation
       'unicorn/prefer-continue': 'off', // many
       'unicorn/prefer-ternary': 'off', // many
+    },
+  },
+  {
+    name: 'dd-trace/packages/src',
+    files: [
+      'packages/*/src/**/*.js',
+      'packages/*/src/**/*.mjs',
+    ],
+    rules: {
+      'no-restricted-syntax': ['error', ...SRC_RESTRICTED_SYNTAX, OBJECT_KEYS_LENGTH_PROBE],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,6 +99,27 @@ const SRC_RESTRICTED_SYNTAX = [
   },
 ]
 
+// Only defaults consumed in place; a stored fallback (`const items = value ?? []`) stays legal.
+const EMPTY_DEFAULT_TRAVERSAL = [
+  {
+    selector:
+      "CallExpression[callee.object.name='Object'][callee.property.name=/^(entries|keys|values)$/]" +
+      " > LogicalExpression[right.type='ObjectExpression'][right.properties.length=0]",
+    message: 'Do not hand `Object.entries|keys|values` an empty-object default; the object and the array it ' +
+      'returns are allocated even when there is nothing to traverse. Guard the traversal with `if (value)`.',
+  },
+  {
+    selector: "ForOfStatement > LogicalExpression[right.type='ArrayExpression'][right.elements.length=0]",
+    message: 'Do not iterate an empty-array default; guard the loop with `if (value)` instead of allocating an ' +
+      'array to iterate zero times.',
+  },
+  {
+    selector: "MemberExpression > LogicalExpression[right.type='ArrayExpression'][right.elements.length=0]",
+    message: 'Do not read through an empty-array default; `value?.method()` yields the same result without ' +
+      'allocating for the absent case.',
+  },
+]
+
 // Matches only probe positions; a genuine count (`writeMapPrefix(Object.keys(x).length)`) must stay allowed.
 const OBJECT_KEYS_LENGTH_PROBE = {
   selector:
@@ -710,7 +731,7 @@ export default [
       'packages/*/src/**/*.mjs',
     ],
     rules: {
-      'no-restricted-syntax': ['error', ...SRC_RESTRICTED_SYNTAX, OBJECT_KEYS_LENGTH_PROBE],
+      'no-restricted-syntax': ['error', ...SRC_RESTRICTED_SYNTAX, OBJECT_KEYS_LENGTH_PROBE, ...EMPTY_DEFAULT_TRAVERSAL],
     },
   },
   {

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -97,7 +97,7 @@ let pickleByFile = {}
 const pickleResultByFile = {}
 
 let skippableSuites = []
-let skippableSuitesCoverage = {}
+let skippableSuitesCoverage
 let skippedSuitesCoverage = {}
 let itrCorrelationId = ''
 let isForcedToRun = false
@@ -127,12 +127,6 @@ function isValidKnownTests (receivedKnownTests) {
   return !!receivedKnownTests.cucumber
 }
 
-function hasSkippableSuitesCoverage () {
-  return skippableSuitesCoverage &&
-    typeof skippableSuitesCoverage === 'object' &&
-    Object.keys(skippableSuitesCoverage).length > 0
-}
-
 function isTiaCoverageBackfillEnabled () {
   return isItrEnabled && isCoverageReportUploadEnabled
 }
@@ -146,7 +140,7 @@ function shouldReportCodeCoverageLinesPct (hasBackfilledCoverage) {
 }
 
 function getSkippedSuitesCoverageForRun () {
-  return isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage()
+  return isSuitesSkipped && isTiaCoverageBackfillEnabled() && skippableSuitesCoverage !== undefined
     ? skippableSuitesCoverage
     : {}
 }
@@ -162,7 +156,7 @@ function getCucumberTestSessionCoverageFiles () {
 
 function resetSuiteSkippingRunState () {
   skippableSuites = []
-  skippableSuitesCoverage = {}
+  skippableSuitesCoverage = undefined
   skippedSuitesCoverage = {}
   skippedSuites = []
   isSuitesSkipped = false
@@ -1102,7 +1096,7 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
 
       errorSkippableRequest = skippableResponse.err
       skippableSuites = skippableResponse.skippableSuites ?? []
-      skippableSuitesCoverage = skippableResponse.skippableSuitesCoverage ?? {}
+      skippableSuitesCoverage = skippableResponse.skippableSuitesCoverage
 
       if (!errorSkippableRequest) {
         const filteredPickles = isCoordinator

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -144,6 +144,7 @@ function wrapHookDone (ctx, request, reply, req, name, doneCallback) {
     ctx.error = error
     publishError(ctx)
 
+    // eslint-disable-next-line no-restricted-syntax -- arbitrary cookie names; publishing {} sets a WAF address
     const hasCookies = request.cookies && Object.keys(request.cookies).length > 0
 
     if (cookieParserReadCh.hasSubscribers && hasCookies && !cookiesPublished.has(req)) {
@@ -191,6 +192,7 @@ function preHandler (request, reply, done) {
   const res = getRes(reply)
   const ctx = { req, res }
 
+  // eslint-disable-next-line no-restricted-syntax -- arbitrary body keys; publishing {} sets a WAF address
   const hasBody = request.body && Object.keys(request.body).length > 0
 
   // For multipart/form-data, the body is not available until after preValidation hook

--- a/packages/datadog-instrumentations/src/helpers/router-helper.js
+++ b/packages/datadog-instrumentations/src/helpers/router-helper.js
@@ -53,11 +53,12 @@ function collectRoutesFromRouter (router, prefix) {
     if (layer.route) {
       // This layer has a direct route
       const route = layer.route
+      if (!route.methods) continue
 
       const fullPaths = getRouteFullPaths(route, prefix)
 
       for (const fullPath of fullPaths) {
-        for (const [method, enabled] of Object.entries(route.methods || {})) {
+        for (const [method, enabled] of Object.entries(route.methods)) {
           if (!enabled) continue
           routeAddedChannel.publish({
             method: normalizeMethodName(method),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -102,7 +102,7 @@ const jestSessionState = (globalThis[JEST_SESSION_STATE] ||= {})
 const RETRY_TIMES = Symbol.for('RETRY_TIMES')
 
 let skippableSuites = []
-let skippableSuitesCoverage = {}
+let skippableSuitesCoverage
 let skippedSuitesCoverage = {}
 let knownTests = {}
 let isCodeCoverageEnabled = false
@@ -125,7 +125,7 @@ let isTestManagementTestsEnabled = false
 let testManagementTests = {}
 let testManagementAttemptToFixRetries = 0
 let isImpactedTestsEnabled = false
-let modifiedFiles = {}
+let modifiedFiles
 let repositoryRoot
 let lastCoverageMap
 let lastCoverageMapRootDir
@@ -546,8 +546,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
       if (this.isImpactedTestsEnabled) {
         try {
-          const hasImpactedTests = Object.keys(modifiedFiles).length > 0
-          this.modifiedFiles = hasImpactedTests ? modifiedFiles : this.testEnvironmentOptions._ddModifiedFiles
+          this.modifiedFiles = modifiedFiles ?? this.testEnvironmentOptions._ddModifiedFiles
         } catch (e) {
           log.error('Error parsing impacted tests', e)
           this.isImpactedTestsEnabled = false
@@ -1757,12 +1756,6 @@ function getRepositoryRootFromTest (test, fallbackRootDir) {
   return getRepositoryRootFromConfig(test?.context?.config, fallbackRootDir)
 }
 
-function hasSkippableSuitesCoverage () {
-  return skippableSuitesCoverage &&
-    typeof skippableSuitesCoverage === 'object' &&
-    Object.keys(skippableSuitesCoverage).length > 0
-}
-
 function shouldCollectJestCoverageForTia () {
   return shouldReportJestSuiteCoverageForTia() ||
     (isJestCoverageBackfillSupported && isItrEnabled && isCoverageReportUploadEnabled)
@@ -1875,7 +1868,7 @@ function resetLibraryConfiguration () {
   testManagementTests = {}
   testManagementAttemptToFixRetries = 0
   isImpactedTestsEnabled = false
-  modifiedFiles = {}
+  modifiedFiles = undefined
   repositoryRoot = undefined
 }
 
@@ -1897,13 +1890,14 @@ function applySuiteSkipping (originalTests, rootDir, frameworkVersion) {
 
   isSuitesSkipped = jestSuitesToRun.suitesToRun.length !== originalTests.length
   numSkippedSuites = jestSuitesToRun.skippedSuites.length
-  skippedSuitesCoverage = isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage()
+  const hasSkippableSuitesCoverage = skippableSuitesCoverage !== undefined
+  skippedSuitesCoverage = isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage
     ? skippableSuitesCoverage
     : {}
   coverageBackfillContexts = isSuitesSkipped && isTiaCoverageBackfillEnabled()
     ? getTestContexts(originalTests)
     : undefined
-  coverageBackfillFiles = isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage()
+  coverageBackfillFiles = isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage
     ? getCoverageBackfillFiles(skippableSuitesCoverage, repositoryRoot, getTestSuitePath)
     : undefined
 
@@ -2294,10 +2288,10 @@ function getCliWrapper (isNewJestVersion) {
             skippableSuitesCoverage: receivedSkippableSuitesCoverage,
           } = skippableSuitesResponse || await getChannelPromise(skippableSuitesCh)
           if (err) {
-            skippableSuitesCoverage = {}
+            skippableSuitesCoverage = undefined
           } else {
             skippableSuites = receivedSkippableSuites
-            skippableSuitesCoverage = receivedSkippableSuitesCoverage || {}
+            skippableSuitesCoverage = receivedSkippableSuitesCoverage
           }
           skippedSuitesCoverage = {}
         } catch (err) {

--- a/packages/datadog-instrumentations/src/jest/coverage-backfill.js
+++ b/packages/datadog-instrumentations/src/jest/coverage-backfill.js
@@ -14,7 +14,7 @@ const TRANSFORM_OPTIONS = {
 
 function getCoverageBackfillFiles (skippableSuitesCoverage, rootDir, getTestSuitePath) {
   const files = []
-  for (const filename of Object.keys(skippableSuitesCoverage || {})) {
+  for (const filename of Object.keys(skippableSuitesCoverage)) {
     const relativeFilename = path.isAbsolute(filename)
       ? getTestSuitePath(filename, rootDir)
       : filename

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -66,7 +66,7 @@ const unskippableSuites = []
 let suitesToSkip = []
 let isSuitesSkipped = false
 let skippedSuites = []
-let skippableSuitesCoverage = {}
+let skippableSuitesCoverage
 let skippedSuitesCoverage = {}
 let itrCorrelationId = ''
 let isForcedToRun = false
@@ -185,12 +185,6 @@ function getFilteredSuites (originalSuites) {
   }, { suitesToRun: [], skippedSuites: new Set(), suitesToSkipForRun })
 }
 
-function hasSkippableSuitesCoverage () {
-  return skippableSuitesCoverage &&
-    typeof skippableSuitesCoverage === 'object' &&
-    Object.keys(skippableSuitesCoverage).length > 0
-}
-
 function isTiaCoverageBackfillEnabled () {
   return config.isItrEnabled && config.isCoverageReportUploadEnabled
 }
@@ -221,7 +215,7 @@ function shouldReportCodeCoverageLinesPct (hasBackfilledCoverage) {
 }
 
 function getSkippedSuitesCoverageForRun () {
-  return isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage()
+  return isSuitesSkipped && isTiaCoverageBackfillEnabled() && skippableSuitesCoverage !== undefined
     ? skippableSuitesCoverage
     : {}
 }
@@ -238,7 +232,7 @@ function getMochaTestSessionCoverageFiles () {
 function resetSuiteSkippingRunState () {
   isSuitesSkipped = false
   skippedSuites = []
-  skippableSuitesCoverage = {}
+  skippableSuitesCoverage = undefined
   skippedSuitesCoverage = {}
   untestedCoverage = undefined
   config.repositoryRoot = undefined
@@ -443,11 +437,11 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     } = response || {}
     if (!response || err) {
       suitesToSkip = []
-      skippableSuitesCoverage = {}
+      skippableSuitesCoverage = undefined
     } else {
       suitesToSkip = skippableSuites
       itrCorrelationId = responseItrCorrelationId
-      skippableSuitesCoverage = responseSkippableSuitesCoverage || {}
+      skippableSuitesCoverage = responseSkippableSuitesCoverage
     }
     if (localSuites) {
       suitesToSkip = getSuitesToSkipFromPaths(localSuites)

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -212,11 +212,7 @@ function retryTest (test, numRetries, tags, slowTestRetries) {
 }
 
 function getConfiguredEfdRetryCount (config) {
-  const { earlyFlakeDetectionSlowTestRetries } = config
-  if (!earlyFlakeDetectionSlowTestRetries || !Object.keys(earlyFlakeDetectionSlowTestRetries).length) {
-    return config.earlyFlakeDetectionNumRetries
-  }
-  return getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries)
+  return getMaxEfdRetryCount(config.earlyFlakeDetectionSlowTestRetries) ?? config.earlyFlakeDetectionNumRetries
 }
 
 function getSuitesByTestFile (root) {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1136,7 +1136,7 @@ function onDispatcherCreateWorker (dispatcher, worker) {
       _ddIsFinalExecution: isFinalExecution,
       _ddIsEfdManagedTest: isEfdManagedTest,
       _ddEarlyFlakeAbortReason: efdSlowAbortedTests.has(getTestEfdKey(test)) ? 'slow' : undefined,
-      _ddHasPassedAnyEfdAttempt: (testsToTestStatuses.get(getTestEfdKey(test)) || []).includes('pass'),
+      _ddHasPassedAnyEfdAttempt: testsToTestStatuses.get(getTestEfdKey(test))?.includes('pass') ?? false,
     }
 
     setDdPropertiesForTest(worker.process, test.id, ddProperties)

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -206,10 +206,7 @@ function getTestEfdKey (test) {
 }
 
 function getConfiguredEfdRetryCount () {
-  if (!earlyFlakeDetectionSlowTestRetries || !Object.keys(earlyFlakeDetectionSlowTestRetries).length) {
-    return earlyFlakeDetectionNumRetries
-  }
-  return getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries)
+  return getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries) ?? earlyFlakeDetectionNumRetries
 }
 
 function markEfdManagedTest (test) {

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -420,6 +420,7 @@ const visitedParams = new WeakSet()
 function wrapHandleRequest (original) {
   return function wrappedHandleRequest (...args) {
     const req = args[0]
+    // eslint-disable-next-line no-restricted-syntax -- arbitrary param names; publishing {} sets a WAF address
     if (routerParamStartCh.hasSubscribers && !visitedParams.has(req.params) && Object.keys(req.params).length) {
       visitedParams.add(req.params)
 
@@ -459,6 +460,7 @@ function wrapParam (original) {
     args[1] = shimmer.wrapFunction(args[1], (originalFn) => {
       return function wrappedFn (...fnArgs) {
         const req = fnArgs[0]
+        // eslint-disable-next-line no-restricted-syntax -- arbitrary param names; publishing {} sets a WAF address
         if (routerParamStartCh.hasSubscribers && Object.keys(req.params).length && !visitedParams.has(req.params)) {
           visitedParams.add(req.params)
 

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -72,10 +72,7 @@ let isMessagePortWrapped = false
 const tinyPoolClassWrappers = new WeakMap()
 
 function getConfiguredEfdRetryCount (slowTestRetries, fallbackRetryCount) {
-  if (!slowTestRetries || !Object.keys(slowTestRetries).length) {
-    return fallbackRetryCount
-  }
-  return getMaxEfdRetryCount(slowTestRetries)
+  return getMaxEfdRetryCount(slowTestRetries) ?? fallbackRetryCount
 }
 
 function getTestCommand () {

--- a/packages/datadog-instrumentations/test/helpers/router-helper.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/router-helper.spec.js
@@ -309,6 +309,21 @@ describe('helpers/router-helper', () => {
         { method: '*', path: '/root/details' },
       ])
     })
+
+    it('should skip a route that carries no methods', () => {
+      const router = {
+        stack: [
+          { route: { path: '/no-methods' } },
+          { route: { path: '/ok', methods: { get: true } } },
+        ],
+      }
+
+      collectRoutesFromRouter(router, '/api')
+
+      assert.deepStrictEqual(published, [
+        { method: 'get', path: '/api/ok' },
+      ])
+    })
   })
 
   describe('wrapRouteMethodsAndPublish', () => {

--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -483,11 +483,13 @@ function extractTextAndResponseReason (response, provider, modelName) {
  * @returns {{ content?: string, role: string, toolCalls?: Array, toolResults?: Array } | undefined}
  */
 function extractMessagesFromConverseContent (role, contentBlocks) {
+  if (!contentBlocks) return
+
   let content = ''
   const toolCalls = []
   const toolResults = []
 
-  for (const block of contentBlocks || []) {
+  for (const block of contentBlocks) {
     if (block == null || typeof block !== 'object') continue
     if (typeof block.text === 'string') {
       content += block.text
@@ -544,7 +546,7 @@ function parseToolInput (inputStr) {
 }
 
 function buildToolResult ({ toolUseId, content }) {
-  const result = (content || []).map(resolveToolResultItem).join('')
+  const result = content?.map(resolveToolResultItem).join('') ?? ''
   return { name: '', result, toolId: toolUseId ?? '', type: 'tool_result' }
 }
 
@@ -572,14 +574,17 @@ function buildUsage (usage = {}) {
  */
 function extractConverseToolDefinitions (params) {
   const toolDefinitions = []
-  for (const tool of params.toolConfig?.tools || []) {
-    const toolSpec = tool?.toolSpec
-    if (!toolSpec?.name) continue
-    toolDefinitions.push({
-      name: toolSpec.name,
-      description: toolSpec.description ?? '',
-      schema: toolSpec.inputSchema ?? {},
-    })
+  const tools = params.toolConfig?.tools
+  if (tools) {
+    for (const tool of tools) {
+      const toolSpec = tool?.toolSpec
+      if (!toolSpec?.name) continue
+      toolDefinitions.push({
+        name: toolSpec.name,
+        description: toolSpec.description ?? '',
+        schema: toolSpec.inputSchema ?? {},
+      })
+    }
   }
   return toolDefinitions
 }
@@ -593,13 +598,17 @@ function extractConverseToolDefinitions (params) {
  */
 function extractRequestParamsConverse (params) {
   const prompt = []
-  for (const block of params.system || []) {
-    if (typeof block?.text === 'string') prompt.push({ content: block.text, role: 'system' })
+  if (params.system) {
+    for (const block of params.system) {
+      if (typeof block?.text === 'string') prompt.push({ content: block.text, role: 'system' })
+    }
   }
-  for (const msg of params.messages || []) {
-    if (msg == null || typeof msg !== 'object') continue
-    const message = extractMessagesFromConverseContent(msg.role || 'user', msg.content)
-    if (message) prompt.push(message)
+  if (params.messages) {
+    for (const msg of params.messages) {
+      if (msg == null || typeof msg !== 'object') continue
+      const message = extractMessagesFromConverseContent(msg.role || 'user', msg.content)
+      if (message) prompt.push(message)
+    }
   }
 
   const { temperature, topP, maxTokens, stopSequences } = params.inferenceConfig || {}
@@ -641,29 +650,31 @@ function extractTextAndResponseReasonConverseFromStream (chunks) {
   let usage = {}
   const blocksByIdx = new Map()
 
-  for (const chunk of chunks || []) {
-    if (chunk.messageStart?.role) {
-      role = chunk.messageStart.role
-    } else if (chunk.messageStop?.stopReason) {
-      stopReason = chunk.messageStop.stopReason
-    } else if (chunk.metadata?.usage) {
-      usage = chunk.metadata.usage
-    } else if (chunk.contentBlockStart?.start?.toolUse) {
-      const { contentBlockIndex, start: { toolUse } } = chunk.contentBlockStart
-      blocksByIdx.set(contentBlockIndex, {
-        toolUse: { toolUseId: toolUse.toolUseId, name: toolUse.name, inputStr: '' },
-      })
-    } else if (chunk.contentBlockDelta) {
-      const { contentBlockIndex, delta } = chunk.contentBlockDelta
-      if (typeof delta?.text === 'string') {
-        const block = blocksByIdx.get(contentBlockIndex) ?? {}
-        block.text = (block.text ?? '') + delta.text
-        blocksByIdx.set(contentBlockIndex, block)
-      } else if (typeof delta?.toolUse?.input === 'string') {
-        const block = blocksByIdx.get(contentBlockIndex) ?? { toolUse: { inputStr: '' } }
-        block.toolUse ??= { inputStr: '' }
-        block.toolUse.inputStr += delta.toolUse.input
-        blocksByIdx.set(contentBlockIndex, block)
+  if (chunks) {
+    for (const chunk of chunks) {
+      if (chunk.messageStart?.role) {
+        role = chunk.messageStart.role
+      } else if (chunk.messageStop?.stopReason) {
+        stopReason = chunk.messageStop.stopReason
+      } else if (chunk.metadata?.usage) {
+        usage = chunk.metadata.usage
+      } else if (chunk.contentBlockStart?.start?.toolUse) {
+        const { contentBlockIndex, start: { toolUse } } = chunk.contentBlockStart
+        blocksByIdx.set(contentBlockIndex, {
+          toolUse: { toolUseId: toolUse.toolUseId, name: toolUse.name, inputStr: '' },
+        })
+      } else if (chunk.contentBlockDelta) {
+        const { contentBlockIndex, delta } = chunk.contentBlockDelta
+        if (typeof delta?.text === 'string') {
+          const block = blocksByIdx.get(contentBlockIndex) ?? {}
+          block.text = (block.text ?? '') + delta.text
+          blocksByIdx.set(contentBlockIndex, block)
+        } else if (typeof delta?.toolUse?.input === 'string') {
+          const block = blocksByIdx.get(contentBlockIndex) ?? { toolUse: { inputStr: '' } }
+          block.toolUse ??= { inputStr: '' }
+          block.toolUse.inputStr += delta.toolUse.input
+          blocksByIdx.set(contentBlockIndex, block)
+        }
       }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
@@ -5,6 +5,9 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 
 const {
+  extractConverseToolDefinitions,
+  extractMessagesFromConverseContent,
+  extractRequestParamsConverse,
   extractTextAndResponseReasonConverseFromStream,
 } = require('../src/services/bedrockruntime/utils')
 
@@ -21,5 +24,68 @@ describe('bedrockruntime converse stream extractor', () => {
       role: 'assistant',
       toolCalls: [{ name: 'get_weather', arguments: {}, toolId: 't-1', type: 'toolUse' }],
     }])
+  })
+
+  it('accumulates streamed text, usage and tool input that arrives without a block start', () => {
+    const generation = extractTextAndResponseReasonConverseFromStream([
+      { messageStart: { role: 'assistant' } },
+      { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'sunny' } } },
+      { contentBlockDelta: { contentBlockIndex: 0, delta: { text: ' and warm' } } },
+      { contentBlockDelta: { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":"Berlin"}' } } } },
+      { metadata: { usage: { inputTokens: 3, outputTokens: 5, totalTokens: 8 } } },
+      { messageStop: { stopReason: 'end_turn' } },
+    ])
+
+    assert.strictEqual(generation.finishReason, 'end_turn')
+    assert.strictEqual(generation.usage.inputTokens, 3)
+    assert.strictEqual(generation.usage.outputTokens, 5)
+    assert.deepStrictEqual(generation.messages, [{
+      role: 'assistant',
+      content: 'sunny and warm',
+      toolCalls: [{ name: '', arguments: { city: 'Berlin' }, toolId: '', type: 'toolUse' }],
+    }])
+  })
+})
+
+describe('bedrockruntime converse request extractor', () => {
+  it('renders system blocks, messages and tool definitions', () => {
+    const params = {
+      system: [{ text: 'be brief' }, { guardContent: {} }],
+      messages: [
+        { content: [{ text: 'hi' }] },
+        { role: 'tool', content: [{ toolResult: { toolUseId: 't-1', content: [{ text: '21C' }] } }] },
+        { role: 'tool', content: [{ toolResult: { toolUseId: 't-2' } }] },
+        null,
+      ],
+      toolConfig: {
+        tools: [
+          { toolSpec: { name: 'get_weather', description: 'looks up the weather', inputSchema: { json: {} } } },
+          { toolSpec: { name: 'bare_tool' } },
+          { toolSpec: { description: 'nameless tools are skipped' } },
+        ],
+      },
+      inferenceConfig: { temperature: 0.5, maxTokens: 32 },
+    }
+
+    const requestParams = extractRequestParamsConverse(params)
+
+    assert.deepStrictEqual(requestParams.prompt, [
+      { content: 'be brief', role: 'system' },
+      { content: 'hi', role: 'user' },
+      { role: 'tool', toolResults: [{ name: '', result: '21C', toolId: 't-1', type: 'tool_result' }] },
+      { role: 'tool', toolResults: [{ name: '', result: '', toolId: 't-2', type: 'tool_result' }] },
+    ])
+    assert.strictEqual(requestParams.temperature, 0.5)
+    assert.strictEqual(requestParams.maxTokens, 32)
+    assert.deepStrictEqual(extractConverseToolDefinitions(params), [
+      { name: 'get_weather', description: 'looks up the weather', schema: { json: {} } },
+      { name: 'bare_tool', description: '', schema: {} },
+    ])
+  })
+
+  it('renders nothing when the request carries no system, messages or tools', () => {
+    assert.deepStrictEqual(extractRequestParamsConverse({}).prompt, [])
+    assert.deepStrictEqual(extractConverseToolDefinitions({}), [])
+    assert.strictEqual(extractMessagesFromConverseContent('user', undefined), undefined)
   })
 })

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -156,7 +156,7 @@ function setSpanLinks (triggerType, tracer, span, ctx) {
     : triggerMetadata.propertiesArray
 
   const addLinkFromProperties = (props) => {
-    if (!props || Object.keys(props).length === 0) return
+    if (!props) return
     const spanContext = tracer.extract('text_map', props)
     if (spanContext) {
       span.addLink({ context: spanContext })

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -473,7 +473,7 @@ class CypressPlugin {
   testsToSkip = []
   skippedTests = []
   skippedTestIds = new Set()
-  skippableTestsCoverage = {}
+  skippableTestsCoverage
   testSessionCoverageMap = createCoverageMap()
   hasForcedToRunSuites = false
   hasUnskippableSuites = false
@@ -562,7 +562,7 @@ class CypressPlugin {
     this.testsToSkip = []
     this.skippedTests = []
     this.skippedTestIds = new Set()
-    this.skippableTestsCoverage = {}
+    this.skippableTestsCoverage = undefined
     this.testSessionCoverageMap = createCoverageMap()
     this.hasForcedToRunSuites = false
     this.hasUnskippableSuites = false
@@ -661,17 +661,6 @@ class CypressPlugin {
   }
 
   /**
-   * Returns whether the backend supplied skipped-test coverage data.
-   *
-   * @returns {boolean}
-   */
-  hasSkippableTestsCoverage () {
-    return !!(this.skippableTestsCoverage &&
-      typeof this.skippableTestsCoverage === 'object' &&
-      Object.keys(this.skippableTestsCoverage).length > 0)
-  }
-
-  /**
    * Returns whether skipped test coverage should be backfilled into the session coverage map.
    *
    * @returns {boolean}
@@ -680,7 +669,7 @@ class CypressPlugin {
     return this.isItrEnabled &&
       this.isCoverageReportUploadEnabled &&
       this.isTestsSkipped &&
-      this.hasSkippableTestsCoverage()
+      this.skippableTestsCoverage !== undefined
   }
 
   /**
@@ -906,11 +895,7 @@ class CypressPlugin {
    * @returns {number}
    */
   getConfiguredEfdRetryCount () {
-    const { earlyFlakeDetectionSlowTestRetries } = this
-    if (!earlyFlakeDetectionSlowTestRetries || !Object.keys(earlyFlakeDetectionSlowTestRetries).length) {
-      return this.earlyFlakeDetectionNumRetries
-    }
-    return getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries)
+    return getMaxEfdRetryCount(this.earlyFlakeDetectionSlowTestRetries) ?? this.earlyFlakeDetectionNumRetries
   }
 
   /**
@@ -1158,7 +1143,7 @@ class CypressPlugin {
       } else {
         const { skippableTests, correlationId, skippableTestsCoverage } = skippableTestsResponse
         this.testsToSkip = skippableTests || []
-        this.skippableTestsCoverage = skippableTestsCoverage || {}
+        this.skippableTestsCoverage = skippableTestsCoverage
         this.itrCorrelationId = correlationId
         incrementCountMetric(TELEMETRY_ITR_SKIPPED, { testLevel: 'test' }, this.testsToSkip.length)
       }

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -125,6 +125,8 @@ function isMarkedAsUnskippable (test) {
 function getJestSuitesToRun (skippableSuites, originalTests, rootDir, fallbackRootDir) {
   const unskippableSuites = {}
   const forcedToRunSuites = {}
+  let hasUnskippableSuites = false
+  let hasForcedToRunSuites = false
 
   const skippedSuites = []
   const suitesToRun = []
@@ -144,11 +146,13 @@ function getJestSuitesToRun (skippableSuites, originalTests, rootDir, fallbackRo
     if (isMarkedAsUnskippable(test)) {
       suitesToRun.push(test)
       unskippableSuites[relativePath] = true
+      hasUnskippableSuites = true
       if (fallbackRelativePath !== undefined) {
         unskippableSuites[fallbackRelativePath] = true
       }
       if (skippedSuite !== undefined) {
         forcedToRunSuites[relativePath] = true
+        hasForcedToRunSuites = true
         if (fallbackRelativePath !== undefined) {
           forcedToRunSuites[fallbackRelativePath] = true
         }
@@ -161,9 +165,6 @@ function getJestSuitesToRun (skippableSuites, originalTests, rootDir, fallbackRo
       skippedSuites.push(skippedSuite)
     }
   }
-
-  const hasUnskippableSuites = Object.keys(unskippableSuites).length > 0
-  const hasForcedToRunSuites = Object.keys(forcedToRunSuites).length > 0
 
   if (originalTests.length) {
     // The config object is shared by all tests, so we can just take the first one

--- a/packages/datadog-plugin-openai-agents/src/integration.js
+++ b/packages/datadog-plugin-openai-agents/src/integration.js
@@ -401,6 +401,7 @@ class OpenAIAgentsIntegration {
 
     this.#tagger.tagTextIO(ddSpan, inputValue, outputValue)
 
+    // eslint-disable-next-line no-restricted-syntax -- SDK trace metadata has no key to probe; tagging {} is observable
     if (info.metadata && Object.keys(info.metadata).length > 0) {
       this.#tagger.tagMetadata(ddSpan, info.metadata)
     }

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -102,23 +102,23 @@ class OpenAiTracingPlugin extends TracingPlugin {
       },
     }, false)
 
-    const openaiStore = Object.create(null)
-
     const tags = {} // The remaining tags are added one at a time
 
     if (payload.stream) {
       tags['openai.request.stream'] = payload.stream
     }
 
+    let openaiStore
+
     switch (normalizedMethodName) {
       case 'createImage':
       case 'createImageEdit':
       case 'createImageVariation':
-        commonCreateImageRequestExtraction(tags, payload, openaiStore)
+        openaiStore = commonCreateImageRequestExtraction(tags, payload)
         break
 
       case 'createChatCompletion':
-        createChatCompletionRequestExtraction(tags, payload, openaiStore)
+        openaiStore = createChatCompletionRequestExtraction(tags, payload)
         break
 
       case 'createFile':
@@ -128,7 +128,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
 
       case 'createTranscription':
       case 'createTranslation':
-        commonCreateAudioRequestExtraction(tags, payload, openaiStore)
+        openaiStore = commonCreateAudioRequestExtraction(tags, payload)
         break
 
       case 'retrieveModel':
@@ -136,11 +136,11 @@ class OpenAiTracingPlugin extends TracingPlugin {
         break
 
       case 'createEdit':
-        createEditRequestExtraction(tags, payload, openaiStore)
+        openaiStore = createEditRequestExtraction(tags, payload)
         break
 
       case 'createResponse':
-        createResponseRequestExtraction(tags, payload, openaiStore)
+        openaiStore = createResponseRequestExtraction(tags, payload)
         break
     }
 
@@ -177,8 +177,6 @@ class OpenAiTracingPlugin extends TracingPlugin {
 
     body = coerceResponseBody(body, normalizedMethodName)
 
-    const openaiStore = store.openai
-
     if (!error && (path?.startsWith('https://') || path?.startsWith('http://'))) {
       // basic checking for if the path was set as a full URL
       // not using a full regex as it will likely be "https://api.openai.com/..."
@@ -204,7 +202,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
           'openai.response.created_at': body.created_at,
         }
 
-    responseDataExtractionByMethod(normalizedMethodName, tags, body, openaiStore)
+    const openaiStore = responseDataExtractionByMethod(normalizedMethodName, tags, body, store.openai)
     span.addTags(tags)
 
     span.finish()
@@ -298,7 +296,6 @@ class OpenAiTracingPlugin extends TracingPlugin {
 
   sendLog (methodName, span, tags, openaiStore, error) {
     if (!openaiStore) return
-    if (!Object.keys(openaiStore).length) return
     if (!this.sampler.isSampled(span)) return
 
     const log = {
@@ -395,45 +392,54 @@ function normalizeMethodName (methodName) {
   }
 }
 
-function createEditRequestExtraction (tags, payload, openaiStore) {
-  const instruction = payload.instruction
-  openaiStore.instruction = instruction
+function createEditRequestExtraction (tags, payload) {
+  const openaiStore = Object.create(null)
+  openaiStore.instruction = payload.instruction
+  return openaiStore
 }
 
-function createResponseRequestExtraction (tags, payload, openaiStore) {
+function createResponseRequestExtraction (tags, payload) {
   // Extract model information
   if (payload.model) {
     tags['openai.request.model'] = payload.model
   }
 
   // Store the full payload for response extraction
+  const openaiStore = Object.create(null)
   openaiStore.responseData = payload
+  return openaiStore
 }
 
 function retrieveModelRequestExtraction (tags, payload) {
   tags['openai.request.id'] = payload.id
 }
 
-function createChatCompletionRequestExtraction (tags, payload, openaiStore) {
+function createChatCompletionRequestExtraction (tags, payload) {
   const messages = payload.messages
   if (!defensiveArrayLength(messages)) return
 
-  openaiStore.messages = payload.messages
+  const openaiStore = Object.create(null)
+  openaiStore.messages = messages
+  return openaiStore
 }
 
-function commonCreateImageRequestExtraction (tags, payload, openaiStore) {
+function commonCreateImageRequestExtraction (tags, payload) {
+  let openaiStore
+
   // createImageEdit, createImageVariation
   const img = payload.file || payload.image
   if (img !== null && typeof img === 'object' && img.path) {
-    const file = path.basename(img.path)
-    openaiStore.file = file
+    openaiStore = Object.create(null)
+    openaiStore.file = path.basename(img.path)
   }
 
   // createImageEdit
   if (payload.mask !== null && typeof payload.mask === 'object' && payload.mask.path) {
-    const mask = path.basename(payload.mask.path)
-    openaiStore.mask = mask
+    openaiStore ??= Object.create(null)
+    openaiStore.mask = path.basename(payload.mask.path)
   }
+
+  return openaiStore
 }
 
 function responseDataExtractionByMethod (methodName, tags, body, openaiStore) {
@@ -441,12 +447,10 @@ function responseDataExtractionByMethod (methodName, tags, body, openaiStore) {
     case 'createCompletion':
     case 'createChatCompletion':
     case 'createEdit':
-      commonCreateResponseExtraction(tags, body, openaiStore, methodName)
-      break
+      return commonCreateResponseExtraction(tags, body, openaiStore, methodName)
 
     case 'createResponse':
-      createResponseResponseExtraction(tags, body, openaiStore)
-      break
+      return createResponseResponseExtraction(tags, body, openaiStore)
 
     case 'listFiles':
     case 'listFineTunes':
@@ -475,6 +479,8 @@ function responseDataExtractionByMethod (methodName, tags, body, openaiStore) {
       retrieveModelResponseExtraction(tags, body)
       break
   }
+
+  return openaiStore
 }
 
 function retrieveModelResponseExtraction (tags, body) {
@@ -513,10 +519,11 @@ function deleteFileResponseExtraction (tags, body) {
   tags['openai.response.id'] = body.id
 }
 
-function commonCreateAudioRequestExtraction (tags, body, openaiStore) {
+function commonCreateAudioRequestExtraction (tags, body) {
   if (body.file !== null && typeof body.file === 'object' && body.file.path) {
-    const filename = path.basename(body.file.path)
-    openaiStore.file = filename
+    const openaiStore = Object.create(null)
+    openaiStore.file = path.basename(body.file.path)
+    return openaiStore
   }
 }
 
@@ -546,9 +553,11 @@ function commonListCountResponseExtraction (tags, body) {
 
 // createCompletion, createChatCompletion, createEdit
 function commonCreateResponseExtraction (tags, body, openaiStore, methodName) {
-  if (!body.choices) return
+  if (!body.choices) return openaiStore
 
+  openaiStore ??= Object.create(null)
   openaiStore.choices = body.choices
+  return openaiStore
 }
 
 function createResponseResponseExtraction (tags, body, openaiStore) {
@@ -568,7 +577,9 @@ function createResponseResponseExtraction (tags, body, openaiStore) {
   }
 
   // Store the full response for potential future use
+  openaiStore ??= Object.create(null)
   openaiStore.response = body
+  return openaiStore
 }
 
 // The server almost always responds with JSON

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -444,9 +444,11 @@ class VitestPlugin extends CiPlugin {
       isVitestNoWorkerInitActive,
       onDone,
     }) => {
-      for (const [tag, value] of Object.entries(requestErrorTags || {})) {
-        this.testSessionSpan.setTag(tag, value)
-        this.testModuleSpan.setTag(tag, value)
+      if (requestErrorTags) {
+        for (const [tag, value] of Object.entries(requestErrorTags)) {
+          this.testSessionSpan.setTag(tag, value)
+          this.testModuleSpan.setTag(tag, value)
+        }
       }
       this.testSessionSpan.setTag(TEST_STATUS, status)
       this.testModuleSpan.setTag(TEST_STATUS, status)

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -182,12 +182,14 @@ class AIGuard extends NoopAIGuard {
     if (!req) return
 
     const newTags = {}
+    let hasNewTags = false
 
     if (needsHttpClientIp) {
       const clientIp = extractIp(this.#config, req)
 
       if (clientIp) {
         newTags[HTTP_CLIENT_IP] = clientIp
+        hasNewTags = true
       }
     }
 
@@ -196,10 +198,11 @@ class AIGuard extends NoopAIGuard {
 
       if (networkClientIp) {
         newTags[NETWORK_CLIENT_IP] = networkClientIp
+        hasNewTags = true
       }
     }
 
-    if (Object.keys(newTags).length > 0) {
+    if (hasNewTags) {
       rootSpan.addTags(newTags)
     }
   }

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
@@ -92,6 +92,7 @@ function removeEmptyCaptureProperties (value) {
       if (current.fields === null || (
         current.fields &&
         typeof current.fields === 'object' &&
+        // eslint-disable-next-line no-restricted-syntax -- snapshot field names are user variables; no key to probe
         Object.keys(current.fields).length === 0
       )) {
         delete current.fields

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -34,9 +34,12 @@ function parseSkippableSuitesResponse (
     validateSkippableTestsResponse(parsedResponse, { validationMode })
   }
   let coverage
-  for (const [filename, bitmap] of Object.entries(parsedResponse.meta?.coverage || {})) {
-    coverage ??= {}
-    coverage[filename.replaceAll('\\', '/')] = bitmap
+  const coverageBitmaps = parsedResponse.meta?.coverage
+  if (coverageBitmaps) {
+    for (const [filename, bitmap] of Object.entries(coverageBitmaps)) {
+      coverage ??= {}
+      coverage[filename.replaceAll('\\', '/')] = bitmap
+    }
   }
 
   const skippableItems = parsedResponse

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -33,8 +33,9 @@ function parseSkippableSuitesResponse (
   if (validateRequiredFields) {
     validateSkippableTestsResponse(parsedResponse, { validationMode })
   }
-  const coverage = {}
+  let coverage
   for (const [filename, bitmap] of Object.entries(parsedResponse.meta?.coverage || {})) {
+    coverage ??= {}
     coverage[filename.replaceAll('\\', '/')] = bitmap
   }
 

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -193,9 +193,10 @@ class Config extends ConfigBase {
     // handling.
     this.debug = log.configure(options)
 
-    // Process stable config warnings, if any
-    for (const warning of this.stableConfig?.warnings ?? []) {
-      log.warn(warning)
+    if (this.stableConfig?.warnings) {
+      for (const warning of this.stableConfig.warnings) {
+        log.warn(warning)
+      }
     }
 
     this.#applyDefaults()

--- a/packages/dd-trace/src/config/remote_config.js
+++ b/packages/dd-trace/src/config/remote_config.js
@@ -236,7 +236,7 @@ const optionLookupTable = {
 
 const transformers = {
   tracing_sampling_rules (samplingRules) {
-    for (const rule of (samplingRules || [])) {
+    for (const rule of samplingRules) {
       if (rule.tags) {
         const reformattedTags = {}
         for (const tag of rule.tags) {

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -111,6 +111,7 @@ class Dataset {
       if (rec.expectedOutput !== null && rec.expectedOutput !== undefined) {
         out.expected_output = rec.expectedOutput
       }
+      // eslint-disable-next-line no-restricted-syntax -- no key to probe; omitting vs sending {} is observable
       if (rec.metadata && Object.keys(rec.metadata).length > 0) {
         out.metadata = rec.metadata
       }

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -116,7 +116,7 @@ class Experiment {
     this.#description = options.description ?? ''
     this.#dataset = options.dataset
     this.#task = options.task
-    this.#evaluators = options.evaluators ? new Map(Object.entries(options.evaluators)) : new Map()
+    this.#evaluators = new Map(options.evaluators && Object.entries(options.evaluators))
     this.#config = {}
     this.#hasConfig = false
     if (options.config) {

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -24,8 +24,10 @@ function stringify (value) {
 // Build the tag list, letting auto tags win over user tags on key conflict.
 function buildTags (userTags, autoTags) {
   const tags = new Map()
-  for (const [k, v] of Object.entries(userTags ?? {})) {
-    tags.set(k, `${k}:${v}`)
+  if (userTags) {
+    for (const [key, value] of Object.entries(userTags)) {
+      tags.set(key, `${key}:${value}`)
+    }
   }
   for (const [k, v] of Object.entries(autoTags)) {
     tags.set(k, `${k}:${v}`)
@@ -114,7 +116,7 @@ class Experiment {
     this.#description = options.description ?? ''
     this.#dataset = options.dataset
     this.#task = options.task
-    this.#evaluators = new Map(Object.entries(options.evaluators ?? {}))
+    this.#evaluators = options.evaluators ? new Map(Object.entries(options.evaluators)) : new Map()
     this.#config = {}
     this.#hasConfig = false
     if (options.config) {

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -117,9 +117,11 @@ class Experiment {
     this.#evaluators = new Map(Object.entries(options.evaluators ?? {}))
     this.#config = {}
     this.#hasConfig = false
-    for (const [key, value] of Object.entries(options.config ?? {})) {
-      this.#config[key] = value
-      this.#hasConfig = true
+    if (options.config) {
+      for (const [key, value] of Object.entries(options.config)) {
+        this.#config[key] = value
+        this.#hasConfig = true
+      }
     }
     this.#tags = { ...options.tags }
     this.#experimentId = null

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -40,6 +40,7 @@ function toSpan (row, metadata, ids, spanName, userTags) {
     output: row.output ?? null,
     expected_output: row.expectedOutput ?? null,
   }
+  // eslint-disable-next-line no-restricted-syntax -- no key to probe; omitting vs sending {} is observable
   if (metadata && Object.keys(metadata).length > 0) {
     meta.metadata = metadata
   }
@@ -99,6 +100,7 @@ class Experiment {
   #task
   #evaluators
   #config
+  #hasConfig
   #tags
   #experimentId
 
@@ -113,7 +115,12 @@ class Experiment {
     this.#dataset = options.dataset
     this.#task = options.task
     this.#evaluators = new Map(Object.entries(options.evaluators ?? {}))
-    this.#config = { ...options.config }
+    this.#config = {}
+    this.#hasConfig = false
+    for (const [key, value] of Object.entries(options.config ?? {})) {
+      this.#config[key] = value
+      this.#hasConfig = true
+    }
     this.#tags = { ...options.tags }
     this.#experimentId = null
   }
@@ -149,7 +156,7 @@ class Experiment {
       description: this.#description,
       ensure_unique: true,
     }
-    if (Object.keys(this.#config).length > 0) attributes.config = this.#config
+    if (this.#hasConfig) attributes.config = this.#config
 
     let created
     try {
@@ -199,12 +206,14 @@ class Experiment {
         const durationNs = Number(process.hrtime.bigint() - startHr)
         const evaluations = {}
         const evaluationErrors = {}
+        let hasEvaluationError = false
         const timestampMs = Date.now()
 
         for (const [label, evaluator] of this.#evaluators) {
           if (errorType !== null) {
             const msg = 'task error; evaluation skipped'
             evaluationErrors[label] = msg
+            hasEvaluationError = true
             metrics.push(toMetric(label, null, msg, spanId, timestampMs, experimentId, this.#tags))
             continue
           }
@@ -216,6 +225,7 @@ class Experiment {
           } catch (err) {
             const msg = err.message ?? String(err)
             evaluationErrors[label] = msg
+            hasEvaluationError = true
             metrics.push(toMetric(label, null, msg, spanId, timestampMs, experimentId, this.#tags))
           }
         }
@@ -235,7 +245,7 @@ class Experiment {
           evaluationErrors,
         })
         rows.push(row)
-        if (row.isError || Object.keys(evaluationErrors).length > 0) hasRowError = true
+        if (row.isError || hasEvaluationError) hasRowError = true
         spans.push(toSpan(row, record.metadata, {
           experimentId,
           projectId,

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -63,11 +63,13 @@ class Experiments {
             'GET',
             `${API_BASE_PATH}/${projectId}/datasets?filter[name]=${encodeURIComponent(name)}`
           )
-          for (const item of listed?.data ?? []) {
-            if (item?.attributes?.name === name) {
-              datasetId = String(item?.id ?? '')
-              description = String(item?.attributes?.description ?? '')
-              break
+          if (listed?.data) {
+            for (const item of listed.data) {
+              if (item?.attributes?.name === name) {
+                datasetId = String(item?.id ?? '')
+                description = String(item?.attributes?.description ?? '')
+                break
+              }
             }
           }
           if (datasetId === null) return false
@@ -84,10 +86,12 @@ class Experiments {
             'GET',
             `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records${query}`
           )
-          for (const item of resp?.data ?? []) {
-            const attrs = item?.attributes ?? item
-            recs.push(new DatasetRecord(attrs?.input ?? null, attrs?.expected_output ?? null, attrs?.metadata ?? {}))
-            ids.push(String(item?.id ?? ''))
+          if (resp?.data) {
+            for (const item of resp.data) {
+              const attrs = item?.attributes ?? item
+              recs.push(new DatasetRecord(attrs?.input ?? null, attrs?.expected_output ?? null, attrs?.metadata ?? {}))
+              ids.push(String(item?.id ?? ''))
+            }
           }
           cursor = resp?.meta?.after ?? ''
           if (!cursor) break

--- a/packages/dd-trace/src/llmobs/plugins/ai/util.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/util.js
@@ -228,6 +228,7 @@ function getJsonStringValue (str, defaultValue) {
 function getModelMetadata (tags) {
   /** @type {Record<string, unknown>} */
   const modelMetadata = {}
+  let hasModelMetadata = false
   for (const tag of Object.keys(tags)) {
     const isModelMetadata = tag.startsWith(VERCEL_AI_MODEL_METADATA_PREFIX)
     if (isModelMetadata) {
@@ -235,6 +236,7 @@ function getModelMetadata (tags) {
       const metadataKey = lastCommaPosition === -1 ? tag : tag.slice(lastCommaPosition + 1)
       if (metadataKey && MODEL_METADATA_KEYS.has(metadataKey)) {
         modelMetadata[metadataKey] = tags[tag]
+        hasModelMetadata = true
       }
     } else {
       const isTelemetryMetadata = tag.startsWith(VERCEL_AI_TELEMETRY_METADATA_PREFIX)
@@ -242,12 +244,13 @@ function getModelMetadata (tags) {
         const metadataKey = tag.slice(VERCEL_AI_TELEMETRY_METADATA_PREFIX.length)
         if (metadataKey) {
           modelMetadata[metadataKey] = tags[tag]
+          hasModelMetadata = true
         }
       }
     }
   }
 
-  return Object.keys(modelMetadata).length ? modelMetadata : null
+  return hasModelMetadata ? modelMetadata : null
 }
 
 /**
@@ -259,6 +262,7 @@ function getModelMetadata (tags) {
 function getGenerationMetadata (tags) {
   /** @type {Record<string, unknown>} */
   const metadata = {}
+  let hasMetadata = false
 
   for (const tag of Object.keys(tags)) {
     const isGenerationMetadata = tag.startsWith(VERCEL_AI_GENERATION_METADATA_PREFIX)
@@ -270,18 +274,20 @@ function getGenerationMetadata (tags) {
 
       const settingValue = tags[tag]
       metadata[settingKey] = settingValue
+      hasMetadata = true
     } else {
       const isTelemetryMetadata = tag.startsWith(VERCEL_AI_TELEMETRY_METADATA_PREFIX)
       if (isTelemetryMetadata) {
         const metadataKey = tag.slice(VERCEL_AI_TELEMETRY_METADATA_PREFIX.length)
         if (metadataKey) {
           metadata[metadataKey] = tags[tag]
+          hasMetadata = true
         }
       }
     }
   }
 
-  return Object.keys(metadata).length ? metadata : null
+  return hasMetadata ? metadata : null
 }
 
 /**
@@ -293,21 +299,26 @@ function getGenerationMetadata (tags) {
 function getGenerationMetadataFromEvent (event) {
   /** @type {Record<string, unknown>} */
   const metadata = {}
+  let hasMetadata = false
 
   for (const [key, value] of Object.entries(event)) {
     const transformedKey = key.replaceAll(/[A-Z]/g, letter => '_' + letter.toLowerCase())
     if (!MODEL_METADATA_KEYS.has(transformedKey)) {
-      if (key === 'runtimeContext') { // custom telemetry metadata
-        Object.assign(metadata, value)
+      if (key === 'runtimeContext' && value !== null && typeof value === 'object') { // custom telemetry metadata
+        for (const [contextKey, contextValue] of Object.entries(value)) {
+          metadata[contextKey] = contextValue
+          hasMetadata = true
+        }
       }
 
       continue
     }
 
     metadata[transformedKey] = value
+    hasMetadata = true
   }
 
-  return Object.keys(metadata).length ? metadata : null
+  return hasMetadata ? metadata : null
 }
 
 /**
@@ -432,6 +443,7 @@ function getLlmObsSpanName (operation, functionId) {
  */
 function getTelemetryMetadata (tags) {
   const metadata = {}
+  let hasMetadata = false
 
   for (const tag of Object.keys(tags)) {
     if (!tag.startsWith(VERCEL_AI_TELEMETRY_METADATA_PREFIX)) continue
@@ -439,10 +451,11 @@ function getTelemetryMetadata (tags) {
     const metadataKey = tag.slice(VERCEL_AI_TELEMETRY_METADATA_PREFIX.length)
     if (metadataKey) {
       metadata[metadataKey] = tags[tag]
+      hasMetadata = true
     }
   }
 
-  return Object.keys(metadata).length ? metadata : null
+  return hasMetadata ? metadata : null
 }
 
 module.exports = {

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -21,14 +21,14 @@ class ContextManager {
     const storedSpan = store ? trace.getSpan(store) : null
 
     // Convert DD baggage to OTel format
-    const baggages = getAllBaggageItems()
-    const hasBaggage = Object.keys(baggages).length > 0
+    let entries
+    for (const [key, value] of Object.entries(getAllBaggageItems())) {
+      entries ??= {}
+      entries[key] = { value }
+    }
+
     let otelBaggages
-    if (hasBaggage) {
-      const entries = {}
-      for (const [key, value] of Object.entries(baggages)) {
-        entries[key] = { value }
-      }
+    if (entries !== undefined) {
       otelBaggages = propagation.createBaggage(entries)
     }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1330,10 +1330,6 @@ function addSkippedCoverageToMap (skippedCoverage, targetMap) {
   }
 }
 
-function hasSkippedCoverage (skippedCoverage) {
-  return skippedCoverage && typeof skippedCoverage === 'object' && Object.keys(skippedCoverage).length > 0
-}
-
 function getTestCoverageLinesPercentage (coverage, skippedCoverage, rootDir) {
   const executableLinesByFile = new Map()
   const coveredLinesByFile = new Map()
@@ -1387,10 +1383,10 @@ function applySkippedCoverageToFileCoverage (fileCoverage, skippedBitmap) {
  * @returns {boolean}
  */
 function applySkippedCoverageToCoverage (coverage, skippedCoverage, rootDir) {
-  if (!hasSkippedCoverage(skippedCoverage)) return false
+  const skippedCoverageByFilename = getSkippedCoverageByFilename(skippedCoverage)
+  if (skippedCoverageByFilename.size === 0) return false
 
   const coverageMap = getCoverageMap(coverage)
-  const skippedCoverageByFilename = getSkippedCoverageByFilename(skippedCoverage)
   let matched = false
 
   for (const filename of coverageMap.files()) {
@@ -1734,6 +1730,7 @@ function getPullRequestBaseBranch (pullRequestBaseBranch) {
   }
 
   const metrics = {}
+  let hasMetrics = false
   for (const candidate of candidateBranches) {
     // Find common ancestor
     const baseSha = getMergeBase(candidate, sourceBranch)
@@ -1752,6 +1749,7 @@ function getPullRequestBaseBranch (pullRequestBaseBranch) {
       ahead,
       baseSha,
     }
+    hasMetrics = true
   }
 
   function isDefaultBranch (branch) {
@@ -1760,7 +1758,7 @@ function getPullRequestBaseBranch (pullRequestBaseBranch) {
     )
   }
 
-  if (Object.keys(metrics).length === 0) {
+  if (!hasMetrics) {
     return null
   }
   // Find branch with smallest "ahead" value, preferring default branch on tie
@@ -1786,6 +1784,7 @@ function getPullRequestDiff (baseCommit, targetCommit) {
 function getModifiedFilesFromDiff (diff) {
   if (!diff) return null
   const result = {}
+  let hasModifiedFiles = false
 
   const filesRegex = /^diff --git a\/(?<file>.+) b\/(?<file2>.+)$/g
   const linesRegex = /^@@ -\d+(,\d+)? \+(?<start>\d+)(,(?<count>\d+))? @@/g
@@ -1800,6 +1799,7 @@ function getModifiedFilesFromDiff (diff) {
     if (fileMatch && fileMatch.groups.file) {
       currentFile = fileMatch.groups.file
       result[currentFile] = []
+      hasModifiedFiles = true
       continue
     }
 
@@ -1818,7 +1818,7 @@ function getModifiedFilesFromDiff (diff) {
     linesRegex.lastIndex = 0
   }
 
-  if (Object.keys(result).length === 0) {
+  if (!hasModifiedFiles) {
     return null
   }
   return result

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -216,7 +216,7 @@ class AgentExporter extends EventSerializer {
             } else {
               // eslint-disable-next-line eslint-rules/eslint-log-printf-style
               log.debug(() => {
-                const bytes = (body.toString('hex').match(/../g) || []).join(' ')
+                const bytes = body.toString('hex').match(/../g)?.join(' ') ?? ''
                 return `Agent export response: ${bytes}`
               })
             }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -35,7 +35,7 @@ function profileHasMissingSourceMaps (profile) {
 }
 
 function processInfo (infos, info, type) {
-  if (Object.keys(info).length > 0) {
+  if (info !== undefined) {
     infos[type] = info
   }
 }

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -66,9 +66,7 @@ class NativeSpaceProfiler {
     return profile
   }
 
-  getInfo () {
-    return {}
-  }
+  getInfo () {}
 
   encode (profile) {
     return encodeProfileAsync(profile)

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -470,7 +470,7 @@ class NativeWallProfiler {
     if (rootSpanId !== undefined) {
       labels[LOCAL_ROOT_SPAN_ID_LABEL] = toBigInt(rootSpanId)
     }
-    if (webTags !== undefined && Object.keys(webTags).length !== 0) {
+    if (webTags !== undefined) {
       labels[TRACE_ENDPOINT_LABEL] = endpointNameFromTags(webTags)
     } else if (endpoint) {
       // fallback to endpoint computed when sample was taken

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -16,6 +16,7 @@ const origRequire = Module.prototype.require
 module.exports = Hook
 
 let moduleHooks = Object.create(null)
+let hookedModuleCount = 0
 let cache = Object.create(null)
 let patching = Object.create(null)
 let patchedRequire = null
@@ -74,6 +75,7 @@ function Hook (modules, options, onrequire) {
         hooks.push(onrequire)
       } else {
         moduleHooks[mod] = [onrequire]
+        hookedModuleCount++
       }
     }
   }
@@ -215,6 +217,7 @@ Hook.reset = function () {
   patching = Object.create(null)
   cache = Object.create(null)
   moduleHooks = Object.create(null)
+  hookedModuleCount = 0
 }
 
 function findProjectRoot (startDir) {
@@ -231,16 +234,20 @@ function findProjectRoot (startDir) {
 
 Hook.prototype.unhook = function () {
   for (const mod of this.modules) {
-    const hooks = (moduleHooks[mod] || []).filter(hook => hook !== this.onrequire)
+    const registeredHooks = moduleHooks[mod]
+    if (registeredHooks === undefined) continue
+
+    const hooks = registeredHooks.filter(hook => hook !== this.onrequire)
 
     if (hooks.length > 0) {
       moduleHooks[mod] = hooks
     } else {
       delete moduleHooks[mod]
+      hookedModuleCount--
     }
   }
 
-  if (Object.keys(moduleHooks).length === 0) {
+  if (hookedModuleCount === 0) {
     Hook.reset()
   }
 }

--- a/packages/dd-trace/src/sampling_rule.js
+++ b/packages/dd-trace/src/sampling_rule.js
@@ -180,8 +180,10 @@ class SamplingRule {
     if (resource) {
       this.matchers.push(matcher(resource, resourceLocator))
     }
-    for (const [key, value] of Object.entries(tags || {})) {
-      this.matchers.push(matcher(value, makeTagLocator(key)))
+    if (tags) {
+      for (const [key, value] of Object.entries(tags)) {
+        this.matchers.push(matcher(value, makeTagLocator(key)))
+      }
     }
 
     this._sampler = new Sampler(sampleRate)

--- a/packages/dd-trace/src/telemetry/telemetry.js
+++ b/packages/dd-trace/src/telemetry/telemetry.js
@@ -130,7 +130,7 @@ function updateRetryData (error, retryObj) {
 
 function getIntegrations () {
   const newIntegrations = /** @type {Integration[]} */ ([])
-  for (const pluginName of Object.keys(pluginManager._pluginsByName ?? {})) {
+  for (const pluginName of Object.keys(pluginManager._pluginsByName)) {
     if (!sentIntegrations.has(pluginName)) {
       newIntegrations.push({
         name: pluginName,

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -8,9 +8,11 @@ const msgpack = require('@msgpack/msgpack')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
+const { storage } = require('../../../datadog-core')
 const aiguardAutoInstrumentation = require('../../src/aiguard')
 const NoopAIGuard = require('../../src/aiguard/noop')
 const AIGuard = require('../../src/aiguard/sdk')
+const { withRequest } = require('../../src/appsec/store')
 const agent = require('../plugins/agent')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 
@@ -18,6 +20,7 @@ const tracerVersion = require('../../../../package.json').version
 const telemetryMetrics = require('../../src/telemetry/metrics')
 const aiguardMetrics = telemetryMetrics.manager.namespace('ai_guard')
 const { USER_KEEP } = require('../../../../ext/priority')
+const { HTTP_CLIENT_IP, NETWORK_CLIENT_IP } = require('../../../../ext/tags')
 const { SAMPLING_MECHANISM_AI_GUARD, DECISION_MAKER_KEY } = require('../../src/constants')
 const {
   EVENT_TAG_KEY,
@@ -498,6 +501,28 @@ describe('AIGuard SDK', () => {
           assert.ok(!Object.hasOwn(span.meta, EVENT_TAG_KEY), `Available keys: ${inspect(Object.keys(span.meta))}`)
         }
       }
+    })
+  })
+
+  it('copies the client ip of the active request onto the root span', async () => {
+    mockFetch({
+      body: { data: { attributes: { action: 'ALLOW', reason: 'OK', is_blocking_enabled: false } } },
+    })
+
+    const req = { headers: { 'x-forwarded-for': '8.8.8.8' }, socket: { remoteAddress: '10.0.0.1' } }
+    await tracer.trace('root', async () => {
+      const legacyStorage = storage('legacy')
+      await legacyStorage.run(withRequest(legacyStorage.getStore(), req), () =>
+        aiguard.evaluate(prompt, { block: false })
+      )
+    })
+
+    await agent.assertSomeTraces(traces => {
+      const rootSpan = traces[0].find(span => span.name === 'root')
+      assertObjectContains(rootSpan.meta, {
+        [HTTP_CLIENT_IP]: '8.8.8.8',
+        [NETWORK_CLIENT_IP]: '10.0.0.1',
+      })
     })
   })
 

--- a/packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js
+++ b/packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js
@@ -373,10 +373,18 @@ describe('parseSkippableSuitesResponse', () => {
     assert.deepStrictEqual(result, {
       skippableSuites: [{ suite: 'suite1.spec.js', name: 'test 1' }],
       correlationId: 'corr-123',
-      coverage: {},
+      coverage: undefined,
       numReceivedSkippableItems: 1,
       numExcludedByMissingLineCoverage: 0,
     })
+  })
+
+  it('leaves coverage undefined when the response carries none', () => {
+    const withoutCoverage = parseSkippableSuitesResponse(JSON.stringify({ data: [], meta: {} }))
+    const withEmptyCoverage = parseSkippableSuitesResponse(JSON.stringify({ data: [], meta: { coverage: {} } }))
+
+    assert.strictEqual(withoutCoverage.coverage, undefined)
+    assert.strictEqual(withEmptyCoverage.coverage, undefined)
   })
 
   it('filters missing line coverage when coverage report upload is enabled', () => {

--- a/packages/dd-trace/test/config/remote_config.spec.js
+++ b/packages/dd-trace/test/config/remote_config.spec.js
@@ -77,6 +77,34 @@ describe('Tracing Remote Config', () => {
         sinon.assert.calledOnce(onConfigUpdated)
       })
 
+      it('should reformat sampling rule tags into a plain object', () => {
+        enable(rc, config, onConfigUpdated)
+
+        const handler = batchHandlers.get('APM_TRACING')
+        const transaction = createTransaction([
+          {
+            id: 'config-1',
+            file: {
+              lib_config: {
+                tracing_sampling_rules: [
+                  { service: 'tagged', tags: [{ key: 'region', value_glob: 'eu-*' }] },
+                  { service: 'untagged' },
+                ],
+              },
+            },
+          },
+        ])
+
+        handler(transaction)
+
+        sinon.assert.calledOnceWithExactly(config.setRemoteConfig, {
+          samplingRules: [
+            { service: 'tagged', tags: { region: 'eu-*' } },
+            { service: 'untagged' },
+          ],
+        })
+      })
+
       it('should reset config on unapply action', () => {
         enable(rc, config, onConfigUpdated)
 

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -1457,6 +1457,7 @@ index 1234567..89abcde 100644
     assert.strictEqual(getModifiedFilesFromDiff(''), null)
     assert.strictEqual(getModifiedFilesFromDiff(null), null)
     assert.strictEqual(getModifiedFilesFromDiff(undefined), null)
+    assert.strictEqual(getModifiedFilesFromDiff('not a diff\n@@ -1 +1 @@\n'), null)
   })
 
   it('should handle multiple line changes in a single hunk', () => {
@@ -1602,6 +1603,21 @@ describe('getPullRequestBaseBranch', () => {
       sinon.assert.calledWith(getMergeBaseStub, 'trunk', 'feature-branch')
       sinon.assert.calledWith(getCountsStub, 'master', 'feature-branch')
       sinon.assert.calledWith(getCountsStub, 'trunk', 'feature-branch')
+    })
+
+    it('returns null when no candidate branch has a merge base', () => {
+      const { getPullRequestBaseBranch } = proxyquire('../../../src/plugins/util/test', {
+        './git': {
+          getGitRemoteName: () => 'origin',
+          getSourceBranch: () => 'feature-branch',
+          getMergeBase: sinon.stub().returns(undefined),
+          checkAndFetchBranch: sinon.stub(),
+          getLocalBranches: sinon.stub().returns(['trunk', 'master', 'feature-branch']),
+          getCounts: sinon.stub().returns({ ahead: 0, behind: 0 }),
+        },
+      })
+
+      assert.strictEqual(getPullRequestBaseBranch(), null)
     })
   })
 })

--- a/packages/dd-trace/test/ritm-tests/module-partially-unhooked.js
+++ b/packages/dd-trace/test/ritm-tests/module-partially-unhooked.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports.foo = 'foo'

--- a/packages/dd-trace/test/ritm-tests/module-sibling.js
+++ b/packages/dd-trace/test/ritm-tests/module-sibling.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports.foo = 'foo'

--- a/packages/dd-trace/test/ritm-tests/module-unhooked.js
+++ b/packages/dd-trace/test/ritm-tests/module-unhooked.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports.foo = 'foo'

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -149,4 +149,37 @@ describe('Ritm', () => {
       }
     }
   })
+
+  describe('unhook', () => {
+    /** @param {Record<string, unknown>} exports */
+    function markPatched (exports) {
+      exports.patched = true
+      return exports
+    }
+
+    it('removes the hook and leaves unrelated registrations intact', () => {
+      Hook(['./ritm-tests/module-sibling'], markPatched)
+      const hook = Hook(['./ritm-tests/module-unhooked'], markPatched)
+
+      hook.unhook()
+      hook.unhook()
+
+      assert.equal(require('./ritm-tests/module-unhooked').patched, undefined)
+      assert.equal(require('./ritm-tests/module-sibling').patched, true)
+    })
+
+    it('keeps the hooks a module still has registered', () => {
+      const hook = Hook(['./ritm-tests/module-partially-unhooked'], markPatched)
+      Hook(['./ritm-tests/module-partially-unhooked'], (exports) => {
+        exports.kept = true
+        return exports
+      })
+
+      hook.unhook()
+
+      const patchedModule = require('./ritm-tests/module-partially-unhooked')
+      assert.equal(patchedModule.patched, undefined)
+      assert.equal(patchedModule.kept, true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

`Object.entries(value ?? {})` and `for (const item of value ?? [])` allocate the
default plus the resulting array on every call that has nothing to traverse. Every
production site under `packages/*/src` now guards the loop with an `if`, or reads
through `?.` when it was a single call, and a `no-restricted-syntax` selector keeps
the shape from coming back.

Where the caller already guarantees a value — the jest coverage backfill, the
telemetry plugin map, the remote-config sampling-rule transformer — the default is
dropped rather than guarded.

A stored fallback (`const items = value ?? []`) stays legal: that is a value the
code keeps, not an allocation made to traverse nothing.

## Why

The rule only fires on defaults consumed in place, so it cannot be satisfied by
moving the `?? {}` one line up into a variable. Guarding also skips the work the
loop body would have done zero times, which is why the bedrock Converse extractors
and the router walker now bail before building their inputs.

Two extractors that the diff re-indents had no unit coverage at all (the bedrock
Converse request path, the remote-config sampling-rule transformer); both got cases
that cover the new guards from both sides.