### PR TITLE
refactor(llmobs): centralize experiments API client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,10 +228,10 @@ services:
       - ENABLED_CHECKS=trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service
       - PORT=9126
       - VCR_CASSETTES_DIRECTORY=/vcr-cassettes
-      - VCR_PROVIDER_MAP=claude-agent-sdk=https://api.anthropic.com
-      - VCR_JSON_BODY_NORMALIZERS=metadata.user_id,output_config.effort
+      - VCR_PROVIDER_MAP=claude-agent-sdk=https://api.anthropic.com,datadog-experiments=${DD_LLMOBS_EXPERIMENTS_VCR_UPSTREAM:-https://api.datadoghq.com}
+      - VCR_JSON_BODY_NORMALIZERS=metadata.user_id,output_config.effort,timestamp_ms,start_ns
       - >-
-        VCR_BODY_REGEX_NORMALIZERS=agentId: [a-f0-9]+,SendMessage with to: '[a-f0-9]+',<usage>[\s\S]*?</usage>,"events":\[\{"event_type":"ClaudeCodeInternalEvent"[^\]]*\],cc_version=[^;]+,cch=[^;]+,<system-reminder>[\s\S]*?</system-reminder>,<env>[\s\S]*?</env>,(?<="input":\{"description":")[^"]*,(?<="name":"Agent"\x2c"description":")(?:[^"\\]|\\.)*,(?:You are an agent for Claude Code|Write the title|Report the result concisely\.|Async agent launched successfully)(?:\\.|[^"\\])*,--openai-[A-Za-z0-9]+
+        VCR_BODY_REGEX_NORMALIZERS=agentId: [a-f0-9]+,SendMessage with to: '[a-f0-9]+',<usage>[\s\S]*?</usage>,"events":\[\{"event_type":"ClaudeCodeInternalEvent"[^\]]*\],cc_version=[^;]+,cch=[^;]+,<system-reminder>[\s\S]*?</system-reminder>,<env>[\s\S]*?</env>,(?<="input":\{"description":")[^"]*,(?<="name":"Agent"\x2c"description":")(?:[^"\\]|\\.)*,(?:You are an agent for Claude Code|Write the title|Report the result concisely\.|Async agent launched successfully)(?:\\.|[^"\\])*,--openai-[A-Za-z0-9]+,(?<="span_id":")[0-9a-f]+,(?<="trace_id":")[0-9a-f]+,(?<="start_ns":)\d+,(?<="duration":)\d+,(?<="timestamp_ms":)\d+,run_id:[0-9a-f]+
       # - AWS_SECRET_ACCESS_KEY # uncomment this line for generating aws service cassettes
     volumes:
       # when there are other products not using the cassette feature from the test agent,

--- a/packages/dd-trace/src/llmobs/experiments/client.js
+++ b/packages/dd-trace/src/llmobs/experiments/client.js
@@ -63,16 +63,16 @@ class ExperimentsClient {
   #site
   #projectName
   #timeout
-  #apiBase
+  apiBase
   #cachedProjectId
 
-  constructor ({ apiKey, appKey, site, apiBase, projectName, timeout = 30_000 } = {}) {
+  constructor ({ apiKey, appKey, site, projectName, timeout = 30_000 } = {}) {
     this.#apiKey = apiKey
     this.#appKey = appKey
     this.#site = site
     this.#projectName = projectName
     this.#timeout = timeout
-    this.#apiBase = apiBase?.replace(/\/$/, '') ?? `https://${apiHost(this.#site)}`
+    this.apiBase = `https://${apiHost(this.#site)}`
     this.#cachedProjectId = null
   }
 
@@ -98,7 +98,7 @@ class ExperimentsClient {
   // Low-level request. Builds https://api.<site><path>, attaches both keys, and
   // returns the parsed JSON body. Throws with status + body on a non-2xx.
   async request (method, path, body) {
-    const url = `${this.#apiBase}${path}`
+    const url = `${this.apiBase}${path}`
     const headers = {
       'DD-API-KEY': this.#apiKey,
       'DD-APPLICATION-KEY': this.#appKey,

--- a/packages/dd-trace/src/llmobs/experiments/client.js
+++ b/packages/dd-trace/src/llmobs/experiments/client.js
@@ -66,7 +66,7 @@ class ExperimentsClient {
   #apiBase
   #cachedProjectId
 
-  constructor ({ apiKey, appKey, site, projectName, timeout = 30_000, apiBase } = {}) {
+  constructor ({ apiKey, appKey, site, apiBase, projectName, timeout = 30_000 } = {}) {
     this.#apiKey = apiKey
     this.#appKey = appKey
     this.#site = site

--- a/packages/dd-trace/src/llmobs/experiments/client.js
+++ b/packages/dd-trace/src/llmobs/experiments/client.js
@@ -53,8 +53,8 @@ function datasetFromResource (client, projectId, resource) {
 }
 
 function experimentFromResource (client, resource) {
-  const id = resource?.id ?? null
-  return new ExperimentResult(id, [], id === null ? null : `${client.appBase}/llm/experiments/${id}`)
+  const id = resource?.id
+  return new ExperimentResult(id, [], id == null ? null : `${client.appBase}/llm/experiments/${id}`)
 }
 
 class ExperimentsClient {
@@ -155,8 +155,7 @@ class ExperimentsClient {
   async listDatasets (projectId, options = {}) {
     const query = new URLSearchParams()
     if (options.name !== undefined) query.set('filter[name]', options.name)
-    const queryString = query.toString() ? `?${query.toString()}` : ''
-    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets${queryString}`)
+    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets?${query.toString()}`)
     const resources = Array.isArray(response?.data) ? response.data : []
     return resources.map(resource => datasetFromResource(this, projectId, resource))
   }
@@ -181,10 +180,9 @@ class ExperimentsClient {
     const query = new URLSearchParams()
     if (options.cursor) query.set('page[cursor]', options.cursor)
     if (options.version !== undefined && options.version !== null) query.set('filter[version]', String(options.version))
-    const queryString = query.toString() ? `?${query.toString()}` : ''
     const response = await this.request(
       'GET',
-      `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records${queryString}`
+      `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records?${query.toString()}`
     )
     const records = Array.isArray(response?.data) ? response.data.map(datasetRecordFromResource) : []
     return { records, after: response?.meta?.after ?? '' }

--- a/packages/dd-trace/src/llmobs/experiments/client.js
+++ b/packages/dd-trace/src/llmobs/experiments/client.js
@@ -63,14 +63,16 @@ class ExperimentsClient {
   #site
   #projectName
   #timeout
+  #apiBase
   #cachedProjectId
 
-  constructor ({ apiKey, appKey, site, projectName, timeout = 30_000 } = {}) {
+  constructor ({ apiKey, appKey, site, projectName, timeout = 30_000, apiBase } = {}) {
     this.#apiKey = apiKey
     this.#appKey = appKey
     this.#site = site
     this.#projectName = projectName
     this.#timeout = timeout
+    this.#apiBase = apiBase?.replace(/\/$/, '') ?? `https://${apiHost(this.#site)}`
     this.#cachedProjectId = null
   }
 
@@ -96,7 +98,7 @@ class ExperimentsClient {
   // Low-level request. Builds https://api.<site><path>, attaches both keys, and
   // returns the parsed JSON body. Throws with status + body on a non-2xx.
   async request (method, path, body) {
-    const url = `https://${apiHost(this.#site)}${path}`
+    const url = `${this.#apiBase}${path}`
     const headers = {
       'DD-API-KEY': this.#apiKey,
       'DD-APPLICATION-KEY': this.#appKey,
@@ -143,6 +145,13 @@ class ExperimentsClient {
     return datasetFromResource(this, projectId, response?.data ?? null)
   }
 
+  deleteDataset (projectId, datasetId) {
+    return this.jsonApiRequest('POST', `${API_BASE_PATH}/${projectId}/datasets/delete`, 'datasets', {
+      type: 'soft',
+      dataset_ids: [datasetId],
+    })
+  }
+
   async listDatasets (projectId, options = {}) {
     const query = new URLSearchParams()
     if (options.name !== undefined) query.set('filter[name]', options.name)
@@ -173,7 +182,10 @@ class ExperimentsClient {
     if (options.cursor) query.set('page[cursor]', options.cursor)
     if (options.version !== undefined && options.version !== null) query.set('filter[version]', String(options.version))
     const queryString = query.toString() ? `?${query.toString()}` : ''
-    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records${queryString}`)
+    const response = await this.request(
+      'GET',
+      `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records${queryString}`
+    )
     const records = Array.isArray(response?.data) ? response.data.map(datasetRecordFromResource) : []
     return { records, after: response?.meta?.after ?? '' }
   }

--- a/packages/dd-trace/src/llmobs/experiments/client.js
+++ b/packages/dd-trace/src/llmobs/experiments/client.js
@@ -3,6 +3,9 @@
 // Control-plane HTTP client for LLM Obs Experiments. Uses the global `fetch`,
 // so this module adds no new dependency; credentials and site come from config.
 
+const { Dataset, DatasetRecord } = require('./dataset')
+const { ExperimentResult } = require('./result')
+
 const API_BASE_PATH = '/api/v2/llm-obs/v1'
 
 // Control-plane host for a Datadog site, e.g.
@@ -20,6 +23,38 @@ function apiHost (site) {
 function appHost (site) {
   if (site === 'datad0g.com') return 'dd.datad0g.com'
   return site.split('.').length === 2 ? `app.${site}` : site
+}
+
+function datasetRecordFromResource (resource) {
+  const attrs = resource?.attributes ?? resource ?? {}
+  return new DatasetRecord(
+    attrs.input ?? null,
+    attrs.expected_output ?? null,
+    attrs.metadata ?? {},
+    String(resource?.id ?? attrs.id ?? '') || null,
+    attrs.valid_from_version ?? attrs.version ?? null
+  )
+}
+
+function datasetFromResource (client, projectId, resource) {
+  const attrs = resource?.attributes ?? resource ?? {}
+  const version = attrs.current_version ?? null
+  return Dataset.fromExisting(
+    client,
+    String(attrs.name ?? ''),
+    String(attrs.description ?? ''),
+    resource?.id ?? attrs.id ?? null,
+    projectId,
+    [],
+    [],
+    version,
+    version
+  )
+}
+
+function experimentFromResource (client, resource) {
+  const id = resource?.id ?? null
+  return new ExperimentResult(id, [], id === null ? null : `${client.appBase}/llm/experiments/${id}`)
 }
 
 class ExperimentsClient {
@@ -92,6 +127,75 @@ class ExperimentsClient {
     return text ? JSON.parse(text) : {}
   }
 
+  jsonApiRequest (method, path, type, attributes) {
+    return this.request(method, path, {
+      data: { type, attributes },
+    })
+  }
+
+  async createProject (name) {
+    const response = await this.jsonApiRequest('POST', `${API_BASE_PATH}/projects`, 'projects', { name })
+    return response?.data ?? null
+  }
+
+  async createDataset (projectId, attributes) {
+    const response = await this.jsonApiRequest('POST', `${API_BASE_PATH}/${projectId}/datasets`, 'datasets', attributes)
+    return datasetFromResource(this, projectId, response?.data ?? null)
+  }
+
+  async listDatasets (projectId, options = {}) {
+    const query = new URLSearchParams()
+    if (options.name !== undefined) query.set('filter[name]', options.name)
+    const queryString = query.toString() ? `?${query.toString()}` : ''
+    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets${queryString}`)
+    const resources = Array.isArray(response?.data) ? response.data : []
+    return resources.map(resource => datasetFromResource(this, projectId, resource))
+  }
+
+  async appendDatasetRecords (projectId, datasetId, records) {
+    const response = await this.jsonApiRequest(
+      'POST',
+      `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records`,
+      'datasets',
+      { records }
+    )
+    // The append-records response has used both a top-level `records` array
+    // and JSON:API `data` resources. Accept either so generated/custom record
+    // ids are preserved for experiment row tagging.
+    const resources = Array.isArray(response?.records)
+      ? response.records
+      : (Array.isArray(response?.data) ? response.data : [])
+    return resources.map(datasetRecordFromResource)
+  }
+
+  async listDatasetRecords (projectId, datasetId, options = {}) {
+    const query = new URLSearchParams()
+    if (options.cursor) query.set('page[cursor]', options.cursor)
+    if (options.version !== undefined && options.version !== null) query.set('filter[version]', String(options.version))
+    const queryString = query.toString() ? `?${query.toString()}` : ''
+    const response = await this.request('GET', `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records${queryString}`)
+    const records = Array.isArray(response?.data) ? response.data.map(datasetRecordFromResource) : []
+    return { records, after: response?.meta?.after ?? '' }
+  }
+
+  async createExperiment (attributes) {
+    const response = await this.jsonApiRequest('POST', `${API_BASE_PATH}/experiments`, 'experiments', attributes)
+    return experimentFromResource(this, response?.data ?? null)
+  }
+
+  postExperimentEvents (experimentId, attributes) {
+    return this.jsonApiRequest(
+      'POST',
+      `${API_BASE_PATH}/experiments/${experimentId}/events`,
+      'experiments',
+      attributes
+    )
+  }
+
+  updateExperiment (experimentId, attributes) {
+    return this.jsonApiRequest('PATCH', `${API_BASE_PATH}/experiments/${experimentId}`, 'experiments', attributes)
+  }
+
   // Resolve the project id for `name`, creating it if absent. The create
   // endpoint is get-or-create on name, so repeated calls return the same id.
   // Cached after the first resolution.
@@ -100,14 +204,12 @@ class ExperimentsClient {
 
     let response
     try {
-      response = await this.request('POST', `${API_BASE_PATH}/projects`, {
-        data: { type: 'projects', attributes: { name } },
-      })
+      response = await this.createProject(name)
     } catch (err) {
       throw new Error(`Failed to create or get project '${name}': ${err.message}`)
     }
 
-    this.#cachedProjectId = response?.data?.id ?? null
+    this.#cachedProjectId = response?.id ?? null
     return this.#cachedProjectId
   }
 }

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -3,16 +3,21 @@
 // Dataset record: { input, expectedOutput?, metadata?, id? }.
 // `id` may be user-provided before push or filled from the backend-created record.
 class DatasetRecord {
+  #version
+
   constructor (input, expectedOutput = null, metadata = {}, id = null, version = null) {
     this.input = input
     this.expectedOutput = expectedOutput ?? null
     this.metadata = metadata ?? {}
     this.id = id ?? null
-    Object.defineProperty(this, 'version', {
-      value: version ?? null,
-      enumerable: false,
-      writable: true,
-    })
+    this.#version = version ?? null
+  }
+
+  /**
+   * @returns {number | string | null} The dataset version where this record became valid.
+   */
+  version () {
+    return this.#version
   }
 }
 
@@ -22,7 +27,7 @@ function recordIdFromCreatedRecord (record) {
 
 function versionFromCreatedRecords (records) {
   const versions = records
-    .map(record => record.version)
+    .map(record => record.version())
     .filter(version => version != null)
     .map(Number)
     .filter(Number.isFinite)

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -22,7 +22,9 @@ function recordIdFromCreatedRecord (record) {
 
 function versionFromCreatedRecords (records) {
   const versions = records
-    .map(record => Number(record.version))
+    .map(record => record.version)
+    .filter(version => version != null)
+    .map(Number)
     .filter(Number.isFinite)
   if (versions.length === 0) return null
   return Math.max(...versions)

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -1,31 +1,28 @@
 'use strict'
 
-const { API_BASE_PATH } = require('./client')
-
 // Dataset record: { input, expectedOutput?, metadata?, id? }.
 // `id` may be user-provided before push or filled from the backend-created record.
 class DatasetRecord {
-  constructor (input, expectedOutput = null, metadata = {}, id = null) {
+  constructor (input, expectedOutput = null, metadata = {}, id = null, version = null) {
     this.input = input
     this.expectedOutput = expectedOutput ?? null
     this.metadata = metadata ?? {}
     this.id = id ?? null
+    Object.defineProperty(this, 'version', {
+      value: version ?? null,
+      enumerable: false,
+      writable: true,
+    })
   }
 }
 
-function createdRecordsFromResponse (response) {
-  if (Array.isArray(response?.records)) return response.records
-  if (Array.isArray(response?.data)) return response.data
-  return []
-}
-
 function recordIdFromCreatedRecord (record) {
-  return String(record?.id ?? record?.attributes?.id ?? '')
+  return String(record?.id ?? '')
 }
 
 function versionFromCreatedRecords (records) {
   const versions = records
-    .map(record => Number(record?.attributes?.valid_from_version ?? record?.attributes?.version))
+    .map(record => Number(record.version))
     .filter(Number.isFinite)
   if (versions.length === 0) return null
   return Math.max(...versions)
@@ -84,6 +81,10 @@ class Dataset {
     return this.#name
   }
 
+  description () {
+    return this.#description
+  }
+
   records () {
     return [...this.#records]
   }
@@ -127,19 +128,17 @@ class Dataset {
     if (this.#id === null) {
       let response
       try {
-        response = await this.#client.request('POST', `${API_BASE_PATH}/${projectId}/datasets`, {
-          data: { type: 'datasets', attributes: { name: this.#name, description: this.#description } },
-        })
+        response = await this.#client.createDataset(projectId, { name: this.#name, description: this.#description })
       } catch (err) {
         throw new Error(`Failed to create dataset '${this.#name}': ${err.message}`)
       }
-      this.#id = response?.data?.id ?? null
+      this.#id = response?.id() ?? null
       if (this.#id === null) {
         throw new Error(`Failed to create dataset '${this.#name}': backend response is missing dataset id`)
       }
       this.#projectId = projectId
-      this.#version = response?.data?.attributes?.current_version ?? this.#version
-      this.#latestVersion = response?.data?.attributes?.current_version ?? this.#latestVersion
+      this.#version = response.version() ?? this.#version
+      this.#latestVersion = response.latestVersion() ?? this.#latestVersion
     }
 
     if (this.#pushedCount >= this.#records.length) return { pushedCount: 0, totalCount: 0 }
@@ -161,19 +160,12 @@ class Dataset {
 
     let response
     try {
-      response = await this.#client.request(
-        'POST',
-        `${API_BASE_PATH}/${projectId}/datasets/${this.#id}/records`,
-        { data: { type: 'datasets', attributes: { records } } }
-      )
+      response = await this.#client.appendDatasetRecords(projectId, this.#id, records)
     } catch (err) {
       throw new Error(`Failed to push records to dataset '${this.#name}': ${err.message}`)
     }
 
-    // The append-records response has used both a top-level `records` array
-    // and JSON:API `data` resources. Accept either so generated/custom record
-    // ids are preserved for experiment row tagging.
-    const created = createdRecordsFromResponse(response)
+    const created = response
     const pushedVersion = versionFromCreatedRecords(created)
     if (pushedVersion === null) {
       // The dataset contents changed, but the backend did not report the new

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -2,7 +2,6 @@
 
 const id = require('../../id')
 
-const { API_BASE_PATH } = require('./client')
 const { Row, ExperimentResult, ExperimentRun } = require('./result')
 const {
   buildExperimentTagObject,
@@ -172,13 +171,11 @@ class Experiment {
 
     let created
     try {
-      created = await this.#client.request('POST', `${API_BASE_PATH}/experiments`, {
-        data: { type: 'experiments', attributes },
-      })
+      created = await this.#client.createExperiment(attributes)
     } catch (err) {
       throw new Error(`Failed to create experiment '${this.#name}': ${err.message}`)
     }
-    this.#experimentId = created?.data?.id ?? null
+    this.#experimentId = created.experimentId
     const experimentId = this.#experimentId
     const runId = id().toString(16).padStart(16, '0')
     const runIteration = 0
@@ -454,9 +451,7 @@ class Experiment {
   async #postEvents (experimentId, spans, metrics) {
     const attributes = { metrics }
     if (spans.length > 0) attributes.spans = spans
-    await this.#client.request('POST', `${API_BASE_PATH}/experiments/${experimentId}/events`, {
-      data: { type: 'experiments', attributes },
-    })
+    await this.#client.postExperimentEvents(experimentId, attributes)
   }
 
   async #updateStatus (experimentId, status, error) {
@@ -465,9 +460,7 @@ class Experiment {
     const attributes = { status }
     if (error !== null) attributes.error = error
     try {
-      await this.#client.request('PATCH', `${API_BASE_PATH}/experiments/${experimentId}`, {
-        data: { type: 'experiments', attributes },
-      })
+      await this.#client.updateExperiment(experimentId, attributes)
     } catch {
       // Status update is best-effort; never let it mask the real result/error.
     }

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -37,7 +37,12 @@ class Experiments {
       appKey: config.DD_APP_KEY,
       site: config.site,
       projectName: this.#projectName,
+      apiBase: config.llmobs?.experimentsApiBase,
     })
+  }
+
+  _deleteDataset (projectId, datasetId) {
+    return this.#client.deleteDataset(projectId, datasetId)
   }
 
   // Create a local dataset buffer. Pushed remotely on first experiment run.

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const log = require('../../log')
-const { ExperimentsClient, API_BASE_PATH } = require('./client')
+const { ExperimentsClient } = require('./client')
 const { Dataset, DatasetRecord } = require('./dataset')
 const { Experiment } = require('./experiment')
 const NoopExperiments = require('./noop')
@@ -78,15 +78,12 @@ class Experiments {
     const succeeded = await retryWithBackoff(async () => {
       try {
         if (datasetId === null) {
-          const listed = await this.#client.request(
-            'GET',
-            `${API_BASE_PATH}/${projectId}/datasets?filter[name]=${encodeURIComponent(name)}`
-          )
-          for (const item of listed?.data ?? []) {
-            if (item?.attributes?.name === name) {
-              datasetId = String(item?.id ?? '')
-              description = String(item?.attributes?.description ?? '')
-              latestVersion = item?.attributes?.current_version ?? null
+          const listed = await this.#client.listDatasets(projectId, { name })
+          for (const item of listed) {
+            if (item.name() === name) {
+              datasetId = item.id()
+              description = item.description()
+              latestVersion = item.latestVersion()
               datasetVersion = version ?? latestVersion
               break
             }
@@ -99,26 +96,16 @@ class Experiments {
         let cursor = ''
         // Follow the meta.after / page[cursor] pagination until the last page.
         for (;;) {
-          const query = new URLSearchParams()
-          if (cursor) query.set('page[cursor]', cursor)
-          if (datasetVersion !== null) query.set('filter[version]', String(datasetVersion))
           // eslint-disable-next-line no-await-in-loop
-          const resp = await this.#client.request(
-            'GET',
-            `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records?${query.toString()}`
-          )
-          for (const item of resp?.data ?? []) {
-            const attrs = item?.attributes ?? item
-            const recordId = String(item?.id ?? attrs?.id ?? '')
-            recs.push(new DatasetRecord(
-              attrs?.input ?? null,
-              attrs?.expected_output ?? null,
-              attrs?.metadata ?? {},
-              recordId === '' ? null : recordId
-            ))
-            ids.push(recordId)
+          const resp = await this.#client.listDatasetRecords(projectId, datasetId, {
+            cursor,
+            version: datasetVersion,
+          })
+          for (const record of resp.records) {
+            recs.push(record)
+            ids.push(record.id ?? '')
           }
-          cursor = resp?.meta?.after ?? ''
+          cursor = resp.after
           if (!cursor) break
         }
         records = recs

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -36,13 +36,9 @@ class Experiments {
       apiKey: config.DD_API_KEY,
       appKey: config.DD_APP_KEY,
       site: config.site,
-      projectName: this.#projectName,
       apiBase: config.llmobs?.experimentsApiBase,
+      projectName: this.#projectName,
     })
-  }
-
-  _deleteDataset (projectId, datasetId) {
-    return this.#client.deleteDataset(projectId, datasetId)
   }
 
   // Create a local dataset buffer. Pushed remotely on first experiment run.

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -70,8 +70,7 @@ class Experiments {
     const { expectedRecordCount, maxWaitMs = 30_000, version } = options
     const projectId = await this.#client.ensureProjectId()
 
-    let datasetId = null
-    let description = ''
+    let pulledDataset = null
     let records = []
     let recordIds = []
     let datasetVersion = version ?? null
@@ -80,24 +79,17 @@ class Experiments {
 
     const succeeded = await retryWithBackoff(async () => {
       try {
-        if (datasetId === null) {
-          const listed = await this.#client.request(
-            'GET',
-            `${API_BASE_PATH}/${projectId}/datasets?filter[name]=${encodeURIComponent(name)}`
-          )
-          const datasets = listed?.data
-          if (datasets) {
-            for (const item of datasets) {
-              if (item?.attributes?.name === name) {
-                datasetId = String(item?.id ?? '')
-                description = String(item?.attributes?.description ?? '')
-                latestVersion = item?.attributes?.current_version ?? null
-                datasetVersion = version ?? latestVersion
-                break
-              }
+        if (pulledDataset === null) {
+          const datasets = await this.#client.listDatasets(projectId, { name })
+          for (const dataset of datasets) {
+            if (dataset.name() === name) {
+              pulledDataset = dataset
+              latestVersion = dataset.latestVersion()
+              datasetVersion = version ?? latestVersion
+              break
             }
           }
-          if (datasetId === null) return false
+          if (pulledDataset === null) return false
         }
 
         const recs = []
@@ -106,25 +98,15 @@ class Experiments {
         // Follow the meta.after / page[cursor] pagination until the last page.
         for (;;) {
           // eslint-disable-next-line no-await-in-loop
-          const resp = await this.#client.request(
-            'GET',
-            `${API_BASE_PATH}/${projectId}/datasets/${datasetId}/records?${query.toString()}`
-          )
-          const recordData = resp?.data
-          if (recordData) {
-            for (const item of recordData) {
-              const attrs = item?.attributes ?? item
-              const recordId = String(item?.id ?? attrs?.id ?? '')
-              recs.push(new DatasetRecord(
-                attrs?.input ?? null,
-                attrs?.expected_output ?? null,
-                attrs?.metadata ?? {},
-                recordId === '' ? null : recordId
-              ))
-              ids.push(recordId)
-            }
+          const page = await this.#client.listDatasetRecords(projectId, pulledDataset.id(), {
+            cursor,
+            version: datasetVersion,
+          })
+          for (const record of page.records) {
+            recs.push(record)
+            ids.push(String(record.id ?? ''))
           }
-          cursor = resp.after
+          cursor = page.after
           if (!cursor) break
         }
         records = recs
@@ -138,10 +120,10 @@ class Experiments {
       }
     }, { maxTotalMs: maxWaitMs })
 
-    if (datasetId === null && lastError) {
+    if (pulledDataset === null && lastError) {
       throw new Error(`Failed to list datasets in project '${this.#projectName}': ${lastError}`)
     }
-    if (datasetId === null) {
+    if (pulledDataset === null) {
       throw new Error(`Dataset '${name}' not found in project '${this.#projectName}' (after ${maxWaitMs}ms)`)
     }
     if (!succeeded && lastError) {
@@ -157,8 +139,8 @@ class Experiments {
     return Dataset.fromExisting(
       this.#client,
       name,
-      description,
-      datasetId,
+      pulledDataset.description(),
+      pulledDataset.id(),
       projectId,
       records,
       recordIds,

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const log = require('../../log')
-const { ExperimentsClient, API_BASE_PATH } = require('./client')
+const { ExperimentsClient } = require('./client')
 const { Dataset, DatasetRecord } = require('./dataset')
 const { Experiment } = require('./experiment')
 const NoopExperiments = require('./noop')
@@ -104,9 +104,6 @@ class Experiments {
         let cursor = ''
         // Follow the meta.after / page[cursor] pagination until the last page.
         for (;;) {
-          const query = new URLSearchParams()
-          if (cursor) query.set('page[cursor]', cursor)
-          if (datasetVersion !== null) query.set('filter[version]', String(datasetVersion))
           // eslint-disable-next-line no-await-in-loop
           const resp = await this.#client.request(
             'GET',
@@ -126,7 +123,7 @@ class Experiments {
               ids.push(recordId)
             }
           }
-          cursor = resp?.meta?.after ?? ''
+          cursor = resp.after
           if (!cursor) break
         }
         records = recs

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -36,7 +36,6 @@ class Experiments {
       apiKey: config.DD_API_KEY,
       appKey: config.DD_APP_KEY,
       site: config.site,
-      apiBase: config.llmobs?.experimentsApiBase,
       projectName: this.#projectName,
     })
   }

--- a/packages/dd-trace/src/llmobs/experiments/noop.js
+++ b/packages/dd-trace/src/llmobs/experiments/noop.js
@@ -4,10 +4,12 @@ const log = require('../../log')
 
 class NoopDataset {
   #name
+  #description
   #records
 
   constructor (name = '', options = {}) {
     this.#name = name
+    this.#description = typeof options === 'string' ? options : (options.description ?? '')
     this.#records = (typeof options === 'string' ? [] : (options.records ?? [])).map(record => ({
       id: record.id ?? null,
       input: record.inputData,
@@ -27,6 +29,10 @@ class NoopDataset {
 
   name () {
     return this.#name
+  }
+
+  description () {
+    return this.#description
   }
 
   id () {

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_01a05521-e815-4d74-88e4-91d73d747b5f_records_filter_version__1_get_87446eff.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_01a05521-e815-4d74-88e4-91d73d747b5f_records_filter_version__1_get_87446eff.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/01a05521-e815-4d74-88e4-91d73d747b5f/records?filter[version]=1",
+    "headers": {
+      "Connection": "keep-alive",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate"
+    },
+    "body": ""
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "900",
+      "date": "Fri, 31 Jul 2026 21:35:35 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"custom-b\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"a4f472e3-90ce-42dd-9fe0-fe88dc503822\",\"created_at\":\"2026-07-31T21:35:30.142299Z\",\"dataset_id\":\"01a05521-e815-4d74-88e4-91d73d747b5f\",\"expected_output\":{\"value\":3},\"input\":{\"value\":2},\"metadata\":{\"source\":\"client-custom-records-test\"},\"ttl\":\"2029-07-30T21:35:30.152264Z\",\"updated_at\":\"2026-07-31T21:35:30.142299Z\"}},{\"id\":\"custom-a\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"7e4ff9f4-188a-44b0-b2e7-f55cf340e0cb\",\"created_at\":\"2026-07-31T21:35:30.142299Z\",\"dataset_id\":\"01a05521-e815-4d74-88e4-91d73d747b5f\",\"expected_output\":{\"value\":2},\"input\":{\"value\":1},\"metadata\":{\"source\":\"client-custom-records-test\"},\"ttl\":\"2029-07-30T21:35:30.152254Z\",\"updated_at\":\"2026-07-31T21:35:30.142299Z\"}}],\"meta\":{\"after\":\"\"}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_01a05521-e815-4d74-88e4-91d73d747b5f_records_post_9217d564.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_01a05521-e815-4d74-88e4-91d73d747b5f_records_post_9217d564.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/01a05521-e815-4d74-88e4-91d73d747b5f/records",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "293"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"records\":[{\"id\":\"custom-a\",\"input\":{\"value\":1},\"expected_output\":{\"value\":2},\"metadata\":{\"source\":\"client-custom-records-test\"}},{\"id\":\"custom-b\",\"input\":{\"value\":2},\"expected_output\":{\"value\":3},\"metadata\":{\"source\":\"client-custom-records-test\"}}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "942",
+      "date": "Fri, 31 Jul 2026 21:35:30 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"custom-a\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"7e4ff9f4-188a-44b0-b2e7-f55cf340e0cb\",\"created_at\":\"2026-07-31T21:35:30.142298637Z\",\"dataset_id\":\"01a05521-e815-4d74-88e4-91d73d747b5f\",\"expected_output\":{\"value\":2},\"input\":{\"value\":1},\"metadata\":{\"source\":\"client-custom-records-test\"},\"tags\":[],\"ttl\":\"2029-07-30T21:35:30.152253983Z\",\"updated_at\":\"2026-07-31T21:35:30.142298637Z\",\"version\":1}},{\"id\":\"custom-b\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"a4f472e3-90ce-42dd-9fe0-fe88dc503822\",\"created_at\":\"2026-07-31T21:35:30.142298637Z\",\"dataset_id\":\"01a05521-e815-4d74-88e4-91d73d747b5f\",\"expected_output\":{\"value\":3},\"input\":{\"value\":2},\"metadata\":{\"source\":\"client-custom-records-test\"},\"tags\":[],\"ttl\":\"2029-07-30T21:35:30.152263591Z\",\"updated_at\":\"2026-07-31T21:35:30.142298637Z\",\"version\":1}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_23fd65b0-d25f-45d7-b15f-cb75447cd6eb_records_post_23816346.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_23fd65b0-d25f-45d7-b15f-cb75447cd6eb_records_post_23816346.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/23fd65b0-d25f-45d7-b15f-cb75447cd6eb/records",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "143"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"records\":[{\"input\":{\"value\":1},\"expected_output\":{\"value\":2},\"metadata\":{\"source\":\"client-test\"}}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "489",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"0f80c0b4-01a2-431b-8524-1beed38f22b0\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"7693ba1a-36b4-4197-9978-779be9f37a23\",\"created_at\":\"2026-07-31T20:41:47.048820483Z\",\"dataset_id\":\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"expected_output\":{\"value\":2},\"input\":{\"value\":1},\"metadata\":{\"source\":\"client-test\"},\"tags\":[],\"ttl\":\"2029-07-30T20:41:47.058642386Z\",\"updated_at\":\"2026-07-31T20:41:47.048820483Z\",\"version\":1}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_53408af7-c8f3-4358-bdba-71b999ce1df8_records_filter_version__1_get_060955e7.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_53408af7-c8f3-4358-bdba-71b999ce1df8_records_filter_version__1_get_060955e7.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/53408af7-c8f3-4358-bdba-71b999ce1df8/records?filter[version]=1",
+    "headers": {
+      "Connection": "keep-alive",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate"
+    },
+    "body": ""
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "926",
+      "date": "Fri, 31 Jul 2026 20:41:46 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"78bedfd0-9515-4b21-92cf-60ccedf82174\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"69eb8f30-9924-446c-ab56-865b31c19179\",\"created_at\":\"2026-07-31T20:41:41.333877Z\",\"dataset_id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"expected_output\":{\"value\":2},\"input\":{\"value\":1},\"metadata\":{\"source\":\"client-test\"},\"ttl\":\"2029-07-30T20:41:41.342647Z\",\"updated_at\":\"2026-07-31T20:41:41.333877Z\"}},{\"id\":\"59c93cb2-df9f-4a5e-8294-153992593bb6\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"79eebbe5-4f64-4b7f-8965-5f108c57ff57\",\"created_at\":\"2026-07-31T20:41:41.333877Z\",\"dataset_id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"expected_output\":{\"value\":3},\"input\":{\"value\":2},\"metadata\":{\"source\":\"client-test\"},\"ttl\":\"2029-07-30T20:41:41.342655Z\",\"updated_at\":\"2026-07-31T20:41:41.333877Z\"}}],\"meta\":{\"after\":\"\"}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_53408af7-c8f3-4358-bdba-71b999ce1df8_records_post_3a04924f.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_53408af7-c8f3-4358-bdba-71b999ce1df8_records_post_3a04924f.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/53408af7-c8f3-4358-bdba-71b999ce1df8/records",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "231"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"records\":[{\"input\":{\"value\":1},\"expected_output\":{\"value\":2},\"metadata\":{\"source\":\"client-test\"}},{\"input\":{\"value\":2},\"expected_output\":{\"value\":3},\"metadata\":{\"source\":\"client-test\"}}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "968",
+      "date": "Fri, 31 Jul 2026 20:41:41 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"78bedfd0-9515-4b21-92cf-60ccedf82174\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"69eb8f30-9924-446c-ab56-865b31c19179\",\"created_at\":\"2026-07-31T20:41:41.333876726Z\",\"dataset_id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"expected_output\":{\"value\":2},\"input\":{\"value\":1},\"metadata\":{\"source\":\"client-test\"},\"tags\":[],\"ttl\":\"2029-07-30T20:41:41.342647153Z\",\"updated_at\":\"2026-07-31T20:41:41.333876726Z\",\"version\":1}},{\"id\":\"59c93cb2-df9f-4a5e-8294-153992593bb6\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"79eebbe5-4f64-4b7f-8965-5f108c57ff57\",\"created_at\":\"2026-07-31T20:41:41.333876726Z\",\"dataset_id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"expected_output\":{\"value\":3},\"input\":{\"value\":2},\"metadata\":{\"source\":\"client-test\"},\"tags\":[],\"ttl\":\"2029-07-30T20:41:41.342654767Z\",\"updated_at\":\"2026-07-31T20:41:41.333876726Z\",\"version\":1}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_78a7925a-6924-4bd4-9b6e-0e2fcc61a747_records_post_a7e39814.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_78a7925a-6924-4bd4-9b6e-0e2fcc61a747_records_post_a7e39814.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/78a7925a-6924-4bd4-9b6e-0e2fcc61a747/records",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "193"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"records\":[{\"input\":{\"q\":\"apple\"},\"expected_output\":\"APPLE\",\"metadata\":{\"row\":0}},{\"input\":{\"q\":\"car\"},\"expected_output\":\"CAR\",\"metadata\":{\"row\":1}}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "930",
+      "date": "Fri, 31 Jul 2026 21:35:35 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"72c42c47-1949-4b6c-8d5f-dc89d1116b53\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"51c31587-1a18-4223-a97d-3848243f5188\",\"created_at\":\"2026-07-31T21:35:35.677877925Z\",\"dataset_id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"expected_output\":\"APPLE\",\"input\":{\"q\":\"apple\"},\"metadata\":{\"row\":0},\"tags\":[],\"ttl\":\"2029-07-30T21:35:35.690708723Z\",\"updated_at\":\"2026-07-31T21:35:35.677877925Z\",\"version\":1}},{\"id\":\"8139a365-5aa4-41c0-aa39-7b13a49f5301\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"5d7b6520-054b-4e28-9105-15698bed0789\",\"created_at\":\"2026-07-31T21:35:35.677877925Z\",\"dataset_id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"expected_output\":\"CAR\",\"input\":{\"q\":\"car\"},\"metadata\":{\"row\":1},\"tags\":[],\"ttl\":\"2029-07-30T21:35:35.690715599Z\",\"updated_at\":\"2026-07-31T21:35:35.677877925Z\",\"version\":1}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_0072c1e0.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_0072c1e0.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/delete",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "112"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"type\":\"soft\",\"dataset_ids\":[\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\"]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "499",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:46.874166Z\",\"current_version\":1,\"dataset_type\":\"user\",\"deleted_at\":\"2026-07-31T20:41:47.537936Z\",\"description\":\"created by a dd-trace-js experiments client VCR test\",\"name\":\"dd-trace-js-experiments-vcr-client-experiment-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:47.061183Z\"}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_0a2ff917.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_0a2ff917.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/delete",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "112"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"type\":\"soft\",\"dataset_ids\":[\"ee6dc95a-ca76-456d-991f-4449cd50b098\"]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "484",
+      "date": "Fri, 31 Jul 2026 20:41:48 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"ee6dc95a-ca76-456d-991f-4449cd50b098\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:47.64414Z\",\"current_version\":1,\"dataset_type\":\"user\",\"deleted_at\":\"2026-07-31T20:41:48.180209Z\",\"description\":\"created by a dd-trace-js experiments VCR test\",\"name\":\"dd-trace-js-experiments-vcr-experiment-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:47.735487Z\"}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_0a979404.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_0a979404.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/delete",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "112"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"type\":\"soft\",\"dataset_ids\":[\"53408af7-c8f3-4358-bdba-71b999ce1df8\"]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "487",
+      "date": "Fri, 31 Jul 2026 20:41:46 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:41.139848Z\",\"current_version\":1,\"dataset_type\":\"user\",\"deleted_at\":\"2026-07-31T20:41:46.783282Z\",\"description\":\"created by a dd-trace-js experiments client VCR test\",\"name\":\"dd-trace-js-experiments-vcr-client-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:41.34567Z\"}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_69fb24ab.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_69fb24ab.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/delete",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "112"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"type\":\"soft\",\"dataset_ids\":[\"01a05521-e815-4d74-88e4-91d73d747b5f\"]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "511",
+      "date": "Fri, 31 Jul 2026 21:35:35 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"01a05521-e815-4d74-88e4-91d73d747b5f\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T21:35:30.026814Z\",\"current_version\":1,\"dataset_type\":\"user\",\"deleted_at\":\"2026-07-31T21:35:35.418141Z\",\"description\":\"created by a dd-trace-js experiments custom records VCR test\",\"name\":\"dd-trace-js-experiments-vcr-client-custom-records-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T21:35:30.156173Z\"}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_ce1d83fa.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_delete_post_ce1d83fa.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/delete",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "112"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"type\":\"soft\",\"dataset_ids\":[\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\"]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "495",
+      "date": "Fri, 31 Jul 2026 21:35:36 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T21:35:35.589615Z\",\"current_version\":1,\"dataset_type\":\"user\",\"deleted_at\":\"2026-07-31T21:35:36.178588Z\",\"description\":\"created by a dd-trace-js experiments rich VCR test\",\"name\":\"dd-trace-js-experiments-vcr-rich-experiment-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T21:35:35.695021Z\"}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_ee6dc95a-ca76-456d-991f-4449cd50b098_records_post_e95d21f8.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_ee6dc95a-ca76-456d-991f-4449cd50b098_records_post_e95d21f8.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets/ee6dc95a-ca76-456d-991f-4449cd50b098/records",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "144"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"records\":[{\"input\":{\"value\":1},\"expected_output\":{\"value\":2},\"metadata\":{\"source\":\"backend-test\"}}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "490",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"f1a85430-c609-49e8-bb84-3f6bcc6e32cf\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"canonical_id\":\"c6846b83-5d71-4101-8d4c-a1593c2abe54\",\"created_at\":\"2026-07-31T20:41:47.721750573Z\",\"dataset_id\":\"ee6dc95a-ca76-456d-991f-4449cd50b098\",\"expected_output\":{\"value\":2},\"input\":{\"value\":1},\"metadata\":{\"source\":\"backend-test\"},\"tags\":[],\"ttl\":\"2029-07-30T20:41:47.730074255Z\",\"updated_at\":\"2026-07-31T20:41:47.721750573Z\",\"version\":1}}]}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_filter_name__dd-trace-js-experiments-vcr-client-dataset_get_77a6a7c8.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_filter_name__dd-trace-js-experiments-vcr-client-dataset_get_77a6a7c8.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets?filter[name]=dd-trace-js-experiments-vcr-client-dataset",
+    "headers": {
+      "Connection": "keep-alive",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate"
+    },
+    "body": ""
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "480",
+      "date": "Fri, 31 Jul 2026 20:41:46 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":[{\"id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:41.139848Z\",\"current_version\":1,\"dataset_type\":\"user\",\"description\":\"created by a dd-trace-js experiments client VCR test\",\"metadata\":null,\"name\":\"dd-trace-js-experiments-vcr-client-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:41.34567Z\"}}],\"meta\":{\"after\":\"\"}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_10a9a03c.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_10a9a03c.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "187"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-client-custom-records-dataset\",\"description\":\"created by a dd-trace-js experiments custom records VCR test\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "450",
+      "date": "Fri, 31 Jul 2026 21:35:30 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"01a05521-e815-4d74-88e4-91d73d747b5f\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T21:35:30.026814273Z\",\"current_version\":0,\"description\":\"created by a dd-trace-js experiments custom records VCR test\",\"name\":\"dd-trace-js-experiments-vcr-client-custom-records-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T21:35:30.026814273Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_89bda741.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_89bda741.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "164"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-client-dataset\",\"description\":\"created by a dd-trace-js experiments client VCR test\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "427",
+      "date": "Fri, 31 Jul 2026 20:41:41 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"53408af7-c8f3-4358-bdba-71b999ce1df8\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:41.139848691Z\",\"current_version\":0,\"description\":\"created by a dd-trace-js experiments client VCR test\",\"name\":\"dd-trace-js-experiments-vcr-client-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:41.139848691Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_bb7e5103.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_bb7e5103.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "161"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-experiment-dataset\",\"description\":\"created by a dd-trace-js experiments VCR test\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "424",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"ee6dc95a-ca76-456d-991f-4449cd50b098\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:47.644140754Z\",\"current_version\":0,\"description\":\"created by a dd-trace-js experiments VCR test\",\"name\":\"dd-trace-js-experiments-vcr-experiment-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:47.644140754Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_c7de9de4.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_c7de9de4.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "175"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-client-experiment-dataset\",\"description\":\"created by a dd-trace-js experiments client VCR test\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "438",
+      "date": "Fri, 31 Jul 2026 20:41:46 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:46.874166342Z\",\"current_version\":0,\"description\":\"created by a dd-trace-js experiments client VCR test\",\"name\":\"dd-trace-js-experiments-vcr-client-experiment-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T20:41:46.874166342Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_d0652a5c.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_5645ffb8-c97e-4ce4-89f2-c41931318fd9_datasets_post_d0652a5c.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/5645ffb8-c97e-4ce4-89f2-c41931318fd9/datasets",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "171"
+    },
+    "body": "{\"data\":{\"type\":\"datasets\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-rich-experiment-dataset\",\"description\":\"created by a dd-trace-js experiments rich VCR test\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "434",
+      "date": "Fri, 31 Jul 2026 21:35:35 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"type\":\"datasets\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T21:35:35.589615805Z\",\"current_version\":0,\"description\":\"created by a dd-trace-js experiments rich VCR test\",\"name\":\"dd-trace-js-experiments-vcr-rich-experiment-dataset\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"updated_at\":\"2026-07-31T21:35:35.589615805Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_5b8a1b64-44f2-4c94-9fb1-15022e56896b_events_post_00e9db1f.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_5b8a1b64-44f2-4c94-9fb1-15022e56896b_events_post_00e9db1f.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments/5b8a1b64-44f2-4c94-9fb1-15022e56896b/events",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "965"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"metrics\":[{\"metric_source\":\"custom\",\"label\":\"exact\",\"span_id\":\"46fce452e5290fb4\",\"trace_id\":\"6a6d088b0000000046fce452e5290fb4\",\"timestamp_ms\":1785530507843,\"tags\":[\"experiment_id:5b8a1b64-44f2-4c94-9fb1-15022e56896b\"],\"experiment_id\":\"5b8a1b64-44f2-4c94-9fb1-15022e56896b\",\"metric_type\":\"boolean\",\"boolean_value\":true}],\"spans\":[{\"span_id\":\"46fce452e5290fb4\",\"trace_id\":\"6a6d088b0000000046fce452e5290fb4\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"ee6dc95a-ca76-456d-991f-4449cd50b098\",\"name\":\"task\",\"start_ns\":1785530507842000000,\"duration\":368666,\"status\":\"ok\",\"meta\":{\"input\":{\"value\":1},\"output\":{\"value\":2},\"expected_output\":{\"value\":2},\"metadata\":{\"source\":\"backend-test\"}},\"tags\":[\"experiment_id:5b8a1b64-44f2-4c94-9fb1-15022e56896b\",\"run_id:2047939deed88e81\",\"run_iteration:0\",\"dataset_id:ee6dc95a-ca76-456d-991f-4449cd50b098\",\"dataset_record_id:f1a85430-c609-49e8-bb84-3f6bcc6e32cf\"]}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 202,
+      "message": "Accepted"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "0",
+      "date": "Fri, 31 Jul 2026 20:41:48 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": ""
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_5b8a1b64-44f2-4c94-9fb1-15022e56896b_patch_347a13e1.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_5b8a1b64-44f2-4c94-9fb1-15022e56896b_patch_347a13e1.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "PATCH",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments/5b8a1b64-44f2-4c94-9fb1-15022e56896b",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "67"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"status\":\"completed\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "0",
+      "date": "Fri, 31 Jul 2026 20:41:48 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": ""
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_c85229a7-f9ee-4c23-803c-3945a698c466_events_post_91119a79.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_c85229a7-f9ee-4c23-803c-3945a698c466_events_post_91119a79.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments/c85229a7-f9ee-4c23-803c-3945a698c466/events",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "956"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"spans\":[{\"span_id\":\"0000000000000001\",\"trace_id\":\"00000000000000000000000000000001\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"name\":\"dd-trace-js-experiments-vcr-client-task\",\"start_ns\":1785530507136000000,\"duration\":1000000,\"status\":\"ok\",\"meta\":{\"input\":{\"value\":1},\"output\":{\"value\":2},\"expected_output\":{\"value\":2},\"metadata\":{\"source\":\"client-test\"}},\"tags\":[\"experiment_id:c85229a7-f9ee-4c23-803c-3945a698c466\",\"dataset_id:23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"dataset_record_id:0f80c0b4-01a2-431b-8524-1beed38f22b0\"]}],\"metrics\":[{\"metric_source\":\"custom\",\"label\":\"exact\",\"span_id\":\"0000000000000001\",\"trace_id\":\"00000000000000000000000000000001\",\"timestamp_ms\":1785530507136,\"tags\":[\"experiment_id:c85229a7-f9ee-4c23-803c-3945a698c466\"],\"experiment_id\":\"c85229a7-f9ee-4c23-803c-3945a698c466\",\"metric_type\":\"boolean\",\"boolean_value\":true}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 202,
+      "message": "Accepted"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "0",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": ""
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_c85229a7-f9ee-4c23-803c-3945a698c466_patch_e59605ba.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_c85229a7-f9ee-4c23-803c-3945a698c466_patch_e59605ba.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "PATCH",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments/c85229a7-f9ee-4c23-803c-3945a698c466",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "67"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"status\":\"completed\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "0",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": ""
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_dba9e243-7c07-4897-9642-5fb36bf423fe_events_post_12a16290.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_dba9e243-7c07-4897-9642-5fb36bf423fe_events_post_12a16290.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments/dba9e243-7c07-4897-9642-5fb36bf423fe/events",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "3982"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"metrics\":[{\"metric_source\":\"custom\",\"label\":\"nonempty\",\"span_id\":\"579d0080104aaa01\",\"trace_id\":\"6a6d152700000000579d0080104aaa01\",\"timestamp_ms\":1785533735794,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"boolean\",\"boolean_value\":true},{\"metric_source\":\"custom\",\"label\":\"len\",\"span_id\":\"579d0080104aaa01\",\"trace_id\":\"6a6d152700000000579d0080104aaa01\",\"timestamp_ms\":1785533735794,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"score\",\"score_value\":5},{\"metric_source\":\"custom\",\"label\":\"label\",\"span_id\":\"579d0080104aaa01\",\"trace_id\":\"6a6d152700000000579d0080104aaa01\",\"timestamp_ms\":1785533735794,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"categorical\",\"categorical_value\":\"match\"},{\"metric_source\":\"custom\",\"label\":\"details\",\"span_id\":\"579d0080104aaa01\",\"trace_id\":\"6a6d152700000000579d0080104aaa01\",\"timestamp_ms\":1785533735794,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"json\",\"json_value\":{\"actual\":\"APPLE\",\"expected\":\"APPLE\"}},{\"metric_source\":\"custom\",\"label\":\"nonempty\",\"span_id\":\"66c44826da849c1b\",\"trace_id\":\"6a6d15270000000066c44826da849c1b\",\"timestamp_ms\":1785533735795,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"boolean\",\"boolean_value\":true},{\"metric_source\":\"custom\",\"label\":\"len\",\"span_id\":\"66c44826da849c1b\",\"trace_id\":\"6a6d15270000000066c44826da849c1b\",\"timestamp_ms\":1785533735795,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"score\",\"score_value\":3},{\"metric_source\":\"custom\",\"label\":\"label\",\"span_id\":\"66c44826da849c1b\",\"trace_id\":\"6a6d15270000000066c44826da849c1b\",\"timestamp_ms\":1785533735795,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"categorical\",\"categorical_value\":\"match\"},{\"metric_source\":\"custom\",\"label\":\"details\",\"span_id\":\"66c44826da849c1b\",\"trace_id\":\"6a6d15270000000066c44826da849c1b\",\"timestamp_ms\":1785533735795,\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\"],\"experiment_id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"metric_type\":\"json\",\"json_value\":{\"actual\":\"CAR\",\"expected\":\"CAR\"}}],\"spans\":[{\"span_id\":\"579d0080104aaa01\",\"trace_id\":\"6a6d152700000000579d0080104aaa01\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"name\":\"task\",\"start_ns\":1785533735793000000,\"duration\":151625,\"status\":\"ok\",\"meta\":{\"input\":{\"q\":\"apple\"},\"output\":{\"answer\":\"APPLE\"},\"expected_output\":\"APPLE\",\"metadata\":{\"row\":0}},\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\",\"run_id:527a4795cf46811d\",\"run_iteration:0\",\"dataset_id:78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"dataset_record_id:72c42c47-1949-4b6c-8d5f-dc89d1116b53\"]},{\"span_id\":\"66c44826da849c1b\",\"trace_id\":\"6a6d15270000000066c44826da849c1b\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"name\":\"task\",\"start_ns\":1785533735794000000,\"duration\":151167,\"status\":\"ok\",\"meta\":{\"input\":{\"q\":\"car\"},\"output\":{\"answer\":\"CAR\"},\"expected_output\":\"CAR\",\"metadata\":{\"row\":1}},\"tags\":[\"source:rich-vcr-test\",\"experiment_id:dba9e243-7c07-4897-9642-5fb36bf423fe\",\"run_id:527a4795cf46811d\",\"run_iteration:0\",\"dataset_id:78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"dataset_record_id:8139a365-5aa4-41c0-aa39-7b13a49f5301\"]}]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 202,
+      "message": "Accepted"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "0",
+      "date": "Fri, 31 Jul 2026 21:35:35 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": ""
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_dba9e243-7c07-4897-9642-5fb36bf423fe_patch_896da13e.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_dba9e243-7c07-4897-9642-5fb36bf423fe_patch_896da13e.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "PATCH",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments/dba9e243-7c07-4897-9642-5fb36bf423fe",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "67"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"status\":\"completed\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "0",
+      "date": "Fri, 31 Jul 2026 21:35:36 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": ""
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_post_482bfc92.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_post_482bfc92.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "372"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-client-experiment\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"description\":\"created by a dd-trace-js experiments client VCR test\",\"ensure_unique\":true,\"run_count\":1,\"metadata\":{\"tags\":[\"source:client-test\"]},\"dataset_version\":1}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "643",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"c85229a7-f9ee-4c23-803c-3945a698c466\",\"type\":\"experiments\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:47.138992846Z\",\"dataset_id\":\"23fd65b0-d25f-45d7-b15f-cb75447cd6eb\",\"dataset_version\":1,\"description\":\"created by a dd-trace-js experiments client VCR test\",\"experiment\":\"dd-trace-js-experiments-vcr-client-experiment\",\"is_auto_experiment\":false,\"metadata\":{\"tags\":[\"source:client-test\"]},\"name\":\"dd-trace-js-experiments-vcr-client-experiment-1785530507138\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"run_count\":1,\"updated_at\":\"2026-07-31T20:41:47.13899292Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_post_7d716687.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_post_7d716687.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "293"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-experiment\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"ee6dc95a-ca76-456d-991f-4449cd50b098\",\"description\":\"\",\"ensure_unique\":true,\"run_count\":1,\"metadata\":{\"tags\":[]},\"dataset_version\":1}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "558",
+      "date": "Fri, 31 Jul 2026 20:41:47 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"5b8a1b64-44f2-4c94-9fb1-15022e56896b\",\"type\":\"experiments\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T20:41:47.845105573Z\",\"dataset_id\":\"ee6dc95a-ca76-456d-991f-4449cd50b098\",\"dataset_version\":1,\"description\":\"\",\"experiment\":\"dd-trace-js-experiments-vcr-experiment\",\"is_auto_experiment\":false,\"metadata\":{\"tags\":[]},\"name\":\"dd-trace-js-experiments-vcr-experiment-1785530507845\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"run_count\":1,\"updated_at\":\"2026-07-31T20:41:47.845105663Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_post_b337eccf.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_experiments_post_b337eccf.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/experiments",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "397"
+    },
+    "body": "{\"data\":{\"type\":\"experiments\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr-rich-experiment\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"dataset_id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"description\":\"created by a dd-trace-js experiments rich VCR test\",\"ensure_unique\":true,\"run_count\":1,\"metadata\":{\"tags\":[\"source:rich-vcr-test\"]},\"dataset_version\":1,\"config\":{\"temperature\":0}}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "667",
+      "date": "Fri, 31 Jul 2026 21:35:35 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"dba9e243-7c07-4897-9642-5fb36bf423fe\",\"type\":\"experiments\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"config\":{\"temperature\":0},\"created_at\":\"2026-07-31T21:35:35.774445093Z\",\"dataset_id\":\"78a7925a-6924-4bd4-9b6e-0e2fcc61a747\",\"dataset_version\":1,\"description\":\"created by a dd-trace-js experiments rich VCR test\",\"experiment\":\"dd-trace-js-experiments-vcr-rich-experiment\",\"is_auto_experiment\":false,\"metadata\":{\"tags\":[\"source:rich-vcr-test\"]},\"name\":\"dd-trace-js-experiments-vcr-rich-experiment-1785533735774\",\"project_id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"run_count\":1,\"updated_at\":\"2026-07-31T21:35:35.774445167Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_projects_post_9c6b4ac6.json
+++ b/packages/dd-trace/test/llmobs/cassettes/datadog-experiments/datadog-experiments_api_v2_llm-obs_v1_projects_post_9c6b4ac6.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datadoghq.com/api/v2/llm-obs/v1/projects",
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "User-Agent": "node",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "80"
+    },
+    "body": "{\"data\":{\"type\":\"projects\",\"attributes\":{\"name\":\"dd-trace-js-experiments-vcr\"}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/vnd.api+json",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "263",
+      "date": "Fri, 31 Jul 2026 20:41:41 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"data\":{\"id\":\"5645ffb8-c97e-4ce4-89f2-c41931318fd9\",\"type\":\"projects\",\"attributes\":{\"author\":{\"id\":\"cc589400-1367-11ed-aee5-da7ad0900002\"},\"created_at\":\"2026-07-31T19:29:12.35331Z\",\"name\":\"dd-trace-js-experiments-vcr\",\"updated_at\":\"2026-07-31T19:29:12.35331Z\"}}}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -110,7 +110,7 @@ describe('LLMObs Experiments control-plane client', () => {
     assert.equal(listed.some(item => item.id() === dataset.id()), true)
 
     const records = await client.listDatasetRecords(projectId, dataset.id(), {
-      version: createdRecords.find(record => record.version !== null)?.version ?? dataset.version(),
+      version: createdRecords.find(record => record.version() !== null)?.version() ?? dataset.version(),
     })
     assert.equal(records.after, '')
     assert.equal(records.records.length, 2)
@@ -154,7 +154,7 @@ describe('LLMObs Experiments control-plane client', () => {
 
     await waitForBackend(5_000)
     const records = await client.listDatasetRecords(projectId, dataset.id(), {
-      version: customRecords.find(record => record.version !== null)?.version ?? dataset.version(),
+      version: customRecords.find(record => record.version() !== null)?.version() ?? dataset.version(),
     })
     assert.equal(records.after, '')
     assert.deepEqual(records.records.map(record => record.id).sort(), ['custom-a', 'custom-b'])
@@ -186,7 +186,7 @@ describe('LLMObs Experiments control-plane client', () => {
       ensure_unique: true,
       run_count: 1,
       metadata: { tags: ['source:client-test'] },
-      dataset_version: createdRecords[0].version ?? dataset.version(),
+      dataset_version: createdRecords[0].version() ?? dataset.version(),
     })
 
     assert.match(experiment.experimentId, /\S+/)

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -46,9 +46,9 @@ describe('LLMObs Experiments control-plane client', () => {
       apiKey: process.env.DD_API_KEY ?? 'test-api-key',
       appKey: process.env.DD_APP_KEY ?? 'test-app-key',
       site: process.env.DD_SITE ?? 'datadoghq.com',
-      projectName: backendProjectName,
       apiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
         'http://127.0.0.1:9126/vcr/datadog-experiments',
+      projectName: backendProjectName,
     })
   }
 

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -30,6 +30,7 @@ describe('LLMObs Experiments control-plane client', () => {
   const backendProjectName = process.env.DD_LLMOBS_EXPERIMENTS_PROJECT_NAME ??
     `dd-trace-js-experiments-${backendTestId}`
   const backendClientDatasetName = `${backendProjectName}-client-dataset`
+  const backendClientCustomRecordsDatasetName = `${backendProjectName}-client-custom-records-dataset`
   const backendClientExperimentDatasetName = `${backendProjectName}-client-experiment-dataset`
   const backendClientExperimentName = `${backendProjectName}-client-experiment`
   const backendClientTaskName = `${backendProjectName}-client-task`
@@ -116,6 +117,50 @@ describe('LLMObs Experiments control-plane client', () => {
     assert.deepEqual(recordDataByInputValue(records.records), [
       { input: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'client-test' } },
       { input: { value: 2 }, expectedOutput: { value: 3 }, metadata: { source: 'client-test' } },
+    ])
+  })
+
+  it('submits custom record ids with append responses', async function () {
+    this.timeout(180_000)
+
+    const client = backendClient()
+    const projectId = await client.ensureProjectId()
+    const dataset = await client.createDataset(projectId, {
+      name: backendClientCustomRecordsDatasetName,
+      description: 'created by a dd-trace-js experiments custom records VCR test',
+    })
+    trackBackendDataset(client, projectId, dataset.id())
+
+    const customRecords = await client.appendDatasetRecords(projectId, dataset.id(), [
+      {
+        id: 'custom-a',
+        input: { value: 1 },
+        expected_output: { value: 2 },
+        metadata: { source: 'client-custom-records-test' },
+      },
+      {
+        id: 'custom-b',
+        input: { value: 2 },
+        expected_output: { value: 3 },
+        metadata: { source: 'client-custom-records-test' },
+      },
+    ])
+    assert.equal(customRecords.length, 2)
+    assert.deepEqual(customRecords.map(record => record.id), ['custom-a', 'custom-b'])
+    assert.deepEqual(recordDataByInputValue(customRecords), [
+      { input: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'client-custom-records-test' } },
+      { input: { value: 2 }, expectedOutput: { value: 3 }, metadata: { source: 'client-custom-records-test' } },
+    ])
+
+    await waitForBackend(5_000)
+    const records = await client.listDatasetRecords(projectId, dataset.id(), {
+      version: customRecords.find(record => record.version !== null)?.version ?? dataset.version(),
+    })
+    assert.equal(records.after, '')
+    assert.deepEqual(records.records.map(record => record.id).sort(), ['custom-a', 'custom-b'])
+    assert.deepEqual(recordDataByInputValue(records.records), [
+      { input: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'client-custom-records-test' } },
+      { input: { value: 2 }, expectedOutput: { value: 3 }, metadata: { source: 'client-custom-records-test' } },
     ])
   })
 

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -80,8 +80,6 @@ describe('LLMObs Experiments control-plane client', () => {
   })
 
   it('creates, appends, lists, reads, and deletes dataset resources', async function () {
-    this.timeout(180_000)
-
     const client = backendClient()
     const projectId = await client.ensureProjectId()
     const dataset = await client.createDataset(projectId, {
@@ -123,8 +121,6 @@ describe('LLMObs Experiments control-plane client', () => {
   })
 
   it('submits custom record ids with append responses', async function () {
-    this.timeout(180_000)
-
     const client = backendClient()
     const projectId = await client.ensureProjectId()
     const dataset = await client.createDataset(projectId, {
@@ -167,8 +163,6 @@ describe('LLMObs Experiments control-plane client', () => {
   })
 
   it('creates an experiment, posts events, and marks it completed', async function () {
-    this.timeout(60_000)
-
     const client = backendClient()
     const projectId = await client.ensureProjectId()
     const dataset = await client.createDataset(projectId, {

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -6,6 +6,7 @@ const { afterEach, describe, it } = require('mocha')
 const { ExperimentsClient, apiHost, appHost } = require('../../../src/llmobs/experiments/client')
 
 const EXPERIMENTS_VCR_API_BASE = 'http://127.0.0.1:9126/vcr/datadog-experiments'
+const EXPERIMENTS_VCR_TIMEOUT_MS = 20_000
 
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -26,7 +27,8 @@ function recordDataByInputValue (records) {
     .sort((left, right) => left.input.value - right.input.value)
 }
 
-describe('LLMObs Experiments control-plane client', () => {
+describe('LLMObs Experiments control-plane client', function () {
+  this.timeout(EXPERIMENTS_VCR_TIMEOUT_MS)
   const backendDatasets = []
   const backendTestId = process.env.DD_LLMOBS_EXPERIMENTS_TEST_ID ?? 'vcr'
   const backendProjectName = process.env.DD_LLMOBS_EXPERIMENTS_PROJECT_NAME ??

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -5,6 +5,8 @@ const { afterEach, describe, it } = require('mocha')
 
 const { ExperimentsClient, apiHost, appHost } = require('../../../src/llmobs/experiments/client')
 
+const EXPERIMENTS_VCR_API_BASE = 'http://127.0.0.1:9126/vcr/datadog-experiments'
+
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
@@ -42,14 +44,14 @@ describe('LLMObs Experiments control-plane client', () => {
   })
 
   function backendClient () {
-    return new ExperimentsClient({
+    const client = new ExperimentsClient({
       apiKey: process.env.DD_API_KEY ?? 'test-api-key',
       appKey: process.env.DD_APP_KEY ?? 'test-app-key',
       site: process.env.DD_SITE ?? 'datadoghq.com',
-      apiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
-        'http://127.0.0.1:9126/vcr/datadog-experiments',
       projectName: backendProjectName,
     })
+    client.apiBase = EXPERIMENTS_VCR_API_BASE
+    return client
   }
 
   function trackBackendDataset (client, projectId, datasetId) {

--- a/packages/dd-trace/test/llmobs/experiments/client.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/client.spec.js
@@ -1,43 +1,58 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { afterEach, beforeEach, describe, it } = require('mocha')
-const sinon = require('sinon')
+const { afterEach, describe, it } = require('mocha')
 
 const { ExperimentsClient, apiHost, appHost } = require('../../../src/llmobs/experiments/client')
 
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function waitForBackend (defaultDelayMs = 2000) {
+  if (process.env.RECORD_REQUESTS === undefined || process.env.RECORD_REQUESTS === '0') return Promise.resolve()
+  return sleep(Number(process.env.DD_LLMOBS_EXPERIMENTS_READ_AFTER_WRITE_DELAY_MS ?? defaultDelayMs))
+}
+
+function recordDataByInputValue (records) {
+  return records
+    .map(record => ({
+      input: record.input,
+      expectedOutput: record.expectedOutput,
+      metadata: record.metadata,
+    }))
+    .sort((left, right) => left.input.value - right.input.value)
+}
+
 describe('LLMObs Experiments control-plane client', () => {
-  let fetchError
-  let fetchResponse
-  let fetchStub
-  let originalFetch
+  const backendDatasets = []
+  const backendTestId = process.env.DD_LLMOBS_EXPERIMENTS_TEST_ID ?? 'vcr'
+  const backendProjectName = process.env.DD_LLMOBS_EXPERIMENTS_PROJECT_NAME ??
+    `dd-trace-js-experiments-${backendTestId}`
+  const backendClientDatasetName = `${backendProjectName}-client-dataset`
+  const backendClientExperimentDatasetName = `${backendProjectName}-client-experiment-dataset`
+  const backendClientExperimentName = `${backendProjectName}-client-experiment`
+  const backendClientTaskName = `${backendProjectName}-client-task`
 
-  beforeEach(() => {
-    originalFetch = global.fetch
-    fetchError = undefined
-    fetchResponse = undefined
-    fetchStub = sinon.stub().callsFake(async () => {
-      if (fetchError) throw fetchError
-      return fetchResponse
+  afterEach(async () => {
+    for (const { client, projectId, datasetId } of backendDatasets.splice(0).reverse()) {
+      await client.deleteDataset(projectId, datasetId)
+    }
+  })
+
+  function backendClient () {
+    return new ExperimentsClient({
+      apiKey: process.env.DD_API_KEY ?? 'test-api-key',
+      appKey: process.env.DD_APP_KEY ?? 'test-app-key',
+      site: process.env.DD_SITE ?? 'datadoghq.com',
+      projectName: backendProjectName,
+      apiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
+        'http://127.0.0.1:9126/vcr/datadog-experiments',
     })
-    global.fetch = fetchStub
-  })
-
-  afterEach(() => {
-    global.fetch = originalFetch
-    sinon.restore()
-  })
-
-  const rejectWith = (error) => {
-    fetchError = error
   }
 
-  const resolveWith = (status, body) => {
-    fetchResponse = {
-      ok: status >= 200 && status < 300,
-      status,
-      text: sinon.stub().resolves(JSON.stringify(body)),
-    }
+  function trackBackendDataset (client, projectId, datasetId) {
+    backendDatasets.push({ client, projectId, datasetId })
   }
 
   it('resolves the control-plane host from the site', () => {
@@ -55,80 +70,120 @@ describe('LLMObs Experiments control-plane client', () => {
     assert.equal(client.site, 'datad0g.com')
   })
 
-  it('ensureProjectId resolves the configured project name', async () => {
-    resolveWith(200, { data: { id: 'proj-9' } })
-    const client = new ExperimentsClient({ apiKey: 'k', appKey: 'a', site: 'datadoghq.com', projectName: 'cfg-app' })
-    const id = await client.ensureProjectId()
-    assert.equal(id, 'proj-9')
-    assert.deepEqual(JSON.parse(fetchStub.firstCall.args[1].body), {
-      data: { type: 'projects', attributes: { name: 'cfg-app' } },
-    })
-  })
-
   it('reports configured only when api key, app key and site are present', () => {
     assert.equal(new ExperimentsClient({ apiKey: 'k', appKey: 'a', site: 's' }).configured, true)
     assert.equal(new ExperimentsClient({ apiKey: 'k', site: 's' }).configured, false)
     assert.equal(new ExperimentsClient({}).configured, false)
   })
 
-  it('get-or-create project: builds the URL, both-key headers and body, and parses the id', async () => {
-    resolveWith(200, { data: { id: 'proj-123', type: 'projects', attributes: { name: 'p' } } })
+  it('creates, appends, lists, reads, and deletes dataset resources', async function () {
+    this.timeout(180_000)
 
-    const client = new ExperimentsClient({ apiKey: 'key', appKey: 'app', site: 'datadoghq.com' })
-    const id = await client.getOrCreateProject('my-project')
-
-    assert.equal(id, 'proj-123')
-    sinon.assert.calledOnce(fetchStub)
-
-    const [url, opts] = fetchStub.firstCall.args
-    assert.equal(url, 'https://api.datadoghq.com/api/v2/llm-obs/v1/projects')
-    assert.equal(opts.method, 'POST')
-    assert.equal(opts.headers['DD-API-KEY'], 'key')
-    assert.equal(opts.headers['DD-APPLICATION-KEY'], 'app')
-    assert.equal(opts.headers['Content-Type'], 'application/json')
-    assert.deepEqual(JSON.parse(opts.body), {
-      data: { type: 'projects', attributes: { name: 'my-project' } },
+    const client = backendClient()
+    const projectId = await client.ensureProjectId()
+    const dataset = await client.createDataset(projectId, {
+      name: backendClientDatasetName,
+      description: 'created by a dd-trace-js experiments client VCR test',
     })
+    trackBackendDataset(client, projectId, dataset.id())
+
+    assert.equal(dataset.name(), backendClientDatasetName)
+    assert.equal(dataset.description(), 'created by a dd-trace-js experiments client VCR test')
+    assert.equal(dataset.projectId(), projectId)
+    assert.match(dataset.id(), /\S+/)
+    assert.match(dataset.url(), /^https:\/\//)
+
+    const createdRecords = await client.appendDatasetRecords(projectId, dataset.id(), [
+      { input: { value: 1 }, expected_output: { value: 2 }, metadata: { source: 'client-test' } },
+      { input: { value: 2 }, expected_output: { value: 3 }, metadata: { source: 'client-test' } },
+    ])
+    assert.equal(createdRecords.length, 2)
+    for (const record of createdRecords) assert.match(record.id, /\S+/)
+    assert.deepEqual(recordDataByInputValue(createdRecords), [
+      { input: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'client-test' } },
+      { input: { value: 2 }, expectedOutput: { value: 3 }, metadata: { source: 'client-test' } },
+    ])
+
+    await waitForBackend(5_000)
+    const listed = await client.listDatasets(projectId, { name: dataset.name() })
+    assert.equal(listed.some(item => item.id() === dataset.id()), true)
+
+    const records = await client.listDatasetRecords(projectId, dataset.id(), {
+      version: createdRecords.find(record => record.version !== null)?.version ?? dataset.version(),
+    })
+    assert.equal(records.after, '')
+    assert.equal(records.records.length, 2)
+    assert.deepEqual(recordDataByInputValue(records.records), [
+      { input: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'client-test' } },
+      { input: { value: 2 }, expectedOutput: { value: 3 }, metadata: { source: 'client-test' } },
+    ])
   })
 
-  it('caches the project id (second call does not hit the network)', async () => {
-    resolveWith(200, { data: { id: 'proj-123' } })
+  it('creates an experiment, posts events, and marks it completed', async function () {
+    this.timeout(60_000)
 
-    const client = new ExperimentsClient({ apiKey: 'key', appKey: 'app', site: 'datadoghq.com' })
-    const first = await client.getOrCreateProject('p')
-    const second = await client.getOrCreateProject('p')
+    const client = backendClient()
+    const projectId = await client.ensureProjectId()
+    const dataset = await client.createDataset(projectId, {
+      name: backendClientExperimentDatasetName,
+      description: 'created by a dd-trace-js experiments client VCR test',
+    })
+    trackBackendDataset(client, projectId, dataset.id())
 
-    assert.equal(first, 'proj-123')
-    assert.equal(second, 'proj-123')
-    sinon.assert.calledOnce(fetchStub)
-  })
+    const createdRecords = await client.appendDatasetRecords(projectId, dataset.id(), [
+      { input: { value: 1 }, expected_output: { value: 2 }, metadata: { source: 'client-test' } },
+    ])
+    const experiment = await client.createExperiment({
+      name: backendClientExperimentName,
+      project_id: projectId,
+      dataset_id: dataset.id(),
+      description: 'created by a dd-trace-js experiments client VCR test',
+      ensure_unique: true,
+      run_count: 1,
+      metadata: { tags: ['source:client-test'] },
+      dataset_version: createdRecords[0].version ?? dataset.version(),
+    })
 
-  it('routes regional sites to api.<region>.<site>', async () => {
-    resolveWith(200, { data: { id: 'x' } })
+    assert.match(experiment.experimentId, /\S+/)
+    assert.match(experiment.url, /^https:\/\//)
 
-    const client = new ExperimentsClient({ apiKey: 'k', appKey: 'a', site: 'us3.datadoghq.com' })
-    await client.getOrCreateProject('p')
-
-    assert.equal(fetchStub.firstCall.args[0], 'https://api.us3.datadoghq.com/api/v2/llm-obs/v1/projects')
-  })
-
-  it('throws a clear error on a non-2xx response', async () => {
-    resolveWith(403, { errors: ['forbidden'] })
-
-    const client = new ExperimentsClient({ apiKey: 'k', appKey: 'a', site: 'datadoghq.com' })
-    await assert.rejects(
-      () => client.getOrCreateProject('p'),
-      /Failed to create or get project 'p'.*HTTP 403/
-    )
-  })
-
-  it('throws a clear error when the request itself fails', async () => {
-    rejectWith(new Error('network down'))
-
-    const client = new ExperimentsClient({ apiKey: 'k', appKey: 'a', site: 'datadoghq.com' })
-    await assert.rejects(
-      () => client.getOrCreateProject('p'),
-      /Failed to create or get project 'p'.*network down/
-    )
+    const spanId = '0000000000000001'
+    const traceId = '00000000000000000000000000000001'
+    const timestampMs = Date.now()
+    await client.postExperimentEvents(experiment.experimentId, {
+      spans: [{
+        span_id: spanId,
+        trace_id: traceId,
+        project_id: projectId,
+        dataset_id: dataset.id(),
+        name: backendClientTaskName,
+        start_ns: timestampMs * 1e6,
+        duration: 1_000_000,
+        status: 'ok',
+        meta: {
+          input: { value: 1 },
+          output: { value: 2 },
+          expected_output: { value: 2 },
+          metadata: { source: 'client-test' },
+        },
+        tags: [
+          `experiment_id:${experiment.experimentId}`,
+          `dataset_id:${dataset.id()}`,
+          `dataset_record_id:${createdRecords[0].id}`,
+        ],
+      }],
+      metrics: [{
+        metric_source: 'custom',
+        label: 'exact',
+        span_id: spanId,
+        trace_id: traceId,
+        timestamp_ms: timestampMs,
+        tags: [`experiment_id:${experiment.experimentId}`],
+        experiment_id: experiment.experimentId,
+        metric_type: 'boolean',
+        boolean_value: true,
+      }],
+    })
+    await client.updateExperiment(experiment.experimentId, { status: 'completed' })
   })
 })

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -17,8 +17,8 @@ function client () {
     apiKey: 'k',
     appKey: 'a',
     site: 'datadoghq.com',
-    projectName: 'my-app',
     apiBase: 'https://api.datadoghq.com',
+    projectName: 'my-app',
   })
 }
 

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -232,7 +232,7 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
 
   it('exposes dataset getters and accepts a DatasetRecord instance', () => {
     const dataset = new Dataset(client(), 'my-name', 'desc')
-      .addRecord(new DatasetRecord('in', 'out', { m: 1 }))
+      .addRecord(new DatasetRecord('in', 'out', { m: 1 }, 'rec', 2))
       .addRecord({ inputData: 'payload' }, 'expected', { explicit: true })
     assert.equal(dataset.name(), 'my-name')
     assert.equal(dataset.id(), null)
@@ -241,6 +241,9 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
     assert.equal(record.input, 'in')
     assert.equal(record.expectedOutput, 'out')
     assert.deepEqual(record.metadata, { m: 1 })
+    assert.equal(record.id, 'rec')
+    assert.equal(record.version(), 2)
+    assert.deepEqual({ ...record }, { input: 'in', expectedOutput: 'out', metadata: { m: 1 }, id: 'rec' })
     assert.deepEqual(dataset.records()[1].input, { inputData: 'payload' })
     assert.equal(dataset.records()[1].expectedOutput, 'expected')
     assert.deepEqual(dataset.records()[1].metadata, { explicit: true })

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -17,7 +17,6 @@ function client () {
     apiKey: 'k',
     appKey: 'a',
     site: 'datadoghq.com',
-    apiBase: 'https://api.datadoghq.com',
     projectName: 'my-app',
   })
 }

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -9,83 +9,62 @@ const { Dataset, DatasetRecord } = require('../../../src/llmobs/experiments/data
 const { Experiment } = require('../../../src/llmobs/experiments/experiment')
 
 function defaultAppendRecordAttributes (_record, index) {
-  return { id: `rec-${index}`, valid_from_version: 2 }
+  return { valid_from_version: 2 }
 }
 
-function stubClient ({ appendRecordAttributes = defaultAppendRecordAttributes, createDatasetError } = {}) {
-  const requests = []
-  return {
-    appBase: 'https://app.datadoghq.com',
-    requests,
-    ensureProjectId: async () => 'proj',
-    request: async (method, requestPath, body) => {
-      requests.push({ method, path: requestPath, body })
-      if (method === 'POST' && requestPath === `${API_BASE_PATH}/proj/datasets`) {
-        if (createDatasetError) throw createDatasetError
-        return { data: { id: 'ds', attributes: { current_version: 1 } } }
-      }
-      if (method === 'POST' && requestPath === `${API_BASE_PATH}/proj/datasets/ds/records`) {
-        return {
-          data: body.data.attributes.records.map((record, index) => ({
-            id: record.id ?? `rec-${index}`,
-            attributes: appendRecordAttributes(record, index),
-          })),
-        }
-      }
-      if (method === 'POST' && requestPath === `${API_BASE_PATH}/experiments`) {
-        return { data: { id: 'exp' } }
-      }
-      if (method === 'POST' && requestPath === `${API_BASE_PATH}/experiments/exp/events`) return {}
-      if (method === 'PATCH' && requestPath === `${API_BASE_PATH}/experiments/exp`) return {}
-      throw new Error(`Unexpected request ${method} ${requestPath}`)
-    },
-  }
-}
-
-describe('LLMObs Experiments — dataset + experiment run', () => {
-  const client = () => new ExperimentsClient({
+function client () {
+  return new ExperimentsClient({
     apiKey: 'k',
     appKey: 'a',
     site: 'datadoghq.com',
     projectName: 'my-app',
+    apiBase: 'https://api.datadoghq.com',
   })
+}
 
-  it('runs an experiment and returns rows, ids and dashboard URLs', async () => {
-    const c = stubClient()
-    const dataset = new Dataset(c, 'demo', 'desc')
-      .addRecord({ q: 'apple' }, 'true', { row: 0 })
-      .addRecord({ q: 'car' }, 'false', { row: 1 })
+function clientWithMockBackend ({
+  appendRecordAttributes = defaultAppendRecordAttributes,
+  createDatasetError,
+} = {}) {
+  const c = client()
+  const requests = []
 
-    const result = await new Experiment(c, {
-      name: 'exp-demo',
-      description: 'desc exp',
-      dataset,
-      task: (input) => ({ answer: input.q.toUpperCase() }),
-      evaluators: {
-        nonempty: (_input, output) => output.answer.length > 0,
-        len: (_input, output) => output.answer.length,
-        label: (_input, output) => (output.answer === 'APPLE' ? 'match' : 'miss'),
-      },
-      config: { temperature: 0 },
-      tags: { env: 'test' },
-    }).run()
+  c.ensureProjectId = async () => 'proj'
+  c.createDataset = async (projectId, attributes) => {
+    requests.push({ method: 'createDataset', projectId, attributes })
+    if (createDatasetError) throw createDatasetError
+    return Dataset.fromExisting(c, attributes.name, attributes.description, 'ds', projectId, [], [], 1, 1)
+  }
+  c.appendDatasetRecords = async (projectId, datasetId, records) => {
+    requests.push({ method: 'appendDatasetRecords', projectId, datasetId, records })
+    return records.map((record, index) => {
+      const attributes = appendRecordAttributes(record, index)
+      return new DatasetRecord(
+        record.input,
+        record.expected_output,
+        record.metadata,
+        record.id ?? `rec-${index}`,
+        attributes.valid_from_version ?? attributes.version ?? null
+      )
+    })
+  }
+  c.createExperiment = async (attributes) => {
+    requests.push({ method: 'createExperiment', attributes })
+    return { experimentId: 'exp', rows: [], url: `${c.appBase}/llm/experiments/exp` }
+  }
+  c.postExperimentEvents = async (experimentId, attributes) => {
+    requests.push({ method: 'postExperimentEvents', experimentId, attributes })
+  }
+  c.updateExperiment = async (experimentId, attributes) => {
+    requests.push({ method: 'updateExperiment', experimentId, attributes })
+  }
 
-    assert.equal(result.experimentId, 'exp')
-    assert.equal(result.url, 'https://app.datadoghq.com/llm/experiments/exp')
-    assert.equal(result.rows.length, 2)
-    assert.deepEqual(result.rows[0].output, { answer: 'APPLE' })
-    assert.equal(result.rows[0].evaluations.nonempty, true)
-    assert.equal(result.rows[0].evaluations.len, 5)
-    assert.equal(result.rows[0].evaluations.label, 'match')
-    assert.equal(result.runs.length, 1)
-    assert.equal(dataset.id(), 'ds')
-    assert.equal(dataset.version(), 2)
-    assert.deepEqual(dataset.recordIds(), ['rec-0', 'rec-1'])
-    assert.equal(dataset.url(), 'https://app.datadoghq.com/llm/datasets/ds')
-  })
+  return { client: c, requests }
+}
 
+describe('LLMObs Experiments — dataset + experiment run', () => {
   it('runs task inside an LLMObs experiment span', async () => {
-    const c = stubClient()
+    const { client: c } = clientWithMockBackend()
     const dataset = new Dataset(c, 'demo').addRecord({ q: 'apple' }, 'apple', { row: 0 })
     const callsToLlmobs = []
     const llmobs = {
@@ -115,22 +94,9 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
     assert.equal(result.rows[0].traceId, '0000000000000000000000000000abcd')
   })
 
-  it('submits custom record ids with append responses', async () => {
-    const dataset = new Dataset(stubClient(), 'demo')
-      .addRecord(new DatasetRecord('a', null, {}, 'custom-a'))
-      .addRecord(new DatasetRecord('b', null, {}, 'custom-b'))
-
-    const result = await dataset.push()
-
-    assert.deepEqual(result, { pushedCount: 2, totalCount: 2 })
-    assert.deepEqual(dataset.recordIds(), ['custom-a', 'custom-b'])
-    assert.deepEqual(dataset.records().map(record => record.id), ['custom-a', 'custom-b'])
-    assert.equal(dataset.version(), 2)
-    assert.equal(dataset.latestVersion(), 2)
-  })
-
   it('surfaces backend failures', async () => {
-    const c = stubClient({ createDatasetError: new Error('HTTP 500 boom') })
+    const createDatasetError = new Error(`POST ${API_BASE_PATH}/proj/datasets failed: HTTP 500 boom`)
+    const { client: c } = clientWithMockBackend({ createDatasetError })
     const dataset = new Dataset(c, 'demo').addRecord('a')
 
     await assert.rejects(
@@ -140,7 +106,7 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
   })
 
   it('clears the pinned dataset version when append responses omit a new version', async () => {
-    const c = stubClient({ appendRecordAttributes: () => ({}) })
+    const { client: c } = clientWithMockBackend({ appendRecordAttributes: () => ({}) })
     const dataset = new Dataset(c, 'demo').addRecord('a')
 
     await dataset.push()
@@ -150,7 +116,7 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
   })
 
   it('keeps evaluator results aligned for summary evaluators when rows fail', async () => {
-    const c = stubClient()
+    const { client: c } = clientWithMockBackend()
     const dataset = new Dataset(c, 'demo')
       .addRecord('good', 'good')
       .addRecord('eval-bad', 'eval-bad')
@@ -189,7 +155,7 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
   })
 
   it('throws task and evaluator errors when throwOnErrors is true', async () => {
-    const taskClient = stubClient()
+    const { client: taskClient } = clientWithMockBackend()
     await assert.rejects(
       () => new Experiment(taskClient, {
         name: 'exp-demo',
@@ -199,7 +165,7 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
       /task-fail/
     )
 
-    const evaluatorClient = stubClient()
+    const { client: evaluatorClient } = clientWithMockBackend()
     await assert.rejects(
       () => new Experiment(evaluatorClient, {
         name: 'exp-demo',
@@ -212,7 +178,7 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
   })
 
   it('normalizes fallback JSON evaluator metrics', async () => {
-    const c = stubClient()
+    const { client: c, requests } = clientWithMockBackend()
     const dataset = new Dataset(c, 'demo').addRecord('x')
     await new Experiment(c, {
       name: 'exp-demo',
@@ -227,8 +193,8 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
       },
     }).run()
 
-    const metrics = c.requests.find(request => request.path.endsWith('/experiments/exp/events'))
-      .body.data.attributes.metrics
+    const metrics = requests.find(request => request.method === 'postExperimentEvents')
+      .attributes.metrics
     const byLabel = (label) => metrics.find(metric => metric.label === label)
 
     assert.deepEqual(byLabel('obj').json_value, { x: 1 })

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -324,8 +324,6 @@ describe('LLMObs Experiments facade', () => {
 
   describe('experiment run', () => {
     it('runs a multi-row experiment and returns rows, ids, metric values, and dashboard URLs', async function () {
-      this.timeout(60_000)
-
       const exp = backendExperiments()
       const dataset = trackBackendDataset(exp.createDataset(backendRichExperimentDatasetName, {
         description: 'created by a dd-trace-js experiments rich VCR test',
@@ -375,13 +373,9 @@ describe('LLMObs Experiments facade', () => {
         label: 'match',
         details: { actual: 'CAR', expected: 'CAR' },
       })
-      // eslint-disable-next-line no-console
-      console.log(`Datadog rich experiment URL: ${result.url}`)
     })
 
     it('creates an experiment, submits row events, and marks the experiment completed', async function () {
-      this.timeout(60_000)
-
       const exp = backendExperiments()
       const dataset = trackBackendDataset(exp.createDataset(backendExperimentDatasetName, {
         description: 'created by a dd-trace-js experiments VCR test',
@@ -401,8 +395,6 @@ describe('LLMObs Experiments facade', () => {
       assert.match(result.url, /^https:\/\//)
       assert.equal(result.rows.length, 1)
       assert.deepEqual(result.rows[0].evaluations, { exact: true })
-      // eslint-disable-next-line no-console
-      console.log(`Datadog experiment URL: ${result.url}`)
     })
   })
 })

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -174,7 +174,8 @@ describe('LLMObs Experiments facade', () => {
       const warn = sinon.spy(log, 'warn')
       const exp = createExperiments({ llmobs: { DD_LLMOBS_ENABLED: false } })
 
-      const dataset = exp.createDataset('d')
+      const dataset = exp.createDataset('d', 'desc')
+      assert.equal(dataset.description(), 'desc')
       assert.deepEqual(await dataset.push(), { pushedCount: 0, totalCount: 0 })
       assert.equal(dataset.url(), null)
 
@@ -192,9 +193,11 @@ describe('LLMObs Experiments facade', () => {
       const exp = new NoopExperiments()
 
       const ignoredDescriptionDataset = exp.createDataset('legacy description', 'ignored')
+      assert.equal(ignoredDescriptionDataset.description(), 'ignored')
       assert.deepEqual(ignoredDescriptionDataset.records(), [])
 
       const dataset = exp.createDataset('d', {
+        description: 'desc',
         records: [{
           id: 'r1',
           inputData: { question: 'q' },
@@ -205,6 +208,7 @@ describe('LLMObs Experiments facade', () => {
       dataset.addRecord('input only')
 
       assert.equal(dataset.name(), 'd')
+      assert.equal(dataset.description(), 'desc')
       assert.equal(dataset.id(), null)
       assert.equal(dataset.projectId(), null)
       assert.equal(dataset.version(), null)
@@ -224,6 +228,7 @@ describe('LLMObs Experiments facade', () => {
 
       const pulled = await exp.pullDataset('pulled')
       assert.equal(pulled.name(), 'pulled')
+      assert.equal(pulled.description(), '')
 
       const experiment = exp.experiment()
       assert.equal(experiment.name(), '')

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -6,6 +6,7 @@ const sinon = require('sinon')
 
 const log = require('../../../src/log')
 const { createExperiments } = require('../../../src/llmobs/experiments')
+const { ExperimentsClient } = require('../../../src/llmobs/experiments/client')
 const NoopExperiments = require('../../../src/llmobs/experiments/noop')
 
 const enabledConfig = (overrides = {}) => ({
@@ -55,6 +56,23 @@ describe('LLMObs Experiments facade', () => {
     return dataset
   }
 
+  function datasetResource ({ name = 'remote-dataset', id = 'ds', description = 'desc', latestVersion = 3 } = {}) {
+    return {
+      name: () => name,
+      id: () => id,
+      description: () => description,
+      latestVersion: () => latestVersion,
+    }
+  }
+
+  function stubPullDatasetClient ({ projectId = 'proj', datasets = [], pages = [] } = {}) {
+    sinon.stub(ExperimentsClient.prototype, 'ensureProjectId').resolves(projectId)
+    sinon.stub(ExperimentsClient.prototype, 'listDatasets').resolves(datasets)
+    const listDatasetRecords = sinon.stub(ExperimentsClient.prototype, 'listDatasetRecords')
+    for (let i = 0; i < pages.length; i++) listDatasetRecords.onCall(i).resolves(pages[i])
+    return { listDatasetRecords }
+  }
+
   describe('createExperiments gating', () => {
     it('returns a no-op when LLM Obs is disabled', () => {
       const warn = sinon.spy(log, 'warn')
@@ -97,6 +115,15 @@ describe('LLMObs Experiments facade', () => {
           records: [{ id: 'r1', inputData: 'a' }, { id: 'r1', inputData: 'b' }],
         }),
         /Duplicate record id 'r1'/
+      )
+    })
+
+    it('rejects invalid custom record ids', () => {
+      assert.throws(
+        () => createExperiments(enabledConfig()).createDataset('d', {
+          records: [{ id: '', inputData: 'a' }],
+        }),
+        /record id must be a non-empty string/
       )
     })
 
@@ -173,6 +200,94 @@ describe('LLMObs Experiments facade', () => {
       assert.equal(experiment.url(), null)
       assert.deepEqual(await experiment.run(), { experimentId: null, rows: [], url: null })
       sinon.assert.callCount(warn, 4)
+    })
+  })
+
+  describe('pullDataset', () => {
+    it('pulls records from the backend client with pagination and an explicit version', async () => {
+      const firstRecord = { id: 'r1', input: { value: 1 }, expectedOutput: 'one', metadata: { page: 1 } }
+      const secondRecord = { input: { value: 2 }, expectedOutput: 'two', metadata: { page: 2 } }
+      const { listDatasetRecords } = stubPullDatasetClient({
+        datasets: [datasetResource({ name: 'remote-dataset', id: 'ds', description: 'desc', latestVersion: 4 })],
+        pages: [
+          { records: [firstRecord], after: 'next-page' },
+          { records: [secondRecord], after: '' },
+        ],
+      })
+
+      const dataset = await createExperiments(enabledConfig()).pullDataset('remote-dataset', {
+        expectedRecordCount: 2,
+        maxWaitMs: 0,
+        version: 2,
+      })
+
+      assert.equal(dataset.name(), 'remote-dataset')
+      assert.equal(dataset.description(), 'desc')
+      assert.equal(dataset.id(), 'ds')
+      assert.equal(dataset.projectId(), 'proj')
+      assert.equal(dataset.version(), 2)
+      assert.equal(dataset.latestVersion(), 4)
+      assert.deepEqual(dataset.records(), [firstRecord, secondRecord])
+      assert.deepEqual(dataset.recordIds(), ['r1', ''])
+      sinon.assert.calledWith(ExperimentsClient.prototype.listDatasets, 'proj', { name: 'remote-dataset' })
+      assert.deepEqual(listDatasetRecords.firstCall.args, ['proj', 'ds', { cursor: '', version: 2 }])
+      assert.deepEqual(listDatasetRecords.secondCall.args, ['proj', 'ds', { cursor: 'next-page', version: 2 }])
+    })
+
+    it('uses the latest dataset version when no version is requested', async () => {
+      const { listDatasetRecords } = stubPullDatasetClient({
+        datasets: [datasetResource({ name: 'remote-dataset', latestVersion: 5 })],
+        pages: [{ records: [], after: '' }],
+      })
+
+      const dataset = await createExperiments(enabledConfig()).pullDataset('remote-dataset', { maxWaitMs: 0 })
+
+      assert.equal(dataset.version(), 5)
+      assert.deepEqual(listDatasetRecords.firstCall.args, ['proj', 'ds', { cursor: '', version: 5 }])
+    })
+
+    it('surfaces list failures from the backend client', async () => {
+      sinon.stub(ExperimentsClient.prototype, 'ensureProjectId').resolves('proj')
+      sinon.stub(ExperimentsClient.prototype, 'listDatasets').rejects(new Error('list failed'))
+
+      await assert.rejects(
+        () => createExperiments(enabledConfig()).pullDataset('missing-dataset', { maxWaitMs: 0 }),
+        /Failed to list datasets in project 'my-app': list failed/
+      )
+    })
+
+    it('surfaces a not-found dataset after the wait budget is exhausted', async () => {
+      stubPullDatasetClient({ datasets: [] })
+
+      await assert.rejects(
+        () => createExperiments(enabledConfig()).pullDataset('missing-dataset', { maxWaitMs: 0 }),
+        /Dataset 'missing-dataset' not found in project 'my-app'/
+      )
+    })
+
+    it('surfaces record fetch failures from the backend client', async () => {
+      stubPullDatasetClient({ datasets: [datasetResource()] })
+      ExperimentsClient.prototype.listDatasetRecords.rejects(new Error('records failed'))
+
+      await assert.rejects(
+        () => createExperiments(enabledConfig()).pullDataset('remote-dataset', { maxWaitMs: 0 }),
+        /Failed to fetch records for dataset 'remote-dataset' in project 'my-app': records failed/
+      )
+    })
+
+    it('surfaces an expected record count miss after the wait budget is exhausted', async () => {
+      stubPullDatasetClient({
+        datasets: [datasetResource()],
+        pages: [{ records: [], after: '' }],
+      })
+
+      await assert.rejects(
+        () => createExperiments(enabledConfig()).pullDataset('remote-dataset', {
+          expectedRecordCount: 1,
+          maxWaitMs: 0,
+        }),
+        /Dataset 'remote-dataset' has 0 record\(s\) after 0ms, expected 1/
+      )
     })
   })
 

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { afterEach, beforeEach, describe, it } = require('mocha')
+const { afterEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const log = require('../../../src/log')
@@ -17,26 +17,40 @@ const enabledConfig = (overrides = {}) => ({
 })
 
 describe('LLMObs Experiments facade', () => {
-  let fetchHandler
-  let fetchStub
-  let originalFetch
+  const backendDatasets = []
 
-  beforeEach(() => {
-    originalFetch = global.fetch
-    fetchHandler = async (url) => {
-      throw new Error(`Unexpected fetch ${url}`)
+  afterEach(async () => {
+    for (const { dataset, exp } of backendDatasets.splice(0).reverse()) {
+      const projectId = dataset.projectId()
+      const datasetId = dataset.id()
+      if (projectId !== null && datasetId !== null) await exp._deleteDataset(projectId, datasetId)
     }
-    fetchStub = sinon.stub().callsFake((...args) => fetchHandler(...args))
-    global.fetch = fetchStub
-  })
-
-  afterEach(() => {
-    global.fetch = originalFetch
     sinon.restore()
   })
 
-  const resolveFetchWith = (handler) => {
-    fetchHandler = handler
+  const backendTestId = process.env.DD_LLMOBS_EXPERIMENTS_TEST_ID ?? 'vcr'
+  const backendProjectName = process.env.DD_LLMOBS_EXPERIMENTS_PROJECT_NAME ??
+    `dd-trace-js-experiments-${backendTestId}`
+  const backendExperimentDatasetName = `${backendProjectName}-experiment-dataset`
+  const backendExperimentName = `${backendProjectName}-experiment`
+
+  function backendExperiments () {
+    return createExperiments(enabledConfig({
+      site: process.env.DD_SITE ?? 'datadoghq.com',
+      DD_API_KEY: process.env.DD_API_KEY ?? 'test-api-key',
+      DD_APP_KEY: process.env.DD_APP_KEY ?? 'test-app-key',
+      llmobs: {
+        DD_LLMOBS_ENABLED: true,
+        experimentsApiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
+          'http://127.0.0.1:9126/vcr/datadog-experiments',
+        mlApp: backendProjectName,
+      },
+    }))
+  }
+
+  function trackBackendDataset (exp, dataset) {
+    backendDatasets.push({ exp, dataset })
+    return dataset
   }
 
   describe('createExperiments gating', () => {
@@ -69,6 +83,12 @@ describe('LLMObs Experiments facade', () => {
       assert.equal(typeof experiment.run, 'function')
     })
 
+    it('returns a working facade when service is used as the project name fallback', () => {
+      const exp = createExperiments(enabledConfig({ service: 'my-service', llmobs: { DD_LLMOBS_ENABLED: true } }))
+      const dataset = exp.createDataset('d')
+      assert.equal(typeof dataset.push, 'function')
+    })
+
     it('rejects duplicate custom record ids', () => {
       assert.throws(
         () => createExperiments(enabledConfig()).createDataset('d', {
@@ -76,21 +96,6 @@ describe('LLMObs Experiments facade', () => {
         }),
         /Duplicate record id 'r1'/
       )
-    })
-
-    it('falls back to config.service for the project name when llmobs.mlApp is not set', async () => {
-      resolveFetchWith(async () => ({
-        ok: true,
-        status: 200,
-        text: sinon.stub().resolves(JSON.stringify({ data: { id: 'proj' } })),
-      }))
-
-      const exp = createExperiments(enabledConfig({ service: 'my-service', llmobs: { DD_LLMOBS_ENABLED: true } }))
-      await exp.createDataset('d').push()
-
-      const [url, opts] = fetchStub.getCall(0).args
-      assert.equal(new URL(url).pathname, '/api/v2/llm-obs/v1/projects')
-      assert.equal(JSON.parse(opts.body).data.attributes.name, 'my-service')
     })
 
     it('returns a no-op with actionable steps when neither mlApp nor service is set', () => {
@@ -169,175 +174,31 @@ describe('LLMObs Experiments facade', () => {
     })
   })
 
-  describe('pullDataset', () => {
-    const resolveRoutes = (recordsResponses) => {
-      let recordsCall = 0
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        let payload
-        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
-          payload = { data: { id: 'proj' } }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets') {
-          payload = { data: [{ id: 'ds9', attributes: { name: 'wanted', description: 'd' } }] }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets/ds9/records') {
-          payload = recordsResponses[Math.min(recordsCall++, recordsResponses.length - 1)]
-        } else {
-          payload = {}
-        }
-        return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
-      })
-    }
+  describe('experiment run', () => {
+    it('creates an experiment, submits row events, and marks the experiment completed', async function () {
+      this.timeout(60_000)
 
-    it('finds a dataset by name and reads records nested under attributes', async () => {
-      resolveRoutes([{
-        data: [
-          { id: 'r1', attributes: { input: { q: '2+2' }, expected_output: '4', metadata: { a: 1 } } },
-          { id: 'r2', attributes: { input: 'i2' } },
-        ],
-      }])
+      const exp = backendExperiments()
+      const dataset = trackBackendDataset(exp, exp.createDataset(backendExperimentDatasetName, {
+        description: 'created by a dd-trace-js experiments VCR test',
+        records: [{ inputData: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'backend-test' } }],
+      }))
 
-      const ds = await createExperiments(enabledConfig()).pullDataset('wanted')
-      assert.equal(ds.id(), 'ds9')
-      assert.equal(ds.projectId(), 'proj')
-      assert.equal(ds.records().length, 2)
-      assert.deepEqual(ds.records()[0].input, { q: '2+2' })
-      assert.equal(ds.records()[0].expectedOutput, '4')
-      assert.deepEqual(ds.records()[0].metadata, { a: 1 })
-      assert.equal(ds.records()[0].id, 'r1')
-      assert.equal(ds.records()[1].id, 'r2')
-    })
+      const result = await exp.experiment({
+        name: backendExperimentName,
+        dataset,
+        task: (input) => ({ value: input.value + 1 }),
+        evaluators: {
+          exact: (_input, output, expected) => output.value === expected.value,
+        },
+      }).run()
 
-    it('passes explicit dataset version when reading records', async () => {
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        let payload
-        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
-          payload = { data: { id: 'proj' } }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets') {
-          payload = { data: [{ id: 'ds9', attributes: { name: 'wanted', description: 'd', current_version: 7 } }] }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets/ds9/records') {
-          assert.equal(u.searchParams.get('filter[version]'), '3')
-          payload = { data: [{ id: 'r1', attributes: { input: 'i1' } }] }
-        } else {
-          payload = {}
-        }
-        return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
-      })
-
-      const ds = await createExperiments(enabledConfig()).pullDataset('wanted', { version: 3 })
-      assert.equal(ds.version(), 3)
-      assert.equal(ds.latestVersion(), 7)
-    })
-
-    it('pins the current version when pulling latest records', async () => {
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        let payload
-        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
-          payload = { data: { id: 'proj' } }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets') {
-          payload = { data: [{ id: 'ds9', attributes: { name: 'wanted', description: 'd', current_version: 7 } }] }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets/ds9/records') {
-          assert.equal(u.searchParams.get('filter[version]'), '7')
-          payload = { data: [{ id: 'r1', attributes: { input: 'i1' } }] }
-        } else {
-          payload = {}
-        }
-        return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
-      })
-
-      const ds = await createExperiments(enabledConfig()).pullDataset('wanted')
-      assert.equal(ds.version(), 7)
-      assert.equal(ds.records().length, 1)
-    })
-
-    it('waits (backoff) until the expected record count is readable', async () => {
-      const one = { data: [{ id: 'r1', attributes: { input: 'i1' } }] }
-      const two = { data: [{ id: 'r1', attributes: { input: 'i1' } }, { id: 'r2', attributes: { input: 'i2' } }] }
-      resolveRoutes([one, two])
-
-      const ds = await createExperiments(enabledConfig()).pullDataset('wanted', {
-        expectedRecordCount: 2,
-        maxWaitMs: 5000,
-      })
-      assert.equal(ds.records().length, 2)
-    })
-
-    it('throws when the dataset is absent (no wait)', async () => {
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        const payload = u.pathname === '/api/v2/llm-obs/v1/projects' ? { data: { id: 'proj' } } : { data: [] }
-        return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
-      })
-      await assert.rejects(
-        () => createExperiments(enabledConfig()).pullDataset('ghost', { maxWaitMs: 0 }),
-        /not found/
-      )
-    })
-
-    it('throws with the underlying error when listing datasets fails', async () => {
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
-          return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify({ data: { id: 'proj' } })) }
-        }
-        return { ok: false, status: 500, text: sinon.stub().resolves('server error') }
-      })
-      await assert.rejects(
-        () => createExperiments(enabledConfig()).pullDataset('wanted', { maxWaitMs: 0 }),
-        /Failed to list datasets/
-      )
-    })
-
-    it('throws when the expected record count never arrives within the budget', async () => {
-      resolveRoutes([{ data: [{ id: 'r1', attributes: { input: 'i1' } }] }]) // only ever 1 record
-      await assert.rejects(
-        () => createExperiments(enabledConfig()).pullDataset('wanted', { expectedRecordCount: 3, maxWaitMs: 0 }),
-        /expected 3.*backend may not have finished ingesting/
-      )
-    })
-
-    it('throws the underlying error when fetching records fails, even without expectedRecordCount', async () => {
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
-          return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify({ data: { id: 'proj' } })) }
-        }
-        if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets') {
-          const payload = { data: [{ id: 'ds9', attributes: { name: 'wanted', description: 'd' } }] }
-          return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
-        }
-        return { ok: false, status: 504, text: sinon.stub().resolves('gateway timeout') }
-      })
-      await assert.rejects(
-        () => createExperiments(enabledConfig()).pullDataset('wanted', { maxWaitMs: 0 }),
-        /Failed to fetch records for dataset 'wanted'/
-      )
-    })
-
-    it('follows the meta.after / page[cursor] pagination across multiple pages', async () => {
-      const pages = {
-        '': { data: [{ id: 'r1', attributes: { input: 'i1' } }], meta: { after: 'cursor1' } },
-        cursor1: { data: [{ id: 'r2', attributes: { input: 'i2' } }], meta: { after: '' } },
-      }
-      resolveFetchWith(async (url) => {
-        const u = new URL(url)
-        let payload
-        if (u.pathname === '/api/v2/llm-obs/v1/projects') {
-          payload = { data: { id: 'proj' } }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets') {
-          payload = { data: [{ id: 'ds9', attributes: { name: 'wanted', description: 'd' } }] }
-        } else if (u.pathname === '/api/v2/llm-obs/v1/proj/datasets/ds9/records') {
-          payload = pages[u.searchParams.get('page[cursor]') ?? '']
-        } else {
-          payload = {}
-        }
-        return { ok: true, status: 200, text: sinon.stub().resolves(JSON.stringify(payload)) }
-      })
-
-      const ds = await createExperiments(enabledConfig()).pullDataset('wanted')
-      assert.deepEqual(ds.records().map((r) => r.input), ['i1', 'i2'])
-      assert.deepEqual(ds.recordIds(), ['r1', 'r2'])
+      assert.match(result.experimentId, /\S+/)
+      assert.match(result.url, /^https:\/\//)
+      assert.equal(result.rows.length, 1)
+      assert.deepEqual(result.rows[0].evaluations, { exact: true })
+      // eslint-disable-next-line no-console
+      console.log(`Datadog experiment URL: ${result.url}`)
     })
   })
 })

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -2,12 +2,26 @@
 
 const assert = require('node:assert/strict')
 const { afterEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 const log = require('../../../src/log')
 const { createExperiments } = require('../../../src/llmobs/experiments')
 const { ExperimentsClient } = require('../../../src/llmobs/experiments/client')
 const NoopExperiments = require('../../../src/llmobs/experiments/noop')
+
+const EXPERIMENTS_VCR_API_BASE = 'http://127.0.0.1:9126/vcr/datadog-experiments'
+
+class VcrExperimentsClient extends ExperimentsClient {
+  constructor (options) {
+    super(options)
+    this.apiBase = EXPERIMENTS_VCR_API_BASE
+  }
+}
+
+const { createExperiments: createVcrExperiments } = proxyquire('../../../src/llmobs/experiments', {
+  './client': { ExperimentsClient: VcrExperimentsClient },
+})
 
 const enabledConfig = (overrides = {}) => ({
   site: 'datadoghq.com',
@@ -45,25 +59,24 @@ describe('LLMObs Experiments facade', () => {
       apiKey: process.env.DD_API_KEY ?? 'test-api-key',
       appKey: process.env.DD_APP_KEY ?? 'test-app-key',
       site: process.env.DD_SITE ?? 'datadoghq.com',
-      apiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
-        'http://127.0.0.1:9126/vcr/datadog-experiments',
       projectName: backendProjectName,
     }
   }
 
   function backendClient () {
-    return new ExperimentsClient(backendClientOptions())
+    const client = new ExperimentsClient(backendClientOptions())
+    client.apiBase = EXPERIMENTS_VCR_API_BASE
+    return client
   }
 
   function backendExperiments () {
     const options = backendClientOptions()
-    return createExperiments(enabledConfig({
+    return createVcrExperiments(enabledConfig({
       site: options.site,
       DD_API_KEY: options.apiKey,
       DD_APP_KEY: options.appKey,
       llmobs: {
         DD_LLMOBS_ENABLED: true,
-        experimentsApiBase: options.apiBase,
         mlApp: options.projectName,
       },
     }))

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -33,6 +33,8 @@ describe('LLMObs Experiments facade', () => {
     `dd-trace-js-experiments-${backendTestId}`
   const backendExperimentDatasetName = `${backendProjectName}-experiment-dataset`
   const backendExperimentName = `${backendProjectName}-experiment`
+  const backendRichExperimentDatasetName = `${backendProjectName}-rich-experiment-dataset`
+  const backendRichExperimentName = `${backendProjectName}-rich-experiment`
 
   function backendExperiments () {
     return createExperiments(enabledConfig({
@@ -175,6 +177,62 @@ describe('LLMObs Experiments facade', () => {
   })
 
   describe('experiment run', () => {
+    it('runs a multi-row experiment and returns rows, ids, metric values, and dashboard URLs', async function () {
+      this.timeout(60_000)
+
+      const exp = backendExperiments()
+      const dataset = trackBackendDataset(exp, exp.createDataset(backendRichExperimentDatasetName, {
+        description: 'created by a dd-trace-js experiments rich VCR test',
+        records: [
+          { inputData: { q: 'apple' }, expectedOutput: 'APPLE', metadata: { row: 0 } },
+          { inputData: { q: 'car' }, expectedOutput: 'CAR', metadata: { row: 1 } },
+        ],
+      }))
+
+      const result = await exp.experiment({
+        name: backendRichExperimentName,
+        description: 'created by a dd-trace-js experiments rich VCR test',
+        dataset,
+        task: (input) => ({ answer: input.q.toUpperCase() }),
+        evaluators: {
+          nonempty: (_input, output) => output.answer.length > 0,
+          len: (_input, output) => output.answer.length,
+          label: (_input, output, expected) => (output.answer === expected ? 'match' : 'miss'),
+          details: (_input, output, expected) => ({ actual: output.answer, expected }),
+        },
+        config: { temperature: 0 },
+        tags: { source: 'rich-vcr-test' },
+      }).run()
+
+      assert.match(result.experimentId, /\S+/)
+      assert.match(result.url, /^https:\/\//)
+      assert.equal(result.rows.length, 2)
+      assert.equal(result.runs.length, 1)
+      assert.equal(result.runs[0].rows, result.rows)
+      assert.match(dataset.id(), /\S+/)
+      assert.match(dataset.url(), /^https:\/\//)
+      assert.equal(dataset.recordIds().length, 2)
+      for (const row of result.rows) {
+        assert.match(row.spanId, /^[a-f0-9]{16}$/)
+        assert.match(row.traceId, /^[a-f0-9]{32}$/)
+      }
+      assert.deepEqual(result.rows.map(row => row.output), [{ answer: 'APPLE' }, { answer: 'CAR' }])
+      assert.deepEqual(result.rows[0].evaluations, {
+        nonempty: true,
+        len: 5,
+        label: 'match',
+        details: { actual: 'APPLE', expected: 'APPLE' },
+      })
+      assert.deepEqual(result.rows[1].evaluations, {
+        nonempty: true,
+        len: 3,
+        label: 'match',
+        details: { actual: 'CAR', expected: 'CAR' },
+      })
+      // eslint-disable-next-line no-console
+      console.log(`Datadog rich experiment URL: ${result.url}`)
+    })
+
     it('creates an experiment, submits row events, and marks the experiment completed', async function () {
       this.timeout(60_000)
 

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -21,10 +21,13 @@ describe('LLMObs Experiments facade', () => {
   const backendDatasets = []
 
   afterEach(async () => {
-    for (const { dataset, exp } of backendDatasets.splice(0).reverse()) {
-      const projectId = dataset.projectId()
-      const datasetId = dataset.id()
-      if (projectId !== null && datasetId !== null) await exp._deleteDataset(projectId, datasetId)
+    if (backendDatasets.length > 0) {
+      const client = backendClient()
+      for (const dataset of backendDatasets.splice(0).reverse()) {
+        const projectId = dataset.projectId()
+        const datasetId = dataset.id()
+        if (projectId !== null && datasetId !== null) await client.deleteDataset(projectId, datasetId)
+      }
     }
     sinon.restore()
   })
@@ -37,22 +40,37 @@ describe('LLMObs Experiments facade', () => {
   const backendRichExperimentDatasetName = `${backendProjectName}-rich-experiment-dataset`
   const backendRichExperimentName = `${backendProjectName}-rich-experiment`
 
-  function backendExperiments () {
-    return createExperiments(enabledConfig({
+  function backendClientOptions () {
+    return {
+      apiKey: process.env.DD_API_KEY ?? 'test-api-key',
+      appKey: process.env.DD_APP_KEY ?? 'test-app-key',
       site: process.env.DD_SITE ?? 'datadoghq.com',
-      DD_API_KEY: process.env.DD_API_KEY ?? 'test-api-key',
-      DD_APP_KEY: process.env.DD_APP_KEY ?? 'test-app-key',
+      apiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
+        'http://127.0.0.1:9126/vcr/datadog-experiments',
+      projectName: backendProjectName,
+    }
+  }
+
+  function backendClient () {
+    return new ExperimentsClient(backendClientOptions())
+  }
+
+  function backendExperiments () {
+    const options = backendClientOptions()
+    return createExperiments(enabledConfig({
+      site: options.site,
+      DD_API_KEY: options.apiKey,
+      DD_APP_KEY: options.appKey,
       llmobs: {
         DD_LLMOBS_ENABLED: true,
-        experimentsApiBase: process.env.DD_LLMOBS_EXPERIMENTS_API_BASE ??
-          'http://127.0.0.1:9126/vcr/datadog-experiments',
-        mlApp: backendProjectName,
+        experimentsApiBase: options.apiBase,
+        mlApp: options.projectName,
       },
     }))
   }
 
-  function trackBackendDataset (exp, dataset) {
-    backendDatasets.push({ exp, dataset })
+  function trackBackendDataset (dataset) {
+    backendDatasets.push(dataset)
     return dataset
   }
 
@@ -296,7 +314,7 @@ describe('LLMObs Experiments facade', () => {
       this.timeout(60_000)
 
       const exp = backendExperiments()
-      const dataset = trackBackendDataset(exp, exp.createDataset(backendRichExperimentDatasetName, {
+      const dataset = trackBackendDataset(exp.createDataset(backendRichExperimentDatasetName, {
         description: 'created by a dd-trace-js experiments rich VCR test',
         records: [
           { inputData: { q: 'apple' }, expectedOutput: 'APPLE', metadata: { row: 0 } },
@@ -352,7 +370,7 @@ describe('LLMObs Experiments facade', () => {
       this.timeout(60_000)
 
       const exp = backendExperiments()
-      const dataset = trackBackendDataset(exp, exp.createDataset(backendExperimentDatasetName, {
+      const dataset = trackBackendDataset(exp.createDataset(backendExperimentDatasetName, {
         description: 'created by a dd-trace-js experiments VCR test',
         records: [{ inputData: { value: 1 }, expectedOutput: { value: 2 }, metadata: { source: 'backend-test' } }],
       }))


### PR DESCRIPTION
## Summary
- move experiments control-plane entity calls into ExperimentsClient
- return domain objects from client methods where applicable (Dataset, DatasetRecord, ExperimentResult)
- refactor dataset pull/push and experiment creation call sites to consume those entities instead of raw JSON:API envelopes

## Testing
- ./node_modules/.bin/mocha packages/dd-trace/test/llmobs/experiments/index.spec.js

First PR in stack. The external experiment recorder PR should be based on this branch.