### PR TITLE
fix(dns): preserve shorthand rrtype with options

### DIFF
--- a/packages/datadog-instrumentations/src/dns.js
+++ b/packages/datadog-instrumentations/src/dns.js
@@ -81,7 +81,7 @@ function buildCallbackArgsContext (rrtype) {
     const captured = [...args]
     captured.pop() // remove the callback
     if (rrtype) {
-      captured.push(rrtype)
+      captured.splice(1, 0, rrtype)
     }
     return { args: captured }
   }
@@ -91,7 +91,7 @@ function buildPromiseArgsContext (rrtype) {
   return function (_, args) {
     const captured = [...args]
     if (rrtype) {
-      captured.push(rrtype)
+      captured.splice(1, 0, rrtype)
     }
     return { args: captured }
   }

--- a/packages/datadog-instrumentations/src/dns.js
+++ b/packages/datadog-instrumentations/src/dns.js
@@ -9,6 +9,7 @@ const rrtypes = {
   resolveAny: 'ANY',
   resolve4: 'A',
   resolve6: 'AAAA',
+  resolveCaa: 'CAA',
   resolveCname: 'CNAME',
   resolveMx: 'MX',
   resolveNs: 'NS',
@@ -17,6 +18,7 @@ const rrtypes = {
   resolvePtr: 'PTR',
   resolveNaptr: 'NAPTR',
   resolveSoa: 'SOA',
+  resolveTlsa: 'TLSA',
 }
 
 // `dns.promises` and `require('dns/promises')` resolve to the same exports object. Both
@@ -81,7 +83,7 @@ function buildCallbackArgsContext (rrtype) {
     const captured = [...args]
     captured.pop() // remove the callback
     if (rrtype) {
-      captured.splice(1, 0, rrtype)
+      insertRrtype(captured, rrtype)
     }
     return { args: captured }
   }
@@ -91,8 +93,25 @@ function buildPromiseArgsContext (rrtype) {
   return function (_, args) {
     const captured = [...args]
     if (rrtype) {
-      captured.splice(1, 0, rrtype)
+      insertRrtype(captured, rrtype)
     }
     return { args: captured }
   }
+}
+
+/**
+ * @param {unknown[]} captured
+ * @param {string} rrtype
+ */
+function insertRrtype (captured, rrtype) {
+  if (captured.length === 0) {
+    captured.push(rrtype)
+    return
+  }
+
+  captured.push(rrtype)
+  for (let index = captured.length - 1; index > 1; index--) {
+    captured[index] = captured[index - 1]
+  }
+  captured[1] = rrtype
 }

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -163,48 +163,69 @@ describe('Plugin', () => {
         dns.resolveAny('localhost', err => err && done(err))
       })
 
-      it('should preserve the shorthand rrtype when callback options are passed', done => {
-        agent
-          .assertSomeTraces(traces => {
-            assertObjectContains(traces[0][0], {
-              name: 'dns.resolve',
-              service: 'test',
-              resource: 'AAAA fakedomain.faketld',
-            })
-            assertObjectContains(traces[0][0].meta, {
-              component: 'dns',
-              'span.kind': 'client',
-              'dns.hostname': 'fakedomain.faketld',
-              'dns.rrtype': 'AAAA',
-            })
+      it('should preserve the shorthand rrtype when callback options are passed', () => {
+        const tracePromise = agent.assertSomeTraces(traces => {
+          assertObjectContains(traces[0][0], {
+            name: 'dns.resolve',
+            service: 'test',
+            resource: 'AAAA fakedomain.faketld',
           })
-          .then(done)
-          .catch(done)
+          assertObjectContains(traces[0][0].meta, {
+            component: 'dns',
+            'span.kind': 'client',
+            'dns.hostname': 'fakedomain.faketld',
+            'dns.rrtype': 'AAAA',
+          })
+        })
 
-        dns.resolve6('fakedomain.faketld', { ttl: true }, () => {})
+        return Promise.all([
+          tracePromise,
+          assert.rejects(promisify(dns.resolve6)('fakedomain.faketld', { ttl: true })),
+        ])
       })
 
-      it('should preserve the shorthand rrtype on callback Resolver instances when options are passed', done => {
+      it('should instrument resolveCaa with options', () => {
+        const tracePromise = agent.assertSomeTraces(traces => {
+          assertObjectContains(traces[0][0], {
+            name: 'dns.resolve',
+            service: 'test',
+            resource: 'CAA fakedomain.faketld',
+          })
+          assertObjectContains(traces[0][0].meta, {
+            component: 'dns',
+            'span.kind': 'client',
+            'dns.hostname': 'fakedomain.faketld',
+            'dns.rrtype': 'CAA',
+          })
+        })
+
+        return Promise.all([
+          tracePromise,
+          assert.rejects(promisify(dns.resolveCaa)('fakedomain.faketld', { ttl: true })),
+        ])
+      })
+
+      it('should preserve the shorthand rrtype on callback Resolver instances when options are passed', () => {
         const resolver = new dns.Resolver()
 
-        agent
-          .assertSomeTraces(traces => {
-            assertObjectContains(traces[0][0], {
-              name: 'dns.resolve',
-              service: 'test',
-              resource: 'AAAA fakedomain.faketld',
-            })
-            assertObjectContains(traces[0][0].meta, {
-              component: 'dns',
-              'span.kind': 'client',
-              'dns.hostname': 'fakedomain.faketld',
-              'dns.rrtype': 'AAAA',
-            })
+        const tracePromise = agent.assertSomeTraces(traces => {
+          assertObjectContains(traces[0][0], {
+            name: 'dns.resolve',
+            service: 'test',
+            resource: 'AAAA fakedomain.faketld',
           })
-          .then(done)
-          .catch(done)
+          assertObjectContains(traces[0][0].meta, {
+            component: 'dns',
+            'span.kind': 'client',
+            'dns.hostname': 'fakedomain.faketld',
+            'dns.rrtype': 'AAAA',
+          })
+        })
 
-        resolver.resolve6('fakedomain.faketld', { ttl: true }, () => {})
+        return Promise.all([
+          tracePromise,
+          assert.rejects(promisify(resolver.resolve6).call(resolver, 'fakedomain.faketld', { ttl: true })),
+        ])
       })
 
       it('should instrument reverse', done => {
@@ -438,7 +459,32 @@ describe('Plugin', () => {
 
           return Promise.all([
             tracePromise,
-            dns.promises.resolve6('fakedomain.faketld', { ttl: true }).catch(() => {}),
+            assert.rejects(dns.promises.resolve6('fakedomain.faketld', { ttl: true })),
+          ])
+        })
+
+        it('should instrument resolveTlsa with options when supported', function () {
+          if (typeof dns.promises.resolveTlsa !== 'function') {
+            this.skip()
+          }
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            assertObjectContains(traces[0][0], {
+              name: 'dns.resolve',
+              service: 'test',
+              resource: 'TLSA fakedomain.faketld',
+            })
+            assertObjectContains(traces[0][0].meta, {
+              component: 'dns',
+              'span.kind': 'client',
+              'dns.hostname': 'fakedomain.faketld',
+              'dns.rrtype': 'TLSA',
+            })
+          })
+
+          return Promise.all([
+            tracePromise,
+            assert.rejects(dns.promises.resolveTlsa('fakedomain.faketld', { ttl: true })),
           ])
         })
 
@@ -461,7 +507,7 @@ describe('Plugin', () => {
 
           return Promise.all([
             tracePromise,
-            resolver.resolve6('fakedomain.faketld', { ttl: true }).catch(() => {}),
+            assert.rejects(resolver.resolve6('fakedomain.faketld', { ttl: true })),
           ])
         })
 
@@ -495,9 +541,8 @@ describe('Plugin', () => {
         })
 
         it('should rethrow synchronous errors from the underlying call', () => {
-          // dns.promises.lookup validates `hostname` synchronously and throws ERR_INVALID_ARG_TYPE
-          // rather than returning a rejected promise; the wrapper must propagate that.
           assert.throws(() => dns.promises.lookup({}), { code: 'ERR_INVALID_ARG_TYPE' })
+          assert.throws(() => dns.promises.resolve6(), { code: 'ERR_INVALID_ARG_TYPE' })
         })
 
         it('should instrument Resolver instances', () => {

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -163,6 +163,50 @@ describe('Plugin', () => {
         dns.resolveAny('localhost', err => err && done(err))
       })
 
+      it('should preserve the shorthand rrtype when callback options are passed', done => {
+        agent
+          .assertSomeTraces(traces => {
+            assertObjectContains(traces[0][0], {
+              name: 'dns.resolve',
+              service: 'test',
+              resource: 'AAAA fakedomain.faketld',
+            })
+            assertObjectContains(traces[0][0].meta, {
+              component: 'dns',
+              'span.kind': 'client',
+              'dns.hostname': 'fakedomain.faketld',
+              'dns.rrtype': 'AAAA',
+            })
+          })
+          .then(done)
+          .catch(done)
+
+        dns.resolve6('fakedomain.faketld', { ttl: true }, () => {})
+      })
+
+      it('should preserve the shorthand rrtype on callback Resolver instances when options are passed', done => {
+        const resolver = new dns.Resolver()
+
+        agent
+          .assertSomeTraces(traces => {
+            assertObjectContains(traces[0][0], {
+              name: 'dns.resolve',
+              service: 'test',
+              resource: 'AAAA fakedomain.faketld',
+            })
+            assertObjectContains(traces[0][0].meta, {
+              component: 'dns',
+              'span.kind': 'client',
+              'dns.hostname': 'fakedomain.faketld',
+              'dns.rrtype': 'AAAA',
+            })
+          })
+          .then(done)
+          .catch(done)
+
+        resolver.resolve6('fakedomain.faketld', { ttl: true }, () => {})
+      })
+
       it('should instrument reverse', done => {
         agent
           .assertSomeTraces(traces => {
@@ -374,6 +418,50 @@ describe('Plugin', () => {
           return Promise.all([
             tracePromise,
             dns.promises.resolveAny('localhost').catch(() => {}),
+          ])
+        })
+
+        it('should preserve the shorthand rrtype when promise options are passed', () => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            assertObjectContains(traces[0][0], {
+              name: 'dns.resolve',
+              service: 'test',
+              resource: 'AAAA fakedomain.faketld',
+            })
+            assertObjectContains(traces[0][0].meta, {
+              component: 'dns',
+              'span.kind': 'client',
+              'dns.hostname': 'fakedomain.faketld',
+              'dns.rrtype': 'AAAA',
+            })
+          })
+
+          return Promise.all([
+            tracePromise,
+            dns.promises.resolve6('fakedomain.faketld', { ttl: true }).catch(() => {}),
+          ])
+        })
+
+        it('should preserve the shorthand rrtype on promise Resolver instances when options are passed', () => {
+          const resolver = new dns.promises.Resolver()
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            assertObjectContains(traces[0][0], {
+              name: 'dns.resolve',
+              service: 'test',
+              resource: 'AAAA fakedomain.faketld',
+            })
+            assertObjectContains(traces[0][0].meta, {
+              component: 'dns',
+              'span.kind': 'client',
+              'dns.hostname': 'fakedomain.faketld',
+              'dns.rrtype': 'AAAA',
+            })
+          })
+
+          return Promise.all([
+            tracePromise,
+            resolver.resolve6('fakedomain.faketld', { ttl: true }).catch(() => {}),
           ])
         })
 


### PR DESCRIPTION
## Summary

DNS shorthand calls such as `resolve6(hostname, { ttl: true })` now report `AAAA` in their span resource and `dns.rrtype` tag. The instrumentation previously appended the synthetic record type after the options object, so the plugin read the object and fell back to `A`.

## Why

The synthetic record type is inserted at the plugin's existing context slot while preserving the original options argument. Regression coverage exercises callback and promise APIs, including `Resolver` instances.

Fixes: https://github.com/DataDog/dd-trace-js/issues/9621