### PR TITLE
feat(openfeature): send API key fingerprint

### DIFF
--- a/packages/dd-trace/src/openfeature/agentless_configuration_source.js
+++ b/packages/dd-trace/src/openfeature/agentless_configuration_source.js
@@ -141,7 +141,7 @@ class AgentlessConfigurationSource {
     headers['Accept-Encoding'] = 'gzip'
     if (this.#config.apiKey) {
       headers['DD-API-KEY'] = this.#config.apiKey
-      headers['DD-Api-Key-Fingerprint'] = generateApiKeyFingerprint(this.#config.apiKey)
+      headers['DD-API-KEY-FINGERPRINT'] = generateApiKeyFingerprint(this.#config.apiKey)
     }
     if (this.#etag) headers['If-None-Match'] = this.#etag
 

--- a/packages/dd-trace/src/openfeature/agentless_configuration_source.js
+++ b/packages/dd-trace/src/openfeature/agentless_configuration_source.js
@@ -7,6 +7,7 @@ const { setTimeout: sleep } = require('node:timers/promises')
 const request = require('../exporters/common/request')
 const { getClientLibraryHeaders } = require('../exporters/common/client-library-headers')
 const log = require('../log')
+const { generateApiKeyFingerprint } = require('./encoding')
 
 const MAX_ATTEMPTS = 3
 const FIRST_RETRY_MIN_MS = 2000
@@ -138,7 +139,10 @@ class AgentlessConfigurationSource {
   #request (signal) {
     const headers = getClientLibraryHeaders()
     headers['Accept-Encoding'] = 'gzip'
-    if (this.#config.apiKey) headers['DD-API-KEY'] = this.#config.apiKey
+    if (this.#config.apiKey) {
+      headers['DD-API-KEY'] = this.#config.apiKey
+      headers['DD-Api-Key-Fingerprint'] = generateApiKeyFingerprint(this.#config.apiKey)
+    }
     if (this.#etag) headers['If-None-Match'] = this.#etag
 
     /**

--- a/packages/dd-trace/src/openfeature/encoding.js
+++ b/packages/dd-trace/src/openfeature/encoding.js
@@ -73,6 +73,9 @@ function hashTargetingKey (targetingKey) {
  * @returns {string} The rijn-prefixed, base62-encoded SHA256 fingerprint
  */
 function generateApiKeyFingerprint (apiKey) {
+  // Clifford v1 fingerprints high-entropy API keys; it does not verify passwords.
+  // The interoperability contract requires one SHA-256 digest.
+  // codeql[js/insufficient-password-hash]
   const digest = crypto.createHash('sha256').update(apiKey, 'utf8').digest('hex')
   let value = BigInt(`0x${digest}`)
   let encoded = ''

--- a/packages/dd-trace/src/openfeature/encoding.js
+++ b/packages/dd-trace/src/openfeature/encoding.js
@@ -2,6 +2,9 @@
 
 const crypto = require('node:crypto')
 
+const BASE62_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const CLIFFORD_SHA256_BASE62_LENGTH = 43
+
 /**
  * Encode a single value as a ULEB128 varint (variable-length integer).
  * Uses 7 bits per byte, with MSB as continuation flag.
@@ -63,8 +66,28 @@ function hashTargetingKey (targetingKey) {
   return crypto.createHash('sha256').update(targetingKey).digest('hex')
 }
 
+/**
+ * Generate a Clifford v1 fingerprint from an API key.
+ *
+ * @param {string} apiKey - The API key to fingerprint
+ * @returns {string} The rijn-prefixed, base62-encoded SHA256 fingerprint
+ */
+function generateApiKeyFingerprint (apiKey) {
+  const digest = crypto.createHash('sha256').update(apiKey, 'utf8').digest('hex')
+  let value = BigInt(`0x${digest}`)
+  let encoded = ''
+
+  while (value > 0n) {
+    encoded = BASE62_ALPHABET[Number(value % 62n)] + encoded
+    value /= 62n
+  }
+
+  return `rijn_${encoded.padStart(CLIFFORD_SHA256_BASE62_LENGTH, '0')}`
+}
+
 module.exports = {
   encodeVarint,
   encodeDeltaVarint,
+  generateApiKeyFingerprint,
   hashTargetingKey,
 }

--- a/packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js
+++ b/packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js
@@ -149,6 +149,10 @@ describe('AgentlessConfigurationSource', () => {
     assert.strictEqual(requests[0].options.retry, false)
     assert.strictEqual(requests[0].options.timeout, 2000)
     assert.strictEqual(requests[0].options.headers['DD-API-KEY'], 'test-api-key')
+    assert.strictEqual(
+      requests[0].options.headers['DD-Api-Key-Fingerprint'],
+      'rijn_i8Jug5ocjALL7JZiV1a8HzXqkwDRKcE7hK9IouPQwio'
+    )
     assert.strictEqual(requests[0].options.headers['Accept-Encoding'], 'gzip')
     assert.strictEqual(requests[0].options.headers['DD-Client-Library-Language'], 'nodejs')
     assert.strictEqual(requests[0].options.headers['DD-Client-Library-Version'], VERSION)
@@ -501,6 +505,7 @@ describe('AgentlessConfigurationSource', () => {
     await flush()
 
     assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-API-KEY'), false)
+    assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-Api-Key-Fingerprint'), false)
     sinon.assert.calledOnceWithExactly(
       log.warn,
       'Feature Flagging agentless endpoint returned HTTP %d; verify endpoint authentication',

--- a/packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js
+++ b/packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js
@@ -150,7 +150,7 @@ describe('AgentlessConfigurationSource', () => {
     assert.strictEqual(requests[0].options.timeout, 2000)
     assert.strictEqual(requests[0].options.headers['DD-API-KEY'], 'test-api-key')
     assert.strictEqual(
-      requests[0].options.headers['DD-Api-Key-Fingerprint'],
+      requests[0].options.headers['DD-API-KEY-FINGERPRINT'],
       'rijn_i8Jug5ocjALL7JZiV1a8HzXqkwDRKcE7hK9IouPQwio'
     )
     assert.strictEqual(requests[0].options.headers['Accept-Encoding'], 'gzip')
@@ -505,7 +505,7 @@ describe('AgentlessConfigurationSource', () => {
     await flush()
 
     assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-API-KEY'), false)
-    assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-Api-Key-Fingerprint'), false)
+    assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-API-KEY-FINGERPRINT'), false)
     sinon.assert.calledOnceWithExactly(
       log.warn,
       'Feature Flagging agentless endpoint returned HTTP %d; verify endpoint authentication',

--- a/packages/dd-trace/test/openfeature/encoding.spec.js
+++ b/packages/dd-trace/test/openfeature/encoding.spec.js
@@ -5,7 +5,12 @@ const { describe, it } = require('mocha')
 
 require('../setup/core')
 
-const { encodeVarint, encodeDeltaVarint, hashTargetingKey } = require('../../src/openfeature/encoding')
+const {
+  encodeVarint,
+  encodeDeltaVarint,
+  generateApiKeyFingerprint,
+  hashTargetingKey,
+} = require('../../src/openfeature/encoding')
 
 describe('encoding', () => {
   describe('encodeVarint()', () => {
@@ -127,5 +132,23 @@ describe('encoding', () => {
       assert.strictEqual(hash.length, 64)
       assert.match(hash, /^[0-9a-f]{64}$/)
     })
+  })
+
+  describe('generateApiKeyFingerprint()', () => {
+    const vectors = [
+      ['', 'rijn_RZwTDmWjELXeEmMEb0eIIegKayGGUPNsuJweEPhlXi5'],
+      ['7b58e278012eec8316224b052d87e6e8b2ba9e49', 'rijn_SddeOoHbx2gFQTblESRn88xKs2B9zEA9ii1CclRfD6s'],
+      ['!@#$%^𐍈한€हИ£', 'rijn_eFLHeyLxwaiNs2hY16pjkjNjVSHWRgf2rlveKc8YA1K'],
+      ['padding-171', 'rijn_053ybBRXypQt9AC6UIlqH1YCFYSV1rQl8HCDIcBZs3D'],
+    ]
+
+    for (const [apiKey, expected] of vectors) {
+      it(`matches the Clifford v1 vector for ${JSON.stringify(apiKey)}`, () => {
+        const fingerprint = generateApiKeyFingerprint(apiKey)
+
+        assert.strictEqual(fingerprint, expected)
+        assert.strictEqual(fingerprint.length, 48)
+      })
+    }
   })
 })


### PR DESCRIPTION
## Motivation

The Feature Flags CDN needs a stable API-key identifier without writing the raw API key to CDN backend API logs. SDKs must send the Clifford v1 fingerprint so ffe-service can verify and log the fingerprint instead of the credential.

## Changes and Decisions

- Generate the Clifford v1 fingerprint with SHA-256 and the Datadog base62 format.
- Send `DD-API-KEY-FINGERPRINT` only when the request also sends `DD-API-KEY`.
- Suppress the CodeQL password-hash rule because Clifford v1 is a protocol-defined fingerprint, not password verification.
- Keep existing API key authentication behavior.