### PR TITLE
feat(llmobs): add external experiment recorder

### DIFF
--- a/packages/dd-trace/src/llmobs/experiments/client.js
+++ b/packages/dd-trace/src/llmobs/experiments/client.js
@@ -3,6 +3,9 @@
 // Control-plane HTTP client for LLM Obs Experiments. Uses the global `fetch`,
 // so this module adds no new dependency; credentials and site come from config.
 
+const { Dataset, DatasetRecord } = require('./dataset')
+const { ExperimentResult } = require('./result')
+
 const API_BASE_PATH = '/api/v2/llm-obs/v1'
 
 // Control-plane host for a Datadog site, e.g.
@@ -20,6 +23,38 @@ function apiHost (site) {
 function appHost (site) {
   if (site === 'datad0g.com') return 'dd.datad0g.com'
   return site.split('.').length === 2 ? `app.${site}` : site
+}
+
+function datasetRecordFromResource (resource) {
+  const attrs = resource?.attributes ?? resource ?? {}
+  return new DatasetRecord(
+    attrs.input ?? null,
+    attrs.expected_output ?? null,
+    attrs.metadata ?? {},
+    String(resource?.id ?? attrs.id ?? '') || null,
+    attrs.valid_from_version ?? attrs.version ?? null
+  )
+}
+
+function datasetFromResource (client, projectId, resource) {
+  const attrs = resource?.attributes ?? resource ?? {}
+  const version = attrs.current_version ?? null
+  return Dataset.fromExisting(
+    client,
+    String(attrs.name ?? ''),
+    String(attrs.description ?? ''),
+    resource?.id ?? attrs.id ?? null,
+    projectId,
+    [],
+    [],
+    version,
+    version
+  )
+}
+
+function experimentFromResource (client, resource) {
+  const id = resource?.id ?? null
+  return new ExperimentResult(id, [], id === null ? null : `${client.appBase}/llm/experiments/${id}`)
 }
 
 class ExperimentsClient {
@@ -92,6 +127,75 @@ class ExperimentsClient {
     return text ? JSON.parse(text) : {}
   }
 
+  jsonApiRequest (method, path, type, attributes) {
+    return this.request(method, path, {
+      data: { type, attributes },
+    })
+  }
+
+  async createProject (name) {
+    const response = await this.jsonApiRequest('POST', `${API_BASE_PATH}/projects`, 'projects', { name })
+    return response?.data ?? null
+  }
+
+  async createDataset (projectId, attributes) {
+    const response = await this.jsonApiRequest('POST', `${API_BASE_PATH}/${projectId}/datasets`, 'datasets', attributes)
+    return datasetFromResource(this, projectId, response?.data ?? null)
+  }
+
+  async listDatasets (projectId, options = {}) {
+    const query = new URLSearchParams()
+    if (options.name !== undefined) query.set('filter[name]', options.name)
+    const queryString = query.toString() ? `?${query.toString()}` : ''
+    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets${queryString}`)
+    const resources = Array.isArray(response?.data) ? response.data : []
+    return resources.map(resource => datasetFromResource(this, projectId, resource))
+  }
+
+  async appendDatasetRecords (projectId, datasetId, records) {
+    const response = await this.jsonApiRequest(
+      'POST',
+      `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records`,
+      'datasets',
+      { records }
+    )
+    // The append-records response has used both a top-level `records` array
+    // and JSON:API `data` resources. Accept either so generated/custom record
+    // ids are preserved for experiment row tagging.
+    const resources = Array.isArray(response?.records)
+      ? response.records
+      : (Array.isArray(response?.data) ? response.data : [])
+    return resources.map(datasetRecordFromResource)
+  }
+
+  async listDatasetRecords (projectId, datasetId, options = {}) {
+    const query = new URLSearchParams()
+    if (options.cursor) query.set('page[cursor]', options.cursor)
+    if (options.version !== undefined && options.version !== null) query.set('filter[version]', String(options.version))
+    const queryString = query.toString() ? `?${query.toString()}` : ''
+    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records${queryString}`)
+    const records = Array.isArray(response?.data) ? response.data.map(datasetRecordFromResource) : []
+    return { records, after: response?.meta?.after ?? '' }
+  }
+
+  async createExperiment (attributes) {
+    const response = await this.jsonApiRequest('POST', `${API_BASE_PATH}/experiments`, 'experiments', attributes)
+    return experimentFromResource(this, response?.data ?? null)
+  }
+
+  postExperimentEvents (experimentId, attributes) {
+    return this.jsonApiRequest(
+      'POST',
+      `${API_BASE_PATH}/experiments/${experimentId}/events`,
+      'experiments',
+      attributes
+    )
+  }
+
+  updateExperiment (experimentId, attributes) {
+    return this.jsonApiRequest('PATCH', `${API_BASE_PATH}/experiments/${experimentId}`, 'experiments', attributes)
+  }
+
   // Resolve the project id for `name`, creating it if absent. The create
   // endpoint is get-or-create on name, so repeated calls return the same id.
   // Cached after the first resolution.
@@ -100,14 +204,12 @@ class ExperimentsClient {
 
     let response
     try {
-      response = await this.request('POST', `${API_BASE_PATH}/projects`, {
-        data: { type: 'projects', attributes: { name } },
-      })
+      response = await this.createProject(name)
     } catch (err) {
       throw new Error(`Failed to create or get project '${name}': ${err.message}`)
     }
 
-    this.#cachedProjectId = response?.data?.id ?? null
+    this.#cachedProjectId = response?.id ?? null
     return this.#cachedProjectId
   }
 }

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -1,31 +1,28 @@
 'use strict'
 
