### PR TITLE
fix(serverless): retain Vercel OTLP logs

### DIFF
--- a/packages/dd-trace/src/opentelemetry/logs/batch_log_processor.js
+++ b/packages/dd-trace/src/opentelemetry/logs/batch_log_processor.js
@@ -18,6 +18,7 @@ class BatchLogRecordProcessor {
   #timer
   #batchTimeout
   #maxExportBatchSize
+  #pendingExports
 
   /**
    * Creates a new BatchLogRecordProcessor instance.
@@ -32,6 +33,7 @@ class BatchLogRecordProcessor {
     this.#maxExportBatchSize = maxExportBatchSize
     this.#logRecords = []
     this.#timer = null
+    this.#pendingExports = new Set()
   }
 
   /**
@@ -53,10 +55,14 @@ class BatchLogRecordProcessor {
 
   /**
    * Forces an immediate flush of all pending log records.
-   * @returns {undefined} Promise that resolves when flush is complete
+   * @returns {Promise<void>} Promise that resolves when flush is complete
    */
   forceFlush () {
-    this.#export()
+    this.#clearTimer()
+    while (this.#logRecords.length > 0) {
+      this.#export()
+    }
+    return Promise.all(this.#pendingExports).then(() => {})
   }
 
   /**
@@ -82,7 +88,16 @@ class BatchLogRecordProcessor {
     this.#logRecords = this.#logRecords.slice(this.#maxExportBatchSize)
 
     this.#clearTimer()
-    this.exporter.export(logRecords, () => {})
+    if (logRecords.length === 0) return
+
+    const pendingExport = new Promise(resolve => {
+      this.exporter.export(logRecords, resolve)
+    })
+    this.#pendingExports.add(pendingExport)
+    pendingExport.then(
+      () => this.#pendingExports.delete(pendingExport),
+      () => this.#pendingExports.delete(pendingExport)
+    )
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/logs/logger_provider.js
+++ b/packages/dd-trace/src/opentelemetry/logs/logger_provider.js
@@ -84,7 +84,7 @@ class LoggerProvider {
 
   /**
    * Forces a flush of all pending log records.
-   * @returns {undefined} Promise that resolves when flush is n ssue cncomplete
+   * @returns {Promise<void> | undefined} Promise that resolves when flush is complete
    */
   forceFlush () {
     if (!this.isShutdown) {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -56,6 +56,18 @@ function getVercelAgentlessExporter (tracer) {
   return tracer._exporter
 }
 
+function getVercelOtelLoggerProvider (tracer) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return
+
+  tracer = tracer?._tracer || tracer
+  if (tracer?._config?.DD_LOGS_OTEL_ENABLED !== true) return
+
+  const { logs } = require('@opentelemetry/api-logs')
+  const loggerProvider = logs.getLoggerProvider()
+  if (typeof loggerProvider?.forceFlush !== 'function') return
+  return loggerProvider
+}
+
 function getVercelWaitUntil () {
   for (const requestContext of VERCEL_REQUEST_CONTEXTS) {
     try {
@@ -75,7 +87,8 @@ function getVercelWaitUntil () {
  */
 function scheduleVercelFlush (tracer) {
   const exporter = getVercelAgentlessExporter(tracer)
-  if (!exporter) return false
+  const loggerProvider = getVercelOtelLoggerProvider(tracer)
+  if (!exporter && !loggerProvider) return false
 
   const waitUntil = getVercelWaitUntil()
   if (!waitUntil) return false
@@ -92,16 +105,20 @@ function scheduleVercelFlush (tracer) {
     return false
   }
 
-  setImmediate(flushExporter, exporter, resolveFlush)
+  setImmediate(flushExporters, exporter, loggerProvider, resolveFlush)
   return true
 }
 
-function flushExporter (exporter, done) {
-  try {
-    exporter.flush(done)
-  } catch {
-    done()
+async function flushExporters (exporter, loggerProvider, done) {
+  const flushes = []
+  if (exporter) {
+    flushes.push(new Promise(resolve => exporter.flush(resolve)))
   }
+  if (loggerProvider) {
+    flushes.push(Promise.resolve().then(() => loggerProvider.forceFlush()))
+  }
+  await Promise.allSettled(flushes)
+  done()
 }
 
 module.exports = {

--- a/packages/dd-trace/test/opentelemetry/logs.spec.js
+++ b/packages/dd-trace/test/opentelemetry/logs.spec.js
@@ -12,6 +12,7 @@ const { trace, context } = require('@opentelemetry/api')
 
 require('../setup/core')
 const { protoLogsService } = require('../../src/opentelemetry/otlp/protobuf_loader').getProtobufTypes()
+const BatchLogRecordProcessor = require('../../src/opentelemetry/logs/batch_log_processor')
 const { getConfigFresh } = require('../helpers/config')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 
@@ -141,6 +142,37 @@ describe('OpenTelemetry Logs', () => {
   })
 
   describe('Logs Export', () => {
+    it('forceFlush waits for queued and in-flight exports', async () => {
+      const callbacks = []
+      const batches = []
+      const processor = new BatchLogRecordProcessor({
+        export (records, callback) {
+          batches.push(records)
+          callbacks.push(callback)
+        },
+      }, 1000, 2)
+
+      processor.onEmit({ body: 'one' }, { name: 'test' })
+      processor.onEmit({ body: 'two' }, { name: 'test' })
+      processor.onEmit({ body: 'three' }, { name: 'test' })
+
+      let flushed = false
+      const flush = processor.forceFlush().then(() => { flushed = true })
+      await Promise.resolve()
+      assert.strictEqual(flushed, false)
+      assert.deepStrictEqual(batches.map(batch => batch.map(record => record.body)), [
+        ['one', 'two'],
+        ['three'],
+      ])
+
+      callbacks[0]({ code: 0 })
+      await Promise.resolve()
+      assert.strictEqual(flushed, false)
+      callbacks[1]({ code: 0 })
+      await flush
+      assert.strictEqual(flushed, true)
+    })
+
     it('exports logs with complete OTLP structure, trace correlation, and instrumentation info', () => {
       mockOtlpExport((decoded, capturedHeaders) => {
         const { resource } = decoded.resourceLogs[0]

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -5,6 +5,7 @@ const { AsyncLocalStorage } = require('node:async_hooks')
 const http = require('node:http')
 
 const { describe, it, afterEach } = require('mocha')
+const { logs } = require('@opentelemetry/api-logs')
 
 require('./setup/core')
 
@@ -50,6 +51,7 @@ describe('Vercel request-lifetime flush', () => {
     else process.env.VERCEL = originalVercel
     delete globalThis[nextRequestContext]
     delete globalThis[vercelRequestContext]
+    logs.disable()
   })
 
   for (const requestContext of [nextRequestContext, vercelRequestContext]) {
@@ -110,10 +112,44 @@ describe('Vercel request-lifetime flush', () => {
     }
   })
 
+  it('retains OTLP logs until their exporter completes', async () => {
+    process.env.VERCEL = '1'
+    let requestTask
+    let finishLogExport
+    const loggerProvider = {
+      getLogger () {},
+      forceFlush () {
+        return new Promise(resolve => { finishLogExport = resolve })
+      },
+    }
+    logs.setGlobalLoggerProvider(loggerProvider)
+    globalThis[vercelRequestContext] = createRequestContext(promise => { requestTask = promise })
+
+    const tracer = {
+      _config: {
+        DD_LOGS_OTEL_ENABLED: true,
+        experimental: { exporter: 'agent' },
+      },
+      _exporter: { flush: assert.fail },
+    }
+    assert.strictEqual(scheduleVercelFlush(tracer), true)
+    await nextImmediate()
+
+    let requestCompleted = false
+    requestTask.then(() => { requestCompleted = true })
+    await Promise.resolve()
+    assert.strictEqual(requestCompleted, false)
+    finishLogExport()
+    await requestTask
+    assert.strictEqual(requestCompleted, true)
+  })
+
   it('does not schedule outside Vercel or for non-agentless exporters', () => {
     let waitUntilCalls = 0
     globalThis[vercelRequestContext] = createRequestContext(() => { waitUntilCalls++ })
     assert.strictEqual(scheduleVercelFlush(createAgentlessTracer(assert.fail)), false)
+    logs.setGlobalLoggerProvider({ getLogger () {}, forceFlush: assert.fail })
+    assert.strictEqual(scheduleVercelFlush({ _config: { DD_LOGS_OTEL_ENABLED: true } }), false)
     process.env.VERCEL = '1'
     const agentTracer = {
       _config: { experimental: { exporter: 'agent' } },


### PR DESCRIPTION
## Problem

The OTLP log processor queues records until a batch fills or its timer expires. In Vercel Functions, the runtime can freeze after the response before that timer or an active OTLP request completes. `forceFlush()` also returned before exporter callbacks completed, and the existing Vercel `waitUntil()` integration retained only agentless trace exports.

In a production Vercel deployment with default OTLP batching, 100 successful requests produced **0/100 direct OTel logs and 0/100 Winston OTel transport logs** in Datadog. Setting the batch size to 1 retained 100/100 of each, isolating the failure to batching and request lifetime rather than intake, credentials, or instrumentation.

## Change

- Make the batch log processor flush every queued batch and await queued plus in-flight exporter callbacks.
- Extend the existing Vercel request-lifetime task to await the enabled global OTLP logger provider alongside the agentless trace exporter.
- Keep this behavior Vercel-only and active only when OTLP logs are enabled.

## Evidence

- `npx mocha packages/dd-trace/test/serverless.spec.js packages/dd-trace/test/opentelemetry/logs.spec.js`: 40 passing.
- Focused ESLint and `git diff --check`: passing.
- Before-fix production stress: default batching retained 0/100 direct OTel and 0/100 Winston records; batch-size 1 retained 100/100 of both with trace correlation and valid Unix timestamps.
- A post-fix deployment stress with default batching will be attached after this stacked branch is integrated into the Vercel test deployment.