### PR TITLE
test(jest): gather known-tests payloads until the child exits

### DIFF
--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -4042,7 +4042,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
   })
 
   context('known tests without early flake detection', () => {
-    it('detects new tests without retrying them', (done) => {
+    it('detects new tests without retrying them', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
       receiver.setKnownTests({
@@ -4057,8 +4057,18 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         known_tests_enabled: true,
       })
 
-      const eventsPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: { ...getCiVisEvpProxyConfig(receiver.port), TESTS_TO_RUN: 'test/ci-visibility-test' },
+        }
+      )
+
+      await receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const testSession = events.find(event => event.type === 'test_session_end').content
@@ -4084,21 +4094,8 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
           // no test has been retried
           assert.strictEqual(retriedTests.length, 0)
-        })
-
-      childProcess = exec(
-        runTestsCommand,
-        {
-          cwd,
-          env: { ...getCiVisEvpProxyConfig(receiver.port), TESTS_TO_RUN: 'test/ci-visibility-test' },
         }
       )
-
-      childProcess.on('exit', () => {
-        eventsPromise.then(() => {
-          done()
-        }).catch(done)
-      })
     })
 
     // Regression test: without the fix, _ddKnownTests is not injected after worker restart,
@@ -4117,8 +4114,27 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         known_tests_enabled: true,
       })
 
-      const eventsPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisEvpProxyConfig(receiver.port),
+            // 4 suites: 2 spacers from test-management/ (sort first), then ci-visibility-test-2
+            // and ci-visibility-test. The new test (ci-visibility-test-2) is the 3rd suite,
+            // running on a child process that has been replaced twice by workerIdleMemoryLimit.
+            TESTS_TO_RUN: '(test/ci-visibility-test|test-management/test-worker-restart-(spacer|known-tests-spacer))',
+            RUN_IN_PARALLEL: 'true',
+            MAX_WORKERS: '1',
+            WORKER_IDLE_MEMORY_LIMIT: '0',
+          },
+        }
+      )
+
+      await receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
@@ -4142,29 +4158,8 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
           const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
           assert.strictEqual(retriedTests.length, 0)
-        })
-
-      childProcess = exec(
-        runTestsCommand,
-        {
-          cwd,
-          env: {
-            ...getCiVisEvpProxyConfig(receiver.port),
-            // 4 suites: 2 spacers from test-management/ (sort first), then ci-visibility-test-2
-            // and ci-visibility-test. The new test (ci-visibility-test-2) is the 3rd suite,
-            // running on a child process that has been replaced twice by workerIdleMemoryLimit.
-            TESTS_TO_RUN: '(test/ci-visibility-test|test-management/test-worker-restart-(spacer|known-tests-spacer))',
-            RUN_IN_PARALLEL: 'true',
-            MAX_WORKERS: '1',
-            WORKER_IDLE_MEMORY_LIMIT: '0',
-          },
         }
       )
-
-      await Promise.all([
-        once(childProcess, 'exit'),
-        eventsPromise,
-      ])
     })
   })
 })


### PR DESCRIPTION
## Summary

Both cases in `known tests without early flake detection` asserted on whatever the
intake had received after a fixed 15 s window, and that window opens before the child
is spawned: one budget covers node boot, a `--no-cache` Jest cold start, both suites
and the tracer flush. Under load the window expires first and the timer runs the
assertion on a buffer that is still empty, so the run fails with `TypeError: Cannot
read properties of undefined (reading 'content')` thrown from `Timeout._onTimeout`,
naming neither the assertion nor the slow child.

`gatherPayloadsUntilChildExit` runs the assertion once on the post-exit buffer, after
an HTTP drain grace period, and keeps a wall clock only as a backstop for a child that
never exits.

## Why

The rest of the file still gathers on the fixed window. Converting one context at a
time keeps each change reviewable against the flake that motivated it.

Refs: https://github.com/DataDog/dd-trace-js/pull/8419