### PR TITLE
test(coverage): group equivalent V8 profiles before conversion

### DIFF
--- a/integration-tests/coverage-merge-lcov.spec.js
+++ b/integration-tests/coverage-merge-lcov.spec.js
@@ -14,20 +14,71 @@ const { REPO_ROOT } = require('./coverage/runtime')
 const REPO_REL = path.join('packages', 'datadog-plugin-jest', 'src', 'index.js')
 const REPO_FILE = path.join(REPO_ROOT, REPO_REL)
 
+/** @typedef {import('node:inspector').Profiler.ScriptCoverage} ScriptCoverage */
+
+/**
+ * @typedef {object} IstanbulFileCoverage
+ * @property {string} path
+ * @property {Record<string, number>} s
+ * @property {Record<string, number[]>} b
+ * @property {Record<string, { name: string }>} fnMap
+ * @property {Record<string, number>} f
+ */
+
 /**
  * One V8 script entry whose single function range spans the whole file, marking every executed
  * line as hit. Enough to prove the file is counted; the hit values themselves are not asserted.
  *
  * @param {string} sourceUrl `file://` url V8 would have recorded for the script
  * @param {number} endOffset byte length of the source the range covers
- * @returns {{ url: string, functions: object[] }}
+ * @param {number} [count]
+ * @returns {ScriptCoverage}
  */
