### PR TITLE
fix(test-optimization): handle bounded validation edge cases

### DIFF
--- a/ci/test-optimization-validation/cli.js
+++ b/ci/test-optimization-validation/cli.js
@@ -320,9 +320,16 @@ async function validateFramework ({ framework, manifest, options, out, packageCh
 
   const unavailable = getUnavailableExecutable(getBasicCommand(framework))
   if (unavailable) {
-    results.push(getUnavailableRunnerResult(framework, unavailable))
+    const unavailableResult = getUnavailableRunnerResult(framework, unavailable)
+    results.push(unavailableResult)
     if (ciResult) results.push(ciResult)
-    addNotReachedLocalResults(results, framework, options.scenarios, 'runner-unavailable')
+    addNotReachedLocalResults(
+      results,
+      framework,
+      options.scenarios,
+      'runner-unavailable',
+      unavailableResult.evidence.blockerCategory
+    )
     return
   }
 
@@ -640,10 +647,11 @@ function addAdvancedNotReached (results, framework, scenarios, blocker) {
  * @param {object} framework framework entry
  * @param {Set<string>} scenarios selected scenarios
  * @param {string} reasonCode blocker id
+ * @param {string} [blockerCategoryOverride] blocker category supplied by a runtime result
  * @returns {void}
  */
-function addNotReachedLocalResults (results, framework, scenarios, reasonCode) {
-  const blockerCategory = framework.blockerCategory || (
+function addNotReachedLocalResults (results, framework, scenarios, reasonCode, blockerCategoryOverride) {
+  const blockerCategory = blockerCategoryOverride || framework.blockerCategory || (
     framework.status === 'requires_manual_setup'
       ? BLOCKER_CATEGORIES.PROJECT_SETUP_REQUIRED
       : BLOCKER_CATEGORIES.VALIDATOR_LIMITATION

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -311,6 +311,9 @@ function getJavascriptProfileDefinitions (source) {
       throw new Error(`profile ${JSON.stringify(name)} must be followed by a comma`)
     }
   }
+  if (!/^[\s;]*$/.test(syntax.slice(objectEnd + 1))) {
+    throw new Error('configuration contains code after the exported profile object')
+  }
   return definitions
 }
 

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -263,10 +263,10 @@ function readProfileDefinitions (filename) {
   if (extension === '.yaml' || extension === '.yml') {
     return getYamlStringProfileDefinitions(source)
   }
-  return getJavascriptStringProfileDefinitions(source)
+  return getJavascriptProfileDefinitions(source)
 }
 
-function getJavascriptStringProfileDefinitions (source) {
+function getJavascriptProfileDefinitions (source) {
   const syntax = maskJavascriptCommentsAndStrings(source)
   const exports = [...syntax.matchAll(/^\s*(?:module\s*\.\s*exports\s*=|export\s+default)\s*\{/gm)]
   if (exports.length === 0) return new Map()
@@ -300,8 +300,11 @@ function getJavascriptStringProfileDefinitions (source) {
     index = skipWhitespace(syntax, index)
     if (syntax[index] !== ':') throw new Error(`profile ${JSON.stringify(name)} must have a literal value`)
     index = skipWhitespace(syntax, index + 1)
-    const definition = readQuotedString(source, index)
-    if (!definition) throw new Error(`profile ${JSON.stringify(name)} must be a literal string`)
+    const definition = readJavascriptLiteral(source, syntax, index)
+    if (!definition || (typeof definition.value !== 'string' &&
+      (!definition.value || typeof definition.value !== 'object' || Array.isArray(definition.value)))) {
+      throw new Error(`profile ${JSON.stringify(name)} must be a literal string or object`)
+    }
     definitions.set(name, definition.value)
     index = skipWhitespace(syntax, definition.end)
     if (index < objectEnd && syntax[index] !== ',') {
@@ -369,6 +372,80 @@ function skipWhitespace (source, start) {
   let index = start
   while (/\s/.test(source[index] || '')) index++
   return index
+}
+
+/**
+ * Reads a bounded JSON-shaped JavaScript literal without evaluating customer code.
+ *
+ * @param {string} source original JavaScript source
+ * @param {string} syntax source with comments and string contents masked
+ * @param {number} start literal start offset
+ * @param {number} [depth] current literal nesting depth
+ * @returns {{end: number, value: unknown}|undefined} parsed literal and ending offset
+ */
+function readJavascriptLiteral (source, syntax, start, depth = 0) {
+  if (depth > 16) return
+  let index = skipWhitespace(syntax, start)
+  const quoted = readQuotedString(source, index)
+  if (quoted) return quoted
+
+  const primitive = /^(true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)(?![\w$.])/.exec(
+    syntax.slice(index)
+  )
+  if (primitive) {
+    const values = { false: false, null: null, true: true }
+    return {
+      end: index + primitive[0].length,
+      value: Object.hasOwn(values, primitive[1]) ? values[primitive[1]] : Number(primitive[1]),
+    }
+  }
+
+  const open = syntax[index]
+  if (open !== '[' && open !== '{') return
+  const close = open === '[' ? ']' : '}'
+  const value = open === '[' ? [] : Object.create(null)
+  index++
+  while (index < syntax.length) {
+    index = skipWhitespace(syntax, index)
+    if (syntax[index] === close) return { end: index + 1, value }
+
+    let item
+    if (open === '[') {
+      item = readJavascriptLiteral(source, syntax, index, depth + 1)
+      if (!item) return
+      value.push(item.value)
+    } else {
+      const property = readJavascriptPropertyName(source, syntax, index)
+      if (!property || Object.hasOwn(value, property.value)) return
+      index = skipWhitespace(syntax, property.end)
+      if (syntax[index] !== ':') return
+      item = readJavascriptLiteral(source, syntax, index + 1, depth + 1)
+      if (!item) return
+      value[property.value] = item.value
+    }
+    index = item.end
+
+    index = skipWhitespace(syntax, index)
+    if (syntax[index] === close) return { end: index + 1, value }
+    if (syntax[index] !== ',') return
+    index++
+  }
+}
+
+/**
+ * Reads one static quoted or identifier JavaScript object property name.
+ *
+ * @param {string} source original JavaScript source
+ * @param {string} syntax source with comments and string contents masked
+ * @param {number} start property start offset
+ * @returns {{end: number, value: string}|undefined} property name and ending offset
+ */
+function readJavascriptPropertyName (source, syntax, start) {
+  const index = skipWhitespace(syntax, start)
+  const quoted = readQuotedString(source, index)
+  if (quoted) return quoted
+  const identifier = /^[A-Za-z_$][\w$]*/.exec(syntax.slice(index))
+  if (identifier) return { end: index + identifier[0].length, value: identifier[0] }
 }
 
 function getDataProfileDefinitions (value) {

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -66,6 +66,18 @@ const RETAINED_PROFILE_VALUES = new Set([
   '--require-module',
   '--world-parameters',
 ])
+const JAVASCRIPT_STRING_ESCAPES = Object.freeze({
+  '"': '"',
+  "'": "'",
+  '/': '/',
+  '\\': '\\',
+  b: '\b',
+  f: '\f',
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  v: '\v',
+})
 
 /**
  * Reports whether the installed Cucumber CLI can bypass customer profiles with a validator-owned config.
@@ -506,18 +518,60 @@ function readQuotedString (source, start) {
   const quote = source[start]
   if (quote !== '"' && quote !== "'") return
   let value = ''
-  for (let index = start + 1; index < source.length; index++) {
+  let index = start + 1
+  while (index < source.length) {
     const character = source[index]
     if (character === quote) return { end: index + 1, value }
+    if (character === '\r' || character === '\n') return
     if (character !== '\\') {
       value += character
+      index++
       continue
     }
-    const escaped = source[++index]
-    const escapes = { n: '\n', r: '\r', t: '\t' }
-    if (escaped === quote || escaped === '\\') value += escaped
-    else if (escapes[escaped]) value += escapes[escaped]
-    else return
+    const escaped = readJavascriptStringEscape(source, index + 1)
+    if (!escaped) return
+    value += escaped.value
+    index = escaped.end
+  }
+}
+
+/**
+ * Decodes one bounded JavaScript string escape without evaluating source.
+ *
+ * @param {string} source original JavaScript source
+ * @param {number} start first character after the backslash
+ * @returns {{end: number, value: string}|undefined} decoded character and ending offset
+ */
+function readJavascriptStringEscape (source, start) {
+  const escaped = source[start]
+  if (Object.hasOwn(JAVASCRIPT_STRING_ESCAPES, escaped)) {
+    return { end: start + 1, value: JAVASCRIPT_STRING_ESCAPES[escaped] }
+  }
+  if (escaped === '\n') return { end: start + 1, value: '' }
+  if (escaped === '\r') {
+    return { end: source[start + 1] === '\n' ? start + 2 : start + 1, value: '' }
+  }
+
+  if (escaped === 'x') {
+    const hexadecimal = source.slice(start + 1, start + 3)
+    if (/^[\da-fA-F]{2}$/.test(hexadecimal)) {
+      return { end: start + 3, value: String.fromCharCode(Number.parseInt(hexadecimal, 16)) }
+    }
+    return
+  }
+  if (escaped !== 'u') return
+
+  if (source[start + 1] === '{') {
+    const match = /^\{([\da-fA-F]{1,6})\}/.exec(source.slice(start + 1))
+    if (!match) return
+    const codePoint = Number.parseInt(match[1], 16)
+    if (codePoint > 1_114_111) return
+    return { end: start + 1 + match[0].length, value: String.fromCodePoint(codePoint) }
+  }
+
+  const hexadecimal = source.slice(start + 1, start + 5)
+  if (/^[\da-fA-F]{4}$/.test(hexadecimal)) {
+    return { end: start + 5, value: String.fromCharCode(Number.parseInt(hexadecimal, 16)) }
   }
 }
 
@@ -539,12 +593,21 @@ function getProfileArgs (definition) {
     }
     const option = PROFILE_VALUE_OPTIONS.get(key)
     if (!option) return { error: `contains unsupported option ${key}`, args: [] }
+
+    if (key === 'worldParameters') {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return { error: 'contains non-object worldParameters', args: [] }
+      }
+      args.push(option, JSON.stringify(value))
+      continue
+    }
+
     const values = Array.isArray(value) ? value : [value]
     for (const item of values) {
-      const serialized = key === 'worldParameters' && item !== null && typeof item === 'object'
-        ? JSON.stringify(item)
-        : String(item)
-      args.push(option, serialized)
+      if (item !== null && typeof item === 'object') {
+        return { error: `contains unsupported object value for ${key}`, args: [] }
+      }
+      args.push(option, String(item))
     }
   }
   return { args }

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -410,7 +410,7 @@ function readJavascriptLiteral (source, syntax, start, depth = 0) {
   if (primitive) {
     const values = { false: false, null: null, true: true }
     const value = Object.hasOwn(values, primitive[1]) ? values[primitive[1]] : Number(primitive[1])
-    if (typeof value === 'number' && !Number.isFinite(value)) return
+    if (typeof value === 'number' && (!Number.isFinite(value) || Object.is(value, -0))) return
     return {
       end: index + primitive[0].length,
       value,
@@ -433,7 +433,7 @@ function readJavascriptLiteral (source, syntax, start, depth = 0) {
       value.push(item.value)
     } else {
       const property = readJavascriptPropertyName(source, syntax, index)
-      if (!property || Object.hasOwn(value, property.value)) return
+      if (!property || property.value === '__proto__' || Object.hasOwn(value, property.value)) return
       index = skipWhitespace(syntax, property.end)
       if (syntax[index] !== ':') return
       item = readJavascriptLiteral(source, syntax, index + 1, depth + 1)

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -409,9 +409,11 @@ function readJavascriptLiteral (source, syntax, start, depth = 0) {
   )
   if (primitive) {
     const values = { false: false, null: null, true: true }
+    const value = Object.hasOwn(values, primitive[1]) ? values[primitive[1]] : Number(primitive[1])
+    if (typeof value === 'number' && !Number.isFinite(value)) return
     return {
       end: index + primitive[0].length,
-      value: Object.hasOwn(values, primitive[1]) ? values[primitive[1]] : Number(primitive[1]),
+      value,
     }
   }
 

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -251,7 +251,8 @@ function isTestProjectsEntry (source, range, objectRanges) {
 function isExportedConfigObject (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, range.start))
   const after = maskJavaScriptNonCode(source.slice(range.end + 1))
-  return DIRECT_EXPORT_PATTERN.test(before) || (CONFIG_CALL_PATTERN.test(before) && /^\s*\)/.test(after))
+  return (DIRECT_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
+    (CONFIG_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after))
 }
 
 /**
@@ -288,6 +289,9 @@ function getDirectContainingArray (source, range) {
   const entryPrefix = maskJavaScriptComments(source.slice(directArray.start, range.start)).trimEnd()
   const entrySuffix = maskJavaScriptComments(source.slice(range.end + 1, directArray.end + 1)).trimStart()
   if (['[', ','].includes(entryPrefix.at(-1)) && [']', ','].includes(entrySuffix[0])) return directArray
+  if (/(?:^|\[|,)\s*defineProject\s*\(\s*$/.test(entryPrefix) && /^\)\s*[\],]/.test(entrySuffix)) {
+    return directArray
+  }
 }
 
 /**

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -8,7 +8,9 @@ const { maskJavaScriptComments, maskJavaScriptNonCode } = require('../source-tex
 
 const CONFIG_PATTERN = /^(?:vite\.config|vitest\.(?:config|workspace))\.[cm]?[jt]s$/
 const WORKSPACE_CONFIG_PATTERN = /^vitest\.workspace\.[cm]?[jt]s$/
-const WORKSPACE_ARRAY_EXPORT_PATTERN = /(?:export\s+default|module\s*\.\s*exports\s*=)\s*$/
+const DIRECT_EXPORT_PATTERN = /(?:export\s+default|module\s*\.\s*exports\s*=)\s*$/
+const CONFIG_CALL_PATTERN =
+  /(?:export\s+default|module\s*\.\s*exports\s*=)\s*defineConfig\s*\(\s*$/
 const WORKSPACE_ARRAY_CALL_PATTERN =
   /(?:export\s+default|module\s*\.\s*exports\s*=)\s*defineWorkspace\s*\(\s*$/
 const PROJECT_CALL_PATTERN =
@@ -73,6 +75,7 @@ function bindLiteralProject ({ configFiles, projectFiles, projectRoot, runnerArg
         bindingRoot: effectiveRoot,
         configFile,
         projectFiles,
+        projectEntry: project.entrySource,
         projectObject: project.source,
         projectRoot,
         standaloneProject: project.standalone,
@@ -116,11 +119,12 @@ function getBindingFromObject ({
   bindingRoot,
   configFile,
   projectFiles,
+  projectEntry,
   projectObject,
   projectRoot,
   standaloneProject,
 }) {
-  if (/\.\.\./.test(maskJavaScriptNonCode(projectObject))) {
+  if (/\.\.\./.test(maskJavaScriptNonCode(projectEntry))) {
     return { error: 'the selected Vitest project uses dynamic spread composition' }
   }
 
@@ -171,7 +175,7 @@ function matchesProjectFile (project, filename) {
  * @param {string} source Vitest configuration source
  * @param {number} nameIndex matching name property offset
  * @param {boolean} workspaceConfig whether the source is a Vitest workspace config
- * @returns {{source: string, standalone: boolean}|undefined} bounded project object
+ * @returns {{entrySource: string, source: string, standalone: boolean}|undefined} bounded project object
  */
 function getProjectObject (source, nameIndex, workspaceConfig) {
   const objectRanges = getObjectRanges(source)
@@ -190,7 +194,11 @@ function getProjectObject (source, nameIndex, workspaceConfig) {
   if (!standalone &&
     !isTestProjectsEntry(source, selected, objectRanges) &&
     !(workspaceConfig && isWorkspaceProjectEntry(source, selected))) return
-  return { source: source.slice(selected.start + 1, selected.end), standalone }
+  return {
+    entrySource: source.slice(selected.start + 1, selected.end),
+    source: source.slice(inner.start + 1, inner.end),
+    standalone,
+  }
 }
 
 /**
@@ -229,7 +237,21 @@ function isTestProjectsEntry (source, range, objectRanges) {
   if (!/(?:^|,)\s*(?:projects|"projects"|'projects')\s*:\s*$/.test(projectsPrefix)) return false
 
   const testPrefix = maskJavaScriptComments(source.slice(configObject.start + 1, testObject.start))
-  return /(?:^|,)\s*(?:test|"test"|'test')\s*:\s*$/.test(testPrefix)
+  return /(?:^|,)\s*(?:test|"test"|'test')\s*:\s*$/.test(testPrefix) &&
+    isExportedConfigObject(source, configObject)
+}
+
+/**
+ * Reports whether an object is the direct exported config or defineConfig argument.
+ *
+ * @param {string} source Vitest configuration source
+ * @param {{end: number, start: number}} range candidate config object range
+ * @returns {boolean} whether the object belongs to the exported configuration
+ */
+function isExportedConfigObject (source, range) {
+  const before = maskJavaScriptNonCode(source.slice(0, range.start))
+  const after = maskJavaScriptNonCode(source.slice(range.end + 1))
+  return DIRECT_EXPORT_PATTERN.test(before) || (CONFIG_CALL_PATTERN.test(before) && /^\s*\)/.test(after))
 }
 
 /**
@@ -245,7 +267,7 @@ function isWorkspaceProjectEntry (source, range) {
 
   const before = maskJavaScriptNonCode(source.slice(0, workspaceArray.start))
   const after = maskJavaScriptNonCode(source.slice(workspaceArray.end + 1))
-  return (WORKSPACE_ARRAY_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
+  return (DIRECT_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
     (WORKSPACE_ARRAY_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after))
 }
 
@@ -403,7 +425,7 @@ function getPropertyPositions (source, property) {
 }
 
 function getLiteralProperty (source, property) {
-  const properties = getPropertyPositions(source, property)
+  const properties = getDirectPropertyPositions(source, property)
   if (properties.length === 0) return {}
   if (properties.length !== 1) return { dynamic: true }
   const literal = /^(["'])([^"'\\]+)\1/.exec(source.slice(properties[0].valueStart))
@@ -412,7 +434,7 @@ function getLiteralProperty (source, property) {
 }
 
 function getLiteralStringArray (source, property) {
-  const properties = getPropertyPositions(source, property)
+  const properties = getDirectPropertyPositions(source, property)
   if (properties.length === 0) return { values: [] }
   if (properties.length !== 1) return { dynamic: true, values: [] }
   const arrayMatch = /^\[([\s\S]{0,8192}?)\]/.exec(source.slice(properties[0].valueStart))
@@ -421,6 +443,20 @@ function getLiteralStringArray (source, property) {
   const values = [...syntax.matchAll(/(["'])([^"'\\]+)\1/g)].map(match => match[2])
   const residue = syntax.replaceAll(/(["'])([^"'\\]+)\1/g, '').replaceAll(',', '').trim()
   return residue ? { dynamic: true, values: [] } : { values }
+}
+
+/**
+ * Returns matching properties that are not nested inside another object.
+ *
+ * @param {string} source JavaScript object contents
+ * @param {string} property property name
+ * @returns {{index: number, valueStart: number}[]} direct property positions
+ */
+function getDirectPropertyPositions (source, property) {
+  const nestedObjects = getObjectRanges(source)
+  return getPropertyPositions(source, property).filter(position => {
+    return !nestedObjects.some(object => object.start < position.index && object.end > position.index)
+  })
 }
 
 function getOptionValues (args, expected) {

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -7,6 +7,12 @@ const { matchesLiteralGlob } = require('../literal-glob')
 const { maskJavaScriptComments, maskJavaScriptNonCode } = require('../source-text')
 
 const CONFIG_PATTERN = /^(?:vite\.config|vitest\.(?:config|workspace))\.[cm]?[jt]s$/
+const WORKSPACE_CONFIG_PATTERN = /^vitest\.workspace\.[cm]?[jt]s$/
+const WORKSPACE_ARRAY_EXPORT_PATTERN = /(?:export\s+default|module\s*\.\s*exports\s*=)\s*$/
+const WORKSPACE_ARRAY_CALL_PATTERN =
+  /(?:export\s+default|module\s*\.\s*exports\s*=)\s*defineWorkspace\s*\(\s*$/
+const PROJECT_CALL_PATTERN =
+  /(?:export\s+default|module\s*\.\s*exports\s*=)\s*defineProject\s*\(\s*$/
 const LITERAL_PROJECT_PATTERN = /^[A-Za-z0-9_.:@/-]+$/
 
 /**
@@ -55,7 +61,11 @@ function bindLiteralProject ({ configFiles, projectFiles, projectRoot, runnerArg
     if (source === undefined) continue
     for (const property of getLiteralStringProperties(source, 'name')) {
       if (property.value !== name) continue
-      const project = getProjectObject(source, property.index)
+      const project = getProjectObject(
+        source,
+        property.index,
+        WORKSPACE_CONFIG_PATTERN.test(path.basename(configFile))
+      )
       if (!project) continue
       const projectName = getLiteralProperty(project.source, 'name')
       if (projectName.dynamic || projectName.value !== name) continue
@@ -160,9 +170,10 @@ function matchesProjectFile (project, filename) {
  *
  * @param {string} source Vitest configuration source
  * @param {number} nameIndex matching name property offset
+ * @param {boolean} workspaceConfig whether the source is a Vitest workspace config
  * @returns {{source: string, standalone: boolean}|undefined} bounded project object
  */
-function getProjectObject (source, nameIndex) {
+function getProjectObject (source, nameIndex, workspaceConfig) {
   const objectRanges = getObjectRanges(source)
   const ranges = objectRanges
     .filter(range => range.start < nameIndex && range.end > nameIndex)
@@ -176,7 +187,9 @@ function getProjectObject (source, nameIndex) {
   const nestedTestObject = /(?:^|,)\s*(?:test|(["'])test\1)\s*:\s*$/.test(parentPrefix || '')
   const selected = nestedTestObject ? parent : inner
   const standalone = isStandaloneProjectObject(source, selected)
-  if (!standalone && !isTestProjectsEntry(source, selected, objectRanges)) return
+  if (!standalone &&
+    !isTestProjectsEntry(source, selected, objectRanges) &&
+    !(workspaceConfig && isWorkspaceProjectEntry(source, selected))) return
   return { source: source.slice(selected.start + 1, selected.end), standalone }
 }
 
@@ -190,7 +203,7 @@ function getProjectObject (source, nameIndex) {
 function isStandaloneProjectObject (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, range.start))
   const after = maskJavaScriptNonCode(source.slice(range.end + 1))
-  return /(?:^|[^\w$.])defineProject\s*\(\s*$/.test(before) && /^\s*\)/.test(after)
+  return PROJECT_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after)
 }
 
 /**
@@ -202,15 +215,8 @@ function isStandaloneProjectObject (source, range) {
  * @returns {boolean} whether the object is a bounded project entry
  */
 function isTestProjectsEntry (source, range, objectRanges) {
-  const arrays = getDelimitedRanges(source, '[', ']')
-    .filter(array => array.start < range.start && array.end > range.end)
-    .sort((left, right) => (left.end - left.start) - (right.end - right.start))
-  const projectsArray = arrays[0]
+  const projectsArray = getDirectContainingArray(source, range)
   if (!projectsArray) return false
-
-  const entryPrefix = maskJavaScriptComments(source.slice(projectsArray.start, range.start)).trimEnd()
-  const entrySuffix = maskJavaScriptComments(source.slice(range.end + 1, projectsArray.end + 1)).trimStart()
-  if (!['[', ','].includes(entryPrefix.at(-1)) || ![']', ','].includes(entrySuffix[0])) return false
 
   const containers = objectRanges
     .filter(object => object.start < projectsArray.start && object.end > projectsArray.end)
@@ -224,6 +230,42 @@ function isTestProjectsEntry (source, range, objectRanges) {
 
   const testPrefix = maskJavaScriptComments(source.slice(configObject.start + 1, testObject.start))
   return /(?:^|,)\s*(?:test|"test"|'test')\s*:\s*$/.test(testPrefix)
+}
+
+/**
+ * Reports whether an object is a direct entry in the exported array of a Vitest workspace config.
+ *
+ * @param {string} source Vitest workspace configuration source
+ * @param {{end: number, start: number}} range candidate object range
+ * @returns {boolean} whether the object is a bounded workspace project entry
+ */
+function isWorkspaceProjectEntry (source, range) {
+  const workspaceArray = getDirectContainingArray(source, range)
+  if (!workspaceArray) return false
+
+  const before = maskJavaScriptNonCode(source.slice(0, workspaceArray.start))
+  const after = maskJavaScriptNonCode(source.slice(workspaceArray.end + 1))
+  return (WORKSPACE_ARRAY_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
+    (WORKSPACE_ARRAY_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after))
+}
+
+/**
+ * Returns the smallest array containing an object as a direct entry.
+ *
+ * @param {string} source JavaScript-like source
+ * @param {{end: number, start: number}} range candidate object range
+ * @returns {{end: number, start: number}|undefined} containing direct array
+ */
+function getDirectContainingArray (source, range) {
+  const arrays = getDelimitedRanges(source, '[', ']')
+    .filter(array => array.start < range.start && array.end > range.end)
+    .sort((left, right) => (left.end - left.start) - (right.end - right.start))
+  const directArray = arrays[0]
+  if (!directArray) return
+
+  const entryPrefix = maskJavaScriptComments(source.slice(directArray.start, range.start)).trimEnd()
+  const entrySuffix = maskJavaScriptComments(source.slice(range.end + 1, directArray.end + 1)).trimStart()
+  if (['[', ','].includes(entryPrefix.at(-1)) && [']', ','].includes(entrySuffix[0])) return directArray
 }
 
 /**

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -155,7 +155,12 @@ function getProjectObject (source, nameIndex) {
     .sort((left, right) => (left.end - left.start) - (right.end - right.start))
   if (ranges.length === 0) return
 
-  const selected = ranges[1] || ranges[0]
+  // Vitest accepts both `{ name }` and `{ test: { name } }` project entries.
+  const inner = ranges[0]
+  const parent = ranges[1]
+  const parentPrefix = parent && maskJavaScriptComments(source.slice(parent.start + 1, inner.start))
+  const nestedTestObject = /(?:^|,)\s*(?:test|(["'])test\1)\s*:\s*$/.test(parentPrefix || '')
+  const selected = nestedTestObject ? parent : inner
   return source.slice(selected.start + 1, selected.end)
 }
 

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -189,6 +189,8 @@ function getProjectObject (source, nameIndex, workspaceConfig) {
   const parent = ranges[1]
   const parentPrefix = parent && maskJavaScriptComments(source.slice(parent.start + 1, inner.start))
   const nestedTestObject = /(?:^|,)\s*(?:test|(["'])test\1)\s*:\s*$/.test(parentPrefix || '')
+  if (nestedTestObject &&
+    getDirectPropertyPositions(source.slice(parent.start + 1, parent.end), 'test').length !== 1) return
   const selected = nestedTestObject ? parent : inner
   const standalone = isStandaloneProjectObject(source, selected)
   if (!standalone &&
@@ -211,7 +213,7 @@ function getProjectObject (source, nameIndex, workspaceConfig) {
 function isStandaloneProjectObject (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, range.start))
   const after = maskJavaScriptNonCode(source.slice(range.end + 1))
-  return PROJECT_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after)
+  return PROJECT_CALL_PATTERN.test(before) && /^\s*,?\s*\)[\s;]*$/.test(after)
 }
 
 /**
@@ -234,10 +236,15 @@ function isTestProjectsEntry (source, range, objectRanges) {
   if (!testObject || !configObject) return false
 
   const projectsPrefix = maskJavaScriptComments(source.slice(testObject.start + 1, projectsArray.start))
-  if (!/(?:^|,)\s*(?:projects|"projects"|'projects')\s*:\s*$/.test(projectsPrefix)) return false
+  if (!/(?:^|,)\s*(?:projects|"projects"|'projects')\s*:\s*$/.test(projectsPrefix) ||
+    getDirectPropertyPositions(
+      source.slice(testObject.start + 1, testObject.end),
+      'projects'
+    ).length !== 1) return false
 
   const testPrefix = maskJavaScriptComments(source.slice(configObject.start + 1, testObject.start))
   return /(?:^|,)\s*(?:test|"test"|'test')\s*:\s*$/.test(testPrefix) &&
+    getDirectPropertyPositions(source.slice(configObject.start + 1, configObject.end), 'test').length === 1 &&
     isExportedConfigObject(source, configObject)
 }
 
@@ -252,7 +259,7 @@ function isExportedConfigObject (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, range.start))
   const after = maskJavaScriptNonCode(source.slice(range.end + 1))
   return (DIRECT_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
-    (CONFIG_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after))
+    (CONFIG_CALL_PATTERN.test(before) && /^\s*,?\s*\)[\s;]*$/.test(after))
 }
 
 /**
@@ -269,7 +276,7 @@ function isWorkspaceProjectEntry (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, workspaceArray.start))
   const after = maskJavaScriptNonCode(source.slice(workspaceArray.end + 1))
   return (DIRECT_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
-    (WORKSPACE_ARRAY_CALL_PATTERN.test(before) && /^\s*\)[\s;]*$/.test(after))
+    (WORKSPACE_ARRAY_CALL_PATTERN.test(before) && /^\s*,?\s*\)[\s;]*$/.test(after))
 }
 
 /**
@@ -289,7 +296,7 @@ function getDirectContainingArray (source, range) {
   const entryPrefix = maskJavaScriptComments(source.slice(directArray.start, range.start)).trimEnd()
   const entrySuffix = maskJavaScriptComments(source.slice(range.end + 1, directArray.end + 1)).trimStart()
   if (['[', ','].includes(entryPrefix.at(-1)) && [']', ','].includes(entrySuffix[0])) return directArray
-  if (/(?:^|\[|,)\s*defineProject\s*\(\s*$/.test(entryPrefix) && /^\)\s*[\],]/.test(entrySuffix)) {
+  if (/(?:^|\[|,)\s*defineProject\s*\(\s*$/.test(entryPrefix) && /^,?\s*\)\s*[\],]/.test(entrySuffix)) {
     return directArray
   }
 }

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -55,17 +55,17 @@ function bindLiteralProject ({ configFiles, projectFiles, projectRoot, runnerArg
     if (source === undefined) continue
     for (const property of getLiteralStringProperties(source, 'name')) {
       if (property.value !== name) continue
-      const projectObject = getProjectObject(source, property.index)
-      if (!projectObject) continue
-      const projectName = getLiteralProperty(projectObject, 'name')
+      const project = getProjectObject(source, property.index)
+      if (!project) continue
+      const projectName = getLiteralProperty(project.source, 'name')
       if (projectName.dynamic || projectName.value !== name) continue
       const binding = getBindingFromObject({
         bindingRoot: effectiveRoot,
         configFile,
         projectFiles,
-        projectObject,
+        projectObject: project.source,
         projectRoot,
-        source,
+        standaloneProject: project.standalone,
       })
       if (binding.error) return binding
       bindings.push(binding)
@@ -102,7 +102,14 @@ function getSelectedConfigFiles ({ configFiles, effectiveRoot, projectRoot, runn
   }
 }
 
-function getBindingFromObject ({ bindingRoot, configFile, projectFiles, projectObject, projectRoot, source }) {
+function getBindingFromObject ({
+  bindingRoot,
+  configFile,
+  projectFiles,
+  projectObject,
+  projectRoot,
+  standaloneProject,
+}) {
   if (/\.\.\./.test(maskJavaScriptNonCode(projectObject))) {
     return { error: 'the selected Vitest project uses dynamic spread composition' }
   }
@@ -110,7 +117,6 @@ function getBindingFromObject ({ bindingRoot, configFile, projectFiles, projectO
   const rootProperty = getLiteralProperty(projectObject, 'root')
   if (rootProperty.dynamic) return { error: 'the selected Vitest project has a dynamic root' }
 
-  const standaloneProject = /\bdefineProject\s*\(/.test(maskJavaScriptNonCode(source))
   const rootBase = standaloneProject ? path.dirname(configFile) : bindingRoot
   const root = rootProperty.value
     ? path.resolve(rootBase, rootProperty.value)
@@ -149,8 +155,16 @@ function matchesProjectFile (project, filename) {
   return included && !project.excludePatterns.some(pattern => matchesLiteralGlob(normalized, pattern))
 }
 
+/**
+ * Returns the literal project object that owns a matching name property.
+ *
+ * @param {string} source Vitest configuration source
+ * @param {number} nameIndex matching name property offset
+ * @returns {{source: string, standalone: boolean}|undefined} bounded project object
+ */
 function getProjectObject (source, nameIndex) {
-  const ranges = getObjectRanges(source)
+  const objectRanges = getObjectRanges(source)
+  const ranges = objectRanges
     .filter(range => range.start < nameIndex && range.end > nameIndex)
     .sort((left, right) => (left.end - left.start) - (right.end - right.start))
   if (ranges.length === 0) return
@@ -161,10 +175,76 @@ function getProjectObject (source, nameIndex) {
   const parentPrefix = parent && maskJavaScriptComments(source.slice(parent.start + 1, inner.start))
   const nestedTestObject = /(?:^|,)\s*(?:test|(["'])test\1)\s*:\s*$/.test(parentPrefix || '')
   const selected = nestedTestObject ? parent : inner
-  return source.slice(selected.start + 1, selected.end)
+  const standalone = isStandaloneProjectObject(source, selected)
+  if (!standalone && !isTestProjectsEntry(source, selected, objectRanges)) return
+  return { source: source.slice(selected.start + 1, selected.end), standalone }
 }
 
+/**
+ * Reports whether an object is the direct literal argument to defineProject.
+ *
+ * @param {string} source Vitest configuration source
+ * @param {{end: number, start: number}} range candidate object range
+ * @returns {boolean} whether the object is a standalone project
+ */
+function isStandaloneProjectObject (source, range) {
+  const before = maskJavaScriptNonCode(source.slice(0, range.start))
+  const after = maskJavaScriptNonCode(source.slice(range.end + 1))
+  return /(?:^|[^\w$.])defineProject\s*\(\s*$/.test(before) && /^\s*\)/.test(after)
+}
+
+/**
+ * Reports whether an object is a direct entry in a literal test.projects array.
+ *
+ * @param {string} source Vitest configuration source
+ * @param {{end: number, start: number}} range candidate object range
+ * @param {{end: number, start: number}[]} objectRanges source object ranges
+ * @returns {boolean} whether the object is a bounded project entry
+ */
+function isTestProjectsEntry (source, range, objectRanges) {
+  const arrays = getDelimitedRanges(source, '[', ']')
+    .filter(array => array.start < range.start && array.end > range.end)
+    .sort((left, right) => (left.end - left.start) - (right.end - right.start))
+  const projectsArray = arrays[0]
+  if (!projectsArray) return false
+
+  const entryPrefix = maskJavaScriptComments(source.slice(projectsArray.start, range.start)).trimEnd()
+  const entrySuffix = maskJavaScriptComments(source.slice(range.end + 1, projectsArray.end + 1)).trimStart()
+  if (!['[', ','].includes(entryPrefix.at(-1)) || ![']', ','].includes(entrySuffix[0])) return false
+
+  const containers = objectRanges
+    .filter(object => object.start < projectsArray.start && object.end > projectsArray.end)
+    .sort((left, right) => (left.end - left.start) - (right.end - right.start))
+  const testObject = containers[0]
+  const configObject = containers[1]
+  if (!testObject || !configObject) return false
+
+  const projectsPrefix = maskJavaScriptComments(source.slice(testObject.start + 1, projectsArray.start))
+  if (!/(?:^|,)\s*(?:projects|"projects"|'projects')\s*:\s*$/.test(projectsPrefix)) return false
+
+  const testPrefix = maskJavaScriptComments(source.slice(configObject.start + 1, testObject.start))
+  return /(?:^|,)\s*(?:test|"test"|'test')\s*:\s*$/.test(testPrefix)
+}
+
+/**
+ * Finds balanced object ranges while ignoring comments and strings.
+ *
+ * @param {string} source JavaScript-like source
+ * @returns {{end: number, start: number}[]} object ranges
+ */
 function getObjectRanges (source) {
+  return getDelimitedRanges(source, '{', '}')
+}
+
+/**
+ * Finds balanced delimiter ranges while ignoring comments and strings.
+ *
+ * @param {string} source JavaScript-like source
+ * @param {string} open opening delimiter
+ * @param {string} close closing delimiter
+ * @returns {{end: number, start: number}[]} delimiter ranges
+ */
+function getDelimitedRanges (source, open, close) {
   const ranges = []
   const stack = []
   let quote
@@ -197,9 +277,9 @@ function getObjectRanges (source) {
       index++
     } else if (character === '"' || character === "'" || character === '`') {
       quote = character
-    } else if (character === '{') {
+    } else if (character === open) {
       stack.push(index)
-    } else if (character === '}') {
+    } else if (character === close) {
       const start = stack.pop()
       if (start !== undefined) ranges.push({ end: index, start })
     }

--- a/ci/test-optimization-validation/manifest-scaffold.js
+++ b/ci/test-optimization-validation/manifest-scaffold.js
@@ -861,7 +861,7 @@ function getStaticTestCount (source) {
   const direct = [...source.matchAll(/\b(?:it|test)((?:\.[A-Za-z]+)*)\s*\(\s*(['"`])/g)]
     .filter(match => !/\.(?:skip|todo)\b/.test(match[1]))
   const parameterized = [...source.matchAll(
-    /\b(?:it|test)((?:\.[A-Za-z]+)*)\.each\s*\([^()]*\)((?:\.[A-Za-z]+)*)\s*\(\s*(['"`])/g
+    /\b(?:it|test)((?:\.[A-Za-z]+)*)\.each\s*(?:\([^()]*\)|`(?:\\[\s\S]|[^\\`])*`)((?:\.[A-Za-z]+)*)\s*\(\s*(['"`])/g
   )].filter(match => !/\.(?:skip|todo)\b/.test(`${match[1]}${match[2]}`))
   return direct.length + parameterized.length
 }

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -200,6 +200,90 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  for (const [description, requireValue] of [
+    ['nested object', "{ path: 'features/steps.js' }"],
+    ['nested object in an array', "[{ path: 'features/steps.js' }]"],
+  ]) {
+    it(`rejects a ${description} for a Cucumber string option without aborting scaffolding`, () => {
+      withRepositoryFixture({
+        framework: 'cucumber',
+        script: 'cucumber-js --profile default',
+      }, fixture => {
+        fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+          'module.exports = {',
+          `  default: { require: ${requireValue} },`,
+          '}',
+          '',
+        ].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'cucumber')
+
+        assert.strictEqual(framework.status, 'requires_manual_setup')
+        assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+        assert.match(framework.notes.join(' '), /require/)
+        assert.strictEqual(framework.validation, undefined)
+      })
+    })
+  }
+
+  it('decodes standard escapes in literal JavaScript Cucumber object profiles', () => {
+    withRepositoryFixture({
+      framework: 'cucumber',
+      script: 'cucumber-js --profile default',
+    }, fixture => {
+      const supportFile = path.join(fixture.root, 'features', 'steps', 'example.js')
+      fs.mkdirSync(path.dirname(supportFile), { recursive: true })
+      fs.writeFileSync(supportFile, 'module.exports = function () {}\n')
+      fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+        'module.exports = {',
+        '  default: {',
+        String.raw`    require: ['features/\u0073teps/**/*.js'],`,
+        '    worldParameters: {',
+        String.raw`      unicode: '\u0041', hex: '\x42', codePoint: '\u{43}',`,
+        String.raw`      max: '\u{10FFFF}', line: 'a\nb',`,
+        '    },',
+        '  },',
+        '}',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'cucumber')
+
+      assert.strictEqual(framework.status, 'runnable')
+      assert.deepStrictEqual(framework.validation.runnerArgs, [
+        '--require', supportFile,
+        '--world-parameters', JSON.stringify({
+          unicode: 'A',
+          hex: 'B',
+          codePoint: 'C',
+          max: String.fromCodePoint(1_114_111),
+          line: 'a\nb',
+        }),
+      ])
+    })
+  })
+
+  it('rejects an out-of-range Unicode escape in a JavaScript Cucumber object profile', () => {
+    withRepositoryFixture({
+      framework: 'cucumber',
+      script: 'cucumber-js --profile default',
+    }, fixture => {
+      fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+        'module.exports = {',
+        String.raw`  default: { worldParameters: { invalid: '\u{110000}' } },`,
+        '}',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'cucumber')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /must be a literal string or object/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
   it('rejects spread-composed JavaScript Cucumber object profiles', () => {
     withRepositoryFixture({
       framework: 'cucumber',
@@ -1123,6 +1207,68 @@ describe('test optimization validation manifest scaffold', () => {
       assert.strictEqual(framework.status, 'runnable')
       assert.strictEqual(framework.validation.testFile, selected)
       assert.deepStrictEqual(framework.validation.runnerArgs, ['--project', 'unit'])
+    })
+  })
+
+  it('does not bind a Vitest project name from an unrelated object', () => {
+    withRepositoryFixture({
+      framework: 'vitest',
+      script: 'vitest --run --project unit',
+    }, fixture => {
+      const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+      fs.rmSync(fixture.testFile)
+      fs.mkdirSync(path.dirname(selected), { recursive: true })
+      fs.writeFileSync(selected, "test('selected', () => {})\n")
+      fs.writeFileSync(path.join(fixture.root, 'vitest.config.ts'), [
+        "import { defineConfig } from 'vitest/config'",
+        'export default defineConfig({',
+        "  metadata: { name: 'unit', root: 'unit', include: ['**/*.test.ts'] },",
+        '  test: {',
+        '    projects: [',
+        "      { name: 'integration', root: 'integration' },",
+        '    ],',
+        '  },',
+        '})',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'vitest')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /does not map to one statically named Vitest project/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
+  it('binds a standalone literal Vitest defineProject configuration', () => {
+    withRepositoryFixture({
+      framework: 'vitest',
+      script: 'vitest --run --config configs/unit.ts --project unit',
+    }, fixture => {
+      const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+      const configFile = path.join(fixture.root, 'configs', 'unit.ts')
+      fs.rmSync(fixture.testFile)
+      fs.mkdirSync(path.dirname(selected), { recursive: true })
+      fs.mkdirSync(path.dirname(configFile), { recursive: true })
+      fs.writeFileSync(selected, "test('selected', () => {})\n")
+      fs.writeFileSync(configFile, [
+        "import { defineProject } from 'vitest/config'",
+        'export default defineProject({',
+        "  name: 'unit',",
+        "  root: '../unit',",
+        "  include: ['**/*.test.ts'],",
+        '})',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'vitest')
+
+      assert.strictEqual(framework.status, 'runnable')
+      assert.strictEqual(framework.validation.testFile, selected)
+      assert.deepStrictEqual(framework.validation.runnerArgs, [
+        '--config', 'configs/unit.ts', '--project', 'unit',
+      ])
     })
   })
 

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -1241,6 +1241,37 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  it('does not bind a Vitest project from an unexported test.projects helper', () => {
+    withRepositoryFixture({
+      framework: 'vitest',
+      script: 'vitest --run --project unit',
+    }, fixture => {
+      const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+      fs.rmSync(fixture.testFile)
+      fs.mkdirSync(path.dirname(selected), { recursive: true })
+      fs.writeFileSync(selected, "test('selected', () => {})\n")
+      fs.writeFileSync(path.join(fixture.root, 'vitest.config.ts'), [
+        "import { defineConfig } from 'vitest/config'",
+        'const helper = {',
+        '  test: {',
+        "    projects: [{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }],",
+        '  },',
+        '}',
+        'export default defineConfig({',
+        "  test: { projects: [{ name: 'integration', root: 'integration' }] },",
+        '})',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'vitest')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /does not map to one statically named Vitest project/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
   it('binds a standalone literal Vitest defineProject configuration', () => {
     withRepositoryFixture({
       framework: 'vitest',
@@ -1304,6 +1335,41 @@ describe('test optimization validation manifest scaffold', () => {
         assert.strictEqual(framework.status, 'runnable')
         assert.strictEqual(framework.validation.testFile, selected)
         assert.deepStrictEqual(framework.validation.runnerArgs, ['--project', 'unit'])
+      })
+    })
+  }
+
+  for (const [description, include] of [
+    ['keeps a direct include separate from coverage include', "      include: ['tests/**/*.test.ts'],"],
+    ['ignores coverage include when test include is absent', undefined],
+  ]) {
+    it(`${description} in a nested Vitest workspace test object`, () => {
+      withRepositoryFixture({
+        framework: 'vitest',
+        script: 'vitest --run --project unit',
+      }, fixture => {
+        const selected = path.join(fixture.root, 'unit', 'tests', 'selected.test.ts')
+        fs.rmSync(fixture.testFile)
+        fs.mkdirSync(path.dirname(selected), { recursive: true })
+        fs.writeFileSync(selected, "test('selected', () => {})\n")
+        fs.writeFileSync(path.join(fixture.root, 'vitest.workspace.ts'), [
+          'export default [',
+          '  {',
+          '    test: {',
+          "      name: 'unit',",
+          "      root: 'unit',",
+          include,
+          "      coverage: { include: ['src/**'] },",
+          '    },',
+          '  },',
+          ']',
+          '',
+        ].filter(line => line !== undefined).join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'vitest')
+
+        assert.strictEqual(framework.status, 'runnable')
+        assert.strictEqual(framework.validation.testFile, selected)
       })
     })
   }

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -305,6 +305,32 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  for (const [description, worldParameters] of [
+    ['negative zero', '{ offset: -0 }'],
+    ['a __proto__ object-literal key', "{ payload: { __proto__: { role: 'admin' } } }"],
+  ]) {
+    it(`rejects ${description} in JavaScript Cucumber world parameters`, () => {
+      withRepositoryFixture({
+        framework: 'cucumber',
+        script: 'cucumber-js --profile default',
+      }, fixture => {
+        fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+          'module.exports = {',
+          `  default: { worldParameters: ${worldParameters} },`,
+          '}',
+          '',
+        ].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'cucumber')
+
+        assert.strictEqual(framework.status, 'requires_manual_setup')
+        assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+        assert.match(framework.notes.join(' '), /must be a literal string or object/)
+        assert.strictEqual(framework.validation, undefined)
+      })
+    })
+  }
+
   it('rejects spread-composed JavaScript Cucumber object profiles', () => {
     withRepositoryFixture({
       framework: 'cucumber',
@@ -1354,6 +1380,95 @@ describe('test optimization validation manifest scaffold', () => {
         assert.strictEqual(framework.status, 'runnable')
         assert.strictEqual(framework.validation.testFile, selected)
         assert.deepStrictEqual(framework.validation.runnerArgs, ['--project', 'unit'])
+      })
+    })
+  }
+
+  for (const [description, body] of [
+    ['project test object', [
+      '  test: { projects: [{',
+      "    test: { name: 'unit', root: 'unit', include: ['**/*.test.ts'] },",
+      "    test: { name: 'integration', root: 'integration' },",
+      '  }] },',
+    ]],
+    ['configuration test object', [
+      "  test: { projects: [{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }] },",
+      "  test: { projects: [{ name: 'integration', root: 'integration' }] },",
+    ]],
+    ['configuration projects array', [
+      '  test: {',
+      "    projects: [{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }],",
+      "    projects: [{ name: 'integration', root: 'integration' }],",
+      '  },',
+    ]],
+  ]) {
+    it(`does not bind a shadowed Vitest ${description}`, () => {
+      withRepositoryFixture({
+        framework: 'vitest',
+        script: 'vitest --run --project unit',
+      }, fixture => {
+        const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+        fs.rmSync(fixture.testFile)
+        fs.mkdirSync(path.dirname(selected), { recursive: true })
+        fs.writeFileSync(selected, "test('selected', () => {})\n")
+        fs.writeFileSync(path.join(fixture.root, 'vitest.config.ts'), [
+          "import { defineConfig } from 'vitest/config'",
+          'export default defineConfig({',
+          ...body,
+          '})',
+          '',
+        ].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'vitest')
+
+        assert.strictEqual(framework.status, 'requires_manual_setup')
+        assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+        assert.match(framework.notes.join(' '), /does not map to one statically named Vitest project/)
+        assert.strictEqual(framework.validation, undefined)
+      })
+    })
+  }
+
+  for (const [description, script, configFile, source] of [
+    ['defineConfig', 'vitest --run --project unit', 'vitest.config.ts', [
+      "import { defineConfig } from 'vitest/config'",
+      'export default defineConfig({',
+      "  test: { projects: [{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }] },",
+      '},)',
+    ]],
+    ['defineWorkspace', 'vitest --run --project unit', 'vitest.workspace.ts', [
+      "import { defineWorkspace } from 'vitest/config'",
+      'export default defineWorkspace([',
+      "  { test: { name: 'unit', root: 'unit', include: ['**/*.test.ts'] } },",
+      '],)',
+    ]],
+    ['standalone defineProject', 'vitest --run --config configs/unit.ts --project unit', 'configs/unit.ts', [
+      "import { defineProject } from 'vitest/config'",
+      'export default defineProject({',
+      "  name: 'unit', root: '../unit', include: ['**/*.test.ts'],",
+      '},)',
+    ]],
+    ['array defineProject', 'vitest --run --project unit', 'vitest.config.ts', [
+      "import { defineConfig, defineProject } from 'vitest/config'",
+      'export default defineConfig({',
+      "  test: { projects: [defineProject({ name: 'unit', root: 'unit', include: ['**/*.test.ts'] },)] },",
+      '})',
+    ]],
+  ]) {
+    it(`binds a Vitest project with a trailing comma in ${description}`, () => {
+      withRepositoryFixture({ framework: 'vitest', script }, fixture => {
+        const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+        const filename = path.join(fixture.root, configFile)
+        fs.rmSync(fixture.testFile)
+        fs.mkdirSync(path.dirname(selected), { recursive: true })
+        fs.mkdirSync(path.dirname(filename), { recursive: true })
+        fs.writeFileSync(selected, "test('selected', () => {})\n")
+        fs.writeFileSync(filename, [...source, ''].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'vitest')
+
+        assert.strictEqual(framework.status, 'runnable')
+        assert.strictEqual(framework.validation.testFile, selected)
       })
     })
   }

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -1272,6 +1272,63 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  for (const [description, opening, closing] of [
+    ['exported array', 'export default [', ']'],
+    ['defineWorkspace array', 'export default defineWorkspace([', '])'],
+  ]) {
+    it(`binds a direct project entry in a literal Vitest workspace ${description}`, () => {
+      withRepositoryFixture({
+        framework: 'vitest',
+        script: 'vitest --run --project unit',
+      }, fixture => {
+        const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+        fs.rmSync(fixture.testFile)
+        fs.mkdirSync(path.dirname(selected), { recursive: true })
+        fs.writeFileSync(selected, "test('selected', () => {})\n")
+        fs.writeFileSync(path.join(fixture.root, 'vitest.workspace.ts'), [
+          "import { defineWorkspace } from 'vitest/config'",
+          opening,
+          '  {',
+          '    test: {',
+          "      name: 'unit',",
+          "      root: 'unit',",
+          "      include: ['**/*.test.ts'],",
+          '    },',
+          '  },',
+          closing,
+          '',
+        ].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'vitest')
+
+        assert.strictEqual(framework.status, 'runnable')
+        assert.strictEqual(framework.validation.testFile, selected)
+        assert.deepStrictEqual(framework.validation.runnerArgs, ['--project', 'unit'])
+      })
+    })
+  }
+
+  it('does not bind a project from a transformed Vitest workspace array', () => {
+    withRepositoryFixture({
+      framework: 'vitest',
+      script: 'vitest --run --project unit',
+    }, fixture => {
+      fs.writeFileSync(path.join(fixture.root, 'vitest.workspace.ts'), [
+        'export default [',
+        "  { test: { name: 'unit', root: 'unit' } },",
+        '].map(project => project)',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'vitest')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /does not map to one statically named Vitest project/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
   it('fails closed when a Vitest project cannot be bound to one static scope', () => {
     withRepositoryFixture({
       framework: 'vitest',

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -220,6 +220,29 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  it('rejects JavaScript Cucumber profiles mutated after export', () => {
+    withRepositoryFixture({
+      framework: 'cucumber',
+      script: 'cucumber-js --profile default',
+    }, fixture => {
+      for (const support of ['active.js', 'actual.js']) {
+        fs.writeFileSync(path.join(fixture.root, 'features', support), 'module.exports = function () {}\n')
+      }
+      fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+        "module.exports = { default: '--require features/active.js' }",
+        "module.exports.default = '--require features/actual.js'",
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'cucumber')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /code after the exported profile object/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
   for (const [description, profile] of [
     ['unquoted', 'ci: --require features/steps.js # --require legacy/stale.js\n'],
     ['quoted', 'ci: "--require features/steps.js" # "--require legacy/stale.js"\n'],
@@ -971,6 +994,7 @@ describe('test optimization validation manifest scaffold', () => {
 
   for (const [frameworkName, script, declaration] of [
     ['jest', 'jest', "test.each(cases)('case %s', () => {})"],
+    ['jest', 'jest', 'test.each`\nvalue\n$' + '{1}\n`("case %s", () => {})'],
     ['vitest', 'vitest run', "it.concurrent.each(cases)('case %s', () => {})"],
   ]) {
     it(`selects a ${frameworkName} test containing only parameterized declarations`, () => {

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -170,6 +170,56 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  it('expands a literal JavaScript Cucumber object profile', () => {
+    withRepositoryFixture({
+      framework: 'cucumber',
+      script: 'cucumber-js --profile default',
+    }, fixture => {
+      const supportFile = path.join(fixture.root, 'features', 'steps', 'example.js')
+      fs.mkdirSync(path.dirname(supportFile), { recursive: true })
+      fs.writeFileSync(supportFile, 'module.exports = function () {}\n')
+      fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+        'module.exports = {',
+        '  default: {',
+        "    require: ['features/steps/**/*.js'],",
+        '    failFast: true,',
+        "    worldParameters: { browser: 'chrome', retries: 2 },",
+        '  },',
+        '}',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'cucumber')
+
+      assert.strictEqual(framework.status, 'runnable')
+      assert.deepStrictEqual(framework.validation.runnerArgs, [
+        '--require', supportFile,
+        '--fail-fast',
+        '--world-parameters', '{"browser":"chrome","retries":2}',
+      ])
+    })
+  })
+
+  it('rejects spread-composed JavaScript Cucumber object profiles', () => {
+    withRepositoryFixture({
+      framework: 'cucumber',
+      script: 'cucumber-js --profile default',
+    }, fixture => {
+      fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+        "const shared = { require: ['features/steps/**/*.js'] }",
+        'module.exports = { default: { ...shared } }',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'cucumber')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /must be a literal string or object/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
   for (const [description, profile] of [
     ['unquoted', 'ci: --require features/steps.js # --require legacy/stale.js\n'],
     ['quoted', 'ci: "--require features/steps.js" # "--require legacy/stale.js"\n'],
@@ -1016,6 +1066,39 @@ describe('test optimization validation manifest scaffold', () => {
       assert.strictEqual(framework.validation.testFile, selected)
       assert.ok(framework.project.configFiles.includes(nestedConfig))
       assert.deepStrictEqual(framework.validation.runnerArgs, ['--root', 'packages/foo', '--project', 'unit'])
+    })
+  })
+
+  it('binds one direct named Vitest project among literal siblings', () => {
+    withRepositoryFixture({
+      framework: 'vitest',
+      script: 'vitest --run --project unit',
+    }, fixture => {
+      const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+      const outside = path.join(fixture.root, 'e2e', 'outside.test.ts')
+      fs.rmSync(fixture.testFile)
+      fs.mkdirSync(path.dirname(selected), { recursive: true })
+      fs.mkdirSync(path.dirname(outside), { recursive: true })
+      fs.writeFileSync(selected, "test('selected', () => {})\n")
+      fs.writeFileSync(outside, "test('outside', () => {})\n")
+      fs.writeFileSync(path.join(fixture.root, 'vitest.config.ts'), [
+        "import { defineConfig } from 'vitest/config'",
+        'export default defineConfig({',
+        '  test: {',
+        '    projects: [',
+        "      { name: 'unit', root: 'unit', include: ['**/*.test.ts'] },",
+        "      { name: 'e2e', root: 'e2e', include: ['**/*.test.ts'] },",
+        '    ],',
+        '  },',
+        '})',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'vitest')
+
+      assert.strictEqual(framework.status, 'runnable')
+      assert.strictEqual(framework.validation.testFile, selected)
+      assert.deepStrictEqual(framework.validation.runnerArgs, ['--project', 'unit'])
     })
   })
 

--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -284,6 +284,27 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  it('rejects non-finite numbers in a JavaScript Cucumber object profile', () => {
+    withRepositoryFixture({
+      framework: 'cucumber',
+      script: 'cucumber-js --profile default',
+    }, fixture => {
+      fs.writeFileSync(path.join(fixture.root, 'cucumber.js'), [
+        'module.exports = {',
+        '  default: { worldParameters: { limit: 1e309 } },',
+        '}',
+        '',
+      ].join('\n'))
+
+      const framework = scaffoldFramework(fixture, 'cucumber')
+
+      assert.strictEqual(framework.status, 'requires_manual_setup')
+      assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+      assert.match(framework.notes.join(' '), /must be a literal string or object/)
+      assert.strictEqual(framework.validation, undefined)
+    })
+  })
+
   it('rejects spread-composed JavaScript Cucumber object profiles', () => {
     withRepositoryFixture({
       framework: 'cucumber',
@@ -1272,6 +1293,71 @@ describe('test optimization validation manifest scaffold', () => {
     })
   })
 
+  for (const [description, source] of [
+    ['an overwritten CommonJS export', [
+      'module.exports = {',
+      "  test: { projects: [{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }] },",
+      '}',
+      'module.exports = {}',
+    ]],
+    ['a transformed defineConfig export', [
+      "import { defineConfig } from 'vitest/config'",
+      'export default defineConfig({',
+      "  test: { projects: [{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }] },",
+      '}).test',
+    ]],
+  ]) {
+    it(`does not bind a Vitest project from ${description}`, () => {
+      withRepositoryFixture({
+        framework: 'vitest',
+        script: 'vitest --run --project unit',
+      }, fixture => {
+        const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+        fs.rmSync(fixture.testFile)
+        fs.mkdirSync(path.dirname(selected), { recursive: true })
+        fs.writeFileSync(selected, "test('selected', () => {})\n")
+        fs.writeFileSync(path.join(fixture.root, 'vitest.config.ts'), [...source, ''].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'vitest')
+
+        assert.strictEqual(framework.status, 'requires_manual_setup')
+        assert.strictEqual(framework.blockerCategory, 'VALIDATOR_LIMITATION')
+        assert.match(framework.notes.join(' '), /does not map to one statically named Vitest project/)
+        assert.strictEqual(framework.validation, undefined)
+      })
+    })
+  }
+
+  for (const [description, project] of [
+    ['direct', "{ name: 'unit', root: 'unit', include: ['**/*.test.ts'] }"],
+    ['nested test', "{ test: { name: 'unit', root: 'unit', include: ['**/*.test.ts'] } }"],
+  ]) {
+    it(`binds a ${description} literal defineProject entry in test.projects`, () => {
+      withRepositoryFixture({
+        framework: 'vitest',
+        script: 'vitest --run --project unit',
+      }, fixture => {
+        const selected = path.join(fixture.root, 'unit', 'selected.test.ts')
+        fs.rmSync(fixture.testFile)
+        fs.mkdirSync(path.dirname(selected), { recursive: true })
+        fs.writeFileSync(selected, "test('selected', () => {})\n")
+        fs.writeFileSync(path.join(fixture.root, 'vitest.config.ts'), [
+          "import { defineConfig, defineProject } from 'vitest/config'",
+          'export default defineConfig({',
+          `  test: { projects: [defineProject(${project})] },`,
+          '})',
+          '',
+        ].join('\n'))
+
+        const framework = scaffoldFramework(fixture, 'vitest')
+
+        assert.strictEqual(framework.status, 'runnable')
+        assert.strictEqual(framework.validation.testFile, selected)
+        assert.deepStrictEqual(framework.validation.runnerArgs, ['--project', 'unit'])
+      })
+    })
+  }
+
   it('binds a standalone literal Vitest defineProject configuration', () => {
     withRepositoryFixture({
       framework: 'vitest',
@@ -1661,7 +1747,11 @@ describe('test optimization validation manifest scaffold', () => {
       fs.writeFileSync(selected, "test('selected', () => {})\n")
       fs.writeFileSync(outside, "test('outside', () => {})\n")
       writeVitestProjectConfig(selectedConfig, 'runtime-tests/selected/**/*.test.ts')
-      fs.appendFileSync(selectedConfig, '// defineProject(\nconst description = "defineProject("\n')
+      fs.writeFileSync(selectedConfig, [
+        '// defineProject(',
+        'const description = "defineProject("',
+        fs.readFileSync(selectedConfig, 'utf8'),
+      ].join('\n'))
       writeVitestProjectConfig(
         path.join(fixture.root, 'vitest.config.ts'),
         'runtime-tests/outside/**/*.test.ts'

--- a/packages/dd-trace/test/ci-visibility/validation-cli.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-cli.spec.js
@@ -17,6 +17,7 @@ const {
 const {
   EXECUTION_LOCK_FILENAME,
 } = require('../../../../ci/test-optimization-validation/execution-lock')
+const { createManifestScaffold } = require('../../../../ci/test-optimization-validation/manifest-scaffold')
 const {
   createRepositoryFixture,
   removeFixture,
@@ -416,6 +417,73 @@ describe('test optimization validation CLI', () => {
       assert.strictEqual(frameworkStatus.evidence.blockerCategory, 'UNSUPPORTED_VERSION')
       assert.strictEqual(basicReporting.evidence.blockerCategory, 'UNSUPPORTED_VERSION')
       assert.strictEqual(reportInput.results.some(result => result.evidence.installedPackageIncomplete), false)
+    } finally {
+      process.exitCode = originalExitCode
+      consoleLog.restore()
+      removeFixture(fixture.root)
+    }
+  })
+
+  it('preserves project setup when an approved direct runner becomes unavailable', async () => {
+    const fixture = createRepositoryFixture({ framework: 'mocha' })
+    const out = path.join(fixture.root, 'dd-test-optimization-validation-results')
+    const manifest = createManifestScaffold({ root: fixture.root, frameworks: new Set(['mocha']) })
+    Object.defineProperty(manifest, '__path', {
+      value: path.join(fixture.root, 'dd-test-optimization-validation-manifest.json'),
+    })
+    let reportInput
+    const originalExitCode = process.exitCode
+    const consoleLog = sinon.stub(console, 'log')
+    const isolatedCli = proxyquire('../../../../ci/test-optimization-validation/cli', {
+      './approval': { assertApprovalDigest () {} },
+      './approval-artifacts': {
+        loadApprovedPlan: () => ({
+          material: {
+            manifest: { path: manifest.__path },
+            selection: { frameworks: [], scenario: 'efd' },
+            validation: {
+              keepTemporaryFiles: false,
+              offlineFixtureNonce: 'fixture-nonce',
+              outputDirectory: out,
+              verbose: false,
+            },
+          },
+        }),
+      },
+      './ci-discovery': { annotateCiDiscovery () {} },
+      './executable': { getUnavailableExecutable: () => fixture.runner },
+      './execution-lock': {
+        acquireExecutionLock: () => ({ path: path.join(out, EXECUTION_LOCK_FILENAME) }),
+        releaseExecutionLock () {},
+      },
+      './generated-files': {
+        cleanupGeneratedFiles: async () => ({ directoriesRemoved: 0, filesRemoved: 0, status: 'completed' }),
+      },
+      './manifest-loader': { loadManifest: () => manifest },
+      './package-check': { checkInstalledPackage: () => ({ ok: true }) },
+      './report-writer': {
+        writePendingReport () {},
+        async writeReport (input) { reportInput = input },
+      },
+      './safe-files': { ensureSafeDirectory () {} },
+      './static-diagnosis': {
+        getStaticBlocker: () => undefined,
+        runStaticDiagnosis: () => ({ report: {}, reportPath: path.join(out, 'diagnosis.json') }),
+      },
+    })
+    try {
+      await isolatedCli.main([
+        '--run-approved-plan', path.join(out, 'approval.json'),
+        '--sha256', 'a'.repeat(64),
+      ])
+
+      const notReached = reportInput.results.filter(result => {
+        return result.frameworkId === manifest.frameworks[0].id && ['basic-reporting', 'efd'].includes(result.scenario)
+      })
+      assert.deepStrictEqual(notReached.map(result => result.evidence.blockerCategory), [
+        'PROJECT_SETUP_REQUIRED',
+        'PROJECT_SETUP_REQUIRED',
+      ])
     } finally {
       process.exitCode = originalExitCode
       consoleLog.restore()


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes bounded static parsing and result-classification gaps in the Test Optimization validator:

- accepts JSON-shaped JavaScript Cucumber object profiles while retaining supported literal options;
- validates retained Cucumber option value types, rejects values that cannot round-trip faithfully, and decodes standard string escapes without evaluating configuration;
- rejects executable code that mutates a Cucumber profile after the exported static object;
- binds named Vitest projects only through terminal exported literal test.projects entries, bounded defineProject entries, complete static workspace exports, or direct defineProject configuration, with settings scoped to the exact selected project object;
- rejects shadowed Vitest structural properties while accepting inert trailing commas in allowlisted helper calls;
- recognizes Jest tagged-template parameterized tests as representative tests;
- preserves PROJECT_SETUP_REQUIRED when an approved direct runner becomes unavailable.

Dynamic JavaScript, transformed or overwritten exports, transformed workspace arrays, spreads, methods, computed values, post-export mutations, unrelated named objects, and ambiguous project structures continue to fail closed. Customer configuration is never evaluated.

### Motivation
<!-- What inspired you to submit this pull request? -->

Post-merge reviews of #9584 found several cases where bounded customer configurations were unnecessarily rejected, malformed static values aborted scaffolding, unrelated configuration objects could be mistaken for Vitest projects, or runtime setup failures were reported as validator limitations. These changes recover statically provable cases while keeping unsupported or mutable configuration incomplete.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Cucumber literal parsing is bounded by the existing 512 KiB config limit and a maximum nesting depth of 16.
- Validation: focused regression tests for all changed behaviors.
- Validation: `./node_modules/.bin/mocha --reporter dot packages/dd-trace/test/ci-visibility/*.spec.js` (`508 passing`).
- Validation: `./node_modules/.bin/eslint ci/test-optimization-validation packages/dd-trace/test/ci-visibility --max-warnings 0`.
