### PR TITLE
fix(instrumentation): wrap Node builtins once across CommonJS and ESM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,19 @@ Composition is the default; inheritance only when ≤2 sibling types share a com
 - Don't use language/runtime features that are too new
 - **Guard breaking changes with version checks** using [`version.js`](./version.js) (e.g., `DD_MAJOR`)
 
+#### The supported Node.js range differs per release line
+
+`engines.node` is `>=22` on `master`, `>=18` on `v5.x`, so never hardcode a major in a runtime gate —
+derive it from `engines.node` + `nodeMaxMajor`, the source `src/guardrails/index.js` reads. Below the
+floor the guardrail aborts instrumentation entirely, yet CI still runs Node 18 and 20 on `master` so
+backports stay honest. A spec needing a live tracer must therefore skip outside the range, honouring
+`DD_INJECT_FORCE` as `withVersions` (`packages/dd-trace/test/setup/mocha.js`) does:
+
+```js
+const runtimeSupported = Boolean(process.env.DD_INJECT_FORCE) ||
+  semver.satisfies(process.version, `${engines.node} <${nodeMaxMajor}`)
+```
+
 ### Public TypeScript Types
 
 The repo carries two public TypeScript surfaces:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -722,6 +722,7 @@ export default [
       'integration-tests/**/*.js',
       'integration-tests/**/*.mjs',
       'packages/datadog-instrumentations/test/helpers/check-require-cache/**/*.js',
+      'packages/datadog-instrumentations/test/helpers/hook-module-views/**/*.js',
       'packages/datadog-plugin-net/test/epipe-crash/**/*.js',
       'packages/datadog-plugin-openai/test/no-init.js',
       'packages/dd-trace/test/custom-metrics-app.js',

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -6,6 +6,7 @@ const iitm = require('../../../dd-trace/src/iitm')
 const ritm = require('../../../dd-trace/src/ritm')
 const log = require('../../../dd-trace/src/log')
 const requirePackageJson = require('../../../dd-trace/src/require-package-json')
+const { isNodeBuiltinModuleName } = require('./shared-utils')
 
 /**
  * @param {string} moduleBaseDir
@@ -101,7 +102,23 @@ function Hook (modules, hookOptions, onrequire) {
       }
     }
 
-    const newExports = wrappedOnrequire(moduleExports, moduleName, moduleBaseDir, moduleVersion, isIitm)
+    // A builtin's named ESM exports are a second view of what `default` already points at, and
+    // `patched` cannot relate them because it keys on the object the hook ran against.
+    let newExports
+    if (defaultWrapResult && isNodeBuiltinModuleName(moduleName)) {
+      // Accessor exports are read, not skipped: `replaceGetter` leaves Node 20's `fs.opendir`
+      // an accessor, and Node's ESM facade resolved every export before handing us this view.
+      for (const key of Object.keys(defaultWrapResult)) {
+        const wrapped = defaultWrapResult[key]
+        const existing = moduleExports[key]
+        if (existing !== wrapped && existing !== undefined) {
+          moduleExports[key] = wrapped
+        }
+      }
+      newExports = moduleExports
+    } else {
+      newExports = wrappedOnrequire(moduleExports, moduleName, moduleBaseDir, moduleVersion, isIitm)
+    }
 
     if (defaultWrapResult && defaultExportAliases) {
       newExports.default = defaultWrapResult

--- a/packages/datadog-instrumentations/src/helpers/shared-utils.js
+++ b/packages/datadog-instrumentations/src/helpers/shared-utils.js
@@ -1,9 +1,48 @@
 'use strict'
 
+const { builtinModules } = require('node:module')
+
+/**
+ * @param {string} moduleName
+ */
+function stripNodePrefix (moduleName) {
+  return moduleName.startsWith('node:') ? moduleName.slice(5) : moduleName
+}
+
+const builtinModuleNames = new Set(builtinModules.map(stripNodePrefix))
+
+/**
+ * @param {string} moduleName
+ */
+function isNodeBuiltinModuleName (moduleName) {
+  return builtinModuleNames.has(stripNodePrefix(moduleName))
+}
+
+/**
+ * @param {string} moduleName
+ */
+function isBuiltinModuleName (moduleName) {
+  return moduleName === 'electron' || isNodeBuiltinModuleName(moduleName)
+}
+
+/**
+ * @param {string} moduleName
+ */
+function normalizeModuleName (moduleName) {
+  const stripped = stripNodePrefix(moduleName)
+  return builtinModuleNames.has(stripped) ? stripped : moduleName
+}
+
+/**
+ * @param {string} moduleName
+ */
 function isRelativeRequire (moduleName) {
   return moduleName.startsWith('./') || moduleName.startsWith('../')
 }
 
 module.exports = {
+  isBuiltinModuleName,
+  isNodeBuiltinModuleName,
   isRelativeRequire,
+  normalizeModuleName,
 }

--- a/packages/datadog-instrumentations/test/helpers/hook-module-views.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/hook-module-views.spec.js
@@ -35,6 +35,7 @@ const bootstrapModes = {
  * @typedef {object} ViewReport
  * @property {string} request
  * @property {number} publishes channel publishes the view produced for one operation
+ * @property {number} [getterPublishes] getter channel publishes for the view
  * @property {boolean} matchesFirstView whether the instrumented function is the same object
  * @property {boolean} [matchesOwnDefaultExport] ESM views only
  */
@@ -67,10 +68,16 @@ async function loadViews (nodeOptions, requests) {
 ;(runtimeSupported ? describe : describe.skip)('builtin instrumentation across CommonJS and ESM views', () => {
   for (const [mode, nodeOptions] of Object.entries(bootstrapModes)) {
     describe(`with ${mode}`, () => {
-      it('wraps url once when CommonJS loads it before ESM', async () => {
+      it('wraps url and its getters once when CommonJS loads it before ESM', async () => {
         assert.deepStrictEqual(await loadViews(nodeOptions, ['cjs:url', 'esm:node:url']), [
-          { request: 'cjs:url', publishes: 1, matchesFirstView: true },
-          { request: 'esm:node:url', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+          { request: 'cjs:url', publishes: 1, getterPublishes: 1, matchesFirstView: true },
+          {
+            request: 'esm:node:url',
+            publishes: 1,
+            getterPublishes: 1,
+            matchesFirstView: true,
+            matchesOwnDefaultExport: true,
+          },
         ])
       })
 

--- a/packages/datadog-instrumentations/test/helpers/hook-module-views.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/hook-module-views.spec.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFile } = require('node:child_process')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+const { promisify } = require('node:util')
+
+const { describe, it } = require('mocha')
+const semver = require('semver')
+
+const { engines, nodeMaxMajor } = require('../../../../package.json')
+
+const execFileAsync = promisify(execFile)
+
+// Outside its supported runtime range the tracer aborts instrumentation on purpose, so a child
+// process has nothing to report. `DD_INJECT_FORCE` overrides that, the same way `withVersions` does.
+const injectForce = process.env.DD_INJECT_FORCE
+const runtimeSupported = Boolean(injectForce) ||
+  semver.satisfies(process.version, `${engines.node} <${nodeMaxMajor}`)
+
+const repositoryRoot = path.resolve(__dirname, '../../../..')
+const fixture = path.join(__dirname, 'hook-module-views', 'load-order.js')
+
+const initPath = path.join(repositoryRoot, 'init.js')
+const moduleUrl = (name) => pathToFileURL(path.join(repositoryRoot, name)).href
+
+const bootstrapModes = {
+  'initialize.mjs': `--import ${moduleUrl('initialize.mjs')}`,
+  'init.js + loader-hook.mjs': `--require ${initPath} --loader ${moduleUrl('loader-hook.mjs')}`,
+  'register.js + init.js': `--import ${moduleUrl('register.js')} --require ${initPath}`,
+}
+
+/**
+ * @typedef {object} ViewReport
+ * @property {string} request
+ * @property {number} publishes channel publishes the view produced for one operation
+ * @property {boolean} matchesFirstView whether the instrumented function is the same object
+ * @property {boolean} [matchesOwnDefaultExport] ESM views only
+ */
+
+/**
+ * @param {string} nodeOptions
+ * @param {string[]} requests view specifiers such as `cjs:url` or `esm:node:url`
+ * @returns {Promise<ViewReport[]>}
+ */
+async function loadViews (nodeOptions, requests) {
+  // A bare environment keeps an instrumented shell (`OTEL_TRACES_EXPORTER`) and a developer's
+  // own `DD_*` settings out of the child, and keeps stdout to the fixture's JSON.
+  const { stdout, stderr } = await execFileAsync(process.execPath, [fixture, ...requests], {
+    cwd: repositoryRoot,
+    env: {
+      PATH: process.env.PATH,
+      DD_INJECT_FORCE: injectForce,
+      DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false',
+      DD_REMOTE_CONFIG_ENABLED: 'false',
+      DD_TRACE_STARTUP_LOGS: 'false',
+      NODE_OPTIONS: nodeOptions,
+    },
+  })
+
+  assert.doesNotMatch(stderr, /Error during ddtrace instrumentation/, stderr)
+
+  return JSON.parse(stdout)
+}
+
+;(runtimeSupported ? describe : describe.skip)('builtin instrumentation across CommonJS and ESM views', () => {
+  for (const [mode, nodeOptions] of Object.entries(bootstrapModes)) {
+    describe(`with ${mode}`, () => {
+      it('wraps url once when CommonJS loads it before ESM', async () => {
+        assert.deepStrictEqual(await loadViews(nodeOptions, ['cjs:url', 'esm:node:url']), [
+          { request: 'cjs:url', publishes: 1, matchesFirstView: true },
+          { request: 'esm:node:url', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+        ])
+      })
+
+      it('wraps crypto once when CommonJS loads it before ESM', async () => {
+        assert.deepStrictEqual(await loadViews(nodeOptions, ['cjs:crypto', 'esm:node:crypto']), [
+          { request: 'cjs:crypto', publishes: 1, matchesFirstView: true },
+          { request: 'esm:node:crypto', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+        ])
+      })
+
+      it('wraps vm once when ESM loads it before CommonJS', async () => {
+        assert.deepStrictEqual(await loadViews(nodeOptions, ['esm:node:vm', 'cjs:vm']), [
+          { request: 'esm:node:vm', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+          { request: 'cjs:vm', publishes: 1, matchesFirstView: true },
+        ])
+      })
+
+      it('wraps zlib once when ESM loads it before CommonJS', async () => {
+        assert.deepStrictEqual(await loadViews(nodeOptions, ['esm:node:zlib', 'cjs:zlib']), [
+          { request: 'esm:node:zlib', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+          { request: 'cjs:zlib', publishes: 1, matchesFirstView: true },
+        ])
+      })
+
+      it('wraps vm once across prefixed and unprefixed requests of every kind', async () => {
+        assert.deepStrictEqual(await loadViews(nodeOptions, ['cjs:vm', 'cjs:node:vm', 'esm:vm', 'esm:node:vm']), [
+          { request: 'cjs:vm', publishes: 1, matchesFirstView: true },
+          { request: 'cjs:node:vm', publishes: 1, matchesFirstView: true },
+          { request: 'esm:vm', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+          { request: 'esm:node:vm', publishes: 1, matchesFirstView: true, matchesOwnDefaultExport: true },
+        ])
+      })
+    })
+  }
+})

--- a/packages/datadog-instrumentations/test/helpers/hook-module-views/load-order.js
+++ b/packages/datadog-instrumentations/test/helpers/hook-module-views/load-order.js
@@ -13,8 +13,12 @@ const builtins = {
   },
   url: {
     channel: 'datadog:url:parse:finish',
+    getterChannel: 'datadog:url:getter:finish',
     probe: 'parse',
-    exercise: (view) => view.parse('https://www.datadoghq.com/path'),
+    exercise: (view) => {
+      const parsed = new view.URL('https://www.datadoghq.com/path')
+      parsed.host
+    },
   },
   vm: {
     channel: 'datadog:vm:run-script:start',
@@ -30,10 +34,12 @@ const builtins = {
 
 async function main () {
   const requests = process.argv.slice(2)
-  const { channel: channelName, probe, exercise } = builtins[requests[0].split(':').at(-1)]
+  const { channel: channelName, getterChannel, probe, exercise } = builtins[requests[0].split(':').at(-1)]
 
   let publishes = 0
+  let getterPublishes = 0
   channel(channelName).subscribe(() => { publishes++ })
+  if (getterChannel) channel(getterChannel).subscribe(() => { getterPublishes++ })
 
   const views = []
   for (const request of requests) {
@@ -44,12 +50,14 @@ async function main () {
   const report = []
   for (const [index, view] of views.entries()) {
     const before = publishes
+    const getterBefore = getterPublishes
     await exercise(view)
     const entry = {
       request: requests[index],
       publishes: publishes - before,
       matchesFirstView: view[probe] === views[0][probe],
     }
+    if (getterChannel) entry.getterPublishes = getterPublishes - getterBefore
     if (view.default !== undefined) {
       entry.matchesOwnDefaultExport = view.default[probe] === view[probe]
     }

--- a/packages/datadog-instrumentations/test/helpers/hook-module-views/load-order.js
+++ b/packages/datadog-instrumentations/test/helpers/hook-module-views/load-order.js
@@ -1,0 +1,63 @@
+'use strict'
+
+// Loads one Node builtin through every view named on the command line (`cjs:url`,
+// `esm:node:url`), exercises each once, and reports the result as JSON on stdout.
+
+const { channel } = require('../../../src/helpers/instrument')
+
+const builtins = {
+  crypto: {
+    channel: 'datadog:crypto:hashing:start',
+    probe: 'createHash',
+    exercise: (view) => view.createHash('sha256').update('a').digest('hex'),
+  },
+  url: {
+    channel: 'datadog:url:parse:finish',
+    probe: 'parse',
+    exercise: (view) => view.parse('https://www.datadoghq.com/path'),
+  },
+  vm: {
+    channel: 'datadog:vm:run-script:start',
+    probe: 'runInNewContext',
+    exercise: (view) => view.runInNewContext('1 + 1'),
+  },
+  zlib: {
+    channel: 'apm:zlib:operation:start',
+    probe: 'gzip',
+    exercise: (view) => new Promise((resolve) => view.gzip(Buffer.from('hello'), resolve)),
+  },
+}
+
+async function main () {
+  const requests = process.argv.slice(2)
+  const { channel: channelName, probe, exercise } = builtins[requests[0].split(':').at(-1)]
+
+  let publishes = 0
+  channel(channelName).subscribe(() => { publishes++ })
+
+  const views = []
+  for (const request of requests) {
+    const specifier = request.slice(request.indexOf(':') + 1)
+    views.push(request.startsWith('esm:') ? await import(specifier) : require(specifier))
+  }
+
+  const report = []
+  for (const [index, view] of views.entries()) {
+    const before = publishes
+    await exercise(view)
+    const entry = {
+      request: requests[index],
+      publishes: publishes - before,
+      matchesFirstView: view[probe] === views[0][probe],
+    }
+    if (view.default !== undefined) {
+      entry.matchesOwnDefaultExport = view.default[probe] === view[probe]
+    }
+    report.push(entry)
+  }
+
+  // The tracer's own timers keep the process alive, so exit once stdout has drained.
+  process.stdout.write(JSON.stringify(report), () => process.exit(0))
+}
+
+main()

--- a/packages/datadog-instrumentations/test/helpers/hook.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/hook.spec.js
@@ -53,6 +53,77 @@ describe('Hook', () => {
     assert.strictEqual(wrapped.default, wrapped)
   })
 
+  it('wraps a builtin once and mirrors the result onto its named ESM exports', () => {
+    const original = sinon.stub()
+    const wrapped = sinon.stub()
+    const cjsExports = { parse: original }
+    const namespace = { default: cjsExports, parse: original }
+    const onrequire = sinon.stub().callsFake(() => {
+      cjsExports.parse = wrapped
+      return cjsExports
+    })
+
+    Hook(['url'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'url', undefined), namespace)
+    assert.strictEqual(namespace.parse, wrapped)
+    sinon.assert.calledOnceWithExactly(onrequire, cjsExports, 'url', undefined, process.version, true)
+  })
+
+  it('leaves a builtin export the ESM view does not carry', () => {
+    const cjsExports = { parse: sinon.stub() }
+    const namespace = { default: cjsExports }
+    const onrequire = sinon.stub().returns(cjsExports)
+
+    Hook(['url'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'url', undefined), namespace)
+    assert.deepStrictEqual(Object.keys(namespace), ['default'])
+  })
+
+  it('mirrors an accessor-backed builtin export, as `replaceGetter` leaves behind', () => {
+    const wrapped = sinon.stub()
+    const cjsExports = {}
+    Object.defineProperty(cjsExports, 'opendir', { get: () => wrapped, enumerable: true, configurable: true })
+    const namespace = { default: cjsExports, opendir: sinon.stub() }
+    const onrequire = sinon.stub().returns(cjsExports)
+
+    Hook(['fs'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'fs', undefined), namespace)
+    assert.strictEqual(namespace.opendir, wrapped)
+  })
+
+  it('leaves electron to the regular hook, since it is not a Node builtin', () => {
+    const cjsExports = { app: sinon.stub() }
+    const namespace = { default: cjsExports, app: cjsExports.app }
+    const onrequire = sinon.stub().returns(cjsExports)
+
+    Hook(['electron'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'electron', undefined), cjsExports)
+    sinon.assert.calledTwice(onrequire)
+  })
+
+  it('rebinds a builtin ESM view when the hook replaces the default export', () => {
+    const original = sinon.stub()
+    const replacement = { parse: sinon.stub() }
+    const cjsExports = { parse: original }
+    const namespace = { default: cjsExports, parse: original }
+    const onrequire = sinon.stub().returns(replacement)
+
+    Hook(['url'], onrequire)
+
+    const hook = iitm.args[0][2]
+    assert.strictEqual(hook(namespace, 'url', undefined), namespace)
+    assert.strictEqual(namespace.default, replacement)
+    assert.strictEqual(namespace.parse, replacement.parse)
+  })
+
   it('does not inspect named ESM exports when the default export is unchanged', () => {
     const original = sinon.stub()
     const ownKeys = sinon.stub().returns(['default', 'named'])

--- a/packages/datadog-instrumentations/test/helpers/shared-utils.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/shared-utils.spec.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const {
+  isBuiltinModuleName,
+  isNodeBuiltinModuleName,
+  normalizeModuleName,
+} = require('../../src/helpers/shared-utils')
+
+describe('shared-utils', () => {
+  describe('isNodeBuiltinModuleName', () => {
+    it('accepts builtins with and without the node: prefix', () => {
+      assert.strictEqual(isNodeBuiltinModuleName('url'), true)
+      assert.strictEqual(isNodeBuiltinModuleName('node:url'), true)
+      assert.strictEqual(isNodeBuiltinModuleName('dns/promises'), true)
+    })
+
+    it('rejects electron, which Node does not resolve as a builtin', () => {
+      assert.strictEqual(isNodeBuiltinModuleName('electron'), false)
+    })
+
+    it('rejects packages and paths that merely look builtin', () => {
+      assert.strictEqual(isNodeBuiltinModuleName('express'), false)
+      assert.strictEqual(isNodeBuiltinModuleName('node:express'), false)
+      assert.strictEqual(isNodeBuiltinModuleName('url-parse'), false)
+      assert.strictEqual(isNodeBuiltinModuleName('/app/node_modules/url/index.js'), false)
+    })
+  })
+
+  describe('isBuiltinModuleName', () => {
+    it('accepts electron, which a packaged binary resolves without a package directory', () => {
+      assert.strictEqual(isBuiltinModuleName('electron'), true)
+      assert.strictEqual(isBuiltinModuleName('url'), true)
+      assert.strictEqual(isBuiltinModuleName('express'), false)
+    })
+  })
+
+  describe('normalizeModuleName', () => {
+    it('strips the node: prefix from a builtin', () => {
+      assert.strictEqual(normalizeModuleName('node:url'), 'url')
+      assert.strictEqual(normalizeModuleName('url'), 'url')
+    })
+
+    it('keeps a name that is not a prefixable builtin', () => {
+      assert.strictEqual(normalizeModuleName('electron'), 'electron')
+      assert.strictEqual(normalizeModuleName('node:express'), 'node:express')
+    })
+  })
+})

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -7,7 +7,11 @@ const Module = require('module')
 const dc = require('dc-polyfill')
 
 const parse = require('../../../vendor/dist/module-details-from-path')
-const { isRelativeRequire } = require('../../datadog-instrumentations/src/helpers/shared-utils')
+const {
+  isBuiltinModuleName,
+  isRelativeRequire,
+  normalizeModuleName,
+} = require('../../datadog-instrumentations/src/helpers/shared-utils')
 const { getConfiguredEnvName, getEnvironmentVariable } = require('./config/helper')
 
 const origRequire = Module.prototype.require
@@ -21,25 +25,6 @@ let patching = Object.create(null)
 let patchedRequire = null
 const moduleLoadStartChannel = dc.channel('dd-trace:moduleLoadStart')
 const moduleLoadEndChannel = dc.channel('dd-trace:moduleLoadEnd')
-
-function stripNodePrefix (name) {
-  if (typeof name !== 'string') return name
-  return name.startsWith('node:') ? name.slice(5) : name
-}
-
-const builtinModules = new Set(Module.builtinModules.map(stripNodePrefix))
-
-function isBuiltinModuleName (name) {
-  if (typeof name !== 'string') return false
-  if (name === 'electron') return true
-  return builtinModules.has(stripNodePrefix(name))
-}
-
-function normalizeModuleName (name) {
-  if (typeof name !== 'string') return name
-  const stripped = stripNodePrefix(name)
-  return builtinModules.has(stripped) ? stripped : name
-}
 
 /**
  * @overload


### PR DESCRIPTION
## Summary

Loading a Node builtin through both `require` and `import` could instrument separate module views, stacking wrappers. This caused duplicate events/spans, divergent function identities, and URL instrumentation failures from wrapping native getters twice.

## Why

Builtin ESM named exports are another view of the implementation exposed through `default`. The hook now mirrors already-wrapped values instead of running instrumentation twice, with regression coverage for load order, prefixes, and bootstrap modes.