### PR TITLE
fix(test-optimization): ignore line coverage for Vitest TIA

### DIFF
--- a/integration-tests/vitest/vitest.tia.spec.js
+++ b/integration-tests/vitest/vitest.tia.spec.js
@@ -372,6 +372,28 @@ versions.forEach((version) => {
         assert.strictEqual(childProcess.exitCode, 0, testOutput)
       })
 
+      it('skips suites with missing line coverage when coverage report upload is enabled', async () => {
+        receiver.setSettings(getTiaSettings({ coverage_report_upload_enabled: true }))
+        receiver.setSuitesToSkip([{
+          type: 'suite',
+          attributes: {
+            suite: secondSuite,
+            _is_missing_line_code_coverage: true,
+          },
+        }])
+
+        await runTiaTests((payloads) => {
+          const { events, testSuiteEvents } = getTiaPayloads(payloads)
+          const skippedSuite = testSuiteEvents.find(({ content }) => content.meta[TEST_SUITE] === secondSuite).content
+
+          assert.strictEqual(events.filter(event => event.type === 'test').length, 1)
+          assert.strictEqual(skippedSuite.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(skippedSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
+        }, { requestFilter: tiaRequestFilter })
+
+        assert.strictEqual(childProcess.exitCode, 0, testOutput)
+      })
+
       it('reports a skipped session and exits successfully when every suite is skipped', async () => {
         receiver.setSuitesToSkip([firstSuite, secondSuite].map(suite => ({
           type: 'suite',

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -190,6 +190,7 @@ class CiVisibilityExporter extends BufferingExporter {
     const cachedSkippableSuites = this._testOptimizationHttpCache.readSkippableSuites({
       testLevel: requestConfiguration.testLevel,
       isCoverageReportUploadEnabled: requestConfiguration.isCoverageReportUploadEnabled,
+      isLineCoverageSupported: requestConfiguration.isLineCoverageSupported,
     })
     if (cachedSkippableSuites !== CACHE_MISS) {
       const { skippableSuites, correlationId, coverage } = cachedSkippableSuites

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -25,6 +25,7 @@ function parseSkippableSuitesResponse (
   {
     testLevel = 'suite',
     isCoverageReportUploadEnabled = false,
+    isLineCoverageSupported = true,
     validateRequiredFields = false,
     validationMode = false,
   } = {}
@@ -51,7 +52,7 @@ function parseSkippableSuitesResponse (
     },
   } of skippableItems) {
     // Only reject candidates without backend line coverage when we need that coverage to backfill reports.
-    if (isCoverageReportUploadEnabled && isMissingLineCodeCoverage) {
+    if (isCoverageReportUploadEnabled && isLineCoverageSupported && isMissingLineCodeCoverage) {
       numExcludedByMissingLineCoverage++
       continue
     }
@@ -78,10 +79,11 @@ function parseSkippableSuitesResponse (
  *   numExcludedByMissingLineCoverage?: number
  * }} result - Parsed skippable response.
  * @param {'suite'|'test'} testLevel - Test optimization skipping level.
+ * @param {boolean} shouldConsiderLineCoverage - Whether line coverage can affect suite skipping.
  * @returns {void}
  */
-function logSkippableSuitesResponse (result, testLevel) {
-  if (result.numReceivedSkippableItems === undefined) {
+function logSkippableSuitesResponse (result, testLevel, shouldConsiderLineCoverage) {
+  if (!shouldConsiderLineCoverage || result.numReceivedSkippableItems === undefined) {
     log.debug('Number of received skippable %ss: %d', testLevel, result.skippableSuites.length)
     return
   }
@@ -122,10 +124,12 @@ function getSkippableSuites ({
   custom,
   testLevel = 'suite',
   isCoverageReportUploadEnabled = false,
+  isLineCoverageSupported = true,
 }, done) {
+  const shouldConsiderLineCoverage = isCoverageReportUploadEnabled && isLineCoverageSupported
   const cacheKey = buildCacheKey('skippable', [
     sha, service, env, repositoryUrl, osPlatform, osVersion, osArchitecture,
-    runtimeName, runtimeVersion, testLevel, custom, isCoverageReportUploadEnabled,
+    runtimeName, runtimeVersion, testLevel, custom, shouldConsiderLineCoverage,
   ])
 
   withCache(cacheKey, (activeCacheKey, cb) => {
@@ -146,11 +150,16 @@ function getSkippableSuites ({
       custom,
       testLevel,
       isCoverageReportUploadEnabled,
+      isLineCoverageSupported,
       cacheKey: activeCacheKey,
     }, cb)
   }, (err, data) => {
     if (err) return done(err)
-    logSkippableSuitesResponse(data, testLevel)
+    logSkippableSuitesResponse(
+      data,
+      testLevel,
+      shouldConsiderLineCoverage
+    )
     done(null, data.skippableSuites, data.correlationId, data.coverage)
   })
 }
@@ -175,6 +184,7 @@ function getSkippableSuites ({
  * @param {object} [params.custom]
  * @param {string} [params.testLevel]
  * @param {boolean} [params.isCoverageReportUploadEnabled]
+ * @param {boolean} [params.isLineCoverageSupported]
  * @param {string | null} params.cacheKey
  * @param {Function} done
  */
@@ -195,6 +205,7 @@ function fetchFromApi ({
   custom,
   testLevel,
   isCoverageReportUploadEnabled,
+  isLineCoverageSupported,
   cacheKey,
 }, done) {
   const options = {
@@ -258,6 +269,7 @@ function fetchFromApi ({
         const result = parseSkippableSuitesResponse(parsedResponse, {
           testLevel,
           isCoverageReportUploadEnabled,
+          isLineCoverageSupported,
           validateRequiredFields: true,
         })
         const skippableItems = parsedResponse.data.filter(({ type }) => type === testLevel)

--- a/packages/dd-trace/src/ci-visibility/test-optimization-http-cache.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-http-cache.js
@@ -145,7 +145,11 @@ class TestOptimizationHttpCache {
         validationMode: Boolean(this._validationManifestPath),
       })
       const testLevel = options.testLevel || 'suite'
-      logSkippableSuitesResponse(result, testLevel)
+      logSkippableSuitesResponse(
+        result,
+        testLevel,
+        options.isCoverageReportUploadEnabled && options.isLineCoverageSupported !== false
+      )
       const skippableItems = parsedResponse.data.filter(({ type }) => type === testLevel)
       incrementCountMetric(
         testLevel === 'test'

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -259,6 +259,7 @@ module.exports = class CiPlugin extends Plugin {
         {
           ...this.testConfiguration,
           isCoverageReportUploadEnabled: this.libraryConfig?.isCoverageReportUploadEnabled,
+          isLineCoverageSupported: this.constructor.id !== 'vitest',
         },
         (err, skippableSuites, itrCorrelationId, skippableSuitesCoverage) => {
           if (err) {

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -148,6 +148,22 @@ describe('CiPlugin', () => {
     sinon.assert.calledOnce(onDone)
   })
 
+  it('does not consider line coverage for Vitest skippable suites', () => {
+    const getSkippableSuites = sinon.stub().callsArgWith(1, null, [])
+    const onDone = sinon.stub()
+    const plugin = createPlugin('vitest_worker', true)
+    plugin.tracer._exporter.getSkippableSuites = getSkippableSuites
+    plugin.libraryConfig = { isCoverageReportUploadEnabled: true }
+
+    dc.channel('ci:vitest:test-suite:skippable').publish({ onDone })
+    plugin.configure(false)
+
+    sinon.assert.calledOnce(getSkippableSuites)
+    assert.strictEqual(getSkippableSuites.firstCall.args[0].isCoverageReportUploadEnabled, true)
+    assert.strictEqual(getSkippableSuites.firstCall.args[0].isLineCoverageSupported, false)
+    sinon.assert.calledOnce(onDone)
+  })
+
   it('replaces frozen policy snapshots when dependent requests fail', () => {
     const plugin = createPlugin('vitest_worker', true)
     plugin.libraryConfig = Object.freeze({

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-http-cache.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-http-cache.spec.js
@@ -452,6 +452,33 @@ describe('CI Visibility Exporter Test Optimization HTTP cache', () => {
     })
   })
 
+  it('keeps cached skippable tests with missing line coverage when line coverage is unsupported', (done) => {
+    writeCacheLayout(tmpRoot, {
+      skippableTests: {
+        ...SKIPPABLE_RESPONSE,
+        data: [{
+          type: 'suite',
+          attributes: {
+            suite: 'suite1.spec.js',
+            _is_missing_line_code_coverage: true,
+          },
+        }],
+      },
+    })
+    const ciVisibilityExporter = new CiVisibilityExporter({ url, testOptimization: ITR_FEATURE_GATE_ENABLED })
+    ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+    ciVisibilityExporter._libraryConfig = { isSuitesSkippingEnabled: true }
+
+    ciVisibilityExporter.getSkippableSuites({
+      isCoverageReportUploadEnabled: true,
+      isLineCoverageSupported: false,
+    }, (err, skippableSuites) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(skippableSuites, ['suite1.spec.js'])
+      done()
+    })
+  })
+
   it('falls back to live skippable tests when cached skippable tests are missing', (done) => {
     fs.rmSync(path.join(tmpRoot, '.testoptimization', 'cache', 'http', 'skippable_tests.json'))
     getConfig().DD_API_KEY = '1'

--- a/packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js
+++ b/packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js
@@ -114,7 +114,7 @@ function cacheKeyForParams (params) {
     params.sha, params.service, params.env, params.repositoryUrl,
     params.osPlatform, params.osVersion, params.osArchitecture,
     params.runtimeName, params.runtimeVersion, params.testLevel, params.custom,
-    params.isCoverageReportUploadEnabled || false,
+    Boolean(params.isCoverageReportUploadEnabled && params.isLineCoverageSupported !== false),
   ])
 }
 
@@ -269,6 +269,36 @@ describe('get-skippable-suites', () => {
       assert.strictEqual(err, null)
       assert.deepStrictEqual(skippableSuites, ['suite1.spec.js', 'suite2.spec.js'])
       assert.strictEqual(correlationId, 'corr-123')
+      sinon.assert.calledWithExactly(log.debug, 'Number of received skippable %ss: %d', 'suite', 2)
+      sinon.assert.neverCalledWith(
+        log.debug,
+        'Received %d skippable %s candidates; excluded %d because line coverage is missing; %d remain.',
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any
+      )
+      sinon.assert.notCalled(log.warn)
+      done()
+    })
+  })
+
+  it('should keep suites with missing line coverage when line coverage is unsupported', (done) => {
+    const params = {
+      ...DEFAULT_PARAMS,
+      isCoverageReportUploadEnabled: true,
+      isLineCoverageSupported: false,
+    }
+    nock(BASE_URL)
+      .post('/api/v2/ci/tests/skippable')
+      .reply(200, JSON.stringify(SKIPPABLE_RESPONSE_WITH_MISSING_LINE_COVERAGE))
+
+    getSkippableSuites(params, (err, skippableSuites, correlationId) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(skippableSuites, ['suite1.spec.js', 'suite2.spec.js'])
+      assert.strictEqual(correlationId, 'corr-123')
+      sinon.assert.calledWithExactly(log.debug, 'Number of received skippable %ss: %d', 'suite', 2)
+      sinon.assert.notCalled(log.warn)
       done()
     })
   })
@@ -388,6 +418,18 @@ describe('parseSkippableSuitesResponse', () => {
     assert.deepStrictEqual(result.skippableSuites, ['suite2.spec.js'])
     assert.strictEqual(result.numReceivedSkippableItems, 2)
     assert.strictEqual(result.numExcludedByMissingLineCoverage, 1)
+  })
+
+  it('keeps missing line coverage when line coverage is unsupported', () => {
+    const result = parseSkippableSuitesResponse(JSON.stringify(SKIPPABLE_RESPONSE_WITH_MISSING_LINE_COVERAGE), {
+      testLevel: 'suite',
+      isCoverageReportUploadEnabled: true,
+      isLineCoverageSupported: false,
+    })
+
+    assert.deepStrictEqual(result.skippableSuites, ['suite1.spec.js', 'suite2.spec.js'])
+    assert.strictEqual(result.numReceivedSkippableItems, 2)
+    assert.strictEqual(result.numExcludedByMissingLineCoverage, 0)
   })
 
   it('validates skippable tests response shape when requested', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Only considers missing executable line coverage when coverage report upload is enabled and the framework supports it.
- Marks Vitest line coverage as unsupported for TIA, while leaving coverage report upload enabled.
- Applies the same behavior to live, filesystem-cached, and Test Optimization HTTP-cached skippable responses.

### Motivation
<!-- What inspired you to submit this pull request? -->

Vitest TIA does not support executable line coverage. The shared skippable-suite response handling previously treated missing line coverage as relevant for Vitest whenever coverage report upload was enabled, which could remove valid Vitest skip candidates. It also emitted line-coverage exclusion diagnostics when coverage report upload was disabled, even though line coverage could not affect the result.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- 135 focused unit and cache tests passed.
- The focused Vitest TIA integration test passed on Vitest 1.6.0 and the latest tested version.
- Targeted ESLint passed.
- Scoped nyc coverage passed with the changed production paths included.
