### PR TITLE
chore(codeowners): cover existing ownership gaps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,6 @@
 /.github/ISSUE_TEMPLATE/ @DataDog/lang-platform-js
 /.gitlab/ @DataDog/lang-platform-js
 /.husky/ @DataDog/lang-platform-js
-/.vscode/ @DataDog/lang-platform-js
-/docs/ @DataDog/lang-platform-js
 /scripts/ @DataDog/lang-platform-js
 /vendor/ @DataDog/lang-platform-js
 
@@ -106,8 +104,10 @@
 /packages/dd-trace/src/exporters/electron/ @DataDog/apm-idm-js
 /packages/dd-trace/src/plugins/ @DataDog/apm-idm-js
 /packages/dd-trace/src/payload-tagging/ @DataDog/apm-idm-js
+/packages/dd-trace/src/process-tags/ @DataDog/apm-idm-js
 /packages/dd-trace/src/propagation-hash/ @DataDog/apm-idm-js
 /packages/dd-trace/test/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/test/process-tags.spec.js @DataDog/apm-idm-js
 /packages/dd-trace/src/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/payload_tagging.spec.js @DataDog/apm-idm-js
@@ -255,7 +255,8 @@
 
 # API SDK Capabilities
 /eslint-rules/ @DataDog/apm-sdk-capabilities-js
-/ext/ @DataDog/apm-sdk-capabilities-js
+/ext/kinds.* @DataDog/apm-sdk-capabilities-js
+/ext/priority.* @DataDog/apm-sdk-capabilities-js
 
 /benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/sampling/ @DataDog/apm-sdk-capabilities-js