-const { API_BASE_PATH } = require('./client')
-
 // Dataset record: { input, expectedOutput?, metadata?, id? }.
 // `id` may be user-provided before push or filled from the backend-created record.
 class DatasetRecord {
-  constructor (input, expectedOutput = null, metadata = {}, id = null) {
+  constructor (input, expectedOutput = null, metadata = {}, id = null, version = null) {
     this.input = input
     this.expectedOutput = expectedOutput ?? null
     this.metadata = metadata ?? {}
     this.id = id ?? null
+    Object.defineProperty(this, 'version', {
+      value: version ?? null,
+      enumerable: false,
+      writable: true,
+    })
   }
 }
 
-function createdRecordsFromResponse (response) {
-  if (Array.isArray(response?.records)) return response.records
-  if (Array.isArray(response?.data)) return response.data
-  return []
-}
-
 function recordIdFromCreatedRecord (record) {
-  return String(record?.id ?? record?.attributes?.id ?? '')
+  return String(record?.id ?? '')
 }
 
 function versionFromCreatedRecords (records) {
   const versions = records
-    .map(record => Number(record?.attributes?.valid_from_version ?? record?.attributes?.version))
+    .map(record => Number(record.version))
     .filter(Number.isFinite)
   if (versions.length === 0) return null
   return Math.max(...versions)
@@ -84,6 +81,10 @@ class Dataset {
     return this.#name
   }
 
+  description () {
+    return this.#description
+  }
+
   records () {
     return [...this.#records]
   }
@@ -127,19 +128,17 @@ class Dataset {
     if (this.#id === null) {
       let response
       try {
-        response = await this.#client.request('POST', `${API_BASE_PATH}/${projectId}/datasets`, {
-          data: { type: 'datasets', attributes: { name: this.#name, description: this.#description } },
-        })
+        response = await this.#client.createDataset(projectId, { name: this.#name, description: this.#description })
       } catch (err) {
         throw new Error(`Failed to create dataset '${this.#name}': ${err.message}`)
       }
-      this.#id = response?.data?.id ?? null
+      this.#id = response?.id() ?? null
       if (this.#id === null) {
         throw new Error(`Failed to create dataset '${this.#name}': backend response is missing dataset id`)
       }
       this.#projectId = projectId
-      this.#version = response?.data?.attributes?.current_version ?? this.#version
-      this.#latestVersion = response?.data?.attributes?.current_version ?? this.#latestVersion
+      this.#version = response.version() ?? this.#version
+      this.#latestVersion = response.latestVersion() ?? this.#latestVersion
     }
 
     if (this.#pushedCount >= this.#records.length) return { pushedCount: 0, totalCount: 0 }
@@ -161,19 +160,12 @@ class Dataset {
 
     let response
     try {
-      response = await this.#client.request(
-        'POST',
-        `${API_BASE_PATH}/${projectId}/datasets/${this.#id}/records`,
-        { data: { type: 'datasets', attributes: { records } } }
-      )
+      response = await this.#client.appendDatasetRecords(projectId, this.#id, records)
     } catch (err) {
       throw new Error(`Failed to push records to dataset '${this.#name}': ${err.message}`)
     }
 
-    // The append-records response has used both a top-level `records` array
-    // and JSON:API `data` resources. Accept either so generated/custom record
-    // ids are preserved for experiment row tagging.
-    const created = createdRecordsFromResponse(response)
+    const created = response
     const pushedVersion = versionFromCreatedRecords(created)
     if (pushedVersion === null) {
       // The dataset contents changed, but the backend did not report the new

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -2,7 +2,6 @@
 
 const id = require('../../id')
 
-const { API_BASE_PATH } = require('./client')
 const { Row, ExperimentResult, ExperimentRun } = require('./result')
 const {
   buildExperimentTagObject,
@@ -17,6 +16,10 @@ const {
   validateEvaluatorName,
 } = require('./util')
 
+function mergeTags (baseTags, overrideTags) {
+  return { ...(baseTags ?? {}), ...(overrideTags ?? {}) }
+}
+
 // One span per experiment row (LLM Obs experiment span wire format).
 function toSpan (row, metadata, ids, spanName, userTags) {
   const meta = {
@@ -28,7 +31,7 @@ function toSpan (row, metadata, ids, spanName, userTags) {
     meta.metadata = metadata
   }
   if (row.isError) {
-    meta.error = { type: row.errorType ?? '', message: row.errorMessage ?? '', stack: '' }
+    meta.error = { type: row.errorType ?? '', message: row.errorMessage ?? '', stack: row.errorStack ?? '' }
   }
 
   return {
@@ -89,6 +92,265 @@ function createFallbackSpanContext (startNs) {
   const spanId = spanIdentifier.toString(16).padStart(16, '0')
   const traceId = spanIdentifier.toTraceIdHex(traceIdHigh).padStart(32, '0')
   return { spanId, traceId }
+}
+
+function timestampMs (value, fallback = Date.now()) {
+  if (value === null || value === undefined) return fallback
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  const parsed = Date.parse(String(value))
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function durationNs (row, startMs) {
+  if (typeof row.durationMs === 'number' && Number.isFinite(row.durationMs)) {
+    return Math.max(0, Math.round(row.durationMs * 1e6))
+  }
+
+  if (row.completedAt !== undefined) {
+    const completedMs = timestampMs(row.completedAt, startMs)
+    return Math.max(0, Math.round((completedMs - startMs) * 1e6))
+  }
+
+  return 0
+}
+
+function normalizeError (error) {
+  if (error === null || error === undefined) {
+    return { errorType: null, errorMessage: null, errorStack: '' }
+  }
+
+  if (typeof error === 'string') {
+    return { errorType: 'Error', errorMessage: error, errorStack: '' }
+  }
+
+  return {
+    errorType: error.type ?? error.name ?? 'Error',
+    errorMessage: error.message ?? String(error),
+    errorStack: error.stack ?? '',
+  }
+}
+
+function errorMessage (error) {
+  if (error === null || error === undefined) return null
+  if (typeof error === 'string') return error
+  return error.message ?? String(error)
+}
+
+class ExperimentRecorder {
+  #client
+  #name
+  #description
+  #config
+  #tags
+  #metadata
+  #dataset
+  #projectId
+  #experimentId
+
+  /**
+   * @param {import('./client').ExperimentsClient} client
+   * @param {object} options
+   */
+  constructor (client, options = {}) {
+    if (!options.name) throw new Error('Experiment name is required')
+
+    this.#client = client
+    this.#name = options.name
+    this.#description = options.description ?? ''
+    this.#config = { ...options.config }
+    this.#tags = { ...options.tags }
+    this.#metadata = { ...options.metadata }
+    this.#dataset = options.dataset ?? {}
+    this.#projectId = null
+    this.#experimentId = null
+  }
+
+  /**
+   * @returns {string | null}
+   */
+  get experimentId () {
+    return this.#experimentId
+  }
+
+  /**
+   * @returns {string | null}
+   */
+  url () {
+    if (this.#experimentId === null) return null
+    return `${this.#client.appBase}/llm/experiments/${this.#experimentId}`
+  }
+
+  /**
+   * @returns {Promise<ExperimentRecorder>}
+   */
+  async start () {
+    this.#projectId = await this.#client.ensureProjectId()
+
+    const dataset = await this.#ensureDataset()
+    const attributes = {
+      name: this.#name,
+      project_id: this.#projectId,
+      dataset_id: dataset.id,
+      description: this.#description,
+      ensure_unique: true,
+    }
+    if (dataset.version !== undefined) attributes.dataset_version = dataset.version
+    if (hasEntries(this.#config)) attributes.config = this.#config
+    if (hasEntries(this.#metadata)) attributes.metadata = this.#metadata
+    if (hasEntries(this.#tags)) attributes.tags = this.#tags
+
+    let created
+    try {
+      created = await this.#client.createExperiment(attributes)
+    } catch (err) {
+      throw new Error(`Failed to create experiment '${this.#name}': ${err.message}`)
+    }
+    this.#experimentId = created.experimentId
+    return this
+  }
+
+  async #ensureDataset () {
+    if (this.#dataset.id) {
+      return { id: this.#dataset.id, version: this.#dataset.version }
+    }
+
+    const name = this.#dataset.name ?? `${this.#name} dataset`
+    const description = this.#dataset.description ?? `Placeholder dataset for externally-driven experiment '${this.#name}'`
+    let response
+    try {
+      response = await this.#client.createDataset(this.#projectId, { name, description })
+    } catch (err) {
+      throw new Error(`Failed to create placeholder dataset '${name}': ${err.message}`)
+    }
+
+    const id = response.id()
+    if (id === null) {
+      throw new Error(`Failed to create placeholder dataset '${name}': backend response is missing dataset id`)
+    }
+
+    this.#dataset = {
+      ...this.#dataset,
+      id,
+      version: this.#dataset.version ?? response.version(),
+    }
+    return { id: this.#dataset.id, version: this.#dataset.version }
+  }
+
+  /**
+   * @param {object} input
+   * @returns {Promise<{experimentId: string, spanId: string, traceId: string, url: string | null}>}
+   */
+  async submitSpan (input = {}) {
+    if (this.#experimentId === null || this.#projectId === null) {
+      throw new Error('Experiment has not been started')
+    }
+
+    const startMs = timestampMs(input.startedAt)
+    const startNs = Math.round(startMs * 1e6)
+    const { spanId, traceId } = createFallbackSpanContext(startNs)
+    const error = normalizeError(input.error)
+    const row = new Row({
+      index: input.id ?? '',
+      spanId,
+      traceId,
+      startNs,
+      durationNs: durationNs(input, startMs),
+      input: input.input,
+      output: input.output,
+      expectedOutput: input.expectedOutput,
+      errorType: error.errorType,
+      errorMessage: error.errorMessage,
+      errorStack: error.errorStack,
+      evaluations: {},
+      evaluationErrors: {},
+    })
+
+    const span = toSpan(row, input.metadata, {
+      experimentId: this.#experimentId,
+      projectId: this.#projectId,
+      datasetId: this.#dataset.id,
+      datasetRecordId: input.datasetRecordId,
+      runId: input.runId,
+      runIteration: input.runIteration,
+    }, input.name ?? this.#name, mergeTags(this.#tags, input.tags))
+
+    await this.#postEvents([span], [])
+
+    return {
+      experimentId: this.#experimentId,
+      spanId,
+      traceId,
+      url: this.url(),
+    }
+  }
+
+  /**
+   * @param {{experimentId?: string, spanId: string, traceId?: string}} span
+   * @param {object[]} metrics
+   * @returns {Promise<void>}
+   */
+  async submitEvaluationMetrics (span, metrics) {
+    if (this.#experimentId === null) {
+      throw new Error('Experiment has not been started')
+    }
+    if (!span?.spanId) {
+      throw new Error('Experiment span id is required')
+    }
+
+    const experimentId = span.experimentId ?? this.#experimentId
+    const payload = []
+    for (const metric of metrics) {
+      payload.push(toMetric(
+        metric.label,
+        metric.value,
+        errorMessage(metric.error),
+        span.spanId,
+        span.traceId ?? '',
+        timestampMs(metric.timestamp),
+        experimentId,
+        mergeTags(this.#tags, metric.tags),
+        metric.source ?? 'custom'
+      ))
+    }
+
+    await this.#postEvents([], payload)
+  }
+
+  /**
+   * @param {object} options
+   * @returns {Promise<void>}
+   */
+  async close (options = {}) {
+    if (this.#experimentId === null) return
+    const status = options.status ?? 'completed'
+    await this.#updateStatus(this.#experimentId, status, errorMessage(options.error))
+  }
+
+  /**
+   * @param {object[]} spans
+   * @param {object[]} metrics
+   * @returns {Promise<void>}
+   */
+  async #postEvents (spans, metrics) {
+    await this.#client.postExperimentEvents(this.#experimentId, { spans, metrics })
+  }
+
+  /**
+   * @param {string} experimentId
+   * @param {string} status
+   * @param {string | null} error
+   * @returns {Promise<void>}
+   */
+  async #updateStatus (experimentId, status, error) {
+    const attributes = { status }
+    if (error !== null) attributes.error = error
+    try {
+      await this.#client.updateExperiment(experimentId, attributes)
+    } catch {
+      // Status update is best-effort; never let it mask the real result/error.
+    }
+  }
 }
 
 // Builder + run() orchestration: runs rows sequentially, emits one root span
@@ -172,13 +434,11 @@ class Experiment {
 
     let created
     try {
-      created = await this.#client.request('POST', `${API_BASE_PATH}/experiments`, {
-        data: { type: 'experiments', attributes },
-      })
+      created = await this.#client.createExperiment(attributes)
     } catch (err) {
       throw new Error(`Failed to create experiment '${this.#name}': ${err.message}`)
     }
-    this.#experimentId = created?.data?.id ?? null
+    this.#experimentId = created.experimentId
     const experimentId = this.#experimentId
     const runId = id().toString(16).padStart(16, '0')
     const runIteration = 0
@@ -454,9 +714,7 @@ class Experiment {
   async #postEvents (experimentId, spans, metrics) {
     const attributes = { metrics }
     if (spans.length > 0) attributes.spans = spans
-    await this.#client.request('POST', `${API_BASE_PATH}/experiments/${experimentId}/events`, {
-      data: { type: 'experiments', attributes },
-    })
+    await this.#client.postExperimentEvents(experimentId, attributes)
   }
 
   async #updateStatus (experimentId, status, error) {
@@ -465,13 +723,11 @@ class Experiment {
     const attributes = { status }
     if (error !== null) attributes.error = error
     try {
-      await this.#client.request('PATCH', `${API_BASE_PATH}/experiments/${experimentId}`, {
-        data: { type: 'experiments', attributes },
-      })
+      await this.#client.updateExperiment(experimentId, attributes)
     } catch {
       // Status update is best-effort; never let it mask the real result/error.
     }
   }
 }
 
-module.exports = { Experiment, normalizeEvaluators, validateEvaluatorName }
+module.exports = { Experiment, ExperimentRecorder, normalizeEvaluators, validateEvaluatorName }

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const log = require('../../log')
-const { ExperimentsClient, API_BASE_PATH } = require('./client')
+const { ExperimentsClient } = require('./client')
 const { Dataset, DatasetRecord } = require('./dataset')
-const { Experiment } = require('./experiment')
+const { Experiment, ExperimentRecorder } = require('./experiment')
 const NoopExperiments = require('./noop')
 
 // Poll `attempt` with exponential backoff until it returns true or the time
@@ -26,17 +26,27 @@ async function retryWithBackoff (attempt, { maxTotalMs = 30_000, baseDelayMs = 2
 // experiments against the LLM Obs backend using the tracer's own config.
 class Experiments {
   #client
+  #config
   #llmobs
   #projectName
 
   constructor (config, llmobs) {
+    this.#config = config
     this.#llmobs = llmobs
     this.#projectName = config.llmobs?.mlApp || config.service
-    this.#client = new ExperimentsClient({
-      apiKey: config.DD_API_KEY,
-      appKey: config.DD_APP_KEY,
-      site: config.site,
-      projectName: this.#projectName,
+    this.#client = this.#clientForProject(this.#projectName)
+  }
+
+  /**
+   * @param {string} projectName
+   * @returns {ExperimentsClient}
+   */
+  #clientForProject (projectName) {
+    return new ExperimentsClient({
+      apiKey: this.#config.DD_API_KEY,
+      appKey: this.#config.DD_APP_KEY,
+      site: this.#config.site,
+      projectName,
     })
   }
 
@@ -78,15 +88,12 @@ class Experiments {
     const succeeded = await retryWithBackoff(async () => {
       try {
         if (datasetId === null) {
-          const listed = await this.#client.request(
-            'GET',
-            `${API_BASE_PATH}/${projectId}/datasets?filter[name]=${encodeURIComponent(name)}`
-          )
-          for (const item of listed?.data ?? []) {
-            if (item?.attributes?.name === name) {
-              datasetId = String(item?.id ?? '')
-              description = String(item?.attributes?.description ?? '')
-              latestVersion = item?.attributes?.current_version ?? null
+          const listed = await this.#client.listDatasets(projectId, { name })
+          for (const item of listed) {
+            if (item.name() === name) {
+              datasetId = item.id()
+              description = item.description()
+              latestVersion = item.latestVersion()
               datasetVersion = version ?? latestVersion
               break
             }
@@ -99,26 +106,16 @@ class Experiments {
         let cursor = ''
         // Follow the meta.after / page[cursor] pagination until the last page.
         for (;;) {
-          const query = new URLSearchParams()
-          if (cursor) query.set('page[cursor]', cursor)
-          if (datasetVersion !== null) query.set('filter[version]', String(datasetVersion))
           // eslint-disable-next-line no-await-in-loop
-          const resp = await this.#client.request(
-            'GET',
-            `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records?${query.toString()}`
-          )
-          for (const item of resp?.data ?? []) {
-            const attrs = item?.attributes ?? item
-            const recordId = String(item?.id ?? attrs?.id ?? '')
-            recs.push(new DatasetRecord(
-              attrs?.input ?? null,
-              attrs?.expected_output ?? null,
-              attrs?.metadata ?? {},
-              recordId === '' ? null : recordId
-            ))
-            ids.push(recordId)
+          const resp = await this.#client.listDatasetRecords(projectId, datasetId, {
+            cursor,
+            version: datasetVersion,
+          })
+          for (const record of resp.records) {
+            recs.push(record)
+            ids.push(record.id ?? '')
           }
-          cursor = resp?.meta?.after ?? ''
+          cursor = resp.after
           if (!cursor) break
         }
         records = recs
@@ -164,6 +161,21 @@ class Experiments {
   // Build an experiment: { name, dataset, task, evaluators, description?, config?, tags? }.
   experiment (options) {
     return new Experiment(this.#client, options, this.#llmobs)
+  }
+
+  /**
+   * Start an externally-driven experiment for eval frameworks that already own
+   * task execution. Call submitSpan() once per completed row, then
+   * submitEvaluationMetrics() with the generated span id.
+   *
+   * @param {object} options
+   * @returns {Promise<ExperimentRecorder>}
+   */
+  async startExperiment (options) {
+    const client = options?.projectName === undefined || options.projectName === this.#projectName
+      ? this.#client
+      : this.#clientForProject(options.projectName)
+    return new ExperimentRecorder(client, options).start()
   }
 }
 

--- a/packages/dd-trace/src/llmobs/experiments/noop.js
+++ b/packages/dd-trace/src/llmobs/experiments/noop.js
@@ -82,6 +82,53 @@ class NoopExperiment {
   }
 }
 
+class NoopExperimentRecorder {
+  #name
+
+  /**
+   * @param {string} name
+   */
+  constructor (name = '') {
+    this.#name = name
+    this.experimentId = null
+  }
+
+  /**
+   * @returns {string}
+   */
+  name () {
+    return this.#name
+  }
+
+  /**
+   * @returns {null}
+   */
+  url () {
+    return null
+  }
+
+  /**
+   * @returns {Promise<{experimentId: null, spanId: null, traceId: null, url: null}>}
+   */
+  submitSpan () {
+    return Promise.resolve({ experimentId: null, spanId: null, traceId: null, url: null })
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  submitEvaluationMetrics () {
+    return Promise.resolve()
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  close () {
+    return Promise.resolve()
+  }
+}
+
 // No-op Experiments used when LLM Observability is disabled or the API/APP keys
 // are not configured. Operations warn and return inert objects rather than
 // throwing, so intentionally disabled experiments remain graceful.
@@ -109,6 +156,15 @@ class NoopExperiments {
   experiment (options = {}) {
     this.#warn()
     return new NoopExperiment(options.name)
+  }
+
+  /**
+   * @param {object} options
+   * @returns {Promise<NoopExperimentRecorder>}
+   */
+  startExperiment (options = {}) {
+    this.#warn()
+    return Promise.resolve(new NoopExperimentRecorder(options.name))
   }
 }
 

--- a/packages/dd-trace/src/llmobs/experiments/result.js
+++ b/packages/dd-trace/src/llmobs/experiments/result.js
@@ -13,6 +13,7 @@ class Row {
     this.expectedOutput = fields.expectedOutput
     this.errorType = fields.errorType
     this.errorMessage = fields.errorMessage
+    this.errorStack = fields.errorStack
     this.evaluations = fields.evaluations
     this.evaluationErrors = fields.evaluationErrors
   }

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -216,6 +216,7 @@ describe('LLMObs Experiments facade', () => {
         } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets') {
           payload = { data: [{ id: 'ds9', attributes: { name: 'wanted', description: 'd', current_version: 7 } }] }
         } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets/ds9/records') {
+          assert.match(url, /\/records\?filter%5Bversion%5D=3$/)
           assert.equal(u.searchParams.get('filter[version]'), '3')
           payload = { data: [{ id: 'r1', attributes: { input: 'i1' } }] }
         } else {
@@ -338,6 +339,129 @@ describe('LLMObs Experiments facade', () => {
       const ds = await createExperiments(enabledConfig()).pullDataset('wanted')
       assert.deepEqual(ds.records().map((r) => r.input), ['i1', 'i2'])
       assert.deepEqual(ds.recordIds(), ['r1', 'r2'])
+    })
+  })
+
+  describe('externally-driven experiments', () => {
+    function resolveExperimentRoutes () {
+      global.fetch.callsFake(async (url, options) => {
+        const u = new URL(url)
+        let payload = {}
+        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
+          payload = { data: { id: 'proj' } }
+        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets' && options.method === 'POST') {
+          payload = { data: { id: 'dataset', attributes: { current_version: 1 } } }
+        } else if (u.pathname === '/api/v2/llm-obs/v1/experiments' && options.method === 'POST') {
+          payload = { data: { id: 'exp' } }
+        }
+        return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
+      })
+    }
+
+    it('starts an experiment, submits a generated row span, and submits metrics for that span', async () => {
+      resolveExperimentRoutes()
+
+      const recorder = await createExperiments(enabledConfig()).startExperiment({
+        name: 'eve-run',
+        description: 'eve eval run',
+        tags: { source: 'eve' },
+        metadata: { suite: 'smoke' },
+        config: { revision: 'abc123' },
+      })
+      assert.equal(recorder.experimentId, 'exp')
+      assert.equal(recorder.url(), 'https://app.datadoghq.com/llm/experiments/exp')
+
+      const span = await recorder.submitSpan({
+        id: 'smoke',
+        name: 'smoke eval',
+        input: 'Say hello.',
+        output: { message: 'hello' },
+        expectedOutput: 'hello',
+        metadata: { verdict: 'passed' },
+        tags: { eval: 'smoke' },
+        startedAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      })
+
+      assert.equal(span.experimentId, 'exp')
+      assert.match(span.spanId, /^[a-f0-9]{16}$/)
+      assert.match(span.traceId, /^[a-f0-9]{32}$/)
+
+      await recorder.submitEvaluationMetrics(span, [
+        { label: 'gate:succeeded', value: true },
+        { label: 'similarity', value: 0.92 },
+        { label: 'verdict', value: 'passed' },
+        { label: 'details', value: { assertions: 3 } },
+        { label: 'judge_error', error: 'judge unavailable' },
+      ])
+      await recorder.close({ status: 'completed' })
+
+      const datasetBody = JSON.parse(global.fetch.getCall(1).args[1].body)
+      assert.deepEqual(datasetBody.data.attributes, {
+        name: 'eve-run dataset',
+        description: "Placeholder dataset for externally-driven experiment 'eve-run'",
+      })
+
+      const createBody = JSON.parse(global.fetch.getCall(2).args[1].body)
+      assert.deepEqual(createBody.data.attributes, {
+        name: 'eve-run',
+        project_id: 'proj',
+        dataset_id: 'dataset',
+        description: 'eve eval run',
+        ensure_unique: true,
+        dataset_version: 1,
+        config: { revision: 'abc123' },
+        metadata: { suite: 'smoke' },
+        tags: { source: 'eve' },
+      })
+
+      const spanBody = JSON.parse(global.fetch.getCall(3).args[1].body)
+      const submittedSpan = spanBody.data.attributes.spans[0]
+      assert.equal(submittedSpan.span_id, span.spanId)
+      assert.equal(submittedSpan.trace_id, span.traceId)
+      assert.equal(submittedSpan.project_id, 'proj')
+      assert.equal(submittedSpan.name, 'smoke eval')
+      assert.equal(submittedSpan.start_ns, 1767225600000000000)
+      assert.equal(submittedSpan.duration, 1000000000)
+      assert.deepEqual(submittedSpan.meta, {
+        input: 'Say hello.',
+        output: { message: 'hello' },
+        expected_output: 'hello',
+        metadata: { verdict: 'passed' },
+      })
+      assert.equal(submittedSpan.dataset_id, 'dataset')
+      assert.deepEqual(new Set(submittedSpan.tags), new Set(['source:eve', 'eval:smoke', 'experiment_id:exp', 'dataset_id:dataset']))
+
+      const metricsBody = JSON.parse(global.fetch.getCall(4).args[1].body)
+      const metrics = metricsBody.data.attributes.metrics
+      assert.equal(metrics.length, 5)
+      assert.deepEqual(metrics.map(metric => metric.span_id), Array(5).fill(span.spanId))
+      assert.deepEqual(metrics.map(metric => metric.tags), Array(5).fill(['source:eve', 'experiment_id:exp']))
+      assert.equal(metrics[0].metric_type, 'boolean')
+      assert.equal(metrics[0].boolean_value, true)
+      assert.equal(metrics[1].metric_type, 'score')
+      assert.equal(metrics[1].score_value, 0.92)
+      assert.equal(metrics[2].metric_type, 'categorical')
+      assert.equal(metrics[2].categorical_value, 'passed')
+      assert.equal(metrics[3].metric_type, 'json')
+      assert.deepEqual(metrics[3].json_value, { assertions: 3 })
+      assert.deepEqual(metrics[4].error, { message: 'judge unavailable' })
+
+      const closeBody = JSON.parse(global.fetch.getCall(5).args[1].body)
+      assert.deepEqual(closeBody.data.attributes, { status: 'completed' })
+    })
+
+    it('supports no-op external experiments when LLM Obs is disabled', async () => {
+      const warn = sinon.spy(log, 'warn')
+      const experiments = createExperiments({ llmobs: { DD_LLMOBS_ENABLED: false } })
+
+      const recorder = await experiments.startExperiment({ name: 'disabled' })
+      assert.equal(recorder.url(), null)
+      assert.deepEqual(await recorder.submitSpan(), { experimentId: null, spanId: null, traceId: null, url: null })
+      await recorder.submitEvaluationMetrics({ spanId: 'span' }, [{ label: 'score', value: 1 }])
+      await recorder.close({ status: 'completed' })
+
+      sinon.assert.calledWith(warn, sinon.match(/LLMObs experiments unavailable/))
     })
   })
 })


### PR DESCRIPTION
## Summary
- add an externally-driven LLMObs ExperimentRecorder exposed via tracer.llmobs.experiments.startExperiment()
- support submitSpan(), submitEvaluationMetrics(), close(), and no-op recorder behavior
- create a placeholder dataset when the backend requires dataset_id for externally-driven experiments

## Testing
- ./node_modules/.bin/mocha packages/dd-trace/test/llmobs/experiments/index.spec.js

Draft while dogfooding with the eve Datadog reporter integration.