### PR TITLE
docs(serverless): add Vercel Next Builder prototype

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 /packages/dd-trace/test/plugins/util/stacktrace.spec.js @DataDog/debugger-nodejs
 
 # Serverless
+/docs/examples/vercel-nextjs/ @DataDog/apm-idm-js @DataDog/apm-serverless
 /packages/dd-trace/src/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/azure_metadata.spec.js @DataDog/apm-serverless

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: ./.github/actions/install
       - run: npm run test:release
       - run: npm run test:scripts
+      - run: npm run test:examples
 
   generated-config-types:
     runs-on: ubuntu-latest

--- a/docs/examples/vercel-nextjs/README.md
+++ b/docs/examples/vercel-nextjs/README.md
@@ -2,48 +2,39 @@
 
 This prototype shows the Builder boundary required to initialize `dd-trace`
 before Next.js in Vercel Node functions. It delegates the framework build to
-Vercel's official `@vercel/next` Builder, then changes only the public Build
-Output API handler in each Node `.func`. Edge functions are left unchanged.
+Vercel's official `@vercel/next` Builder, then packages the tracer and configures
+an early Node preload in each public Node `.func`. Edge functions are left
+unchanged.
 
 ## Application Setup
 
-Install `dd-trace` as a production dependency and add
-[`instrumentation.js`](./instrumentation.js) at the application root. If the
-application already has one, merge the Node-runtime import into `register`.
-
-Keep `dd-trace` external in `next.config.js` so Next's output-file tracing
-includes its runtime dependency closure:
-
-```js
-/** @type {import('next').NextConfig} */
-module.exports = {
-  serverExternalPackages: ['dd-trace'],
-}
-```
+No application source or Next.js configuration is required. The published
+Builder owns a supported `dd-trace` dependency and uses the application's
+installed version when one is available.
 
 ## Builder Setup
 
 Configure the intended Datadog Builder once in `vercel.json`, as shown in
-[`vercel.json`](./vercel.json). Its package must provide `builder.js` from this
-directory and declare `@vercel/next` as its dependency.
+[`vercel.json`](./vercel.json). The Datadog Vercel integration should eventually
+own this configuration so the customer only enables APM and deploys.
 
-The Builder writes a CommonJS launcher next to each public Node function
-handler. The launcher requires `dd-trace/init` before loading the unchanged
-Next launcher. It does not set project-global `NODE_OPTIONS`, mutate a local
-prebuilt deployment, alter Edge output, use Vercel private file maps, or depend
-on Trace Drain.
+The Builder stages the complete installed tracer dependency graph once, keeps
+its transitive dependencies isolated under `dd-trace/node_modules`, maps those
+files into each Node function, and merges
+`--import=dd-trace/initialize.mjs` into that function's existing `NODE_OPTIONS`.
+It does not change the function handler, set project-global `NODE_OPTIONS`,
+alter Edge output, or depend on Trace Drain.
 
-Use Vercel's normal source-build deployment path. Configure `DD_API_KEY` and
-normal Datadog service tags through the Vercel integration or encrypted project
-environment settings. Do not commit API keys or enable `DD_TRACE_DEBUG` in
-production.
+Use Vercel's normal source-build deployment path. The Datadog integration must
+configure the selected agentless exporter, `DD_API_KEY`, and normal Datadog
+service tags as encrypted project settings. Do not commit API keys or enable
+`DD_TRACE_DEBUG` in production.
 
 ## Release Status
 
-`@datadog/vercel-next-builder` is not published by this repository. The
-repository release workflow publishes only `dd-trace`, and
-`packages/datadog-plugin-next` is not an independently publishable package.
-This directory is therefore a tested prototype and onboarding contract, not a
+`@datadog/vercel-next-builder` is not published by this repository. This
+directory is therefore a tested prototype and onboarding contract, not a
 customer-installable release. Publishing the Builder requires a package owner,
-package manifest, registry/release workflow, and live Vercel acceptance before
-this configuration can be supported.
+package manifest with `@vercel/next` and `dd-trace` dependencies,
+registry/release workflow, and live Vercel acceptance before this configuration
+can be supported.

--- a/docs/examples/vercel-nextjs/README.md
+++ b/docs/examples/vercel-nextjs/README.md
@@ -1,0 +1,49 @@
+# Datadog APM For Next.js On Vercel
+
+This prototype shows the Builder boundary required to initialize `dd-trace`
+before Next.js in Vercel Node functions. It delegates the framework build to
+Vercel's official `@vercel/next` Builder, then changes only the public Build
+Output API handler in each Node `.func`. Edge functions are left unchanged.
+
+## Application Setup
+
+Install `dd-trace` as a production dependency and add
+[`instrumentation.js`](./instrumentation.js) at the application root. If the
+application already has one, merge the Node-runtime import into `register`.
+
+Keep `dd-trace` external in `next.config.js` so Next's output-file tracing
+includes its runtime dependency closure:
+
+```js
+/** @type {import('next').NextConfig} */
+module.exports = {
+  serverExternalPackages: ['dd-trace'],
+}
+```
+
+## Builder Setup
+
+Configure the intended Datadog Builder once in `vercel.json`, as shown in
+[`vercel.json`](./vercel.json). Its package must provide `builder.js` from this
+directory and declare `@vercel/next` as its dependency.
+
+The Builder writes a CommonJS launcher next to each public Node function
+handler. The launcher requires `dd-trace/init` before loading the unchanged
+Next launcher. It does not set project-global `NODE_OPTIONS`, mutate a local
+prebuilt deployment, alter Edge output, use Vercel private file maps, or depend
+on Trace Drain.
+
+Use Vercel's normal source-build deployment path. Configure `DD_API_KEY` and
+normal Datadog service tags through the Vercel integration or encrypted project
+environment settings. Do not commit API keys or enable `DD_TRACE_DEBUG` in
+production.
+
+## Release Status
+
+`@datadog/vercel-next-builder` is not published by this repository. The
+repository release workflow publishes only `dd-trace`, and
+`packages/datadog-plugin-next` is not an independently publishable package.
+This directory is therefore a tested prototype and onboarding contract, not a
+customer-installable release. Publishing the Builder requires a package owner,
+package manifest, registry/release workflow, and live Vercel acceptance before
+this configuration can be supported.

--- a/docs/examples/vercel-nextjs/README.md
+++ b/docs/examples/vercel-nextjs/README.md
@@ -8,9 +8,9 @@ unchanged.
 
 ## Application Setup
 
-No application source or Next.js configuration is required. The published
-Builder owns a supported `dd-trace` dependency and uses the application's
-installed version when one is available.
+No application source, Next.js configuration, or `dd-trace` dependency is
+required. The published Builder owns the supported tracer version so its
+runtime artifact is reproducible and tested as one release unit.
 
 ## Builder Setup
 
@@ -18,9 +18,9 @@ Configure the intended Datadog Builder once in `vercel.json`, as shown in
 [`vercel.json`](./vercel.json). The Datadog Vercel integration should eventually
 own this configuration so the customer only enables APM and deploys.
 