@@ -292,32 +293,16 @@
 /packages/dd-trace/test/carrier.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/*sampler.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/*sampler.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/rate_limiter.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/sampling_rule.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/sampling_rule.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/custom-metrics.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/custom-metrics-app.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/fixtures/config/span-sampling-rules.json @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/helpers/config.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/process-tags/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/process-tags.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/runtime_metrics/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/runtime_metrics.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/rate_limiter.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/scope.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/scope.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/span_format.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/span_format.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/span_processor.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/span_processor.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/span_stats.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/span_stats.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/startup-log.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/startup-log.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/tagger.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/tagger.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/tracer.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/tracer.spec.js @DataDog/apm-sdk-capabilities-js
 
 /scripts/generate-config-types.js @DataDog/apm-sdk-capabilities-js
 /scripts/generate-supported-integrations.js @DataDog/apm-sdk-capabilities-js
@@ -346,7 +331,7 @@
 /.github/workflows/all-green.yml @Datadog/lang-platform-js
 /.github/workflows/audit.yml @DataDog/lang-platform-js
 /.github/workflows/custom-node-version-dispatch.yml @Datadog/lang-platform-js
-/.github/workflows/dependabot-automation.yml @DataDog/lang-platform-js
+/.github/workflows/dependabot-automation.yml @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js
 /.github/workflows/flakiness.yml @DataDog/lang-platform-js
 /.github/workflows/platform.yml @DataDog/lang-platform-js
 /.github/workflows/project.yml @Datadog/lang-platform-js
@@ -385,7 +370,7 @@
 /* @DataDog/lang-platform-js
 
 /.github/CODEOWNERS @DataDog/lang-platform-js
-/.github/dependabot.yml @DataDog/lang-platform-js
+/.github/dependabot.yml @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js
 /.github/pull_request_template.md @DataDog/lang-platform-js
 /.github/vendored-dependencies.csv @DataDog/lang-platform-js
 
@@ -404,6 +389,8 @@
 /benchmark/sirun/shimmer-startup/ @DataDog/lang-platform-js
 /benchmark/sirun/startup/ @DataDog/lang-platform-js
 /benchmark/sirun/tracing-channel/ @DataDog/lang-platform-js
+
+/ext/scopes.* @DataDog/lang-platform-js
 
 /integration-tests/bun/ @DataDog/lang-platform-js
 /integration-tests/coverage/ @DataDog/lang-platform-js
@@ -438,11 +425,20 @@
 /packages/dd-trace/src/heap_snapshots.js @DataDog/lang-platform-js
 /packages/dd-trace/src/histogram.js @DataDog/lang-platform-js
 /packages/dd-trace/src/id.js @DataDog/lang-platform-js
+/packages/dd-trace/src/iitm.js @DataDog/lang-platform-js
 /packages/dd-trace/src/index.js @DataDog/lang-platform-js
 /packages/dd-trace/src/pkg.js @DataDog/lang-platform-js
 /packages/dd-trace/src/proxy.js @DataDog/lang-platform-js
+/packages/dd-trace/src/rate_limiter.js @DataDog/lang-platform-js
 /packages/dd-trace/src/require-package-json.js @DataDog/lang-platform-js
+/packages/dd-trace/src/ritm.js @DataDog/lang-platform-js
+/packages/dd-trace/src/scope.js @DataDog/lang-platform-js
+/packages/dd-trace/src/span_format.js @DataDog/lang-platform-js
+/packages/dd-trace/src/span_processor.js @DataDog/lang-platform-js
+/packages/dd-trace/src/span_stats.js @DataDog/lang-platform-js
 /packages/dd-trace/src/spanleak.js @DataDog/lang-platform-js
+/packages/dd-trace/src/tagger.js @DataDog/lang-platform-js
+/packages/dd-trace/src/tracer.js @DataDog/lang-platform-js
 /packages/dd-trace/src/util.js @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
@@ -462,6 +458,7 @@
 /packages/dd-trace/test/log.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/msgpack/ @DataDog/lang-platform-js
 /packages/dd-trace/test/mocha-hooks.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/node_modules/ @DataDog/lang-platform-js
 /packages/dd-trace/test/noop.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/pkg.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/plugin_manager.spec.js @DataDog/lang-platform-js
@@ -471,20 +468,30 @@
 /packages/dd-trace/test/profile.js @DataDog/lang-platform-js
 /packages/dd-trace/test/proxy.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/proxyquire.js @DataDog/lang-platform-js
+/packages/dd-trace/test/rate_limiter.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/register.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/require-package-json.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm-tests/ @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/scope.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/setup/ @DataDog/lang-platform-js
+/packages/dd-trace/test/span_format.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/span_processor.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/span_stats.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/tagger.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/tracer.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/util.spec.js @DataDog/lang-platform-js
 
 # Multiple teams
 /devdocs/ @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
+/docs/ @DataDog/apm-idm-js @DataDog/lang-platform-js
 /docs/API.md @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
 /docs/test.ts @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
 /.gitlab/benchmarks/ @DataDog/lang-platform-js @DataDog/ecosystems-performance
 /eslint-rules/* @DataDog/apm-sdk-capabilities-js @DataDog/lang-platform-js
-/packages/dd-trace/src/iitm.js @DataDog/lang-platform-js @DataDog/apm-idm-js
+/ext/exporters.* @DataDog/apm-idm-js @DataDog/ci-app-libraries @DataDog/lang-platform-js
+/ext/formats.* @DataDog/apm-sdk-capabilities-js @DataDog/data-streams-monitoring
+/ext/index.* @DataDog/apm-idm-js @DataDog/apm-sdk-capabilities-js @DataDog/apm-serverless @DataDog/ci-app-libraries @DataDog/data-streams-monitoring @DataDog/lang-platform-js
+/ext/tags.* @DataDog/apm-idm-js @DataDog/apm-sdk-capabilities-js @DataDog/data-streams-monitoring
+/ext/types.* @DataDog/apm-idm-js @DataDog/apm-serverless
 /packages/dd-trace/src/plugin_manager.js @DataDog/lang-platform-js @DataDog/apm-idm-js
-/packages/dd-trace/src/ritm.js @DataDog/lang-platform-js @DataDog/apm-idm-js
-/packages/dd-trace/test/node_modules/ @DataDog/lang-platform-js @DataDog/apm-idm-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 /packages/dd-trace/src/guardrails/ @DataDog/lang-platform-js
 /packages/dd-trace/src/msgpack/ @DataDog/lang-platform-js
 /packages/dd-trace/src/noop/ @DataDog/lang-platform-js
+/packages/dd-trace/test/encode/ @DataDog/lang-platform-js
 /packages/dd-trace/test/fixtures/esm/ @DataDog/lang-platform-js
 
 # AppSec
@@ -133,7 +134,9 @@
 /packages/dd-trace/src/plugins/ci_plugin.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/ci-visibility/ @DataDog/ci-app-libraries
 /packages/dd-trace/test/encode/agentless-ci-visibility.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/agentless-json.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/encode/coverage-ci-visibility.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/tags-processors.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/git_metadata.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/git_metadata_tagger.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/fixtures/config/git-folder*/ @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
