### PR TITLE
feat(test-optimization): optimize WebdriverIO Jasmine tests

### DIFF
--- a/integration-tests/webdriverio/fixtures/atr-always-fail.e2e.js
+++ b/integration-tests/webdriverio/fixtures/atr-always-fail.e2e.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+describe('WebdriverIO ATR', () => {
+  it('fails every retry', () => {
+    assert.fail('ATR failure')
+  })
+})

--- a/integration-tests/webdriverio/fixtures/atr-hook-fail.e2e.js
+++ b/integration-tests/webdriverio/fixtures/atr-hook-fail.e2e.js
@@ -1,0 +1,24 @@
+'use strict'
+
+let afterEachAttempts = 0
+let beforeEachAttempts = 0
+
+describe('WebdriverIO ATR beforeEach failure', () => {
+  beforeEach(() => {
+    if (beforeEachAttempts++ === 0) {
+      throw new Error('ATR beforeEach failure')
+    }
+  })
+
+  it('does not retry the test', () => {})
+})
+
+describe('WebdriverIO ATR afterEach failure', () => {
+  afterEach(() => {
+    if (afterEachAttempts++ === 0) {
+      throw new Error('ATR afterEach failure')
+    }
+  })
+
+  it('does not retry the test', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/efd-failed-test-replay.e2e.js
+++ b/integration-tests/webdriverio/fixtures/efd-failed-test-replay.e2e.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const sum = require('./dependency')
+
+let attempts = 0
+
+describe('WebdriverIO EFD Failed Test Replay', () => {
+  it('captures a failure after a passing attempt', () => {
+    const attempt = attempts++
+    if (attempt === 0) {
+      assert.strictEqual(sum(1, 3), 4)
+      return
+    }
+    if (attempt === 1) {
+      sum(11, 3)
+    }
+
+    assert.throws(() => sum(11, 3), /a is too big/)
+  })
+})

--- a/integration-tests/webdriverio/fixtures/jasmine-attempt-to-fix-skipped.e2e.js
+++ b/integration-tests/webdriverio/fixtures/jasmine-attempt-to-fix-skipped.e2e.js
@@ -1,0 +1,6 @@
+'use strict'
+
+describe('WebdriverIO Jasmine skipped attempt to fix', () => {
+  // eslint-disable-next-line mocha/no-pending-tests -- this fixture verifies skipped attempt-to-fix reporting.
+  xit('stays skipped', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/jasmine-efd-skipped.e2e.js
+++ b/integration-tests/webdriverio/fixtures/jasmine-efd-skipped.e2e.js
@@ -1,0 +1,8 @@
+'use strict'
+
+describe('WebdriverIO Jasmine EFD statuses', () => {
+  it('passes', () => {})
+
+  // eslint-disable-next-line mocha/no-pending-tests -- this fixture verifies skipped EFD-test reporting.
+  xit('stays skipped', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/jasmine-expectation-hook-fail.e2e.js
+++ b/integration-tests/webdriverio/fixtures/jasmine-expectation-hook-fail.e2e.js
@@ -1,0 +1,23 @@
+'use strict'
+
+describe('WebdriverIO Jasmine expectation hook failures', () => {
+  describe('beforeEach', () => {
+    beforeEach(() => {
+      globalThis.expect(true).toBe(false)
+    })
+
+    it('does not retry with ATR', () => {})
+  })
+
+  describe('afterEach', () => {
+    let attempts = 0
+
+    afterEach(() => {
+      if (attempts++ === 2) {
+        globalThis.expect(true).toBe(false)
+      }
+    })
+
+    it('keeps the final EFD failure', () => {})
+  })
+})

--- a/integration-tests/webdriverio/fixtures/jasmine-filtered.e2e.js
+++ b/integration-tests/webdriverio/fixtures/jasmine-filtered.e2e.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+describe('WebdriverIO Jasmine filtering', () => {
+  it('runs selected test', () => {})
+
+  it('stays filtered', () => {
+    assert.fail('filtered test ran')
+  })
+})

--- a/integration-tests/webdriverio/fixtures/jasmine-no-expectations.e2e.js
+++ b/integration-tests/webdriverio/fixtures/jasmine-no-expectations.e2e.js
@@ -1,0 +1,5 @@
+'use strict'
+
+describe('WebdriverIO Jasmine no expectations', () => {
+  it('fails without expectations', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/jasmine-retry.e2e.js
+++ b/integration-tests/webdriverio/fixtures/jasmine-retry.e2e.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const tracer = require('dd-trace')
+
+const assert = require('node:assert/strict')
+
+let attempt = 0
+
+describe('WebdriverIO Jasmine retries', () => {
+  it('reports every Jasmine attempt', () => {
+    assert.ok(tracer.scope().active())
+    attempt++
+    assert.strictEqual(attempt, 2)
+  // eslint-disable-next-line no-undef -- Jasmine exposes its timeout through WebdriverIO.
+  }, jasmine.DEFAULT_TIMEOUT_INTERVAL, 1)
+})

--- a/integration-tests/webdriverio/fixtures/subdirectory/nested-first.e2e.js
+++ b/integration-tests/webdriverio/fixtures/subdirectory/nested-first.e2e.js
@@ -1,0 +1,5 @@
+'use strict'
+
+describe('WebdriverIO nested first worker', () => {
+  it('runs with an active Test Optimization span', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/subdirectory/nested-impacted.e2e.js
+++ b/integration-tests/webdriverio/fixtures/subdirectory/nested-impacted.e2e.js
@@ -1,0 +1,5 @@
+'use strict'
+
+describe('WebdriverIO nested impacted tests', () => {
+  it('marks a modified test', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/subdirectory/wdio.conf.js
+++ b/integration-tests/webdriverio/fixtures/subdirectory/wdio.conf.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { config } = require('../wdio.conf')
+
+exports.config = {
+  ...config,
+  specs: [[
+    './nested-impacted.e2e.js',
+    './nested-first.e2e.js',
+  ]],
+}

--- a/integration-tests/webdriverio/fixtures/suite-hook-fail.e2e.js
+++ b/integration-tests/webdriverio/fixtures/suite-hook-fail.e2e.js
@@ -1,14 +1,16 @@
 'use strict'
 
 const hookType = process.env.WEBDRIVERIO_SUITE_HOOK
+const beforeSuite = process.env.WEBDRIVERIO_FRAMEWORK === 'jasmine' ? globalThis.beforeAll : globalThis.before
+const afterSuite = process.env.WEBDRIVERIO_FRAMEWORK === 'jasmine' ? globalThis.afterAll : globalThis.after
 
 describe('WebdriverIO suite hook failure', () => {
   if (hookType === 'beforeAll') {
-    before(() => {
+    beforeSuite(() => {
       throw new Error('beforeAll failure')
     })
   } else {
-    after(() => {
+    afterSuite(() => {
       throw new Error('afterAll failure')
     })
   }

--- a/integration-tests/webdriverio/fixtures/test-management-disabled-hook.e2e.js
+++ b/integration-tests/webdriverio/fixtures/test-management-disabled-hook.e2e.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+describe('WebdriverIO disabled hook', () => {
+  beforeEach(() => {
+    assert.fail('disabled test hook ran')
+  })
+
+  it('is disabled', () => {
+    assert.fail('disabled test ran')
+  })
+})
+
+describe('WebdriverIO disabled hook control', () => {
+  it('passes', () => {})
+})

--- a/integration-tests/webdriverio/fixtures/test-management.e2e.js
+++ b/integration-tests/webdriverio/fixtures/test-management.e2e.js
@@ -11,5 +11,14 @@ describe('WebdriverIO Test Management', () => {
     assert.fail('quarantined failure')
   })
 
-  it('is attempt to fix', () => {})
+  it('passes every attempt to fix', () => {})
+
+  it('fails every attempt to fix', () => {
+    assert.fail('attempt to fix failure')
+  })
+
+  let mixedAttempts = 0
+  it('has mixed attempt to fix results', () => {
+    assert.strictEqual(mixedAttempts++, 1)
+  })
 })

--- a/integration-tests/webdriverio/fixtures/wdio.conf.js
+++ b/integration-tests/webdriverio/fixtures/wdio.conf.js
@@ -36,6 +36,14 @@ const scenarioConfig = {
     maxInstances: 1,
     specs: ['./atr.e2e.js'],
   },
+  atrAlwaysFails: {
+    maxInstances: 1,
+    specs: ['./atr-always-fail.e2e.js'],
+  },
+  atrHookFailures: {
+    maxInstances: 1,
+    specs: ['./atr-hook-fail.e2e.js'],
+  },
   bail: {
     maxInstances: 1,
     mochaOpts: {
@@ -69,6 +77,10 @@ const scenarioConfig = {
   efd: {
     maxInstances: 1,
     specs: ['./efd.e2e.js'],
+  },
+  efdFailedTestReplay: {
+    maxInstances: 1,
+    specs: ['./efd-failed-test-replay.e2e.js'],
   },
   efdAfterEachFailure: {
     maxInstances: 1,
@@ -121,7 +133,10 @@ const scenarioConfig = {
   },
   impacted: {
     maxInstances: 1,
-    specs: ['./impacted.e2e.js'],
+    specs: [[
+      './impacted.e2e.js',
+      './first.e2e.js',
+    ]],
   },
   jasmineStatuses: {
     maxInstances: 1,
@@ -131,9 +146,28 @@ const scenarioConfig = {
     maxInstances: 1,
     specs: ['./jasmine-after-all-fail.e2e.js'],
   },
+  jasmineAttemptToFixSkipped: {
+    maxInstances: 1,
+    specs: ['./jasmine-attempt-to-fix-skipped.e2e.js'],
+  },
   jasmineDelayedSettings: {
     maxInstances: 1,
     specs: ['./first.e2e.js'],
+  },
+  jasmineEfdSkipped: {
+    maxInstances: 1,
+    specs: ['./jasmine-efd-skipped.e2e.js'],
+  },
+  jasmineExpectationHookFailures: {
+    maxInstances: 1,
+    specs: ['./jasmine-expectation-hook-fail.e2e.js'],
+  },
+  jasmineFiltered: {
+    jasmineOpts: {
+      grep: 'runs selected test',
+    },
+    maxInstances: 1,
+    specs: ['./jasmine-filtered.e2e.js'],
   },
   jasmineGlobalAfterAllFailure: {
     maxInstances: 1,
@@ -145,6 +179,17 @@ const scenarioConfig = {
   jasmineHooks: {
     maxInstances: 1,
     specs: ['./jasmine-hooks.e2e.js'],
+  },
+  jasmineNoExpectations: {
+    jasmineOpts: {
+      failSpecWithNoExpectations: true,
+    },
+    maxInstances: 1,
+    specs: ['./jasmine-no-expectations.e2e.js'],
+  },
+  jasmineRetry: {
+    maxInstances: 1,
+    specs: ['./jasmine-retry.e2e.js'],
   },
   loadFailure: {
     maxInstances: 1,
@@ -200,6 +245,10 @@ const scenarioConfig = {
     maxInstances: 1,
     specs: ['./test-management.e2e.js'],
   },
+  testManagementDisabledHook: {
+    maxInstances: 1,
+    specs: ['./test-management-disabled-hook.e2e.js'],
+  },
 }
 
 const selectedScenario = scenarioConfig[scenario]
@@ -210,6 +259,10 @@ if (!selectedScenario) {
 exports.config = {
   ...baseConfig,
   ...selectedScenario,
+  jasmineOpts: {
+    ...baseConfig.jasmineOpts,
+    ...selectedScenario.jasmineOpts,
+  },
   mochaOpts: {
     ...baseConfig.mochaOpts,
     ...selectedScenario.mochaOpts,

--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -59,24 +59,6 @@ const disabledSettings = {
   coverage_report_upload_enabled: false,
 }
 
-const enabledSettings = {
-  code_coverage: true,
-  tests_skipping: true,
-  itr_enabled: true,
-  require_git: false,
-  early_flake_detection: {
-    enabled: true,
-  },
-  flaky_test_retries_enabled: true,
-  di_enabled: true,
-  known_tests_enabled: true,
-  test_management: {
-    enabled: true,
-  },
-  impacted_tests_enabled: true,
-  coverage_report_upload_enabled: true,
-}
-
 const advancedRequestPaths = [
   '/api/v2/ci/libraries/tests',
   '/api/v2/ci/tests/skippable',
@@ -189,7 +171,7 @@ function assertOneTestPerSuiteExecution (suites, tests) {
 }
 
 /**
- * Extracts events and verifies the WebdriverIO run stayed in reporting-only mode.
+ * Extracts events and verifies the WebdriverIO run kept TIA disabled.
  *
  * @param {object[]} payloads
  * @param {string} requestedVersion
@@ -209,7 +191,7 @@ function getReportingEvents (payloads, requestedVersion, frameworkAdapter) {
   const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
   assert.strictEqual(settingsRequests.length, 1)
-  assert.strictEqual(advancedRequests.length, 0)
+  assert.strictEqual(advancedRequests.length, 0, JSON.stringify(advancedRequests.map(({ url }) => url)))
   assert.strictEqual(sessions.length, 1, JSON.stringify({
     events: events.map(event => ({
       name: event.content?.name,
@@ -228,23 +210,13 @@ function getReportingEvents (payloads, requestedVersion, frameworkAdapter) {
   assert.ok(metadata.length > 0)
   for (const metadataEntry of metadata) {
     assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_IMPACT_ANALYSIS], undefined)
-    if (frameworkAdapter === 'jasmine') {
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_EARLY_FLAKE_DETECTION], undefined)
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], undefined)
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_IMPACTED_TESTS], undefined)
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], undefined)
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], undefined)
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], undefined)
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_FAILED_TEST_REPLAY], undefined)
-    } else {
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_EARLY_FLAKE_DETECTION], '1')
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_IMPACTED_TESTS], '1')
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '5')
-      assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_FAILED_TEST_REPLAY], '1')
-    }
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_EARLY_FLAKE_DETECTION], '1')
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_IMPACTED_TESTS], '1')
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '5')
+    assert.strictEqual(metadataEntry.test[DD_CAPABILITIES_FAILED_TEST_REPLAY], '1')
   }
 
   for (const event of [sessions[0], modules[0], ...suites, ...tests]) {
@@ -383,9 +355,7 @@ for (const version of versions) {
       })
     })
 
-    it('reports parallel Jasmine workers as one basic-reporting session', async () => {
-      receiver.setSettings(enabledSettings)
-
+    it('reports parallel Jasmine workers as one session', async () => {
       await runScenario('parallel', 2, ({ session, suites, tests }) => {
         assert.strictEqual(suites.length, 2)
         assert.strictEqual(tests.length, 2)
@@ -404,8 +374,6 @@ for (const version of versions) {
     })
 
     it('reports Jasmine pass, fail, and skip statuses', async () => {
-      receiver.setSettings(enabledSettings)
-
       await runScenario('jasmineStatuses', 1, ({ session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'fail')
         assert.strictEqual(suites.length, 1)

--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -22,6 +22,7 @@ const {
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_EARLY_FLAKE_ENABLED,
   TEST_FINAL_STATUS,
+  TEST_HAS_FAILED_ALL_RETRIES,
   TEST_IS_MODIFIED,
   TEST_IS_NEW,
   TEST_IS_RETRY,
@@ -34,6 +35,7 @@ const {
   TEST_NAME,
   TEST_RETRY_REASON,
   TEST_RETRY_REASON_TYPES,
+  TEST_SOURCE_FILE,
   TEST_STATUS,
   TEST_SUITE,
 } = require('../../packages/dd-trace/src/plugins/util/test')
@@ -149,10 +151,12 @@ for (const version of versions) {
 
     useSandbox([
       `@wdio/cli@${version}`,
+      `@wdio/jasmine-framework@${version}`,
       `@wdio/local-runner@${version}`,
       `@wdio/mocha-framework@${version}`,
     ], true, [
       './integration-tests/webdriverio/fixtures/*',
+      './integration-tests/webdriverio/fixtures/subdirectory',
       './integration-tests/ci-visibility/dynamic-instrumentation/dependency.js',
     ])
 
@@ -162,7 +166,11 @@ for (const version of versions) {
 
       execFileSync('git', ['switch', '-c', 'feature-branch'], { cwd })
       fs.appendFileSync(path.join(cwd, 'impacted.e2e.js'), '\n// modified by the integration test\n')
-      execFileSync('git', ['add', 'impacted.e2e.js'], { cwd })
+      fs.appendFileSync(
+        path.join(cwd, 'subdirectory', 'nested-impacted.e2e.js'),
+        '\n// modified by the integration test\n'
+      )
+      execFileSync('git', ['add', 'impacted.e2e.js', 'subdirectory/nested-impacted.e2e.js'], { cwd })
       execFileSync('git', ['commit', '-m', 'modify impacted test'], { cwd })
     })
 
@@ -183,28 +191,35 @@ for (const version of versions) {
     /**
      * Runs one WebdriverIO Test Optimization scenario.
      *
+     * @param {'mocha'|'jasmine'} framework
      * @param {string} scenario
      * @param {number} expectedWebDriverSessions
      * @param {(payloads: object[]) => void} assertPayloads
      * @param {object} [extraEnvironment]
      * @param {number} [expectedExitCode]
+     * @param {string} [workingDirectory]
      * @returns {Promise<void>}
      */
-    async function runScenario (
+    async function runFrameworkScenario (
+      framework,
       scenario,
       expectedWebDriverSessions,
       assertPayloads,
       extraEnvironment = {},
-      expectedExitCode = 0
+      expectedExitCode = 0,
+      workingDirectory = cwd
     ) {
       const initialWebDriverSessionCount = webDriver.getSessionCount()
-      childProcess = exec('./node_modules/.bin/wdio run ./wdio.conf.js', {
-        cwd,
+      const executable = path.join(cwd, 'node_modules', '.bin', 'wdio')
+      childProcess = exec(`"${executable}" run ./wdio.conf.js`, {
+        cwd: workingDirectory,
         env: {
           ...getCiVisAgentlessConfig(receiver.port),
+          DD_EXPERIMENTAL_TEST_REQUESTS_FS_CACHE: 'false',
           NODE_OPTIONS: '-r dd-trace/ci/init --import dd-trace/register.js',
           DD_TEST_SESSION_NAME: 'webdriverio-test-optimization',
           GITHUB_BASE_REF: '',
+          WEBDRIVERIO_FRAMEWORK: framework,
           WEBDRIVERIO_SCENARIO: scenario,
           WEBDRIVER_PORT: String(webDriver.port),
           ...extraEnvironment,
@@ -243,458 +258,1099 @@ for (const version of versions) {
       )
     }
 
-    it('requests enabled data once and keeps TIA disabled across parallel workers', async () => {
-      receiver.setSettings({
-        code_coverage: true,
-        coverage_report_upload_enabled: true,
-        impacted_tests_enabled: true,
-        itr_enabled: true,
-        known_tests_enabled: true,
-        test_management: { enabled: true },
-        tests_skipping: true,
-      })
-      receiver.setKnownTests({ webdriverio: {} })
-      receiver.setTestManagementTests({ webdriverio: { suites: {} } })
-
-      await runScenario('parallel', 2, payloads => {
-        assert.strictEqual(countRequests(payloads, SETTINGS_PATH), 1)
-        assert.strictEqual(countRequests(payloads, KNOWN_TESTS_PATH), 1)
-        assert.strictEqual(countRequests(payloads, TEST_MANAGEMENT_PATH), 1)
-        assert.strictEqual(countRequests(payloads, SKIPPABLE_TESTS_PATH), 0)
-        assert.strictEqual(countRequests(payloads, '/api/v2/citestcov'), 0)
-
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const tests = events.filter(event => event.type === 'test')
-
-        assert.strictEqual(tests.length, 2)
-        assert.strictEqual(session.meta[TEST_ITR_SKIPPING_ENABLED], 'false')
-        assert.strictEqual(session.meta[TEST_CODE_COVERAGE_ENABLED], 'false')
-        assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], 'true')
-      })
-    })
-
-    it('retries new tests with EFD', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 100,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-      })
-      receiver.setKnownTests({ webdriverio: {} })
-
-      await runScenario('efd', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const suite = events.find(event => event.type === 'test_suite_end').content
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-        assert.strictEqual(countRequests(payloads, KNOWN_TESTS_PATH), 1)
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
-        assert.strictEqual(session.meta[TEST_STATUS], 'pass')
-        assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
-        assert.strictEqual(tests.length, 3)
-        assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['fail', 'pass', 'fail'])
-        assert.strictEqual(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
-        for (const test of tests) {
-          assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+    for (const framework of ['mocha', 'jasmine']) {
+      describe(`${framework} adapter`, function () {
+        /**
+         * Runs one optimization scenario for this adapter.
+         *
+         * @param {string} scenario
+         * @param {number} expectedWebDriverSessions
+         * @param {(payloads: object[]) => void} assertPayloads
+         * @param {object} [extraEnvironment]
+         * @param {number} [expectedExitCode]
+         * @param {string} [workingDirectory]
+         * @returns {Promise<void>}
+         */
+        function runScenario (
+          scenario,
+          expectedWebDriverSessions,
+          assertPayloads,
+          extraEnvironment,
+          expectedExitCode,
+          workingDirectory
+        ) {
+          return runFrameworkScenario(
+            framework,
+            scenario,
+            expectedWebDriverSessions,
+            assertPayloads,
+            extraEnvironment,
+            expectedExitCode,
+            workingDirectory
+          )
         }
-        for (const test of tests.slice(1)) {
-          assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
-        }
-      })
-    })
 
-    it('does not retry disabled modified or new tests with EFD', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 100,
-          slow_test_retries: { '5s': 2 },
-        },
-        impacted_tests_enabled: true,
-        known_tests_enabled: true,
-        test_management: { enabled: true },
-      })
-      receiver.setKnownTests({
-        webdriverio: {
-          'first.e2e.js': ['WebdriverIO first worker runs with an active Test Optimization span'],
-          'impacted.e2e.js': ['WebdriverIO impacted tests marks a modified test'],
-        },
-      })
-      receiver.setTestManagementTests({
-        webdriverio: {
-          suites: {
-            'disabled-efd.e2e.js': {
-              tests: {
-                'WebdriverIO disabled EFD is new': {
-                  properties: { disabled: true },
-                },
-              },
-            },
-            'impacted.e2e.js': {
-              tests: {
-                'WebdriverIO impacted tests marks a modified test': {
-                  properties: { disabled: true },
-                },
-              },
-            },
-          },
-        },
-      })
+        it('requests enabled data once and keeps TIA disabled across parallel workers', async () => {
+          receiver.setSettings({
+            code_coverage: true,
+            coverage_report_upload_enabled: true,
+            impacted_tests_enabled: true,
+            itr_enabled: true,
+            known_tests_enabled: true,
+            test_management: { enabled: true },
+            tests_skipping: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+          receiver.setTestManagementTests({ webdriverio: { suites: {} } })
 
-      await runScenario('disabledEfd', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-        const disabledTests = tests.filter(test => test.meta[TEST_MANAGEMENT_IS_DISABLED] === 'true')
-        const modified = disabledTests.find(test => test.meta[TEST_SUITE] === 'impacted.e2e.js')
-        const newTest = disabledTests.find(test => test.meta[TEST_SUITE] === 'disabled-efd.e2e.js')
+          await runScenario('parallel', 2, payloads => {
+            assert.strictEqual(countRequests(payloads, SETTINGS_PATH), 1)
+            assert.strictEqual(countRequests(payloads, KNOWN_TESTS_PATH), 1)
+            assert.strictEqual(countRequests(payloads, TEST_MANAGEMENT_PATH), 1)
+            assert.strictEqual(countRequests(payloads, SKIPPABLE_TESTS_PATH), 0)
+            assert.strictEqual(countRequests(payloads, '/api/v2/citestcov'), 0)
 
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
-        assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], 'true')
-        assert.deepStrictEqual(
-          tests.map(test => test.meta[TEST_SUITE]).sort(),
-          ['disabled-efd.e2e.js', 'first.e2e.js', 'impacted.e2e.js']
-        )
-        assert.strictEqual(disabledTests.length, 2)
-        for (const test of disabledTests) {
-          assert.strictEqual(test.meta[TEST_STATUS], 'skip')
-          assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'skip')
-          assert.strictEqual(test.meta[TEST_IS_RETRY], undefined)
-        }
-        assert.strictEqual(modified.meta[TEST_IS_MODIFIED], 'true')
-        assert.strictEqual(modified.meta[TEST_IS_NEW], undefined)
-        assert.strictEqual(newTest.meta[TEST_IS_MODIFIED], undefined)
-        assert.strictEqual(newTest.meta[TEST_IS_NEW], 'true')
-      })
-    })
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test')
 
-    it('stops EFD when the run exceeds the faulty-session threshold', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 0,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-      })
-      receiver.setKnownTests({ webdriverio: {} })
-
-      await runScenario('efd', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
-        assert.strictEqual(tests.length, 1)
-        assert.strictEqual(tests[0].meta[TEST_IS_NEW], undefined)
-        assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
-      }, {}, 1)
-    })
-
-    it('evaluates EFD faultiness from specs that have not started yet', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 1,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-      })
-      receiver.setKnownTests({
-        webdriverio: {
-          'first.e2e.js': ['WebdriverIO first worker runs with an active Test Optimization span'],
-        },
-      })
-
-      await runScenario('efdFaultySchedule', 2, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const efdTests = events
-          .filter(event => event.type === 'test')
-          .map(event => event.content)
-          .filter(test => test.meta[TEST_NAME].endsWith('retries a new test'))
-
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
-        assert.strictEqual(efdTests.length, 1)
-        assert.strictEqual(efdTests[0].meta[TEST_IS_NEW], undefined)
-        assert.strictEqual(efdTests[0].meta[TEST_IS_RETRY], undefined)
-      }, {}, 1)
-    })
-
-    it('retries failures with ATR', async () => {
-      receiver.setSettings({
-        flaky_test_retries_count: 2,
-        flaky_test_retries_enabled: true,
-      })
-
-      await runScenario('atr', 1, payloads => {
-        const tests = getEvents(payloads)
-          .filter(event => event.type === 'test')
-          .map(event => event.content)
-
-        assert.strictEqual(tests.length, 2)
-        assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]).sort(), ['fail', 'pass'])
-        const retry = tests.find(test => test.meta[TEST_IS_RETRY] === 'true')
-        assert.ok(retry)
-        assert.strictEqual(retry.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
-      })
-    })
-
-    it('applies disabled, quarantined, and attempt-to-fix policies', async () => {
-      receiver.setSettings({
-        test_management: {
-          attempt_to_fix_retries: 2,
-          enabled: true,
-        },
-      })
-      receiver.setTestManagementTests({
-        webdriverio: {
-          suites: {
-            'test-management.e2e.js': {
-              tests: {
-                'WebdriverIO Test Management is attempt to fix': {
-                  properties: { attempt_to_fix: true },
-                },
-                'WebdriverIO Test Management is disabled': {
-                  properties: { disabled: true },
-                },
-                'WebdriverIO Test Management is quarantined': {
-                  properties: { quarantined: true },
-                },
-              },
-            },
-          },
-        },
-      })
-
-      await runScenario('testManagement', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-        const disabled = tests.find(test => test.meta[TEST_NAME].endsWith('is disabled'))
-        const quarantined = tests.find(test => test.meta[TEST_NAME].endsWith('is quarantined'))
-        const attemptToFix = tests.filter(test => test.meta[TEST_NAME].endsWith('is attempt to fix'))
-
-        assert.strictEqual(countRequests(payloads, TEST_MANAGEMENT_PATH), 1)
-        assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], 'true')
-        assert.strictEqual(disabled.meta[TEST_STATUS], 'skip')
-        assert.strictEqual(disabled.meta[TEST_FINAL_STATUS], 'skip')
-        assert.strictEqual(disabled.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
-        assert.strictEqual(quarantined.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(quarantined.meta[TEST_FINAL_STATUS], 'skip')
-        assert.strictEqual(quarantined.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
-        assert.strictEqual(attemptToFix.length, 3)
-        for (const test of attemptToFix) {
-          assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
-        }
-        const finalAttempt = attemptToFix.find(test => TEST_FINAL_STATUS in test.meta)
-        assert.ok(finalAttempt)
-        assert.strictEqual(finalAttempt.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'true')
-      })
-    })
-
-    it('suppresses quarantined and recovered EFD hook failures', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 100,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-        test_management: { enabled: true },
-      })
-      receiver.setKnownTests({
-        webdriverio: {
-          'managed-hook-fail.e2e.js': ['WebdriverIO quarantined hook failure is quarantined'],
-        },
-      })
-      receiver.setTestManagementTests({
-        webdriverio: {
-          suites: {
-            'managed-hook-fail.e2e.js': {
-              tests: {
-                'WebdriverIO quarantined hook failure is quarantined': {
-                  properties: { quarantined: true },
-                },
-              },
-            },
-          },
-        },
-      })
-
-      await runScenario('managedHookFailures', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const suite = events.find(event => event.type === 'test_suite_end').content
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-        const quarantined = tests.find(test => test.meta[TEST_NAME].endsWith('is quarantined'))
-        const earlyFlakeDetectionTests = tests.filter(test =>
-          test.meta[TEST_NAME].endsWith('passes an EFD retry'))
-
-        assert.strictEqual(session.meta[TEST_STATUS], 'pass')
-        assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
-        assert.strictEqual(quarantined.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(quarantined.meta[TEST_FINAL_STATUS], 'skip')
-        assert.strictEqual(quarantined.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
-        assert.strictEqual(earlyFlakeDetectionTests.length, 2)
-        assert.deepStrictEqual(
-          earlyFlakeDetectionTests.map(test => test.meta[TEST_STATUS]).sort(),
-          ['fail', 'pass']
-        )
-      })
-    })
-
-    it('fails the run when every EFD attempt has a failing afterEach hook', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 100,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-      })
-      receiver.setKnownTests({ webdriverio: {} })
-
-      await runScenario('efdAfterEachFailure', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const suite = events.find(event => event.type === 'test_suite_end').content
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-        assert.strictEqual(session.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(tests.length, 1)
-        assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'fail'))
-      }, {}, 1)
-    })
-
-    for (const hookType of ['beforeAll', 'afterAll']) {
-      it(`does not suppress a quarantined test's ${hookType} failure`, async () => {
-        receiver.setSettings({
-          test_management: { enabled: true },
+            assert.strictEqual(tests.length, 2)
+            assert.strictEqual(session.meta[TEST_ITR_SKIPPING_ENABLED], 'false')
+            assert.strictEqual(session.meta[TEST_CODE_COVERAGE_ENABLED], 'false')
+            assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], 'true')
+          })
         })
-        receiver.setTestManagementTests({
-          webdriverio: {
-            suites: {
-              'suite-hook-fail.e2e.js': {
-                tests: {
-                  'WebdriverIO suite hook failure is quarantined': {
-                    properties: { quarantined: true },
+
+        it('retries new tests with EFD', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+
+          await runScenario('efd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suite = events.find(event => event.type === 'test_suite_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(countRequests(payloads, KNOWN_TESTS_PATH), 1)
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+            assert.strictEqual(
+              session.meta[TEST_STATUS],
+              'pass',
+              JSON.stringify(tests.map(test => test.meta))
+            )
+            assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(tests.length, 3)
+            assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['fail', 'pass', 'fail'])
+            assert.strictEqual(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+            for (const test of tests) {
+              assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+            }
+            for (const test of tests.slice(1)) {
+              assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+            }
+          })
+        })
+
+        if (framework === 'jasmine') {
+          it('keeps skipped tests and their suite and session successful with EFD', async () => {
+            receiver.setSettings({
+              early_flake_detection: {
+                enabled: true,
+                faulty_session_threshold: 100,
+                slow_test_retries: { '5s': 2 },
+              },
+              known_tests_enabled: true,
+            })
+            receiver.setKnownTests({ webdriverio: {} })
+
+            await runScenario('jasmineEfdSkipped', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const passingTests = tests.filter(test => test.meta[TEST_NAME].endsWith('passes'))
+              const skippedTests = tests.filter(test => test.meta[TEST_NAME].endsWith('stays skipped'))
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(passingTests.length, 3)
+              assert.ok(passingTests.every(test => test.meta[TEST_STATUS] === 'pass'))
+              assert.strictEqual(
+                passingTests.filter(test => test.meta[TEST_FINAL_STATUS] === 'pass').length,
+                1
+              )
+              assert.strictEqual(skippedTests.length, 1)
+              assert.strictEqual(skippedTests[0].meta[TEST_STATUS], 'skip')
+              assert.strictEqual(skippedTests[0].meta[TEST_FINAL_STATUS], 'skip')
+              assert.strictEqual(skippedTests[0].meta[TEST_IS_NEW], 'true')
+              assert.strictEqual(skippedTests[0].meta[TEST_IS_RETRY], undefined)
+              assert.strictEqual(skippedTests[0].meta[TEST_HAS_FAILED_ALL_RETRIES], undefined)
+            })
+          })
+        }
+
+        if (framework === 'jasmine') {
+          it('keeps tests filtered by jasmineOpts.grep skipped with EFD', async () => {
+            receiver.setSettings({
+              early_flake_detection: {
+                enabled: true,
+                faulty_session_threshold: 100,
+                slow_test_retries: { '5s': 2 },
+              },
+              known_tests_enabled: true,
+            })
+            receiver.setKnownTests({ webdriverio: {} })
+
+            await runScenario('jasmineFiltered', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const selectedTests = tests.filter(test => test.meta[TEST_NAME].endsWith('runs selected test'))
+              const filteredTests = tests.filter(test => test.meta[TEST_NAME].endsWith('stays filtered'))
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(selectedTests.length, 3)
+              assert.ok(selectedTests.every(test => test.meta[TEST_STATUS] === 'pass'))
+              assert.strictEqual(filteredTests.length, 1)
+              assert.strictEqual(filteredTests[0].meta[TEST_STATUS], 'skip')
+              assert.strictEqual(filteredTests[0].meta[TEST_FINAL_STATUS], 'skip')
+              assert.strictEqual(filteredTests[0].meta[TEST_IS_RETRY], undefined)
+            })
+          })
+        }
+
+        it('uses the first attempt duration to select the EFD retry count', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: {
+                '5s': 0,
+                '10s': 2,
+              },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+
+          await runScenario('efd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+            assert.strictEqual(tests.length, 1)
+            assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+            assert.strictEqual(tests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+            assert.strictEqual(tests[0].meta[TEST_HAS_FAILED_ALL_RETRIES], undefined)
+            assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+          }, {}, 1)
+        })
+
+        it('does not retry EFD tests when locally disabled', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+
+          await runScenario('efd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
+            assert.strictEqual(tests.length, 1)
+            assert.strictEqual(tests[0].meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+          }, {
+            DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false',
+          }, 1)
+        })
+
+        it('does not retry disabled modified or new tests with EFD', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            impacted_tests_enabled: true,
+            known_tests_enabled: true,
+            test_management: { enabled: true },
+          })
+          receiver.setKnownTests({
+            webdriverio: {
+              'first.e2e.js': ['WebdriverIO first worker runs with an active Test Optimization span'],
+              'impacted.e2e.js': ['WebdriverIO impacted tests marks a modified test'],
+            },
+          })
+          receiver.setTestManagementTests({
+            webdriverio: {
+              suites: {
+                'disabled-efd.e2e.js': {
+                  tests: {
+                    'WebdriverIO disabled EFD is new': {
+                      properties: { disabled: true },
+                    },
+                  },
+                },
+                'impacted.e2e.js': {
+                  tests: {
+                    'WebdriverIO impacted tests marks a modified test': {
+                      properties: { disabled: true },
+                    },
                   },
                 },
               },
             },
-          },
+          })
+
+          await runScenario('disabledEfd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const disabledTests = tests.filter(test => test.meta[TEST_MANAGEMENT_IS_DISABLED] === 'true')
+            const modified = disabledTests.find(test => test.meta[TEST_SUITE] === 'impacted.e2e.js')
+            const newTest = disabledTests.find(test => test.meta[TEST_SUITE] === 'disabled-efd.e2e.js')
+
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+            assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], 'true')
+            assert.deepStrictEqual(
+              tests.map(test => test.meta[TEST_SUITE]).sort(),
+              ['disabled-efd.e2e.js', 'first.e2e.js', 'impacted.e2e.js']
+            )
+            assert.strictEqual(disabledTests.length, 2)
+            for (const test of disabledTests) {
+              assert.strictEqual(test.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'skip')
+              assert.strictEqual(test.meta[TEST_IS_RETRY], undefined)
+            }
+            assert.strictEqual(modified.meta[TEST_IS_MODIFIED], 'true')
+            assert.strictEqual(modified.meta[TEST_IS_NEW], undefined)
+            assert.strictEqual(newTest.meta[TEST_IS_MODIFIED], undefined)
+            assert.strictEqual(newTest.meta[TEST_IS_NEW], 'true')
+          })
         })
 
-        await runScenario('suiteHookFailure', 1, payloads => {
-          const events = getEvents(payloads)
-          const session = events.find(event => event.type === 'test_session_end').content
-          const suite = events.find(event => event.type === 'test_suite_end').content
+        it('stops EFD when the run exceeds the faulty-session threshold', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 0,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
 
-          assert.strictEqual(session.meta[TEST_STATUS], 'fail')
-          assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
-        }, {
-          WEBDRIVERIO_SUITE_HOOK: hookType,
-        }, 1)
+          await runScenario('efd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
+            assert.strictEqual(tests.length, 1)
+            assert.strictEqual(tests[0].meta[TEST_IS_NEW], undefined)
+            assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+          }, {}, 1)
+        })
+
+        it('treats known-tests data missing both supported framework keys as faulty', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ 'not-webdriverio': {} })
+
+          await runScenario('efd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
+            assert.strictEqual(tests.length, 1)
+            assert.strictEqual(tests[0].meta[TEST_IS_NEW], undefined)
+            assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+          }, {}, 1)
+        })
+
+        it('evaluates EFD faultiness from specs that have not started yet', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 1,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({
+            webdriverio: {
+              'first.e2e.js': ['WebdriverIO first worker runs with an active Test Optimization span'],
+            },
+          })
+
+          await runScenario('efdFaultySchedule', 2, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const efdTests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME].endsWith('retries a new test'))
+
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
+            assert.strictEqual(efdTests.length, 1)
+            assert.strictEqual(efdTests[0].meta[TEST_IS_NEW], undefined)
+            assert.strictEqual(efdTests[0].meta[TEST_IS_RETRY], undefined)
+          }, {}, 1)
+        })
+
+        it('retries failures with ATR', async () => {
+          receiver.setSettings({
+            flaky_test_retries_count: 2,
+            flaky_test_retries_enabled: true,
+          })
+
+          await runScenario('atr', 1, payloads => {
+            const tests = getEvents(payloads)
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+
+            assert.strictEqual(tests.length, 2)
+            assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]).sort(), ['fail', 'pass'])
+            const retry = tests.find(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.ok(retry)
+            assert.strictEqual(retry.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+          })
+        })
+
+        if (framework === 'jasmine') {
+          it('falls back to ATR when the EFD retry policy has no retries', async () => {
+            receiver.setSettings({
+              early_flake_detection: {
+                enabled: true,
+                faulty_session_threshold: 100,
+                slow_test_retries: { '5s': 0 },
+              },
+              flaky_test_retries_count: 1,
+              flaky_test_retries_enabled: true,
+              known_tests_enabled: true,
+            })
+            receiver.setKnownTests({ webdriverio: {} })
+
+            await runScenario('atr', 1, payloads => {
+              const tests = getEvents(payloads)
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+
+              assert.strictEqual(tests.length, 2)
+              assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['fail', 'pass'])
+              assert.ok(tests.every(test => test.meta[TEST_IS_NEW] === 'true'))
+              assert.ok(tests.every(test => test.meta[TEST_EARLY_FLAKE_ABORT_REASON] === undefined))
+              const retry = tests.find(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.ok(retry)
+              assert.strictEqual(retry.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+            })
+          })
+        }
+
+        if (framework === 'jasmine') {
+          it('does not retry tests with ATR when their hooks fail', async () => {
+            receiver.setSettings({
+              flaky_test_retries_count: 1,
+              flaky_test_retries_enabled: true,
+            })
+
+            await runScenario('atrHookFailures', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(tests.length, 2)
+              assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'fail'))
+              assert.ok(tests.every(test => test.meta[TEST_IS_RETRY] === undefined))
+              assert.ok(tests.every(test => test.meta[TEST_HAS_FAILED_ALL_RETRIES] === undefined))
+            }, {}, 1)
+          })
+        }
+
+        if (framework === 'jasmine') {
+          it('applies ATR before WebdriverIO retries the spec file', async () => {
+            receiver.setSettings({
+              flaky_test_retries_count: 1,
+              flaky_test_retries_enabled: true,
+            })
+
+            await runScenario('specFileRetries', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.strictEqual(countRequests(payloads, SETTINGS_PATH), 1)
+              assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(suites.length, 1)
+              assert.strictEqual(suites[0].meta[TEST_STATUS], 'pass')
+              assert.strictEqual(tests.length, 2)
+              assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['fail', 'pass'])
+              assert.strictEqual(tests[1].meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(tests[1].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+            }, {
+              DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            })
+          })
+        }
+
+        if (framework === 'jasmine') {
+          it('applies ATR to failures caused by jasmineOpts.failSpecWithNoExpectations', async () => {
+            receiver.setSettings({
+              flaky_test_retries_count: 1,
+              flaky_test_retries_enabled: true,
+            })
+
+            await runScenario('jasmineNoExpectations', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(tests.length, 2)
+              assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'fail'))
+              assert.strictEqual(tests[1].meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(tests[1].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+              assert.strictEqual(tests[1].meta[TEST_FINAL_STATUS], 'fail')
+            }, {
+              DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            }, 1)
+          })
+        }
+
+        it('reports exhausted ATR retries', async () => {
+          receiver.setSettings({
+            flaky_test_retries_count: 2,
+            flaky_test_retries_enabled: true,
+          })
+
+          await runScenario('atrAlwaysFails', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suite = events.find(event => event.type === 'test_suite_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(tests.length, 3)
+            assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'fail'))
+            assert.strictEqual(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+            for (const test of tests.slice(1)) {
+              assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+            }
+            const finalAttempt = tests.find(test => TEST_FINAL_STATUS in test.meta)
+            assert.ok(finalAttempt)
+            assert.strictEqual(finalAttempt.meta[TEST_FINAL_STATUS], 'fail')
+            assert.strictEqual(finalAttempt.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+          }, {
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '2',
+          }, 1)
+        })
+
+        it('does not retry ATR failures when locally disabled', async () => {
+          receiver.setSettings({
+            flaky_test_retries_count: 2,
+            flaky_test_retries_enabled: true,
+          })
+
+          await runScenario('atrAlwaysFails', 1, payloads => {
+            const tests = getEvents(payloads)
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+
+            assert.strictEqual(tests.length, 1)
+            assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+            assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+            assert.strictEqual(tests[0].meta[TEST_HAS_FAILED_ALL_RETRIES], undefined)
+          }, {
+            DD_CIVISIBILITY_FLAKY_RETRY_ENABLED: 'false',
+          }, 1)
+        })
+
+        if (framework === 'jasmine') {
+          it('reports user-configured Jasmine retries as external retries', async () => {
+            await runScenario('jasmineRetry', 1, payloads => {
+              const tests = getEvents(payloads)
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+
+              assert.strictEqual(tests.length, 2)
+              assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['fail', 'pass'])
+              assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+              assert.strictEqual(tests[1].meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(tests[1].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.ext)
+            })
+          })
+        }
+
+        it('applies disabled, quarantined, and attempt-to-fix policies', async () => {
+          receiver.setSettings({
+            test_management: {
+              attempt_to_fix_retries: 2,
+              enabled: true,
+            },
+          })
+          receiver.setTestManagementTests({
+            webdriverio: {
+              suites: {
+                'test-management.e2e.js': {
+                  tests: {
+                    'WebdriverIO Test Management fails every attempt to fix': {
+                      properties: { attempt_to_fix: true },
+                    },
+                    'WebdriverIO Test Management has mixed attempt to fix results': {
+                      properties: { attempt_to_fix: true },
+                    },
+                    'WebdriverIO Test Management passes every attempt to fix': {
+                      properties: { attempt_to_fix: true },
+                    },
+                    'WebdriverIO Test Management is disabled': {
+                      properties: { disabled: true },
+                    },
+                    'WebdriverIO Test Management is quarantined': {
+                      properties: { quarantined: true },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          await runScenario('testManagement', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const disabled = tests.find(test => test.meta[TEST_NAME].endsWith('is disabled'))
+            const quarantined = tests.find(test => test.meta[TEST_NAME].endsWith('is quarantined'))
+            const allPassed = tests.filter(test => test.meta[TEST_NAME].endsWith('passes every attempt to fix'))
+            const allFailed = tests.filter(test => test.meta[TEST_NAME].endsWith('fails every attempt to fix'))
+            const mixed = tests.filter(test => test.meta[TEST_NAME].endsWith('has mixed attempt to fix results'))
+
+            assert.strictEqual(countRequests(payloads, TEST_MANAGEMENT_PATH), 1)
+            assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], 'true')
+            assert.strictEqual(disabled.meta[TEST_STATUS], 'skip')
+            assert.strictEqual(disabled.meta[TEST_FINAL_STATUS], 'skip')
+            assert.strictEqual(disabled.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+            assert.strictEqual(quarantined.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(quarantined.meta[TEST_FINAL_STATUS], 'skip')
+            assert.strictEqual(quarantined.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+            for (const attempts of [allPassed, allFailed, mixed]) {
+              assert.strictEqual(attempts.length, 3)
+            }
+            for (const test of [...allPassed, ...allFailed, ...mixed]) {
+              assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+            }
+            for (const attempts of [allPassed, allFailed, mixed]) {
+              for (const test of attempts.slice(1)) {
+                assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atf)
+              }
+            }
+
+            const finalPassed = allPassed.find(test => TEST_FINAL_STATUS in test.meta)
+            const finalFailed = allFailed.find(test => TEST_FINAL_STATUS in test.meta)
+            const finalMixed = mixed.find(test => TEST_FINAL_STATUS in test.meta)
+            assert.strictEqual(finalPassed.meta[TEST_FINAL_STATUS], 'pass')
+            assert.strictEqual(finalPassed.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'true')
+            assert.strictEqual(finalFailed.meta[TEST_FINAL_STATUS], 'fail')
+            assert.strictEqual(finalFailed.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+            assert.strictEqual(finalFailed.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+            assert.strictEqual(finalMixed.meta[TEST_FINAL_STATUS], 'fail')
+            assert.strictEqual(finalMixed.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+            assert.strictEqual(finalMixed.meta[TEST_HAS_FAILED_ALL_RETRIES], undefined)
+          }, {}, 1)
+        })
+
+        if (framework === 'jasmine') {
+          it('keeps skipped attempt-to-fix tests skipped', async () => {
+            receiver.setSettings({
+              test_management: {
+                attempt_to_fix_retries: 2,
+                enabled: true,
+              },
+            })
+            receiver.setTestManagementTests({
+              webdriverio: {
+                suites: {
+                  'jasmine-attempt-to-fix-skipped.e2e.js': {
+                    tests: {
+                      'WebdriverIO Jasmine skipped attempt to fix stays skipped': {
+                        properties: { attempt_to_fix: true },
+                      },
+                    },
+                  },
+                },
+              },
+            })
+
+            await runScenario('jasmineAttemptToFixSkipped', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(tests.length, 1)
+              assert.strictEqual(tests[0].meta[TEST_STATUS], 'skip')
+              assert.strictEqual(tests[0].meta[TEST_FINAL_STATUS], 'skip')
+              assert.strictEqual(tests[0].meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+              assert.strictEqual(tests[0].meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], undefined)
+              assert.strictEqual(tests[0].meta[TEST_IS_RETRY], undefined)
+              assert.strictEqual(tests[0].meta[TEST_HAS_FAILED_ALL_RETRIES], undefined)
+            })
+          })
+
+          it('does not run hooks for disabled tests', async () => {
+            receiver.setSettings({
+              test_management: { enabled: true },
+            })
+            receiver.setTestManagementTests({
+              webdriverio: {
+                suites: {
+                  'test-management-disabled-hook.e2e.js': {
+                    tests: {
+                      'WebdriverIO disabled hook is disabled': {
+                        properties: { disabled: true },
+                      },
+                    },
+                  },
+                },
+              },
+            })
+
+            await runScenario('testManagementDisabledHook', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const disabled = tests.find(test => test.meta[TEST_NAME].endsWith('is disabled'))
+              const passing = tests.find(test => test.meta[TEST_NAME].endsWith('passes'))
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(disabled.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(disabled.meta[TEST_FINAL_STATUS], 'skip')
+              assert.strictEqual(disabled.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+              assert.strictEqual(passing.meta[TEST_STATUS], 'pass')
+            }, {}, 0)
+          })
+        }
+
+        it('does not apply Test Management policies when locally disabled', async () => {
+          receiver.setSettings({
+            test_management: {
+              attempt_to_fix_retries: 2,
+              enabled: true,
+            },
+          })
+          receiver.setTestManagementTests({
+            webdriverio: {
+              suites: {
+                'test-management.e2e.js': {
+                  tests: {
+                    'WebdriverIO Test Management is disabled': {
+                      properties: { disabled: true },
+                    },
+                    'WebdriverIO Test Management is quarantined': {
+                      properties: { quarantined: true },
+                    },
+                    'WebdriverIO Test Management passes every attempt to fix': {
+                      properties: { attempt_to_fix: true },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          await runScenario('testManagement', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(countRequests(payloads, TEST_MANAGEMENT_PATH), 0)
+            assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], undefined)
+            assert.strictEqual(tests.length, 5)
+            for (const test of tests) {
+              assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], undefined)
+              assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_DISABLED], undefined)
+              assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_QUARANTINED], undefined)
+              assert.strictEqual(test.meta[TEST_IS_RETRY], undefined)
+            }
+          }, {
+            DD_TEST_MANAGEMENT_ENABLED: '0',
+          }, 1)
+        })
+
+        it('suppresses quarantined and recovered EFD hook failures', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+            test_management: { enabled: true },
+          })
+          receiver.setKnownTests({
+            webdriverio: {
+              'managed-hook-fail.e2e.js': ['WebdriverIO quarantined hook failure is quarantined'],
+            },
+          })
+          receiver.setTestManagementTests({
+            webdriverio: {
+              suites: {
+                'managed-hook-fail.e2e.js': {
+                  tests: {
+                    'WebdriverIO quarantined hook failure is quarantined': {
+                      properties: { quarantined: true },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          await runScenario('managedHookFailures', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suite = events.find(event => event.type === 'test_suite_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const quarantined = tests.find(test => test.meta[TEST_NAME].endsWith('is quarantined'))
+            const earlyFlakeDetectionTests = tests.filter(test =>
+              test.meta[TEST_NAME].endsWith('passes an EFD retry'))
+
+            assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(quarantined.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(quarantined.meta[TEST_FINAL_STATUS], 'skip')
+            assert.strictEqual(quarantined.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+            const expectedStatuses = framework === 'jasmine' ? ['fail', 'pass', 'pass'] : ['fail', 'pass']
+            assert.strictEqual(earlyFlakeDetectionTests.length, expectedStatuses.length)
+            assert.deepStrictEqual(
+              earlyFlakeDetectionTests.map(test => test.meta[TEST_STATUS]).sort(),
+              expectedStatuses
+            )
+          })
+        })
+
+        it('fails the run when every EFD attempt has a failing afterEach hook', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+
+          await runScenario('efdAfterEachFailure', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suite = events.find(event => event.type === 'test_suite_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(tests.length, framework === 'jasmine' ? 3 : 1)
+            assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'fail'))
+          }, {}, 1)
+        })
+
+        if (framework === 'jasmine') {
+          it('does not retry or suppress expectation-based hook failures', async () => {
+            receiver.setSettings({
+              early_flake_detection: {
+                enabled: true,
+                faulty_session_threshold: 100,
+                slow_test_retries: { '5s': 2 },
+              },
+              flaky_test_retries_count: 1,
+              flaky_test_retries_enabled: true,
+              known_tests_enabled: true,
+            })
+            receiver.setKnownTests({
+              webdriverio: {
+                'jasmine-expectation-hook-fail.e2e.js': [
+                  'WebdriverIO Jasmine expectation hook failures beforeEach does not retry with ATR',
+                ],
+              },
+            })
+
+            await runScenario('jasmineExpectationHookFailures', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const beforeEachTests = tests.filter(test => test.meta[TEST_NAME].endsWith('does not retry with ATR'))
+              const afterEachTests = tests.filter(test => test.meta[TEST_NAME].endsWith('keeps the final EFD failure'))
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(beforeEachTests.length, 1)
+              assert.strictEqual(beforeEachTests[0].meta[TEST_STATUS], 'fail')
+              assert.strictEqual(beforeEachTests[0].meta[TEST_IS_RETRY], undefined)
+              assert.deepStrictEqual(afterEachTests.map(test => test.meta[TEST_STATUS]), ['pass', 'pass', 'fail'])
+              assert.strictEqual(afterEachTests[2].meta[TEST_FINAL_STATUS], 'fail')
+            }, {}, 1)
+          })
+        }
+
+        for (const hookType of ['beforeAll', 'afterAll']) {
+          it(`does not suppress a quarantined test's ${hookType} failure`, async () => {
+            receiver.setSettings({
+              test_management: { enabled: true },
+            })
+            receiver.setTestManagementTests({
+              webdriverio: {
+                suites: {
+                  'suite-hook-fail.e2e.js': {
+                    tests: {
+                      'WebdriverIO suite hook failure is quarantined': {
+                        properties: { quarantined: true },
+                      },
+                    },
+                  },
+                },
+              },
+            })
+
+            await runScenario('suiteHookFailure', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+            }, {
+              WEBDRIVERIO_SUITE_HOOK: hookType,
+            }, framework === 'jasmine' ? 0 : 1)
+          })
+        }
+
+        it('does not suppress an afterAll failure after passing EFD attempts', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+
+          await runScenario('suiteHookFailure', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suite = events.find(event => event.type === 'test_suite_end').content
+
+            assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
+          }, {
+            WEBDRIVERIO_SUITE_HOOK: 'afterAll',
+          }, framework === 'jasmine' ? 0 : 1)
+        })
+
+        it('marks tests from modified files as impacted', async () => {
+          receiver.setSettings({ impacted_tests_enabled: true })
+
+          await runScenario('impacted', 1, payloads => {
+            const tests = getEvents(payloads)
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+            const impacted = tests.find(test => test.meta[TEST_SUITE] === 'impacted.e2e.js')
+            const unmodified = tests.find(test => test.meta[TEST_SUITE] === 'first.e2e.js')
+
+            assert.strictEqual(tests.length, 2)
+            assert.strictEqual(impacted.meta[TEST_IS_MODIFIED], 'true')
+            assert.strictEqual(unmodified.meta[TEST_IS_MODIFIED], undefined)
+          })
+        })
+
+        if (framework === 'jasmine') {
+          it('marks tests as impacted when WebdriverIO runs below the repository root', async () => {
+            receiver.setSettings({ impacted_tests_enabled: true })
+
+            await runScenario('impacted', 1, payloads => {
+              const tests = getEvents(payloads)
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+              const impacted = tests.find(test => test.meta[TEST_SUITE] === 'nested-impacted.e2e.js')
+              const unmodified = tests.find(test => test.meta[TEST_SUITE] === 'nested-first.e2e.js')
+
+              assert.strictEqual(tests.length, 2)
+              assert.strictEqual(impacted.meta[TEST_SOURCE_FILE], 'subdirectory/nested-impacted.e2e.js')
+              assert.strictEqual(impacted.meta[TEST_IS_MODIFIED], 'true')
+              assert.strictEqual(unmodified.meta[TEST_IS_MODIFIED], undefined)
+            }, {}, 0, path.join(cwd, 'subdirectory'))
+          })
+        }
+
+        it('does not mark impacted tests when locally disabled', async () => {
+          receiver.setSettings({ impacted_tests_enabled: true })
+
+          await runScenario('impacted', 1, payloads => {
+            const tests = getEvents(payloads)
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+
+            assert.strictEqual(tests.length, 2)
+            assert.ok(tests.every(test => test.meta[TEST_IS_MODIFIED] === undefined))
+          }, {
+            DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED: '0',
+          })
+        })
+
+        it('captures Failed Test Replay snapshots in workers', async () => {
+          receiver.setSettings({
+            di_enabled: true,
+            flaky_test_retries_count: 1,
+            flaky_test_retries_enabled: true,
+          })
+
+          await runScenario('failedTestReplay', 1, payloads => {
+            const tests = getEvents(payloads)
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+            const retriedTest = tests.find(test =>
+              test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
+            const logPayload = payloads.find(({ url }) => url.endsWith('/api/v2/logs'))
+
+            assert.ok(retriedTest)
+            assert.strictEqual(retriedTest.meta[DI_ERROR_DEBUG_INFO_CAPTURED], 'true')
+            assert.ok(Object.keys(retriedTest.meta).some(tag => tag.startsWith(DI_DEBUG_ERROR_PREFIX)))
+            assert.ok(logPayload)
+            assert.strictEqual(logPayload.logMessage[0].ddsource, 'dd_debugger')
+          }, {
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            _DD_TRACE_INTEGRATION_COVERAGE_DISABLE: '1',
+          })
+        })
+
+        if (framework === 'jasmine') {
+          it('captures Failed Test Replay when the first EFD attempt passes', async () => {
+            receiver.setSettings({
+              di_enabled: true,
+              early_flake_detection: {
+                enabled: true,
+                faulty_session_threshold: 100,
+                slow_test_retries: { '5s': 2 },
+              },
+              flaky_test_retries_count: 1,
+              flaky_test_retries_enabled: true,
+              known_tests_enabled: true,
+            })
+            receiver.setKnownTests({ webdriverio: {} })
+
+            await runScenario('efdFailedTestReplay', 1, payloads => {
+              const tests = getEvents(payloads)
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+              const finalRetry = tests[2]
+              const logPayload = payloads.find(({ url }) => url.endsWith('/api/v2/logs'))
+
+              assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['pass', 'fail', 'pass'])
+              assert.strictEqual(finalRetry.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+              assert.strictEqual(
+                finalRetry.meta[DI_ERROR_DEBUG_INFO_CAPTURED],
+                'true',
+                JSON.stringify(tests.map(test => test.meta))
+              )
+              assert.ok(Object.keys(finalRetry.meta).some(tag => tag.startsWith(DI_DEBUG_ERROR_PREFIX)))
+              assert.ok(logPayload)
+              assert.strictEqual(logPayload.logMessage[0].ddsource, 'dd_debugger')
+            }, {
+              _DD_TRACE_INTEGRATION_COVERAGE_DISABLE: '1',
+            })
+          })
+        }
+
+        it('does not capture Failed Test Replay snapshots when locally disabled', async () => {
+          receiver.setSettings({
+            di_enabled: true,
+            flaky_test_retries_count: 1,
+            flaky_test_retries_enabled: true,
+          })
+
+          await runScenario('failedTestReplay', 1, payloads => {
+            const tests = getEvents(payloads)
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+            const retriedTest = tests.find(test =>
+              test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
+            const logPayload = payloads.find(({ url }) => url.endsWith('/api/v2/logs'))
+
+            assert.ok(retriedTest)
+            assert.strictEqual(retriedTest.meta[DI_ERROR_DEBUG_INFO_CAPTURED], undefined)
+            assert.ok(!Object.keys(retriedTest.meta).some(tag => tag.startsWith(DI_DEBUG_ERROR_PREFIX)))
+            assert.strictEqual(logPayload, undefined)
+          }, {
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            DD_TEST_FAILED_TEST_REPLAY_ENABLED: 'false',
+          })
+        })
+
+        it('falls back safely when policy requests fail', async () => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: { '5s': 2 },
+            },
+            known_tests_enabled: true,
+            test_management: { enabled: true },
+          })
+          receiver.setKnownTestsResponseCode(500)
+          receiver.setTestManagementTestsResponseCode(500)
+
+          await runScenario('efd', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(tests.length, 1)
+            assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
+            assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], undefined)
+            for (const event of [session, ...suites, ...tests]) {
+              assert.strictEqual(event.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
+              assert.strictEqual(event.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true')
+            }
+          }, {}, 1)
+        })
       })
     }
