### PR TITLE
ci: pin docker/login-action to a commit SHA

### DIFF
--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -28,7 +28,7 @@ jobs:
           policy: self.mirror-image
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- `docker/login-action` in `mirror-image.yml` was referenced by version tag (`v4.5.1`) instead of a commit SHA, unlike the rest of our GitHub Actions.
- Pinned it to the SHA matching `v4.5.1`, the same commit already used for `docker/login-action` elsewhere in the repo. Dependabot will continue to bump this pin on new releases.

## Test plan
- [x] N/A — workflow-only change, no code paths affected.

Generated by Claude Code.