### PR TITLE
refactor(lint): clear shellcheck and regexp findings ahead of enabling the rules

### DIFF
--- a/.github/workflows/flakiness.yml
+++ b/.github/workflows/flakiness.yml
@@ -49,9 +49,9 @@ jobs:
       - run: node scripts/flakiness.mjs
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-      - run: cat flakiness.md >> $GITHUB_STEP_SUMMARY
+      - run: cat flakiness.md >> "$GITHUB_STEP_SUMMARY"
       - id: slack
-        run: echo "report=$(cat flakiness.txt)" >> $GITHUB_OUTPUT
+        run: echo "report=$(cat flakiness.txt)" >> "$GITHUB_OUTPUT"
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v2.1.0
         if: github.event_name == 'schedule'
         with:

--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -40,7 +40,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           GHCR_TARGET="$(echo "ghcr.io/${REPOSITORY}/${IMAGE}" | tr '[:upper:]' '[:lower:]')"
-          echo "GHCR_TARGET=${GHCR_TARGET}" >> $GITHUB_ENV
+          echo "GHCR_TARGET=${GHCR_TARGET}" >> "$GITHUB_ENV"
 
       - name: Mirror manifest to GHCR
         env:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
-      - run: FILENAME=$(npm pack --silent --pack-destination /tmp) && mv /tmp/$FILENAME /tmp/dd-trace.tgz
+      - run: FILENAME=$(npm pack --silent --pack-destination /tmp) && mv "/tmp/$FILENAME" /tmp/dd-trace.tgz
       - run: mkdir -p /tmp/app
       - run: npm i -g pnpm
         if: matrix.manager.name == 'pnpm'
@@ -71,7 +71,7 @@ jobs:
       - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: mkdir npm bun
-      - run: FILENAME=$(npm pack --silent) && tar -zxf $FILENAME -C npm
+      - run: FILENAME=$(npm pack --silent) && tar -zxf "$FILENAME" -C npm
       - run: ./node_modules/.bin/bun pm pack --gzip-level 0 --filename bun.tgz && tar -zxf bun.tgz -C bun
       - run: diff -r npm bun
 

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -34,7 +34,6 @@ jobs:
           echo "actionlint found ${{ steps.actionlint.outputs.total-errors }} errors"
           echo "actionlint checked ${{ steps.actionlint.outputs.total-files }} files"
           echo "actionlint cache used: ${{ steps.actionlint.outputs.cache-hit }}"
-          exit ${{ steps.actionlint.outputs.exit-code }}
 
   lint:
     runs-on: ubuntu-latest
@@ -48,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: docker build -q -t ec .github/editorconfig-checker && docker run --rm --volume=$PWD:/check ec
+      - run: docker build -q -t ec .github/editorconfig-checker && docker run --rm --volume="$PWD":/check ec
 
   release-scripts:
     runs-on: ubuntu-latest