-
-    it('does not suppress an afterAll failure after passing EFD attempts', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          faulty_session_threshold: 100,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-      })
-      receiver.setKnownTests({ webdriverio: {} })
-
-      await runScenario('suiteHookFailure', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const suite = events.find(event => event.type === 'test_suite_end').content
-
-        assert.strictEqual(session.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(suite.meta[TEST_STATUS], 'fail')
-      }, {
-        WEBDRIVERIO_SUITE_HOOK: 'afterAll',
-      }, 1)
-    })
-
-    it('marks tests from modified files as impacted', async () => {
-      receiver.setSettings({ impacted_tests_enabled: true })
-
-      await runScenario('impacted', 1, payloads => {
-        const tests = getEvents(payloads)
-          .filter(event => event.type === 'test')
-          .map(event => event.content)
-
-        assert.strictEqual(tests.length, 1)
-        assert.strictEqual(tests[0].meta[TEST_SUITE], 'impacted.e2e.js')
-        assert.strictEqual(tests[0].meta[TEST_IS_MODIFIED], 'true')
-      })
-    })
-
-    it('captures Failed Test Replay snapshots in workers', async () => {
-      receiver.setSettings({
-        di_enabled: true,
-        flaky_test_retries_count: 1,
-        flaky_test_retries_enabled: true,
-      })
-
-      await runScenario('failedTestReplay', 1, payloads => {
-        const tests = getEvents(payloads)
-          .filter(event => event.type === 'test')
-          .map(event => event.content)
-        const retriedTest = tests.find(test =>
-          test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
-        const logPayload = payloads.find(({ url }) => url.endsWith('/api/v2/logs'))
-
-        assert.ok(retriedTest)
-        assert.strictEqual(retriedTest.meta[DI_ERROR_DEBUG_INFO_CAPTURED], 'true')
-        assert.ok(Object.keys(retriedTest.meta).some(tag => tag.startsWith(DI_DEBUG_ERROR_PREFIX)))
-        assert.ok(logPayload)
-        assert.strictEqual(logPayload.logMessage[0].ddsource, 'dd_debugger')
-      }, {
-        DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
-        _DD_TRACE_INTEGRATION_COVERAGE_DISABLE: '1',
-      })
-    })
-
-    it('falls back safely when policy requests fail', async () => {
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          slow_test_retries: { '5s': 2 },
-        },
-        known_tests_enabled: true,
-        test_management: { enabled: true },
-      })
-      receiver.setKnownTestsResponseCode(500)
-      receiver.setTestManagementTestsResponseCode(500)
-
-      await runScenario('efd', 1, payloads => {
-        const events = getEvents(payloads)
-        const session = events.find(event => event.type === 'test_session_end').content
-        const suites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
-        const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-        assert.strictEqual(tests.length, 1)
-        assert.strictEqual(session.meta[TEST_EARLY_FLAKE_ENABLED], undefined)
-        assert.strictEqual(session.meta[TEST_MANAGEMENT_ENABLED], undefined)
-        for (const event of [session, ...suites, ...tests]) {
-          assert.strictEqual(event.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
-          assert.strictEqual(event.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true')
-        }
-      }, {}, 1)
-    })
   })
 }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/webdriverio.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/webdriverio.js
