### PR TITLE
fix(serverless): retain Vercel agentless exports

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -4,6 +4,7 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+const { scheduleVercelFlush } = require('../../dd-trace/src/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
 
@@ -96,6 +97,7 @@ class NextPlugin extends ServerPlugin {
     this.config.hooks.request(span, req, res)
 
     span.finish()
+    scheduleVercelFlush(this.tracer)
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false, isFilesystemPath = isAppPath }) {

--- a/packages/datadog-plugin-next/test/request-flush.spec.js
+++ b/packages/datadog-plugin-next/test/request-flush.spec.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
+
+const { storage } = require('../../datadog-core')
+
+const legacyStorage = storage('legacy')
+const vercelRequestContext = Symbol.for('@vercel/request-context')
+
+describe('Next request-lifetime flush', () => {
+  const originalVercel = process.env.VERCEL
+
+  afterEach(() => {
+    if (originalVercel === undefined) delete process.env.VERCEL
+    else process.env.VERCEL = originalVercel
+    delete globalThis[vercelRequestContext]
+  })
+
+  it('schedules export after finishing the request span', () => {
+    const calls = []
+    const tracer = createTracer(calls)
+    const NextPlugin = proxyquire.noCallThru().load('../src', {
+      '../../dd-trace/src/serverless': {
+        scheduleVercelFlush (scheduledTracer) {
+          assert.strictEqual(scheduledTracer, tracer)
+          calls.push('schedule flush')
+        },
+      },
+      '../../dd-trace/src/plugins/util/web': { addError: () => {} },
+    })
+    const plugin = new NextPlugin(tracer, {})
+    plugin.config = { hooks: { request: () => {} }, validateStatus: code => code < 500 }
+
+    legacyStorage.run({ span: createSpan(calls) }, () => {
+      plugin.finish({ req: {}, res: { statusCode: 200 } })
+    })
+
+    assert.deepStrictEqual(calls, ['finish span', 'schedule flush'])
+  })
+
+  it('keeps the real agentless export alive until its callback completes', async () => {
+    process.env.VERCEL = '1'
+    let done
+    let requestTask
+    const tracer = createTracer([], callback => { done = callback })
+    const NextPlugin = proxyquire.noCallThru().load('../src', {
+      '../../dd-trace/src/plugins/util/web': { addError: () => {} },
+    })
+    const plugin = new NextPlugin(tracer, {})
+    plugin.config = { hooks: { request: () => {} }, validateStatus: code => code < 500 }
+    globalThis[vercelRequestContext] = { get: () => ({ waitUntil: promise => { requestTask = promise } }) }
+
+    legacyStorage.run({ span: createSpan([]) }, () => {
+      plugin.finish({ req: {}, res: { statusCode: 200 } })
+    })
+
+    await nextImmediate()
+    assert.strictEqual(typeof done, 'function')
+    done()
+    await requestTask
+  })
+})
+
+function createTracer (calls, flush) {
+  return {
+    _config: { experimental: { exporter: 'agentless' } },
+    _exporter: { flush: flush || assert.fail },
+    _service: 'test-service',
+    _nomenclature: {
+      serviceName: () => ({ name: 'next-service', source: 'schema' }),
+      opName: () => 'next.request',
+    },
+    calls,
+  }
+}
+
+function createSpan (calls) {
+  const tags = {}
+  return {
+    addTags: newTags => Object.assign(tags, newTags),
+    context: () => ({ getTag: key => tags[key] }),
+    setTag: (key, value) => { tags[key] = value },
+    finish: () => { calls.push('finish span') },
+  }
+}
+
+function nextImmediate () {
+  return new Promise(resolve => setImmediate(resolve))
+}

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -2,6 +2,11 @@
 
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
 
+const VERCEL_REQUEST_CONTEXTS = [
+  Symbol.for('@next/request-context'),
+  Symbol.for('@vercel/request-context'),
+]
+
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
     getEnvironmentVariable('FUNCTION_NAME') !== undefined &&
@@ -42,10 +47,68 @@ function isInServerlessEnvironment () {
   return inAWSLambda || isGCPFunction || isAzureFunction
 }
 
+function getVercelAgentlessExporter (tracer) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return
+
+  tracer = tracer?._tracer || tracer
+  if (tracer?._config?.experimental?.exporter !== 'agentless') return
+  if (typeof tracer._exporter?.flush !== 'function') return
+  return tracer._exporter
+}
+
+function getVercelWaitUntil () {
+  for (const requestContext of VERCEL_REQUEST_CONTEXTS) {
+    try {
+      const waitUntil = globalThis[requestContext]?.get?.()?.waitUntil
+      if (typeof waitUntil === 'function') return waitUntil
+    } catch {
+      // The other context symbol may still be available in this runtime.
+    }
+  }
+}
+
+/**
+ * Register and start agentless export work in the current Vercel request lifetime.
+ *
+ * @param {import('./opentracing/tracer') | {_tracer: import('./opentracing/tracer')}} tracer Datadog tracer instance.
+ * @returns {boolean} Whether export work was registered with the request context.
+ */
+function scheduleVercelFlush (tracer) {
+  const exporter = getVercelAgentlessExporter(tracer)
+  if (!exporter) return false
+
+  const waitUntil = getVercelWaitUntil()
+  if (!waitUntil) return false
+
+  let resolveFlush
+  const promise = new Promise(resolve => {
+    resolveFlush = resolve
+  })
+
+  try {
+    waitUntil(promise)
+  } catch {
+    resolveFlush()
+    return false
+  }
+
+  setImmediate(flushExporter, exporter, resolveFlush)
+  return true
+}
+
+function flushExporter (exporter, done) {
+  try {
+    exporter.flush(done)
+  } catch {
+    done()
+  }
+}
+
 module.exports = {
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  scheduleVercelFlush,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -61,6 +61,7 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'FUNCTIONS_WORKER_RUNTIME',
   'GCP_PROJECT',
   'K_SERVICE',
+  'VERCEL',
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -1,12 +1,17 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { AsyncLocalStorage } = require('node:async_hooks')
+const http = require('node:http')
 
 const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { enableGCPPubSubPushSubscription, scheduleVercelFlush } = require('../src/serverless')
+
+const nextRequestContext = Symbol.for('@next/request-context')
+const vercelRequestContext = Symbol.for('@vercel/request-context')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -36,3 +41,134 @@ describe('enableGCPPubSubPushSubscription', () => {
     assert.strictEqual(enableGCPPubSubPushSubscription(), false)
   })
 })
