### PR TITLE
test(test-optimization): set the API key on the config the exporter reads

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -16,6 +16,7 @@ const proxyquire = require('proxyquire')
 const { assertObjectContains } = require('../../../../../integration-tests/helpers')
 const { version: tracerVersion } = require('../../../../../package.json')
 require('../../../../dd-trace/test/setup/core')
+const getConfig = require('../../../src/config')
 const { defaults: { hostname, port } } = require('../../../src/config/defaults')
 const ciVisibilityLog = require('../../../src/log')
 const { uploadCoverageReport: actualUploadCoverageReportRequest } =
@@ -40,17 +41,21 @@ class CiVisibilityExporter extends CiVisibilityExporterBase {
 
 describe('CI Visibility Exporter', () => {
   const url = new URL(`http://${hostname}:${port}`)
+  let originalApiKey
 
   beforeEach(() => {
     // to make sure `isShallowRepository` in `git.js` returns false
     sinon.stub(cp, 'execFileSync').returns('false')
     sinon.stub(fs, 'readFileSync').returns('')
-    process.env.DD_API_KEY = '1'
+    const config = getConfig()
+    originalApiKey = config.DD_API_KEY
+    config.DD_API_KEY = '1'
     nock.cleanAll()
     uploadCoverageReportRequest = actualUploadCoverageReportRequest
   })
 
   afterEach(() => {
+    getConfig().DD_API_KEY = originalApiKey
     sinon.restore()
   })
 


### PR DESCRIPTION
## Summary

`getConfig()` memoizes the `Config` instance on its first call, so the `beforeEach`
in `ci-visibility-exporter.spec.js` writing `process.env.DD_API_KEY` was only
visible while that spec was the first thing in the process to build it. Sibling
specs build the singleton too, some of them while mocha collects files. After any
of those the exporter sees no API key, so every request path that needs a
`dd-api-key` header bails out with "… because Datadog API key is not defined."
before sending: the nock interceptors never fire, and `getKnownTests` hands an
error to a spec asserting a null one. Under `allowUncaught` that assertion crashes
the run before mocha prints a summary.

Setting the key on the config the exporter actually reads, and restoring the
previous value in `afterEach`, makes the spec independent of run order and stops
it leaving the key set for everything that runs after it.

## Why

`npm run test:trace:core` shards spec files across child processes, so the defect
never surfaces in CI. It reproduces in one process with, for example:

    ./node_modules/.bin/mocha \
      packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js \
      packages/dd-trace/test/plugins/util/test.spec.js