### PR TITLE
test(test-optimization): make preload path assertion portable

### DIFF
--- a/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-execution-phases.spec.js
@@ -401,7 +401,7 @@ describe('test optimization validation execution boundary', () => {
       serializeApprovalCommand({ argv: ['/path with spaces/node', 'a\'b', '--flag'] }),
       expectedCommand
     )
-    assert.match(withCiPreloads('', framework).replaceAll('\\', '/'), /dd-trace-js\/ci\/init\.js/)
+    assert.match(withCiPreloads('', framework).replaceAll('\\', '/'), /-r "?[^"]*\/ci\/init\.js"?$/)
   })
 
   /**


### PR DESCRIPTION
## Summary
The validation execution spec asserted that the preload path contained the checkout directory name `dd-trace-js`. Dedicated worktrees and CI checkouts can use different directory names, so the test failed even though `withCiPreloads()` produced the correct `ci/init.js` preload.

The assertion now checks the stable `-r .../ci/init.js` shape instead of the repository path.