-function scriptEntry (sourceUrl, endOffset) {
+function scriptEntry (sourceUrl, endOffset, count = 1) {
   return {
+    scriptId: '0',
     url: sourceUrl,
     functions: [
-      { functionName: '', isBlockCoverage: false, ranges: [{ startOffset: 0, endOffset, count: 1 }] },
+      { functionName: '', isBlockCoverage: false, ranges: [{ startOffset: 0, endOffset, count }] },
     ],
+  }
+}
+
+/**
+ * @param {string} sourceUrl
+ * @param {number} endOffset
+ * @param {number} branchCount
+ * @returns {ScriptCoverage}
+ */
+function blockEntry (sourceUrl, endOffset, branchCount) {
+  return {
+    scriptId: '0',
+    url: sourceUrl,
+    functions: [{
+      functionName: '',
+      isBlockCoverage: true,
+      ranges: [
+        { startOffset: 0, endOffset, count: 1 },
+        { startOffset: 10, endOffset: 20, count: branchCount },
+      ],
+    }],
+  }
+}
+
+/**
+ * @param {string} sourceUrl
+ * @param {number} endOffset
+ * @returns {ScriptCoverage}
+ */
+function functionEntry (sourceUrl, endOffset) {
+  return {
+    scriptId: '0',
+    url: sourceUrl,
+    functions: [{
+      functionName: 'coveredFunction',
+      isBlockCoverage: false,
+      ranges: [{ startOffset: 0, endOffset, count: 1 }],
+    }],
   }
 }
 
@@ -44,17 +95,22 @@ describe('integration coverage merge', () => {
   after(() => fs.rm(workDir, { force: true, recursive: true }))
 
   /**
-   * Write `result` as one process profile, convert it, and return both the run summary and the
+   * Write each `result` as one process profile, convert them, and return both the run summary and the
    * parsed coverage map (empty object when the run produced no files).
    *
-   * @param {object[]} result V8 `result` entries to write as one process profile
-   * @returns {Promise<{ summary: { files: number }, coverage: Record<string, { path: string }> }>}
+   * @param {...ScriptCoverage[]} results V8 `result` entries to write as process profiles
+   * @returns {Promise<{
+   *   summary: { scripts: number, profiles: number, files: number },
+   *   coverage: Record<string, IstanbulFileCoverage>
+   * }>}
    */
-  async function convert (result) {
+  async function convert (...results) {
     await fs.rm(v8Dir, { force: true, recursive: true })
     await fs.rm(outputDir, { force: true, recursive: true })
     await fs.mkdir(v8Dir, { recursive: true })
-    await fs.writeFile(path.join(v8Dir, 'profile.json'), JSON.stringify({ result }))
+    for (let i = 0; i < results.length; i++) {
+      await fs.writeFile(path.join(v8Dir, `profile-${i}.json`), JSON.stringify({ result: results[i] }))
+    }
     const summary = await convertV8DirToReport(v8Dir, outputDir)
     let coverage = {}
     if (summary.files > 0) {
@@ -78,6 +134,82 @@ describe('integration coverage merge', () => {
     const { coverage } = await convert([scriptEntry(pathToFileURL(REPO_FILE).href, sourceLength)])
 
     assert.ok(coverage[REPO_FILE], 'repo-pathed entry should be counted as-is')
+  })
+
+  it('merges execution counts from repository and sandbox profiles', async () => {
+    const sandboxFile = path.join(
+      os.tmpdir(), 'deleted-sandbox', '1234', 'node_modules', 'dd-trace', REPO_REL
+    )
+    const { summary, coverage } = await convert(
+      [scriptEntry(pathToFileURL(REPO_FILE).href, sourceLength, 2)],
+      [scriptEntry(pathToFileURL(sandboxFile).href, sourceLength, 3)]
+    )
+
+    assert.deepStrictEqual(summary, { scripts: 2, profiles: 2, files: 1 })
+    assert.ok(Object.values(coverage[REPO_FILE].s).every(count => count === 5))
+  })
+
+  it('merges count-independent defaults from partially covered profiles', async () => {
+    const sourceUrl = pathToFileURL(REPO_FILE).href
+    const { coverage } = await convert(
+      [scriptEntry(sourceUrl, 20, 2)],
+      [scriptEntry(sourceUrl, 20, 3)]
+    )
+
+    const statementCounts = Object.values(coverage[REPO_FILE].s)
+    assert.ok(statementCounts.includes(5))
+    assert.ok(statementCounts.includes(2))
+  })
+
+  it('merges nested block ranges from multiple profiles', async () => {
+    const sourceUrl = pathToFileURL(REPO_FILE).href
+    const { coverage } = await convert(
+      [blockEntry(sourceUrl, sourceLength, 0)],
+      [blockEntry(sourceUrl, sourceLength, 1)]
+    )
+
+    const branchCounts = Object.values(coverage[REPO_FILE].b).flat().sort((countA, countB) => countA - countB)
+    assert.deepStrictEqual(branchCounts, [1, 2])
+  })
+
+  it('preserves distinct function and block coverage shapes', async () => {
+    const sourceUrl = pathToFileURL(REPO_FILE).href
+    const { coverage } = await convert(
+      [functionEntry(sourceUrl, sourceLength)],
+      [functionEntry(sourceUrl, sourceLength)],
+      [blockEntry(sourceUrl, sourceLength, 1)]
+    )
+
+    const functionMapEntry = Object.entries(coverage[REPO_FILE].fnMap)
+      .find(([, { name }]) => name === 'coveredFunction')
+    assert.ok(functionMapEntry)
+    assert.strictEqual(coverage[REPO_FILE].f[functionMapEntry[0]], 2)
+    assert.deepStrictEqual(Object.values(coverage[REPO_FILE].b).flat(), [1, 1])
+  })
+
+  it('ignores malformed profiles and entries', async () => {
+    await fs.rm(v8Dir, { force: true, recursive: true })
+    await fs.rm(outputDir, { force: true, recursive: true })
+    await fs.mkdir(v8Dir, { recursive: true })
+    await fs.writeFile(path.join(v8Dir, 'malformed.json'), '{')
+    await fs.writeFile(path.join(v8Dir, 'invalid-entries.json'), JSON.stringify({
+      result: [
+        {},
+        { url: 'node:internal/test', functions: [] },
+        { url: pathToFileURL(REPO_FILE).href, functions: undefined },
+      ],
+    }))
+
+    const summary = await convertV8DirToReport(v8Dir, outputDir)
+
+    assert.deepStrictEqual(summary, { scripts: 0, profiles: 2, files: 0 })
+  })
+
+  it('skips source files that cannot be loaded', async () => {
+    const missingFile = path.join(REPO_ROOT, 'packages', 'dd-trace', 'src', 'missing-coverage-source.js')
+    const { summary } = await convert([scriptEntry(pathToFileURL(missingFile).href, 10)])
+
+    assert.deepStrictEqual(summary, { scripts: 0, profiles: 1, files: 0 })
   })
 
   it('still drops coverage for unrelated dependencies', async () => {

--- a/integration-tests/coverage/merge-lcov.js
+++ b/integration-tests/coverage/merge-lcov.js
@@ -13,6 +13,14 @@ const TestExclude = require('test-exclude')
 const baseNycConfig = require('../../nyc.config')
 const { REPO_ROOT, getMergedReportDir, getV8CoverageDir } = require('./runtime')
 
+/** @typedef {import('node:inspector').Profiler.FunctionCoverage} FunctionCoverage */
+
+/**
+ * @typedef {object} MergedScriptCoverage
+ * @property {FunctionCoverage[]} functions
+ * @property {number} entries
+ */
+
 // Same include/exclude as the istanbul reporters used, so the file set is identical regardless of
 // which tool collected. c8's own `excludeAfterRemap` semantics are reproduced here: we decide
 // inclusion on the resolved on-disk path, after mapping the V8 url back to a real file.
@@ -54,25 +62,76 @@ function shouldInclude (filePath) {
 }
 
 /**
- * Convert one process' raw V8 coverage file into an istanbul coverage map and merge it into `into`.
- * Each entry whose source is an in-scope repo file is run through `v8-to-istanbul` (patched to fix
- * the multi-line-statement over-report) and folded in; everything else (node internals, deps,
- * test files) is skipped.
+ * Zero execution counts while serializing a coverage shape. Entries with the same shape can
+ * safely have their corresponding counts summed before conversion, while the serialized shape can
+ * be reused to reproduce v8-to-istanbul's count-independent defaults.
  *
- * @param {import('istanbul-lib-coverage').CoverageMap} into
- * @param {string} v8File absolute path to a raw V8 coverage JSON file
- * @returns {Promise<number>} count of in-scope script entries merged
+ * @param {string} key
+ * @param {unknown} value
+ * @returns {unknown}
  */
-async function mergeV8File (into, v8File) {
+function zeroCoverageCount (key, value) {
+  return key === 'count' ? 0 : value
+}
+
+/**
+ * @param {FunctionCoverage[]} target
+ * @param {FunctionCoverage[]} source
+ * @returns {void}
+ */
+function mergeCoverageCounts (target, source) {
+  for (let functionIndex = 0; functionIndex < target.length; functionIndex++) {
+    const targetRanges = target[functionIndex].ranges
+    const sourceRanges = source[functionIndex].ranges
+    for (let rangeIndex = 0; rangeIndex < targetRanges.length; rangeIndex++) {
+      targetRanges[rangeIndex].count += sourceRanges[rangeIndex].count
+    }
+  }
+}
+
+/**
+ * Add the count-independent part of one converted coverage object into another. v8-to-istanbul
+ * initializes untouched source lines to one, so converting N entries separately contributes that
+ * default N times while converting their summed ranges contributes it once.
+ *
+ * @param {Record<string, import('istanbul-lib-coverage').FileCoverageData>} target
+ * @param {Record<string, import('istanbul-lib-coverage').FileCoverageData>} source
+ * @param {number} multiplier
+ * @returns {void}
+ */
+function addCoverageCounts (target, source, multiplier) {
+  for (const [filePath, targetFile] of Object.entries(target)) {
+    const sourceFile = source[filePath]
+    for (const [statementId, count] of Object.entries(sourceFile.s)) {
+      targetFile.s[statementId] += count * multiplier
+    }
+    for (const [branchId, counts] of Object.entries(sourceFile.b)) {
+      const targetCounts = targetFile.b[branchId]
+      for (let index = 0; index < counts.length; index++) {
+        targetCounts[index] += counts[index] * multiplier
+      }
+    }
+    for (const [functionId, count] of Object.entries(sourceFile.f)) {
+      targetFile.f[functionId] += count * multiplier
+    }
+  }
+}
+
+/**
+ * @param {Map<string, Map<string, MergedScriptCoverage>>} mergedScripts
+ * @param {Map<string, boolean>} inclusionCache
+ * @param {string} v8File absolute path to a raw V8 coverage JSON file
+ * @returns {Promise<void>}
+ */
+async function mergeV8File (mergedScripts, inclusionCache, v8File) {
   let parsed
   try {
     parsed = JSON.parse(await fs.readFile(v8File, 'utf8'))
   } catch {
-    return 0
+    return
   }
-  let merged = 0
   for (const entry of parsed.result ?? []) {
-    if (!entry.url || !entry.url.startsWith('file://')) continue
+    if (!entry.url || !entry.url.startsWith('file://') || !Array.isArray(entry.functions)) continue
     let filePath
     try {
       filePath = fileURLToPath(entry.url)
@@ -80,20 +139,27 @@ async function mergeV8File (into, v8File) {
       continue
     }
     filePath = rebaseSandboxPath(filePath)
-    if (!shouldInclude(filePath)) continue
+    let included = inclusionCache.get(filePath)
+    if (included === undefined) {
+      included = shouldInclude(filePath)
+      inclusionCache.set(filePath, included)
+    }
+    if (!included) continue
 
-    const converter = v8toIstanbul(filePath, 0)
-    try {
-      await converter.load()
-      converter.applyCoverage(entry.functions)
-      into.merge(converter.toIstanbul())
-      merged++
-    } catch {
-      // A file that changed on disk since the run, or a source map we can't resolve, is skipped
-      // rather than failing the whole merge.
+    let fileScripts = mergedScripts.get(filePath)
+    if (!fileScripts) {
+      fileScripts = new Map()
+      mergedScripts.set(filePath, fileScripts)
+    }
+    const shape = JSON.stringify(entry.functions, zeroCoverageCount)
+    const existing = fileScripts.get(shape)
+    if (existing) {
+      mergeCoverageCounts(existing.functions, entry.functions)
+      existing.entries++
+    } else {
+      fileScripts.set(shape, { functions: entry.functions, entries: 1 })
     }
   }
-  return merged
 }
 
 /**
@@ -116,12 +182,34 @@ async function convertV8DirToReport (v8Dir, outputDir) {
   }
   const v8Files = files.filter(f => f.endsWith('.json'))
 
+  const mergedScripts = new Map()
+  const inclusionCache = new Map()
+  for (const file of v8Files) {
+    await mergeV8File(mergedScripts, inclusionCache, path.join(v8Dir, file))
+  }
+
   const coverageMap = libCoverage.createCoverageMap({})
   let scripts = 0
-  // Sequential rather than parallel: v8-to-istanbul reads + parses each source, and a wide fan-out
-  // across thousands of entries spikes memory; the merge is not the slow part of a coverage run.
-  for (const file of v8Files) {
-    scripts += await mergeV8File(coverageMap, path.join(v8Dir, file))
+  for (const [filePath, fileScripts] of mergedScripts) {
+    for (const [shape, { functions, entries }] of fileScripts) {
+      const converter = v8toIstanbul(filePath, 0)
+      try {
+        await converter.load()
+        converter.applyCoverage(functions)
+        const converted = converter.toIstanbul()
+        if (entries > 1) {
+          const defaultsConverter = v8toIstanbul(filePath, 0)
+          await defaultsConverter.load()
+          defaultsConverter.applyCoverage(JSON.parse(shape))
+          addCoverageCounts(converted, defaultsConverter.toIstanbul(), entries - 1)
+        }
+        coverageMap.merge(converted)
+        scripts += entries
+      } catch {
+        // A file that changed on disk since the run, or a source map we can't resolve, is skipped
+        // rather than failing the whole merge.
+      }
+    }
   }
 
   if (coverageMap.files().length === 0) {


### PR DESCRIPTION
## Summary

- Group V8 script entries by canonical path and count-independent coverage shape before converting them to Istanbul.
- Sum equivalent entries while preserving existing statement, branch, and function counts.
- Cache inclusion decisions for paths repeated across process profiles.
- Cover repeated, partial, mixed-shape, malformed, and unloadable profiles.

## Why

The V8-to-Istanbul step in [this coverage job](https://github.com/DataDog/dd-trace-js/actions/runs/30808074430/job/91667997408?pr=9335) took 6m 42s because it reloaded the same source, remapped ranges, and merged Istanbul maps for every process profile.

On Node 24.18.0, a 160-profile fixture with 14,670 in-scope entries improved from 5.893s to 0.938s and reproduced at 5.890s to 0.934s. Both runs produced identical `coverage-final.json`; peak RSS fell from 316 MiB to 189 MiB and from 319 MiB to 190 MiB.

The merger is shared by integration coverage and `scripts/c8-ci.js`, so this speeds native V8 report conversion across workflows. It does not change test execution or shipped tracer code.