@@ -172,4 +172,85 @@ module.exports = [
     },
     channelName: 'testFrameworkFnWrapper',
   },
+  {
+    module: {
+      name: '@wdio/utils',
+      versionRange: '>=9.0.0',
+      filePath: 'build/index.js',
+    },
+    functionQuery: {
+      functionName: 'executeAsync',
+      kind: 'Async',
+    },
+    channelName: 'executeAsync',
+  },
+  {
+    module: {
+      name: '@wdio/utils',
+      versionRange: '>=9.0.0',
+      filePath: 'build/index.js',
+    },
+    astQuery: 'FunctionDeclaration[id.name="executeAsync"] CatchClause ' +
+      'IfStatement[test.operator=">"][test.left.object.name="retries"]' +
+      '[test.left.property.name="limit"][test.right.object.name="retries"]' +
+      '[test.right.property.name="attempts"]',
+    channelName: 'executeAsync',
+    transform: 'awaitContextCallback',
+    transformOptions: {
+      callbackArgumentNames: ['err'],
+      callbackName: 'retryCallback',
+    },
+  },
+  {
+    module: {
+      name: 'jasmine-core',
+      versionRange: '>=5.0.0 <6.0.0',
+      filePath: 'lib/jasmine-core/jasmine.js',
+    },
+    astQuery: 'AssignmentExpression[left.object.object.name="Spec"]' +
+      '[left.object.property.name="prototype"][left.property.name="execute"] > FunctionExpression',
+    functionQuery: {
+      kind: 'Sync',
+    },
+    channelName: 'Spec_execute',
+  },
+  {
+    module: {
+      name: 'jasmine-core',
+      versionRange: '>=5.0.0 <6.0.0',
+      filePath: 'lib/jasmine-core/jasmine.js',
+    },
+    astQuery: 'AssignmentExpression[left.object.object.name="Spec"]' +
+      '[left.object.property.name="prototype"][left.property.name="status"] > FunctionExpression',
+    functionQuery: {
+      kind: 'Sync',
+    },
+    channelName: 'Spec_attemptDone',
+  },
+  {
+    module: {
+      name: 'jasmine-core',
+      versionRange: '>=5.0.0 <6.0.0',
+      filePath: 'lib/jasmine-core/jasmine.js',
+    },
+    functionQuery: {
+      className: 'Spec',
+      methodName: 'executionFinished',
+      kind: 'Sync',
+    },
+    channelName: 'Spec_attemptDone',
+  },
+  {
+    module: {
+      name: 'jasmine-core',
+      versionRange: '>=5.0.0 <6.0.0',
+      filePath: 'lib/jasmine-core/jasmine.js',
+    },
+    functionQuery: {
+      className: 'TreeRunner',
+      methodName: '_executeSpec',
+      kind: 'Sync',
+    },
+    channelName: 'Spec_execute',
+  },
 ]

