### PR TITLE
feat(types): expose plugin name and options types

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks'
 import ddTrace, { tracer, Tracer, TracerOptions, Span, SpanContext, SpanOptions, Scope, User } from '..';
-import type { plugins } from '..';
+import type { PluginName, PluginOptions, plugins } from '..';
 import { opentelemetry } from '..';
 import { formats, kinds, priority, tags, types } from '../ext';
 import { BINARY, HTTP_HEADERS, LOG, TEXT_MAP } from '../ext/formats';
@@ -420,6 +420,14 @@ tracer.use('undici');
 tracer.use('vitest');
 tracer.use('vitest', { service: 'vitest-service' });
 tracer.use('winston');
+
+type PluginUse = <P extends PluginName>(plugin: P, config?: PluginOptions[P] | boolean) => Tracer
+const usePlugin: PluginUse = tracer.use.bind(tracer)
+usePlugin('express', { service: 'name' })
+// @ts-expect-error Only built-in plugin names are supported.
+usePlugin('unknown-plugin')
+// @ts-expect-error Redis options must not be accepted by the express plugin.
+usePlugin('express', { splitByInstance: true })
 
 tracer.use('express', false)
 tracer.use('express', { enabled: false })

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ interface Tracer extends opentracing.Tracer {
    * @param plugin The name of a built-in plugin.
    * @param config Configuration options. Can also be `false` to disable the plugin.
    */
-  use<P extends keyof Plugins> (plugin: P, config?: Plugins[P] | boolean): this;
+  use<P extends tracer.PluginName> (plugin: P, config?: tracer.PluginOptions[P] | boolean): this;
 
   /**
    * Returns a reference to the current scope.
@@ -314,6 +314,9 @@ interface Plugins {
 }
 
 declare namespace tracer {
+  export interface PluginOptions extends Plugins {}
+  export type PluginName = keyof PluginOptions;
+
   export type SpanOptions = Omit<opentracing.SpanOptions, 'childOf'> & {
   /**
    * Set childOf to 'null' to create a root span without a parent, even when a parent span

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -71,7 +71,7 @@ interface Tracer extends opentracing.Tracer {
    * @param plugin The name of a built-in plugin.
    * @param config Configuration options. Can also be `false` to disable the plugin.
    */
-  use<P extends keyof Plugins> (plugin: P, config?: Plugins[P] | boolean): this;
+  use<P extends tracer.PluginName> (plugin: P, config?: tracer.PluginOptions[P] | boolean): this;
 
   /**
    * Returns a reference to the current scope.
@@ -316,6 +316,9 @@ interface Plugins {
 }
 
 declare namespace tracer {
+  export interface PluginOptions extends Plugins {}
+  export type PluginName = keyof PluginOptions;
+
   export type SpanOptions = Omit<opentracing.SpanOptions, 'childOf'> & {
   /**
    * Set childOf to 'null' to create a root span without a parent, even when a parent span


### PR DESCRIPTION
## Summary

Expose `PluginName` and `PluginOptions` so TypeScript wrappers around `tracer.use()` can retain the plugin-to-options relationship. Wrappers with their own return type cannot reuse `Tracer['use']` directly, and extracting its parameters widens the options parameter to an uncorrelated union.

Fixes: https://github.com/DataDog/dd-trace-js/issues/691