@@ -444,7 +447,6 @@
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/encode/ @DataDog/lang-platform-js
 /packages/dd-trace/test/esm-named-exports.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/exporter.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/exporters/ @DataDog/lang-platform-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /.github/ISSUE_TEMPLATE/ @DataDog/lang-platform-js
 /.gitlab/ @DataDog/lang-platform-js
 /.husky/ @DataDog/lang-platform-js
+/.vscode/ @DataDog/lang-platform-js
 /scripts/ @DataDog/lang-platform-js
 /vendor/ @DataDog/lang-platform-js
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,29 @@
 # TODO: Restructure the project by product and clean up this file.
 
-# Default recursive ownership
+# Shared repository tooling
 /.agents/ @DataDog/lang-platform-js
 /.claude/ @DataDog/lang-platform-js
 /.github/actions/ @DataDog/lang-platform-js
+/.github/ISSUE_TEMPLATE/ @DataDog/lang-platform-js
+/.gitlab/ @DataDog/lang-platform-js
+/.husky/ @DataDog/lang-platform-js
+/.vscode/ @DataDog/lang-platform-js
+/docs/ @DataDog/lang-platform-js
 /scripts/ @DataDog/lang-platform-js
+/vendor/ @DataDog/lang-platform-js
+
+# Shared tracer infrastructure; product-specific rules below take precedence.
+/packages/dd-trace/src/agent/ @DataDog/lang-platform-js
+/packages/dd-trace/src/encode/ @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/agent/ @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/log/ @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/span-stats/ @DataDog/lang-platform-js
+/packages/dd-trace/src/external-logger/ @DataDog/lang-platform-js
+/packages/dd-trace/src/flare/ @DataDog/lang-platform-js
+/packages/dd-trace/src/guardrails/ @DataDog/lang-platform-js
+/packages/dd-trace/src/msgpack/ @DataDog/lang-platform-js
+/packages/dd-trace/src/noop/ @DataDog/lang-platform-js
+/packages/dd-trace/test/fixtures/esm/ @DataDog/lang-platform-js
 
 # AppSec
 /benchmark/sirun/appsec/ @DataDog/asm-js
@@ -15,6 +34,7 @@
 /integration-tests/standalone-asm/ @DataDog/asm-js
 /packages/dd-trace/src/appsec/ @DataDog/asm-js
 /packages/dd-trace/test/appsec/ @DataDog/asm-js
+/packages/dd-trace/test/fixtures/config/appsec-* @DataDog/asm-js
 
 /integration-tests/aiguard/ @DataDog/asm-js
 /packages/dd-trace/src/aiguard/ @DataDog/asm-js
@@ -39,6 +59,8 @@
 
 # Serverless
 /packages/dd-trace/src/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/src/azure_metadata.js @DataDog/apm-serverless
+/packages/dd-trace/src/serverless.js @DataDog/apm-serverless
 /packages/dd-trace/test/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/azure_metadata.spec.js @DataDog/apm-serverless
 /packages/dd-trace/test/serverless.spec.js @DataDog/apm-serverless
@@ -83,6 +105,8 @@
 /packages/dd-trace/index.electron.js @DataDog/apm-idm-js
 /packages/dd-trace/src/exporters/electron/ @DataDog/apm-idm-js
 /packages/dd-trace/src/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/src/payload-tagging/ @DataDog/apm-idm-js
+/packages/dd-trace/src/propagation-hash/ @DataDog/apm-idm-js
 /packages/dd-trace/test/plugins/ @DataDog/apm-idm-js
 /packages/dd-trace/src/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/service-naming/ @DataDog/apm-idm-js