@@ -96,9 +95,9 @@ jobs:
           policy: package-size-report
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/node/latest
-      - run: FILENAME=$(npm pack --silent --pack-destination /tmp) && mv /tmp/$FILENAME /tmp/dd-trace.tgz
-      - run: rm -rf *
-      - run: tar -zxf /tmp/dd-trace.tgz -C $(pwd) --strip-components=1
+      - run: FILENAME=$(npm pack --silent --pack-destination /tmp) && mv /tmp/"$FILENAME" /tmp/dd-trace.tgz
+      - run: rm -rf ./*
+      - run: tar -zxf /tmp/dd-trace.tgz -C "$(pwd)" --strip-components=1
       - run: yarn --prod --ignore-optional
       - run: ls -lisa
       - name: Compute module size tree and report
@@ -174,7 +173,7 @@ jobs:
           set -euo pipefail
 
           if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -211,7 +210,7 @@ jobs:
           fi
 
           cp yarn.lock "${RUNNER_TEMP}/yarn.lock"
-          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,8 @@ jobs:
           registry-url: https://registry.npmjs.org
       - id: pkg
         run: |
-          content=`cat ./package.json | tr '\n' ' '`
-          echo "json=$content" >> $GITHUB_OUTPUT
+          content=$(tr '\n' ' ' < ./package.json)
+          echo "json=$content" >> "$GITHUB_OUTPUT"
       - name: Publish
         run: |
           version="${{ fromJson(steps.pkg.outputs.json).version }}"
@@ -159,8 +159,8 @@ jobs:
       - uses: ./.github/actions/node
       - id: pkg
         run: |
-          content=`cat ./package.json | tr '\n' ' '`
-          echo "json=$content" >> $GITHUB_OUTPUT
+          content=$(tr '\n' ' ' < ./package.json)
+          echo "json=$content" >> "$GITHUB_OUTPUT"
       - run: yarn
       - name: Build
         working-directory: docs
@@ -173,7 +173,7 @@ jobs:
           ref: gh-pages
       - name: Deploy
         run: |
-          rm -rf *
+          rm -rf ./*
           mv /tmp/out/* .
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -205,9 +205,9 @@ jobs:
       - uses: ./.github/actions/install
       - id: pkg
         run: |
-          content=`cat ./package.json | tr '\n' ' '`
-          echo "json=$content" >> $GITHUB_OUTPUT
-      - run: npm version --no-git-tag-version ${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}
+          content=$(tr '\n' ' ' < ./package.json)
+          echo "json=$content" >> "$GITHUB_OUTPUT"
+      - run: npm version --no-git-tag-version "${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}"
       - run: npm publish --tag dev
       - run: |
           git tag --force dev
@@ -233,7 +233,7 @@ jobs:
       - uses: ./.github/actions/install
       - id: pkg
         run: |
-          content=`cat ./package.json | tr '\n' ' '`
-          echo "json=$content" >> $GITHUB_OUTPUT
-      - run: npm version --no-git-tag-version ${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}
+          content=$(tr '\n' ' ' < ./package.json)
+          echo "json=$content" >> "$GITHUB_OUTPUT"
+      - run: npm version --no-git-tag-version "${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}"
       - run: node scripts/release/publish-electron.js --tag dev

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: dd-trace-js
       - name: Pack dd-trace-js
-        run: mkdir -p ./binaries && echo /binaries/$(npm pack --silent --pack-destination ./binaries ./dd-trace-js) > ./binaries/nodejs-load-from-npm
+        run: mkdir -p ./binaries && echo "/binaries/$(npm pack --silent --pack-destination ./binaries ./dd-trace-js)" > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -61,7 +61,7 @@ jobs:
             versions.getLatestPlaywrightSpecifier() === 'latest' \
               ? versions.latest \
               : versions.latestSupportedByNode18")
-          echo "version=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Playwright version: $PLAYWRIGHT_VERSION"
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -117,9 +117,11 @@ jobs:
               IMAGE_TAG="$OLDEST_TAG"
               ;;
           esac
-          echo "images=$IMAGES" >> $GITHUB_OUTPUT
-          echo "pw-version=$PW_VERSION" >> $GITHUB_OUTPUT
-          echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          {
+            echo "images=$IMAGES"
+            echo "pw-version=$PW_VERSION"
+            echo "image-tag=$IMAGE_TAG"
+          } >> "$GITHUB_OUTPUT"
       - name: Log in to GHCR
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
@@ -352,7 +354,7 @@ jobs:
         run: |
           DOCKER_HASH=$(sha256sum .github/selenium/Dockerfile | cut -c1-8)
           IMAGE="ghcr.io/datadog/dd-trace-js/selenium-tools:${DOCKER_HASH}"
-          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
       - name: Log in to GHCR
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
@@ -472,7 +474,7 @@ jobs:
           else
             RESOLVED="${{ matrix.cypress-version }}"
           fi
-          echo "resolved=$RESOLVED" >> $GITHUB_OUTPUT
+          echo "resolved=$RESOLVED" >> "$GITHUB_OUTPUT"
       - name: Cache Cypress binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -90,20 +90,20 @@ jobs:
         run: |
           set -e
 
-          echo "head_oid=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          echo "head_oid=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
 
           if git diff --ignore-space-at-eol --exit-code LICENSE-3rdparty.csv; then
             echo "✅ LICENSE-3rdparty.csv is already up to date"
-            echo "needs_update=false" >> $GITHUB_OUTPUT
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
           else
             echo "📝 LICENSE-3rdparty.csv was modified by license attribution command"
-            echo "needs_update=true" >> $GITHUB_OUTPUT
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$PR_USER_TYPE" == "Bot" ]] && [[ "$PR_HEAD_REPO" == "$BASE_REPO" ]]; then
-            echo "is_bot_same_repo=true" >> $GITHUB_OUTPUT
+            echo "is_bot_same_repo=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_bot_same_repo=false" >> $GITHUB_OUTPUT
+            echo "is_bot_same_repo=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Release proposal branches are built by cherry-picking master onto a release
@@ -113,9 +113,9 @@ jobs:
           # fail loudly instead — the license CSV is already correct on master and should
           # never need attribution work done directly on a proposal branch.
           if [[ "$HEAD_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-proposal$ ]]; then
-            echo "is_release_proposal=true" >> $GITHUB_OUTPUT
+            echo "is_release_proposal=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_release_proposal=false" >> $GITHUB_OUTPUT
+            echo "is_release_proposal=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload updated LICENSE-3rdparty.csv

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -145,7 +145,7 @@ esbuildVersions.forEach((version) => {
         })
 
         const builtFile = readFileSync('./out.mjs').toString()
-        assert.match(builtFile, /\/\* js test \*\//m)
+        assert.match(builtFile, /\/\* js test \*\//)
       })
 
       it('should contain the definitions when esm is inferred from outfile', () => {
@@ -154,7 +154,7 @@ esbuildVersions.forEach((version) => {
         })
 
         const builtFile = readFileSync('./out.mjs').toString()
-        assert.match(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/m)
+        assert.match(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/)
       })
 
       it('should contain the definitions when esm is inferred from format', () => {
@@ -163,7 +163,7 @@ esbuildVersions.forEach((version) => {
         })
 
         const builtFile = readFileSync('./out.mjs').toString()
-        assert.match(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/m)
+        assert.match(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/)
       })
 
       it('should contain the definitions when format is inferred from out extension', () => {
@@ -172,7 +172,7 @@ esbuildVersions.forEach((version) => {
         })
 
         const builtFile = readFileSync('./basic-test.mjs').toString()
-        assert.match(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/m)
+        assert.match(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/)
       })
 
       it('should not contain the definitions when no esm is specified', () => {
@@ -181,7 +181,7 @@ esbuildVersions.forEach((version) => {
         })
 
         const builtFile = readFileSync('./out.js').toString()
-        assert.doesNotMatch(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/m)
+        assert.doesNotMatch(builtFile, /globalThis\.__filename \?\?= \$dd_fileURLToPath\(import\.meta\.url\);/)
       })
 
       it('should not crash when it is already patched using global', () => {

--- a/integration-tests/package-guardrails.spec.js
+++ b/integration-tests/package-guardrails.spec.js
@@ -136,7 +136,7 @@ addHook({ name: 'bluebird', versions: ['*'] }, Promise => {
           log => {
             assert.match(
               log,
-              /\nError during ddtrace instrumentation of application, aborting.\nReferenceError: this is a test error\n {4}at /m
+              /\nError during ddtrace instrumentation of application, aborting.\nReferenceError: this is a test error\n {4}at /
             )
             assert.match(log, /\nfalse\n/)
           }, []))

--- a/packages/datadog-core/src/utils/src/kebabcase.js
+++ b/packages/datadog-core/src/utils/src/kebabcase.js
@@ -5,10 +5,16 @@ module.exports = function kebabcase (str) {
     throw new TypeError('Expected a string')
   }
 
-  return str
+  const kebab = str
     .trim()
     .replaceAll(/([a-z])([A-Z])/g, '$1-$2') // Convert camelCase to kebab-case
     .replaceAll(/[\s_]+/g, '-') // Replace spaces and underscores with a single dash
-    .replaceAll(/^-+|-+$/g, '') // Trim leading and trailing dashes
     .toLowerCase()
+
+  // Trim by index; a `/-+$/` regex re-examines the dash run once per start position.
+  let start = 0
+  let end = kebab.length
+  while (kebab.charCodeAt(start) === 45) start++ // '-'
+  while (end > start && kebab.charCodeAt(end - 1) === 45) end--
+  return kebab.slice(start, end)
 }

--- a/packages/datadog-core/test/utils/src/kebabcase.spec.js
+++ b/packages/datadog-core/test/utils/src/kebabcase.spec.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+require('../../../../dd-trace/test/setup/core')
+const kebabcase = require('../../../src/utils/src/kebabcase')
+
+describe('kebabcase', () => {
+  it('converts camelCase and collapses spaces/underscores', () => {
+    assert.strictEqual(kebabcase('fooBar'), 'foo-bar')
+    assert.strictEqual(kebabcase('foo_bar baz'), 'foo-bar-baz')
+    assert.strictEqual(kebabcase('XMLHttpRequest'), 'xmlhttp-request')
+  })
+
+  it('trims leading and trailing dashes but keeps internal ones', () => {
+    assert.strictEqual(kebabcase('-a-'), 'a')
+    assert.strictEqual(kebabcase('--a--'), 'a')
+    assert.strictEqual(kebabcase('_a_'), 'a')
+    assert.strictEqual(kebabcase('a-b'), 'a-b')
+    assert.strictEqual(kebabcase('a--b'), 'a--b')
+  })
+
+  it('handles all-dash and empty inputs', () => {
+    assert.strictEqual(kebabcase('---'), '')
+    assert.strictEqual(kebabcase(''), '')
+    assert.strictEqual(kebabcase('   '), '')
+  })
+
+  it('throws on non-string input', () => {
+    assert.throws(() => kebabcase(42), { name: 'TypeError', message: 'Expected a string' })
+  })
+})

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -696,7 +696,7 @@ function publishRetriedAttempt (runner, state) {
 
   // ATR: record this attempt as failed so when run().finally runs (after retry) we have all statuses
   if (isFlakyTestRetriesEnabled) {
-    const nameForKey = runner.pickle.name.replace(/\s*\(attempt \d+(?:, retried)?\)\s*$/, '')
+    const nameForKey = runner.pickle.name.replace(/ ?\(attempt \d+(?:, retried)?\) ?$/, '')
     const atrKey = `${runner.pickle.uri}:${nameForKey}`
     if (atrStatusesByScenarioKey.has(atrKey)) {
       atrStatusesByScenarioKey.get(atrKey).push('fail')
@@ -889,7 +889,7 @@ function wrapRun (pl, isLatestVersion, version) {
         // ATR: accumulate statuses by stable scenario key (uri:name) so retries are grouped.
         // Cucumber appends " (attempt N)" or " (attempt N, retried)" to the scenario name; normalize for keying.
         if (isFlakyTestRetriesEnabled && !isAttemptToFix && !isEfdRetry && numTestRetries > 0) {
-          const nameForKey = this.pickle.name.replace(/\s*\(attempt \d+(?:, retried)?\)\s*$/, '')
+          const nameForKey = this.pickle.name.replace(/ ?\(attempt \d+(?:, retried)?\) ?$/, '')
           const atrKey = `${this.pickle.uri}:${nameForKey}`
           if (atrStatusesByScenarioKey.has(atrKey)) {
             atrStatusesByScenarioKey.get(atrKey).push(status)

--- a/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
+++ b/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
@@ -5,7 +5,7 @@ const shellParser = require('../../../vendor/dist/shell-quote').parse
 const ALLOWED_ENV_VARIABLES = new Set(['LD_PRELOAD', 'LD_LIBRARY_PATH', 'PATH'])
 const PROCESS_DENYLIST = new Set(['md5'])
 
-const VARNAMES_REGEX = /\$(\w*)(?:[^\w]|$)/gmi
+const VARNAMES_REGEX = /\$(\w*)(?:[^\w]|$)/gm
 // eslint-disable-next-line @stylistic/max-len
 const PARAM_PATTERN = '^-{0,2}(?:p(?:ass(?:w(?:or)?d)?)?|address|api[-_]?key|e?mail|secret(?:[-_]?key)?|a(?:ccess|uth)[-_]?token|mysql_pwd|credentials|(?:stripe)?token)$'
 const regexParam = new RegExp(PARAM_PATTERN, 'i')

--- a/packages/datadog-plugin-cypress/src/source-map-utils.js
+++ b/packages/datadog-plugin-cypress/src/source-map-utils.js
@@ -61,7 +61,7 @@ function decodeVLQ (str, cursor) {
  * @returns {string | null}
  */
 function resolveSourcePath (mapDir, sourceRoot, sourcePath) {
-  const cleanSourcePath = sourcePath.replace(/[?#].*$/, '')
+  const cleanSourcePath = sourcePath.split(/[?#]/)[0]
   if (/^[A-Za-z][A-Za-z\d+.-]*:\/\//.test(cleanSourcePath)) {
     // Virtual sources may use URL-like schemes (e.g. file://, webpack://, vite://).
     // If they encode an absolute local path in the URL pathname, use it.

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -996,7 +996,7 @@ describe('Plugin', () => {
                   'user span must be contained within its live parent, not start after it finished',
                 )
               }
-            }, { spanResourceMatch: /items:\[Item]/ }),
+            }, { spanResourceMatch: /items:\[Item\]/ }),
             graphql.graphql({ schema: localSchema, source: '{ items { name } }' }),
           ])
 
