### PR TITLE
feat(llmobs): add submit feedback method for submitting end-user feedback

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -680,6 +680,28 @@ llmobs.trace({ kind: 'llm', name: 'myLLM' }, (span) => {
     metricType: 'boolean',
     value: 'true'
   })
+
+  // submit end-user feedback
+  llmobs.submitFeedback({
+    label: 'thumbs_up',
+    metricType: 'boolean',
+    value: true,
+    submitter: { id: 'user-123', type: 'user' },
+    span: llmobsSpanCtx
+  })
+
+  llmobs.submitFeedback({
+    label: 'comment',
+    metricType: 'text',
+    value: 'this answer was helpful',
+    submitter: { id: 'user-123' },
+    feedbackJoinKey: 'my-join-key',
+    mlApp: 'myApp',
+    tags: {},
+    timestampMs: Date.now(),
+    assessment: 'pass',
+    reasoning: 'the user was satisfied'
+  })
 })
 
 // annotate a span

--- a/index.d.ts
+++ b/index.d.ts
@@ -4026,8 +4026,9 @@ declare namespace tracer {
 
       /**
        * An object of string key-value pairs to tag the feedback with.
+       * A `null` or `undefined` value is sent as the string `"null"` or `"undefined"`.
        */
-      tags?: { [key: string]: any },
+      tags?: { [key: string]: string | null | undefined },
 
       /**
        * The name of the ML application

--- a/index.d.ts
+++ b/index.d.ts
@@ -3711,6 +3711,13 @@ declare namespace tracer {
        */
       submitEvaluation (spanContext: llmobs.ExportedLLMObsSpan, options: llmobs.EvaluationOptions): void
 
+      /**
+       * Submits end-user feedback for a span, trace, session, or customer-defined entity.
+       * Exactly one target must be provided in the options.
+       * @param options An object containing the label, metric type, value, submitter and target of the feedback.
+       */
+      submitFeedback (options: llmobs.FeedbackOptions): void
+
 
       /**
        * Annotates all spans, including auto-instrumented spans, with the provided tags created in the context of the callback function.
@@ -3955,6 +3962,92 @@ declare namespace tracer {
        * Arbitrary JSON data associated with the evaluation.
        */
       metadata?: { [key: string]: any }
+    }
+
+    interface FeedbackSubmitter {
+      /**
+       * The identifier of the end user who submitted the feedback.
+       */
+      id: string,
+
+      /**
+       * The type of submitter, e.g. 'user'.
+       */
+      type?: string
+    }
+
+    interface FeedbackOptions {
+      /**
+       * The name of the feedback metric
+       */
+      label: string,
+
+      /**
+       * The type of feedback metric, one of 'categorical', 'score', 'boolean', 'json' or 'text'
+       */
+      metricType: 'categorical' | 'score' | 'boolean' | 'json' | 'text',
+
+      /**
+       * The value of the feedback metric.
+       * Must be string for 'categorical' and 'text' metrics, number for 'score' metrics, boolean for 'boolean' metrics and a JSON object for 'json' metrics.
+       */
+      value: string | number | boolean | { [key: string]: any },
+
+      /**
+       * Who submitted the feedback.
+       */
+      submitter: llmobs.FeedbackSubmitter,
+
+      /**
+       * The span context of the span to attach the feedback to, as returned by `llmobs.exportSpan()`.
+       * Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` must be provided.
+       */
+      span?: llmobs.ExportedLLMObsSpan,
+
+      /**
+       * The ID of the span to attach the feedback to.
+       */
+      spanId?: string,
+
+      /**
+       * The ID of the trace to attach the feedback to.
+       */
+      traceId?: string,
+
+      /**
+       * The ID of the session to attach the feedback to.
+       */
+      sessionId?: string,
+
+      /**
+       * A customer-defined key to attach the feedback to.
+       */
+      feedbackJoinKey?: string,
+
+      /**
+       * An object of string key-value pairs to tag the feedback with.
+       */
+      tags?: { [key: string]: any },
+
+      /**
+       * The name of the ML application
+       */
+      mlApp?: string,
+
+      /**
+       * The timestamp in milliseconds when the feedback was generated.
+       */
+      timestampMs?: number,
+
+      /**
+       * Reasoning for the feedback.
+       */
+      reasoning?: string,
+
+      /**
+       * Whether the feedback passed or failed. Valid values are pass and fail.
+       */
+      assessment?: 'pass' | 'fail'
     }
 
     interface Document {

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -3908,6 +3908,13 @@ declare namespace tracer {
        */
       submitEvaluation (spanContext: llmobs.ExportedLLMObsSpan, options: llmobs.EvaluationOptions): void
 
+      /**
+       * Submits end-user feedback for a span, trace, session, or customer-defined entity.
+       * Exactly one target must be provided in the options.
+       * @param options An object containing the label, metric type, value, submitter and target of the feedback.
+       */
+      submitFeedback (options: llmobs.FeedbackOptions): void
+
 
       /**
        * Annotates all spans, including auto-instrumented spans, with the provided tags created in the context of the callback function.
@@ -4152,6 +4159,92 @@ declare namespace tracer {
        * Arbitrary JSON data associated with the evaluation.
        */
       metadata?: { [key: string]: any }
+    }
+
+    interface FeedbackSubmitter {
+      /**
+       * The identifier of the end user who submitted the feedback.
+       */
+      id: string,
+
+      /**
+       * The type of submitter, e.g. 'user'.
+       */
+      type?: string
+    }
+
+    interface FeedbackOptions {
+      /**
+       * The name of the feedback metric
+       */
+      label: string,
+
+      /**
+       * The type of feedback metric, one of 'categorical', 'score', 'boolean', 'json' or 'text'
+       */
+      metricType: 'categorical' | 'score' | 'boolean' | 'json' | 'text',
+
+      /**
+       * The value of the feedback metric.
+       * Must be string for 'categorical' and 'text' metrics, number for 'score' metrics, boolean for 'boolean' metrics and a JSON object for 'json' metrics.
+       */
+      value: string | number | boolean | { [key: string]: any },
+
+      /**
+       * Who submitted the feedback.
+       */
+      submitter: llmobs.FeedbackSubmitter,
+
+      /**
+       * The span context of the span to attach the feedback to, as returned by `llmobs.exportSpan()`.
+       * Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` must be provided.
+       */
+      span?: llmobs.ExportedLLMObsSpan,
+
+      /**
+       * The ID of the span to attach the feedback to.
+       */
+      spanId?: string,
+
+      /**
+       * The ID of the trace to attach the feedback to.
+       */
+      traceId?: string,
+
+      /**
+       * The ID of the session to attach the feedback to.
+       */
+      sessionId?: string,
+
+      /**
+       * A customer-defined key to attach the feedback to.
+       */
+      feedbackJoinKey?: string,
+
+      /**
+       * An object of string key-value pairs to tag the feedback with.
+       */
+      tags?: { [key: string]: any },
+
+      /**
+       * The name of the ML application
+       */
+      mlApp?: string,
+
+      /**
+       * The timestamp in milliseconds when the feedback was generated.
+       */
+      timestampMs?: number,
+
+      /**
+       * Reasoning for the feedback.
+       */
+      reasoning?: string,
+
+      /**
+       * Whether the feedback passed or failed. Valid values are pass and fail.
+       */
+      assessment?: 'pass' | 'fail'
     }
 
     interface Document {

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -4223,8 +4223,9 @@ declare namespace tracer {
 
       /**
        * An object of string key-value pairs to tag the feedback with.
+       * A `null` or `undefined` value is sent as the string `"null"` or `"undefined"`.
        */
-      tags?: { [key: string]: any },
+      tags?: { [key: string]: string | null | undefined },
 
       /**
        * The name of the ML application

--- a/packages/dd-trace/src/llmobs/eval-metric.js
+++ b/packages/dd-trace/src/llmobs/eval-metric.js
@@ -88,6 +88,14 @@ function taggedError (errorTag, message) {
 }
 
 /**
+ * @param {MetricEventKind} kind
+ * @returns {Error} the tagged error, to be thrown by the caller.
+ */
+function invalidTagsError (kind) {
+  return taggedError('invalid_tags', `Failed to parse tags. Tags for ${TERMS[kind].metrics} must be strings`)
+}
+
+/**
  * @param {unknown} timestampMs
  * @param {MetricEventKind} kind
  * @returns {void}
@@ -102,20 +110,23 @@ function validateTimestamp (timestampMs, kind) {
 }
 
 /**
- * @param {string | undefined} label
+ * Validates the label and returns it coerced to the string the intake expects.
+ * @param {unknown} label
  * @param {MetricEventKind} kind
- * @returns {void}
+ * @returns {string} the label, as sent on the wire.
  */
 function validateLabel (label, kind) {
   if (!label) {
     throw taggedError('invalid_metric_label', `label must be the specified name of the ${TERMS[kind].metric}`)
   }
 
-  // A dot makes the label unusable as a facet key on the feedback side. `submitEvaluation` has
-  // always accepted dotted labels, so the check stays scoped to feedback to avoid a breaking change.
-  if (kind === 'feedback' && typeof label === 'string' && label.includes('.')) {
+  // A dot makes the label unusable as a facet key, for both kinds.
+  const labelValue = String(label)
+  if (labelValue.includes('.')) {
     throw taggedError('invalid_label_value', 'label value must not contain a "."')
   }
+
+  return labelValue
 }
 
 /**
@@ -182,25 +193,28 @@ function validateReasoning (reasoning) {
  * @returns {string[]} the serialized tag list.
  */
 function buildMetricTags (tags, mlApp, kind, otelEnabled = false) {
+  // An array or a string would otherwise be walked by index and produce tags named after
+  // their offsets, which the intake would happily store.
+  if (tags != null && (typeof tags !== 'object' || Array.isArray(tags))) {
+    throw invalidTagsError(kind)
+  }
+
   const metricTags = {
     'ddtrace.version': tracerVersion,
     ml_app: mlApp,
   }
 
   if (tags) {
-    for (const key in tags) {
+    for (const key of Object.keys(tags)) {
       const tag = tags[key]
       if (typeof tag === 'string') {
         metricTags[key] = tag
-      } else if (typeof tag.toString === 'function') {
-        metricTags[key] = tag.toString()
-      } else if (tag == null) {
-        metricTags[key] = Object.prototype.toString.call(tag)
+      } else if (tag == null || typeof tag.toString !== 'function') {
+        // Nullish values have no meaningful string form, and every other value in JS carries a
+        // `toString` — either its own or the one inherited from `Object.prototype`.
+        throw invalidTagsError(kind)
       } else {
-        // should be a rare case
-        // every object in JS has a toString, otherwise every primitive has its own toString
-        // null and undefined are handled above
-        throw taggedError('invalid_tags', `Failed to parse tags. Tags for ${TERMS[kind].metrics} must be strings`)
+        metricTags[key] = tag.toString()
       }
     }
   }

--- a/packages/dd-trace/src/llmobs/eval-metric.js
+++ b/packages/dd-trace/src/llmobs/eval-metric.js
@@ -10,8 +10,9 @@ const tracerVersion = require('../../../../package.json').version
  */
 
 /**
- * Tag value the intake accepts: a string, or anything the SDK can coerce through `toString()`.
- * @typedef {string | { toString?: unknown }} MetricTagValue
+ * Tag value the intake accepts: a string, a nullish value, or anything the SDK can coerce
+ * through `toString()`.
+ * @typedef {string | null | undefined | { toString?: unknown }} MetricTagValue
  */
 
 /** @type {string[]} */
@@ -110,17 +111,21 @@ function validateTimestamp (timestampMs, kind) {
 }
 
 /**
- * Validates the label and returns it coerced to the string the intake expects.
+ * Validates the label and returns it as sent on the wire.
  * @param {unknown} label
  * @param {MetricEventKind} kind
- * @returns {string} the label, as sent on the wire.
+ * @returns {unknown} the label, coerced to a string for feedback and left untouched for evaluations.
  */
 function validateLabel (label, kind) {
   if (!label) {
     throw taggedError('invalid_metric_label', `label must be the specified name of the ${TERMS[kind].metric}`)
   }
 
-  // A dot makes the label unusable as a facet key, for both kinds.
+  // Evaluations keep the looser check they shipped with: a dotted or non-string label reaches the
+  // intake as-is. Aligning them with feedback rejects calls that succeed today, so it is deferred.
+  if (kind === 'evaluation') return label
+
+  // A dot makes the label unusable as a facet key.
   const labelValue = String(label)
   if (labelValue.includes('.')) {
     throw taggedError('invalid_label_value', 'label value must not contain a "."')
@@ -209,12 +214,16 @@ function buildMetricTags (tags, mlApp, kind, otelEnabled = false) {
       const tag = tags[key]
       if (typeof tag === 'string') {
         metricTags[key] = tag
-      } else if (tag == null || typeof tag.toString !== 'function') {
-        // Nullish values have no meaningful string form, and every other value in JS carries a
-        // `toString` — either its own or the one inherited from `Object.prototype`.
-        throw invalidTagsError(kind)
-      } else {
+      } else if (tag == null) {
+        // A nullish value can be intentional, so it is serialized rather than rejected. Checked
+        // before the `toString` lookup below, which would throw a raw TypeError on it.
+        metricTags[key] = String(tag)
+      } else if (typeof tag.toString === 'function') {
         metricTags[key] = tag.toString()
+      } else {
+        // Every other value carries a `toString`, either its own or the one inherited from
+        // `Object.prototype`, so this is only reached for a null-prototype object.
+        throw invalidTagsError(kind)
       }
     }
   }

--- a/packages/dd-trace/src/llmobs/eval-metric.js
+++ b/packages/dd-trace/src/llmobs/eval-metric.js
@@ -1,0 +1,226 @@
+'use strict'
+
+const tracerVersion = require('../../../../package.json').version
+
+/**
+ * Kind of event submitted through the evaluation metrics intake. Both kinds share the
+ * writer, the endpoint and most of their validation, and are told apart on the wire by
+ * the `event_kind` field.
+ * @typedef {'evaluation' | 'feedback'} MetricEventKind
+ */
+
+/**
+ * Tag value the intake accepts: a string, or anything the SDK can coerce through `toString()`.
+ * @typedef {string | { toString?: unknown }} MetricTagValue
+ */
+
+/** @type {string[]} */
+const EVALUATION_METRIC_TYPES = ['categorical', 'score', 'boolean', 'json']
+
+/**
+ * End-user feedback additionally accepts free-form text values.
+ * @type {string[]}
+ */
+const FEEDBACK_METRIC_TYPES = [...EVALUATION_METRIC_TYPES, 'text']
+
+/** @type {Record<MetricEventKind, string[]>} */
+const METRIC_TYPES = {
+  evaluation: EVALUATION_METRIC_TYPES,
+  feedback: FEEDBACK_METRIC_TYPES,
+}
+
+/**
+ * Feedback target option accepted by the SDK, mapped to the payload key it is sent as. `span` and
+ * `spanId` are two ways of naming the same target.
+ * @type {Record<string, string>}
+ */
+const FEEDBACK_TARGET_KEYS = {
+  span: 'span_id',
+  spanId: 'span_id',
+  traceId: 'trace_id',
+  sessionId: 'session_id',
+  feedbackJoinKey: 'feedback_join_key',
+}
+
+// The validation is shared but the user-facing wording is per-kind. Keeping the terms in one
+// table avoids threading three near-identical strings through every validator.
+/** @type {Record<MetricEventKind, { metric: string, metrics: string, data: string }>} */
+const TERMS = {
+  evaluation: {
+    metric: 'evaluation metric',
+    metrics: 'evaluation metrics',
+    data: 'Evaluation metric data',
+  },
+  feedback: {
+    metric: 'feedback metric',
+    metrics: 'feedback metrics',
+    data: 'Feedback data',
+  },
+}
+
+/**
+ * @param {string[]} metricTypes
+ * @returns {string} the quoted list, e.g. `"categorical", "score" or "json"`
+ */
+function formatMetricTypes (metricTypes) {
+  const quoted = metricTypes.map(metricType => `"${metricType}"`)
+  return `${quoted.slice(0, -1).join(', ')} or ${quoted.at(-1)}`
+}
+
+// Built once at load time: only ever used to build an error message.
+/** @type {Record<MetricEventKind, string>} */
+const METRIC_TYPES_MESSAGE = {
+  evaluation: formatMetricTypes(EVALUATION_METRIC_TYPES),
+  feedback: formatMetricTypes(FEEDBACK_METRIC_TYPES),
+}
+
+/**
+ * Builds an error carrying the telemetry error tag the SDK reports for the failed submission.
+ * @param {string} errorTag - Telemetry `error_type` tag value.
+ * @param {string} message - User-facing message.
+ * @returns {Error} the tagged error, to be thrown by the caller.
+ */
+function taggedError (errorTag, message) {
+  const error = new Error(message)
+  // Same shape as the tagger's failures, which the SDK already reads back as `e.ddErrorTag`.
+  Object.defineProperty(error, 'ddErrorTag', { get () { return errorTag } })
+  return error
+}
+
+/**
+ * @param {unknown} timestampMs
+ * @param {MetricEventKind} kind
+ * @returns {void}
+ */
+function validateTimestamp (timestampMs, kind) {
+  if (typeof timestampMs !== 'number' || timestampMs < 0) {
+    throw taggedError(
+      'invalid_timestamp',
+      `timestampMs must be a non-negative integer. ${TERMS[kind].data} will not be sent`
+    )
+  }
+}
+
+/**
+ * @param {string | undefined} label
+ * @param {MetricEventKind} kind
+ * @returns {void}
+ */
+function validateLabel (label, kind) {
+  if (!label) {
+    throw taggedError('invalid_metric_label', `label must be the specified name of the ${TERMS[kind].metric}`)
+  }
+
+  // A dot makes the label unusable as a facet key on the feedback side. `submitEvaluation` has
+  // always accepted dotted labels, so the check stays scoped to feedback to avoid a breaking change.
+  if (kind === 'feedback' && typeof label === 'string' && label.includes('.')) {
+    throw taggedError('invalid_label_value', 'label value must not contain a "."')
+  }
+}
+
+/**
+ * @param {string | undefined} metricType - Already lower-cased metric type.
+ * @param {MetricEventKind} kind
+ * @returns {void}
+ */
+function validateMetricType (metricType, kind) {
+  if (!metricType || !METRIC_TYPES[kind].includes(metricType)) {
+    throw taggedError('invalid_metric_type', `metricType must be one of ${METRIC_TYPES_MESSAGE[kind]}`)
+  }
+}
+
+/**
+ * @param {string | undefined} metricType - Metric type already validated for the submitted kind.
+ * @param {unknown} value
+ * @returns {void}
+ */
+function validateMetricValue (metricType, value) {
+  if (metricType === 'categorical' && typeof value !== 'string') {
+    throw taggedError('invalid_metric_value', 'value must be a string for a categorical metric.')
+  }
+  if (metricType === 'score' && typeof value !== 'number') {
+    throw taggedError('invalid_metric_value', 'value must be a number for a score metric.')
+  }
+  if (metricType === 'boolean' && typeof value !== 'boolean') {
+    throw taggedError('invalid_metric_value', 'value must be a boolean for a boolean metric')
+  }
+  if (metricType === 'json' && (typeof value !== 'object' || value == null || Array.isArray(value))) {
+    throw taggedError('invalid_metric_value', 'value must be a JSON object for a json metric')
+  }
+  if (metricType === 'text' && typeof value !== 'string') {
+    throw taggedError('invalid_metric_value', 'value must be a string for a text metric')
+  }
+}
+
+/**
+ * @param {unknown} assessment
+ * @returns {void}
+ */
+function validateAssessment (assessment) {
+  if (assessment != null && assessment !== 'pass' && assessment !== 'fail') {
+    throw taggedError('invalid_assessment', 'assessment must be pass or fail')
+  }
+}
+
+/**
+ * @param {unknown} reasoning
+ * @returns {void}
+ */
+function validateReasoning (reasoning) {
+  if (reasoning != null && typeof reasoning !== 'string') {
+    throw taggedError('invalid_reasoning', 'reasoning must be a string')
+  }
+}
+
+/**
+ * Serializes the user-provided tags into the `key:value` list expected by the intake, along
+ * with the tags every submission carries.
+ * @param {Record<string, MetricTagValue> | undefined} tags - User-provided tags, coerced when not strings.
+ * @param {string} mlApp - Resolved ML app name.
+ * @param {MetricEventKind} kind
+ * @param {boolean} [otelEnabled] - Adds `source:otel` so the backend waits for OTel span conversion.
+ * @returns {string[]} the serialized tag list.
+ */
+function buildMetricTags (tags, mlApp, kind, otelEnabled = false) {
+  const metricTags = {
+    'ddtrace.version': tracerVersion,
+    ml_app: mlApp,
+  }
+
+  if (tags) {
+    for (const key in tags) {
+      const tag = tags[key]
+      if (typeof tag === 'string') {
+        metricTags[key] = tag
+      } else if (typeof tag.toString === 'function') {
+        metricTags[key] = tag.toString()
+      } else if (tag == null) {
+        metricTags[key] = Object.prototype.toString.call(tag)
+      } else {
+        // should be a rare case
+        // every object in JS has a toString, otherwise every primitive has its own toString
+        // null and undefined are handled above
+        throw taggedError('invalid_tags', `Failed to parse tags. Tags for ${TERMS[kind].metrics} must be strings`)
+      }
+    }
+  }
+
+  if (otelEnabled) {
+    metricTags.source = 'otel'
+  }
+
+  return Object.entries(metricTags).map(([key, value]) => `${key}:${value}`)
+}
+
+module.exports = {
+  EVALUATION_METRIC_TYPES,
+  FEEDBACK_METRIC_TYPES,
+  FEEDBACK_TARGET_KEYS,
+  buildMetricTags,
+  validateAssessment,
+  validateLabel,
+  validateMetricType,
+  validateMetricValue,
+  validateReasoning,
+  validateTimestamp,
+}

--- a/packages/dd-trace/src/llmobs/noop.js
+++ b/packages/dd-trace/src/llmobs/noop.js
@@ -80,6 +80,8 @@ class NoopLLMObs {
 
   submitEvaluation (llmobsSpanContext, options) {}
 
+  submitFeedback (options) {}
+
   flush () {}
 
   registerProcessor (processor) {}

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -405,7 +405,7 @@ class LLMObs extends NoopLLMObs {
 
       const { label, value, tags, reasoning, assessment, metadata } = options
       const metricType = options.metricType?.toLowerCase()
-      validateLabel(label, 'evaluation')
+      const labelValue = validateLabel(label, 'evaluation')
       validateMetricType(metricType, 'evaluation')
       validateMetricValue(metricType, value)
       validateAssessment(assessment)
@@ -423,7 +423,7 @@ class LLMObs extends NoopLLMObs {
             trace_id: traceId,
           },
         },
-        label,
+        label: labelValue,
         metric_type: metricType,
         ml_app: mlApp,
         [`${metricType}_value`]: value,
@@ -538,7 +538,7 @@ class LLMObs extends NoopLLMObs {
 
       const { label, value, tags, reasoning, assessment } = options
       const metricType = options.metricType?.toLowerCase()
-      validateLabel(label, 'feedback')
+      const labelValue = validateLabel(label, 'feedback')
       validateMetricType(metricType, 'feedback')
       validateMetricValue(metricType, value)
       validateAssessment(assessment)
@@ -547,7 +547,7 @@ class LLMObs extends NoopLLMObs {
       const payload = {
         event_kind: 'feedback',
         [targetType]: targetValue,
-        label,
+        label: labelValue,
         metric_type: metricType,
         ml_app: mlApp,
         [`${metricType}_value`]: value,

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -13,6 +13,7 @@ const {
   TRACE_ID,
 } = require('./constants/tags')
 const {
+  FEEDBACK_METRIC_TYPES,
   FEEDBACK_TARGET_KEYS,
   buildMetricTags,
   validateAssessment,
@@ -481,19 +482,27 @@ class LLMObs extends NoopLLMObs {
 
     let err = ''
     let targetType = 'other'
+    let metricTypeTag = 'other'
     try {
       const { span, spanId, traceId, sessionId, feedbackJoinKey, submitter } = options
 
-      // The intake keys feedback off a single top-level identifier, so more than one target
-      // would be ambiguous and none would leave the feedback unattached.
-      const providedTargets = []
-      if (span != null) providedTargets.push('span')
-      if (spanId != null) providedTargets.push('spanId')
-      if (traceId != null) providedTargets.push('traceId')
-      if (sessionId != null) providedTargets.push('sessionId')
-      if (feedbackJoinKey != null) providedTargets.push('feedbackJoinKey')
+      // Resolved before any validation so telemetry still reports the metric type of a
+      // submission that fails on an unrelated field.
+      const metricType = options.metricType?.toLowerCase()
+      if (FEEDBACK_METRIC_TYPES.includes(metricType)) metricTypeTag = metricType
 
-      if (providedTargets.length !== 1) {
+      // The intake keys feedback off a single top-level identifier, so more than one target
+      // would be ambiguous and none would leave the feedback unattached. `span` also carries a
+      // traceId, but passing it is wire-equivalent to passing its `spanId` directly.
+      let targetName, targetValue
+      let targetCount = 0
+      if (span != null) { targetName = 'span'; targetValue = span.spanId; targetCount++ }
+      if (spanId != null) { targetName = 'spanId'; targetValue = spanId; targetCount++ }
+      if (traceId != null) { targetName = 'traceId'; targetValue = traceId; targetCount++ }
+      if (sessionId != null) { targetName = 'sessionId'; targetValue = sessionId; targetCount++ }
+      if (feedbackJoinKey != null) { targetName = 'feedbackJoinKey'; targetValue = feedbackJoinKey; targetCount++ }
+
+      if (targetCount !== 1) {
         err = 'invalid_target_count'
         throw new Error(
           'Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` ' +
@@ -501,11 +510,7 @@ class LLMObs extends NoopLLMObs {
         )
       }
 
-      const targetName = providedTargets[0]
       targetType = FEEDBACK_TARGET_KEYS[targetName]
-      // `span` also carries a traceId, but feedback targets a single identifier: passing
-      // `span` is wire-equivalent to passing its `spanId` directly.
-      const targetValue = targetName === 'span' ? span?.spanId : options[targetName]
       if (typeof targetValue !== 'string' || !targetValue) {
         if (targetName === 'span') {
           err = 'invalid_span'
@@ -537,7 +542,6 @@ class LLMObs extends NoopLLMObs {
       validateTimestamp(timestampMs, 'feedback')
 
       const { label, value, tags, reasoning, assessment } = options
-      const metricType = options.metricType?.toLowerCase()
       const labelValue = validateLabel(label, 'feedback')
       validateMetricType(metricType, 'feedback')
       validateMetricValue(metricType, value)
@@ -569,7 +573,7 @@ class LLMObs extends NoopLLMObs {
       if (e.ddErrorTag) err = e.ddErrorTag
       throw e
     } finally {
-      telemetry.recordSubmitFeedback(options, targetType, err)
+      telemetry.recordSubmitFeedback(metricTypeTag, targetType, err)
     }
   }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -3,7 +3,6 @@
 const { channel } = require('dc-polyfill')
 
 const { isError } = require('../util')
-const tracerVersion = require('../../../../package.json').version
 const logger = require('../log')
 const { getValueFromEnvSources } = require('../config/helper')
 const Span = require('../opentracing/span')
@@ -13,6 +12,16 @@ const {
   INPUT_VALUE,
   TRACE_ID,
 } = require('./constants/tags')
+const {
+  FEEDBACK_TARGET_KEYS,
+  buildMetricTags,
+  validateAssessment,
+  validateLabel,
+  validateMetricType,
+  validateMetricValue,
+  validateReasoning,
+  validateTimestamp,
+} = require('./eval-metric')
 const {
   getFunctionArguments,
   validateKind,
@@ -392,80 +401,22 @@ class LLMObs extends NoopLLMObs {
       }
 
       const timestampMs = options.timestampMs || Date.now()
-      if (typeof timestampMs !== 'number' || timestampMs < 0) {
-        err = 'invalid_timestamp'
-        throw new Error('timestampMs must be a non-negative integer. Evaluation metric data will not be sent')
-      }
+      validateTimestamp(timestampMs, 'evaluation')
 
       const { label, value, tags, reasoning, assessment, metadata } = options
       const metricType = options.metricType?.toLowerCase()
-      if (!label) {
-        err = 'invalid_metric_label'
-        throw new Error('label must be the specified name of the evaluation metric')
-      }
-      if (!metricType || !['categorical', 'score', 'boolean', 'json'].includes(metricType)) {
-        err = 'invalid_metric_type'
-        throw new Error('metricType must be one of "categorical", "score", "boolean" or "json"')
-      }
-      if (metricType === 'categorical' && typeof value !== 'string') {
-        err = 'invalid_metric_value'
-        throw new Error('value must be a string for a categorical metric.')
-      }
-      if (metricType === 'score' && typeof value !== 'number') {
-        err = 'invalid_metric_value'
-        throw new Error('value must be a number for a score metric.')
-      }
-      if (metricType === 'boolean' && typeof value !== 'boolean') {
-        err = 'invalid_metric_value'
-        throw new Error('value must be a boolean for a boolean metric')
-      }
-      if (metricType === 'json' && (typeof value !== 'object' || value == null || Array.isArray(value))) {
-        err = 'invalid_metric_value'
-        throw new Error('value must be a JSON object for a json metric')
-      }
-      if (assessment != null && assessment !== 'pass' && assessment !== 'fail') {
-        err = 'invalid_assessment'
-        throw new Error('assessment must be pass or fail')
-      }
-      if (reasoning != null && typeof reasoning !== 'string') {
-        err = 'invalid_reasoning'
-        throw new Error('reasoning must be a string')
-      }
+      validateLabel(label, 'evaluation')
+      validateMetricType(metricType, 'evaluation')
+      validateMetricValue(metricType, value)
+      validateAssessment(assessment)
+      validateReasoning(reasoning)
       if (metadata != null && (typeof metadata !== 'object' || Array.isArray(metadata))) {
         err = 'invalid_metadata'
         throw new Error('metadata must be a JSON object')
       }
 
-      const evaluationTags = {
-        'ddtrace.version': tracerVersion,
-        ml_app: mlApp,
-      }
-
-      if (tags) {
-        for (const key in tags) {
-          const tag = tags[key]
-          if (typeof tag === 'string') {
-            evaluationTags[key] = tag
-          } else if (typeof tag.toString === 'function') {
-            evaluationTags[key] = tag.toString()
-          } else if (tag == null) {
-            evaluationTags[key] = Object.prototype.toString.call(tag)
-          } else {
-            // should be a rare case
-            // every object in JS has a toString, otherwise every primitive has its own toString
-            // null and undefined are handled above
-            err = 'invalid_tags'
-            throw new Error('Failed to parse tags. Tags for evaluation metrics must be strings')
-          }
-        }
-      }
-
-      // When OTel tracing is enabled, add source:otel tag to allow backend to wait for OTel span conversion
-      if (this._config.DD_TRACE_OTEL_ENABLED) {
-        evaluationTags.source = 'otel'
-      }
-
       const payload = {
+        event_kind: 'evaluation',
         join_on: {
           span: {
             span_id: spanId,
@@ -477,7 +428,8 @@ class LLMObs extends NoopLLMObs {
         ml_app: mlApp,
         [`${metricType}_value`]: value,
         timestamp_ms: timestampMs,
-        tags: Object.entries(evaluationTags).map(([key, value]) => `${key}:${value}`),
+        // When OTel tracing is enabled, `source:otel` lets the backend wait for OTel span conversion
+        tags: buildMetricTags(tags, mlApp, 'evaluation', this._config.DD_TRACE_OTEL_ENABLED),
       }
       if (reasoning != null) {
         payload.reasoning = reasoning
@@ -491,8 +443,133 @@ class LLMObs extends NoopLLMObs {
       const currentStore = storage.getStore()
       const routing = currentStore?.routingContext
       evalMetricAppendCh.publish({ payload, routing })
+    } catch (e) {
+      if (e.ddErrorTag) err = e.ddErrorTag
+      throw e
     } finally {
       telemetry.recordSubmitEvaluation(options, err)
+    }
+  }
+
+  /**
+   * Submits end-user feedback for a span, trace, session, or customer-defined entity.
+   *
+   * Exactly one target must be provided: `span` (as returned by `llmobs.exportSpan()`) or
+   * `spanId` to target a span, `traceId` a trace, `sessionId` a session, or `feedbackJoinKey`
+   * a customer-defined entity.
+   * `label`, `metricType`, `value` and `submitter` are required, and are validated at call time.
+   * @param {object} [options] - The feedback options.
+   * @param {string} [options.label] - The name of the feedback metric.
+   * @param {'categorical' | 'score' | 'boolean' | 'json' | 'text'} [options.metricType] - The value type.
+   * @param {string | number | boolean | Record<string, unknown>} [options.value] - The feedback value,
+   *   matching `metricType`.
+   * @param {{ id: string, type?: string }} [options.submitter] - Who submitted the feedback.
+   * @param {{ traceId: string, spanId: string }} [options.span] - Span context to attach the feedback to.
+   * @param {string} [options.spanId] - ID of the span to attach the feedback to.
+   * @param {string} [options.traceId] - ID of the trace to attach the feedback to.
+   * @param {string} [options.sessionId] - ID of the session to attach the feedback to.
+   * @param {string} [options.feedbackJoinKey] - Customer-defined key to attach the feedback to.
+   * @param {Record<string, string>} [options.tags] - Tags to attach to the feedback.
+   * @param {string} [options.mlApp] - The ML app name. Defaults to the configured one.
+   * @param {number} [options.timestampMs] - When the feedback was generated. Defaults to now.
+   * @param {'pass' | 'fail'} [options.assessment] - Assessment of the feedback.
+   * @param {string} [options.reasoning] - Explanation of the feedback.
+   * @returns {void}
+   */
+  submitFeedback (options = {}) {
+    if (!this.enabled) return
+
+    let err = ''
+    let targetType = 'other'
+    try {
+      const { span, spanId, traceId, sessionId, feedbackJoinKey, submitter } = options
+
+      // The intake keys feedback off a single top-level identifier, so more than one target
+      // would be ambiguous and none would leave the feedback unattached.
+      const providedTargets = []
+      if (span != null) providedTargets.push('span')
+      if (spanId != null) providedTargets.push('spanId')
+      if (traceId != null) providedTargets.push('traceId')
+      if (sessionId != null) providedTargets.push('sessionId')
+      if (feedbackJoinKey != null) providedTargets.push('feedbackJoinKey')
+
+      if (providedTargets.length !== 1) {
+        err = 'invalid_target_count'
+        throw new Error(
+          'Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` ' +
+          'must be specified to submit feedback.'
+        )
+      }
+
+      const targetName = providedTargets[0]
+      targetType = FEEDBACK_TARGET_KEYS[targetName]
+      // `span` also carries a traceId, but feedback targets a single identifier: passing
+      // `span` is wire-equivalent to passing its `spanId` directly.
+      const targetValue = targetName === 'span' ? span?.spanId : options[targetName]
+      if (typeof targetValue !== 'string' || !targetValue) {
+        if (targetName === 'span') {
+          err = 'invalid_span'
+          throw new TypeError(
+            '`span` must be an object containing a non-empty string spanId. ' +
+            '`llmobs.exportSpan()` can be used to generate this object from a given span.'
+          )
+        }
+        err = `invalid_${targetType}`
+        throw new TypeError(`\`${targetName}\` must be a non-empty string`)
+      }
+
+      if (typeof submitter?.id !== 'string' || !submitter.id) {
+        err = 'invalid_submitter'
+        throw new TypeError('submitter must be an object containing a non-empty string id')
+      }
+      if (submitter.type != null && typeof submitter.type !== 'string') {
+        err = 'invalid_submitter'
+        throw new TypeError('submitter.type must be a string')
+      }
+
+      const mlApp = options.mlApp || this._config.llmobs.mlApp
+      if (!mlApp) {
+        err = 'missing_ml_app'
+        throw new Error('ML App name is required for sending feedback. Feedback data will not be sent.')
+      }
+
+      const timestampMs = options.timestampMs || Date.now()
+      validateTimestamp(timestampMs, 'feedback')
+
+      const { label, value, tags, reasoning, assessment } = options
+      const metricType = options.metricType?.toLowerCase()
+      validateLabel(label, 'feedback')
+      validateMetricType(metricType, 'feedback')
+      validateMetricValue(metricType, value)
+      validateAssessment(assessment)
+      validateReasoning(reasoning)
+
+      const payload = {
+        event_kind: 'feedback',
+        [targetType]: targetValue,
+        label,
+        metric_type: metricType,
+        ml_app: mlApp,
+        [`${metricType}_value`]: value,
+        timestamp_ms: timestampMs,
+        tags: buildMetricTags(tags, mlApp, 'feedback'),
+        submitter: submitter.type == null ? { id: submitter.id } : { id: submitter.id, type: submitter.type },
+      }
+      if (reasoning != null) {
+        payload.reasoning = reasoning
+      }
+      if (assessment != null) {
+        payload.assessment = assessment
+      }
+
+      const currentStore = storage.getStore()
+      const routing = currentStore?.routingContext
+      evalMetricAppendCh.publish({ payload, routing })
+    } catch (e) {
+      if (e.ddErrorTag) err = e.ddErrorTag
+      throw e
+    } finally {
+      telemetry.recordSubmitFeedback(options, targetType, err)
     }
   }
 

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -15,9 +15,13 @@ const {
   DECORATOR,
 } = require('./constants/tags')
 
+const { FEEDBACK_METRIC_TYPES, FEEDBACK_TARGET_KEYS } = require('./eval-metric')
 const LLMObsTagger = require('./tagger')
 
 const llmobsMetrics = telemetryMetrics.manager.namespace('mlobs')
+
+// `span` and `spanId` both report as `span_id`, hence the deduplication by the Set.
+const FEEDBACK_TARGET_TYPES = new Set(Object.values(FEEDBACK_TARGET_KEYS))
 
 function extractIntegrationFromTags (tags) {
   if (!Array.isArray(tags)) return null
@@ -183,6 +187,24 @@ function recordSubmitEvaluation (options, err, value = 1) {
   llmobsMetrics.count('evals_submitted', tags).inc(value)
 }
 
+/**
+ * @param {object | undefined} options - The options `submitFeedback` was called with.
+ * @param {string} targetType - The payload key the feedback was attached to, `'other'` if unresolved.
+ * @param {string} err - The telemetry error tag, empty when the submission succeeded.
+ * @param {number} [value]
+ * @returns {void}
+ */
+function recordSubmitFeedback (options, targetType, err, value = 1) {
+  const metricType = options?.metricType?.toLowerCase()
+  const tags = {
+    error: Number(!!err),
+    metric_type: FEEDBACK_METRIC_TYPES.includes(metricType) ? metricType : 'other',
+    target_type: FEEDBACK_TARGET_TYPES.has(targetType) ? targetType : 'other',
+  }
+  if (err) tags.error_type = err
+  llmobsMetrics.count('feedback_submitted', tags).inc(value)
+}
+
 function recordLLMObsUserProcessorCalled (error, value = 1) {
   const tags = { error: error ? 1 : 0 }
   llmobsMetrics.count('user_processor_called', tags).inc(value)
@@ -201,5 +223,6 @@ module.exports = {
   recordUserFlush,
   recordExportSpan,
   recordSubmitEvaluation,
+  recordSubmitFeedback,
   recordLLMObsUserProcessorCalled,
 }

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -15,13 +15,9 @@ const {
   DECORATOR,
 } = require('./constants/tags')
 
-const { FEEDBACK_METRIC_TYPES, FEEDBACK_TARGET_KEYS } = require('./eval-metric')
 const LLMObsTagger = require('./tagger')
 
 const llmobsMetrics = telemetryMetrics.manager.namespace('mlobs')
-
-// `span` and `spanId` both report as `span_id`, hence the deduplication by the Set.
-const FEEDBACK_TARGET_TYPES = new Set(Object.values(FEEDBACK_TARGET_KEYS))
 
 function extractIntegrationFromTags (tags) {
   if (!Array.isArray(tags)) return null
@@ -188,18 +184,17 @@ function recordSubmitEvaluation (options, err, value = 1) {
 }
 
 /**
- * @param {object | undefined} options - The options `submitFeedback` was called with.
+ * @param {string} metricType - The submitted metric type, `'other'` if unrecognized.
  * @param {string} targetType - The payload key the feedback was attached to, `'other'` if unresolved.
  * @param {string} err - The telemetry error tag, empty when the submission succeeded.
  * @param {number} [value]
  * @returns {void}
  */
-function recordSubmitFeedback (options, targetType, err, value = 1) {
-  const metricType = options?.metricType?.toLowerCase()
+function recordSubmitFeedback (metricType, targetType, err, value = 1) {
   const tags = {
     error: Number(!!err),
-    metric_type: FEEDBACK_METRIC_TYPES.includes(metricType) ? metricType : 'other',
-    target_type: FEEDBACK_TARGET_TYPES.has(targetType) ? targetType : 'other',
+    metric_type: metricType,
+    target_type: targetType,
   }
   if (err) tags.error_type = err
   llmobsMetrics.count('feedback_submitted', tags).inc(value)

--- a/packages/dd-trace/test/llmobs/noop.spec.js
+++ b/packages/dd-trace/test/llmobs/noop.spec.js
@@ -64,6 +64,10 @@ describe('noop', () => {
     llmobs.submitEvaluation()
   })
 
+  it('using "submitFeedback" should not throw', () => {
+    llmobs.submitFeedback()
+  })
+
   it('using "flush" should not throw', () => {
     llmobs.flush()
   })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1550,6 +1550,75 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
+    it('throws for a dotted label', () => {
+      assert.throws(() => {
+        llmobs.submitEvaluation(spanCtx, {
+          mlApp: 'test',
+          timestampMs: 1234,
+          label: 'has.toxicity',
+          metricType: 'score',
+          value: 0.6,
+        })
+      }, { message: 'label value must not contain a "."' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('sends a non-string label as a string', () => {
+      llmobs.submitEvaluation(spanCtx, {
+        mlApp: 'test',
+        timestampMs: 1234,
+        label: 1234,
+        metricType: 'score',
+        value: 0.6,
+      })
+
+      assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].label, '1234')
+    })
+
+    it('throws for non-object tags', () => {
+      assert.throws(() => {
+        llmobs.submitEvaluation(spanCtx, {
+          mlApp: 'test',
+          timestampMs: 1234,
+          label: 'test',
+          metricType: 'score',
+          value: 0.6,
+          tags: 'host',
+        })
+      }, { message: 'Failed to parse tags. Tags for evaluation metrics must be strings' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a nullish tag value', () => {
+      assert.throws(() => {
+        llmobs.submitEvaluation(spanCtx, {
+          mlApp: 'test',
+          timestampMs: 1234,
+          label: 'test',
+          metricType: 'score',
+          value: 0.6,
+          tags: { host: null },
+        })
+      }, { message: 'Failed to parse tags. Tags for evaluation metrics must be strings' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('coerces non-string tag values', () => {
+      llmobs.submitEvaluation(spanCtx, {
+        mlApp: 'test',
+        timestampMs: 1234,
+        label: 'test',
+        metricType: 'score',
+        value: 0.6,
+        tags: { port: 8126 },
+      })
+
+      assert.deepStrictEqual(
+        LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].tags,
+        [`ddtrace.version:${tracerVersion}`, 'ml_app:test', 'port:8126']
+      )
+    })
+
     it('throws for an invalid metric type', () => {
       assert.throws(() => {
         llmobs.submitEvaluation(spanCtx, {
@@ -1982,6 +2051,43 @@ describe('sdk', () => {
         submitter,
         spanId: '5678',
       }), { message: 'label value must not contain a "."' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('sends a non-string label as a string', () => {
+      llmobs.submitFeedback({
+        label: 1234,
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        timestampMs: 1234,
+      })
+
+      assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].label, '1234')
+    })
+
+    it('throws for non-object tags', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        tags: ['host'],
+      }), { message: 'Failed to parse tags. Tags for feedback metrics must be strings' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a nullish tag value', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        tags: { host: undefined },
+      }), { message: 'Failed to parse tags. Tags for feedback metrics must be strings' })
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1550,20 +1550,19 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
-    it('throws for a dotted label', () => {
-      assert.throws(() => {
-        llmobs.submitEvaluation(spanCtx, {
-          mlApp: 'test',
-          timestampMs: 1234,
-          label: 'has.toxicity',
-          metricType: 'score',
-          value: 0.6,
-        })
-      }, { message: 'label value must not contain a "."' })
-      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    it('sends a dotted label as-is', () => {
+      llmobs.submitEvaluation(spanCtx, {
+        mlApp: 'test',
+        timestampMs: 1234,
+        label: 'has.toxicity',
+        metricType: 'score',
+        value: 0.6,
+      })
+
+      assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].label, 'has.toxicity')
     })
 
-    it('sends a non-string label as a string', () => {
+    it('sends a non-string label as-is', () => {
       llmobs.submitEvaluation(spanCtx, {
         mlApp: 'test',
         timestampMs: 1234,
@@ -1572,7 +1571,7 @@ describe('sdk', () => {
         value: 0.6,
       })
 
-      assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].label, '1234')
+      assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].label, 1234)
     })
 
     it('throws for non-object tags', () => {
@@ -1589,7 +1588,7 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
-    it('throws for a nullish tag value', () => {
+    it('throws for a tag value that cannot be coerced to a string', () => {
       assert.throws(() => {
         llmobs.submitEvaluation(spanCtx, {
           mlApp: 'test',
@@ -1597,10 +1596,26 @@ describe('sdk', () => {
           label: 'test',
           metricType: 'score',
           value: 0.6,
-          tags: { host: null },
+          tags: { host: Object.create(null) },
         })
       }, { message: 'Failed to parse tags. Tags for evaluation metrics must be strings' })
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('serializes nullish tag values', () => {
+      llmobs.submitEvaluation(spanCtx, {
+        mlApp: 'test',
+        timestampMs: 1234,
+        label: 'test',
+        metricType: 'score',
+        value: 0.6,
+        tags: { host: null, port: undefined },
+      })
+
+      assert.deepStrictEqual(
+        LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].tags,
+        [`ddtrace.version:${tracerVersion}`, 'ml_app:test', 'host:null', 'port:undefined']
+      )
     })
 
     it('coerces non-string tag values', () => {
@@ -1899,15 +1914,6 @@ describe('sdk', () => {
       submitter = { id: 'user-1', type: 'user' }
     })
 
-    it('does not submit feedback if llmobs is disabled', () => {
-      tracer._tracer._config.llmobs.DD_LLMOBS_ENABLED = false
-      llmobs.submitFeedback()
-
-      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
-
-      tracer._tracer._config.llmobs.DD_LLMOBS_ENABLED = true
-    })
-
     it('throws when no target is provided', () => {
       assert.throws(() => llmobs.submitFeedback({
         label: 'thumbs_up',
@@ -1921,13 +1927,30 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
-    it('throws when more than one target is provided', () => {
+    it('throws when two targets are provided', () => {
       assert.throws(() => llmobs.submitFeedback({
         label: 'thumbs_up',
         metricType: 'boolean',
         value: true,
         submitter,
         spanId: '5678',
+        sessionId: 'session-1',
+      }), {
+        message: 'Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` ' +
+          'must be specified to submit feedback.',
+      })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    // An odd target count is what a parity check (`^`) would wrongly accept.
+    it('throws when three targets are provided', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        traceId: '1234',
         sessionId: 'session-1',
       }), {
         message: 'Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` ' +
@@ -2005,22 +2028,6 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
-    it('throws for a missing mlApp', () => {
-      const mlApp = tracer._tracer._config.llmobs.mlApp
-      delete tracer._tracer._config.llmobs.mlApp
-
-      assert.throws(() => llmobs.submitFeedback({
-        label: 'thumbs_up',
-        metricType: 'boolean',
-        value: true,
-        submitter,
-        spanId: '5678',
-      }), { message: 'ML App name is required for sending feedback. Feedback data will not be sent.' })
-      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
-
-      tracer._tracer._config.llmobs.mlApp = mlApp
-    })
-
     it('throws for an invalid timestamp', () => {
       assert.throws(() => llmobs.submitFeedback({
         label: 'thumbs_up',
@@ -2079,16 +2086,33 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
-    it('throws for a nullish tag value', () => {
+    it('throws for a tag value that cannot be coerced to a string', () => {
       assert.throws(() => llmobs.submitFeedback({
         label: 'thumbs_up',
         metricType: 'boolean',
         value: true,
         submitter,
         spanId: '5678',
-        tags: { host: undefined },
+        tags: { host: Object.create(null) },
       }), { message: 'Failed to parse tags. Tags for feedback metrics must be strings' })
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('serializes nullish tag values', () => {
+      llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        timestampMs: 1234,
+        tags: { host: null, port: undefined },
+      })
+
+      assert.deepStrictEqual(
+        LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].tags,
+        [`ddtrace.version:${tracerVersion}`, 'ml_app:mlApp', 'host:null', 'port:undefined']
+      )
     })
 
     it('throws for an invalid metric type', () => {
@@ -2292,6 +2316,46 @@ describe('sdk', () => {
         })
 
         assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].timestamp_ms, 1234)
+      })
+    })
+
+    describe('with no mlApp configured', () => {
+      let mlApp
+
+      before(() => {
+        mlApp = tracer._tracer._config.llmobs.mlApp
+        delete tracer._tracer._config.llmobs.mlApp
+      })
+
+      after(() => {
+        tracer._tracer._config.llmobs.mlApp = mlApp
+      })
+
+      it('throws', () => {
+        assert.throws(() => llmobs.submitFeedback({
+          label: 'thumbs_up',
+          metricType: 'boolean',
+          value: true,
+          submitter,
+          spanId: '5678',
+        }), { message: 'ML App name is required for sending feedback. Feedback data will not be sent.' })
+        sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+      })
+    })
+
+    describe('with llmobs disabled', () => {
+      before(() => {
+        tracer._tracer._config.llmobs.DD_LLMOBS_ENABLED = false
+      })
+
+      after(() => {
+        tracer._tracer._config.llmobs.DD_LLMOBS_ENABLED = true
+      })
+
+      it('does not submit feedback', () => {
+        llmobs.submitFeedback()
+
+        sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
       })
     })
   })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1602,6 +1602,7 @@ describe('sdk', () => {
       })
 
       assert.deepStrictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0], {
+        event_kind: 'evaluation',
         join_on: {
           span: {
             trace_id: spanCtx.traceId,
@@ -1669,6 +1670,7 @@ describe('sdk', () => {
       const evalMetric = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
 
       assert.deepStrictEqual(evalMetric, {
+        event_kind: 'evaluation',
         join_on: {
           span: {
             span_id: '5678',
@@ -1703,6 +1705,7 @@ describe('sdk', () => {
       const evalMetric = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
 
       assert.deepStrictEqual(evalMetric, {
+        event_kind: 'evaluation',
         join_on: {
           span: {
             span_id: '5678',
@@ -1742,6 +1745,7 @@ describe('sdk', () => {
       })
 
       assert.deepStrictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0], {
+        event_kind: 'evaluation',
         join_on: {
           span: {
             span_id: spanCtx.spanId,
@@ -1815,6 +1819,373 @@ describe('sdk', () => {
 
         const evalMetric = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
         assert.ok(evalMetric.tags.includes('source:otel'), 'Expected source:otel tag to be present')
+      })
+    })
+  })
+
+  describe('submitFeedback', () => {
+    let submitter
+
+    beforeEach(() => {
+      submitter = { id: 'user-1', type: 'user' }
+    })
+
+    it('does not submit feedback if llmobs is disabled', () => {
+      tracer._tracer._config.llmobs.DD_LLMOBS_ENABLED = false
+      llmobs.submitFeedback()
+
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+
+      tracer._tracer._config.llmobs.DD_LLMOBS_ENABLED = true
+    })
+
+    it('throws when no target is provided', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+      }), {
+        message: 'Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` ' +
+          'must be specified to submit feedback.',
+      })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws when more than one target is provided', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        sessionId: 'session-1',
+      }), {
+        message: 'Exactly one of `span`, `spanId`, `traceId`, `sessionId` or `feedbackJoinKey` ' +
+          'must be specified to submit feedback.',
+      })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a span without a spanId', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        span: { traceId: '1234' },
+      }), {
+        name: 'TypeError',
+        message: '`span` must be an object containing a non-empty string spanId. ' +
+          '`llmobs.exportSpan()` can be used to generate this object from a given span.',
+      })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for an empty target', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        sessionId: '',
+      }), { name: 'TypeError', message: '`sessionId` must be a non-empty string' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a non-string target', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        traceId: 1234,
+      }), { name: 'TypeError', message: '`traceId` must be a non-empty string' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a missing submitter', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        spanId: '5678',
+      }), { name: 'TypeError', message: 'submitter must be an object containing a non-empty string id' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a submitter without an id', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter: { type: 'user' },
+        spanId: '5678',
+      }), { name: 'TypeError', message: 'submitter must be an object containing a non-empty string id' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a non-string submitter type', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter: { id: 'user-1', type: 1 },
+        spanId: '5678',
+      }), { name: 'TypeError', message: 'submitter.type must be a string' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a missing mlApp', () => {
+      const mlApp = tracer._tracer._config.llmobs.mlApp
+      delete tracer._tracer._config.llmobs.mlApp
+
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+      }), { message: 'ML App name is required for sending feedback. Feedback data will not be sent.' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+
+      tracer._tracer._config.llmobs.mlApp = mlApp
+    })
+
+    it('throws for an invalid timestamp', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        timestampMs: 'invalid',
+      }), { message: 'timestampMs must be a non-negative integer. Feedback data will not be sent' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a missing label', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+      }), { message: 'label must be the specified name of the feedback metric' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a dotted label', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs.up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+      }), { message: 'label value must not contain a "."' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for an invalid metric type', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'invalid',
+        value: true,
+        submitter,
+        spanId: '5678',
+      }), { message: 'metricType must be one of "categorical", "score", "boolean", "json" or "text"' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a mismatched value for a text metric', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'comment',
+        metricType: 'text',
+        value: 1,
+        submitter,
+        spanId: '5678',
+      }), { message: 'value must be a string for a text metric' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a mismatched value for a score metric', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'rating',
+        metricType: 'score',
+        value: 'good',
+        submitter,
+        spanId: '5678',
+      }), { message: 'value must be a number for a score metric.' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a non pass/fail assessment', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        assessment: 'correct',
+      }), { message: 'assessment must be pass or fail' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('throws for a non-string reasoning', () => {
+      assert.throws(() => llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        reasoning: 1,
+      }), { message: 'reasoning must be a string' })
+      sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
+    })
+
+    it('submits feedback for a span id', () => {
+      llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        spanId: '5678',
+        mlApp: 'test',
+        timestampMs: 1234,
+        tags: { host: 'localhost' },
+      })
+
+      assert.deepStrictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0], {
+        event_kind: 'feedback',
+        span_id: '5678',
+        label: 'thumbs_up',
+        metric_type: 'boolean',
+        ml_app: 'test',
+        boolean_value: true,
+        timestamp_ms: 1234,
+        tags: [`ddtrace.version:${tracerVersion}`, 'ml_app:test', 'host:localhost'],
+        submitter: { id: 'user-1', type: 'user' },
+      })
+    })
+
+    it('submits feedback for an exported span, using its span id only', () => {
+      llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter,
+        span: { traceId: '1234', spanId: '5678' },
+        timestampMs: 1234,
+      })
+
+      assert.deepStrictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0], {
+        event_kind: 'feedback',
+        span_id: '5678',
+        label: 'thumbs_up',
+        metric_type: 'boolean',
+        ml_app: 'mlApp',
+        boolean_value: true,
+        timestamp_ms: 1234,
+        tags: [`ddtrace.version:${tracerVersion}`, 'ml_app:mlApp'],
+        submitter: { id: 'user-1', type: 'user' },
+      })
+    })
+
+    it('omits the submitter type when not provided', () => {
+      llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'boolean',
+        value: true,
+        submitter: { id: 'user-1' },
+        spanId: '5678',
+        timestampMs: 1234,
+      })
+
+      assert.deepStrictEqual(
+        LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].submitter,
+        { id: 'user-1' }
+      )
+    })
+
+    it('submits enriched text feedback for a feedback join key', () => {
+      llmobs.submitFeedback({
+        label: 'comment',
+        metricType: 'text',
+        value: 'this answer was helpful',
+        submitter,
+        feedbackJoinKey: 'my-join-key',
+        timestampMs: 1234,
+        assessment: 'pass',
+        reasoning: 'the user was satisfied',
+      })
+
+      assert.deepStrictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0], {
+        event_kind: 'feedback',
+        feedback_join_key: 'my-join-key',
+        label: 'comment',
+        metric_type: 'text',
+        ml_app: 'mlApp',
+        text_value: 'this answer was helpful',
+        timestamp_ms: 1234,
+        tags: [`ddtrace.version:${tracerVersion}`, 'ml_app:mlApp'],
+        submitter: { id: 'user-1', type: 'user' },
+        assessment: 'pass',
+        reasoning: 'the user was satisfied',
+      })
+    })
+
+    it('submits feedback for a trace id', () => {
+      llmobs.submitFeedback({
+        label: 'rating',
+        metricType: 'score',
+        value: 0.5,
+        submitter,
+        traceId: '1234',
+        timestampMs: 1234,
+      })
+
+      const feedback = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
+      assert.strictEqual(feedback.trace_id, '1234')
+      assert.strictEqual(feedback.score_value, 0.5)
+      assert.ok(!('span_id' in feedback))
+    })
+
+    it('submits feedback for a session id', () => {
+      llmobs.submitFeedback({
+        label: 'thumbs_up',
+        metricType: 'categorical',
+        value: 'up',
+        submitter,
+        sessionId: 'session-1',
+        timestampMs: 1234,
+      })
+
+      const feedback = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
+      assert.strictEqual(feedback.session_id, 'session-1')
+      assert.strictEqual(feedback.categorical_value, 'up')
+    })
+
+    describe('with no timestamp provided', () => {
+      let prevTime
+
+      before(() => {
+        prevTime = clock.now
+        clock.setSystemTime(1234)
+      })
+
+      after(() => {
+        clock.setSystemTime(prevTime)
+      })
+
+      it('defaults to the current time', () => {
+        llmobs.submitFeedback({
+          label: 'thumbs_up',
+          metricType: 'boolean',
+          value: true,
+          submitter,
+          spanId: '5678',
+        })
+
+        assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].timestamp_ms, 1234)
       })
     })
   })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1550,18 +1550,6 @@ describe('sdk', () => {
       sinon.assert.notCalled(LLMObsEvalMetricsWriter.prototype.append)
     })
 
-    it('sends a dotted label as-is', () => {
-      llmobs.submitEvaluation(spanCtx, {
-        mlApp: 'test',
-        timestampMs: 1234,
-        label: 'has.toxicity',
-        metricType: 'score',
-        value: 0.6,
-      })
-
-      assert.strictEqual(LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0].label, 'has.toxicity')
-    })
-
     it('sends a non-string label as-is', () => {
       llmobs.submitEvaluation(spanCtx, {
         mlApp: 'test',

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -341,6 +341,7 @@ function assertLlmObsEvaluationMetric (actual, expected) {
   }
 
   const expectedEvaluationMetric = {
+    event_kind: 'evaluation',
     join_on: {
       span: {
         trace_id: joinOn.span.traceId,


### PR DESCRIPTION
### What does this PR do?

Adds `llmobs.submitFeedback(options)` for submitting end-user feedback through the Node.js SDK.
Today this is only reachable by calling the Evaluations API directly. (requested by customers)

### Testing
Apart from passing new and old tests, I also created a demo app to confirm that things are working.


[Here is a span](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Atest-feedback-thibault%20%40event_type%3Aspan%20%40is_root_span%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=sliding&selectedTab=feedback&sidepanelContextScopeKind=workflow&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ_G2LNspn7upgAAABhBWl9HMkxOc0FBQlJqekJUTFppRUFBQUEAAAAkMDE5ZmM2ZDktZjI3ZS00ZGNjLTkxODMtYjM0ZmY4M2YwZTIyAAJ7zw%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=2748774003796643082&start=1783172030655&end=1785764030655&paused=false) with feedback and evals submitted to it, using the NodeJS SDK.

[here is a submitted feedback](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Atest-feedback-thibault%20%40event_type%3Aspan%20%40is_root_span%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=sliding&selectedTab=feedback&sidepanelContextScope=1030141265088222152&sidepanelContextScopeKind=agent&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ_G8yYRkd2kiAAAABhBWl9HOHlZUkFBQnJDaUZXUWdxR0FBQUEAAAAkMDE5ZmM2ZjUtNjliZi00MDczLTg5YTAtMzI3NWM0YzlkZjJhAAsqfQ%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=4939325680111322720&start=1785677812043&end=1785764212043&paused=false) attached to the key `incident-123` and not a span