### PR TITLE
fix(agentless): complete intake flush callbacks

### DIFF
--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -14,7 +14,10 @@ const { computeIntakeUrl, INTAKE_PATH } = require('./intake')
  * Sends traces directly to the Datadog intake endpoint without an agent.
  */
 class AgentlessWriter extends BaseWriter {
+  #activeRequests = new Set()
   #apiKeyMissing = false
+  #flushWaiters = new Set()
+  #lastRequestId = 0
   #urlMissing = false
 
   /**
@@ -64,14 +67,14 @@ class AgentlessWriter extends BaseWriter {
         log.error('Maximum number of active requests reached. Dropping %d trace(s).', count)
       }
       this._encoder.reset()
-      done()
+      this.#callWhenRequestsComplete(done)
       return
     }
 
     const count = this._encoder.count()
 
     if (count === 0) {
-      done()
+      this.#callWhenRequestsComplete(done)
       return
     }
 
@@ -79,23 +82,22 @@ class AgentlessWriter extends BaseWriter {
 
     if (payload.length === 0) {
       log.debug('Skipping send of empty payload')
-      done()
+      this.#callWhenRequestsComplete(done)
       return
     }
 
-    this._sendPayload(payload, count, done)
+    this._sendPayload(payload, count)
+    this.#callWhenRequestsComplete(done)
   }
 
   /**
    * Sends the encoded payload to the intake endpoint.
    * @param {Buffer} data - The encoded JSON payload
    * @param {number} count - Number of traces in the payload
-   * @param {Function} done - Callback when complete
    */
-  _sendPayload (data, count, done) {
+  _sendPayload (data, count) {
     if (!data || data.length === 0) {
       log.debug('Skipping send of empty payload')
-      done()
       return
     }
 
@@ -105,7 +107,6 @@ class AgentlessWriter extends BaseWriter {
         log.error('No valid URL configured for agentless trace intake. Traces will not be sent.')
       }
       log.debug('Dropping %d trace(s) due to missing URL', count)
-      done()
       return
     }
 
@@ -116,7 +117,6 @@ class AgentlessWriter extends BaseWriter {
         log.error('DD_API_KEY is required for agentless trace intake. Set DD_API_KEY. Traces will not be sent.')
       }
       log.debug('Dropping %d trace(s) due to missing DD_API_KEY', count)
-      done()
       return
     }
     this.#apiKeyMissing = false
@@ -137,18 +137,75 @@ class AgentlessWriter extends BaseWriter {
       url: this._url,
     }
 
-    log.debug('Request to the agentless intake: %j', options)
+    log.debug(
+      'Request to the agentless intake: method=%s host=%s path=%s trace_count=%d timeout_ms=%d',
+      options.method,
+      this._url.hostname,
+      options.path,
+      count,
+      options.timeout
+    )
 
-    request(data, options, (err, res, statusCode) => {
-      if (err) {
-        this.#logRequestError(err, statusCode, count)
-        done()
-        return
-      }
+    const activeRequest = ++this.#lastRequestId
+    this.#activeRequests.add(activeRequest)
 
-      log.debug('Response from the agentless intake: %s', res)
+    try {
+      request(data, options, (err, _res, statusCode) => {
+        if (err) {
+          this.#logRequestError(err, statusCode, count)
+        } else {
+          log.debug('Agentless intake request completed with status=%d', statusCode)
+        }
+
+        this.#finishRequest(activeRequest)
+      })
+    } catch (err) {
+      this.#finishRequest(activeRequest)
+      throw err
+    }
+  }
+
+  /**
+   * Waits for the intake requests that were active when this method was called.
+   * Requests started by later flushes do not delay this callback.
+   * @param {Function} done - Callback when the current requests have completed
+   */
+  #callWhenRequestsComplete (done) {
+    if (this.#activeRequests.size === 0) {
       done()
-    })
+      return
+    }
+
+    this.#flushWaiters.add({ done, lastRequestId: this.#lastRequestId })
+  }
+
+  /**
+   * Completes waiters whose request snapshot no longer contains an active request.
+   * @param {number} activeRequest - Identifier of the completed request
+   */
+  #finishRequest (activeRequest) {
+    if (!this.#activeRequests.delete(activeRequest)) return
+
+    // Request IDs increase with Set insertion order, so the first value is the oldest active request.
+    const oldestActiveRequest = this.#activeRequests.values().next().value
+    const callbacks = []
+    for (const waiter of this.#flushWaiters) {
+      if (oldestActiveRequest === undefined || oldestActiveRequest > waiter.lastRequestId) {
+        this.#flushWaiters.delete(waiter)
+        callbacks.push(waiter.done)
+      }
+    }
+
+    let callbackError
+    for (const callback of callbacks) {
+      try {
+        callback()
+      } catch (err) {
+        callbackError ??= err
+      }
+    }
+
+    if (callbackError) throw callbackError
   }
 
   /**

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const http = require('node:http')
 const { URL } = require('node:url')
 const { inspect } = require('node:util')
 
@@ -128,6 +129,141 @@ describe('AgentlessWriter', () => {
       writer.flush(done)
     })
 
+    it('should wait for an active intake request when empty', (done) => {
+      let requestCallback
+      let flushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.onSecondCall().returns(0)
+
+      writer.flush()
+      writer.flush(() => {
+        flushed = true
+        done()
+      })
+
+      assert.strictEqual(flushed, false)
+      requestCallback(null, '{}', 200)
+    })
+
+    it('should wait for prior and newly submitted intake requests', (done) => {
+      const requestCallbacks = []
+      let flushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush()
+      writer.flush(() => {
+        flushed = true
+        done()
+      })
+
+      requestCallbacks[1](null, '{}', 200)
+      assert.strictEqual(flushed, false)
+      requestCallbacks[0](null, '{}', 200)
+    })
+
+    it('should not wait for requests submitted by a later flush', () => {
+      const requestCallbacks = []
+      let firstFlushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush(() => {
+        firstFlushed = true
+      })
+      writer.flush()
+
+      requestCallbacks[0](null, '{}', 200)
+      assert.strictEqual(firstFlushed, true)
+      requestCallbacks[1](null, '{}', 200)
+    })
+
+    it('should release an empty flush when an active request fails', (done) => {
+      let requestCallback
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.onSecondCall().returns(0)
+
+      writer.flush()
+      writer.flush(done)
+
+      requestCallback(new Error('ECONNRESET'))
+    })
+
+    it('should release every waiter when one callback throws', () => {
+      const error = new Error('flush callback failed')
+      let requestCallback
+      let secondCallbackCalled = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallback = callback
+      })
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.returns(0)
+
+      writer.flush()
+      writer.flush(() => {
+        throw error
+      })
+      writer.flush(() => {
+        secondCallbackCalled = true
+      })
+
+      assert.throws(() => requestCallback(null, '{}', 200), error)
+      assert.strictEqual(secondCallbackCalled, true)
+    })
+
+    it('should allow a waiter to flush re-entrantly', () => {
+      const requestCallbacks = []
+      let reentrantFlushed = false
+
+      request.callsFake((data, options, callback) => {
+        requestCallbacks.push(callback)
+      })
+      encoder.count.returns(1)
+
+      writer.flush(() => {
+        writer.flush(() => {
+          reentrantFlushed = true
+        })
+      })
+
+      requestCallbacks[0](null, '{}', 200)
+      assert.strictEqual(reentrantFlushed, false)
+      requestCallbacks[1](null, '{}', 200)
+      assert.strictEqual(reentrantFlushed, true)
+    })
+
+    it('should not retain a request when submission throws', () => {
+      const error = new Error('submission failed')
+
+      request.throws(error)
+      encoder.count.onFirstCall().returns(1)
+      encoder.count.onSecondCall().returns(0)
+
+      assert.throws(() => writer.flush(), error)
+
+      request.resetBehavior()
+      let flushed = false
+      writer.flush(() => {
+        flushed = true
+      })
+      assert.strictEqual(flushed, true)
+    })
+
     it('should flush traces to the intake with correct headers', (done) => {
       const expectedData = Buffer.from('{"traces":[]}')
 
@@ -151,7 +287,41 @@ describe('AgentlessWriter', () => {
             'Datadog-Meta-Tracer-Version': 'tracerVersion',
           },
         })
+        const debugOutput = log.debug.args.flat().join(' ')
+        assert.ok(!debugOutput.includes('test-api-key'))
+        const requestLog = log.debug.args.find(args => args[0].startsWith('Request to the agentless intake'))
+        assert.ok(requestLog)
+        assert.ok(requestLog.every(arg => arg?.headers === undefined))
         done()
+      })
+    })
+
+    it('should send a loopback intake request and wait for its response', (done) => {
+      const RealWriter = proxyquire('../../../src/exporters/agentless/writer', {
+        '../common/request': require('../../../src/exporters/common/request'),
+        '../../encode/agentless-json': { AgentlessJSONEncoder: function () { return encoder } },
+        '../../../../../package.json': { version: 'tracerVersion' },
+        '../../log': log,
+        '../../config': () => ({ DD_API_KEY: apiKey }),
+      })
+      let flushed = false
+      const server = http.createServer((req, res) => {
+        assert.strictEqual(req.method, 'POST')
+        assert.strictEqual(req.url, '/api/v2/spans')
+        assert.strictEqual(req.headers['dd-api-key'], 'test-api-key')
+        assert.strictEqual(flushed, false)
+        res.end('accepted')
+      })
+
+      server.listen(0, '127.0.0.1', () => {
+        const port = server.address().port
+        const loopbackWriter = new RealWriter({ url: new URL(`http://127.0.0.1:${port}`) })
+        encoder.count.returns(1)
+
+        loopbackWriter.flush(() => {
+          flushed = true
+          server.close(done)
+        })
       })
     })
 

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -310,6 +310,7 @@ describe('AgentlessWriter', () => {
         assert.strictEqual(req.url, '/api/v2/spans')
         assert.strictEqual(req.headers['dd-api-key'], 'test-api-key')
         assert.strictEqual(flushed, false)
+        res.setHeader('Connection', 'close')
         res.end('accepted')
       })
 


### PR DESCRIPTION
## Problem

AgentlessWriter reports flush completion immediately after submitting the intake request, not after the intake response. In short-lived serverless runtimes, callers can therefore believe a flush is complete while the network request is still active and the platform can freeze the invocation.

The previous debug statement also serialized the complete request options object, including the dd-api-key header. Vercel happened to mask the value in its log backend, but the tracer still passed the credential to the logging pipeline.

## Change

- track active intake requests and complete each flush callback only after the requests visible to that flush finish
- preserve correct behavior under concurrent, failed, throwing, and reentrant requests
- log only method, host, path, trace count, and timeout; never serialize request headers

## Evidence

- a real loopback HTTP test proves the flush callback remains pending until the intake response is received
- regression tests cover an empty flush behind an active request, concurrent requests, later requests, failures, thrown callbacks, and reentrant flushes
- a credential-safety assertion verifies that the API key and headers are absent from debug output
- live Vercel direct export completed through the agentless intake, and the full repository CI passes

Stack 2/5; based on #9597.