@@ -1069,7 +1069,7 @@ describe('Plugin', () => {
               },
             })
             assert.strictEqual(petsName.parent_id.toString(), pets.span_id.toString())
-          }, { spanResourceMatch: /friends:\[Human]/ })
+          }, { spanResourceMatch: /friends:\[Human\]/ })
 
           return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
@@ -2775,7 +2775,7 @@ describe('Plugin', () => {
               },
             })
             assert.strictEqual(friend1Name.parent_id.toString(), friends.span_id.toString())
-          }, { spanResourceMatch: /friends:\[Human]/ })
+          }, { spanResourceMatch: /friends:\[Human\]/ })
 
           return Promise.all([assertion, graphql.graphql({ schema, source })])
         })

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -43,7 +43,8 @@ function getFormattedJestTestParameters (testParameters) {
 
 // @fast-check/jest appends a random seed to the reported test name. A test name that keeps changing
 // breaks some Test Optimization features, so normalize this narrow suffix regardless of import style.
-const SEED_SUFFIX_RE = /\s*\(with seed=-?\d+\)\s*$/i
+// fast-check emits exactly one space before the suffix.
+const SEED_SUFFIX_RE = / ?\(with seed=-?\d+\) ?$/i
 
 function removeSeedSuffixFromTestName (testName) {
   return testName.replace(SEED_SUFFIX_RE, '')

--- a/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
@@ -26,7 +26,7 @@ const SETTINGS_BOOLEAN_KEYS = [
 ]
 const EARLY_FLAKE_DETECTION_KEYS = ['enabled', 'faulty_session_threshold', 'slow_test_retries']
 const TEST_MANAGEMENT_KEYS = ['attempt_to_fix_retries', 'enabled']
-const RETRY_THRESHOLD_PATTERN = /^\d+(?:ms|s|m|h)$/
+const RETRY_THRESHOLD_PATTERN = /^\d+(?:ms|[smh])$/
 const MAX_VALIDATION_MODULES = 1000
 const MAX_VALIDATION_SUITES = 10_000
 const MAX_VALIDATION_TESTS = 100_000

--- a/packages/dd-trace/src/config/parsers.js
+++ b/packages/dd-trace/src/config/parsers.js
@@ -172,7 +172,14 @@ const transformers = {
         return transformers.stripColonWhitespace(item)
       })
     }
