### PR TITLE
refactor(lint): simplify regexes and enable the actionlint shellcheck pass

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           # Poll every 10s (30x = 5 min total), matching the official action's
           # timeout but halving the API calls vs its default 5s interval.
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             RESULT=$(curl -sf \
               -H "Authorization: Bearer $TOKEN" \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           matcher: true
           fail-on-error: true
-          shellcheck: false # TODO should we enable this?
+          shellcheck: true
       - name: actionlint Summary
         if: ${{ steps.actionlint.outputs.exit-code != 0 }}
         run: |

--- a/ci/diagnose.js
+++ b/ci/diagnose.js
@@ -72,11 +72,11 @@ const TEXT_FILE_NAMES = new Set([
 
 const NODE_OPTIONS_RE = /\bNODE_OPTIONS\b/
 const INIT_PRELOAD_TARGET =
-  String.raw`(?:dd-trace\/ci\/init|(?:[^\s'"]*[\/\\])?node_modules[\/\\]dd-trace[\/\\]ci[\/\\]init|\.\/ci\/init)`
+  String.raw`(?:dd-trace/ci/init|(?:[^\s'"]*[/\\])?node_modules[/\\]dd-trace[/\\]ci[/\\]init|\./ci/init)`
 const INIT_PRELOAD_RE =
-  new RegExp(String.raw`(?:^|[\s='"])(?:-r|--require)(?:=|\s+)['"]?${INIT_PRELOAD_TARGET}(?:\.js)?['"]?(?=$|\s|["'])`)
+  new RegExp(String.raw`(?:^|[\s='"])(?:-r|--require)(?:=|\s+)['"]?${INIT_PRELOAD_TARGET}(?:\.js)?['"]?(?=$|[\s"'])`)
 const REGISTER_PRELOAD_RE =
-  /(?:^|[\s='"])(?:--import|-r|--require)(?:=|\s+)['"]?dd-trace\/register(?:\.js)?['"]?(?=$|\s|["'])/
+  /(?:^|[\s='"])(?:--import|-r|--require)(?:=|\s+)['"]?dd-trace\/register(?:\.js)?['"]?(?=$|[\s"'])/
 const WRONG_INIT_RE = /dd-trace\/(?:init|initialize\.mjs)\b|require\(['"]dd-trace['"]\)\.init\s*\(/
 const DIRECT_CI_INIT_RE = /(?:require\(|import\s+)['"]dd-trace\/ci\/init(?:\.js)?['"]/
 const CI_DISABLED_RE = /DD_CIVISIBILITY_ENABLED["'\s:=]+(?:false|0)\b/i
@@ -86,21 +86,21 @@ const AGENTLESS_ENABLED_RE = /DD_CIVISIBILITY_AGENTLESS_ENABLED["'\s:=]+(?:true|
 const API_KEY_RE = /\b(?:DD_API_KEY|DATADOG_API_KEY)\b/
 const SERVICE_RE = /\bDD_SERVICE\b/
 const OTEL_OTLP_RE = /OTEL_TRACES_EXPORTER["'\s:=]+otlp\b/i
-const WATCH_MODE_RE = /(?:^|\s)(?:watch|--watch|--watchAll)(?!(?:=false)(?:\s|$))(?:\s|=|$)/
+const WATCH_MODE_RE = /(?:^|\s)(?:watch|--watch|--watchAll)(?!=false(?:\s|$))(?:\s|=|$)/
 
 const CYPRESS_MANUAL_PLUGIN_RE = /dd-trace\/ci\/cypress\/(?:plugin|after-run|after-spec)\b/
 const CYPRESS_SUPPORT_RE = /dd-trace\/ci\/cypress\/support\b/
 const CYPRESS_SUPPORT_DISABLED_RE = /supportFile\s*:\s*false|"supportFile"\s*:\s*false/
 const CUCUMBER_RUNNER_COMMAND_RE = new RegExp(
   String.raw`(?:^|(?:&&|\|\||[;|])\s*)` +
-  String.raw`(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s;&|]+)|` +
-  String.raw`cross-env|env|npx|nyc|c8|npm\s+exec|pnpm\s+exec|yarn\s+exec|--?[^\s;&|]+)\s+)*` +
-  String.raw`(?:(?:[^\s"';&|]+[\/\\])?(?:cucumber-js(?:\.cmd)?|cucumber(?:\.cmd)?)|` +
-  String.raw`node(?:\.exe)?\s+(?:[^\s"';&|]+[\/\\])?bin[\/\\]cucumber\.js)` +
+  String.raw`(?:(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"';&|][^\s;&|]*)|` +
+  String.raw`cross-env|env|npx|nyc|c8|npm\s+exec|pnpm\s+exec|yarn\s+exec|-[^\s;&|]+)\s+)*` +
+  String.raw`(?:(?:[^\s"';&|]+[/\\])?(?:cucumber-js(?:\.cmd)?|cucumber(?:\.cmd)?)|` +
+  String.raw`node(?:\.exe)?\s+(?:[^\s"';&|]+[/\\])?bin[/\\]cucumber\.js)` +
   String.raw`(?=$|[\s"';&|])`
 )
 const CUCUMBER_PARALLEL_RE =
-  /\bcucumber(?:-js)?\b[\s\S]{0,200}\s--parallel\b|--parallel\b[\s\S]{0,200}\bcucumber(?:-js)?\b/
+  /\bcucumber(?:-js)?\b[\s\S]{0,200}\s--parallel\b|--parallel\b[\s\S]{1,200}\bcucumber(?:-js)?\b/
 const JEST_FORCE_EXIT_RE = /\bforceExit\s*:\s*true\b|--forceExit\b|"forceExit"\s*:\s*true/
 const JEST_JASMINE_RE = /jest-jasmine2/
 
@@ -1876,7 +1876,7 @@ function isTestSetupOrCiFile (file) {
   if (/^(?:jest|config-jest|vitest|vite|playwright|cypress|cucumber)\.config\./.test(basename)) return true
   if (/^\.mocharc\./.test(basename)) return true
   if (basename === 'cypress.json') return true
-  if (/(?:setup|bootstrap)/i.test(basename)) return true
+  if (/setup|bootstrap/i.test(basename)) return true
   if (relativePath.startsWith('cypress/support/')) return true
 
   return false

--- a/ci/test-optimization-validation/ci-package-scripts.js
+++ b/ci/test-optimization-validation/ci-package-scripts.js
@@ -3,7 +3,7 @@
 const { parseLiteralEnvironmentPrefix } = require('./literal-environment')
 
 const MAX_SCRIPT_EXPANSIONS = 16
-const DYNAMIC_VALUE_PATTERN = /[$`]|\r|\n|%[^%\s]+%|![^!\s]+!/
+const DYNAMIC_VALUE_PATTERN = /[$`\r\n]|%[^%\s]+%|![^!\s]+!/
 
 /**
  * Expands bounded local package-script references without executing them.

--- a/ci/test-optimization-validation/ci-remediation.js
+++ b/ci/test-optimization-validation/ci-remediation.js
@@ -183,7 +183,7 @@ function isDatadogModuleSpecifier (specifier, entrypoint) {
 }
 
 function hasDynamicEnvironmentReference (value) {
-  return /(?:\$[A-Za-z_{]|\$\(|%[A-Za-z_][A-Za-z0-9_]*%)/.test(value)
+  return /\$[A-Za-z_{]|\$\(|%[A-Za-z_][A-Za-z0-9_]*%/.test(value)
 }
 
 function getRecommendedValues (framework) {

--- a/ci/test-optimization-validation/cli.js
+++ b/ci/test-optimization-validation/cli.js
@@ -534,7 +534,7 @@ function normalizeScenarioSelection (scenario) {
  * @returns {string} normalized target
  */
 function normalizeFrameworkTarget (target) {
-  const normalized = String(target).trim().replaceAll(/:+$/g, '')
+  const normalized = String(target).trim().replace(/(?<!:):+$/, '')
   if (!normalized) throw new Error('Framework target cannot be empty.')
   return normalized
 }

--- a/ci/test-optimization-validation/command-blocker.js
+++ b/ci/test-optimization-validation/command-blocker.js
@@ -8,22 +8,22 @@ const CONNECTION_REFUSED_PATTERN = /\bECONNREFUSED\b|\bconnection refused\b/i
 const NO_TESTS_FOUND_PATTERN =
   /\b(?:No test files? found|No tests? found|No test files? were found|0 tests? collected)\b/i
 const MODULE_OR_TRANSFORM_PATTERN =
-  /\b(?:Cannot find (?:module|package)|ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|ERR_PACKAGE_PATH_NOT_EXPORTED|Package subpath\b[\s\S]*\bnot defined by "exports"|Could not resolve|transform failed)\b/i
+  /\b(?:Cannot find (?:module|package)|ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|ERR_PACKAGE_PATH_NOT_EXPORTED|Package subpath\b[\s\S]+\bnot defined by "exports"|Could not resolve|transform failed)\b/i
 const CYPRESS_BINARY_PATTERN =
-  /(?:Cypress executable not found|Cypress binary is missing|Cypress failed to start|Please reinstall Cypress)/i
+  /Cypress executable not found|Cypress binary is missing|Cypress failed to start|Please reinstall Cypress/i
 const PLAYWRIGHT_BROWSER_PATTERN = new RegExp(
-  String.raw`(?:browserType\.launch: Executable doesn't exist|` +
-  'Please run the following command to download new browsers|playwright install)',
+  String.raw`browserType\.launch: Executable doesn't exist|` +
+  'Please run the following command to download new browsers|playwright install',
   'i'
 )
 const PLAYWRIGHT_BROWSER_LAUNCH_PATTERN =
-  /(?:browserType\.launch: Failed to launch the browser process|bootstrap_check_in|MachPortRendezvous)/i
+  /browserType\.launch: Failed to launch the browser process|bootstrap_check_in|MachPortRendezvous/i
 const PLAYWRIGHT_BROWSER_ABORT_PATTERN =
   /(?:browserType\.launch: Target page, context or browser has been closed|Browser logs:)[\s\S]*?(?:signal=SIGABRT|Received signal 6|Abort trap: 6)/i
 const VITEST_BROWSER_PROVIDER_PATTERN =
-  /(?:Cannot find (?:module|package).*@vitest\/browser|@vitest\/browser-[^\s'"]+.*(?:missing|not (?:found|installed)))/i
+  /Cannot find (?:module|package).*@vitest\/browser|@vitest\/browser-[^\s'"].*(?:missing|not (?:found|installed))/i
 const RUNNER_COMMAND_NOT_FOUND_PATTERN =
-  /(?:command not found|is not recognized as an internal or external command|spawn [^\r\n]+ ENOENT)/i
+  /command not found|is not recognized as an internal or external command|spawn [^\r\n]+ ENOENT/i
 
 /**
  * Identifies toolchain and execution-environment failures that happen before tests start.

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -23,7 +23,7 @@ function isTestFile (filename) {
  * @returns {number} declared scenario count
  */
 function getScenarioCount (source) {
-  return [...source.matchAll(/^\s*Scenario(?: Outline)?:\s*\S/gm)].length
+  return [...source.matchAll(/^[ \t]*Scenario(?: Outline)?:[ \t]*\S/gm)].length
 }
 
 /**

--- a/ci/test-optimization-validation/manifest-scaffold.js
+++ b/ci/test-optimization-validation/manifest-scaffold.js
@@ -77,9 +77,9 @@ const IMPLICIT_CONFIG_FILENAMES = {
 const TEST_FILE_PATTERN = /^.+[._-](?:test|spec)\.[cm]?[jt]sx?$/
 const BARE_TEST_FILE_PATTERN = /^test\.[cm]?[jt]sx?$/
 const TYPE_ONLY_TEST_PATTERN = /\.(?:test|spec)-d\.[cm]?tsx?$|\.d\.[cm]?ts$/i
-const TYPE_ONLY_DIRECTORY_PATTERN = /(?:^|\/)(?:type[-_]?tests?|typetests?|test-dts?)(?:\/|$)/i
+const TYPE_ONLY_DIRECTORY_PATTERN = /(?:^|\/)(?:type[-_]?tests?|test-dts?)(?:\/|$)/i
 const LOCAL_SOCKET_PATTERN =
-  /(?:\bcreateServer\s*\(|\.listen\s*\(|\b(?:localhost|127\.0\.0\.1)\b|\bcy\.(?:visit|request)\s*\()/
+  /\bcreateServer\s*\(|\.listen\s*\(|\b(?:localhost|127\.0\.0\.1)\b|\bcy\.(?:visit|request)\s*\(/
 const CYPRESS_LOCAL_ORIGIN_PATTERN =
   /\bcy\.(?:visit|request)\s*\([\s\S]{0,512}\b(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?=[:/'"`\s}])/i
 
@@ -597,7 +597,7 @@ function hasExplicitFrameworkImport (source, framework) {
  */
 function hasFrameworkOwnership (filename, source, framework, packageName) {
   const normalized = filename.replaceAll('\\', '/').toLowerCase()
-  if (framework === 'cucumber') return /^\s*(?:Feature|Rule):/m.test(source)
+  if (framework === 'cucumber') return /^[ \t]*(?:Feature|Rule):/m.test(source)
   if (framework === 'cypress') return /\.cy\./.test(filename) || normalized.includes('/cypress/')
   if (framework === 'playwright') {
     return /@playwright\/test/.test(source) || normalized.includes('/playwright/') ||
@@ -643,7 +643,7 @@ function getTestRank (filename, source, projectRoot) {
   let rank = relative.split('/').length
   if (/(?:^|\/)(?:test|tests|__tests__|spec)\//.test(relative)) rank -= 20
   if (/(?:^|[._/-])unit(?:[._/-]|$)/.test(relative)) rank -= 15
-  if (/(?:e2e|integration|acceptance|browser|conformance|fixtures?)/.test(relative)) rank += 20
+  if (/e2e|integration|acceptance|browser|conformance|fixtures?/.test(relative)) rank += 20
   if (LOCAL_SOCKET_PATTERN.test(source)) rank += 30
   rank += Math.min(getStaticTestCount(source), 50)
   return rank
@@ -823,9 +823,9 @@ function getTestExtension (framework, representative) {
   if (framework === 'cucumber') return '.feature'
   if (framework === 'cypress') return cypress.getTestExtension(representative)
   if (framework === 'playwright') return playwright.getTestExtension(representative)
-  const match = /((?:[.-](?:test|spec))\.[cm]?[jt]sx?)$/.exec(representative)
+  const match = /([.-](?:test|spec)\.[cm]?[jt]sx?)$/.exec(representative)
   if (match) return match[1]
-  const moduleExtension = /\.((?:[cm]js|[cm]ts))$/.exec(representative)?.[1]
+  const moduleExtension = /\.([cm]js|[cm]ts)$/.exec(representative)?.[1]
   return moduleExtension ? `.test.${moduleExtension}` : '.test.js'
 }
 
@@ -899,7 +899,7 @@ function rankCiReviewTargets (files) {
  */
 function getCiRank (filename) {
   const value = filename.toLowerCase()
-  if (/(?:test|ci|build|unit|integration)/.test(value)) return 0
+  if (/test|ci|build|unit|integration/.test(value)) return 0
   return 10
 }
 

--- a/ci/test-optimization-validation/redaction.js
+++ b/ci/test-optimization-validation/redaction.js
@@ -13,7 +13,6 @@ const SECRET_NAME_SOURCE = [
   'PASSPHRASE',
   'CREDENTIAL',
   'PRIVATE_?KEY',
-  'CLIENT_?SECRET',
   'ACCESS_?KEY',
   'COOKIE',
 ].join('|')
@@ -22,23 +21,18 @@ const EXACT_SECRET_ASSIGNMENT_NAME_SOURCE = [
   'AUTH',
   'AUTHORIZATION',
   'PASS',
-  'SET-COOKIE',
   'PAT',
   'JWT',
   'WEBHOOK(?:_URL)?',
 ].join('|')
-const SECRET_NAME_CHARS = '[A-Za-z0-9_.-]'
+// Every pattern built from these name sources carries the `i` flag; the classes list uppercase only.
+const SECRET_NAME_CHARS = '[A-Z0-9_.-]'
 const SECRET_ASSIGNMENT_NAME_SOURCE = [
-  `(?:${EXACT_SECRET_ASSIGNMENT_NAME_SOURCE})`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*(?:${SECRET_NAME_SOURCE})${SECRET_NAME_CHARS}*`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*[-_]PASS`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*[-_]AUTH(?:ORIZATION)?`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*[-_](?:PAT|JWT|WEBHOOK(?:_URL)?)`,
-  'PASS',
-  'AUTH',
-  'AUTHORIZATION',
-  'COOKIE',
-  'SET-COOKIE',
+  EXACT_SECRET_ASSIGNMENT_NAME_SOURCE,
+  `[A-Z_]${SECRET_NAME_CHARS}*(?:${SECRET_NAME_SOURCE})${SECRET_NAME_CHARS}*`,
+  `[A-Z_]${SECRET_NAME_CHARS}*[-_]PASS`,
+  `[A-Z_]${SECRET_NAME_CHARS}*[-_]AUTH(?:ORIZATION)?`,
+  `[A-Z_]${SECRET_NAME_CHARS}*[-_](?:PAT|JWT|WEBHOOK(?:_URL)?)`,
 ].join('|')
 const SECRET_FLAG_SOURCE = [
   'api-key',
@@ -54,7 +48,7 @@ const SECRET_FLAG_SOURCE = [
   'auth',
 ].join('|')
 const SECRET_VALUE_SOURCE = String.raw`("[^"]*"|'[^']*'|[^\s,;]+)`
-const SENSITIVE_NAME_PATTERN = new RegExp(`(?:${SECRET_NAME_SOURCE})`, 'i')
+const SENSITIVE_NAME_PATTERN = new RegExp(SECRET_NAME_SOURCE, 'i')
 const SENSITIVE_AUTH_NAME_PATTERN = /(?:^|_)AUTH(?:ORIZATION)?(?:_|$)/i
 const SENSITIVE_COOKIE_NAME_PATTERN = /(?:^|_)SET_?COOKIE(?:_|$)|(?:^|_)COOKIE(?:_|$)/i
 const SENSITIVE_PASS_NAME_PATTERN = /(?:^|_)PASS(?:_|$)/i
@@ -64,16 +58,16 @@ const SECRET_ASSIGNMENT_PATTERN = new RegExp(
   'gi'
 )
 const SECRET_FLAG_PATTERN = new RegExp(
-  String.raw`(--(?:${SECRET_FLAG_SOURCE})(?:-[A-Za-z0-9]+)*)(=|\s+)` + SECRET_VALUE_SOURCE,
+  String.raw`(--(?:${SECRET_FLAG_SOURCE})(?:-[A-Z0-9]+)*)(=|\s+)` + SECRET_VALUE_SOURCE,
   'gi'
 )
 const SECRET_FLAG_NAME_PATTERN = new RegExp(
-  `^--(?:${SECRET_FLAG_SOURCE})(?:-[A-Za-z0-9]+)*$`,
+  `^--(?:${SECRET_FLAG_SOURCE})(?:-[A-Z0-9]+)*$`,
   'i'
 )
 const AUTH_HEADER_PATTERN = /\b(Bearer)\s+([^\s'",}\]]+)/gi
 const AUTH_SCHEME_ASSIGNMENT_QUOTED_PATTERN = new RegExp(
-  String.raw`\b(${SECRET_ASSIGNMENT_NAME_SOURCE})\s*=\s*(["'])(?:Bearer|Basic)\s+.*?\2`,
+  String.raw`\b(${SECRET_ASSIGNMENT_NAME_SOURCE})\s*=\s*(["'])(?:Bearer|Basic)\s.*?\2`,
   'gi'
 )
 const AUTH_SCHEME_ASSIGNMENT_PATTERN = new RegExp(
@@ -83,7 +77,7 @@ const AUTH_SCHEME_ASSIGNMENT_PATTERN = new RegExp(
 const DEFAULT_IGNORABLE_PATTERN = /\p{Default_Ignorable_Code_Point}/gu
 const DEFAULT_IGNORABLE_TEST_PATTERN = /\p{Default_Ignorable_Code_Point}/u
 const CONTROL_CHARACTER_TEST_PATTERN = /\p{Cc}/u
-const UNSAFE_CONTROL_SOURCE = String.raw`[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]`
+const UNSAFE_CONTROL_SOURCE = String.raw`[\u0000-\u0008\v\f\u000E-\u001F\u007F-\u009F]`
 const UNSAFE_CONTROL_PATTERN = new RegExp(UNSAFE_CONTROL_SOURCE, 'g')
 const UNSAFE_CONTROL_TEST_PATTERN = new RegExp(UNSAFE_CONTROL_SOURCE)
 const PRIVATE_KEY_BLOCK_PATTERN =
@@ -92,10 +86,10 @@ const JWT_VALUE_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9
 const KNOWN_TOKEN_VALUE_PATTERN =
   /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,})\b/g
 const SECRET_HEADER_ENV_NAME_SOURCE = [
-  `(?:${SECRET_NAME_SOURCE}|PAT|JWT|WEBHOOK(?:_URL)?)`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*(?:${SECRET_NAME_SOURCE})${SECRET_NAME_CHARS}*`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*[-_]AUTH(?:ORIZATION)?`,
-  `[A-Za-z_]${SECRET_NAME_CHARS}*[-_](?:PAT|JWT|WEBHOOK(?:_URL)?)`,
+  `${SECRET_NAME_SOURCE}|PAT|JWT|WEBHOOK(?:_URL)?`,
+  `[A-Z_]${SECRET_NAME_CHARS}*(?:${SECRET_NAME_SOURCE})${SECRET_NAME_CHARS}*`,
+  `[A-Z_]${SECRET_NAME_CHARS}*[-_]AUTH(?:ORIZATION)?`,
+  `[A-Z_]${SECRET_NAME_CHARS}*[-_](?:PAT|JWT|WEBHOOK(?:_URL)?)`,
 ].join('|')
 const SECRET_HEADER_NAME_SOURCE = [
   'dd-api-key',
@@ -103,16 +97,13 @@ const SECRET_HEADER_NAME_SOURCE = [
   'api-key',
   'authorization',
   'proxy-authorization',
-  'token',
-  'cookie',
-  'set-cookie',
   SECRET_HEADER_ENV_NAME_SOURCE,
 ].join('|')
 const SECRET_HEADER_PATTERN = new RegExp(
-  String.raw`\b((?:${SECRET_HEADER_NAME_SOURCE}))\s*:\s*("[^"]*"|'[^']*'|[^\r\n,}]+)`,
+  String.raw`\b(${SECRET_HEADER_NAME_SOURCE})\s*:\s*("[^"]*"|'[^']*'|[^\r\n,}]+)`,
   'gi'
 )
-const URL_CREDENTIAL_PATTERN = /([a-z][a-z0-9+.-]*:\/\/)([^@\s/]+)(@)/gi
+const URL_CREDENTIAL_PATTERN = /(?<![a-z0-9+.-])([a-z][a-z0-9+.-]*:\/\/)([^@\s/]+)(@)/gi
 const GITHUB_SECRET_REFERENCE_PATTERN =
   /(?:\b[A-Za-z_][A-Za-z0-9_.-]*\s*[:=]\s*)?\$\{\{\s*secrets\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g
 const SAFE_REFERENCE_MARKER_PATTERN = /DDCIVARREF([0-9]+)X/g

--- a/ci/test-optimization-validation/runner-contract.js
+++ b/ci/test-optimization-validation/runner-contract.js
@@ -239,7 +239,7 @@ function getRunnerSearchRoots (framework, command, projectRoot, repositoryRoot) 
  */
 function addRunnerSearchRoot (roots, value, projectRoot, repositoryRoot, directory) {
   if (typeof value !== 'string' || !value) return
-  const literal = value.split(/[*?{[]/, 1)[0].replace(/[\\/]+$/, '')
+  const literal = value.split(/[*?{[]/, 1)[0].replace(/(?<![\\/])[\\/]+$/, '')
   if (!literal) return
   const candidate = path.resolve(projectRoot, literal)
   const searchRoot = directory || !path.extname(candidate) ? candidate : path.dirname(candidate)

--- a/ci/test-optimization-validation/scenarios/ci-wiring.js
+++ b/ci/test-optimization-validation/scenarios/ci-wiring.js
@@ -346,18 +346,18 @@ function classifyUnresolved (ci, resolution, matrixRelevant, jobSource) {
   const ignored = []
   const unresolved = Array.isArray(ci.unresolved) ? ci.unresolved : []
   const githubHosted = /[/\\]\.github[/\\]workflows[/\\]/.test(ci.configFile) &&
-    /^\s*runs-on:\s*(?:ubuntu|windows|macos)-/mi.test(jobSource)
+    /^[ \t]*runs-on:[ \t]*(?:ubuntu|windows|macos)-/mi.test(jobSource)
 
   for (const item of unresolved) {
     const isMatrix = /\bmatrix\b/i.test(item)
     const isResolvedPackagePath = resolution.source === 'local_package_script' &&
       /\b(?:lifecycle|npm|package script|pnpm|pretest|posttest|yarn)\b/i.test(item)
     const isAmbientGithubSettings = githubHosted &&
-      /\b(?:repository|organization|environment)[-\s,\w]*\b(?:secrets?|variables?)\b/i.test(item) &&
+      /\b(?:repository|organization|environment)[-\s,\w]+\b(?:secrets?|variables?)\b/i.test(item) &&
       /\b(?:inject|inherit|outside)\b/i.test(item)
     const isOtherJob = /^Other jobs?\b/i.test(item) ||
-      /\bsecond\b.*\bjob\b.*\bonly\b.*\bselected\b/i.test(item) ||
-      /\brelease\b.*\bcontains no test job\b/i.test(item)
+      /\bsecond\b.+\bjob\b.+\bonly\b.+\bselected\b/i.test(item) ||
+      /\brelease\b.+\bcontains no test job\b/i.test(item)
     if ((isMatrix && !matrixRelevant) ||
       isResolvedPackagePath ||
       isAmbientGithubSettings ||
@@ -446,7 +446,7 @@ function getSelectedJobSource (source, ci) {
 
 function getYamlKeyEntry (line, index) {
   if (!line || /^\s*(?:#|$)/.test(line) || /^\s/.test(line) && line.includes('\t')) return
-  const match = /^(\s*)(?:"([^"]+)"|'([^']+)'|([^:#][^:]*)):\s*(?:#.*)?$/.exec(line)
+  const match = /^(\s*)(?:"([^"]+)"|'([^']+)'|([^\s:#][^:]*)):\s*(?:#.*)?$/.exec(line)
   if (!match) return
   return {
     indent: match[1].length,
@@ -522,8 +522,8 @@ function containsExecutionCommand (source, value) {
   if (!command || command.includes('\n')) return false
   return source.split(/\r?\n/).some(line => {
     if (/^\s*#/.test(line)) return false
-    const match = /^\s*(?:-\s*)?(?:run|script):\s*(.*?)\s*$/.exec(line)
-    return match?.[1] === command
+    const match = /^\s*(?:-\s*)?(?:run|script):(.*)$/.exec(line)
+    return match?.[1].trim() === command
   })
 }
 

--- a/ci/test-optimization-validation/scenarios/helpers.js
+++ b/ci/test-optimization-validation/scenarios/helpers.js
@@ -20,7 +20,8 @@ const { sanitizeForReport, sanitizeString } = require('../redaction')
 const { getGeneratedCommand } = require('../runner-command')
 const { ensureSafeDirectory, writeFileSafely } = require('../safe-files')
 
-const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}${String.raw`\[[0-?]*[ -/]*[@-~]`}`, 'g')
+const ANSI_PATTERN =
+  new RegExp(`${String.fromCharCode(27)}${String.raw`\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]`}`, 'g')
 
 function frameworkOutDir (out, framework, scenario) {
   return path.join(out, 'runs', getArtifactId(framework.id), scenario)

--- a/ci/test-optimization-validation/static-diagnosis.js
+++ b/ci/test-optimization-validation/static-diagnosis.js
@@ -149,7 +149,7 @@ function normalizeRelativePath (location) {
 
 function parseVersion (rawVersion) {
   if (typeof rawVersion !== 'string') return null
-  const match = rawVersion.match(/\d+\.\d+\.\d+/)
+  const match = rawVersion.match(/(?<!\d)\d+\.\d+\.\d+/)
   return match ? match[0] : null
 }
 

--- a/ci/test-optimization-validation/test-output.js
+++ b/ci/test-optimization-validation/test-output.js
@@ -4,7 +4,8 @@ const cypressAdapter = require('./framework-adapters/cypress')
 const cucumberAdapter = require('./framework-adapters/cucumber')
 const playwrightAdapter = require('./framework-adapters/playwright')
 
-const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}${String.raw`\[[0-?]*[ -/]*[@-~]`}`, 'g')
+const ANSI_PATTERN =
+  new RegExp(`${String.fromCharCode(27)}${String.raw`\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]`}`, 'g')
 
 /**
  * Extracts the final test count from common JavaScript test-runner summaries.

--- a/integration-tests/vitest/vitest.no-worker-init.spec.js
+++ b/integration-tests/vitest/vitest.no-worker-init.spec.js
@@ -671,7 +671,7 @@ describe('vitest no-worker init instrumentation selection', () => {
         '    at /repo/test.mjs:60:13',
         '    at runHelper (/repo/helper.mjs?foo=bar:10:5)',
       ].join('\n'))
-      assert.match(error.stack, /[?]import&browserv=/)
+      assert.match(error.stack, /\?import&browserv=/)
     })
 
     it('preserves Node error URLs for final and repeated attempts', () => {

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -63,7 +63,7 @@ class ExposuresWriter extends BaseFFEWriter {
    * @param {import('../../config/config-base')} config - Tracer configuration object
    */
   constructor (config) {
-    const basePath = EVP_PROXY_AGENT_BASE_PATH.replace(/\/+$/, '')
+    const basePath = EVP_PROXY_AGENT_BASE_PATH.replace(/\/$/, '')
     const endpoint = EXPOSURES_ENDPOINT.replace(/^\/+/, '')
     const fullEndpoint = `${basePath}/${endpoint}`
 

--- a/packages/dd-trace/src/openfeature/writers/util.js
+++ b/packages/dd-trace/src/openfeature/writers/util.js
@@ -18,7 +18,7 @@ function setAgentStrategy (config, setWriterEnabledValue) {
     }
 
     const endpoints = agentInfo.endpoints
-    const normalizedPath = EVP_PROXY_AGENT_BASE_PATH.replace(/\/+$/, '')
+    const normalizedPath = EVP_PROXY_AGENT_BASE_PATH.replace(/\/$/, '')
     const hasEndpoint = Array.isArray(endpoints) &&
       endpoints.includes(normalizedPath) || endpoints.includes(normalizedPath + '/')
 

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -884,6 +884,36 @@ describe('test optimization validation manifest scaffold', () => {
     }
   })
 
+  it('ranks test-named workflows ahead of alphabetically earlier ones', () => {
+    const fixture = createRepositoryFixture({
+      framework: 'jest',
+      ciSource: ['jobs:', '  test:', '    steps:', '      - run: npx jest'].join('\n'),
+    })
+    try {
+      const workflows = path.join(fixture.root, '.github', 'workflows')
+      fs.writeFileSync(path.join(workflows, 'audit.yml'), 'jobs:\n  audit:\n    steps: []\n')
+      fs.writeFileSync(path.join(workflows, 'release.yml'), 'jobs:\n  release:\n    steps: []\n')
+
+      const manifest = createManifestScaffold({
+        root: fixture.root,
+        frameworks: new Set(['jest']),
+      })
+
+      assert.deepStrictEqual(manifest.ciDiscovery.found, [
+        '.github/workflows/audit.yml',
+        '.github/workflows/release.yml',
+        '.github/workflows/test.yml',
+      ])
+      assert.deepStrictEqual(manifest.ciDiscovery.reviewTargets, [
+        '.github/workflows/test.yml',
+        '.github/workflows/audit.yml',
+        '.github/workflows/release.yml',
+      ])
+    } finally {
+      removeFixture(fixture.root)
+    }
+  })
+
   it('does not accept a runner that physically resolves outside the repository', () => {
     const fixture = createRepositoryFixture({ framework: 'mocha' })
     const external = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-validation-external-runner-'))


### PR DESCRIPTION
### What does this PR do?

Simplifies a set of regular expressions so each states its intent directly, and enables actionlint's shellcheck pass.

- **actionlint shellcheck** sat behind a `TODO should we enable this?`. #9586 cleared what it reports, so this turns it on to keep those findings from creeping back as workflows are edited. Drive-by: the CodeQL status-polling loop never referenced its index variable, so it becomes `_`.
- **Test Optimization validation CLI and diagnose command** carried redundant non-capturing groups, single-character alternations that belong in a character class, and quantifiers able to match the empty string. Most rewrites are equivalence-preserving. Three narrow what the matcher accepts, the notable one being that `^\s*` under the `m` flag spans line terminators, so the `Scenario:` counter and the `Feature:`/`Rule:` ownership check could anchor on one line and match text on the next — the same shape as #9587.
- **OpenFeature writers** trim the trailing slash of `EVP_PROXY_AGENT_BASE_PATH`, which is `/evp_proxy/v2/` and carries exactly one, so `/\/$/` yields the same string as `/\/+$/`.
- **Redaction name lists** fold repeated entries into the sources that already matched them — `SECRET` covers `CLIENT_?SECRET`, `COOKIE` covers `SET-COOKIE` at the word boundary after the hyphen. Which values get redacted does not change: these patterns replace the value and locate it the same way either form. The redaction spec is unchanged and still passes, which is what pins that.

The `ci/` modules ship in the package, but nothing in the tracer runtime loads them — they run only when a developer invokes the validation CLI or the diagnose command directly.

Draft until the follow-up that enables the rules is ready.
