### PR TITLE
test(playwright): stabilize flaky integration tests

### DIFF
--- a/integration-tests/playwright/playwright-atr.spec.js
+++ b/integration-tests/playwright/playwright-atr.spec.js
@@ -267,9 +267,14 @@ versions.forEach((version) => {
         proc.stdout?.on('data', chunk => { testOutput += chunk.toString() })
         proc.stderr?.on('data', chunk => { testOutput += chunk.toString() })
 
-        await once(proc, 'exit')
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(proc, ({ url }) => url.endsWith('/api/v2/citestcycle'), () => {
+            assert.match(testOutput, /detected as new but their names contain dynamic data/)
+          })
 
-        assert.match(testOutput, /detected as new but their names contain dynamic data/)
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+        // Dynamic names differ between discovery and worker processes, so Playwright cannot find these tests.
+        assert.strictEqual(exitCode, 1, testOutput)
       })
     })
   })

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -449,8 +449,22 @@ versions.forEach((version) => {
           early_flake_detection: { enabled: false },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+        // Only run the serial suite. The other test in this fixture intentionally exhausts its retries,
+        // delaying the serial retry until this test's payload collection timeout on slower runners.
+        const proc = run(
+          './node_modules/.bin/playwright test --retries=1 --grep "playwright serial" -c playwright.config.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              PW_BASE_URL: `http://localhost:${webAppPort}`,
+              TEST_DIR: './ci-visibility/playwright-tests-automatic-retry-serial',
+            },
+          }
+        )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(proc, ({ url }) => url === '/api/v2/citestcycle', (payloads) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
@@ -464,23 +478,10 @@ versions.forEach((version) => {
             const passExecution = seriallySkippedTests.find(t => t.meta[TEST_STATUS] === 'pass')
             assert.ok(passExecution, 'Expected a passing execution on the retry cycle')
             assert.strictEqual(passExecution.meta[TEST_FINAL_STATUS], 'pass')
-          }, 30000)
+          })
 
-        // --retries=1 is Playwright's native retry — no dd-trace retry features needed.
-        // dd-trace won't override it since its guard is `if (project.retries === 0)`.
-        const proc = run(
-          './node_modules/.bin/playwright test --retries=1 -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`,
-              TEST_DIR: './ci-visibility/playwright-tests-automatic-retry-serial',
-            },
-          }
-        )
-
-        await Promise.all([once(proc, 'exit'), receiverPromise])
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+        assert.strictEqual(exitCode, 0)
       })
 
       it(

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -181,8 +181,19 @@ versions.forEach((version) => {
           }
         )
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+        const proc = run(
+          './node_modules/.bin/playwright test -c playwright.config.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              PW_BASE_URL: `http://localhost:${webAppPort}`,
+            },
+          }
+        )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(proc, ({ url }) => url === '/api/v2/citestcycle', (payloads) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSession = events.find(event => event.type === 'test_session_end').content
@@ -203,18 +214,9 @@ versions.forEach((version) => {
             assert.strictEqual(retriedTests.length, 0)
           })
 
-        const proc = run(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`,
-            },
-          }
-        )
-
-        await Promise.all([once(proc, 'exit'), receiverPromise])
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+        // The default fixture includes a known failing test.
+        assert.strictEqual(exitCode, 1)
       })
     })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stabilizes three flaky Playwright integration-test scenarios by collecting CI Visibility payloads until the child process exits instead of racing fixed collection timeouts.

It also scopes the serial final-status fixture to the serial suite under test and asserts each fixture's expected child exit code so process failures remain visible.

### Motivation
<!-- What inspired you to submit this pull request? -->

Repeated GitHub Actions failures showed three timing-dependent symptoms:

- final-status assertions ran before the serial retry completed because an unrelated retry-exhausting test delayed it;
- test-management assertions sometimes missed the final `test_session_end` payload;
- the dynamic-name ATR scenario could leave collection and child-process completion out of sync.

Tying payload collection to the child lifecycle removes those races while preserving the existing behavioral assertions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- Node 18.20.8 / Playwright 1.61 final-status spec: 8 passing
- Node 18.20.8 / Playwright 1.61 ATR spec: 5 passing
- latest Playwright test-management spec: 23 passing
- final-status spec repeated three additional times: all passing
- ESLint, `node --check`, and `git diff --check`: passing