--- a/packages/datadog-instrumentations/src/helpers/rewriter/targets.json
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/targets.json
@@ -54,6 +54,7 @@
   "graphql/utilities/index.mjs": "graphql",
   "graphql/validation/validate.js": "graphql",
   "graphql/validation/validate.mjs": "graphql",
+  "jasmine-core/lib/jasmine-core/jasmine.js": "jasmine-core",
   "mercurius/index.js": "mercurius",
   "playwright-core/lib/coreBundle.js": "playwright-core",
   "playwright/lib/index.js": "playwright",

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -11,6 +11,7 @@ const {
 const {
   getTestSuitePath,
   DYNAMIC_NAME_RE,
+  getFailedTestReplayPromise,
   recordTestManagementExecution,
   recordAttemptToFixExecution,
   logAttemptToFixTestExecution,
@@ -953,14 +954,7 @@ function getOnTestRetryHandler (config) {
         promises,
         ...ctx.currentStore,
       })
-      if (promises.setProbePromise && promises.finishTestPromise) {
-        test._ddFailedTestReplayPromise = Promise.all([
-          promises.setProbePromise,
-          promises.finishTestPromise,
-        ]).then(() => {})
-      } else if (promises.setProbePromise || promises.finishTestPromise) {
-        test._ddFailedTestReplayPromise = promises.setProbePromise || promises.finishTestPromise
-      }
+      test._ddFailedTestReplayPromise = getFailedTestReplayPromise(promises)
     }
     const key = getTestToContextKey(test)
     testToContext.delete(key)

