### PR TITLE
bench(dogstatsd): stop reaching into DogStatsDClient's internal buffer fields

### DIFF
--- a/benchmark/sirun/dogstatsd/index.js
+++ b/benchmark/sirun/dogstatsd/index.js
@@ -15,9 +15,12 @@ const OPERATIONS = Number(process.env.OPERATIONS)
 // tree that runtime metrics build before flushing. The UDP socket is stubbed so
 // nothing leaves the process — the bench measures the in-process formatting and
 // buffering only.
+let sent
 class BenchClient extends DogStatsDClient {
+  // Fakes just enough of dgram.Socket for on()/unref() at construction and send() at flush -
+  // send() only needs the buffer, so the rest of its dgram args go unused.
   _socket () {
-    return { send () {}, on () {}, unref () {} }
+    return { send (message) { sent = message }, on () {}, unref () {} }
   }
 }
 
@@ -35,11 +38,10 @@ for (let i = 0; i < 12; i++) MANY_TAGS.push(`dim_${i}:value_${i}`)
 
 function preflight () {
   client._add(NAME, 42, 'g', FEW_TAGS)
-  assert.ok(client._buffer.includes(NAME) && client._buffer.includes('env:bench'),
+  // flush() also clears the buffer/offset/queue, so the run below starts clean.
+  client.flush()
+  assert.ok(sent?.toString().includes(NAME) && sent.toString().includes('env:bench'),
     '_add did not format the metric line with global tags')
-  client._buffer = ''
-  client._offset = 0
-  client._queue = []
 }
 preflight()
 
@@ -59,8 +61,9 @@ if (VARIANT === 'aggregated') {
   const type = VARIANT === 'no-tags' ? 'c' : 'g'
   for (let i = 0; i < OPERATIONS; i++) {
     client._add(NAME, i, type, tags)
-    // Drain the datagram queue without sending so memory stays flat.
-    if ((i & 0x7FF) === 0) client._queue.length = 0
+    // _enqueue() returns the live queue array; truncating it drains memory in O(1) without
+    // flush()'s send-path overhead.
+    if ((i & 0x7FF) === 0) client._enqueue().length = 0
   }
 }
 guard.done()


### PR DESCRIPTION
## Summary
- The dogstatsd microbenchmark reached into `DogStatsDClient`'s internal `_buffer`/`_offset`/`_queue` fields directly instead of using its public API.
- Split out of #9355, whose MicroVM identity-refresh work turns those fields into true `#private` class fields, which would break this benchmark.
- Replaces the direct field access with `flush()` (drains buffer/offset/queue and sends) and `_enqueue()` (returns the live queue array to truncate), which produce the same net effect and work unchanged against both the current and upcoming `DogStatsDClient`.

## Test plan
- [x] Ran all four benchmark variants (`few-tags`, `no-tags`, `many-tags`, `aggregated`) locally against `master`'s current `DogStatsDClient` — all pass, including the `preflight()` assertion.
- [x] `npm run lint` on the changed file.