@@ -90,6 +114,7 @@
 /packages/dd-trace/test/payload-tagging/ @DataDog/apm-idm-js
 /packages/dd-trace/test/propagation-hash.spec.js @DataDog/apm-idm-js
 /packages/dd-trace/test/tracer_metadata.spec.js @DataDog/apm-idm-js
+/packages/dd-trace/src/tracer_metadata.js @DataDog/apm-idm-js
 
 # Test Optimization
 /ci/ @DataDog/ci-app-libraries
@@ -110,6 +135,8 @@
 /packages/dd-trace/test/encode/coverage-ci-visibility.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/git_metadata.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/git_metadata_tagger.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/fixtures/config/git-folder*/ @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/fixtures/config/git.properties* @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/plugins/util/git.spec.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/plugins/util/ci-env/ @DataDog/ci-app-libraries
 /packages/dd-trace/test/plugins/util/fixtures/jest/ @DataDog/ci-app-libraries
@@ -210,7 +237,7 @@
 /packages/datadog-plugin-anthropic/ @DataDog/ml-observability
 /packages/datadog-plugin-claude-agent-sdk/ @DataDog/ml-observability
 /benchmark/sirun/plugin-claude-agent-sdk/ @DataDog/ml-observability
-/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/ @DataDog/ml-observability
 /packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js @DataDog/ml-observability
 /packages/datadog-plugin-google-cloud-vertexai/ @DataDog/ml-observability
 /packages/datadog-plugin-langchain/ @DataDog/ml-observability
@@ -228,6 +255,7 @@
 
 # API SDK Capabilities
 /eslint-rules/ @DataDog/apm-sdk-capabilities-js
+/ext/ @DataDog/apm-sdk-capabilities-js
 
 /benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/sampling/ @DataDog/apm-sdk-capabilities-js
@@ -262,27 +290,33 @@
 /packages/dd-trace/test/baggage.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/carrier.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/carrier.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/sampler.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/sampler.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/priority_sampler.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/priority_sampler.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/ramdom_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/*sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/*sampler.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/rate_limiter.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/sampling_rule.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/sampling_rule.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/span_sampler.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/analytics_sampler.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/custom-metrics.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/custom-metrics-app.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/fixtures/config/span-sampling-rules.json @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/helpers/config.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/process-tags/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/process-tags.spec.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/runtime_metrics/ @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/runtime_metrics.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/rate_limiter.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/scope.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/scope.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/span_format.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/span_format.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/span_processor.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/span_processor.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/span_stats.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/span_stats.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/span_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/startup-log.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/startup-log.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/tagger.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/tagger.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/tracer.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/tracer.spec.js @DataDog/apm-sdk-capabilities-js
 
 /scripts/generate-config-types.js @DataDog/apm-sdk-capabilities-js
@@ -310,11 +344,19 @@
 /.github/workflows/codeql-analysis.yml @DataDog/sdlc-security
 /.github/workflows/mirror-image.yml @Datadog/lang-platform-js
 /.github/workflows/all-green.yml @Datadog/lang-platform-js
+/.github/workflows/audit.yml @DataDog/lang-platform-js
 /.github/workflows/custom-node-version-dispatch.yml @Datadog/lang-platform-js
+/.github/workflows/dependabot-automation.yml @DataDog/lang-platform-js
+/.github/workflows/flakiness.yml @DataDog/lang-platform-js
+/.github/workflows/platform.yml @DataDog/lang-platform-js
 /.github/workflows/project.yml @Datadog/lang-platform-js
+/.github/workflows/release-proposal.yml @DataDog/lang-platform-js
+/.github/workflows/release-validate.yml @DataDog/lang-platform-js
 /.github/workflows/stale.yml @Datadog/lang-platform-js
+/.github/workflows/update-3rdparty-licenses.yml @DataDog/lang-platform-js
 
 /.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
+/.github/workflows/eslint-rules.yml @DataDog/apm-sdk-capabilities-js
 /.github/workflows/apm-integrations.yml @DataDog/apm-idm-js
 /.github/workflows/aiguard.yml @DataDog/asm-js
 /.github/workflows/appsec.yml @DataDog/asm-js
@@ -336,10 +378,16 @@
 /integration-tests/profiler/ @DataDog/profiling-js
 
 /packages/dd-trace/*/profiling/ @DataDog/profiling-js