--- a/packages/datadog-instrumentations/src/webdriverio.js
+++ b/packages/datadog-instrumentations/src/webdriverio.js
@@ -171,7 +171,7 @@ function createWorkerConfiguration () {
 }
 
 /**
- * Configures a Jasmine worker for reporting-only execution and notifies its coordinator.
+ * Configures a Jasmine worker and waits for its coordinator-owned optimization settings.
  *
  * @param {{_jrunner?: {env?: {addReporter?: (reporter: object) => void}}, _specs?: string[]}} adapter
  * @param {{
@@ -185,13 +185,7 @@ function initializeJasmineWorker (adapter, context) {
     return
   }
 
-  workerConfigurationCh.publish({
-    libraryConfig: createWorkerConfiguration(),
-    repositoryRoot: undefined,
-    specs: adapter?._specs || [],
-    testFramework: TEST_FRAMEWORK,
-    testFrameworkAdapter: JASMINE_FRAMEWORK_ADAPTER,
-  })
+  const specs = adapter?._specs || []
 
   if (jasmineDoneCh.hasSubscribers) {
     adapter?._jrunner?.env?.addReporter?.({
@@ -220,9 +214,10 @@ function initializeJasmineWorker (adapter, context) {
     /**
      * Releases Jasmine initialization exactly once.
      *
+     * @param {object} [configuration]
      * @returns {void}
      */
