### PR TITLE
test(bullmq): support version 6

### DIFF
--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -13,7 +13,7 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
   category: 'messaging',
 }, (meta) => {
   const { agent } = meta
-  const queueAddErrorMessage = semver.gte(meta.version, '6.0.0')
+  const queueAddErrorMessage = semver.gte(semver.coerce(meta.version), '6.0.0')
     ? 'Constraint error, got value 0 expected range 1-12'
     : 'Validation error, cannot resolve alias "inv"'
 

--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -13,8 +13,9 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
   category: 'messaging',
 }, (meta) => {
   const { agent } = meta
-  const queueAddErrorMessage = semver.gte(semver.coerce(meta.version), '6.0.0')
-    ? 'Constraint error, got value 0 expected range 1-12'
+  const isBullmq6 = semver.gte(semver.coerce(meta.version), '6.0.0')
+  const queueAddErrorMessage = isBullmq6
+    ? "JobId cannot be '0' or start with '0:'"
     : 'Validation error, cannot resolve alias "inv"'
 
   before(async () => {
@@ -57,7 +58,7 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
         },
       })
 
-      await assert.rejects(testSetup.queueAddError(), {
+      await assert.rejects(testSetup.queueAddError(isBullmq6), {
         name: 'Error',
         message: queueAddErrorMessage,
       })

--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -198,7 +198,7 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
 
       try {
         await testSetup.flowProducerAddError()
-      } catch (err) {
+      } catch {
         // Expected error
       }
 

--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const assert = require('node:assert')
+const semver = require('semver')
 const sinon = require('sinon')
 const { createIntegrationTestSuite } = require('../../dd-trace/test/setup/helpers/plugin-test-helpers')
 const { ANY_STRING } = require('../../../integration-tests/helpers')
 const TestSetup = require('./test-setup')
-
-const CIRCULAR_DATA_ERROR = 'Converting circular structure to JSON\n    --> ' +
-  "starting at object with constructor 'Object'\n    --- property 'self' closes the circle"
 
 const testSetup = new TestSetup()
 
@@ -15,6 +13,9 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
   category: 'messaging',
 }, (meta) => {
   const { agent } = meta
+  const queueAddErrorMessage = semver.gte(meta.version, '6.0.0')
+    ? 'Constraint error, got value 0 expected range 1-12'
+    : 'Validation error, cannot resolve alias "inv"'
 
   before(async () => {
     await testSetup.setup(meta.mod)
@@ -50,15 +51,15 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
         meta: {
           'span.kind': 'producer',
           'messaging.system': 'bullmq',
-          'error.type': 'TypeError',
-          'error.message': CIRCULAR_DATA_ERROR,
+          'error.type': 'Error',
+          'error.message': queueAddErrorMessage,
           'error.stack': ANY_STRING,
         },
       })
 
       await assert.rejects(testSetup.queueAddError(), {
-        name: 'TypeError',
-        message: CIRCULAR_DATA_ERROR,
+        name: 'Error',
+        message: queueAddErrorMessage,
       })
 
       return traceAssertion
@@ -188,15 +189,17 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
           'span.kind': 'producer',
           'messaging.system': 'bullmq',
           'error.type': 'TypeError',
-          'error.message': CIRCULAR_DATA_ERROR,
+          'error.message': 'Converting circular structure to JSON\n    --> ' +
+            "starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
           'error.stack': ANY_STRING,
         },
       })
 
-      await assert.rejects(testSetup.flowProducerAddError(), {
-        name: 'TypeError',
-        message: CIRCULAR_DATA_ERROR,
-      })
+      try {
+        await testSetup.flowProducerAddError()
+      } catch (err) {
+        // Expected error
+      }
 
       return traceAssertion
     })

--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -6,6 +6,9 @@ const { createIntegrationTestSuite } = require('../../dd-trace/test/setup/helper
 const { ANY_STRING } = require('../../../integration-tests/helpers')
 const TestSetup = require('./test-setup')
 
+const CIRCULAR_DATA_ERROR = 'Converting circular structure to JSON\n    --> ' +
+  "starting at object with constructor 'Object'\n    --- property 'self' closes the circle"
+
 const testSetup = new TestSetup()
 
 createIntegrationTestSuite('bullmq', 'bullmq', {
@@ -47,17 +50,16 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
         meta: {
           'span.kind': 'producer',
           'messaging.system': 'bullmq',
-          'error.type': 'Error',
-          'error.message': 'Validation error, cannot resolve alias "inv"',
+          'error.type': 'TypeError',
+          'error.message': CIRCULAR_DATA_ERROR,
           'error.stack': ANY_STRING,
         },
       })
 
-      try {
-        await testSetup.queueAddError()
-      } catch (err) {
-        // Expected error
-      }
+      await assert.rejects(testSetup.queueAddError(), {
+        name: 'TypeError',
+        message: CIRCULAR_DATA_ERROR,
+      })
 
       return traceAssertion
     })
