### PR TITLE
fix(test-optimization): detect swapped directories when inode numbers exceed 2^53

### DIFF
--- a/ci/test-optimization-validation/command-output-policy.js
+++ b/ci/test-optimization-validation/command-output-policy.js
@@ -71,21 +71,21 @@ function cleanupCommandOutputs (states) {
  *
  * @param {string} outputPath output path
  * @param {string} repositoryRoot repository root
- * @returns {{path: string, dev: number, ino: number}[]} parent identities
+ * @returns {{path: string, dev: bigint, ino: bigint}[]} parent identities
  */
 function captureExistingParentIdentities (outputPath, repositoryRoot) {
   const identities = []
   const relative = path.relative(repositoryRoot, path.dirname(outputPath))
   let current = repositoryRoot
   for (const segment of relative ? relative.split(path.sep) : []) {
-    const stat = fs.lstatSync(current)
+    const stat = fs.lstatSync(current, { bigint: true })
     assertRegularDirectory(stat, current)
     identities.push({ path: current, dev: stat.dev, ino: stat.ino })
     current = path.join(current, segment)
     if (!pathExists(current)) return identities
   }
 
-  const stat = fs.lstatSync(current)
+  const stat = fs.lstatSync(current, { bigint: true })
   assertRegularDirectory(stat, current)
   identities.push({ path: current, dev: stat.dev, ino: stat.ino })
   return identities
@@ -98,7 +98,7 @@ function captureExistingParentIdentities (outputPath, repositoryRoot) {
  */
 function assertOutputParentsUnchanged (state) {
   for (const identity of state.parentIdentities) {
-    const stat = fs.lstatSync(identity.path)
+    const stat = fs.lstatSync(identity.path, { bigint: true })
     assertRegularDirectory(stat, identity.path)
     if (stat.dev !== identity.dev || stat.ino !== identity.ino) {
       throw new Error(`Refusing command output cleanup because a parent directory changed: ${identity.path}`)
@@ -118,7 +118,7 @@ function assertOutputParentsUnchanged (state) {
 /**
  * Refuses symbolic links and non-directory parent components.
  *
- * @param {fs.Stats} stat path status
+ * @param {fs.Stats | fs.BigIntStats} stat path status
  * @param {string} directory directory path
  */
 function assertRegularDirectory (stat, directory) {

--- a/ci/test-optimization-validation/generated-files.js
+++ b/ci/test-optimization-validation/generated-files.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const {
   MAX_GENERATED_FILES,
@@ -251,7 +251,7 @@ function forgetWrittenGeneratedFiles (filenames) {
 function authorizePathForCleanup (root, filename) {
   const lexicalRoot = path.resolve(root)
   const physicalRoot = fs.realpathSync(lexicalRoot)
-  const rootStat = fs.statSync(physicalRoot)
+  const rootStat = fs.statSync(physicalRoot, { bigint: true })
   const authorization = {
     lexicalRoot,
     physicalRoot,
@@ -276,7 +276,7 @@ function pinCleanupParent (authorization, filename) {
   try {
     const physicalParent = fs.realpathSync(path.dirname(filename))
     if (!isPathInside(authorization.physicalRoot, physicalParent)) return
-    const parentStat = fs.statSync(physicalParent)
+    const parentStat = fs.statSync(physicalParent, { bigint: true })
     authorization.physicalParent = physicalParent
     authorization.parentDevice = parentStat.dev
     authorization.parentInode = parentStat.ino
@@ -285,7 +285,7 @@ function pinCleanupParent (authorization, filename) {
 
 function pinCleanupTarget (authorization, filename) {
   try {
-    const targetStat = fs.lstatSync(filename)
+    const targetStat = fs.lstatSync(filename, { bigint: true })
     authorization.targetDevice = targetStat.dev
     authorization.targetInode = targetStat.ino
   } catch {}
@@ -294,7 +294,7 @@ function pinCleanupTarget (authorization, filename) {
 function isCleanupAuthorizationValid (filename, authorization) {
   try {
     const currentPhysicalRoot = fs.realpathSync(authorization.lexicalRoot)
-    const rootStat = fs.statSync(currentPhysicalRoot)
+    const rootStat = fs.statSync(currentPhysicalRoot, { bigint: true })
     if (currentPhysicalRoot !== authorization.physicalRoot ||
       rootStat.dev !== authorization.rootDevice || rootStat.ino !== authorization.rootInode) {
       return false
@@ -302,14 +302,14 @@ function isCleanupAuthorizationValid (filename, authorization) {
 
     if (authorization.physicalParent === undefined) return false
     const physicalParent = fs.realpathSync(path.dirname(filename))
-    const parentStat = fs.statSync(physicalParent)
+    const parentStat = fs.statSync(physicalParent, { bigint: true })
     if (physicalParent !== authorization.physicalParent ||
       parentStat.dev !== authorization.parentDevice || parentStat.ino !== authorization.parentInode) {
       return false
     }
 
     if (authorization.targetDevice !== undefined) {
-      const targetStat = fs.lstatSync(filename)
+      const targetStat = fs.lstatSync(filename, { bigint: true })
       if (targetStat.dev !== authorization.targetDevice || targetStat.ino !== authorization.targetInode) {
         return false
       }

--- a/ci/test-optimization-validation/offline-output.js
+++ b/ci/test-optimization-validation/offline-output.js
@@ -57,8 +57,8 @@ function readOfflineOutput (outputRoot) {
   if (!exporterInitialized) return emptyOutput()
 
   const state = {
-    bytes: 0,
-    completionBytes: 0,
+    bytes: 0n,
+    completionBytes: 0n,
     decodedEntries: 0,
     files: 0,
   }
@@ -150,7 +150,7 @@ function readPayloadFiles (payloadsRoot, kind, state, consume) {
 }
 
 function readRegularFile (filename, individualLimit, state, completion) {
-  const stat = fs.lstatSync(filename)
+  const stat = fs.lstatSync(filename, { bigint: true })
   if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink > 1) {
     throw new Error('Offline validation artifact must be a regular, unlinked file.')
   }
@@ -163,16 +163,16 @@ function readRegularFile (filename, individualLimit, state, completion) {
 
   const file = fs.openSync(filename, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0))
   try {
-    const opened = fs.fstatSync(file)
+    const opened = fs.fstatSync(file, { bigint: true })
     if (!opened.isFile() || opened.nlink > 1 || opened.dev !== stat.dev || opened.ino !== stat.ino) {
       throw new Error('Offline validation artifact changed while it was opened.')
     }
     const buffer = fs.readFileSync(file)
-    const completed = fs.fstatSync(file)
+    const completed = fs.fstatSync(file, { bigint: true })
     if (completed.size !== opened.size || completed.mtimeMs !== opened.mtimeMs) {
       throw new Error('Offline validation artifact changed while it was read.')
     }
-    state[totalKey] += buffer.length
+    state[totalKey] += BigInt(buffer.length)
     return buffer
   } finally {
     fs.closeSync(file)

--- a/ci/test-optimization-validation/safe-files.js
+++ b/ci/test-optimization-validation/safe-files.js
@@ -129,10 +129,10 @@ function openAndWrite (root, filename, data, label, creationFlag) {
  *
  * @param {string} directory directory path
  * @param {string} label customer-facing path label
- * @returns {{dev: number, ino: number}} directory identity
+ * @returns {{dev: bigint, ino: bigint}} directory identity
  */
 function getDirectoryIdentity (directory, label) {
-  const stat = fs.lstatSync(directory)
+  const stat = fs.lstatSync(directory, { bigint: true })
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new Error(`Refusing ${label} because its parent is not a regular directory: ${directory}`)
   }
@@ -143,7 +143,7 @@ function getDirectoryIdentity (directory, label) {
  * Refuses replacement of a parent directory between safe creation and publication.
  *
  * @param {string} directory directory path
- * @param {{dev: number, ino: number}} expected expected identity
+ * @param {{dev: bigint, ino: bigint}} expected expected identity
  * @param {string} label customer-facing path label
  */
 function assertDirectoryIdentity (directory, expected, label) {
@@ -158,7 +158,7 @@ function assertDirectoryIdentity (directory, expected, label) {
  *
  * @param {string} filename temporary filename
  * @param {string} parent expected parent directory
- * @param {{dev: number, ino: number}} parentIdentity expected parent identity
+ * @param {{dev: bigint, ino: bigint}} parentIdentity expected parent identity
  */
 function removeTemporaryFile (filename, parent, parentIdentity) {
   try {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-validation/sink.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-validation/sink.js
@@ -303,10 +303,11 @@ function writeNewFile (filename, payload) {
  *
  * @param {string} directory directory path
  * @param {string} label directory label
- * @returns {{dev: number, ino: number}} stable directory identity
+ * @returns {{dev: bigint, ino: bigint}} stable directory identity
  */
 function captureDirectory (directory, label) {
-  const stat = fs.lstatSync(directory)
+  // Windows file reference numbers exceed 2^53, where distinct directories round to one number.
+  const stat = fs.lstatSync(directory, { bigint: true })
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new Error(`Offline Test Optimization validation ${label} must be a regular directory.`)
   }
@@ -317,10 +318,10 @@ function captureDirectory (directory, label) {
  * Creates or validates one child directory without accepting symbolic links.
  *
  * @param {string} parent parent directory path
- * @param {{dev: number, ino: number}} parentIdentity expected parent identity
+ * @param {{dev: bigint, ino: bigint}} parentIdentity expected parent identity
  * @param {string} directory child directory path
  * @param {string} label directory label
- * @returns {{dev: number, ino: number}} stable child identity
+ * @returns {{dev: bigint, ino: bigint}} stable child identity
  */
 function createDirectory (parent, parentIdentity, directory, label) {
   assertDirectoryUnchanged(parent, parentIdentity, 'parent output')
@@ -336,7 +337,7 @@ function createDirectory (parent, parentIdentity, directory, label) {
  * Rejects a directory that changed after sink construction.
  *
  * @param {string} directory directory path
- * @param {{dev: number, ino: number}} identity expected directory identity
+ * @param {{dev: bigint, ino: bigint}} identity expected directory identity
  * @param {string} label directory label
  */
 function assertDirectoryUnchanged (directory, identity, label) {
@@ -351,7 +352,7 @@ function assertDirectoryUnchanged (directory, identity, label) {
  *
  * @param {string} filename partial payload path
  * @param {string} directory expected parent directory
- * @param {{dev: number, ino: number}} identity expected parent identity
+ * @param {{dev: bigint, ino: bigint}} identity expected parent identity
  */
 function removePartialFile (filename, directory, identity) {
   try {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js
@@ -11,6 +11,7 @@ const path = require('node:path')
 
 const msgpack = require('@msgpack/msgpack')
 const { afterEach, beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('../../setup/core')
@@ -26,6 +27,7 @@ const { CiValidationSink, MAX_OUTPUT_FILES, SUMMARY_PREFIX } =
   require('../../../src/ci-visibility/exporters/ci-validation/sink')
 const CiValidationWriter = require('../../../src/ci-visibility/exporters/ci-validation/writer')
 const CiValidationExporter = require('../../../src/ci-visibility/exporters/ci-validation')
+const { createWindowsFileReferenceFs } = require('../validation-test-helpers')
 
 const VALIDATION_MANIFEST_ENV = '_DD_TEST_OPTIMIZATION_VALIDATION_MANIFEST_FILE'
 const VALIDATION_OUTPUT_ENV = '_DD_TEST_OPTIMIZATION_VALIDATION_OUTPUT_DIR'
@@ -134,6 +136,28 @@ describe('CI validation offline output', () => {
     writer.flush()
     sink.writeSummary()
 
+    assert.strictEqual(process.exitCode, 1)
+    const summary = JSON.parse(stderrWrite.firstCall.args[0].slice(SUMMARY_PREFIX.length))
+    assert.deepStrictEqual(summary.errors, ['output_write_failed'])
+  })
+
+  it('fails closed when a swapped payload directory reuses a file reference above 2^53', () => {
+    const { CiValidationSink: WindowsCiValidationSink } =
+      proxyquire('../../../src/ci-visibility/exporters/ci-validation/sink', {
+        'node:fs': createWindowsFileReferenceFs(),
+      })
+
+    const sink = new WindowsCiValidationSink(outputRoot)
+    const writer = new CiValidationWriter({ sink, tags: {} })
+    const testsDirectory = path.join(outputRoot, 'payloads', 'tests')
+    fs.renameSync(testsDirectory, `${testsDirectory}-original`)
+    fs.mkdirSync(testsDirectory)
+
+    writer.append([createTestSpan()])
+    writer.flush()
+    sink.writeSummary()
+
+    assert.strictEqual(getPayloadFiles(outputRoot, 'tests').length, 0)
     assert.strictEqual(process.exitCode, 1)
     const summary = JSON.parse(stderrWrite.firstCall.args[0].slice(SUMMARY_PREFIX.length))
     assert.deepStrictEqual(summary.errors, ['output_write_failed'])

--- a/packages/dd-trace/test/ci-visibility/generated-files.spec.js
+++ b/packages/dd-trace/test/ci-visibility/generated-files.spec.js
@@ -5,11 +5,14 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
+const proxyquire = require('proxyquire')
+
 const {
   cleanupGeneratedFiles,
   cleanupGeneratedRuntimeFiles,
   writeGeneratedFiles,
 } = require('../../../../ci/test-optimization-validation/generated-files')
+const { createWindowsFileReferenceFs } = require('./validation-test-helpers')
 
 describe('test optimization validation generated files', () => {
   it('allows existing generated files when the content matches', () => {
@@ -269,6 +272,30 @@ describe('test optimization validation generated files', () => {
       assert.strictEqual(cleanup.filesRetained, 1)
       assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'customer replacement\n')
       assert.strictEqual(fs.existsSync(original), true)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('retains a replaced generated file that reuses a file reference above 2^53', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-generated-files-windows-'))
+    const filename = path.join(root, 'dd-test-optimization-validation.test.js')
+    const original = path.join(root, 'original-generated.test.js')
+    const framework = getFramework(root, filename)
+    const windowsGeneratedFiles = proxyquire('../../../../ci/test-optimization-validation/generated-files', {
+      'node:fs': createWindowsFileReferenceFs(),
+    })
+
+    try {
+      windowsGeneratedFiles.writeGeneratedFiles(framework)
+      fs.renameSync(filename, original)
+      fs.writeFileSync(filename, 'customer replacement\n')
+
+      const cleanup = windowsGeneratedFiles.cleanupGeneratedFiles({ frameworks: [framework] })
+
+      assert.strictEqual(cleanup.status, 'incomplete')
+      assert.strictEqual(cleanup.filesRetained, 1)
+      assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'customer replacement\n')
     } finally {
       fs.rmSync(root, { recursive: true, force: true })
     }

--- a/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
@@ -25,6 +25,7 @@ const { getBasicCommand } = require('../../../../ci/test-optimization-validation
 const {
   createLoadedManifest,
   createRepositoryFixture,
+  createWindowsFileReferenceFs,
   removeFixture,
 } = require('./validation-test-helpers')
 
@@ -402,6 +403,50 @@ describe('test optimization validation execution boundary', () => {
       expectedCommand
     )
     assert.match(withCiPreloads('', framework).replaceAll('\\', '/'), /dd-trace-js\/ci\/init\.js/)
+  })
+
+  it('refuses command output cleanup when a parent is swapped and reuses a file reference above 2^53', () => {
+    const { cleanupCommandOutputs, prepareCommandOutputs } =
+      proxyquire('../../../../ci/test-optimization-validation/command-output-policy', {
+        'node:fs': createWindowsFileReferenceFs(),
+      })
+    const outputParent = path.join(fixture.root, 'command-output')
+    fs.mkdirSync(outputParent)
+    const states = prepareCommandOutputs({
+      artifactRoot: out,
+      command: { cwd: fixture.root, outputPaths: [path.join(outputParent, 'result.json')] },
+      repositoryRoot: fixture.root,
+    })
+
+    fs.renameSync(outputParent, `${outputParent}-original`)
+    fs.mkdirSync(outputParent)
+
+    assert.throws(() => cleanupCommandOutputs(states), /parent directory changed/)
+  })
+
+  it('refuses to publish a report when its parent is swapped and reuses a file reference above 2^53', () => {
+    const parent = path.join(fixture.root, 'safe-write')
+    fs.mkdirSync(parent)
+    let swapped = false
+    const { writeFileSafely } = proxyquire('../../../../ci/test-optimization-validation/safe-files', {
+      'node:fs': createWindowsFileReferenceFs({
+        openSync: (...args) => {
+          const file = fs.openSync(...args)
+          if (!swapped) {
+            swapped = true
+            fs.renameSync(parent, `${parent}-original`)
+            fs.mkdirSync(parent)
+          }
+          return file
+        },
+      }),
+    })
+
+    assert.throws(
+      () => writeFileSafely(fixture.root, path.join(parent, 'report.json'), '{}', 'validation report'),
+      /parent directory changed during the write/
+    )
+    assert.strictEqual(swapped, true)
   })
 
   /**

--- a/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
@@ -430,14 +430,15 @@ describe('test optimization validation execution boundary', () => {
     let swapped = false
     const { writeFileSafely } = proxyquire('../../../../ci/test-optimization-validation/safe-files', {
       'node:fs': createWindowsFileReferenceFs({
-        openSync: (...args) => {
-          const file = fs.openSync(...args)
+        // Windows refuses to rename a directory that still holds an open handle, so the swap waits
+        // until the temporary file is closed.
+        closeSync: (file) => {
+          fs.closeSync(file)
           if (!swapped) {
             swapped = true
             fs.renameSync(parent, `${parent}-original`)
             fs.mkdirSync(parent)
           }
-          return file
         },
       }),
     })

--- a/packages/dd-trace/test/ci-visibility/validation-test-helpers.js
+++ b/packages/dd-trace/test/ci-visibility/validation-test-helpers.js
@@ -7,6 +7,8 @@ const path = require('node:path')
 const { createManifestScaffold } = require('../../../../ci/test-optimization-validation/manifest-scaffold')
 const { loadManifest } = require('../../../../ci/test-optimization-validation/manifest-loader')
 
+const WINDOWS_SEQUENCE_NUMBER = 1024n
+
 const FRAMEWORKS = {
   cucumber: {
     bin: 'cucumber-js',
@@ -121,9 +123,44 @@ function removeFixture (root) {
   fs.rmSync(root, { force: true, recursive: true })
 }
 
+/**
+ * Emulates a volume whose file reference numbers carry a Windows sequence number above the 48-bit
+ * file index, so distinct paths round to one number outside the safe integer range.
+ *
+ * @param {Partial<import('node:fs')>} [overrides] further `node:fs` members to replace
+ * @returns {Partial<import('node:fs')>} `node:fs` replacement for proxyquire
+ */
+function createWindowsFileReferenceFs (overrides) {
+  const references = new Map()
+
+  /**
+   * @param {import('node:fs').Stats | import('node:fs').BigIntStats} stat real path status
+   * @param {boolean} [bigint] whether the caller asked for bigint values
+   */
+  const toWindowsStat = (stat, bigint) => {
+    const key = String(stat.ino)
+    if (!references.has(key)) {
+      references.set(key, (WINDOWS_SEQUENCE_NUMBER << 48n) + BigInt(references.size))
+    }
+    const reference = references.get(key)
+    const windowsStat = { ...stat, ino: bigint ? reference : Number(reference) }
+    windowsStat.isDirectory = () => stat.isDirectory()
+    windowsStat.isFile = () => stat.isFile()
+    windowsStat.isSymbolicLink = () => stat.isSymbolicLink()
+    return windowsStat
+  }
+
+  return {
+    lstatSync: (target, options) => toWindowsStat(fs.lstatSync(target, options), options?.bigint),
+    statSync: (target, options) => toWindowsStat(fs.statSync(target, options), options?.bigint),
+    ...overrides,
+  }
+}
+
 module.exports = {
   FRAMEWORKS,
   createLoadedManifest,
   createRepositoryFixture,
+  createWindowsFileReferenceFs,
   removeFixture,
 }


### PR DESCRIPTION
## Summary
Windows reports 64-bit file reference numbers in `fs.Stats.ino`, but Node exposes number-typed stat values with precision loss above 2^53. Distinct swapped directories could therefore compare equal, allowing payload writes or cleanup to operate on paths no longer owned by the validator.

The validation filesystem guards now compare full-precision BigInt identities, with regression coverage for payload output, command output cleanup, generated files, and offline artifact reads.

## Why
The `tracing-windows` job failed when a replaced `payloads/tests` directory was not detected. Preserving the complete Windows file reference prevents that failure and keeps the validator fail-closed.
