### PR TITLE
fix(serverless): flush Vercel OTLP signals

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -6,6 +6,7 @@ const { withRequest } = require('../../dd-trace/src/appsec/store')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+const { flushVercelOtlp } = require('../../dd-trace/src/serverless')
 
 const legacyStorage = storage('legacy')
 
@@ -96,6 +97,7 @@ class HttpServerPlugin extends ServerPlugin {
     }
 
     web.finishAll(context)
+    flushVercelOtlp(this.tracer)
   }
 
   exit ({ req }) {

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -6,7 +6,7 @@ const { withRequest } = require('../../dd-trace/src/appsec/store')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
-const { flushVercelOtlp } = require('../../dd-trace/src/serverless')
+const { onRequestEnd } = require('../../dd-trace/src/serverless')
 
 const legacyStorage = storage('legacy')
 
@@ -97,7 +97,7 @@ class HttpServerPlugin extends ServerPlugin {
     }
 
     web.finishAll(context)
-    flushVercelOtlp(this.tracer)
+    onRequestEnd(this.tracer)
   }
 
   exit ({ req }) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -4,9 +4,11 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+const { flushVercelOtlp } = require('../../dd-trace/src/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
+const NEEDS_OTLP_FLUSH = Symbol('needsOtlpFlush')
 
 class NextPlugin extends ServerPlugin {
   static id = 'next'
@@ -42,7 +44,7 @@ class NextPlugin extends ServerPlugin {
 
     analyticsSampler.sample(span, this.config.measured, true)
 
-    return { ...store, span, req }
+    return { ...store, span, req, [NEEDS_OTLP_FLUSH]: childOf?._integrationName !== 'http' }
   }
 
   error ({ span, error }) {
@@ -86,6 +88,7 @@ class NextPlugin extends ServerPlugin {
     this.config.hooks.request(span, req, res)
 
     span.finish()
+    if (store[NEEDS_OTLP_FLUSH]) flushVercelOtlp(this.tracer)
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false }) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -4,11 +4,10 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
-const { flushVercelOtlp } = require('../../dd-trace/src/serverless')
+const { onRequestEnd } = require('../../dd-trace/src/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
-const NEEDS_OTLP_FLUSH = Symbol('needsOtlpFlush')
 
 class NextPlugin extends ServerPlugin {
   static id = 'next'
@@ -44,7 +43,8 @@ class NextPlugin extends ServerPlugin {
 
     analyticsSampler.sample(span, this.config.measured, true)
 
-    return { ...store, span, req, [NEEDS_OTLP_FLUSH]: childOf?._integrationName !== 'http' }
+    const httpPluginWillFlush = childOf?._integrationName === 'http'
+    return { ...store, span, req, shouldFlushOtlp: !httpPluginWillFlush }
   }
 
   error ({ span, error }) {
@@ -88,7 +88,7 @@ class NextPlugin extends ServerPlugin {
     this.config.hooks.request(span, req, res)
 
     span.finish()
-    if (store[NEEDS_OTLP_FLUSH]) flushVercelOtlp(this.tracer)
+    if (store.shouldFlushOtlp) onRequestEnd(this.tracer)
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false }) {

--- a/packages/dd-trace/src/opentelemetry/logs/batch_log_processor.js
+++ b/packages/dd-trace/src/opentelemetry/logs/batch_log_processor.js
@@ -53,10 +53,12 @@ class BatchLogRecordProcessor {
 
   /**
    * Forces an immediate flush of all pending log records.
-   * @returns {undefined} Promise that resolves when flush is complete
+   * @returns {Promise<void>} Promise that resolves when flush is complete
    */
   forceFlush () {
-    this.#export()
+    this.#clearTimer()
+    while (this.#logRecords.length > 0) this.#export()
+    return this.exporter.forceFlush()
   }
 
   /**
@@ -82,6 +84,7 @@ class BatchLogRecordProcessor {
     this.#logRecords = this.#logRecords.slice(this.#maxExportBatchSize)
 
     this.#clearTimer()
+    if (logRecords.length === 0) return
     this.exporter.export(logRecords, () => {})
   }
 

--- a/packages/dd-trace/src/opentelemetry/logs/logger_provider.js
+++ b/packages/dd-trace/src/opentelemetry/logs/logger_provider.js
@@ -84,7 +84,7 @@ class LoggerProvider {
 
   /**
    * Forces a flush of all pending log records.
-   * @returns {undefined} Promise that resolves when flush is n ssue cncomplete
+   * @returns {Promise<void> | undefined} Promise that resolves when flush is complete
    */
   forceFlush () {
     if (!this.isShutdown) {

--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -197,14 +197,15 @@ class PeriodicMetricReader {
 
   /**
    * Forces an immediate collection and export of all metrics.
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   forceFlush () {
     if (this.#isShutdown) {
       log.warn('PeriodicMetricReader is shutdown. %d measurement(s) were dropped', this.#droppedCount)
-      return
+      return Promise.resolve()
     }
     this.#collectAndExport()
+    return this.exporter.forceFlush()
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -205,7 +205,7 @@ class PeriodicMetricReader {
       return Promise.resolve()
     }
     this.#collectAndExport()
-    return this.exporter.forceFlush()
+    return this.exporter.forceFlush?.() || Promise.resolve()
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -5,6 +5,7 @@ const https = require('node:https')
 const { URL } = require('node:url')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
+const { retainVercelRequest } = require('../../serverless')
 const telemetryMetrics = require('../../telemetry/metrics')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
@@ -20,6 +21,7 @@ const legacyStorage = storage('legacy')
  */
 class OtlpHttpExporterBase {
   #transport = https
+  #pendingRequests = new Set()
 
   /**
    * Creates a new OtlpHttpExporterBase instance.
@@ -88,39 +90,67 @@ class OtlpHttpExporterBase {
       },
     }
 
-    legacyStorage.run({ noop: true }, () => {
-      const req = this.#transport.request(options, (res) => {
-        let data = ''
+    let resolvePending
+    const pending = new Promise(resolve => { resolvePending = resolve })
+    this.#pendingRequests.add(pending)
+    retainVercelRequest(pending)
 
-        res.on('data', (chunk) => {
-          data += chunk
+    let completed = false
+    const complete = (result) => {
+      if (completed) return
+      completed = true
+
+      try {
+        resultCallback(result)
+      } finally {
+        this.#pendingRequests.delete(pending)
+        resolvePending()
+      }
+    }
+
+    try {
+      legacyStorage.run({ noop: true }, () => {
+        const req = this.#transport.request(options, (res) => {
+          let data = ''
+
+          res.on('data', (chunk) => {
+            data += chunk
+          })
+
+          res.once('end', () => {
+            // @ts-expect-error - res.statusCode can be undefined
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+              complete({ code: 0 })
+            } else {
+              const error = new Error(`HTTP ${res.statusCode}: ${data}`)
+              complete({ code: 1, error })
+            }
+          })
         })
 
-        res.once('end', () => {
-          // @ts-expect-error - res.statusCode can be undefined
-          if (res.statusCode >= 200 && res.statusCode < 300) {
-            resultCallback({ code: 0 })
-          } else {
-            const error = new Error(`HTTP ${res.statusCode}: ${data}`)
-            resultCallback({ code: 1, error })
-          }
+        req.on('error', (error) => {
+          log.error('Error sending OTLP %s:', this.signalType, error)
+          complete({ code: 1, error })
         })
-      })
 
-      req.on('error', (error) => {
-        log.error('Error sending OTLP %s:', this.signalType, error)
-        resultCallback({ code: 1, error })
-      })
+        req.once('timeout', () => {
+          req.destroy()
+          const error = new Error('Request timeout')
+          complete({ code: 1, error })
+        })
 
-      req.once('timeout', () => {
-        req.destroy()
-        const error = new Error('Request timeout')
-        resultCallback({ code: 1, error })
+        req.write(payload)
+        req.end()
       })
+    } catch (error) {
+      this.#pendingRequests.delete(pending)
+      resolvePending()
+      throw error
+    }
+  }
 
-      req.write(payload)
-      req.end()
-    })
+  forceFlush () {
+    return Promise.all(this.#pendingRequests).then(() => {})
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -5,7 +5,6 @@ const https = require('node:https')
 const { URL } = require('node:url')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
-const { retainVercelRequest } = require('../../serverless')
 const telemetryMetrics = require('../../telemetry/metrics')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
@@ -93,7 +92,6 @@ class OtlpHttpExporterBase {
     let resolvePending
     const pending = new Promise(resolve => { resolvePending = resolve })
     this.#pendingRequests.add(pending)
-    retainVercelRequest(pending)
 
     let completed = false
     const complete = (result) => {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -64,11 +64,46 @@ function retainVercelRequest (promise) {
   return false
 }
 
+function flushVercelOtlp (tracer) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return false
+
+  tracer = tracer?._tracer || tracer
+  const flushes = []
+
+  if (tracer?._config?.OTEL_TRACES_EXPORTER === 'otlp' && typeof tracer._exporter?.forceFlush === 'function') {
+    flushes.push(() => tracer._exporter.forceFlush())
+  }
+
+  if (tracer?._config?.DD_LOGS_OTEL_ENABLED === true) {
+    const { logs } = require('@opentelemetry/api-logs')
+    const loggerProvider = logs.getLoggerProvider()
+    if (typeof loggerProvider?.forceFlush === 'function') flushes.push(() => loggerProvider.forceFlush())
+  }
+
+  if (tracer?._config?.DD_METRICS_OTEL_ENABLED === true) {
+    const { metrics } = require('@opentelemetry/api')
+    const metricReader = metrics.getMeterProvider()?.reader
+    if (typeof metricReader?.forceFlush === 'function') flushes.push(() => metricReader.forceFlush())
+  }
+
+  if (flushes.length === 0) return false
+
+  const pending = flushes.map(flush => {
+    try {
+      return flush()
+    } catch (error) {
+      return Promise.reject(error)
+    }
+  })
+  return retainVercelRequest(Promise.allSettled(pending))
+}
+
 module.exports = {
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  flushVercelOtlp,
   retainVercelRequest,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -64,9 +64,13 @@ function retainVercelRequest (promise) {
   return false
 }
 
-function flushVercelOtlp (tracer) {
-  if (getEnvironmentVariable('VERCEL') !== '1') return false
-
+/**
+ * Force-flushes configured OTLP signal exporters.
+ *
+ * @param {object} tracer tracer instance or public tracer wrapper
+ * @returns {Promise<void> | undefined} settles after every configured exporter completes
+ */
+function forceFlush (tracer) {
   tracer = tracer?._tracer || tracer
   const flushes = []
 
@@ -86,16 +90,28 @@ function flushVercelOtlp (tracer) {
     if (typeof metricReader?.forceFlush === 'function') flushes.push(() => metricReader.forceFlush())
   }
 
-  if (flushes.length === 0) return false
+  if (flushes.length === 0) return
 
-  const pending = flushes.map(flush => {
+  return Promise.allSettled(flushes.map(flush => {
     try {
       return flush()
     } catch (error) {
       return Promise.reject(error)
     }
-  })
-  return retainVercelRequest(Promise.allSettled(pending))
+  }))
+}
+
+/**
+ * Retains configured OTLP exports when a Vercel request completes.
+ *
+ * @param {object} tracer tracer instance or public tracer wrapper
+ * @returns {boolean} whether a Vercel request context retained the flush
+ */
+function onRequestEnd (tracer) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return false
+
+  const pending = forceFlush(tracer)
+  return pending ? retainVercelRequest(pending) : false
 }
 
 module.exports = {
@@ -103,7 +119,8 @@ module.exports = {
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
-  flushVercelOtlp,
+  forceFlush,
   retainVercelRequest,
+  onRequestEnd,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -2,6 +2,11 @@
 
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
 
+const VERCEL_REQUEST_CONTEXTS = [
+  Symbol.for('@next/request-context'),
+  Symbol.for('@vercel/request-context'),
+]
+
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
     getEnvironmentVariable('FUNCTION_NAME') !== undefined &&
@@ -42,10 +47,28 @@ function isInServerlessEnvironment () {
   return inAWSLambda || isGCPFunction || isAzureFunction
 }
 
+function retainVercelRequest (promise) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return false
+
+  for (const requestContext of VERCEL_REQUEST_CONTEXTS) {
+    try {
+      const waitUntil = globalThis[requestContext]?.get?.()?.waitUntil
+      if (typeof waitUntil !== 'function') continue
+      waitUntil(promise)
+      return true
+    } catch {
+      // The other request-context implementation may still be available.
+    }
+  }
+
+  return false
+}
+
 module.exports = {
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  retainVercelRequest,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/test/opentelemetry/logs.spec.js
+++ b/packages/dd-trace/test/opentelemetry/logs.spec.js
@@ -12,6 +12,7 @@ const { trace, context } = require('@opentelemetry/api')
 
 require('../setup/core')
 const { protoLogsService } = require('../../src/opentelemetry/otlp/protobuf_loader').getProtobufTypes()
+const BatchLogRecordProcessor = require('../../src/opentelemetry/logs/batch_log_processor')
 const { getConfigFresh } = require('../helpers/config')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 
@@ -141,6 +142,32 @@ describe('OpenTelemetry Logs', () => {
   })
 
   describe('Logs Export', () => {
+    it('forceFlush drains queued records and waits for the exporter', async () => {
+      const batches = []
+      let finishExport
+      const processor = new BatchLogRecordProcessor({
+        export: records => batches.push(records),
+        forceFlush: () => new Promise(resolve => { finishExport = resolve }),
+      }, 1000, 2)
+
+      processor.onEmit({ body: 'one' }, { name: 'test' })
+      processor.onEmit({ body: 'two' }, { name: 'test' })
+      processor.onEmit({ body: 'three' }, { name: 'test' })
+
+      let flushed = false
+      const flush = processor.forceFlush().then(() => { flushed = true })
+      await Promise.resolve()
+      assert.strictEqual(flushed, false)
+      assert.deepStrictEqual(batches.map(batch => batch.map(record => record.body)), [
+        ['one', 'two'],
+        ['three'],
+      ])
+
+      finishExport()
+      await flush
+      assert.strictEqual(flushed, true)
+    })
+
     it('exports logs with complete OTLP structure, trace correlation, and instrumentation info', () => {
       mockOtlpExport((decoded, capturedHeaders) => {
         const { resource } = decoded.resourceLogs[0]

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -682,6 +682,28 @@ describe('OpenTelemetry Meter Provider', () => {
       validator()
     })
 
+    it('forceFlush waits for the exporter', async () => {
+      setupMetrics()
+      const meter = metrics.getMeter('app')
+      const provider = metrics.getMeterProvider()
+      let finishExport
+      sinon.stub(provider.reader.exporter, 'export')
+      sinon.stub(provider.reader.exporter, 'forceFlush').returns(
+        new Promise(resolve => { finishExport = resolve })
+      )
+      meter.createCounter('test').add(1)
+
+      let flushed = false
+      const flush = provider.reader.forceFlush().then(() => { flushed = true })
+      await Promise.resolve()
+      assert.strictEqual(flushed, false)
+      assert.strictEqual(provider.reader.exporter.export.callCount, 1)
+
+      finishExport()
+      await flush
+      assert.strictEqual(flushed, true)
+    })
+
     it('removes callbacks from observable instruments', (done) => {
       const validator = mockOtlpExport((decoded) => {
         const gauge = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -25,9 +25,11 @@ const OTEL_ENV_KEYS = [
   'OTEL_EXPORTER_OTLP_TIMEOUT',
   'OTEL_EXPORTER_OTLP_TRACES_TIMEOUT',
 ]
+const VERCEL_REQUEST_CONTEXT = Symbol.for('@vercel/request-context')
 
 describe('OpenTelemetry Traces', () => {
   let originalEnv
+  let originalVercelRequestContext
 
   /**
    * Creates a mock DD-formatted span (as produced by span_format.js).
@@ -113,12 +115,15 @@ describe('OpenTelemetry Traces', () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env }
+    originalVercelRequestContext = globalThis[VERCEL_REQUEST_CONTEXT]
     // Clear OTEL env vars that may be set by the host environment to prevent test pollution.
     for (const key of OTEL_ENV_KEYS) delete process.env[key]
   })
 
   afterEach(() => {
     process.env = originalEnv
+    if (originalVercelRequestContext === undefined) delete globalThis[VERCEL_REQUEST_CONTEXT]
+    else globalThis[VERCEL_REQUEST_CONTEXT] = originalVercelRequestContext
     sinon.restore()
   })
 
@@ -617,6 +622,38 @@ describe('OpenTelemetry Traces', () => {
   })
 
   describe('Exporter', () => {
+    it('retains in-flight requests in Vercel', async () => {
+      let finishResponse
+      let retained
+      process.env.VERCEL = '1'
+      globalThis[VERCEL_REQUEST_CONTEXT] = {
+        get: () => ({ waitUntil: promise => { retained = promise } }),
+      }
+      sinon.stub(http, 'request').callsFake((options, callback) => {
+        const response = {
+          statusCode: 200,
+          on: () => {},
+          once (event, handler) {
+            if (event === 'end') finishResponse = handler
+          },
+        }
+        const request = {
+          write: () => {},
+          end: () => callback(response),
+          on: () => request,
+          once: () => request,
+        }
+        return request
+      })
+
+      const exporter = buildExporter({ OTEL_TRACES_EXPORTER: 'otlp' })
+      exporter.export([createMockSpan()])
+
+      assert.ok(retained)
+      finishResponse()
+      await retained
+    })
+
     it('waits for in-flight requests when force flushed', async () => {
       let finishResponse
       sinon.stub(http, 'request').callsFake((options, callback) => {

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -617,6 +617,38 @@ describe('OpenTelemetry Traces', () => {
   })
 
   describe('Exporter', () => {
+    it('waits for in-flight requests when force flushed', async () => {
+      let finishResponse
+      sinon.stub(http, 'request').callsFake((options, callback) => {
+        const response = {
+          statusCode: 200,
+          on: () => {},
+          once (event, handler) {
+            if (event === 'end') finishResponse = handler
+          },
+        }
+        const request = {
+          write: () => {},
+          end: () => callback(response),
+          on: () => request,
+          once: () => request,
+        }
+        return request
+      })
+
+      const exporter = buildExporter({ OTEL_TRACES_EXPORTER: 'otlp' })
+      exporter.export([createMockSpan()])
+
+      let flushed = false
+      const flush = exporter.forceFlush().then(() => { flushed = true })
+      await Promise.resolve()
+      assert.strictEqual(flushed, false)
+
+      finishResponse()
+      await flush
+      assert.strictEqual(flushed, true)
+    })
+
     it('exports spans via OTLP HTTP with JSON encoding', () => {
       mockOtlpExport((decoded) => {
         const otlpSpan = decoded.resourceSpans[0].scopeSpans[0].spans[0]

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -25,11 +25,8 @@ const OTEL_ENV_KEYS = [
   'OTEL_EXPORTER_OTLP_TIMEOUT',
   'OTEL_EXPORTER_OTLP_TRACES_TIMEOUT',
 ]
-const VERCEL_REQUEST_CONTEXT = Symbol.for('@vercel/request-context')
-
 describe('OpenTelemetry Traces', () => {
   let originalEnv
-  let originalVercelRequestContext
 
   /**
    * Creates a mock DD-formatted span (as produced by span_format.js).
@@ -115,15 +112,12 @@ describe('OpenTelemetry Traces', () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env }
-    originalVercelRequestContext = globalThis[VERCEL_REQUEST_CONTEXT]
     // Clear OTEL env vars that may be set by the host environment to prevent test pollution.
     for (const key of OTEL_ENV_KEYS) delete process.env[key]
   })
 
   afterEach(() => {
     process.env = originalEnv
-    if (originalVercelRequestContext === undefined) delete globalThis[VERCEL_REQUEST_CONTEXT]
-    else globalThis[VERCEL_REQUEST_CONTEXT] = originalVercelRequestContext
     sinon.restore()
   })
 
@@ -622,38 +616,6 @@ describe('OpenTelemetry Traces', () => {
   })
 
   describe('Exporter', () => {
-    it('retains in-flight requests in Vercel', async () => {
-      let finishResponse
-      let retained
-      process.env.VERCEL = '1'
-      globalThis[VERCEL_REQUEST_CONTEXT] = {
-        get: () => ({ waitUntil: promise => { retained = promise } }),
-      }
-      sinon.stub(http, 'request').callsFake((options, callback) => {
-        const response = {
-          statusCode: 200,
-          on: () => {},
-          once (event, handler) {
-            if (event === 'end') finishResponse = handler
-          },
-        }
-        const request = {
-          write: () => {},
-          end: () => callback(response),
-          on: () => request,
-          once: () => request,
-        }
-        return request
-      })
-
-      const exporter = buildExporter({ OTEL_TRACES_EXPORTER: 'otlp' })
-      exporter.export([createMockSpan()])
-
-      assert.ok(retained)
-      finishResponse()
-      await retained
-    })
-
     it('waits for in-flight requests when force flushed', async () => {
       let finishResponse
       sinon.stub(http, 'request').callsFake((options, callback) => {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -61,6 +61,7 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'FUNCTIONS_WORKER_RUNTIME',
   'GCP_PROJECT',
   'K_SERVICE',
+  'VERCEL',
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -6,7 +6,7 @@ const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { enableGCPPubSubPushSubscription, retainVercelRequest } = require('../src/serverless')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -34,5 +34,37 @@ describe('enableGCPPubSubPushSubscription', () => {
     process.env.K_SERVICE = 'svc'
     process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED = 'false'
     assert.strictEqual(enableGCPPubSubPushSubscription(), false)
+  })
+})
+
+describe('retainVercelRequest', () => {
+  const requestContext = Symbol.for('@vercel/request-context')
+  const originalVercel = process.env.VERCEL
+  const originalRequestContext = globalThis[requestContext]
+
+  afterEach(() => {
+    if (originalVercel === undefined) delete process.env.VERCEL
+    else process.env.VERCEL = originalVercel
+
+    if (originalRequestContext === undefined) delete globalThis[requestContext]
+    else globalThis[requestContext] = originalRequestContext
+  })
+
+  it('retains a promise in the active Vercel request context', () => {
+    const promise = Promise.resolve()
+    let retained
+    process.env.VERCEL = '1'
+    globalThis[requestContext] = {
+      get: () => ({ waitUntil: value => { retained = value } }),
+    }
+
+    assert.strictEqual(retainVercelRequest(promise), true)
+    assert.strictEqual(retained, promise)
+  })
+
+  it('does nothing outside Vercel', () => {
+    delete process.env.VERCEL
+
+    assert.strictEqual(retainVercelRequest(Promise.resolve()), false)
   })
 })

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -8,7 +8,7 @@ const { logs } = require('@opentelemetry/api-logs')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription, flushVercelOtlp, retainVercelRequest } = require('../src/serverless')
+const { enableGCPPubSubPushSubscription, onRequestEnd, retainVercelRequest } = require('../src/serverless')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -89,7 +89,7 @@ describe('retainVercelRequest', () => {
       reader: { forceFlush: pendingFlush },
     })
 
-    assert.strictEqual(flushVercelOtlp({
+    assert.strictEqual(onRequestEnd({
       _config: {
         DD_LOGS_OTEL_ENABLED: true,
         DD_METRICS_OTEL_ENABLED: true,

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -3,10 +3,12 @@
 const assert = require('node:assert/strict')
 
 const { describe, it, afterEach } = require('mocha')
+const { metrics } = require('@opentelemetry/api')
+const { logs } = require('@opentelemetry/api-logs')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription, retainVercelRequest } = require('../src/serverless')
+const { enableGCPPubSubPushSubscription, flushVercelOtlp, retainVercelRequest } = require('../src/serverless')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -48,6 +50,8 @@ describe('retainVercelRequest', () => {
 
     if (originalRequestContext === undefined) delete globalThis[requestContext]
     else globalThis[requestContext] = originalRequestContext
+    metrics.disable()
+    logs.disable()
   })
 
   it('retains a promise in the active Vercel request context', () => {
@@ -66,5 +70,42 @@ describe('retainVercelRequest', () => {
     delete process.env.VERCEL
 
     assert.strictEqual(retainVercelRequest(Promise.resolve()), false)
+  })
+
+  it('retains trace, log, and metric flushes until they complete', async () => {
+    process.env.VERCEL = '1'
+    let retained
+    const resolvers = []
+    const pendingFlush = () => new Promise(resolve => resolvers.push(resolve))
+    globalThis[requestContext] = {
+      get: () => ({ waitUntil: promise => { retained = promise } }),
+    }
+    logs.setGlobalLoggerProvider({
+      getLogger () {},
+      forceFlush: pendingFlush,
+    })
+    metrics.setGlobalMeterProvider({
+      getMeter () {},
+      reader: { forceFlush: pendingFlush },
+    })
+
+    assert.strictEqual(flushVercelOtlp({
+      _config: {
+        DD_LOGS_OTEL_ENABLED: true,
+        DD_METRICS_OTEL_ENABLED: true,
+        OTEL_TRACES_EXPORTER: 'otlp',
+      },
+      _exporter: { forceFlush: pendingFlush },
+    }), true)
+    assert.strictEqual(resolvers.length, 3)
+
+    let completed = false
+    retained.then(() => { completed = true })
+    for (const resolve of resolvers.slice(0, -1)) resolve()
+    await Promise.resolve()
+    assert.strictEqual(completed, false)
+    resolvers.at(-1)()
+    await retained
+    assert.strictEqual(completed, true)
   })
 })


### PR DESCRIPTION
## What is broken

Vercel may freeze a Node function as soon as the response completes. Direct OTLP trace, log, and metric exports can still be queued or have an active HTTPS request at that point, causing intermittent signal loss under normal requests and bursts.

## Change

- detect Vercel only in the serverless lifecycle layer
- force queued trace, log, and metric batches when an HTTP-rooted or Next-rooted request completes
- retain that combined flush through Vercel's request-context `waitUntil()` mechanism
- implement the normal OTLP `forceFlush()` contract so it waits for active transport callbacks

The shared OTLP exporter and processors contain no Vercel detection, request-context access, or Vercel-specific bypass. They only provide normal signal-flush completion semantics; all platform behavior remains in `serverless.js` and the request-finalization hooks.

This does not modify DD-agentless export or native spans.

## Evidence

- focused serverless and OTLP trace/log/metric suites: 149 passing
- ESLint and `git diff --check`: clean
- latest Next 16.2.12 integration suite on the combined branch: 45 passing
- deployed Vercel app survived 100 concurrent requests with direct OTLP enabled
- live distributed flow and parallel traces contain downstream function spans plus DNS/TCP children after each request returned
- direct OTLP metric `vercel.next.ping.requests` was visible in Datadog for the deployed service

Live flow trace: https://app.datadoghq.com/apm/trace/946e0c66a163355eb1fc736f59bd0581

Live parallel trace: https://app.datadoghq.com/apm/trace/6b155611d5f7f63875cf51621201b36b