-The Builder stages the complete installed tracer dependency graph once, keeps
-its transitive dependencies isolated under `dd-trace/node_modules`, maps those
-files into each Node function, and merges
+The Builder stages the published tracer package and uses Vercel's Node File
+Trace for its declared runtime dependencies. It maps that runtime into each
+Node function and merges
 `--import=dd-trace/initialize.mjs` into that function's existing `NODE_OPTIONS`.
 It does not change the function handler, set project-global `NODE_OPTIONS`,
 alter Edge output, or depend on Trace Drain.
@@ -35,6 +35,6 @@ service tags as encrypted project settings. Do not commit API keys or enable
 `@datadog/vercel-next-builder` is not published by this repository. This
 directory is therefore a tested prototype and onboarding contract, not a
 customer-installable release. Publishing the Builder requires a package owner,
-package manifest with `@vercel/next` and `dd-trace` dependencies,
-registry/release workflow, and live Vercel acceptance before this configuration
-can be supported.
+package manifest with `@vercel/next`, `@vercel/nft`, and `dd-trace`
+dependencies, registry/release workflow, and live Vercel acceptance before this
+configuration can be supported.

--- a/docs/examples/vercel-nextjs/builder.js
+++ b/docs/examples/vercel-nextjs/builder.js
@@ -37,7 +37,16 @@ async function findFunctionPaths (directory) {
 }
 
 async function instrumentBuildOutput (outputPath) {
-  const functionPaths = await findFunctionPaths(path.join(outputPath, 'functions'))
+  const functionsPath = path.join(outputPath, 'functions')
+
+  try {
+    await fs.access(functionsPath)
+  } catch (error) {
+    if (error.code === 'ENOENT') return
+    throw error
+  }
+
+  const functionPaths = await findFunctionPaths(functionsPath)
 
   for (const functionPath of functionPaths) {
     const configPath = path.join(functionPath, '.vc-config.json')
@@ -53,6 +62,7 @@ async function instrumentBuildOutput (outputPath) {
 
 async function build (options) {
   // Load Vercel's official Builder only when Vercel invokes this entry point.
+  // eslint-disable-next-line n/no-missing-require -- Declared by the published Builder package.
   const { build: buildNext } = require('@vercel/next')
   const result = await buildNext(options)
 

--- a/docs/examples/vercel-nextjs/builder.js
+++ b/docs/examples/vercel-nextjs/builder.js
@@ -54,17 +54,8 @@ async function findPackageRoot (packageName, searchPath) {
   throw new Error(`Unable to find the package root for ${packageName}`)
 }
 
-async function resolveTracerRoot (workPath) {
-  let tracerRoot
-
-  try {
-    tracerRoot = await findPackageRoot('dd-trace', workPath)
-  } catch (error) {
-    if (error.code !== 'MODULE_NOT_FOUND') throw error
-    tracerRoot = await findPackageRoot('dd-trace', __dirname)
-  }
-
-  return validateTracerRoot(tracerRoot)
+async function resolveTracerRoot () {
+  return validateTracerRoot(await findPackageRoot('dd-trace', __dirname))
 }
 
 async function validateTracerRoot (tracerRoot) {
@@ -87,109 +78,70 @@ async function validateTracerRoot (tracerRoot) {
   return tracerRoot
 }
 
-async function collectPackageGraph (tracerRoot) {
-  const installationRoot = path.dirname(tracerRoot)
-  const packages = new Map()
-  const pending = [{ destination: 'dd-trace', name: 'dd-trace', root: tracerRoot, required: true }]
+function findTraceBase (tracerRoot) {
+  let directory = tracerRoot
 
-  while (pending.length > 0) {
-    const current = pending.pop()
-    let manifest
+  while (directory !== path.dirname(directory)) {
+    if (path.join(directory, 'node_modules', 'dd-trace') === tracerRoot) return directory
+    directory = path.dirname(directory)
+  }
 
+  throw new Error(`dd-trace must be installed under node_modules: ${tracerRoot}`)
+}
+
+async function stageTracerFiles (tracerRoot, workPath) {
+  // eslint-disable-next-line import/no-extraneous-dependencies, n/no-extraneous-require -- Builder dependency.
+  const { nodeFileTrace } = require('@vercel/nft')
+  const traceBase = await fs.realpath(findTraceBase(tracerRoot))
+  tracerRoot = await fs.realpath(tracerRoot)
+  const manifest = JSON.parse(await fs.readFile(path.join(tracerRoot, 'package.json'), 'utf8'))
+  const packageRequire = Module.createRequire(path.join(tracerRoot, 'package.json'))
+  // The tracer loads vendored modules and features dynamically, so NFT alone
+  // cannot discover its complete runtime.
+  const packageFiles = await listPackageFiles(tracerRoot)
+  const entrypoints = [path.join(tracerRoot, 'initialize.mjs')]
+
+  for (const dependency of [
+    ...Object.keys(manifest.dependencies || {}),
+    ...Object.keys(manifest.optionalDependencies || {}),
+  ]) {
     try {
-      manifest = JSON.parse(await fs.readFile(path.join(current.root, 'package.json'), 'utf8'))
+      entrypoints.push(packageRequire.resolve(dependency))
     } catch (error) {
-      if (!current.required && error.code === 'ENOENT') continue
-      throw error
-    }
-
-    const existing = packages.get(current.destination)
-    if (existing) {
-      if (existing.root !== current.root) {
-        throw new Error(
-          `dd-trace dependency graph maps multiple packages to node_modules/${current.destination}`
-        )
-      }
-      continue
-    }
-
-    packages.set(current.destination, { manifest, root: current.root })
-
-    const dependencies = Object.keys(manifest.dependencies || {})
-    const optionalDependencies = Object.keys(manifest.optionalDependencies || {})
-
-    for (const name of dependencies) {
-      const root = await findPackageRoot(name, current.root)
-      const destination = tracerDependencyDestination(name, root, installationRoot)
-      pending.push({ destination, name, root, required: true })
-    }
-    for (const name of optionalDependencies) {
-      try {
-        const root = await findPackageRoot(name, current.root)
-        pending.push({
-          destination: tracerDependencyDestination(name, root, installationRoot),
-          name,
-          root,
-          required: false,
-        })
-      } catch (error) {
-        if (error.code !== 'MODULE_NOT_FOUND') throw error
-      }
+      if (error.code !== 'MODULE_NOT_FOUND') throw error
     }
   }
 
-  return packages
-}
+  const { fileList } = await nodeFileTrace(entrypoints, {
+    base: traceBase,
+    processCwd: workPath,
+  })
+  for (const filePath of packageFiles) fileList.add(path.relative(traceBase, filePath))
 
-function tracerDependencyDestination (name, packageRoot, installationRoot) {
-  const destination = packageDestination(name, packageRoot, installationRoot)
-  return path.join('dd-trace', 'node_modules', destination)
-}
-
-function packageDestination (name, packageRoot, installationRoot) {
-  const relativePath = path.relative(installationRoot, packageRoot)
-  if (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath)) {
-    return relativePath
-  }
-  return name
-}
-
-async function stagePackageGraph (packages, workPath) {
-  const runtimeRoot = path.join(workPath, '.datadog', 'vercel-runtime', 'node_modules')
+  const runtimeRoot = path.join(workPath, '.datadog', 'vercel-runtime')
   const filePathMap = {}
 
   await fs.rm(runtimeRoot, { force: true, recursive: true })
 
-  for (const [destinationPath, packageInfo] of packages) {
-    const destination = path.join(runtimeRoot, destinationPath)
-    await fs.cp(packageInfo.root, destination, {
-      recursive: true,
-      dereference: true,
-      filter: source => {
-        const relativePath = path.relative(packageInfo.root, source)
-        return relativePath === '' || relativePath.split(path.sep)[0] !== 'node_modules'
-      },
-    })
-
-    for (const filePath of await listFiles(destination)) {
-      const functionPath = path.join('node_modules', destinationPath, path.relative(destination, filePath))
-      filePathMap[toPosixPath(functionPath)] = toPosixPath(path.relative(workPath, filePath))
-    }
+  for (const relativePath of fileList) {
+    const source = path.join(traceBase, relativePath)
+    const destination = path.join(runtimeRoot, relativePath)
+    await fs.mkdir(path.dirname(destination), { recursive: true })
+    await fs.copyFile(source, destination)
+    filePathMap[toPosixPath(relativePath)] = toPosixPath(path.relative(workPath, destination))
   }
 
   return filePathMap
 }
 
-async function listFiles (directory) {
+async function listPackageFiles (directory) {
   const files = []
 
   for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue
     const entryPath = path.join(directory, entry.name)
-    if (entry.isDirectory()) {
-      files.push(...await listFiles(entryPath))
-    } else if (entry.isFile()) {
-      files.push(entryPath)
-    }
+    if (entry.isDirectory()) files.push(...await listPackageFiles(entryPath))
+    if (entry.isFile()) files.push(entryPath)
   }
 
   return files
@@ -222,8 +174,7 @@ async function instrumentBuildOutput (outputPath, tracerRoot, workPath) {
 
   if (nodeFunctions.length === 0) return
 
-  const packageGraph = await collectPackageGraph(tracerRoot)
-  const tracerFilePathMap = await stagePackageGraph(packageGraph, workPath)
+  const tracerFilePathMap = await stageTracerFiles(tracerRoot, workPath)
 
   for (const { config, configPath } of nodeFunctions) {
     config.filePathMap = {
@@ -244,7 +195,7 @@ async function build (options) {
   const result = await buildNext(options)
 
   if (result.buildOutputPath) {
-    const tracerRoot = await resolveTracerRoot(options.workPath)
+    const tracerRoot = await resolveTracerRoot()
     await instrumentBuildOutput(result.buildOutputPath, tracerRoot, options.workPath)
   }
 
@@ -253,9 +204,11 @@ async function build (options) {
 
 module.exports = {
   build,
-  collectPackageGraph,
+  findTraceBase,
   instrumentBuildOutput,
+  listPackageFiles,
   mergeNodeOptions,
   resolveTracerRoot,
+  stageTracerFiles,
   validateTracerRoot,
 }

--- a/docs/examples/vercel-nextjs/builder.js
+++ b/docs/examples/vercel-nextjs/builder.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
+const WRAPPER_FILE = '___datadog_next_launcher.cjs'
+
+function wrapperSource (handler) {
+  if (typeof handler !== 'string' || handler.length === 0) {
+    throw new TypeError('Vercel Node function handler must be a non-empty string')
+  }
+
+  const modulePath = handler.startsWith('.') ? handler : `./${handler}`
+
+  return `'use strict'
+
+require('dd-trace/init')
+module.exports = require(${JSON.stringify(modulePath)})
+`
+}
+
+async function findFunctionPaths (directory) {
+  const functionPaths = []
+
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+
+    const entryPath = path.join(directory, entry.name)
+    if (entry.name.endsWith('.func')) {
+      functionPaths.push(entryPath)
+    } else {
+      functionPaths.push(...await findFunctionPaths(entryPath))
+    }
+  }
+
+  return functionPaths
+}
+
+async function instrumentBuildOutput (outputPath) {
+  const functionPaths = await findFunctionPaths(path.join(outputPath, 'functions'))
+
+  for (const functionPath of functionPaths) {
+    const configPath = path.join(functionPath, '.vc-config.json')
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8'))
+
+    if (!String(config.runtime).startsWith('nodejs') || config.handler === WRAPPER_FILE) continue
+
+    await fs.writeFile(path.join(functionPath, WRAPPER_FILE), wrapperSource(config.handler))
+    config.handler = WRAPPER_FILE
+    await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`)
+  }
+}
+
+async function build (options) {
+  // Load Vercel's official Builder only when Vercel invokes this entry point.
+  const { build: buildNext } = require('@vercel/next')
+  const result = await buildNext(options)
+
+  if (result.buildOutputPath) await instrumentBuildOutput(result.buildOutputPath)
+
+  return result
+}
+
+module.exports = {
+  build,
+  instrumentBuildOutput,
+}

--- a/docs/examples/vercel-nextjs/builder.js
+++ b/docs/examples/vercel-nextjs/builder.js
@@ -55,12 +55,36 @@ async function findPackageRoot (packageName, searchPath) {
 }
 
 async function resolveTracerRoot (workPath) {
+  let tracerRoot
+
   try {
-    return await findPackageRoot('dd-trace', workPath)
+    tracerRoot = await findPackageRoot('dd-trace', workPath)
   } catch (error) {
     if (error.code !== 'MODULE_NOT_FOUND') throw error
-    return findPackageRoot('dd-trace', __dirname)
+    tracerRoot = await findPackageRoot('dd-trace', __dirname)
   }
+
+  return validateTracerRoot(tracerRoot)
+}
+
+async function validateTracerRoot (tracerRoot) {
+  const manifestPath = path.join(tracerRoot, 'package.json')
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+
+  if (manifest.name !== 'dd-trace') {
+    throw new Error(`Expected ${manifestPath} to describe dd-trace`)
+  }
+
+  try {
+    await fs.access(path.join(tracerRoot, 'initialize.mjs'))
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+    throw new Error(
+      `dd-trace ${manifest.version || 'unknown'} does not provide initialize.mjs; install a supported version`
+    )
+  }
+
+  return tracerRoot
 }
 
 async function collectPackageGraph (tracerRoot) {
@@ -233,4 +257,5 @@ module.exports = {
   instrumentBuildOutput,
   mergeNodeOptions,
   resolveTracerRoot,
+  validateTracerRoot,
 }

--- a/docs/examples/vercel-nextjs/builder.js
+++ b/docs/examples/vercel-nextjs/builder.js
@@ -1,22 +1,14 @@
 'use strict'
 
 const fs = require('node:fs/promises')
+const Module = require('node:module')
 const path = require('node:path')
 
-const WRAPPER_FILE = '___datadog_next_launcher.cjs'
+const DATADOG_PRELOAD = '--import=dd-trace/initialize.mjs'
 
-function wrapperSource (handler) {
-  if (typeof handler !== 'string' || handler.length === 0) {
-    throw new TypeError('Vercel Node function handler must be a non-empty string')
-  }
-
-  const modulePath = handler.startsWith('.') ? handler : `./${handler}`
-
-  return `'use strict'
-
-require('dd-trace/init')
-module.exports = require(${JSON.stringify(modulePath)})
-`
+function mergeNodeOptions (nodeOptions = '') {
+  if (nodeOptions.includes('dd-trace/initialize.mjs')) return nodeOptions
+  return `${DATADOG_PRELOAD} ${nodeOptions}`.trim()
 }
 
 async function findFunctionPaths (directory) {
@@ -36,7 +28,154 @@ async function findFunctionPaths (directory) {
   return functionPaths
 }
 
-async function instrumentBuildOutput (outputPath) {
+async function findPackageRoot (packageName, searchPath) {
+  const packageRequire = Module.createRequire(path.join(searchPath, 'package.json'))
+  let resolved
+
+  try {
+    resolved = packageRequire.resolve(`${packageName}/package.json`)
+  } catch (error) {
+    if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw error
+    resolved = packageRequire.resolve(packageName)
+  }
+
+  let directory = path.dirname(resolved)
+
+  while (directory !== path.dirname(directory)) {
+    try {
+      const manifest = JSON.parse(await fs.readFile(path.join(directory, 'package.json'), 'utf8'))
+      if (manifest.name === packageName) return directory
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error
+    }
+    directory = path.dirname(directory)
+  }
+
+  throw new Error(`Unable to find the package root for ${packageName}`)
+}
+
+async function resolveTracerRoot (workPath) {
+  try {
+    return await findPackageRoot('dd-trace', workPath)
+  } catch (error) {
+    if (error.code !== 'MODULE_NOT_FOUND') throw error
+    return findPackageRoot('dd-trace', __dirname)
+  }
+}
+
+async function collectPackageGraph (tracerRoot) {
+  const installationRoot = path.dirname(tracerRoot)
+  const packages = new Map()
+  const pending = [{ destination: 'dd-trace', name: 'dd-trace', root: tracerRoot, required: true }]
+
+  while (pending.length > 0) {
+    const current = pending.pop()
+    let manifest
+
+    try {
+      manifest = JSON.parse(await fs.readFile(path.join(current.root, 'package.json'), 'utf8'))
+    } catch (error) {
+      if (!current.required && error.code === 'ENOENT') continue
+      throw error
+    }
+
+    const existing = packages.get(current.destination)
+    if (existing) {
+      if (existing.root !== current.root) {
+        throw new Error(
+          `dd-trace dependency graph maps multiple packages to node_modules/${current.destination}`
+        )
+      }
+      continue
+    }
+
+    packages.set(current.destination, { manifest, root: current.root })
+
+    const dependencies = Object.keys(manifest.dependencies || {})
+    const optionalDependencies = Object.keys(manifest.optionalDependencies || {})
+
+    for (const name of dependencies) {
+      const root = await findPackageRoot(name, current.root)
+      const destination = tracerDependencyDestination(name, root, installationRoot)
+      pending.push({ destination, name, root, required: true })
+    }
+    for (const name of optionalDependencies) {
+      try {
+        const root = await findPackageRoot(name, current.root)
+        pending.push({
+          destination: tracerDependencyDestination(name, root, installationRoot),
+          name,
+          root,
+          required: false,
+        })
+      } catch (error) {
+        if (error.code !== 'MODULE_NOT_FOUND') throw error
+      }
+    }
+  }
+
+  return packages
+}
+
+function tracerDependencyDestination (name, packageRoot, installationRoot) {
+  const destination = packageDestination(name, packageRoot, installationRoot)
+  return path.join('dd-trace', 'node_modules', destination)
+}
+
+function packageDestination (name, packageRoot, installationRoot) {
+  const relativePath = path.relative(installationRoot, packageRoot)
+  if (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath)) {
+    return relativePath
+  }
+  return name
+}
+
+async function stagePackageGraph (packages, workPath) {
+  const runtimeRoot = path.join(workPath, '.datadog', 'vercel-runtime', 'node_modules')
+  const filePathMap = {}
+
+  await fs.rm(runtimeRoot, { force: true, recursive: true })
+
+  for (const [destinationPath, packageInfo] of packages) {
+    const destination = path.join(runtimeRoot, destinationPath)
+    await fs.cp(packageInfo.root, destination, {
+      recursive: true,
+      dereference: true,
+      filter: source => {
+        const relativePath = path.relative(packageInfo.root, source)
+        return relativePath === '' || relativePath.split(path.sep)[0] !== 'node_modules'
+      },
+    })
+
+    for (const filePath of await listFiles(destination)) {
+      const functionPath = path.join('node_modules', destinationPath, path.relative(destination, filePath))
+      filePathMap[toPosixPath(functionPath)] = toPosixPath(path.relative(workPath, filePath))
+    }
+  }
+
+  return filePathMap
+}
+
+async function listFiles (directory) {
+  const files = []
+
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(entryPath))
+    } else if (entry.isFile()) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}
+
+function toPosixPath (filePath) {
+  return filePath.split(path.sep).join('/')
+}
+
+async function instrumentBuildOutput (outputPath, tracerRoot, workPath) {
   const functionsPath = path.join(outputPath, 'functions')
 
   try {
@@ -47,31 +186,51 @@ async function instrumentBuildOutput (outputPath) {
   }
 
   const functionPaths = await findFunctionPaths(functionsPath)
+  const nodeFunctions = []
 
   for (const functionPath of functionPaths) {
     const configPath = path.join(functionPath, '.vc-config.json')
     const config = JSON.parse(await fs.readFile(configPath, 'utf8'))
+    if (!String(config.runtime).startsWith('nodejs')) continue
 
-    if (!String(config.runtime).startsWith('nodejs') || config.handler === WRAPPER_FILE) continue
+    nodeFunctions.push({ config, configPath })
+  }
 
-    await fs.writeFile(path.join(functionPath, WRAPPER_FILE), wrapperSource(config.handler))
-    config.handler = WRAPPER_FILE
+  if (nodeFunctions.length === 0) return
+
+  const packageGraph = await collectPackageGraph(tracerRoot)
+  const tracerFilePathMap = await stagePackageGraph(packageGraph, workPath)
+
+  for (const { config, configPath } of nodeFunctions) {
+    config.filePathMap = {
+      ...config.filePathMap,
+      ...tracerFilePathMap,
+    }
+    config.environment = {
+      ...config.environment,
+      NODE_OPTIONS: mergeNodeOptions(config.environment?.NODE_OPTIONS),
+    }
     await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`)
   }
 }
 
 async function build (options) {
-  // Load Vercel's official Builder only when Vercel invokes this entry point.
   // eslint-disable-next-line n/no-missing-require -- Declared by the published Builder package.
   const { build: buildNext } = require('@vercel/next')
   const result = await buildNext(options)
 
-  if (result.buildOutputPath) await instrumentBuildOutput(result.buildOutputPath)
+  if (result.buildOutputPath) {
+    const tracerRoot = await resolveTracerRoot(options.workPath)
+    await instrumentBuildOutput(result.buildOutputPath, tracerRoot, options.workPath)
+  }
 
   return result
 }
 
 module.exports = {
   build,
+  collectPackageGraph,
   instrumentBuildOutput,
+  mergeNodeOptions,
+  resolveTracerRoot,
 }

--- a/docs/examples/vercel-nextjs/builder.spec.js
+++ b/docs/examples/vercel-nextjs/builder.spec.js
@@ -26,6 +26,8 @@ describe('Vercel Next Builder prototype', () => {
       optionalDependencies: { 'missing-optional-dependency': '1.0.0' },
     }))
     await fs.writeFile(path.join(tracerRoot, 'initialize.mjs'), 'globalThis.__datadogInitialized = true\n')
+    await fs.mkdir(path.join(tracerRoot, 'vendor'), { recursive: true })
+    await fs.writeFile(path.join(tracerRoot, 'vendor', 'runtime.js'), 'module.exports = true\n')
 
     const dependencyRoot = path.join(workPath, 'packages', 'node_modules', 'tracer-dependency')
     await fs.mkdir(dependencyRoot, { recursive: true })
@@ -71,8 +73,12 @@ describe('Vercel Next Builder prototype', () => {
       '.datadog/vercel-runtime/node_modules/dd-trace/initialize.mjs'
     )
     assert.strictEqual(
-      nodeConfig.filePathMap['node_modules/dd-trace/node_modules/tracer-dependency/index.js'],
-      '.datadog/vercel-runtime/node_modules/dd-trace/node_modules/tracer-dependency/index.js'
+      nodeConfig.filePathMap['node_modules/tracer-dependency/index.js'],
+      '.datadog/vercel-runtime/node_modules/tracer-dependency/index.js'
+    )
+    assert.strictEqual(
+      nodeConfig.filePathMap['node_modules/dd-trace/vendor/runtime.js'],
+      '.datadog/vercel-runtime/node_modules/dd-trace/vendor/runtime.js'
     )
     await fs.access(path.join(workPath, nodeConfig.filePathMap['node_modules/dd-trace/initialize.mjs']))
     await assert.rejects(fs.access(path.join(nodeFunction, 'node_modules', 'dd-trace')))

--- a/docs/examples/vercel-nextjs/builder.spec.js
+++ b/docs/examples/vercel-nextjs/builder.spec.js
@@ -6,80 +6,101 @@ const Module = require('node:module')
 const os = require('node:os')
 const path = require('node:path')
 
-const { build, instrumentBuildOutput } = require('./builder')
+const { build, instrumentBuildOutput, mergeNodeOptions } = require('./builder')
 
 describe('Vercel Next Builder prototype', () => {
   let outputPath
+  let tracerRoot
+  let workPath
 
   beforeEach(async () => {
     outputPath = await fs.mkdtemp(path.join(os.tmpdir(), 'dd-vercel-build-output-'))
+    workPath = path.join(outputPath, 'work')
+    tracerRoot = path.join(workPath, 'packages', 'node_modules', 'dd-trace')
+
+    await fs.mkdir(tracerRoot, { recursive: true })
+    await fs.writeFile(path.join(tracerRoot, 'package.json'), JSON.stringify({
+      name: 'dd-trace',
+      version: '1.0.0',
+      dependencies: { 'tracer-dependency': '1.0.0' },
+      optionalDependencies: { 'missing-optional-dependency': '1.0.0' },
+    }))
+    await fs.writeFile(path.join(tracerRoot, 'initialize.mjs'), 'globalThis.__datadogInitialized = true\n')
+
+    const dependencyRoot = path.join(workPath, 'packages', 'node_modules', 'tracer-dependency')
+    await fs.mkdir(dependencyRoot, { recursive: true })
+    await fs.writeFile(path.join(dependencyRoot, 'package.json'), JSON.stringify({
+      name: 'tracer-dependency',
+      version: '1.0.0',
+    }))
+    await fs.writeFile(path.join(dependencyRoot, 'index.js'), 'module.exports = true\n')
   })
 
   afterEach(async () => {
     await fs.rm(outputPath, { force: true, recursive: true })
   })
 
-  it('preloads dd-trace for Node functions and preserves Edge functions', async () => {
+  it('packages dd-trace and preloads it for Node functions without changing handlers', async () => {
     const nodeFunction = path.join(outputPath, 'functions', 'api', 'ping.func')
     const edgeFunction = path.join(outputPath, 'functions', 'api', 'edge.func')
-    const orderPath = path.join(nodeFunction, 'initialization-order')
     await fs.mkdir(nodeFunction, { recursive: true })
     await fs.mkdir(edgeFunction, { recursive: true })
-    await fs.mkdir(path.join(nodeFunction, 'node_modules', 'dd-trace'), { recursive: true })
     await fs.writeFile(path.join(nodeFunction, '.vc-config.json'), JSON.stringify({
+      environment: { NODE_OPTIONS: '--enable-source-maps', USER_SETTING: 'preserved' },
       handler: '___next_launcher.cjs',
       runtime: 'nodejs22.x',
     }))
-    await fs.writeFile(
-      path.join(nodeFunction, 'node_modules', 'dd-trace', 'init.js'),
-      `require('node:fs').appendFileSync(${JSON.stringify(orderPath)}, 'dd-trace\\n')\n`
-    )
-    await fs.writeFile(
-      path.join(nodeFunction, '___next_launcher.cjs'),
-      `require('node:fs').appendFileSync(${JSON.stringify(orderPath)}, 'next\\n')\n`
-    )
     await fs.writeFile(path.join(edgeFunction, '.vc-config.json'), JSON.stringify({
       handler: 'index.js',
       runtime: 'edge',
     }))
 
-    await instrumentBuildOutput(outputPath)
+    await instrumentBuildOutput(outputPath, tracerRoot, workPath)
 
     const nodeConfig = JSON.parse(await fs.readFile(path.join(nodeFunction, '.vc-config.json'), 'utf8'))
     const edgeConfig = JSON.parse(await fs.readFile(path.join(edgeFunction, '.vc-config.json'), 'utf8'))
-    require(path.join(nodeFunction, nodeConfig.handler))
 
-    assert.strictEqual(nodeConfig.handler, '___datadog_next_launcher.cjs')
-    assert.deepStrictEqual((await fs.readFile(orderPath, 'utf8')).trim().split('\n'), ['dd-trace', 'next'])
+    assert.strictEqual(nodeConfig.handler, '___next_launcher.cjs')
+    assert.strictEqual(
+      nodeConfig.environment.NODE_OPTIONS,
+      '--import=dd-trace/initialize.mjs --enable-source-maps'
+    )
+    assert.strictEqual(nodeConfig.environment.USER_SETTING, 'preserved')
+    assert.strictEqual(
+      nodeConfig.filePathMap['node_modules/dd-trace/initialize.mjs'],
+      '.datadog/vercel-runtime/node_modules/dd-trace/initialize.mjs'
+    )
+    assert.strictEqual(
+      nodeConfig.filePathMap['node_modules/dd-trace/node_modules/tracer-dependency/index.js'],
+      '.datadog/vercel-runtime/node_modules/dd-trace/node_modules/tracer-dependency/index.js'
+    )
+    await fs.access(path.join(workPath, nodeConfig.filePathMap['node_modules/dd-trace/initialize.mjs']))
+    await assert.rejects(fs.access(path.join(nodeFunction, 'node_modules', 'dd-trace')))
+
     assert.deepStrictEqual(edgeConfig, { handler: 'index.js', runtime: 'edge' })
-    await assert.rejects(fs.access(path.join(edgeFunction, '___datadog_next_launcher.cjs')))
+    await assert.rejects(fs.access(path.join(edgeFunction, 'node_modules', 'dd-trace')))
   })
 
-  it('does not wrap an already transformed Node function again', async () => {
-    const functionPath = path.join(outputPath, 'functions', 'api.func')
-    await fs.mkdir(functionPath, { recursive: true })
-    await fs.writeFile(path.join(functionPath, '.vc-config.json'), JSON.stringify({
-      handler: '___datadog_next_launcher.cjs',
-      runtime: 'nodejs22.x',
-    }))
-
-    await instrumentBuildOutput(outputPath)
-
-    await assert.rejects(fs.access(path.join(functionPath, '___datadog_next_launcher.cjs')))
+  it('does not add the preload twice', async () => {
+    assert.strictEqual(
+      mergeNodeOptions('--import=dd-trace/initialize.mjs --enable-source-maps'),
+      '--import=dd-trace/initialize.mjs --enable-source-maps'
+    )
   })
 
   it('preserves a static-only Build Output directory', async () => {
     await fs.mkdir(path.join(outputPath, 'static'), { recursive: true })
 
-    await instrumentBuildOutput(outputPath)
+    await instrumentBuildOutput(outputPath, tracerRoot, workPath)
 
     await fs.access(path.join(outputPath, 'static'))
+    await assert.rejects(fs.access(path.join(workPath, '.datadog')))
   })
 
   it('instruments the public directory returned by the Next Builder', async () => {
     const functionPath = path.join(outputPath, 'functions', 'api.func')
     const originalLoad = Module._load
-    const options = { workPath: '/app' }
+    const options = { workPath }
     const result = { buildOutputPath: outputPath, buildOutputVersion: 3 }
     await fs.mkdir(functionPath, { recursive: true })
     await fs.writeFile(path.join(functionPath, '.vc-config.json'), JSON.stringify({
@@ -99,13 +120,22 @@ describe('Vercel Next Builder prototype', () => {
       return originalLoad(request, parent, isMain)
     }
 
+    const originalResolve = Module._resolveFilename
+    Module._resolveFilename = (request, parent, isMain, options) => {
+      if (request === 'dd-trace/package.json') return path.join(tracerRoot, 'package.json')
+      return originalResolve(request, parent, isMain, options)
+    }
+
     try {
       assert.strictEqual(await build(options), result)
     } finally {
       Module._load = originalLoad
+      Module._resolveFilename = originalResolve
     }
 
     const config = JSON.parse(await fs.readFile(path.join(functionPath, '.vc-config.json'), 'utf8'))
-    assert.strictEqual(config.handler, '___datadog_next_launcher.cjs')
+    assert.strictEqual(config.handler, '___next_launcher.cjs')
+    assert.strictEqual(config.environment.NODE_OPTIONS, '--import=dd-trace/initialize.mjs')
+    assert.ok(config.filePathMap['node_modules/dd-trace/initialize.mjs'])
   })
 })

--- a/docs/examples/vercel-nextjs/builder.spec.js
+++ b/docs/examples/vercel-nextjs/builder.spec.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const assert = require('node:assert')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const { afterEach, beforeEach, describe, it } = require('node:test')
+
+const { instrumentBuildOutput } = require('./builder')
+
+describe('Vercel Next Builder prototype', () => {
+  let outputPath
+
+  beforeEach(async () => {
+    outputPath = await fs.mkdtemp(path.join(os.tmpdir(), 'dd-vercel-build-output-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(outputPath, { force: true, recursive: true })
+  })
+
+  it('preloads dd-trace for Node functions and preserves Edge functions', async () => {
+    const nodeFunction = path.join(outputPath, 'functions', 'api', 'ping.func')
+    const edgeFunction = path.join(outputPath, 'functions', 'api', 'edge.func')
+    const orderPath = path.join(nodeFunction, 'initialization-order')
+    await fs.mkdir(nodeFunction, { recursive: true })
+    await fs.mkdir(edgeFunction, { recursive: true })
+    await fs.mkdir(path.join(nodeFunction, 'node_modules', 'dd-trace'), { recursive: true })
+    await fs.writeFile(path.join(nodeFunction, '.vc-config.json'), JSON.stringify({
+      handler: '___next_launcher.cjs',
+      runtime: 'nodejs22.x',
+    }))
+    await fs.writeFile(
+      path.join(nodeFunction, 'node_modules', 'dd-trace', 'init.js'),
+      `require('node:fs').appendFileSync(${JSON.stringify(orderPath)}, 'dd-trace\\n')\n`
+    )
+    await fs.writeFile(
+      path.join(nodeFunction, '___next_launcher.cjs'),
+      `require('node:fs').appendFileSync(${JSON.stringify(orderPath)}, 'next\\n')\n`
+    )
+    await fs.writeFile(path.join(edgeFunction, '.vc-config.json'), JSON.stringify({
+      handler: 'index.js',
+      runtime: 'edge',
+    }))
+
+    await instrumentBuildOutput(outputPath)
+
+    const nodeConfig = JSON.parse(await fs.readFile(path.join(nodeFunction, '.vc-config.json'), 'utf8'))
+    const edgeConfig = JSON.parse(await fs.readFile(path.join(edgeFunction, '.vc-config.json'), 'utf8'))
+    require(path.join(nodeFunction, nodeConfig.handler))
+
+    assert.strictEqual(nodeConfig.handler, '___datadog_next_launcher.cjs')
+    assert.deepStrictEqual((await fs.readFile(orderPath, 'utf8')).trim().split('\n'), ['dd-trace', 'next'])
+    assert.deepStrictEqual(edgeConfig, { handler: 'index.js', runtime: 'edge' })
+    await assert.rejects(fs.access(path.join(edgeFunction, '___datadog_next_launcher.cjs')))
+  })
+
+  it('does not wrap an already transformed Node function again', async () => {
+    const functionPath = path.join(outputPath, 'functions', 'api.func')
+    await fs.mkdir(functionPath, { recursive: true })
+    await fs.writeFile(path.join(functionPath, '.vc-config.json'), JSON.stringify({
+      handler: '___datadog_next_launcher.cjs',
+      runtime: 'nodejs22.x',
+    }))
+
+    await instrumentBuildOutput(outputPath)
+
+    await assert.rejects(fs.access(path.join(functionPath, '___datadog_next_launcher.cjs')))
+  })
+})

--- a/docs/examples/vercel-nextjs/builder.spec.js
+++ b/docs/examples/vercel-nextjs/builder.spec.js
@@ -2,11 +2,11 @@
 
 const assert = require('node:assert')
 const fs = require('node:fs/promises')
+const Module = require('node:module')
 const os = require('node:os')
 const path = require('node:path')
-const { afterEach, beforeEach, describe, it } = require('node:test')
 
-const { instrumentBuildOutput } = require('./builder')
+const { build, instrumentBuildOutput } = require('./builder')
 
 describe('Vercel Next Builder prototype', () => {
   let outputPath
@@ -66,5 +66,46 @@ describe('Vercel Next Builder prototype', () => {
     await instrumentBuildOutput(outputPath)
 
     await assert.rejects(fs.access(path.join(functionPath, '___datadog_next_launcher.cjs')))
+  })
+
+  it('preserves a static-only Build Output directory', async () => {
+    await fs.mkdir(path.join(outputPath, 'static'), { recursive: true })
+
+    await instrumentBuildOutput(outputPath)
+
+    await fs.access(path.join(outputPath, 'static'))
+  })
+
+  it('instruments the public directory returned by the Next Builder', async () => {
+    const functionPath = path.join(outputPath, 'functions', 'api.func')
+    const originalLoad = Module._load
+    const options = { workPath: '/app' }
+    const result = { buildOutputPath: outputPath, buildOutputVersion: 3 }
+    await fs.mkdir(functionPath, { recursive: true })
+    await fs.writeFile(path.join(functionPath, '.vc-config.json'), JSON.stringify({
+      handler: '___next_launcher.cjs',
+      runtime: 'nodejs22.x',
+    }))
+
+    Module._load = (request, parent, isMain) => {
+      if (request === '@vercel/next') {
+        return {
+          build: async receivedOptions => {
+            assert.strictEqual(receivedOptions, options)
+            return result
+          },
+        }
+      }
+      return originalLoad(request, parent, isMain)
+    }
+
+    try {
+      assert.strictEqual(await build(options), result)
+    } finally {
+      Module._load = originalLoad
+    }
+
+    const config = JSON.parse(await fs.readFile(path.join(functionPath, '.vc-config.json'), 'utf8'))
+    assert.strictEqual(config.handler, '___datadog_next_launcher.cjs')
   })
 })

--- a/docs/examples/vercel-nextjs/builder.spec.js
+++ b/docs/examples/vercel-nextjs/builder.spec.js
@@ -6,7 +6,7 @@ const Module = require('node:module')
 const os = require('node:os')
 const path = require('node:path')
 
-const { build, instrumentBuildOutput, mergeNodeOptions } = require('./builder')
+const { build, instrumentBuildOutput, mergeNodeOptions, validateTracerRoot } = require('./builder')
 
 describe('Vercel Next Builder prototype', () => {
   let outputPath
@@ -85,6 +85,15 @@ describe('Vercel Next Builder prototype', () => {
     assert.strictEqual(
       mergeNodeOptions('--import=dd-trace/initialize.mjs --enable-source-maps'),
       '--import=dd-trace/initialize.mjs --enable-source-maps'
+    )
+  })
+
+  it('rejects an installed tracer that cannot be preloaded', async () => {
+    await fs.rm(path.join(tracerRoot, 'initialize.mjs'))
+
+    await assert.rejects(
+      validateTracerRoot(tracerRoot),
+      /dd-trace 1\.0\.0 does not provide initialize\.mjs; install a supported version/
     )
   })
 

--- a/docs/examples/vercel-nextjs/instrumentation.js
+++ b/docs/examples/vercel-nextjs/instrumentation.js
@@ -1,0 +1,5 @@
+export async function register () {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('dd-trace/initialize.mjs')
+  }
+}

--- a/docs/examples/vercel-nextjs/instrumentation.js
+++ b/docs/examples/vercel-nextjs/instrumentation.js
@@ -1,5 +1,0 @@
-export async function register () {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    await import('dd-trace/initialize.mjs')
-  }
-}

--- a/docs/examples/vercel-nextjs/vercel.json
+++ b/docs/examples/vercel-nextjs/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@datadog/vercel-next-builder"
+    }
+  ]
+}

--- a/docs/vercel-next-builder.md
+++ b/docs/vercel-next-builder.md
@@ -6,21 +6,22 @@ must not attempt to load the Node tracer.
 
 The prototype in [`examples/vercel-nextjs`](./examples/vercel-nextjs/README.md)
 delegates to `@vercel/next.build()`. When the official Builder returns a public
-Build Output API directory, it visits Node `.func` outputs, writes a launcher
-that initializes `dd-trace`, and changes only the function's public
-`.vc-config.json` handler. It preserves Edge output and does not use global
-`NODE_OPTIONS`, trace drain, Vercel private file maps, source mapping, debug
-logging, or customer secrets.
+Build Output API directory, it stages the Builder's installed `dd-trace`
+dependency graph once, isolates transitive dependencies under the tracer,
+maps it into each Node `.func`, and prepends
+`--import=dd-trace/initialize.mjs` to each function's existing `NODE_OPTIONS`.
+It preserves handlers and Edge output and does not use project-global
+`NODE_OPTIONS`, trace drain, source mapping, debug logging, or customer secrets.
 
-The target package name is `@datadog/vercel-next-builder`. It cannot be
-legitimately added as a new package to this repository without release
-ownership: the current release workflow publishes only the root `dd-trace`
-package, and the existing Next plugin is source code included in that package.
-The prototype intentionally does not support older returned Lambda output,
-because this slice has evidence only for the current public Build Output API
-directory contract. A future Builder package may add that compatibility path
-after it has a versioned Vercel contract and tests.
+The target package name is `@datadog/vercel-next-builder`. It must declare
+`@vercel/next` and a supported `dd-trace` version as dependencies. It cannot be
+legitimately added as a published package to this repository without release
+ownership because the current release workflow publishes only the root
+`dd-trace` package. The prototype intentionally supports only the current public
+Build Output API directory contract.
 
-Before release, validate source-build Preview and Production deployments with
-Node routes, mixed Edge routes, concurrent requests, and trace delivery. This
-slice verifies the local public Build Output transformation only.
+Live source-build verification on Next.js 16 exercised App and Pages Router
+routes, concurrent requests, and outbound calls. Direct OTLP intake received a
+14-span distributed trace containing `web.request`, `next.request`, `fetch`,
+TCP, and DNS spans. Mixed Edge output still requires a dedicated acceptance
+deployment before release.

--- a/docs/vercel-next-builder.md
+++ b/docs/vercel-next-builder.md
@@ -1,0 +1,26 @@
+# Vercel Next Builder Prototype
+
+Vercel may deploy Next.js applications as a mix of Node and Edge functions.
+`dd-trace` must load before Next in each Node function, while Edge functions
+must not attempt to load the Node tracer.
+
+The prototype in [`examples/vercel-nextjs`](./examples/vercel-nextjs/README.md)
+delegates to `@vercel/next.build()`. When the official Builder returns a public
+Build Output API directory, it visits Node `.func` outputs, writes a launcher
+that initializes `dd-trace`, and changes only the function's public
+`.vc-config.json` handler. It preserves Edge output and does not use global
+`NODE_OPTIONS`, trace drain, Vercel private file maps, source mapping, debug
+logging, or customer secrets.
+
+The target package name is `@datadog/vercel-next-builder`. It cannot be
+legitimately added as a new package to this repository without release
+ownership: the current release workflow publishes only the root `dd-trace`
+package, and the existing Next plugin is source code included in that package.
+The prototype intentionally does not support older returned Lambda output,
+because this slice has evidence only for the current public Build Output API
+directory contract. A future Builder package may add that compatibility path
+after it has a versioned Vercel contract and tests.
+
+Before release, validate source-build Preview and Production deployments with
+Node routes, mixed Edge routes, concurrent requests, and trace delivery. This
+slice verifies the local public Build Output transformation only.

--- a/docs/vercel-next-builder.md
+++ b/docs/vercel-next-builder.md
@@ -6,19 +6,19 @@ must not attempt to load the Node tracer.
 
 The prototype in [`examples/vercel-nextjs`](./examples/vercel-nextjs/README.md)
 delegates to `@vercel/next.build()`. When the official Builder returns a public
-Build Output API directory, it stages the Builder's installed `dd-trace`
-dependency graph once, isolates transitive dependencies under the tracer,
-maps it into each Node `.func`, and prepends
+Build Output API directory, it stages the published `dd-trace` package and uses
+Vercel's Node File Trace for its declared runtime dependencies. It maps that
+runtime into each Node `.func` and prepends
 `--import=dd-trace/initialize.mjs` to each function's existing `NODE_OPTIONS`.
 It preserves handlers and Edge output and does not use project-global
 `NODE_OPTIONS`, trace drain, source mapping, debug logging, or customer secrets.
 
 The target package name is `@datadog/vercel-next-builder`. It must declare
-`@vercel/next` and a supported `dd-trace` version as dependencies. It cannot be
-legitimately added as a published package to this repository without release
-ownership because the current release workflow publishes only the root
-`dd-trace` package. The prototype intentionally supports only the current public
-Build Output API directory contract.
+`@vercel/next`, `@vercel/nft`, and a supported `dd-trace` version as
+dependencies. It cannot be legitimately added as a published package to this
+repository without release ownership because the current release workflow
+publishes only the root `dd-trace` package. The prototype intentionally supports
+only the current public Build Output API directory contract.
 
 Live source-build verification on Next.js 16 exercised App Router, Pages
 Router, and Edge routes, concurrent requests, and outbound calls. The Edge

--- a/docs/vercel-next-builder.md
+++ b/docs/vercel-next-builder.md
@@ -20,8 +20,8 @@ ownership because the current release workflow publishes only the root
 `dd-trace` package. The prototype intentionally supports only the current public
 Build Output API directory contract.
 
-Live source-build verification on Next.js 16 exercised App and Pages Router
-routes, concurrent requests, and outbound calls. Direct OTLP intake received a
-14-span distributed trace containing `web.request`, `next.request`, `fetch`,
-TCP, and DNS spans. Mixed Edge output still requires a dedicated acceptance
-deployment before release.
+Live source-build verification on Next.js 16 exercised App Router, Pages
+Router, and Edge routes, concurrent requests, and outbound calls. The Edge
+route remained unmodified and returned successfully. Direct OTLP intake
+received a 14-span distributed Node trace containing `web.request`,
+`next.request`, `fetch`, TCP, and DNS spans.

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "test:integration:plugins:coverage": "yarn services && node ./integration-tests/coverage/run-suite.js \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/${SPEC:-*}*.spec.js\"",
     "test:unit:plugins": "mocha \"packages/datadog-instrumentations/test/@(${PLUGINS}).spec.js\" \"packages/datadog-plugin-@(${PLUGINS})/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/*.spec.js\"",
     "test:release": "mocha \"scripts/release/**/*.spec.js\"",
+    "test:examples": "mocha \"docs/examples/**/*.spec.js\"",
     "test:scripts": "mocha \"scripts/helpers/**/*.spec.js\" \"scripts/*.spec.mjs\"",
     "test:shimmer": "mocha \"packages/datadog-shimmer/test/**/*.spec.js\"",
     "test:shimmer:ci": "node scripts/c8-ci.js test:shimmer",


### PR DESCRIPTION
## Problem

Vercel owns the final Next.js function bundles. Adding `dd-trace` to application source does not guarantee that it loads before Next.js in every generated Node function, while a project-wide preload can break Edge output.

## Builder contract

- delegate the source build to the official `@vercel/next` Builder
- use the application's installed `dd-trace` when present, otherwise the Builder's supported dependency
- stage the complete tracer dependency graph once and isolate transitive packages under `dd-trace/node_modules`
- map that runtime into every generated Node function through the public Build Output `filePathMap`
- merge `--import=dd-trace/initialize.mjs` into each Node function's existing `NODE_OPTIONS`
- preserve function handlers, static output, and Edge functions
- reject incompatible tracer artifacts at build time with a clear error

No application source changes, handler wrappers, project-global `NODE_OPTIONS`, Trace Drain, or debug logging are required. The Datadog integration should eventually own Builder selection and encrypted exporter configuration.

## Evidence

- focused Builder suite: 5 passing; targeted ESLint and `git diff --check` pass
- clean Vercel source build on Next.js 16.2.12 with App Router, Pages Router, and Edge routes
- Edge route returned 200 without the Node tracer preload
- Node routes, errors, AI route, and distributed parallel calls completed successfully
- direct OTLP intake retained a 14-span trace with `web.request`, `next.request`, fetch, TCP, and DNS spans: https://app.datadoghq.com/apm/trace/95b8c9270a1ebd92c55511f2b830561d

## Scope

This repository contains the executable architecture prototype and onboarding contract. Publishing and owning `@datadog/vercel-next-builder` remains a product/release decision.

Stack 5/5; based on #9600.