-    return value.replaceAll(/\s*:\s*/g, ':')
+    // Only whitespace adjacent to a colon is removed; the outer whitespace of the first and
+    // last segment stays.
+    const parts = value.split(':')
+    for (let i = 0; i < parts.length; i++) {
+      if (i !== 0) parts[i] = parts[i].trimStart()
+      if (i !== parts.length - 1) parts[i] = parts[i].trimEnd()
+    }
+    return parts.join(':')
   },
   /**
    * @param {string} value

--- a/packages/dd-trace/src/llmobs/plugins/claude-agent-sdk/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/claude-agent-sdk/index.js
@@ -8,7 +8,7 @@ const { splitModel } = require('../../../../../datadog-plugin-claude-agent-sdk/s
 const subagentToolIds = new Set()
 
 function normalizeToolOutputString (raw) {
-  const footerIndex = raw.search(/\s*agentId: [^\s]+ \(use SendMessage\b/)
+  const footerIndex = raw.search(/agentId: \S+ \(use SendMessage\b/)
   if (footerIndex === -1) return raw
 
   return raw.slice(0, footerIndex).trimEnd()

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -76,7 +76,7 @@ function normalizeRef (ref) {
   if (!ref) {
     return ref
   }
-  return ref.replaceAll(/origin\/|refs\/heads\/|tags\//gm, '')
+  return ref.replaceAll(/origin\/|refs\/heads\/|tags\//g, '')
 }
 
 function resolveTilde (filePath) {
@@ -216,7 +216,7 @@ const githubWellKnownDiagnosticDirPatternsUnix = [
 ]
 const githubWellKnownDiagnosticDirPatternsWin = ['C:/actions-runner/*/_diag', 'C:/actions-runner/*/*/_diag']
 