@@ -186,17 +188,15 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
           'span.kind': 'producer',
           'messaging.system': 'bullmq',
           'error.type': 'TypeError',
-          'error.message': 'Converting circular structure to JSON\n    --> ' +
-            "starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
+          'error.message': CIRCULAR_DATA_ERROR,
           'error.stack': ANY_STRING,
         },
       })
 
-      try {
-        await testSetup.flowProducerAddError()
-      } catch (err) {
-        // Expected error
-      }
+      await assert.rejects(testSetup.flowProducerAddError(), {
+        name: 'TypeError',
+        message: CIRCULAR_DATA_ERROR,
+      })
 
       return traceAssertion
     })

--- a/packages/datadog-plugin-bullmq/test/index.spec.js
+++ b/packages/datadog-plugin-bullmq/test/index.spec.js
@@ -6,6 +6,9 @@ const { createIntegrationTestSuite } = require('../../dd-trace/test/setup/helper
 const { ANY_STRING } = require('../../../integration-tests/helpers')
 const TestSetup = require('./test-setup')
 
+const CIRCULAR_DATA_ERROR = 'Converting circular structure to JSON\n    --> ' +
+  "starting at object with constructor 'Object'\n    --- property 'self' closes the circle"
+
 const testSetup = new TestSetup()
 
 createIntegrationTestSuite('bullmq', 'bullmq', {
@@ -47,17 +50,16 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
         meta: {
           'span.kind': 'producer',
           'messaging.system': 'bullmq',
-          'error.type': 'Error',
-          'error.message': 'Validation error, cannot resolve alias "inv"',
+          'error.type': 'TypeError',
+          'error.message': CIRCULAR_DATA_ERROR,
           'error.stack': ANY_STRING,
         },
       })
 
-      try {
-        await testSetup.queueAddError()
-      } catch {
-        // Expected error
-      }
+      await assert.rejects(testSetup.queueAddError(), {
+        name: 'TypeError',
+        message: CIRCULAR_DATA_ERROR,
+      })
 
       return traceAssertion
     })
@@ -186,17 +188,15 @@ createIntegrationTestSuite('bullmq', 'bullmq', {
           'span.kind': 'producer',
           'messaging.system': 'bullmq',
           'error.type': 'TypeError',
-          'error.message': 'Converting circular structure to JSON\n    --> ' +
-            "starting at object with constructor 'Object'\n    --- property 'self' closes the circle",
+          'error.message': CIRCULAR_DATA_ERROR,
           'error.stack': ANY_STRING,
         },
       })
 
-      try {
-        await testSetup.flowProducerAddError()
-      } catch {
-        // Expected error
-      }
+      await assert.rejects(testSetup.flowProducerAddError(), {
+        name: 'TypeError',
+        message: CIRCULAR_DATA_ERROR,
+      })
 
       return traceAssertion
     })

--- a/packages/datadog-plugin-bullmq/test/test-setup.js
+++ b/packages/datadog-plugin-bullmq/test/test-setup.js
@@ -1,11 +1,5 @@
 'use strict'
 
