### PR TITLE
fix(agentless): preserve trace encoding semantics

### DIFF
--- a/packages/dd-trace/src/encode/agentless-json.js
+++ b/packages/dd-trace/src/encode/agentless-json.js
@@ -46,9 +46,7 @@ function formatSpan (span, isFirstSpan, isTopLevel) {
 function getSpanId (span) {
   try {
     return span.span_id?.toString(16)
-  } catch {
-    return undefined
-  }
+  } catch {}
 }
 
 function getTopLevelSpanIds (trace) {

--- a/packages/dd-trace/src/encode/agentless-json.js
+++ b/packages/dd-trace/src/encode/agentless-json.js
@@ -14,7 +14,7 @@ const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
  * @param {boolean} isFirstSpan - Whether this is the first span in the trace
  * @returns {object} The formatted span
  */
-function formatSpan (span, isFirstSpan) {
+function formatSpan (span, isFirstSpan, isTopLevel) {
   span = normalizeSpan(span)
 
   // Remove _dd.p.tid (the upper 64 bits of a 128-bit trace ID) since trace_id is truncated to lower 64 bits
@@ -36,17 +36,53 @@ function formatSpan (span, isFirstSpan) {
     span.metrics._trace_root = 1
   }
 
-  if (span.metrics[TOP_LEVEL_KEY]) {
+  if (span.metrics[TOP_LEVEL_KEY] || isTopLevel) {
     span.metrics._top_level = 1
   }
 
   return span
 }
 
+function getSpanId (span) {
+  try {
+    return span.span_id?.toString(16)
+  } catch {
+    return undefined
+  }
+}
+
+function getTopLevelSpanIds (trace) {
+  const spansById = new Map()
+  const topLevelSpanIds = new Set()
+
+  for (const span of trace) {
+    const spanId = getSpanId(span)
+    if (spanId !== undefined) spansById.set(spanId, span)
+  }
+
+  for (const span of trace) {
+    const spanId = getSpanId(span)
+    if (spanId === undefined) continue
+
+    let parent
+    try {
+      parent = spansById.get(span.parent_id?.toString(16))
+    } catch {
+      continue
+    }
+
+    if (parent === undefined || parent.service !== span.service) {
+      topLevelSpanIds.add(spanId)
+    }
+  }
+
+  return topLevelSpanIds
+}
+
 /**
  * Converts a span to JSON-serializable format.
- * IDs are converted to lowercase hex strings. Start time is converted from
- * nanoseconds to seconds for the intake format.
+ * IDs are converted to lowercase hex strings. Start time and duration are kept
+ * in nanoseconds for the intake format.
  * @param {object} span - The formatted span
  * @returns {object} JSON-serializable span object
  */
@@ -59,7 +95,7 @@ function spanToJSON (span) {
     resource: span.resource,
     service: span.service,
     error: span.error,
-    start: Math.floor(span.start / 1e9),
+    start: span.start,
     duration: span.duration,
     meta: span.meta,
     metrics: span.metrics,
@@ -114,10 +150,15 @@ class AgentlessJSONEncoder {
   encode (trace) {
     const spanStrings = []
     let traceSize = 0
+    const topLevelSpanIds = getTopLevelSpanIds(trace)
 
     for (const span of trace) {
       try {
-        const formattedSpan = formatSpan(span, spanStrings.length === 0)
+        const formattedSpan = formatSpan(
+          span,
+          spanStrings.length === 0,
+          topLevelSpanIds.has(getSpanId(span))
+        )
         const serialized = JSON.stringify(spanToJSON(formattedSpan))
         spanStrings.push(serialized)
         traceSize += serialized.length

--- a/packages/dd-trace/test/encode/agentless-json.spec.js
+++ b/packages/dd-trace/test/encode/agentless-json.spec.js
@@ -119,7 +119,7 @@ describe('AgentlessJSONEncoder', () => {
       assert.strictEqual(span.meta['_dd.p.tid'], undefined)
     })
 
-    it('should include span fields with start time converted to seconds', () => {
+    it('should include span fields with start time in nanoseconds', () => {
       encoder.encode(data)
 
       const buffer = encoder.makePayload()
@@ -132,11 +132,27 @@ describe('AgentlessJSONEncoder', () => {
         service: 'test-service',
         type: 'web',
         error: 0,
-        start: 1234567890,
+        start: 1234567890000000000,
         duration: 5000000,
       })
       assert.deepStrictEqual(span.meta, { foo: 'bar', '_dd.compute_stats': '1' })
-      assert.deepStrictEqual(span.metrics, { example: 1.5, _trace_root: 1 })
+      assert.deepStrictEqual(span.metrics, { example: 1.5, _trace_root: 1, _top_level: 1 })
+    })
+
+    it('should preserve nanosecond start times across separately encoded distributed chunks', () => {
+      data[0].duration = 2_000_000_000
+
+      encoder.encode(data)
+      encoder.encode([childSpan])
+
+      const decoded = JSON.parse(encoder.makePayload().toString())
+      const parent = decoded.traces[0].spans[0]
+      const child = decoded.traces[1].spans[0]
+
+      assert.strictEqual(parent.start, data[0].start)
+      assert.strictEqual(child.start, childSpan.start)
+      assert.strictEqual(child.start - parent.start, 1_000_000_000)
+      assert.ok(child.start < parent.start + parent.duration)
     })
 
     it('should handle multiple spans in one trace', () => {
@@ -249,15 +265,29 @@ describe('AgentlessJSONEncoder', () => {
       assert.strictEqual(decoded.traces[0].spans[1].metrics._top_level, undefined)
     })
 
-    it('should not set _top_level when _dd.top_level is 0', () => {
-      data[0].metrics['_dd.top_level'] = 0
+    it('should not infer _top_level for a child with an in-chunk same-service parent', () => {
+      childSpan.metrics['_dd.top_level'] = 0
 
-      encoder.encode(data)
+      encoder.encode([data[0], childSpan])
 
       const buffer = encoder.makePayload()
       const decoded = JSON.parse(buffer.toString())
 
-      assert.strictEqual(decoded.traces[0].spans[0].metrics._top_level, undefined)
+      assert.strictEqual(decoded.traces[0].spans[1].metrics._top_level, undefined)
+    })
+
+    it('should infer _top_level for local roots and service boundaries', () => {
+      data[0].metrics['_dd.top_level'] = 0
+      data[0].service = 'upstream-service'
+      childSpan.metrics['_dd.top_level'] = 0
+
+      encoder.encode([data[0], childSpan])
+
+      const decoded = JSON.parse(encoder.makePayload().toString())
+      const [root, serviceBoundary] = decoded.traces[0].spans
+
+      assert.strictEqual(root.metrics._top_level, 1)
+      assert.strictEqual(serviceBoundary.metrics._top_level, 1)
     })
 
     it('should set _dd.compute_stats on next span when first span is malformed', () => {

--- a/packages/dd-trace/test/encode/agentless-json.spec.js
+++ b/packages/dd-trace/test/encode/agentless-json.spec.js
@@ -145,7 +145,11 @@ describe('AgentlessJSONEncoder', () => {
       encoder.encode(data)
       encoder.encode([childSpan])
 
-      const decoded = JSON.parse(encoder.makePayload().toString())
+      const payload = encoder.makePayload()
+      assert.ok(payload.includes(Buffer.from('"start":1234567890000000000')))
+      assert.ok(payload.includes(Buffer.from('"start":1234567891000000000')))
+
+      const decoded = JSON.parse(payload.toString())
       const parent = decoded.traces[0].spans[0]
       const child = decoded.traces[1].spans[0]
 
@@ -153,6 +157,7 @@ describe('AgentlessJSONEncoder', () => {
       assert.strictEqual(child.start, childSpan.start)
       assert.strictEqual(child.start - parent.start, 1_000_000_000)
       assert.ok(child.start < parent.start + parent.duration)
+      assert.strictEqual(child.metrics._top_level, 1)
     })
 
     it('should handle multiple spans in one trace', () => {


### PR DESCRIPTION
## Problem

The agentless JSON encoder divides span start timestamps by 1e9 even though the /api/v2/spans wire format expects nanoseconds. Duration remains in nanoseconds, leaving start and duration in different units. Separately exported distributed-trace chunks can therefore appear outside their parent timing window or in the wrong order.

A separately encoded span also cannot rely on its parent being present in the same payload when determining whether it is a top-level span.

## Change

- preserve nanosecond start timestamps in the JSON payload
- infer top-level spans from the spans available in each exported chunk, including local roots and service boundaries
- preserve the existing behavior for children whose same-service parent is present

## Evidence

- regression coverage encodes a two-second parent and a child starting one second later as separate distributed chunks, then verifies both raw nanosecond values and that the child remains inside the parent timing window
- regression coverage verifies local-root, service-boundary, and same-service-child top-level semantics
- the malformed timing was observed in Datadog trace https://app.datadoghq.com/api/ui/trace/8615128178830110017
- focused agentless encoder tests and the full repository CI pass

Stack 1/5.