+/packages/dd-trace/src/profiler.js @DataDog/profiling-js
 /packages/dd-trace/test/exporters/common/form-data.spec.js @DataDog/profiling-js
 
 # Language Platform
 /* @DataDog/lang-platform-js
+
+/.github/CODEOWNERS @DataDog/lang-platform-js
+/.github/dependabot.yml @DataDog/lang-platform-js
+/.github/pull_request_template.md @DataDog/lang-platform-js
+/.github/vendored-dependencies.csv @DataDog/lang-platform-js
 
 /benchmark/* @DataDog/lang-platform-js
 /benchmark/sirun/* @DataDog/lang-platform-js
@@ -379,12 +427,23 @@
 /packages/datadog-core/ @DataDog/lang-platform-js
 /packages/datadog-shimmer/ @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking/ @DataDog/lang-platform-js
+/packages/dd-trace/index.js @DataDog/lang-platform-js
 /packages/dd-trace/src/bootstrap.js @DataDog/lang-platform-js
+/packages/dd-trace/src/constants.js @DataDog/lang-platform-js
+/packages/dd-trace/src/dogstatsd.js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporter.js @DataDog/lang-platform-js
 /packages/dd-trace/src/feature-registry.js @DataDog/lang-platform-js
 /packages/dd-trace/src/exporters/common/ @DataDog/lang-platform-js
 /packages/dd-trace/src/exporters/common/client-library-headers.js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
-/packages/dd-trace/src/guardrails/ @DataDog/lang-platform-js
+/packages/dd-trace/src/heap_snapshots.js @DataDog/lang-platform-js
+/packages/dd-trace/src/histogram.js @DataDog/lang-platform-js
+/packages/dd-trace/src/id.js @DataDog/lang-platform-js
+/packages/dd-trace/src/index.js @DataDog/lang-platform-js
+/packages/dd-trace/src/pkg.js @DataDog/lang-platform-js
 /packages/dd-trace/src/proxy.js @DataDog/lang-platform-js
+/packages/dd-trace/src/require-package-json.js @DataDog/lang-platform-js
+/packages/dd-trace/src/spanleak.js @DataDog/lang-platform-js
+/packages/dd-trace/src/util.js @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js
@@ -408,7 +467,10 @@
 /packages/dd-trace/test/plugin_manager.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/plugins/plugin.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/plugins/util/env.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/pkg-loader.js @DataDog/lang-platform-js
+/packages/dd-trace/test/profile.js @DataDog/lang-platform-js
 /packages/dd-trace/test/proxy.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/proxyquire.js @DataDog/lang-platform-js
 /packages/dd-trace/test/register.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/require-package-json.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm-tests/ @DataDog/lang-platform-js
@@ -417,5 +479,12 @@
 /packages/dd-trace/test/util.spec.js @DataDog/lang-platform-js
 
 # Multiple teams
+/devdocs/ @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
+/docs/API.md @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
+/docs/test.ts @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
 /.gitlab/benchmarks/ @DataDog/lang-platform-js @DataDog/ecosystems-performance
 /eslint-rules/* @DataDog/apm-sdk-capabilities-js @DataDog/lang-platform-js
+/packages/dd-trace/src/iitm.js @DataDog/lang-platform-js @DataDog/apm-idm-js
+/packages/dd-trace/src/plugin_manager.js @DataDog/lang-platform-js @DataDog/apm-idm-js
+/packages/dd-trace/src/ritm.js @DataDog/lang-platform-js @DataDog/apm-idm-js
+/packages/dd-trace/test/node_modules/ @DataDog/lang-platform-js @DataDog/apm-idm-js


### PR DESCRIPTION
## Summary

Add product-team owners for 146 existing gaps. Use directory and wildcard rules where ownership is unambiguous. Mixed roots and `.cursor`/`.gemini` remain without fallback ownership.

I am not always going to be correct here, while I believe it is a good `work in progress` improvement.

## Why

New files in established single-team folders should inherit owners without assigning unrelated paths to Language Platform.

## Test plan

- `npm run lint`
- Full CODEOWNERS audit reports only six `.cursor`/`.gemini` paths
