### PR TITLE
fix(playwright): upload one failure screenshot per attempt

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-screenshot-multiple-pages/failure-screenshot-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-screenshot-multiple-pages/failure-screenshot-test.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const { test, expect } = require('@playwright/test')
+
+test('uploads one automatic failure screenshot for multiple pages', async ({ page, browser }) => {
+  await page.goto(process.env.PW_BASE_URL)
+  await browser.newPage()
+
+  expect(true).toBe(false)
+})

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -356,7 +356,8 @@ versions.forEach((version) => {
         run,
         screenshotMode = 'only-on-failure',
         isScreenshotUploadEnabled = true,
-        testOptimizationConfig = getCiVisAgentlessConfig(receiver.port)
+        testOptimizationConfig = getCiVisAgentlessConfig(receiver.port),
+        extraEnv = {}
       ) {
         let testOutput = ''
         const proc = run(
@@ -372,6 +373,7 @@ versions.forEach((version) => {
               DD_TEST_FAILURE_SCREENSHOTS_ENABLED: isScreenshotUploadEnabled ? 'true' : undefined,
               DD_TRACE_DEBUG: 'true',
               DD_TRACE_LOG_LEVEL: 'warn',
+              ...extraEnv,
             },
           }
         )
@@ -438,6 +440,55 @@ versions.forEach((version) => {
           assert.ok(!getTestOutput().includes(SCREENSHOT_CAPTURE_DISABLED_WARNING))
         })
       }
+
+      it('uploads one automatic failure screenshot for a test with multiple pages', async (receiver, run) => {
+        const testName = 'uploads one automatic failure screenshot for multiple pages'
+        const { proc, getTestOutput } = runWithFailureScreenshots(
+          receiver,
+          run,
+          'only-on-failure',
+          true,
+          getCiVisAgentlessConfig(receiver.port),
+          { TEST_DIR: './ci-visibility/playwright-tests-screenshot-multiple-pages' }
+        )
+        const payloadsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            proc,
+            ({ url }) => url.startsWith('/api/v2/ci/test-runs/') || url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const testOutput = getTestOutput()
+              const failedTest = payloads
+                .filter(({ url }) => url.endsWith('/api/v2/citestcycle'))
+                .flatMap(({ payload }) => payload.events)
+                .filter(event => event.type === 'test')
+                .find(event => event.content.meta[TEST_NAME] === testName)
+
+              assert.ok(failedTest, `failed test event should be reported\n${testOutput}`)
+              assert.strictEqual(failedTest.content.meta[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
+
+              const expectedTraceId = failedTest.content.trace_id.toString()
+              const screenshotPayloads = payloads.filter(({ url, media }) =>
+                url.startsWith('/api/v2/ci/test-runs/') && media.traceId === expectedTraceId
+              )
+              assert.strictEqual(
+                screenshotPayloads.length,
+                1,
+                `only the first automatic screenshot should upload\n${testOutput}`
+              )
+
+              const [, encodedFilename] = screenshotPayloads[0].media.idempotencyKey.split(':')
+              assert.strictEqual(Buffer.from(encodedFilename, 'hex').toString('utf8'), 'test-failed-1.png')
+            },
+            { hardTimeout: 60000 }
+          )
+          .catch((error) => {
+            error.message += `\nPlaywright output:\n${getTestOutput()}`
+            throw error
+          })
+
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), payloadsPromise])
+        assert.strictEqual(exitCode, 1)
+      })
 
       for (const isScreenshotUploadEnabled of [true, false]) {
         const testName = isScreenshotUploadEnabled

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -10,7 +10,6 @@ const {
   SCREENSHOT_UPLOAD_RESULT_ERROR,
   SCREENSHOT_UPLOAD_RESULT_UPLOADED,
   getScreenshotCapturedAtMs,
-  getScreenshotUploadResult,
   getScreenshotUploadTag,
 } = require('../../dd-trace/src/ci-visibility/test-screenshot')
 
@@ -547,7 +546,7 @@ class PlaywrightPlugin extends CiPlugin {
   }
 
   /**
-   * Uploads automatic failure screenshots for a Playwright test attempt.
+   * Uploads the first automatic failure screenshot for a Playwright test attempt.
    *
    * @param {object} options - Upload options
    * @param {Array<object>} options.screenshots - Playwright test attachments
@@ -563,36 +562,27 @@ class PlaywrightPlugin extends CiPlugin {
       return false
     }
 
-    const screenshotPaths = new Set()
+    let filePath
     for (const screenshot of screenshots) {
       if (isPlaywrightFailureScreenshot(screenshot)) {
-        screenshotPaths.add(screenshot.path)
+        filePath = screenshot.path
+        break
       }
     }
-    if (!screenshotPaths.size) return false
+    if (!filePath) return false
 
-    const uploadResults = new Array(screenshotPaths.size)
-    let pendingUploads = screenshotPaths.size
-    let index = 0
-    for (const filePath of screenshotPaths) {
-      const resultIndex = index++
-      exporter.uploadTestScreenshot({
-        filePath,
-        traceId,
-        idempotencyKey: `${traceId}:${basename(filePath)}`,
-        capturedAtMs: getScreenshotCapturedAtMs(filePath, filePath),
-      }, (error, uploaded = true) => {
-        if (uploaded) {
-          uploadResults[resultIndex] = error
-            ? SCREENSHOT_UPLOAD_RESULT_ERROR
-            : SCREENSHOT_UPLOAD_RESULT_UPLOADED
-        }
-        pendingUploads--
-        if (pendingUploads === 0) {
-          onDone(getScreenshotUploadResult(uploadResults))
-        }
-      })
-    }
+    exporter.uploadTestScreenshot({
+      filePath,
+      traceId,
+      idempotencyKey: `${traceId}:${basename(filePath)}`,
+      capturedAtMs: getScreenshotCapturedAtMs(filePath, filePath),
+    }, (error, uploaded = true) => {
+      if (!uploaded) {
+        onDone()
+        return
+      }
+      onDone(error ? SCREENSHOT_UPLOAD_RESULT_ERROR : SCREENSHOT_UPLOAD_RESULT_UPLOADED)
+    })
     return true
   }
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Limits Playwright failure screenshot uploads to the first automatic screenshot for each test attempt.

Adds an integration fixture with a navigated primary page and an extra blank page. Playwright creates `test-failed-1.png` and `test-failed-2.png`; the regression test verifies that only `test-failed-1.png` reaches the media intake.

### Motivation
<!-- What inspired you to submit this pull request? -->

Playwright captures one automatic failure screenshot for every live page. The Playwright plugin uploaded every distinct automatic attachment, which could show both a useful failure screenshot and a blank screenshot for the same test attempt in Test Optimization.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verification:

- Confirmed the new integration test fails before the production change with two uploads (`2 !== 1`).
- `PLAYWRIGHT_VERSION=latest npm run test:integration:playwright -- --grep 'uploads (only automatic|one automatic)'` — 4 passing.
- Targeted ESLint on the three changed files — passing.
- Playwright 1.38.0 could not be validated locally because its bundled Chromium 117 closed during browser launch on this machine in two consecutive runs, before the test body executed.