-    function finish () {
+    function finish (configuration = createWorkerConfiguration()) {
       if (finished) {
         return
       }
@@ -230,6 +225,13 @@ function initializeJasmineWorker (adapter, context) {
       clearTimeout(timeout)
       process.off('message', onMessage)
       process.off('disconnect', finish)
+      workerConfigurationCh.publish({
+        libraryConfig: configuration,
+        repositoryRoot: configuration.repositoryRoot,
+        specs,
+        testFramework: TEST_FRAMEWORK,
+        testFrameworkAdapter: JASMINE_FRAMEWORK_ADAPTER,
+      })
       onDone()
     }
 
@@ -241,7 +243,7 @@ function initializeJasmineWorker (adapter, context) {
      */
     function onMessage (message) {
       if (message?.name === WORKER_READY_RESPONSE && message.content?.requestId === requestId) {
-        finish()
+        finish(message.content.configuration)
       }
     }
 
@@ -447,6 +449,18 @@ function getMochaFrameworkData (frameworkData) {
 }
 
 /**
+ * Applies the worker configuration for an EFD session with faulty known-tests data.
+ *
+ * @param {object} configuration
+ * @returns {void}
+ */
+function setEarlyFlakeDetectionFaulty (configuration) {
+  configuration.isEarlyFlakeDetectionEnabled = false
+  configuration.isEarlyFlakeDetectionFaulty = true
+  configuration.isKnownTestsEnabled = false
+}
+
+/**
  * Applies settings and requests the enabled non-TIA datasets once for the whole run.
  *
  * @param {CoordinatorState} state
@@ -498,9 +512,11 @@ function configureCoordinator (state, response) {
     pendingRequests++
     requestCoordinatorData(state, knownTestsCh, ({ err, knownTests } = {}) => {
       const mochaKnownTests = getMochaFrameworkData(knownTests)
-      if (err || !mochaKnownTests) {
+      if (err) {
         configuration.isEarlyFlakeDetectionEnabled = false
         configuration.isKnownTestsEnabled = false
+      } else if (mochaKnownTests === undefined) {
+        setEarlyFlakeDetectionFaulty(configuration)
       } else {
         configuration.knownTests = { mocha: mochaKnownTests }
       }
@@ -564,7 +580,6 @@ function initializeCoordinator (state, onDone) {
 
   try {
     libraryConfigurationCh.runStores({
-      basicReportingOnly: state.testFrameworkAdapter === JASMINE_FRAMEWORK_ADAPTER,
       disableTestImpactAnalysis: true,
       frameworkVersion: state.frameworkVersion,
       isParallel: state.maxActiveWorkers > 1,
@@ -727,9 +742,7 @@ function updateEarlyFlakeDetectionFaultyState (state, files) {
     configuration.earlyFlakeDetectionFaultyThreshold
   )
   if (isFaulty) {
-    configuration.isEarlyFlakeDetectionEnabled = false
-    configuration.isEarlyFlakeDetectionFaulty = true
-    configuration.isKnownTestsEnabled = false
+    setEarlyFlakeDetectionFaulty(configuration)
   }
 }
 
@@ -809,15 +822,16 @@ function handleWorkerMessage (state, workerRecord, message) {
   }
 
   if (message.name === WORKER_READY) {
-    initializeCoordinator(state, () => {
+    initializeCoordinator(state, configuration => {
       if (state.testFrameworkAdapter === JASMINE_FRAMEWORK_ADAPTER) {
+        updateEarlyFlakeDetectionFaultyState(state, workerRecord.specs)
         startWorkerSuites(workerRecord, workerRecord.specs)
       }
       if (message.content?.requestId) {
         sendWorkerMessage(workerRecord, {
           origin: 'datadog',
           name: WORKER_READY_RESPONSE,
-          content: { requestId: message.content.requestId },
+          content: { configuration, requestId: message.content.requestId },
         })
       }
     })

--- a/packages/datadog-instrumentations/test/fixtures/jasmine-core.js
+++ b/packages/datadog-instrumentations/test/fixtures/jasmine-core.js
@@ -1,0 +1,30 @@
+'use strict'
+
+function Spec () {}
+
+Spec.prototype.execute = function (queueRunnerFactory, onComplete) {
+  queueRunnerFactory(onComplete)
+}
+
+Spec.prototype.status = function () {
+  return 'passed'
+}
+
+function createModernJasmine () {
+  class Spec {
+    executionFinished () {
+      this.result.status = 'passed'
+    }
+  }
+
+  class TreeRunner {
+    _executeSpec (spec, onComplete) {
+      spec.executionFinished()
+      onComplete()
+    }
+  }
+
+  return { Spec, TreeRunner }
+}
+
+module.exports = { createModernJasmine, Spec }

--- a/packages/datadog-instrumentations/test/fixtures/node_modules/jasmine-core/package.json
+++ b/packages/datadog-instrumentations/test/fixtures/node_modules/jasmine-core/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "jasmine-core",
+  "version": "5.13.0"
+}

--- a/packages/datadog-instrumentations/test/fixtures/webdriverio-utils.mjs
+++ b/packages/datadog-instrumentations/test/fixtures/webdriverio-utils.mjs
@@ -2,4 +2,17 @@ const testFrameworkFnWrapper = async function (type, spec) {
   return spec(type)
 }
 
-export { testFrameworkFnWrapper }
+async function executeAsync (fn, retries, args = [], timeout) {
+  try {
+    const result = await fn(...args)
+    return await result
+  } catch (err) {
+    if (retries.limit > retries.attempts) {
+      retries.attempts++
+      return await executeAsync.call(this, fn, retries, args, timeout)
+    }
+    throw err
+  }
+}
+
+export { executeAsync, testFrameworkFnWrapper }

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -63,6 +63,16 @@ const jasmineFixtureModulePath = path.join(
   'build',
   'index.js'
 )
+const jasmineCoreFixturePath = path.join(__dirname, 'fixtures', 'jasmine-core.js')
+const jasmineCoreFixtureModulePath = path.join(
+  __dirname,
+  'fixtures',
+  'node_modules',
+  'jasmine-core',
+  'lib',
+  'jasmine-core',
+  'jasmine.js'
+)
 const launcherFixturePath = path.join(__dirname, 'fixtures', 'webdriverio-launcher.mjs')
 const launcherFixtureModulePath = path.join(
   __dirname,
@@ -125,7 +135,123 @@ describe('webdriverio instrumentation', () => {
     const rewrittenSource = rewriter.rewrite(source, utilsFixtureModulePath, 'module')
 
     assert.notStrictEqual(rewrittenSource, source)
+    assert.match(rewrittenSource, /orchestrion:@wdio\/utils:executeAsync/)
     assert.match(rewrittenSource, /orchestrion:@wdio\/utils:testFrameworkFnWrapper/)
+  })
+
+  it('rewrites legacy and modern Jasmine spec lifecycles', () => {
+    const source = fs.readFileSync(jasmineCoreFixturePath, 'utf8')
+    const rewrittenSource = rewriter.rewrite(source, jasmineCoreFixtureModulePath)
+
+    assert.notStrictEqual(rewrittenSource, source)
+    assert.match(rewrittenSource, /orchestrion:jasmine-core:Spec_execute/)
+    assert.match(rewrittenSource, /orchestrion:jasmine-core:Spec_attemptDone/)
+  })
+
+  it('runs the WebdriverIO retry callback before a failed test is retried', async () => {
+    const source = fs.readFileSync(utilsFixturePath, 'utf8')
+    const rewrittenSource = rewriter.rewrite(source, utilsFixtureModulePath, 'module')
+    const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-webdriverio-utils-rewriter-'))
+    const outputPath = path.join(outputDirectory, 'index.mjs')
+    const callbacks = []
+    const retries = { attempts: 0, limit: 2 }
+    const executeAsyncCh = tracingChannel('orchestrion:@wdio/utils:executeAsync')
+    const subscriber = {
+      start (ctx) {
+        ctx.retryCallback = error => {
+          callbacks.push(error.message)
+        }
+      },
+    }
+    let attempts = 0
+
+    executeAsyncCh.subscribe(subscriber)
+    try {
+      fs.writeFileSync(outputPath, rewrittenSource)
+
+      const { executeAsync } = await import(pathToFileURL(outputPath))
+      const result = await executeAsync(() => {
+        attempts++
+        if (attempts === 1) {
+          throw new Error('failed attempt')
+        }
+        return attempts
+      }, retries)
+
+      assert.strictEqual(result, 2)
+      assert.strictEqual(retries.attempts, 1)
+      assert.deepStrictEqual(callbacks, ['failed attempt'])
+    } finally {
+      executeAsyncCh.unsubscribe(subscriber)
+    }
+  })
+
+  it('honors WebdriverIO retry limits changed by the callback', async () => {
+    const source = fs.readFileSync(utilsFixturePath, 'utf8')
+    const rewrittenSource = rewriter.rewrite(source, utilsFixtureModulePath, 'module')
+    const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-webdriverio-utils-rewriter-'))
+    const outputPath = path.join(outputDirectory, 'index.mjs')
+    const failedRetries = { attempts: 0, limit: 1 }
+    const executeAsyncCh = tracingChannel('orchestrion:@wdio/utils:executeAsync')
+    const subscriber = {
+      start (ctx) {
+        ctx.retryCallback = () => {
+          failedRetries.limit = 0
+        }
+      },
+    }
+    let failedAttempts = 0
+
+    executeAsyncCh.subscribe(subscriber)
+    try {
+      fs.writeFileSync(outputPath, rewrittenSource)
+
+      const { executeAsync } = await import(pathToFileURL(outputPath))
+      await assert.rejects(executeAsync(() => {
+        failedAttempts++
+        throw new Error('failed attempt')
+      }, failedRetries), /failed attempt/)
+
+      assert.strictEqual(failedAttempts, 1)
+      assert.strictEqual(failedRetries.attempts, 0)
+    } finally {
+      executeAsyncCh.unsubscribe(subscriber)
+    }
+  })
+
+  it('preserves WebdriverIO retries when the retry callback rejects', async () => {
+    const source = fs.readFileSync(utilsFixturePath, 'utf8')
+    const rewrittenSource = rewriter.rewrite(source, utilsFixtureModulePath, 'module')
+    const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-webdriverio-utils-rewriter-'))
+    const outputPath = path.join(outputDirectory, 'index.mjs')
+    const retries = { attempts: 0, limit: 1 }
+    const executeAsyncCh = tracingChannel('orchestrion:@wdio/utils:executeAsync')
+    const subscriber = {
+      start (ctx) {
+        ctx.retryCallback = () => Promise.reject(new Error('observability callback failed'))
+      },
+    }
+    let attempts = 0
+
+    executeAsyncCh.subscribe(subscriber)
+    try {
+      fs.writeFileSync(outputPath, rewrittenSource)
+
+      const { executeAsync } = await import(pathToFileURL(outputPath))
+      const result = await executeAsync(() => {
+        attempts++
+        if (attempts === 1) {
+          throw new Error('test failed')
+        }
+        return 'passed'
+      }, retries)
+
+      assert.strictEqual(result, 'passed')
+      assert.strictEqual(attempts, 2)
+      assert.strictEqual(retries.attempts, 1)
+    } finally {
+      executeAsyncCh.unsubscribe(subscriber)
+    }
   })
 
   it('waits for coordinator shutdown before preserving a LocalRunner.shutdown rejection', async () => {
@@ -333,7 +459,488 @@ describe('webdriverio instrumentation', () => {
     }
   })
 
-  it('keeps Jasmine suite results reported before basic-reporting configuration completes', async () => {
+  it('falls back to ATR when the Jasmine EFD retry policy has no retries', () => {
+    const { plugin } = createJasminePlugin({
+      earlyFlakeDetectionRetryPolicy: createEfdRetryPolicy(),
+      flakyTestRetriesCount: 1,
+      isEarlyFlakeDetectionEnabled: true,
+      isFlakyTestRetriesEnabled: true,
+      isKnownTestsEnabled: true,
+      knownTests: { mocha: {} },
+    })
+    const file = path.join(process.cwd(), 'zero-efd-retries.spec.js')
+    const result = createJasmineResult('zero EFD retries', file, 'failed')
+
+    try {
+      reportJasmineSpecStarted(result, file)
+
+      const test = plugin._webdriverioJasmineState.tests.get(result.id)
+      assert.strictEqual(test.isEarlyFlakeDetection, false)
+      assert.strictEqual(test.isAtr, true)
+      assert.strictEqual(test.retryCount, 1)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('uses repository-relative paths for impacted Jasmine tests', () => {
+    const sourceRoot = path.join(process.cwd(), 'packages', 'browser-tests')
+    const file = path.join(sourceRoot, 'impacted.spec.js')
+    const { plugin } = createJasminePlugin({
+      isImpactedTestsEnabled: true,
+      modifiedFiles: {
+        'packages/browser-tests/impacted.spec.js': [1],
+      },
+    })
+    const result = createJasmineResult('impacted test', file, 'passed')
+
+    try {
+      plugin.sourceRoot = sourceRoot
+      reportJasmineSpecStarted(result, file)
+
+      const test = plugin._webdriverioJasmineState.tests.get(result.id)
+      assert.strictEqual(test.isModified, true)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('starts managed Jasmine retry spans after retry setup settles', async () => {
+    const retryCh = channel('ci:mocha:test:retry')
+    const { plugin, spans } = createJasminePlugin({
+      flakyTestRetriesCount: 1,
+      isFlakyTestRetriesEnabled: true,
+    })
+    const file = path.join(process.cwd(), 'managed-retry.spec.js')
+    const result = createJasmineResult('managed-retry', file, 'failed')
+    let finishRetrySetup
+    const retrySetup = new Promise(resolve => {
+      finishRetrySetup = resolve
+    })
+    const onRetry = ({ promises }) => {
+      promises.setProbePromise = retrySetup
+    }
+    const onComplete = sinon.spy()
+    const spec = {
+      execute: sinon.spy(),
+      id: result.id,
+      queueableFn: { fn () {} },
+      reset: sinon.spy(),
+    }
+    const executeContext = {
+      arguments: [() => {}, onComplete, true, {}],
+      self: spec,
+    }
+
+    retryCh.subscribe(onRetry)
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_execute:start').runStores(executeContext, () => {})
+
+      const attemptContext = { result: 'failed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      assert.strictEqual(attemptContext.result, 'passed')
+
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [{
+          ...result,
+          failedExpectations: [{ message: 'managed retry failure' }],
+        }],
+        self: { _specs: [file] },
+      })
+      executeContext.arguments[1]()
+
+      assert.strictEqual(spans.length, 1)
+      assert.strictEqual(spec.execute.callCount, 0)
+
+      finishRetrySetup()
+      await retrySetup
+      await Promise.resolve()
+
+      assert.strictEqual(spans.length, 2)
+      assert.strictEqual(spec.execute.callCount, 1)
+      assert.strictEqual(onComplete.callCount, 0)
+    } finally {
+      retryCh.unsubscribe(onRetry)
+      plugin.configure(false)
+    }
+  })
+
+  it('finishes Failed Test Replay before the next Jasmine spec starts', async () => {
+    const source = fs.readFileSync(jasmineFixturePath, 'utf8')
+    const rewrittenSource = rewriter.rewrite(source, jasmineFixtureModulePath, 'module')
+    const outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-webdriverio-jasmine-reporter-'))
+    const outputPath = path.join(outputDirectory, 'index.mjs')
+    const { plugin, spans } = createJasminePlugin({})
+    const file = path.join(process.cwd(), 'failed-test-replay.spec.js')
+    const firstResult = createJasmineResult('captures a replay', file, 'failed')
+    const secondResult = createJasmineResult('runs after the replay', file, 'passed')
+    let finishReplay
+    const replayFinished = new Promise(resolve => {
+      finishReplay = resolve
+    })
+
+    sinon.stub(plugin, 'waitForDiBreakpointHits').returns(replayFinished)
+    fs.writeFileSync(outputPath, rewrittenSource)
+
+    try {
+      const { JasmineReporter } = await import(pathToFileURL(outputPath))
+      const reporter = new JasmineReporter([file])
+      reportJasmineSpecStarted(firstResult, file)
+      plugin._webdriverioJasmineState.tests.get(firstResult.id)._ddShouldWaitForHitProbe = true
+
+      const reportFirstSpec = Promise.resolve(reporter.specDone(firstResult)).then(() => {
+        reportJasmineSpecStarted(secondResult, file)
+      })
+      await Promise.resolve()
+
+      assert.strictEqual(spans.length, 1)
+
+      finishReplay()
+      await reportFirstSpec
+
+      assert.strictEqual(spans.length, 2)
+      assert.strictEqual(plugin.activeTestSpan, spans[1])
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('installs Failed Test Replay on the first Jasmine failure after a passing attempt', () => {
+    const { plugin } = createJasminePlugin({
+      earlyFlakeDetectionRetryPolicy: createEfdRetryPolicy({ '5s': 2 }),
+      isDiEnabled: true,
+      isEarlyFlakeDetectionEnabled: true,
+      isKnownTestsEnabled: true,
+      knownTests: { mocha: {} },
+    })
+    const file = path.join(process.cwd(), 'delayed-failure.spec.js')
+    const result = createJasmineResult('delayed failure', file, 'failed')
+    result.failedExpectations = [{ message: 'delayed failure' }]
+    const addDiProbe = sinon.stub(plugin, 'addDiProbe').returns({
+      file,
+      line: 1,
+      setProbePromise: Promise.resolve(),
+      stackIndex: 0,
+    })
+    sinon.stub(plugin, 'prepareDiBreakpointHitWait')
+    plugin.di = {}
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      const test = plugin._webdriverioJasmineState.tests.get(result.id)
+      test.attempt = 1
+      test.statuses.push('pass')
+      test.willRetry = true
+
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      assert.strictEqual(addDiProbe.callCount, 1)
+      assert.strictEqual(test.hasFailedAttempt, true)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('starts native WebdriverIO retry spans after retry setup settles', async () => {
+    const retryCh = channel('ci:mocha:test:retry')
+    const { plugin, spans } = createJasminePlugin({})
+    const file = path.join(process.cwd(), 'native-retry.spec.js')
+    const result = createJasmineResult('native-retry', file, 'failed')
+    const retries = { attempts: 0, limit: 1 }
+    let finishRetrySetup
+    const retrySetup = new Promise(resolve => {
+      finishRetrySetup = resolve
+    })
+    const onRetry = ({ promises }) => {
+      promises.setProbePromise = retrySetup
+    }
+
+    retryCh.subscribe(onRetry)
+    try {
+      reportJasmineSpecStarted(result, file)
+      const wrapperContext = {
+        arguments: [undefined, 'Test', { specFn () {} }, undefined, undefined, undefined, 1],
+      }
+      const executeAsyncContext = { arguments: [undefined, retries] }
+      channel('tracing:orchestrion:@wdio/utils:testFrameworkFnWrapper:start').runStores(wrapperContext, () => {
+        channel('tracing:orchestrion:@wdio/utils:executeAsync:start').runStores(executeAsyncContext, () => {})
+      })
+
+      const retryPromise = executeAsyncContext.retryCallback(new Error('native retry failure'))
+      assert.strictEqual(spans.length, 1)
+
+      finishRetrySetup()
+      await retryPromise
+
+      assert.strictEqual(spans.length, 2)
+
+      retryCh.unsubscribe(onRetry)
+      assert.strictEqual(executeAsyncContext.retryCallback(new Error('immediate native retry failure')), undefined)
+      assert.strictEqual(spans.length, 3)
+    } finally {
+      retryCh.unsubscribe(onRetry)
+      plugin.configure(false)
+    }
+  })
+
+  it('does not apply ATR to Jasmine hook failures', () => {
+    const { plugin, spans } = createJasminePlugin({
+      flakyTestRetriesCount: 1,
+      isFlakyTestRetriesEnabled: true,
+    })
+    const file = path.join(process.cwd(), 'hook-failure.spec.js')
+    const result = createJasmineResult('hook-failure', file, 'failed')
+    const spec = { id: result.id }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      const wrapperContext = {
+        arguments: [undefined, 'Hook', { specFn () {} }, undefined, undefined, undefined, 1],
+      }
+      channel('tracing:orchestrion:@wdio/utils:testFrameworkFnWrapper:start').runStores(wrapperContext, () => {
+        channel('tracing:orchestrion:@wdio/utils:executeAsync:error').publish({})
+      })
+
+      const attemptContext = { result: 'failed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      assert.strictEqual(attemptContext.result, 'failed')
+      assert.strictEqual(spans.length, 1)
+      assert.strictEqual(plugin._webdriverioJasmineState.tests.size, 0)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('does not apply ATR to expectation-based Jasmine hook failures', () => {
+    const { plugin, spans } = createJasminePlugin({
+      flakyTestRetriesCount: 1,
+      isFlakyTestRetriesEnabled: true,
+    })
+    const file = path.join(process.cwd(), 'expectation-hook-failure.spec.js')
+    const result = createJasmineResult('expectation-hook-failure', file, 'failed')
+    result.failedExpectations = []
+    const spec = { id: result.id }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      const wrapperContext = {
+        arguments: [undefined, 'Hook', { specFn () {} }, undefined, undefined, undefined, 1],
+      }
+      channel('tracing:orchestrion:@wdio/utils:testFrameworkFnWrapper:start').runStores(wrapperContext, () => {
+        channel('tracing:orchestrion:@wdio/utils:executeAsync:start').runStores({
+          arguments: [undefined, { attempts: 0, limit: 0 }],
+        }, () => {
+          result.failedExpectations.push({ message: 'hook expectation failed' })
+          channel('tracing:orchestrion:@wdio/utils:executeAsync:asyncEnd').publish({})
+        })
+      })
+
+      const attemptContext = { result: 'failed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      assert.strictEqual(attemptContext.result, 'failed')
+      assert.strictEqual(spans.length, 1)
+      assert.strictEqual(plugin._webdriverioJasmineState.tests.size, 0)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('does not mistake test-body expectations for Jasmine hook failures', () => {
+    const { plugin } = createJasminePlugin({
+      flakyTestRetriesCount: 1,
+      isFlakyTestRetriesEnabled: true,
+    })
+    const file = path.join(process.cwd(), 'test-expectation-failure.spec.js')
+    const result = createJasmineResult('test-expectation-failure', file, 'failed')
+    result.failedExpectations = []
+    const spec = { id: result.id }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      result.failedExpectations.push({ message: 'test expectation failed' })
+      const wrapperContext = {
+        arguments: [undefined, 'Hook', { specFn () {} }, undefined, undefined, undefined, 1],
+      }
+      channel('tracing:orchestrion:@wdio/utils:testFrameworkFnWrapper:start').runStores(wrapperContext, () => {
+        channel('tracing:orchestrion:@wdio/utils:executeAsync:start').runStores({
+          arguments: [undefined, { attempts: 0, limit: 0 }],
+        }, () => {
+          channel('tracing:orchestrion:@wdio/utils:executeAsync:asyncEnd').publish({})
+        })
+      })
+
+      const attemptContext = { result: 'failed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+
+      assert.strictEqual(attemptContext.result, 'passed')
+      assert.strictEqual(plugin._webdriverioJasmineState.tests.get(result.id).hasFinalHookFailure, false)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('releases completed Jasmine test records while preserving their terminal status', () => {
+    const { plugin, spans } = createJasminePlugin({})
+    const file = path.join(process.cwd(), 'completed.spec.js')
+    const result = createJasmineResult('completed', file, 'passed')
+    const spec = { id: result.id }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+
+      const attemptContext = { result: 'passed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      assert.strictEqual(plugin._webdriverioJasmineState.tests.size, 0)
+      assert.deepStrictEqual([...plugin._webdriverioJasmineState.completedTestStatuses], [[result.id, 'passed']])
+
+      const lateAttemptContext = { result: 'failed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(lateAttemptContext)
+      reportJasmineSpecStarted(result, file)
+
+      assert.strictEqual(lateAttemptContext.result, 'passed')
+      assert.strictEqual(spans.length, 1)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('keeps skipped Jasmine EFD tests skipped', () => {
+    const { plugin, spans } = createJasminePlugin({
+      earlyFlakeDetectionRetryPolicy: createEfdRetryPolicy({ '5s': 2 }),
+      isEarlyFlakeDetectionEnabled: true,
+      isKnownTestsEnabled: true,
+      knownTests: { mocha: {} },
+    })
+    const file = path.join(process.cwd(), 'skipped-efd.spec.js')
+    const result = createJasmineResult('skipped-efd', file, 'excluded')
+    const spec = { id: result.id }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+
+      const attemptContext = { result: 'excluded', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      assert.strictEqual(attemptContext.result, 'excluded')
+      assert.strictEqual(spans.length, 1)
+      assert.strictEqual(plugin._webdriverioJasmineState.suiteStatuses.get(file), 'skip')
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('keeps skipped Jasmine attempt-to-fix tests skipped', () => {
+    const file = path.join(process.cwd(), 'skipped-attempt-to-fix.spec.js')
+    const testName = 'skipped attempt to fix'
+    const testFinishes = []
+    const testFinishCh = channel('ci:mocha:test:finish')
+    const { plugin, spans } = createJasminePlugin({
+      isTestManagementTestsEnabled: true,
+      testManagementAttemptToFixRetries: 2,
+      testManagementTests: {
+        mocha: {
+          suites: {
+            'skipped-attempt-to-fix.spec.js': {
+              tests: {
+                [testName]: { properties: { attempt_to_fix: true } },
+              },
+            },
+          },
+        },
+      },
+    })
+    const result = createJasmineResult(testName, file, 'excluded')
+    const spec = { id: result.id }
+    const onTestFinish = context => testFinishes.push(context)
+
+    testFinishCh.subscribe(onTestFinish)
+    try {
+      reportJasmineSpecStarted(result, file)
+
+      const attemptContext = { result: 'excluded', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      assert.strictEqual(attemptContext.result, 'excluded')
+      assert.strictEqual(spans.length, 1)
+      assert.strictEqual(plugin._webdriverioJasmineState.suiteStatuses.get(file), 'skip')
+      assert.strictEqual(testFinishes.length, 1)
+      assert.strictEqual(testFinishes[0].status, 'skip')
+      assert.strictEqual(testFinishes[0].finalStatus, 'skip')
+      assert.strictEqual(testFinishes[0].attemptToFixPassed, false)
+      assert.strictEqual(testFinishes[0].attemptToFixFailed, false)
+    } finally {
+      testFinishCh.unsubscribe(onTestFinish)
+      plugin.configure(false)
+    }
+  })
+
+  it('marks disabled Jasmine specs pending before their hooks are queued', () => {
+    const file = path.join(process.cwd(), 'disabled-hook.spec.js')
+    const testName = 'disabled hook'
+    const { plugin } = createJasminePlugin({
+      isTestManagementTestsEnabled: true,
+      testManagementTests: {
+        mocha: {
+          suites: {
+            'disabled-hook.spec.js': {
+              tests: {
+                [testName]: { properties: { disabled: true } },
+              },
+            },
+          },
+        },
+      },
+    })
+    const result = createJasmineResult(testName, file, 'pending')
+    const spec = {
+      id: result.id,
+      pend: sinon.spy(),
+      queueableFn: { fn () {} },
+      result,
+    }
+    const executeContext = {
+      arguments: [() => {}, () => {}, false, {}],
+      self: spec,
+    }
+
+    try {
+      channel('tracing:orchestrion:jasmine-core:Spec_execute:start').runStores(executeContext, () => {})
+
+      assert.strictEqual(spec.pend.callCount, 1)
+      assert.strictEqual(spec.pend.firstCall.args[0], 'Skipped by Datadog Test Management')
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('keeps Jasmine suite results reported before configuration completes', async () => {
     const testFinishCh = channel('ci:mocha:test:finish')
     const knownTestsCh = channel('ci:mocha:known-tests')
     const libraryConfigurationCh = channel('ci:mocha:library-configuration')
@@ -359,7 +966,7 @@ describe('webdriverio instrumentation', () => {
     }
     function onLibraryConfiguration (request) {
       configurationRequests++
-      assert.strictEqual(request.basicReportingOnly, true)
+      assert.strictEqual(request.basicReportingOnly, undefined)
       assert.strictEqual(request.disableTestImpactAnalysis, true)
       assert.strictEqual(request.testFramework, 'webdriverio')
       finishConfiguration = () => request.onDone({
@@ -937,6 +1544,66 @@ describe('webdriverio instrumentation', () => {
     }
   })
 
+  it('marks missing framework known-tests data as faulty independently of the threshold', async () => {
+    const testFinishCh = channel('ci:mocha:test:finish')
+    const knownTestsCh = channel('ci:mocha:known-tests')
+    const libraryConfigurationCh = channel('ci:mocha:library-configuration')
+    const testSessionFinishCh = channel('ci:mocha:session:finish')
+
+    function onTestFinish () {}
+    function onKnownTestsRequest (request) {
+      request.onDone({ knownTests: { 'not-webdriverio': {} } })
+    }
+    function onLibraryConfiguration (request) {
+      request.onDone({
+        libraryConfig: {
+          earlyFlakeDetectionFaultyThreshold: 100,
+          isEarlyFlakeDetectionEnabled: true,
+          isKnownTestsEnabled: true,
+        },
+        repositoryRoot: process.cwd(),
+      })
+    }
+    function onSessionFinish (event) {
+      event.onDone()
+    }
+
+    testFinishCh.subscribe(onTestFinish)
+    knownTestsCh.subscribe(onKnownTestsRequest)
+    libraryConfigurationCh.subscribe(onLibraryConfiguration)
+    testSessionFinishCh.subscribe(onSessionFinish)
+
+    try {
+      require('../src/webdriverio')
+
+      const localRunner = {
+        config: {
+          framework: 'jasmine',
+          rootDir: process.cwd(),
+        },
+      }
+      const worker = createWorker()
+      const file = path.join(process.cwd(), 'new.spec.js')
+
+      registerWorker(localRunner, worker, file)
+      requestConfiguration(worker, file, 'missing-framework')
+      await new Promise(setImmediate)
+
+      const { configuration } = worker.sentMessages[0].content
+      assert.strictEqual(configuration.isEarlyFlakeDetectionEnabled, false)
+      assert.strictEqual(configuration.isEarlyFlakeDetectionFaulty, true)
+      assert.strictEqual(configuration.isKnownTestsEnabled, false)
+
+      worker.emit('exit', { exitCode: 0, retries: 0 })
+      await finishLocalRunner(localRunner)
+    } finally {
+      testFinishCh.unsubscribe(onTestFinish)
+      knownTestsCh.unsubscribe(onKnownTestsRequest)
+      libraryConfigurationCh.unsubscribe(onLibraryConfiguration)
+      testSessionFinishCh.unsubscribe(onSessionFinish)
+    }
+  })
+
   it('uses the worker suite-name root when evaluating EFD faultiness', async () => {
     const testFinishCh = channel('ci:mocha:test:finish')
     const knownTestsCh = channel('ci:mocha:known-tests')
@@ -1322,6 +1989,78 @@ function createWorker () {
     },
   }
   return worker
+}
+
+/**
+ * Creates a configured Jasmine worker plugin with observable test spans.
+ *
+ * @param {object} libraryConfig
+ * @returns {{plugin: MochaPlugin, spans: object[]}}
+ */
+function createJasminePlugin (libraryConfig) {
+  const plugin = new MochaPlugin({ _exporter: {} }, { testOptimization: {} })
+  const spans = []
+  sinon.stub(plugin, 'startTestSpan').callsFake(() => {
+    const tags = {}
+    const context = {
+      _isFinished: false,
+      _trace: { started: [] },
+      getTags: () => tags,
+    }
+    const span = {
+      context: () => context,
+      finish: () => {
+        context._isFinished = true
+      },
+      setTag: (name, value) => {
+        tags[name] = value
+      },
+    }
+    context._trace.started.push(span)
+    spans.push(span)
+    return span
+  })
+  plugin.configure({ enabled: true })
+  channel('ci:mocha:worker:configuration').publish({
+    libraryConfig,
+    repositoryRoot: process.cwd(),
+    specs: [],
+    testFramework: 'webdriverio',
+    testFrameworkAdapter: 'jasmine',
+  })
+  return { plugin, spans }
+}
+
+/**
+ * Creates a Jasmine reporter result.
+ *
+ * @param {string} id
+ * @param {string} file
+ * @param {string} status
+ * @returns {object}
+ */
+function createJasmineResult (id, file, status) {
+  return {
+    description: id,
+    file,
+    fullName: id,
+    id,
+    status,
+  }
+}
+
+/**
+ * Reports the start of a Jasmine spec.
+ *
+ * @param {object} result
+ * @param {string} file
+ * @returns {void}
+ */
+function reportJasmineSpecStarted (result, file) {
+  channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specStarted:end').publish({
+    arguments: [result],
+    self: { _specs: [file] },
+  })
 }
 
 /**

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,11 +1,16 @@
 'use strict'
 
+const { performance } = require('node:perf_hooks')
 const { fileURLToPath } = require('node:url')
 
 const { channel } = require('dc-polyfill')
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
+const {
+  getEfdRetryCountForDuration,
+  hasEfdRetries,
+} = require('../../dd-trace/src/ci-visibility/efd-retry-policy')
 const log = require('../../dd-trace/src/log')
 const {
   sendWebdriverioWorkerMessage,
@@ -44,6 +49,8 @@ const {
   TEST_FINAL_STATUS,
   TEST_HAS_DYNAMIC_NAME,
   TEST_FRAMEWORK_ADAPTER,
+  DYNAMIC_NAME_RE,
+  getFailedTestReplayPromise,
   getTestSuiteExecutionKey,
   isModifiedTest,
 } = require('../../dd-trace/src/plugins/util/test')
@@ -62,14 +69,24 @@ const {
 
 const jasmineAdapterRunAsyncEndCh = 'tracing:orchestrion:@wdio/jasmine-framework:JasmineAdapter_run:asyncEnd'
 const jasmineDoneCh = 'ci:webdriverio:jasmine:done'
+const jasmineExecuteAsyncEndCh = 'tracing:orchestrion:@wdio/utils:executeAsync:asyncEnd'
+const jasmineExecuteAsyncErrorCh = 'tracing:orchestrion:@wdio/utils:executeAsync:error'
+const jasmineExecuteAsyncStartCh = 'tracing:orchestrion:@wdio/utils:executeAsync:start'
 const jasmineReporterSpecDoneEndCh = 'tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end'
+const jasmineReporterSpecDoneStartCh = 'tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:start'
 const jasmineReporterSpecStartedEndCh = 'tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specStarted:end'
 const jasmineReporterSuiteDoneEndCh = 'tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_suiteDone:end'
 const jasmineReporterSuiteStartedEndCh = 'tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_suiteStarted:end'
+const jasmineSpecAttemptDoneEndCh = 'tracing:orchestrion:jasmine-core:Spec_attemptDone:end'
+const jasmineSpecExecuteStartCh = 'tracing:orchestrion:jasmine-core:Spec_execute:start'
 const jasmineTestFunctionStartCh = 'tracing:orchestrion:@wdio/utils:testFrameworkFnWrapper:start'
 const testFinishCh = channel('ci:mocha:test:finish')
+const testRetryCh = channel('ci:mocha:test:retry')
 const WEBDRIVERIO_JASMINE_ADAPTER = 'jasmine'
 const workerFinishCh = channel('ci:mocha:worker:finish')
+const WEBDRIVERIO_JASMINE_FAILED_EXPECTATION_COUNT = Symbol('webdriverioJasmineFailedExpectationCount')
+const WEBDRIVERIO_JASMINE_FUNCTION_TYPE = Symbol('webdriverioJasmineFunctionType')
+const WEBDRIVERIO_JASMINE_TEST = Symbol('webdriverioJasmineTest')
 
 /**
  * @typedef {object} WebdriverioJasmineResult
@@ -170,7 +187,10 @@ class MochaPlugin extends CiPlugin {
       this._setRepositoryRoot(repositoryRoot)
       if (testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER) {
         this._webdriverioJasmineState = {
+          completedTestStatuses: new Map(),
           currentResult: undefined,
+          pendingTestFinishCallbacks: [],
+          pendingTestFinishes: 0,
           specs: specs || [],
           suiteErrors: new Map(),
           suiteFiles: new Map(),
@@ -188,9 +208,80 @@ class MochaPlugin extends CiPlugin {
       const result = this._webdriverioJasmineState?.currentResult
       const type = ctx.arguments?.[1]
       if (type === 'Test' || (type === 'Hook' && result)) {
-        return this.#startWebdriverioJasmineTest(result)
+        return this.#configureWebdriverioJasmineFunction(ctx, result, type)
       }
       return storage('legacy').getStore()
+    })
+
+    this.addBind(jasmineExecuteAsyncStartCh, (ctx) => {
+      const currentStore = storage('legacy').getStore()
+      const test = currentStore?.[WEBDRIVERIO_JASMINE_TEST]
+      if (this.testFrameworkAdapter !== WEBDRIVERIO_JASMINE_ADAPTER || !test) {
+        return currentStore
+      }
+
+      const functionType = currentStore[WEBDRIVERIO_JASMINE_FUNCTION_TYPE]
+      if (functionType === 'Test') {
+        ctx.retryCallback = error => this.#retryWebdriverioJasmineTest(test, error)
+      }
+      const nextStore = {
+        ...test.currentStore,
+        [WEBDRIVERIO_JASMINE_FUNCTION_TYPE]: functionType,
+      }
+      if (functionType === 'Hook') {
+        nextStore[WEBDRIVERIO_JASMINE_FAILED_EXPECTATION_COUNT] =
+          this._webdriverioJasmineState.currentResult?.failedExpectations?.length || 0
+      }
+      return nextStore
+    })
+
+    this.addBind(jasmineSpecExecuteStartCh, (ctx) => {
+      if (this.testFrameworkAdapter !== WEBDRIVERIO_JASMINE_ADAPTER) {
+        return storage('legacy').getStore()
+      }
+
+      this.#configureWebdriverioJasmineLifecycle(ctx)
+      return storage('legacy').getStore()
+    })
+
+    this.addSub(jasmineSpecAttemptDoneEndCh, (ctx) => {
+      if (this.testFrameworkAdapter !== WEBDRIVERIO_JASMINE_ADAPTER) {
+        return
+      }
+
+      const status = typeof ctx.result === 'string' ? ctx.result : ctx.self?.result?.status
+      const runnerStatus = this.#prepareWebdriverioJasmineAttempt(ctx.self, status)
+      if (typeof ctx.result === 'string') {
+        ctx.result = runnerStatus
+      } else if (ctx.self?.result) {
+        ctx.self.result.status = runnerStatus
+      }
+    })
+
+    this.addSub(jasmineExecuteAsyncErrorCh, (ctx) => {
+      const currentStore = ctx.currentStore || storage('legacy').getStore()
+      const test = currentStore?.[WEBDRIVERIO_JASMINE_TEST]
+      if (
+        this.testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER &&
+        test &&
+        currentStore[WEBDRIVERIO_JASMINE_FUNCTION_TYPE] === 'Hook'
+      ) {
+        test.hasFinalHookFailure = true
+      }
+    })
+
+    this.addSub(jasmineExecuteAsyncEndCh, (ctx) => {
+      const currentStore = ctx.currentStore || storage('legacy').getStore()
+      const test = currentStore?.[WEBDRIVERIO_JASMINE_TEST]
+      const failedExpectationCount = currentStore?.[WEBDRIVERIO_JASMINE_FAILED_EXPECTATION_COUNT]
+      if (
+        this.testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER &&
+        test &&
+        currentStore[WEBDRIVERIO_JASMINE_FUNCTION_TYPE] === 'Hook' &&
+        this._webdriverioJasmineState.currentResult?.failedExpectations?.length > failedExpectationCount
+      ) {
+        test.hasFinalHookFailure = true
+      }
     })
 
     this.addSub(jasmineReporterSuiteStartedEndCh, (ctx) => {
@@ -239,9 +330,32 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
+    this.addBind(jasmineReporterSpecDoneStartCh, (ctx) => {
+      if (this.testFrameworkAdapter !== WEBDRIVERIO_JASMINE_ADAPTER) {
+        return storage('legacy').getStore()
+      }
+
+      const result = ctx.arguments?.[0]
+      const test = this._webdriverioJasmineState?.tests.get(result?.id)
+      const recoveredEarlyFlakeDetection = test?.isEarlyFlakeDetection &&
+        !test.hasFinalHookFailure && test.statuses.includes('pass')
+      if (
+        result.status === 'failed' &&
+        ((test?.isQuarantined && !test.isAttemptToFix) || recoveredEarlyFlakeDetection)
+      ) {
+        test.reportedStatus = result.status
+        result.status = 'passed'
+      }
+      return test?.currentStore || storage('legacy').getStore()
+    })
+
     this.addSub(jasmineReporterSpecDoneEndCh, (ctx) => {
       if (this.testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER) {
-        this.#finishWebdriverioJasmineTest(ctx.arguments?.[0], ctx.self?._specs)
+        const result = ctx.result
+        const finishPromise = this.#finishWebdriverioJasmineTest(ctx.arguments?.[0], ctx.self?._specs)
+        if (finishPromise) {
+          ctx.result = finishPromise.then(() => result)
+        }
       }
     })
 
@@ -510,10 +624,13 @@ class MochaPlugin extends CiPlugin {
     this.addSub('ci:mocha:test:retry', ({
       span,
       isFirstAttempt,
+      isFirstFailure = isFirstAttempt,
       willBeRetried,
       err,
       test,
+      isAttemptToFixRetry,
       isAtrRetry,
+      isEfdRetry,
       promises,
     }) => {
       if (span) {
@@ -528,8 +645,12 @@ class MochaPlugin extends CiPlugin {
         span.setTag(TEST_STATUS, 'fail')
         if (!isFirstAttempt) {
           span.setTag(TEST_IS_RETRY, 'true')
-          if (isAtrRetry) {
+          if (isAttemptToFixRetry) {
+            span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
+          } else if (isAtrRetry) {
             span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
+          } else if (isEfdRetry) {
+            span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
           } else {
             span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
           }
@@ -543,7 +664,7 @@ class MochaPlugin extends CiPlugin {
           'test',
           this.getTestTelemetryTags(span)
         )
-        if (isFirstAttempt && willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
+        if (isFirstFailure && willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
           const probeInformation = this.addDiProbe(err)
           if (probeInformation) {
             const { file, line, stackIndex, setProbePromise } = probeInformation
@@ -557,7 +678,7 @@ class MochaPlugin extends CiPlugin {
           }
         }
 
-        if (!isFirstAttempt &&
+        if (!isFirstFailure &&
           willBeRetried &&
           this.di &&
           this.libraryConfig?.isDiEnabled &&
@@ -683,6 +804,9 @@ class MochaPlugin extends CiPlugin {
     if (!state || !result?.id) {
       return currentStore
     }
+    if (state.completedTestStatuses.has(result.id)) {
+      return currentStore
+    }
 
     const existingTest = state.tests.get(result.id)
     if (existingTest) {
@@ -702,20 +826,333 @@ class MochaPlugin extends CiPlugin {
       return currentStore
     }
 
-    const span = this.startTestSpan({
-      testName: result.fullName || result.description,
+    const testName = result.fullName || result.description
+    const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.sourceRoot)
+    const properties = this.libraryConfig?.testManagementTests?.mocha
+      ?.suites?.[testSuite]?.tests?.[testName]?.properties || {}
+    const isAttemptToFix = this.libraryConfig?.isTestManagementTestsEnabled && properties.attempt_to_fix
+    const isDisabled = this.libraryConfig?.isTestManagementTestsEnabled && properties.disabled
+    const isQuarantined = this.libraryConfig?.isTestManagementTestsEnabled && properties.quarantined
+    const isModified = this.libraryConfig?.isImpactedTestsEnabled && isModifiedTest(
+      getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot || this.sourceRoot),
+      null,
+      null,
+      this.libraryConfig.modifiedFiles,
+      this.constructor.id
+    )
+    const knownTests = this.libraryConfig?.knownTests?.mocha
+    const isNew = this.libraryConfig?.isKnownTestsEnabled && knownTests &&
+      !(knownTests[testSuite] || []).includes(testName)
+    const isEarlyFlakeDetection = this.libraryConfig?.isEarlyFlakeDetectionEnabled &&
+      hasEfdRetries(this.libraryConfig.earlyFlakeDetectionRetryPolicy) &&
+      !isAttemptToFix && !isDisabled && (isNew || isModified)
+    const isAtr = this.libraryConfig?.isFlakyTestRetriesEnabled &&
+      !isAttemptToFix && !isEarlyFlakeDetection
+    let retryCount = 0
+    if (isAttemptToFix) {
+      retryCount = this.libraryConfig.testManagementAttemptToFixRetries
+    } else if (isEarlyFlakeDetection) {
+      retryCount = this.libraryConfig.earlyFlakeDetectionRetryPolicy.schedulingRetryCount
+    } else if (isAtr) {
+      retryCount = this.libraryConfig.flakyTestRetriesCount
+    }
+
+    const test = {
+      attempt: 0,
+      attemptStart: undefined,
+      currentStore: undefined,
+      earlyFlakeAbortReason: undefined,
+      hasDynamicName: isNew && DYNAMIC_NAME_RE.test(testName),
+      hasFailedAttempt: false,
+      hasFinalHookFailure: false,
+      isAttemptToFix,
+      isAtr,
+      isDisabled,
+      isEarlyFlakeDetection,
+      isModified,
+      isNew,
+      isQuarantined,
+      reportedStatus: undefined,
+      retryCount,
+      retryWait: undefined,
+      runnerStatus: undefined,
+      span: undefined,
+      statuses: [],
+      testName,
       testSuiteAbsolutePath,
       title: result.description,
-    })
-    const testStore = { ...currentStore, span }
-    state.tests.set(result.id, {
-      currentStore: testStore,
-      span,
-      testSuiteAbsolutePath,
-    })
-    this.activeTestSpan = span
+    }
+    state.tests.set(result.id, test)
+    this.#startWebdriverioJasmineAttempt(test, currentStore)
 
-    return testStore
+    return test.currentStore
+  }
+
+  /**
+   * Applies a managed Jasmine test's skip and retry policy to WebdriverIO's function wrapper.
+   *
+   * @param {object} context
+   * @param {WebdriverioJasmineResult|undefined} result
+   * @param {'Test'|'Hook'} type
+   * @returns {object|undefined}
+   */
+  #configureWebdriverioJasmineFunction (context, result, type) {
+    const currentStore = this.#startWebdriverioJasmineTest(result)
+    const test = this._webdriverioJasmineState?.tests.get(result?.id)
+    if (!test) {
+      return currentStore
+    }
+
+    if (test.isAttemptToFix || test.isAtr || test.isEarlyFlakeDetection) {
+      context.arguments[6] = 0
+    }
+    return {
+      ...test.currentStore,
+      [WEBDRIVERIO_JASMINE_FUNCTION_TYPE]: type,
+    }
+  }
+
+  /**
+   * Starts one WebdriverIO Jasmine test attempt under its suite span.
+   *
+   * @param {object} test
+   * @param {object|undefined} parentStore
+   * @returns {void}
+   */
+  #startWebdriverioJasmineAttempt (test, parentStore) {
+    test.attemptStart = performance.now()
+    test.hasFinalHookFailure = false
+    const span = this.startTestSpan({
+      hasDynamicName: test.hasDynamicName,
+      isAttemptToFix: test.isAttemptToFix,
+      isDisabled: test.isDisabled,
+      isEfdRetry: test.isEarlyFlakeDetection && test.attempt > 0,
+      isModified: test.isModified,
+      isNew: test.isNew,
+      isParallel: true,
+      isQuarantined: test.isQuarantined,
+      testName: test.testName,
+      testSuiteAbsolutePath: test.testSuiteAbsolutePath,
+      title: test.title,
+    })
+    test.span = span
+    test.currentStore = {
+      ...parentStore,
+      span,
+      [WEBDRIVERIO_JASMINE_TEST]: test,
+    }
+    this.activeTestSpan = span
+  }
+
+  /**
+   * Delays Jasmine's parent runner until every Datadog-managed spec execution has completed.
+   *
+   * @param {object} context
+   * @returns {void}
+   */
+  #configureWebdriverioJasmineLifecycle (context) {
+    const isLegacyJasmine = Boolean(context.self?.queueableFn)
+    const spec = isLegacyJasmine ? context.self : context.arguments?.[0]
+    const onComplete = context.arguments?.[1]
+    const originalTestFunction = spec?.queueableFn?.fn
+    if (!spec?.id || typeof onComplete !== 'function' || typeof originalTestFunction !== 'function') {
+      return
+    }
+
+    if (this.libraryConfig?.isTestManagementTestsEnabled) {
+      this.#startWebdriverioJasmineTest(spec.result)
+      const test = this._webdriverioJasmineState?.tests.get(spec.id)
+      if (test?.isDisabled && !test.isAttemptToFix) {
+        spec.pend('Skipped by Datadog Test Management')
+      }
+    }
+
+    const executionArguments = [...context.arguments]
+    context.arguments[1] = (...completeArguments) => {
+      const test = this._webdriverioJasmineState?.tests.get(spec.id)
+      if (!test?.willRetry) {
+        return onComplete(...completeArguments)
+      }
+
+      test.willRetry = false
+      const retry = () => {
+        try {
+          this.#startNextWebdriverioJasmineAttempt(test)
+          spec.reset()
+          spec.queueableFn.fn = originalTestFunction
+          if (isLegacyJasmine) {
+            spec.execute(
+              executionArguments[0],
+              onComplete,
+              executionArguments[2],
+              executionArguments[3]
+            )
+          } else {
+            context.self._executeSpec(spec, onComplete)
+          }
+        } catch (error) {
+          log.error('WebdriverIO Jasmine retry error', error)
+          onComplete(...completeArguments)
+        }
+      }
+      const retryWait = test.retryWait
+      test.retryWait = undefined
+      if (retryWait?.then) {
+        retryWait.then(retry, retry)
+      } else {
+        retry()
+      }
+    }
+  }
+
+  /**
+   * Selects the runner-visible status and whether Jasmine should execute the full spec again.
+   *
+   * @param {object|undefined} spec
+   * @param {string|undefined} status
+   * @returns {string|undefined}
+   */
+  #prepareWebdriverioJasmineAttempt (spec, status) {
+    const state = this._webdriverioJasmineState
+    const completedStatus = state?.completedTestStatuses.get(spec?.id)
+    if (completedStatus) {
+      return completedStatus
+    }
+
+    const test = state?.tests.get(spec?.id)
+    if (!test || !status) {
+      return status
+    }
+
+    const testStatus = getJasmineStatus(status)
+    if (
+      testStatus !== 'skip' &&
+      test.isEarlyFlakeDetection &&
+      test.attempt === 0
+    ) {
+      test.retryCount = getEfdRetryCountForDuration(
+        performance.now() - test.attemptStart,
+        this.libraryConfig.earlyFlakeDetectionRetryPolicy
+      )
+      if (test.retryCount === 0) {
+        test.earlyFlakeAbortReason = 'slow'
+      }
+    }
+
+    const hasManagedRetry = testStatus !== 'skip' && test.attempt < test.retryCount
+    test.willRetry = hasManagedRetry && (
+      test.isAttemptToFix ||
+      test.isEarlyFlakeDetection ||
+      (test.isAtr && testStatus === 'fail' && !test.hasFinalHookFailure)
+    )
+
+    let runnerStatus = status
+    const recoveredEarlyFlakeDetection = test.isEarlyFlakeDetection &&
+      !test.hasFinalHookFailure && test.statuses.includes('pass')
+    if (
+      testStatus === 'fail' &&
+      (test.willRetry || (test.isQuarantined && !test.isAttemptToFix) || recoveredEarlyFlakeDetection)
+    ) {
+      runnerStatus = 'passed'
+    } else if (testStatus !== 'skip' && !test.willRetry && test.isAttemptToFix) {
+      runnerStatus = test.statuses.every(previousStatus => previousStatus === 'pass') && testStatus === 'pass'
+        ? 'passed'
+        : 'failed'
+    }
+
+    if (runnerStatus !== status) {
+      test.reportedStatus = status
+    }
+    if (!test.willRetry) {
+      test.runnerStatus = runnerStatus
+    }
+    return runnerStatus
+  }
+
+  /**
+   * Finishes one Datadog-managed Jasmine attempt before the full spec is executed again.
+   *
+   * @param {object} test
+   * @param {WebdriverioJasmineResult} result
+   * @returns {void}
+   */
+  #finishWebdriverioJasmineRetry (test, result) {
+    const status = getJasmineStatus(test.reportedStatus || result.status)
+    const error = getJasmineError(result)
+    test.statuses.push(status)
+
+    if (error) {
+      const isFirstFailure = !test.hasFailedAttempt
+      test.hasFailedAttempt = true
+      const promises = {}
+      testRetryCh.publish({
+        err: error,
+        isAttemptToFixRetry: test.isAttemptToFix && test.attempt > 0,
+        isAtrRetry: test.isAtr && test.attempt > 0,
+        isEfdRetry: test.isEarlyFlakeDetection && test.attempt > 0,
+        isFirstAttempt: test.attempt === 0,
+        isFirstFailure,
+        promises,
+        test,
+        willBeRetried: true,
+        ...test.currentStore,
+      })
+      test.retryWait = getFailedTestReplayPromise(promises)
+    } else {
+      testFinishCh.publish({
+        hasBeenRetried: test.isAtr && test.attempt > 0,
+        isAttemptToFixRetry: test.isAttemptToFix && test.attempt > 0,
+        isAtrRetry: false,
+        isLastRetry: false,
+        status,
+        ...test.currentStore,
+      })
+    }
+  }
+
+  /**
+   * Advances a Jasmine test and starts its next attempt span.
+   *
+   * @param {object} test
+   * @returns {void}
+   */
+  #startNextWebdriverioJasmineAttempt (test) {
+    test.attempt++
+    test.reportedStatus = undefined
+    this.#startWebdriverioJasmineAttempt(test, test.currentStore)
+  }
+
+  /**
+   * Finishes an intermediate native WebdriverIO retry and starts its next span.
+   *
+   * @param {object} test
+   * @param {Error|undefined} error
+   * @returns {Promise<void>|undefined}
+   */
+  #retryWebdriverioJasmineTest (test, error) {
+    test.statuses.push('fail')
+    const isFirstFailure = !test.hasFailedAttempt
+    test.hasFailedAttempt = true
+    const promises = {}
+    testRetryCh.publish({
+      err: error,
+      isAttemptToFixRetry: false,
+      isAtrRetry: false,
+      isEfdRetry: false,
+      isFirstAttempt: test.attempt === 0,
+      isFirstFailure,
+      promises,
+      test,
+      willBeRetried: true,
+      ...test.currentStore,
+    })
+
+    const retryWait = getFailedTestReplayPromise(promises)
+    if (retryWait?.then) {
+      const startNextAttempt = () => this.#startNextWebdriverioJasmineAttempt(test)
+      return retryWait.then(startNextAttempt, startNextAttempt)
+    }
+    this.#startNextWebdriverioJasmineAttempt(test)
   }
 
   /**
@@ -723,7 +1160,7 @@ class MochaPlugin extends CiPlugin {
    *
    * @param {WebdriverioJasmineResult|undefined} result
    * @param {string[]} [specs]
-   * @returns {void}
+   * @returns {Promise<void>|undefined}
    */
   #finishWebdriverioJasmineTest (result, specs) {
     const state = this._webdriverioJasmineState