-function createCircularData () {
-  const data = { test: true }
-  data.self = data
-  return data
-}
-
 class BullmqTestSetup {
   async setup (module) {
     const connection = {
@@ -51,7 +45,9 @@ class BullmqTestSetup {
   }
 
   async queueAddError () {
-    await this.queue.add('error-job', createCircularData())
+    await this.queue.add('error-job', { data: 'test' }, {
+      repeat: { pattern: 'invalid-cron-pattern' },
+    })
   }
 
   async queueAddBulk () {
@@ -94,10 +90,13 @@ class BullmqTestSetup {
   }
 
   async flowProducerAddError () {
+    // Pass circular reference to trigger JSON serialization error
+    const circularData = { test: true }
+    circularData.self = circularData
     await this.flowProducer.add({
       name: 'invalid-flow',
       queueName: 'test-queue',
-      data: createCircularData(),
+      data: circularData,
     })
   }
 

--- a/packages/datadog-plugin-bullmq/test/test-setup.js
+++ b/packages/datadog-plugin-bullmq/test/test-setup.js
@@ -49,10 +49,10 @@ class BullmqTestSetup {
    * @returns {Promise<void>}
    */
   async queueAddError (isBullmq6) {
-    const opts = isBullmq6
+    const options = isBullmq6
       ? { jobId: '0' }
       : { repeat: { pattern: 'invalid-cron-pattern' } }
-    await this.queue.add('error-job', { data: 'test' }, opts)
+    await this.queue.add('error-job', { data: 'test' }, options)
   }
 
   async queueAddBulk () {

--- a/packages/datadog-plugin-bullmq/test/test-setup.js
+++ b/packages/datadog-plugin-bullmq/test/test-setup.js
@@ -1,5 +1,11 @@
 'use strict'
 
+function createCircularData () {
+  const data = { test: true }
+  data.self = data
+  return data
+}
+
 class BullmqTestSetup {
   async setup (module) {
     const connection = {
@@ -45,9 +51,7 @@ class BullmqTestSetup {
   }
 
   async queueAddError () {
-    await this.queue.add('error-job', { data: 'test' }, {
-      repeat: { pattern: 'invalid-cron-pattern' },
-    })
+    await this.queue.add('error-job', createCircularData())
   }
 
   async queueAddBulk () {
@@ -90,13 +94,10 @@ class BullmqTestSetup {
   }
 
   async flowProducerAddError () {
-    // Pass circular reference to trigger JSON serialization error
-    const circularData = { test: true }
-    circularData.self = circularData
     await this.flowProducer.add({
       name: 'invalid-flow',
       queueName: 'test-queue',
-      data: circularData,
+      data: createCircularData(),
     })
   }
 

--- a/packages/datadog-plugin-bullmq/test/test-setup.js
+++ b/packages/datadog-plugin-bullmq/test/test-setup.js
@@ -44,10 +44,15 @@ class BullmqTestSetup {
     })
   }
 
-  async queueAddError () {
-    await this.queue.add('error-job', { data: 'test' }, {
-      repeat: { pattern: 'invalid-cron-pattern' },
-    })
+  /**
+   * @param {boolean} isBullmq6
+   * @returns {Promise<void>}
+   */
+  async queueAddError (isBullmq6) {
+    const opts = isBullmq6
+      ? { jobId: '0' }
+      : { repeat: { pattern: 'invalid-cron-pattern' } }
+    await this.queue.add('error-job', { data: 'test' }, opts)
   }
 
   async queueAddBulk () {

--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -100,6 +100,10 @@ module.exports = {
   ],
   bullmq: [
     {
+      name: 'ioredis',
+      dep: true,
+    },
+    {
       name: 'redis',
       versions: ['>=4'],
     },

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -111,7 +111,7 @@
     "bluebird": "3.7.2",
     "body-parser": "2.3.0",
     "bson": "7.3.1",
-    "bullmq": "6.0.0",
+    "bullmq": "6.0.6",
     "bunyan": "2.0.5",
     "cassandra-driver": "4.9.0",
     "collections": "5.1.13",

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -111,7 +111,7 @@
     "bluebird": "3.7.2",
     "body-parser": "2.3.0",
     "bson": "7.3.1",
-    "bullmq": "5.81.2",
+    "bullmq": "6.0.0",
     "bunyan": "2.0.5",
     "cassandra-driver": "4.9.0",
     "collections": "5.1.13",

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -110,7 +110,7 @@
     "bluebird": "3.7.2",
     "body-parser": "2.3.0",
     "bson": "7.3.1",
-    "bullmq": "5.81.2",
+    "bullmq": "6.0.0",
     "bunyan": "2.0.5",
     "cassandra-driver": "4.9.0",
     "collections": "5.1.13",


### PR DESCRIPTION
## Summary

Install BullMQ's declared ioredis dependency in generated test workspaces and update the latest tested version to 6.0.0.

## Why

BullMQ 6 moved its default ioredis backend to an optional peer. Without declaring it in the test workspace, integration processes exit during module loading.