### PR TITLE
fix(loader): avoid Node 20.0 loader recursion

### DIFF
--- a/initialize.mjs
+++ b/initialize.mjs
@@ -30,6 +30,8 @@ let hasInsertedInit = false
 const initJsUrl = new URL('init.js', import.meta.url).href
 // `--loader` only reliably influences ESM entrypoints; for CJS apps use `--import`/`--require`.
 
+// `globalPreload` is deprecated in favor of the `initialize` hook, but `initialize` only exists
+// from Node 20.6 on, so it is the only way to run code in the application realm on Node 20.0.
 export const globalPreload = isNode20LoaderWorker
   ? () => `if (getBuiltin('module').createRequire(${JSON.stringify(import.meta.url)})('./init.js')) {
   process.emitWarning('dd-trace cannot instrument ES modules on Node.js 20.0.0. Upgrade to Node.js 20.1.0 or newer.')
@@ -75,6 +77,11 @@ function insertInit (result, _url_, context) {
 // before Node 18.19 share the application thread, where `loader-hook.mjs` builds no matcher.
 let needsHookInitialize = !isMainThread && !useDefaultLoader
 
+/**
+ * @param {string} url
+ * @param {import('node:module').LoadHookContext & { isMain?: boolean }} context
+ * @param {Parameters<import('node:module').LoadHook>[2]} nextLoad
+ */
 async function loadWithInit (url, context, nextLoad) {
   if (needsHookInitialize) {
     needsHookInitialize = false

--- a/initialize.mjs
+++ b/initialize.mjs
@@ -16,18 +16,25 @@ import * as Module from 'module'
 import { types } from 'util'
 import { isMainThread } from 'worker_threads'
 
-// This file must support Node.js 12.0.0 syntax
+// This file must support Node.js 14.13.1 syntax
 
-import {
-  iitmExclusionRegExp,
-  initialize as hookInitialize,
-  load as hookLoad,
-  resolve as hookResolve,
-} from './loader-hook.mjs?initialize'
+const [NODE_MAJOR, NODE_MINOR] = process.versions.node.split('.').map(Number)
+
+const brokenLoaders = NODE_MAJOR === 18 && NODE_MINOR === 0
+const isNode20LoaderWorker = !isMainThread && NODE_MAJOR === 20 && NODE_MINOR === 0
+const useDefaultLoader = brokenLoaders || isNode20LoaderWorker
+// Avoid CommonJS in the loader worker on Node 20.0: https://github.com/nodejs/node/issues/47566
+const loaderHook = useDefaultLoader ? undefined : await import('./loader-hook.mjs?initialize')
 
 let hasInsertedInit = false
 const initJsUrl = new URL('init.js', import.meta.url).href
 // `--loader` only reliably influences ESM entrypoints; for CJS apps use `--import`/`--require`.
+
+export const globalPreload = isNode20LoaderWorker
+  ? () => `if (getBuiltin('module').createRequire(${JSON.stringify(import.meta.url)})('./init.js')) {
+  process.emitWarning('dd-trace cannot instrument ES modules on Node.js 20.0.0. Upgrade to Node.js 20.1.0 or newer.')
+}`
+  : undefined
 
 /**
  * @param {{ source?: string|Buffer|Uint8Array, format?: string }} result
@@ -63,26 +70,23 @@ function insertInit (result, _url_, context) {
   return result
 }
 
-const [NODE_MAJOR, NODE_MINOR] = process.versions.node.split('.').map(Number)
-
-const brokenLoaders = NODE_MAJOR === 18 && NODE_MINOR === 0
-
 // Node calls `initialize` only through `module.register`, never for `--loader`; without it
 // import-in-the-middle keeps its default matcher and proxies every application module. Loaders
 // before Node 18.19 share the application thread, where `loader-hook.mjs` builds no matcher.
-let needsHookInitialize = !isMainThread && !brokenLoaders
+let needsHookInitialize = !isMainThread && !useDefaultLoader
 
-export async function load (url, context, nextLoad) {
+async function loadWithInit (url, context, nextLoad) {
   if (needsHookInitialize) {
     needsHookInitialize = false
-    hookInitialize()
+    loaderHook.initialize()
   }
 
-  const loadHook = (brokenLoaders || iitmExclusionRegExp.test(url)) ? nextLoad : hookLoad
-  return insertInit(await loadHook(url, context, nextLoad), url, context)
+  const load = (useDefaultLoader || loaderHook.iitmExclusionRegExp.test(url)) ? nextLoad : loaderHook.load
+  return insertInit(await load(url, context, nextLoad), url, context)
 }
 
-export const resolve = brokenLoaders ? undefined : hookResolve
+export const load = isNode20LoaderWorker ? undefined : loadWithInit
+export const resolve = useDefaultLoader ? undefined : loaderHook.resolve
 
 if (isMainThread) {
   const require = Module.createRequire(import.meta.url)

--- a/initialize.mjs
+++ b/initialize.mjs
@@ -18,10 +18,10 @@ import { isMainThread } from 'worker_threads'
 
 // This file must support Node.js 14.13.1 syntax
 
-const [NODE_MAJOR, NODE_MINOR] = process.versions.node.split('.').map(Number)
+const NODE_VERSION = process.versions.node
 
-const brokenLoaders = NODE_MAJOR === 18 && NODE_MINOR === 0
-const isNode20LoaderWorker = !isMainThread && NODE_MAJOR === 20 && NODE_MINOR === 0
+const brokenLoaders = NODE_VERSION.startsWith('18.0')
+const isNode20LoaderWorker = !isMainThread && NODE_VERSION.startsWith('20.0')
 const useDefaultLoader = brokenLoaders || isNode20LoaderWorker
 // Avoid CommonJS in the loader worker on Node 20.0: https://github.com/nodejs/node/issues/47566
 const loaderHook = useDefaultLoader ? undefined : await import('./loader-hook.mjs?initialize')

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -330,6 +330,23 @@ if (semver.satisfies(process.versions.node, '>=14.13.1')) {
     useSandbox()
     stubTracerIfNeeded()
 
+    context('globalPreload', () => {
+      useEnv({ DD_TEST_NODE_VERSION: '20.0.0', NODE_OPTIONS: '' })
+
+      /**
+       * @param {string} out
+       */
+      function checkGlobalPreload (out) {
+        assert.match(out,
+          /^if \(getBuiltin\('module'\)\.createRequire\("file:.+\/initialize\.mjs"\)\('\.\/init\.js'\)\) {\n/)
+        assert.match(out,
+          /\n {2}process\.emitWarning\('dd-trace cannot instrument ES modules on Node\.js 20\.0\.0\. Upgrade to Node\.js 20\.1\.0 or newer\.'\)\n}\n$/)
+      }
+
+      it('provides application-realm preload source', () =>
+        testFile('init/loader-worker.mjs', checkGlobalPreload, [], ''))
+    })
+
     context('as --loader', () => {
       const esmWorks = process.versions.node !== '18.0.0' && process.versions.node !== '20.0.0'
 
@@ -362,6 +379,11 @@ if (semver.satisfies(process.versions.node, '>=14.13.1')) {
 
             it('initializes before a CommonJS entrypoint', () =>
               testFile('init/trace.js', 'true\n', [], ''))
+
+            // The loader worker cannot instrument ESM here, but globalPreload still
+            // initializes the tracer in the application realm before the entrypoint runs.
+            it('initializes before an ESM entrypoint', () =>
+              testFile('init/trace.mjs', 'true\n', [], ''))
 
             it('initializes inside inherited Workers', () =>
               testFile('init/loader-worker.mjs', 'true\n', [], ''))

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -32,11 +32,8 @@ delete process.env.DD_INJECT_FORCE
 function testInjectionScenarios (arg, filename, esmWorks = false) {
   if (!currentVersionIsSupported) return
 
-  // For `--loader`, we generally want ESM fixtures to ensure the loader hook actually applies.
-  // However, Node 18.0.0 is a known outlier where ESM via custom loaders is not supportable.
-  const isNode1800 = process.versions.node === '18.0.0'
-  const tracerFile = arg === 'loader' && !isNode1800 ? 'init/trace.mjs' : 'init/trace.js'
-  const instrFile = arg === 'loader' && !isNode1800 ? 'init/instrument.mjs' : 'init/instrument.js'
+  const tracerFile = arg === 'loader' && esmWorks ? 'init/trace.mjs' : 'init/trace.js'
+  const instrFile = arg === 'loader' && esmWorks ? 'init/instrument.mjs' : 'init/instrument.js'
 
   context('preferring app-dir dd-trace', () => {
     context('when dd-trace is not in the app dir', () => {
@@ -329,15 +326,15 @@ describe('init.js', () => {
 // or on 18.0.0 in particular.
 if (semver.satisfies(process.versions.node, '>=14.13.1')) {
   describe('initialize.mjs', () => {
-    // Node 20.0.0 can leave short-lived loader-based children alive after they
-    // print the expected output, so terminate them after a short grace period.
-    setShouldKill(process.versions.node === '20.0.0')
+    setShouldKill(false)
     useSandbox()
     stubTracerIfNeeded()
 
     context('as --loader', () => {
+      const esmWorks = process.versions.node !== '18.0.0' && process.versions.node !== '20.0.0'
+
       testInjectionScenarios('loader', 'initialize.mjs',
-        process.versions.node !== '18.0.0')
+        esmWorks)
       testRuntimeVersionChecks('loader', 'initialize.mjs')
 
       // Only off-thread loaders install the matcher; see initialize.mjs.
@@ -353,6 +350,22 @@ if (semver.satisfies(process.versions.node, '>=14.13.1')) {
 
           it('wraps instrumented and PM2 security control modules and nothing else', () =>
             testFile('init/loader-matcher.mjs', 'true\n', [], ''))
+        })
+      }
+
+      if (process.versions.node === '20.0.0') {
+        context('with the Node.js 20.0.0 loader', () => {
+          const NODE_OPTIONS = '--no-warnings --loader dd-trace/initialize.mjs'
+
+          context('with force', () => {
+            useEnv({ DD_INJECT_FORCE, NODE_OPTIONS })
+
+            it('initializes before a CommonJS entrypoint', () =>
+              testFile('init/trace.js', 'true\n', [], ''))
+
+            it('initializes inside inherited Workers', () =>
+              testFile('init/loader-worker.mjs', 'true\n', [], ''))
+          })
         })
       }
     })

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -355,7 +355,7 @@ if (semver.satisfies(process.versions.node, '>=14.13.1')) {
       testRuntimeVersionChecks('loader', 'initialize.mjs')
 
       // Only off-thread loaders install the matcher; see initialize.mjs.
-      if (semver.satisfies(process.versions.node, '>=18.19.0')) {
+      if (esmWorks && semver.satisfies(process.versions.node, '>=18.19.0')) {
         context('import-in-the-middle include matcher', () => {
           useEnv({
             NODE_OPTIONS: '--no-warnings --loader dd-trace/initialize.mjs',
@@ -384,6 +384,9 @@ if (semver.satisfies(process.versions.node, '>=14.13.1')) {
             // initializes the tracer in the application realm before the entrypoint runs.
             it('initializes before an ESM entrypoint', () =>
               testFile('init/trace.mjs', 'true\n', [], ''))
+
+            it('does not initialize ESM instrumentation', () =>
+              testFile('init/instrument.mjs', 'false\n', [], ''))
 
             it('initializes inside inherited Workers', () =>
               testFile('init/loader-worker.mjs', 'true\n', [], ''))

--- a/integration-tests/init/loader-worker.mjs
+++ b/integration-tests/init/loader-worker.mjs
@@ -1,0 +1,12 @@
+import { once } from 'node:events'
+import { isMainThread, parentPort, Worker } from 'node:worker_threads'
+
+if (isMainThread) {
+  const worker = new Worker(new URL(import.meta.url))
+  const [initialized] = await once(worker, 'message')
+
+  // eslint-disable-next-line no-console
+  console.log(initialized)
+} else {
+  parentPort.postMessage(!!globalThis._ddtrace)
+}

--- a/integration-tests/init/loader-worker.mjs
+++ b/integration-tests/init/loader-worker.mjs
@@ -1,12 +1,21 @@
 import { once } from 'node:events'
-import { isMainThread, parentPort, Worker } from 'node:worker_threads'
+import { isMainThread, parentPort, Worker, workerData } from 'node:worker_threads'
 
 if (isMainThread) {
-  const worker = new Worker(new URL(import.meta.url))
-  const [initialized] = await once(worker, 'message')
+  const worker = new Worker(new URL(import.meta.url), {
+    workerData: process.env.DD_TEST_NODE_VERSION,
+  })
+  const [[initialized]] = await Promise.all([
+    once(worker, 'message'),
+    once(worker, 'exit'),
+  ])
 
   // eslint-disable-next-line no-console
   console.log(initialized)
+} else if (workerData) {
+  Object.defineProperty(process.versions, 'node', { value: workerData })
+  const { globalPreload } = await import('dd-trace/initialize.mjs')
+  parentPort.postMessage(globalPreload())
 } else {
   parentPort.postMessage(!!globalThis._ddtrace)
 }


### PR DESCRIPTION
## Summary

Node 20.0 recursively starts loader workers when a custom loader enters CommonJS, which can hang before application startup. This keeps the custom-loader worker ESM-only and initializes the tracer in the application realm through `globalPreload`.

## Why

Native ESM instrumentation stays disabled on Node 20.0 because its loader cannot safely enter CommonJS. The tracer still initializes for both CommonJS and ESM applications and warns users to upgrade to Node 20.1 or newer.

Refs: https://github.com/nodejs/node/issues/47566