### PR TITLE
fix(id): drop redundant tags optional chaining in agentless exporter/encoder

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -62,7 +62,7 @@ class DogStatsDClient {
     this._family = isIP(this._host)
     this._port = options.port
     this._tags = options.tags
-    this.#tagsPrefix = this._tags?.length ? `|#${this._tags.join(',')}` : ''
+    this.#tagsPrefix = this._tags.length ? `|#${this._tags.join(',')}` : ''
     this._queue = []
     this._buffer = ''
     this._offset = 0
@@ -78,7 +78,7 @@ class DogStatsDClient {
    * @param {string[]} tags - DogStatsD-formatted tags (e.g. `['key:value']`)
    */
   updateTags (tags) {
-    const tagsPrefix = tags?.length ? `|#${tags.join(',')}` : ''
+    const tagsPrefix = tags.length ? `|#${tags.join(',')}` : ''
 
     this._tags = tags
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -406,10 +406,10 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       events: [],
     }
 
-    if (this.tags?.env) {
+    if (this.tags.env) {
       payload.metadata['*'].env = this.tags.env
     }
-    const runtimeId = this.tags?.['runtime-id']
+    const runtimeId = this.tags['runtime-id']
     if (runtimeId) {
       payload.metadata['*']['runtime-id'] = runtimeId
     }

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -23,7 +23,7 @@ class AgentlessExporter {
    * @param {string} [config.site] - The Datadog site. Defaults to 'datadoghq.com'.
    * @param {number} [config.flushInterval] - Batch flush interval in ms
    * @param {string} [config.env] - Environment name
-   * @param {object} [config.tags] - Tags including runtime-id
+   * @param {object} config.tags - Tags including runtime-id
    */
   constructor (config) {
     this.#config = config
@@ -46,7 +46,7 @@ class AgentlessExporter {
       // Read live off `config` (instead of copying the value) so a later change
       // (e.g. a MicroVM clone resume) is picked up by the next `JSON.stringify` in the encoder.
       get env () { return config.env },
-      get runtimeID () { return config.tags?.['runtime-id'] },
+      get runtimeID () { return config.tags['runtime-id'] },
       ...(entityId ? { containerID: entityId } : {}),
     }
 

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -39,7 +39,7 @@ describe('agentless-ci-visibility-encode', () => {
       '../log': logger,
     }).AgentlessCiVisibilityEncoder
     writer = { flush: sinon.spy() }
-    encoder = new AgentlessCiVisibilityEncoder(writer, {})
+    encoder = new AgentlessCiVisibilityEncoder(writer, { tags: {} })
 
     trace = [{
       trace_id: id('1234abcd1234abcd'),


### PR DESCRIPTION
## Summary
Follow-up to #9355 addressing BridgeAR's review comments that `tags` will always be an object by the time these getters/checks run:

- `packages/dd-trace/src/exporters/agentless/index.js` — `config.tags?.['runtime-id']` → `config.tags['runtime-id']` ([comment](https://github.com/DataDog/dd-trace-js/pull/9355#discussion_r3685102302))
- `packages/dd-trace/src/encode/agentless-ci-visibility.js` — `this.tags?.env` / `this.tags?.['runtime-id']` → non-optional ([comment](https://github.com/DataDog/dd-trace-js/pull/9355#discussion_r3685106616), [comment](https://github.com/DataDog/dd-trace-js/pull/9355#discussion_r3685107574))
- `packages/dd-trace/src/dogstatsd.js` — same redundant `?.` on `DogStatsDClient#tags`, which is always built as an array by `generateClientConfig()`/`buildClientConfig()`

In every case, traced the constructor back to its only production caller: `config.tags` comes from the tracer's `Config`, which seeds `tags` to `{}` (never `undefined`) in `#applyDefaults()` before any other config logic runs.

Updated one test (`test/encode/agentless-ci-visibility.spec.js`) that constructed `AgentlessCiVisibilityEncoder` without `tags` — a shape no real caller produces — to pass `tags: {}` instead.

## Test plan
- [x] `./node_modules/.bin/mocha packages/dd-trace/test/exporters/agentless/exporter.spec.js` — 19 passing
- [x] `./node_modules/.bin/mocha packages/dd-trace/test/encode/agentless-ci-visibility.spec.js` — 27 passing
- [x] `./node_modules/.bin/mocha packages/dd-trace/test/dogstatsd.spec.js` — 48 passing, 1 pre-existing unrelated timeout (reproduced identically without this change)
- [x] `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js` — 30 passing
- [x] `npm run lint` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)