### PR TITLE
feat(serverless): tag Vercel runtime spans

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -14,7 +14,7 @@ const { isTrue } = require('../util')
 const telemetry = require('../telemetry')
 const telemetryMetrics = require('../telemetry/metrics')
 const {
-  addVercelSpanTags,
+  getPlatformTags,
   IS_SERVERLESS,
   getIsGCPFunction,
   getIsAzureFunction,
@@ -587,7 +587,9 @@ class Config extends ConfigBase {
       this.tags.version = this.version
     }
     this.tags['runtime-id'] = RUNTIME_ID
-    addVercelSpanTags(this.tags)
+    for (const [name, value] of Object.entries(getPlatformTags())) {
+      this.tags[name] ??= value
+    }
 
     if (IS_SERVERLESS) {
       setAndTrack(this, 'telemetry.DD_INSTRUMENTATION_TELEMETRY_ENABLED', false)

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -14,6 +14,7 @@ const { isTrue } = require('../util')
 const telemetry = require('../telemetry')
 const telemetryMetrics = require('../telemetry/metrics')
 const {
+  addVercelSpanTags,
   IS_SERVERLESS,
   getIsGCPFunction,
   getIsAzureFunction,
@@ -586,6 +587,7 @@ class Config extends ConfigBase {
       this.tags.version = this.version
     }
     this.tags['runtime-id'] = RUNTIME_ID
+    addVercelSpanTags(this.tags)
 
     if (IS_SERVERLESS) {
       setAndTrack(this, 'telemetry.DD_INSTRUMENTATION_TELEMETRY_ENABLED', false)

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -42,7 +42,27 @@ function isInServerlessEnvironment () {
   return inAWSLambda || isGCPFunction || isAzureFunction
 }
 
+/**
+ * Adds Vercel runtime metadata without replacing user-provided tags.
+ *
+ * @param {Record<string, string>} tags
+ */
+function addVercelSpanTags (tags) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return
+
+  const metadata = {
+    'vercel.project_id': getEnvironmentVariable('VERCEL_PROJECT_ID'),
+    'vercel.environment': getEnvironmentVariable('VERCEL_ENV'),
+    'vercel.region': getEnvironmentVariable('VERCEL_REGION'),
+  }
+
+  for (const [name, value] of Object.entries(metadata)) {
+    if (value) tags[name] ??= value
+  }
+}
+
 module.exports = {
+  addVercelSpanTags,
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -43,26 +43,35 @@ function isInServerlessEnvironment () {
 }
 
 /**
- * Adds Vercel runtime metadata without replacing user-provided tags.
+ * Gets tags describing the platform where the tracer is running.
  *
- * @param {Record<string, string>} tags
+ * @returns {Record<string, string>}
  */
-function addVercelSpanTags (tags) {
-  if (getEnvironmentVariable('VERCEL') !== '1') return
+function getPlatformTags () {
+  return getVercelTags()
+}
 
-  const metadata = {
+/**
+ * @returns {Record<string, string>}
+ */
+function getVercelTags () {
+  if (getEnvironmentVariable('VERCEL') !== '1') return {}
+
+  const tags = {
     'vercel.project_id': getEnvironmentVariable('VERCEL_PROJECT_ID'),
     'vercel.environment': getEnvironmentVariable('VERCEL_ENV'),
     'vercel.region': getEnvironmentVariable('VERCEL_REGION'),
   }
 
-  for (const [name, value] of Object.entries(metadata)) {
-    if (value) tags[name] ??= value
+  for (const [name, value] of Object.entries(tags)) {
+    if (!value) delete tags[name]
   }
+
+  return tags
 }
 
 module.exports = {
-  addVercelSpanTags,
+  getPlatformTags,
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -61,6 +61,10 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'FUNCTIONS_WORKER_RUNTIME',
   'GCP_PROJECT',
   'K_SERVICE',
+  'VERCEL',
+  'VERCEL_ENV',
+  'VERCEL_PROJECT_ID',
+  'VERCEL_REGION',
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -6,7 +6,8 @@ const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { addVercelSpanTags, enableGCPPubSubPushSubscription } = require('../src/serverless')
+const agent = require('./plugins/agent')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -34,5 +35,70 @@ describe('enableGCPPubSubPushSubscription', () => {
     process.env.K_SERVICE = 'svc'
     process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED = 'false'
     assert.strictEqual(enableGCPPubSubPushSubscription(), false)
+  })
+})
+
+describe('Vercel span metadata', () => {
+  const environment = process.env
+
+  afterEach(async () => {
+    process.env = environment
+    await agent.close()
+  })
+
+  it('does not add tags outside Vercel', async () => {
+    process.env = {
+      ...environment,
+      VERCEL_DEPLOYMENT_ID: 'dpl_123',
+      VERCEL_ENV: 'preview',
+      VERCEL_PROJECT_ID: 'prj_123',
+      VERCEL_REGION: 'iad1',
+      VERCEL_TARGET_ENV: 'staging',
+    }
+    delete process.env.VERCEL
+
+    const tracer = await agent.load([], [], { service: 'vercel-metadata-test' })
+    tracer.startSpan('non-vercel-span').finish()
+
+    await agent.assertSomeTraces(traces => {
+      const { meta } = traces[0][0]
+      assert.strictEqual(meta['vercel.project_id'], undefined)
+      assert.strictEqual(meta['vercel.environment'], undefined)
+      assert.strictEqual(meta['vercel.region'], undefined)
+    })
+  })
+
+  it('adds present Vercel metadata to encoded spans', async () => {
+    process.env = {
+      ...environment,
+      VERCEL: '1',
+      VERCEL_DEPLOYMENT_ID: 'dpl_123',
+      VERCEL_ENV: 'preview',
+      VERCEL_PROJECT_ID: 'prj_123',
+      VERCEL_REGION: 'iad1',
+      VERCEL_TARGET_ENV: 'staging',
+    }
+
+    const tracer = await agent.load([], [], { service: 'vercel-metadata-test' })
+    tracer.startSpan('vercel-span').finish()
+
+    await agent.assertSomeTraces(traces => {
+      assert.deepStrictEqual(Object.fromEntries(
+        Object.entries(traces[0][0].meta).filter(([name]) => name.startsWith('vercel.'))
+      ), {
+        'vercel.project_id': 'prj_123',
+        'vercel.environment': 'preview',
+        'vercel.region': 'iad1',
+      })
+    })
+  })
+
+  it('omits absent Vercel metadata and preserves explicit tags', () => {
+    process.env = { ...environment, VERCEL: '1' }
+    const tags = { 'vercel.region': 'custom-region' }
+
+    addVercelSpanTags(tags)
+
+    assert.deepStrictEqual(tags, { 'vercel.region': 'custom-region' })
   })
 })

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -6,7 +6,7 @@ const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { addVercelSpanTags, enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { getPlatformTags, enableGCPPubSubPushSubscription } = require('../src/serverless')
 const agent = require('./plugins/agent')
 
 describe('enableGCPPubSubPushSubscription', () => {
@@ -79,7 +79,10 @@ describe('Vercel span metadata', () => {
       VERCEL_TARGET_ENV: 'staging',
     }
 
-    const tracer = await agent.load([], [], { service: 'vercel-metadata-test' })
+    const tracer = await agent.load([], [], {
+      service: 'vercel-metadata-test',
+      tags: { 'vercel.region': 'custom-region' },
+    })
     tracer.startSpan('vercel-span').finish()
 
     await agent.assertSomeTraces(traces => {
@@ -88,17 +91,22 @@ describe('Vercel span metadata', () => {
       ), {
         'vercel.project_id': 'prj_123',
         'vercel.environment': 'preview',
-        'vercel.region': 'iad1',
+        'vercel.region': 'custom-region',
       })
     })
   })
 
-  it('omits absent Vercel metadata and preserves explicit tags', () => {
-    process.env = { ...environment, VERCEL: '1' }
-    const tags = { 'vercel.region': 'custom-region' }
+  it('discovers only present Vercel metadata as platform tags', () => {
+    process.env = {
+      ...environment,
+      VERCEL: '1',
+      VERCEL_ENV: 'preview',
+      VERCEL_PROJECT_ID: 'prj_123',
+    }
 
-    addVercelSpanTags(tags)
-
-    assert.deepStrictEqual(tags, { 'vercel.region': 'custom-region' })
+    assert.deepStrictEqual(getPlatformTags(), {
+      'vercel.project_id': 'prj_123',
+      'vercel.environment': 'preview',
+    })
   })
 })


### PR DESCRIPTION
## What is broken

Vercel-hosted Node.js spans do not carry the project and runtime metadata needed to associate application traces with Datadog's Vercel project experience. The Vercel trace UI already queries `vercel.project_id`, but dd-trace-js does not populate it when tracing directly from a Vercel Function.

## Change

When the documented `VERCEL=1` runtime marker is present:

- add `vercel.project_id` from `VERCEL_PROJECT_ID`
- add `vercel.environment` from `VERCEL_ENV`
- add `vercel.region` from `VERCEL_REGION`
- preserve explicit customer-provided values

Deployment IDs, URLs, Git metadata, and custom target-environment values are intentionally excluded to avoid high-cardinality or unrelated metadata.

## Evidence

- Existing Datadog Vercel trace UI searches spans by `@vercel.project_id`.
- Encoded-span regression tests verify metadata is emitted only in Vercel and explicit tags win.
- A local tracer export decoded the expected msgpack span tags.
- `packages/dd-trace/test/serverless.spec.js`: 6 passing.
- ESLint and `git diff --check`: clean.
