### PR TITLE
test(plugins): drop the removed agent.close options argument

### DIFF
--- a/packages/datadog-plugin-azure-cosmos/test/index.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/index.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
 
       afterEach(async () => {
         await teardown(client)
-        return agent.close({ ritmReset: false })
+        return agent.close()
       })
 
       it('should create a span', async () => {

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -436,10 +436,7 @@ describe('Plugin', () => {
 
         // Loading both `dns` and `dns/promises` reaches the same exports object through
         // two ritm hooks. Without a WeakSet guard, the second hook to fire would stack a
-        // second wrap layer and publish `apm:dns:*` events twice per call. The mocha test
-        // agent resets ritm between tests (default `ritmReset: true` in `agent.close`),
-        // so the assertions that prove "one hook fire per call" have to run inside a
-        // single `it` body to share one ritm lifecycle.
+        // second wrap layer and publish `apm:dns:*` events twice per call.
         it('does not double-wrap when both dns and dns/promises are loaded', async () => {
           const startCh = dc.channel('apm:dns:lookup:start')
           let startCount = 0

--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -66,7 +66,7 @@ describe('Plugin', () => {
           startApp(done)
         })
 
-        afterEach(() => agent.close({ ritmReset: false }))
+        afterEach(() => agent.close())
         afterEach(done => {
           const proc = child
           child = undefined

--- a/packages/datadog-plugin-mercurius/test/index.spec.js
+++ b/packages/datadog-plugin-mercurius/test/index.spec.js
@@ -78,7 +78,7 @@ describe('Plugin', () => {
 
       after(async () => {
         await app?.close()
-        await agent.close({ ritmReset: false })
+        await agent.close()
       })
 
       withNamingSchema(
@@ -407,7 +407,7 @@ describe('Plugin', () => {
 
         after(async () => {
           await plainApp?.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         it('omits graphql.source unless source is enabled', () => {
@@ -447,7 +447,7 @@ describe('Plugin', () => {
 
         after(async () => {
           await extApp?.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         it('copies the configured error extension onto the request span error event', () => {
@@ -500,7 +500,7 @@ describe('Plugin', () => {
 
         after(async () => {
           await batchApp?.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         it('opens one graphql.request span per operation in the batch', () => {

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -700,7 +700,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close({ ritmReset: false })
+          return agent.close()
         })
 
         beforeEach(async () => {
@@ -740,7 +740,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close({ ritmReset: false })
+          return agent.close()
         })
 
         beforeEach(async () => {

--- a/packages/datadog-plugin-nats/test/index.spec.js
+++ b/packages/datadog-plugin-nats/test/index.spec.js
@@ -56,7 +56,7 @@ describe('Plugin', () => {
           connection = await connect({ servers: '127.0.0.1:4222' })
         })
 
-        afterEach(() => agent.close({ ritmReset: false }))
+        afterEach(() => agent.close())
 
         it('should run commands normally without a plugin loaded', async () => {
           // Sanity: published message must round-trip even when only producer spans matter.
@@ -436,7 +436,7 @@ describe('Plugin', () => {
           connection = await connect({ servers: '127.0.0.1:4222' })
         })
 
-        afterEach(() => agent.close({ ritmReset: false }))
+        afterEach(() => agent.close())
 
         it('skips the publish wrapper fast-path', () => {
           // The wrap's `!hasSubscribers` branch returns the original immediately,

--- a/packages/datadog-plugin-rhea/test/dsm.spec.js
+++ b/packages/datadog-plugin-rhea/test/dsm.spec.js
@@ -15,7 +15,7 @@ describe('Plugin', () => {
       process.env.DD_DATA_STREAMS_ENABLED = 'true'
     })
 
-    after(() => agent.close({ ritmReset: false }))
+    after(() => agent.close())
 
     withVersions('rhea', 'rhea', version => {
       describe('data stream monitoring', function () {
@@ -31,7 +31,7 @@ describe('Plugin', () => {
           container?.removeAllListeners('message')
           connection?.close()
           connection = null
-          return agent.close({ ritmReset: false })
+          return agent.close()
         })
 
         describe('concurrent context isolation', () => {

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close({ ritmReset: false })
+          return agent.close()
         })
 
         beforeEach(() => {


### PR DESCRIPTION
## Summary

`agent.close()` takes no parameters, so every `{ ritmReset: false }` argument was
silently ignored while documenting an option the helper no longer accepts. The dns
comment describing a per-test ritm reset went with it, because `close()` no longer
resets ritm.