-const githubJobIDRegex = /"job":\s*{[\s\S]*?"v"\s*:\s*(\d+)(?:\.0)?/
+const githubJobIDRegex = /"job":\s*\{[\s\S]*?"v"\s*:\s*(\d+)(?:\.0)?/
 
 function getJobIDFromDiagFile () {
   const runnerTemp = getEnvironmentVariable('RUNNER_TEMP')
@@ -650,7 +650,7 @@ module.exports = {
         [GIT_TAG]: BITBUCKET_TAG,
         [GIT_REPOSITORY_URL]: BITBUCKET_GIT_SSH_ORIGIN || BITBUCKET_GIT_HTTP_ORIGIN,
         [CI_WORKSPACE_PATH]: BITBUCKET_CLONE_DIR,
-        [CI_PIPELINE_ID]: BITBUCKET_PIPELINE_UUID && BITBUCKET_PIPELINE_UUID.replaceAll(/[{}]/gm, ''),
+        [CI_PIPELINE_ID]: BITBUCKET_PIPELINE_UUID && BITBUCKET_PIPELINE_UUID.replaceAll(/[{}]/g, ''),
         [GIT_PULL_REQUEST_BASE_BRANCH]: BITBUCKET_PR_DESTINATION_BRANCH,
         [PR_NUMBER]: BITBUCKET_PR_ID,
       }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -62,7 +62,7 @@ function sanitizedExec (
       let result = cachedExec(cmd, flags, { stdio: 'pipe' }).toString()
 
       if (shouldTrim) {
-        result = result.replaceAll(/(\r\n|\n|\r)/gm, '')
+        result = result.replaceAll(/(\r\n|\n|\r)/g, '')
       }
 
       if (durationMetric) {

--- a/packages/dd-trace/src/plugins/util/url.js
+++ b/packages/dd-trace/src/plugins/util/url.js
@@ -8,13 +8,13 @@ const HTTP2_HEADER_AUTHORITY = ':authority'
 const HTTP2_HEADER_SCHEME = ':scheme'
 const HTTP2_HEADER_PATH = ':path'
 
-const PATH_REGEX = /^(?:[a-z]+:\/\/(?:[^?/]+))?(?<path>\/[^?]*)(?:(\?).*)?$/
+const PATH_REGEX = /^(?:[a-z]+:\/\/[^?/]+)?(?<path>\/[^?]*)(?:(\?).*)?$/
 
 const INT_SEGMENT = /^[1-9][0-9]+$/ // Integer of size at least 2 (>=10)
-const INT_ID_SEGMENT = /^(?=.*[0-9].*)[0-9._-]{3,}$/ // Mixed string with digits and delimiters
-const HEX_SEGMENT = /^(?=.*[0-9].*)[A-Fa-f0-9]{6,}$/ // Hexadecimal digits of size at least 6 with at least one decimal digit
-const HEX_ID_SEGMENT = /^(?=.*[0-9].*)[A-Fa-f0-9._-]{6,}$/ // Mixed string with hex digits and delimiters
-const STRING_SEGMENT = /^.{20,}|.*[%&'()*+,:=@].*$/ // Long string or a string containing special characters
+const INT_ID_SEGMENT = /^(?=.*[0-9])[0-9._-]{3,}$/ // Mixed string with digits and delimiters
+const HEX_SEGMENT = /^(?=.*[0-9])[A-Fa-f0-9]{6,}$/ // Hexadecimal digits of size at least 6 with at least one decimal digit
+const HEX_ID_SEGMENT = /^(?=.*[0-9])[A-Fa-f0-9._-]{6,}$/ // Mixed string with hex digits and delimiters
+const STRING_SEGMENT = /^.{20,}|[%&'()*+,:=@]/ // Long string or a string containing special characters
 
 /**
  * Extract full URL from HTTP request

--- a/packages/dd-trace/src/plugins/util/user-provided-git.js
+++ b/packages/dd-trace/src/plugins/util/user-provided-git.js
@@ -36,7 +36,7 @@ function removeEmptyValues (tagsAndValues) {
 // https://github.com/jonschlinkert/is-git-url/blob/396965ffabf2f46656c8af4c47bef1d69f09292e/index.js#L9C15-L9C87
 // The `.git` suffix is optional in this version
 function validateGitRepositoryUrl (repoUrl) {
-  return /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|#[-\w.]+?)$/.test(repoUrl)
+  return /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|#[-\w.]+)$/.test(repoUrl)
 }
 
 function validateGitCommitSha (gitCommitSha) {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -376,7 +376,7 @@ function isOriginAllowed (req, headers) {
 }
 
 function splitHeader (str) {
-  return typeof str === 'string' ? str.split(/\s*,\s*/) : []
+  return typeof str === 'string' ? str.split(',').map((header) => header.trim()) : []
 }
 
 function addRequestTags (context, spanType) {

--- a/packages/dd-trace/src/telemetry/logs/log-collector.js
+++ b/packages/dd-trace/src/telemetry/logs/log-collector.js
@@ -31,7 +31,9 @@ function isValid (logEntry) {
 }
 
 const EOL = '\n'
-const STACK_FRAME_LINE_REGEX = /^\s*at\s/gm
+// `[ \t]*` (horizontal whitespace) cannot span line terminators, so under `m` the `^`-anchored
+// match runs once per line instead of rescanning across lines. Stack frames indent with spaces.
+const STACK_FRAME_LINE_REGEX = /^[ \t]*at\s/gm
 
 function sanitize (logEntry) {
   const stack = logEntry.stack_trace

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -4743,6 +4743,11 @@ rules:
       ])
     })
 
+    it('collapses only whitespace adjacent to a colon in header tags', () => {
+      const config = getConfig({ headerTags: ['  a : b  ', 'k : : v'] })
+      assert.deepStrictEqual(config.headerTags, ['  a:b  ', 'k::v'])
+    })
+
     it('should map tracing_tags to tags', () => {
       const config = getConfig({ tags: { foo: 'bar' } })
       assertObjectContains(config.tags, { foo: 'bar' })

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -305,7 +305,7 @@ describe('log', () => {
         sinon.assert.calledOnce(console.debug)
         const debugMessage = console.debug.firstCall.args[0]
         assert.match(debugMessage,
-          /^Trace: Context.foo\('argument', { hello: 'world' }, Foo { bar: 'baz' }\)/
+          /^Trace: Context.foo\('argument', \{ hello: 'world' \}, Foo \{ bar: 'baz' \}\)/
         )
         const lineCount = debugMessage.split('\n').length
         assert.ok(lineCount >= 3, `Expected at least 3 lines in trace, got ${lineCount}: ${inspect(debugMessage)}`)

--- a/packages/dd-trace/test/plugins/plugin-structure.spec.js
+++ b/packages/dd-trace/test/plugins/plugin-structure.spec.js
@@ -57,7 +57,7 @@ function extractPluginIds (source, re, index) {
 }
 
 function extractPluginsInterfaceKeys (dtsSource) {
-  const m = dtsSource.match(/interface Plugins\s*\{([\s\S]*?)\n\}/m)
+  const m = dtsSource.match(/interface Plugins\s*\{([\s\S]*?)\n\}/)
   assert.ok(m, 'Could not find `interface Plugins { ... }` in index.d.ts')
 
   const body = m[1]

--- a/packages/dd-trace/test/plugins/util/url.spec.js
+++ b/packages/dd-trace/test/plugins/util/url.spec.js
@@ -341,6 +341,12 @@ describe('plugins/util/url', () => {
         )
       })
 
+      it('should treat 20 chars as the {param:str} length boundary', () => {
+        // 19 plain chars (no digit, no special) stay verbatim; 20 cross into {param:str}.
+        assert.strictEqual(url.calculateHttpEndpoint('/x/abcdefghijklmnopqrs'), '/x/abcdefghijklmnopqrs')
+        assert.strictEqual(url.calculateHttpEndpoint('/x/abcdefghijklmnopqrst'), '/x/{param:str}')
+      })
+
       it('should replace strings with special characters as {param:str}', () => {
         assert.strictEqual(url.calculateHttpEndpoint('/search/hello%20world'), '/search/{param:str}')
         assert.strictEqual(url.calculateHttpEndpoint('/filter/foo&bar'), '/filter/{param:str}')

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -834,5 +834,21 @@ describe('plugins/util/web', () => {
         [204, 'No Content', { 'x-test': '1' }]
       )
     })
+
+    it('trims whitespace surrounding each requested header entry', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = '  x-datadog-parent-id  ,x-datadog-trace-id  '
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'x-datadog-parent-id,x-datadog-trace-id']
+      )
+    })
   })
 })

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -218,7 +218,7 @@ function splitPlugins (value) {
   const raw = unwrapLiteralEnvValue(value)
   if (!raw) return []
   return raw
-    .split(/[,\s|]+/g)
+    .split(/[,\s|]+/)
     .map(s => s.trim())
     .filter(Boolean)
 }


### PR DESCRIPTION
## Summary

`eslint-plugin-regexp` and actionlint's shellcheck pass both report findings across
the tree. This clears the three groups that need no judgement call, so enabling the
rules later is a small diff on its own.

1. Workflow steps quote their expansions. An unquoted `$GITHUB_OUTPUT`, `$PWD`,
   `$FILENAME`, or version string splits on whitespace, and `rm -rf *` hands any
   dash-prefixed filename to `rm` as an option. The redundant `exit` in the
   actionlint summary step goes with them, since `fail-on-error` already fails the job.
2. Regex pieces that cannot change which strings match are removed: `m` without an
   anchor, `i` without a letter, a group wrapping a whole pattern, `.*` padding in a
   lookahead only reached through `test()`, a lazy quantifier before `$`, and
   unescaped `{` / `]` meant as literals.
3. Matchers that walk the same characters again for every start position the engine
   tries are replaced with ones that examine each character once — trailing-delimiter
   trims, the header and colon splitters, the telemetry frame filter, and two
   test-name suffix matchers.

The one visible behaviour change is `splitHeader`, which now trims the first and last
entry as well; `web.spec.js` pins it. Two uncovered boundaries are added along the
way: the 20-character `{param:str}` threshold and `kebabcase` on all-dash and empty
input.

## Why

The rule enablement cannot merge until every finding in the tree is fixed, or CI is
red. Landing the fixes separately lets each group be reviewed and reverted on its
own, and keeps the commit that flips the rules readable.

Not in here, because each needs a real judgement call: the stack-frame parser in
`plugins/util/test.js`, the IAST evidence-redaction scanners, the `ci/`
validation-runbook findings, and the rule enablement itself.