@@ -737,20 +1174,86 @@ class MochaPlugin extends CiPlugin {
       return
     }
 
-    const status = getJasmineStatus(result.status)
+    if (state.currentResult?.id === result.id) {
+      state.currentResult = undefined
+    }
+    if (test.willRetry) {
+      this.#finishWebdriverioJasmineRetry(test, result)
+      return
+    }
+    if (test._ddShouldWaitForHitProbe) {
+      delete test._ddShouldWaitForHitProbe
+      state.pendingTestFinishes++
+      const finishTest = () => {
+        this.#completeWebdriverioJasmineTest(test, result)
+        state.pendingTestFinishes--
+        if (state.pendingTestFinishes === 0) {
+          const callbacks = state.pendingTestFinishCallbacks
+          state.pendingTestFinishCallbacks = []
+          for (const callback of callbacks) {
+            callback()
+          }
+        }
+      }
+      return this.waitForDiBreakpointHits().then(finishTest, finishTest)
+    }
+
+    this.#completeWebdriverioJasmineTest(test, result)
+  }
+
+  /**
+   * Finalizes the last reported attempt for one WebdriverIO Jasmine test.
+   *
+   * @param {object} test
+   * @param {WebdriverioJasmineResult} result
+   * @returns {void}
+   */
+  #completeWebdriverioJasmineTest (test, result) {
+    const state = this._webdriverioJasmineState
+
+    const status = getJasmineStatus(test.reportedStatus || result.status)
     const error = getJasmineError(result)
     if (error) {
       test.span.setTag('error', error)
     }