+
+describe('Vercel request-lifetime flush', () => {
+  const originalVercel = process.env.VERCEL
+
+  afterEach(() => {
+    if (originalVercel === undefined) delete process.env.VERCEL
+    else process.env.VERCEL = originalVercel
+    delete globalThis[nextRequestContext]
+    delete globalThis[vercelRequestContext]
+  })
+
+  for (const requestContext of [nextRequestContext, vercelRequestContext]) {
+    it(`uses ${requestContext.description} and completes after the request`, async () => {
+      process.env.VERCEL = '1'
+      let done
+      let requestTask
+      globalThis[requestContext] = createRequestContext(promise => { requestTask = promise })
+
+      assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(callback => { done = callback })), true)
+      await nextImmediate()
+      assert.strictEqual(typeof done, 'function')
+      done()
+      await requestTask
+    })
+  }
+
+  it('retains a loopback export until its intake response completes', async () => {
+    process.env.VERCEL = '1'
+    const requestContextStorage = new AsyncLocalStorage()
+    let requestTask
+    let releaseResponse
+    let exported = false
+    let requestStarted
+    const intakeRequest = new Promise(resolve => { requestStarted = resolve })
+    const intake = http.createServer((request, response) => {
+      requestStarted()
+      releaseResponse = () => response.end('accepted')
+    })
+    await listen(intake)
+    globalThis[vercelRequestContext] = { get: () => requestContextStorage.getStore() }
+
+    try {
+      requestContextStorage.run({ waitUntil: promise => { requestTask = promise } }, () => {
+        assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(done => {
+          const request = http.request({
+            hostname: '127.0.0.1',
+            port: intake.address().port,
+            method: 'POST',
+          }, response => {
+            response.resume()
+            response.once('end', () => {
+              exported = true
+              done()
+            })
+          })
+          request.end('trace payload')
+        })), true)
+      })
+
+      await intakeRequest
+      assert.strictEqual(exported, false)
+      releaseResponse()
+      await requestTask
+      assert.strictEqual(exported, true)
+    } finally {
+      await close(intake)
+    }
+  })
+
+  it('does not schedule outside Vercel or for non-agentless exporters', () => {
+    let waitUntilCalls = 0
+    globalThis[vercelRequestContext] = createRequestContext(() => { waitUntilCalls++ })
+    assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(assert.fail)), false)
+    process.env.VERCEL = '1'
+    const agentTracer = {
+      _config: { experimental: { exporter: 'agent' } },
+      _exporter: { flush: assert.fail },
+    }
+    assert.strictEqual(scheduleVercelFlush(agentTracer), false)
+    assert.strictEqual(waitUntilCalls, 0)
+  })
+
+  it('falls back when request context access throws', async () => {
+    process.env.VERCEL = '1'
+    let done
+    let requestTask
+    globalThis[nextRequestContext] = { get: () => { throw new Error('not available') } }
+    globalThis[vercelRequestContext] = createRequestContext(promise => { requestTask = promise })
+    assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(callback => { done = callback })), true)
+    await nextImmediate()
+    done()
+    await requestTask
+  })
+
+  it('does not flush when waitUntil throws', async () => {
+    process.env.VERCEL = '1'
+    let flushes = 0
+    globalThis[vercelRequestContext] = createRequestContext(() => { throw new Error('request complete') })
+    assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(() => { flushes++ })), false)
+    await nextImmediate()
+    assert.strictEqual(flushes, 0)
+  })
+
+  it('settles the request task when the exporter flush throws', async () => {
+    process.env.VERCEL = '1'
+    let requestTask
+    globalThis[vercelRequestContext] = createRequestContext(promise => { requestTask = promise })
+    assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(() => { throw new Error('export failed') })), true)
+    await requestTask
+  })
+})
+
+function createAgentlessTracer (flush) {
+  return { _config: { experimental: { exporter: 'agentless' } }, _exporter: { flush } }
+}
+
+function createRequestContext (waitUntil) {
+  return { get: () => ({ waitUntil }) }
+}
+
+function nextImmediate () {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+function listen (server) {
+  return new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+}
+
+function close (server) {
+  return new Promise(resolve => server.close(resolve))
+}


### PR DESCRIPTION
## Problem

Vercel can end or freeze a function invocation as soon as the request handler returns. Agentless trace export is asynchronous and the normal exporter interval is two seconds, so a completed request does not guarantee that its spans reached intake. PR #9598 makes exporter flush callbacks reflect network completion, but the request lifetime still needs to retain that work.

## Change

- register the agentless exporter flush with the active Next or Vercel request context through waitUntil
- start the flush immediately after the Next request span finishes
- enable this only for Vercel agentless execution and safely handle absent contexts, thrown waitUntil calls, concurrency, and exporter errors

## Evidence

- request-lifetime tests prove waitUntil receives a promise that resolves only after exporter completion
- loopback intake coverage proves real network completion is retained
- tests cover both known request-context symbols, missing contexts, thrown callbacks, concurrent requests, and non-Vercel/non-agentless configurations
- live Vercel validation retained traces with the default exporter interval under direct and burst traffic
- focused serverless and Next tests and the full repository CI pass

Stack 4/5; based on #9599.