### PR TITLE
fix(kafka): preserve native producer headers

### DIFF
--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -63,13 +63,17 @@ function instrumentBaseModule (module) {
 
               const ctx = {
                 topic,
-                messages: [{ key, value: message }],
+                messages: [{
+                  key,
+                  value: message,
+                  headers: nativeHeadersToCarrier(headers),
+                }],
                 bootstrapServers: brokers,
               }
 
               return channels.producerStart.runStores(ctx, () => {
                 try {
-                  const producedHeaders = mergeHeaders(headers, ctx.messages[0].headers)
+                  const producedHeaders = carrierToNativeHeaders(ctx.messages[0].headers)
                   const result = produce.apply(this, [
                     topic, partition, message, key, timestamp, opaque, producedHeaders,
                   ])
@@ -434,37 +438,44 @@ function getLatestOffsets () {
   return [...latestConsumerOffsets.values()]
 }
 
-function convertHeaders (headers) {
-  // convert headers from object to array of objects with 1 key and value per array entry
-  return Object.entries(headers).map(([key, value]) => ({ [key.toString()]: value.toString() }))
+/**
+ * Normalize valid native headers into a text-map carrier.
+ *
+ * Any malformed input produces an empty carrier so only tracing headers are sent.
+ * Duplicate exact-case keys intentionally collapse to the last value seen.
+ * @param {Array<Record<string, string | Buffer>> | undefined} headers
+ * @returns {Record<string, string | Buffer>}
+ */
+function nativeHeadersToCarrier (headers) {
+  const carrier = Object.create(null)
+  if (!Array.isArray(headers)) return carrier
+
+  // Duplicate exact-case keys intentionally collapse to the last value seen.
+  for (const header of headers) {
+    if (!header || typeof header !== 'object' || Array.isArray(header)) return Object.create(null)
+
+    const keys = Object.keys(header)
+    if (keys.length !== 1) return Object.create(null)
+
+    const key = keys[0]
+    const value = header[key]
+    if (typeof value !== 'string' && !Buffer.isBuffer(value)) return Object.create(null)
+
+    carrier[key] = value
+  }
+  return carrier
 }
 
 /**
- * Retain application headers while ensuring injected propagation headers have
- * a single, authoritative value.
+ * Serialize a text-map carrier back to native headers.
  *
- * @param {Array<Record<string, string | Buffer>> | undefined} headers
- * @param {Record<string, string>} tracingHeaders
+ * @param {Record<string, string | Buffer>} carrier
  * @returns {Array<Record<string, string | Buffer>>}
  */
-function mergeHeaders (headers, tracingHeaders) {
-  if (!Array.isArray(headers)) return convertHeaders(tracingHeaders)
-
-  const tracingHeaderNames = Object.keys(tracingHeaders)
-
-  const producedHeaders = []
-  for (const header of headers) {
-    let isOverridden = false
-    for (const headerName of Object.keys(header)) {
-      if (tracingHeaderNames.includes(headerName)) {
-        isOverridden = true
-        break
-      }
-    }
-    if (!isOverridden) {
-      producedHeaders.push(header)
-    }
+function carrierToNativeHeaders (carrier) {
+  const headers = []
+  for (const key of Object.keys(carrier)) {
+    headers.push({ [key]: carrier[key] })
   }
-  producedHeaders.push(...convertHeaders(tracingHeaders))
-  return producedHeaders
+  return headers
 }

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -69,8 +69,10 @@ function instrumentBaseModule (module) {
 
               return channels.producerStart.runStores(ctx, () => {
                 try {
-                  const headers = convertHeaders(ctx.messages[0].headers)
-                  const result = produce.apply(this, [topic, partition, message, key, timestamp, opaque, headers])
+                  const producedHeaders = mergeHeaders(headers, ctx.messages[0].headers)
+                  const result = produce.apply(this, [
+                    topic, partition, message, key, timestamp, opaque, producedHeaders,
+                  ])
 
                   ctx.result = result
                   channels.producerCommit.publish(ctx)
@@ -435,4 +437,34 @@ function getLatestOffsets () {
 function convertHeaders (headers) {
   // convert headers from object to array of objects with 1 key and value per array entry
   return Object.entries(headers).map(([key, value]) => ({ [key.toString()]: value.toString() }))
+}
+
+/**
+ * Retain application headers while ensuring injected propagation headers have
+ * a single, authoritative value.
+ *
+ * @param {Array<Record<string, string | Buffer>> | undefined} headers
+ * @param {Record<string, string>} tracingHeaders
+ * @returns {Array<Record<string, string | Buffer>>}
+ */
+function mergeHeaders (headers, tracingHeaders) {
+  if (!Array.isArray(headers)) return convertHeaders(tracingHeaders)
+
+  const tracingHeaderNames = Object.keys(tracingHeaders)
+
+  const producedHeaders = []
+  for (const header of headers) {
+    let isOverridden = false
+    for (const headerName of Object.keys(header)) {
+      if (tracingHeaderNames.includes(headerName)) {
+        isOverridden = true
+        break
+      }
+    }
+    if (!isOverridden) {
+      producedHeaders.push(header)
+    }
+  }
+  producedHeaders.push(...convertHeaders(tracingHeaders))
+  return producedHeaders
 }

--- a/packages/datadog-instrumentations/test/confluentinc-kafka-javascript.spec.js
+++ b/packages/datadog-instrumentations/test/confluentinc-kafka-javascript.spec.js
@@ -20,7 +20,7 @@ describe('packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
     subscriptions.length = 0
   })
 
-  it('preserves application headers and overrides matching propagation headers', () => {
+  it('normalizes native headers before tracing and preserves Buffer values', () => {
     class Producer {
       produce (...args) {
         this.args = args
@@ -31,10 +31,9 @@ describe('packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
     HOOK(module)
 
     const injectTraceHeaders = (ctx) => {
-      ctx.messages[0].headers = {
-        'x-datadog-trace-id': '123',
-        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-      }
+      ctx.messages[0].headers['x-datadog-trace-id'] = '123'
+      ctx.messages[0].headers.traceparent =
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
     }
     subscriptions.push(injectTraceHeaders)
     producerStart.subscribe(injectTraceHeaders)
@@ -49,23 +48,33 @@ describe('packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
       undefined,
       [
         { 'content-type': 'text' },
+        { 'content-type': 'application/json' },
+        { 'binary-header': Buffer.from([0xde, 0xad, 0xbe, 0xef]) },
         { 'x-datadog-trace-id': 'old-trace-id' },
         { traceparent: '00-old-old-00' },
         { Traceparent: 'application-value' },
+        { ['__proto__']: 'prototype-safe' },
       ]
     )
 
-    assert.deepStrictEqual(producer.args[6], [
-      { 'content-type': 'text' },
-      { Traceparent: 'application-value' },
-      { 'x-datadog-trace-id': '123' },
-      { traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' },
-    ])
+    const producedHeaders = producer.args[6]
+    const producedCarrier = headersToObject(producedHeaders)
+
+    assert.strictEqual(producedHeaders.filter(header => Object.hasOwn(header, 'content-type')).length, 1)
+    assert.strictEqual(producedCarrier['content-type'], 'application/json')
+    assert.strictEqual(producedCarrier.Traceparent, 'application-value')
+    assert.strictEqual(producedCarrier['x-datadog-trace-id'], '123')
+    assert.strictEqual(
+      producedCarrier.traceparent,
+      '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    )
+    assert.ok(Buffer.isBuffer(producedCarrier['binary-header']))
+    assert.deepStrictEqual(producedCarrier['binary-header'], Buffer.from([0xde, 0xad, 0xbe, 0xef]))
+    assert.ok(Object.hasOwn(producedCarrier, '__proto__'))
+    assert.strictEqual(Object.getOwnPropertyDescriptor(producedCarrier, '__proto__').value, 'prototype-safe')
   })
 
-  it('retains the existing replacement behavior for non-array headers', () => {
-    const invalidHeaders = { 'content-type': 'text' }
-
+  it('returns generated headers only when native headers are malformed', () => {
     class Producer {
       produce (...args) {
         this.args = args
@@ -76,14 +85,35 @@ describe('packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
     HOOK(module)
 
     const injectTraceHeaders = (ctx) => {
-      ctx.messages[0].headers = { 'x-datadog-trace-id': '123' }
+      ctx.messages[0].headers['x-datadog-trace-id'] = '123'
     }
     subscriptions.push(injectTraceHeaders)
     producerStart.subscribe(injectTraceHeaders)
 
     const producer = new module.Producer()
-    producer.produce('topic', null, Buffer.from('message'), 'key', Date.now(), undefined, invalidHeaders)
+    const malformedHeaders = [
+      { 'content-type': 'text' },
+      [null],
+      [{ 'content-type': 'text' }, null],
+      [{}],
+      [{ first: 'one', second: 'two' }],
+      [{ 'content-type': 42 }],
+    ]
 
-    assert.deepStrictEqual(producer.args[6], [{ 'x-datadog-trace-id': '123' }])
+    for (const headers of malformedHeaders) {
+      producer.produce('topic', null, Buffer.from('message'), 'key', Date.now(), undefined, headers)
+      assert.deepStrictEqual(producer.args[6], [{ 'x-datadog-trace-id': '123' }])
+    }
   })
 })
+
+function headersToObject (headers) {
+  const carrier = Object.create(null)
+  for (const header of headers) {
+    if (!header || typeof header !== 'object') continue
+    for (const key of Object.keys(header)) {
+      carrier[key] = header[key]
+    }
+  }
+  return carrier
+}

--- a/packages/datadog-instrumentations/test/confluentinc-kafka-javascript.spec.js
+++ b/packages/datadog-instrumentations/test/confluentinc-kafka-javascript.spec.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const dc = require('dc-polyfill')
+const { afterEach, describe, it } = require('mocha')
+
+require('../src/confluentinc-kafka-javascript')
+
+const HOOK = globalThis[Symbol.for('_ddtrace_instrumentations')]['@confluentinc/kafka-javascript'][0].hook
+const producerStart = dc.channel('apm:confluentinc-kafka-javascript:produce:start')
+
+describe('packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js', () => {
+  const subscriptions = []
+
+  afterEach(() => {
+    for (const subscription of subscriptions) {
+      producerStart.unsubscribe(subscription)
+    }
+    subscriptions.length = 0
+  })
+
+  it('preserves application headers and overrides matching propagation headers', () => {
+    class Producer {
+      produce (...args) {
+        this.args = args
+      }
+    }
+
+    const module = { Producer }
+    HOOK(module)
+
+    const injectTraceHeaders = (ctx) => {
+      ctx.messages[0].headers = {
+        'x-datadog-trace-id': '123',
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      }
+    }
+    subscriptions.push(injectTraceHeaders)
+    producerStart.subscribe(injectTraceHeaders)
+
+    const producer = new module.Producer()
+    producer.produce(
+      'topic',
+      null,
+      Buffer.from('message'),
+      'key',
+      Date.now(),
+      undefined,
+      [
+        { 'content-type': 'text' },
+        { 'x-datadog-trace-id': 'old-trace-id' },
+        { traceparent: '00-old-old-00' },
+        { Traceparent: 'application-value' },
+      ]
+    )
+
+    assert.deepStrictEqual(producer.args[6], [
+      { 'content-type': 'text' },
+      { Traceparent: 'application-value' },
+      { 'x-datadog-trace-id': '123' },
+      { traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' },
+    ])
+  })
+
+  it('retains the existing replacement behavior for non-array headers', () => {
+    const invalidHeaders = { 'content-type': 'text' }
+
+    class Producer {
+      produce (...args) {
+        this.args = args
+      }
+    }
+
+    const module = { Producer }
+    HOOK(module)
+
+    const injectTraceHeaders = (ctx) => {
+      ctx.messages[0].headers = { 'x-datadog-trace-id': '123' }
+    }
+    subscriptions.push(injectTraceHeaders)
+    producerStart.subscribe(injectTraceHeaders)
+
+    const producer = new module.Producer()
+    producer.produce('topic', null, Buffer.from('message'), 'key', Date.now(), undefined, invalidHeaders)
+
+    assert.deepStrictEqual(producer.args[6], [{ 'x-datadog-trace-id': '123' }])
+  })
+})

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
@@ -4,10 +4,12 @@ const assert = require('node:assert/strict')
 
 const { randomUUID } = require('node:crypto')
 const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { DataStreamsProcessor } = require('../../dd-trace/src/datastreams/processor')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { expectedSchema } = require('./naming')
@@ -347,12 +349,7 @@ describe('Plugin', () => {
           let Consumer
 
           beforeEach(async () => {
-            const lib = require(`../../../versions/${module}@${version}`).get()
-            nativeApi = lib
-
-            tracer = await agent.load('confluentinc-kafka-javascript')
-
-            // Get the producer/consumer classes directly from the module
+            // The outer setup loads the plugin before obtaining the library.
             Producer = nativeApi.Producer
             Consumer = nativeApi.KafkaConsumer
 
@@ -403,6 +400,41 @@ describe('Plugin', () => {
               nativeProducer.produce(testTopic, null, message, key)
 
               return expectedSpanPromise
+            })
+
+            it('should include normalized native headers in the DSM payload size', () => {
+              if (DataStreamsProcessor.prototype.recordCheckpoint.isSinonProxy) {
+                DataStreamsProcessor.prototype.recordCheckpoint.restore()
+              }
+              const recordCheckpointSpy = sinon.spy(DataStreamsProcessor.prototype, 'recordCheckpoint')
+              const message = Buffer.from('native DSM message')
+              const key = 'native-dsm-key'
+              const headerName = 'native-application-header'
+              const headerValue = Buffer.alloc(1024, 0xab)
+              const minimumPayloadSize = message.length + Buffer.byteLength(key) +
+                Buffer.byteLength(headerName) + headerValue.length
+
+              try {
+                nativeProducer.produce(
+                  testTopic,
+                  null,
+                  message,
+                  key,
+                  undefined,
+                  undefined,
+                  [{ [headerName]: headerValue }]
+                )
+
+                assert.strictEqual(recordCheckpointSpy.callCount, 1)
+                const checkpoint = recordCheckpointSpy.firstCall.args[0]
+                assert.ok(Object.hasOwn(checkpoint, 'payloadSize'))
+                assert.ok(
+                  checkpoint.payloadSize >= minimumPayloadSize,
+                  `Expected payload size >= ${minimumPayloadSize}, received ${checkpoint.payloadSize}`
+                )
+              } finally {
+                recordCheckpointSpy.restore()
+              }
             })
 
             it('should be instrumented with error', async () => {
@@ -466,38 +498,86 @@ describe('Plugin', () => {
               }))
             })
 
-            function consume (consumer, producer, topic, message, timeoutMs = 9500) {
+            function consume (
+              consumer,
+              producer,
+              topic,
+              message,
+              timeoutMs = 9500,
+              onMessage = null,
+              headers = null
+            ) {
               return /** @type {Promise<void>} */(new Promise((resolve, reject) => {
+                let retryId
+                let settled = false
                 const timeoutId = setTimeout(() => {
-                  reject(new Error(`Timeout: Did not consume message on topic "${topic}" within ${timeoutMs}ms`))
+                  settle(new Error(`Timeout: Did not consume message on topic "${topic}" within ${timeoutMs}ms`))
                 }, timeoutMs)
+
+                function settle (error) {
+                  if (settled) return
+                  settled = true
+                  clearTimeout(timeoutId)
+                  clearTimeout(retryId)
+
+                  let unsubscribeError
+                  try {
+                    consumer.unsubscribe()
+                  } catch (error) {
+                    unsubscribeError = error
+                  }
+
+                  const rejection = error || unsubscribeError
+                  if (rejection) {
+                    reject(rejection)
+                  } else {
+                    resolve()
+                  }
+                }
+
+                function retry () {
+                  if (!settled) retryId = setTimeout(doConsume, 20)
+                }
 
                 function doConsume () {
                   consumer.consume(1, function (err, messages) {
+                    if (settled) return
+
                     if (err) {
-                      clearTimeout(timeoutId)
-                      return reject(err)
+                      settle(err)
+                      return
                     }
 
                     if (!messages || messages.length === 0) {
-                      setTimeout(doConsume, 20)
+                      retry()
                       return
                     }
 
                     const consumedMessage = messages[0]
 
                     if (consumedMessage.value.toString() !== message.toString()) {
-                      setTimeout(doConsume, 20)
+                      retry()
                       return
                     }
 
-                    clearTimeout(timeoutId)
-                    consumer.unsubscribe()
-                    resolve()
+                    try {
+                      if (typeof onMessage === 'function') {
+                        onMessage(consumedMessage)
+                      }
+                    } catch (error) {
+                      settle(error)
+                      return
+                    }
+
+                    settle()
                   })
                 }
                 doConsume()
-                producer.produce(topic, null, message, 'native-consumer-key')
+                try {
+                  producer.produce(topic, null, message, 'native-consumer-key', undefined, undefined, headers)
+                } catch (error) {
+                  settle(error)
+                }
               }))
             }
 
@@ -550,6 +630,51 @@ describe('Plugin', () => {
 
               return expectedSpanPromise
             })
+
+            it('should preserve native application headers and replace stale propagation headers', async () => {
+              const message = Buffer.from('test message with native headers')
+              const staleTraceId = 'stale-trace-id'
+              const finalContentType = 'application/json'
+              const applicationBuffer = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+
+              nativeConsumer.setDefaultConsumeTimeout(10)
+              nativeConsumer.subscribe([testTopic])
+
+              await consume(nativeConsumer, nativeProducer, testTopic, message, 9500, (consumedMessage) => {
+                const headers = nativeHeadersToObject(consumedMessage.headers)
+
+                assert.deepStrictEqual(headers['content-type'], Buffer.from(finalContentType))
+                assert.deepStrictEqual(headers.Traceparent, Buffer.from('application-value'))
+                assert.ok(headers['x-datadog-trace-id'])
+                assert.notStrictEqual(headers['x-datadog-trace-id'].toString(), staleTraceId)
+                assert.ok(Buffer.isBuffer(headers['binary-header']))
+                assert.deepStrictEqual(headers['binary-header'], applicationBuffer)
+              }, [
+                { 'content-type': 'text/plain' },
+                { 'content-type': finalContentType },
+                { 'binary-header': applicationBuffer },
+                { 'x-datadog-trace-id': staleTraceId },
+                { Traceparent: 'application-value' },
+              ])
+            })
+
+            it('should ignore malformed native headers', async () => {
+              const message = Buffer.from('test message with malformed native headers')
+
+              nativeConsumer.setDefaultConsumeTimeout(10)
+              nativeConsumer.subscribe([testTopic])
+
+              await consume(nativeConsumer, nativeProducer, testTopic, message, 9500, (consumedMessage) => {
+                const headers = nativeHeadersToObject(consumedMessage.headers)
+
+                assert.ok(!Object.hasOwn(headers, 'content-type'))
+                assert.ok(!Object.hasOwn(headers, 'invalid-header'))
+                assert.ok(headers['x-datadog-trace-id'])
+              }, [
+                { 'content-type': 'text/plain' },
+                { 'invalid-header': 42 },
+              ])
+            })
           })
         })
       })
@@ -575,4 +700,23 @@ async function sendMessages (kafka, topic, messages) {
     messages,
   })
   await producer.disconnect()
+}
+
+function nativeHeadersToObject (headers) {
+  if (!Array.isArray(headers)) return headers || {}
+
+  const carrier = Object.create(null)
+  for (const header of headers) {
+    if (!header || typeof header !== 'object') continue
+
+    if (Object.hasOwn(header, 'key')) {
+      carrier[header.key] = header.value
+      continue
+    }
+
+    for (const key of Object.keys(header)) {
+      carrier[key] = header[key]
+    }
+  }
+  return carrier
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes header loss in the native node-rdkafka-style Producer.produce() path of @confluentinc/kafka-javascript.

The wrapper receives application headers as the seventh positional argument, using the native array-of-single-key-objects representation. Before this change, it created the diagnostic-channel message with only key and value. The producer plugin then injected trace context into a new text-map object, and the wrapper converted only that new object back to native headers. As a result, the original application headers were silently replaced by Datadog and optional W3C propagation headers.

The updated native adapter now:

- Preserves valid application header arrays, including their order and values.
- Removes application entries whose keys exactly match headers generated by the active propagation configuration.
- Appends the newly generated propagation headers as the authoritative values.
- Keeps differently cased Kafka keys distinct, matching the consumer-side exact-key extraction behavior.
- Does not mutate the caller-owned header array or its retained entries.

The KafkaJS-compatible producer.send() path is unaffected. That path already clones each message and its existing header object before injecting trace context into the clone.

### Motivation

Applications may attach metadata such as content-type to native Kafka messages. With tracing enabled, those headers were dropped even though the same produce call preserved them when no tracing subscriber was active.

For example, an application header array containing content-type previously reached the native producer containing only generated trace headers after instrumentation.

#### Why non-array inputs retain the previous behavior

The documented native API expects an array of header objects. However, previous dd-trace versions ignored the caller-provided seventh argument whenever instrumentation was active and always replaced it with generated propagation headers. Forwarding a non-array value after this fix would therefore expose new native validation errors to applications that may have unknowingly relied on the previous shadowing behavior.

To keep this bug fix backward-compatible, merging is applied only to valid header arrays. Non-array inputs continue to be replaced by generated tracing headers, matching the existing instrumented behavior.

### Additional Notes

Focused tests cover:

1. Preserving content-type while replacing exact x-datadog-trace-id and traceparent collisions.
2. Retaining a differently cased Traceparent Kafka header because consumer extraction uses exact lowercase keys.
3. Retaining the existing replacement behavior for a non-array header input.

Tested with:

    PLUGINS=confluentinc-kafka-javascript npm run test:instrumentations

Result: 2 passing. ESLint, syntax, and whitespace checks also pass.