-    testFinishCh.publish({ span: test.span, status })
-    state.tests.delete(result.id)
-    if (state.currentResult?.id === result.id) {
-      state.currentResult = undefined
+    if (!test.isEarlyFlakeDetection || status !== 'skip') {
+      test.statuses.push(status)
     }
+    const hasFailedAllRetries = test.attempt > 0 &&
+      (test.isAttemptToFix || test.isAtr || test.isEarlyFlakeDetection) &&
+      test.statuses.every(testStatus => testStatus === 'fail')
+    const isSkipped = status === 'skip'
+    const attemptToFixPassed = !isSkipped && test.isAttemptToFix &&
+      test.statuses.every(testStatus => testStatus === 'pass')
+    const attemptToFixFailed = !isSkipped && test.isAttemptToFix && !attemptToFixPassed
+    let finalStatus = status
+    if (isSkipped || (!test.isAttemptToFix && (test.isDisabled || test.isQuarantined))) {
+      finalStatus = 'skip'
+    } else if (test.isAttemptToFix) {
+      finalStatus = attemptToFixPassed ? 'pass' : 'fail'
+    } else if (test.isEarlyFlakeDetection && status !== 'skip' && !test.hasFinalHookFailure) {
+      finalStatus = test.statuses.includes('pass') ? 'pass' : 'fail'
+    }
+    testFinishCh.publish({
+      attemptToFixFailed,
+      attemptToFixPassed,
+      earlyFlakeAbortReason: test.earlyFlakeAbortReason,
+      finalStatus,
+      hasBeenRetried: !test.isAttemptToFix && !test.isEarlyFlakeDetection && test.attempt > 0,
+      hasFailedAllRetries,
+      isAttemptToFixRetry: test.isAttemptToFix && test.attempt > 0,
+      isAtrRetry: test.isAtr && test.attempt > 0,
+      isLastRetry: true,
+      status,
+      ...test.currentStore,
+    })
+    state.completedTestStatuses.set(result.id, test.runnerStatus || result.status)
+    state.tests.delete(result.id)
 
+    const suiteStatus = test.isQuarantined && !test.isAttemptToFix ? 'pass' : finalStatus
     const previousStatus = state.suiteStatuses.get(test.testSuiteAbsolutePath)
-    if (status === 'fail' || !previousStatus || previousStatus === 'skip') {
-      state.suiteStatuses.set(test.testSuiteAbsolutePath, status)
+    if (suiteStatus === 'fail' || !previousStatus || previousStatus === 'skip') {
+      state.suiteStatuses.set(test.testSuiteAbsolutePath, suiteStatus)
     }
   }
 
@@ -765,28 +1268,28 @@ class MochaPlugin extends CiPlugin {
    */
   #finishWebdriverioJasmineWorker (context) {
     const state = this._webdriverioJasmineState
-    const results = []
-    const reportedFiles = new Set()
-    for (const [file, status] of state.suiteStatuses) {
-      const error = state.suiteErrors.get(file)
-      const result = { file, status }
-      if (error) {
-        result.error = {
-          message: error.message,
-          stack: error.stack,
+    const reportWorker = onDone => {
+      const results = []
+      const reportedFiles = new Set()
+      for (const [file, status] of state.suiteStatuses) {
+        const error = state.suiteErrors.get(file)
+        const result = { file, status }
+        if (error) {
+          result.error = {
+            message: error.message,
+            stack: error.stack,
+          }
+        }
+        results.push(result)
+        reportedFiles.add(file)
+      }
+      for (const spec of state.specs) {
+        const file = normalizeJasmineFile(spec)
+        if (!reportedFiles.has(file)) {
+          results.push({ file, status: 'skip' })
         }
       }
-      results.push(result)
-      reportedFiles.add(file)
-    }
-    for (const spec of state.specs) {
-      const file = normalizeJasmineFile(spec)
-      if (!reportedFiles.has(file)) {
-        results.push({ file, status: 'skip' })
-      }
-    }
 
-    const waitForWorker = onDone => {
       sendWebdriverioWorkerMessage({
         origin: 'datadog',
         name: SUITE_FINISH,
@@ -796,6 +1299,14 @@ class MochaPlugin extends CiPlugin {
           log.error('WebdriverIO Test Optimization IPC error', error)
         }
       }, () => workerFinishCh.publish({ onDone }))
+    }
+
+    const waitForWorker = onDone => {
+      if (state?.pendingTestFinishes) {
+        state.pendingTestFinishCallbacks.push(() => reportWorker(onDone))
+      } else {
+        reportWorker(onDone)
+      }
     }
     context.resolveCallback = waitForWorker
     context.rejectCallback = waitForWorker

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -550,6 +550,7 @@ module.exports = {
   removeInvalidMetadata,
   parseAnnotations,
   getIsFaultyEarlyFlakeDetection,
+  getFailedTestReplayPromise,
   TEST_BROWSER_DRIVER,
   TEST_BROWSER_DRIVER_VERSION,
   TEST_BROWSER_NAME,
@@ -1602,6 +1603,22 @@ function parseAnnotations (annotations) {
     }
     return tags
   }, {})
+}
+
+/**
+ * Combines the optional Failed Test Replay operations that must settle before a retry.
+ *
+ * @param {{setProbePromise?: Promise<void>, finishTestPromise?: Promise<void>}} promises
+ * @returns {Promise<void>|undefined}
+ */
+function getFailedTestReplayPromise (promises) {
+  if (promises.setProbePromise && promises.finishTestPromise) {
+    return Promise.all([
+      promises.setProbePromise,
+      promises.finishTestPromise,
+    ]).then(() => {})
+  }
+  return promises.setProbePromise || promises.finishTestPromise
 }
 
 function getIsFaultyEarlyFlakeDetection (projectSuites, testsBySuiteName, faultyThresholdPercentage) {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Adds Test Optimization support to WebdriverIO's Jasmine adapter at the same level as the existing WebdriverIO Mocha adapter:

- Early Flake Detection (EFD)
- Automatic Test Retries (ATR)
- Impacted Tests
- Test Management (disabled, quarantined, and attempt-to-fix tests)
- Failed Test Replay

Jasmine workers now wait for the coordinator-owned configuration. EFD selects retries from the first attempt's duration, including hook failures. Invalid known-tests data is handled as a faulty EFD session. TIA remains disabled because WebdriverIO browser code coverage is not supported yet.

| Feature | WebdriverIO/Mocha | WebdriverIO/Jasmine |
| --- | --- | --- |
| Basic reporting | Supported | Supported |
| EFD | Supported | Supported |
| ATR | Supported | Supported |
| Impacted Tests | Supported | Supported |
| Test Management | Supported | Supported |
| Failed Test Replay | Supported | Supported |
| TIA | Not supported | Not supported |

### Motivation

#9607 added basic WebdriverIO Jasmine reporting while deliberately disabling optimization features. This follow-up enables and validates those features without changing the existing TIA limitation.

This PR is stacked on #9678, which only adds the generic ability to await a context callback at a selected conditional boundary. This PR owns the WebdriverIO `executeAsync` selector, callback options, fixture coverage, and Jasmine retry consumer.

### Additional Notes

The shared WebdriverIO optimization matrix runs every scenario against both Mocha and Jasmine. It covers feature environment gates, duration-based EFD retries, faulty known-tests data, exhausted ATR retries, Test Management final outcomes, impacted and unmodified tests, hook failures, native WebdriverIO retries, and Failed Test Replay enablement.

Validation on the combined stack:

- Latest WebdriverIO Test Optimization matrix: 58 passing across Mocha and Jasmine
- WebdriverIO instrumentation unit tests: 42 passing
- Targeted ESLint passed
- `npm run verify:rewriter:targets`
