### PR TITLE
test(jest): gather multiproject payloads until the child exits

### DIFF
--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -735,7 +735,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       })
     })
 
-    it('works with multi project setup and test skipping', (done) => {
+    it('works with multi project setup and test skipping', async () => {
       const projects = ['standard', 'node'].map(displayName => ({
         displayName,
         rootDir: 'ci-visibility/test',
@@ -762,24 +762,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         'ci-visibility/test/ci-visibility-test.js': getLinesBitmapBase64(1, 20),
       })
 
-      const eventsPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          // suites for both projects in the multi-project config are reported as skipped
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
-
-          const skippedSuites = testSuites.filter(
-            suite => suite.resource === 'test_suite.ci-visibility/test/ci-visibility-test.js'
-          )
-          assert.strictEqual(skippedSuites.length, 2)
-
-          skippedSuites.forEach(skippedSuite => {
-            assert.strictEqual(skippedSuite.meta[TEST_STATUS], 'skip')
-            assert.strictEqual(skippedSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
-          })
-        })
-
       childProcess = exec(
         'node ./node_modules/jest/bin/jest --config config-jest.js',
         {
@@ -791,11 +773,29 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         }
       )
 
-      childProcess.on('exit', () => {
-        eventsPromise.then(() => {
-          done()
-        }).catch(done)
-      })
+      await receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            // suites for both projects in the multi-project config are reported as skipped
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+
+            const skippedSuites = testSuites.filter(
+              suite => suite.resource === 'test_suite.ci-visibility/test/ci-visibility-test.js'
+            )
+            assert.strictEqual(skippedSuites.length, 2)
+
+            skippedSuites.forEach(skippedSuite => {
+              assert.strictEqual(skippedSuite.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(skippedSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
+            })
+          }
+        )
+
+      assert.strictEqual(childProcess.exitCode, 0)
     })
 
     it('does not run coverage reporters when TIA forces coverage collection', async () => {


### PR DESCRIPTION
## Summary

The multiproject test-skipping case in `jest.tia-efd.spec.js` now collects intake
payloads until the Jest child exits instead of for a fixed 15 s window, and
asserts the child's exit code.

## Why

The fixed window let the assertion run before the two skipped-suite payloads
arrived — a slow Jest start or a request that was still draining produced
`0 !== 2`. Tying the collection to the process it asserts on removes the race,
and the exit-code assertion keeps a child that died before reporting anything
from passing silently.