### PR TITLE
fix(test-optimization): allow null skippable coverage metadata

### DIFF
--- a/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-http-cache-schema.js
@@ -137,7 +137,7 @@ function validateSkippableTestsResponse (response, options = {}) {
   if (response.meta !== undefined) {
     assertObject(response.meta, 'Invalid skippable tests response: meta must be an object')
   }
-  if (response.meta?.coverage !== undefined) {
+  if (response.meta?.coverage !== undefined && response.meta.coverage !== null) {
     assertObject(response.meta.coverage, 'Invalid skippable tests response: meta.coverage must be an object')
   }
   if (response.meta?.correlation_id !== undefined && typeof response.meta.correlation_id !== 'string') {

--- a/packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js
+++ b/packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js
@@ -73,6 +73,14 @@ const SKIPPABLE_RESPONSE_WITH_COVERAGE = {
   },
 }
 
+const SKIPPABLE_RESPONSE_WITH_NULL_COVERAGE = {
+  ...SKIPPABLE_RESPONSE,
+  meta: {
+    ...SKIPPABLE_RESPONSE.meta,
+    coverage: null,
+  },
+}
+
 const SKIPPABLE_RESPONSE_WITH_MISSING_LINE_COVERAGE = {
   data: [
     {
@@ -187,6 +195,20 @@ describe('get-skippable-suites', () => {
         'src/file1.js': 'gA==',
         'src/file2.js': 'IA==',
       })
+      done()
+    })
+  })
+
+  it('should accept null coverage metadata when coverage report upload is disabled', (done) => {
+    nock(BASE_URL)
+      .post('/api/v2/ci/tests/skippable')
+      .reply(200, JSON.stringify(SKIPPABLE_RESPONSE_WITH_NULL_COVERAGE))
+
+    getSkippableSuites(DEFAULT_PARAMS, (err, skippableSuites, correlationId, coverage) => {
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(skippableSuites, ['suite1.spec.js', 'suite2.spec.js'])
+      assert.strictEqual(correlationId, 'corr-123')
+      assert.deepStrictEqual(coverage, {})
       done()
     })
   })
@@ -406,6 +428,13 @@ describe('parseSkippableSuitesResponse', () => {
         { validateRequiredFields: true }
       ),
       /Invalid skippable tests response: data entry suite must be a string/
+    )
+    assert.throws(
+      () => parseSkippableSuitesResponse(
+        JSON.stringify({ data: [], meta: { coverage: [] } }),
+        { validateRequiredFields: true }
+      ),
+      /Invalid skippable tests response: meta.coverage must be an object/
     )
   })
 })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allows the skippable-tests response to provide `meta.coverage` as `null`, treating it the same as an omitted coverage attribute. Present coverage values must still be objects.

### Motivation
<!-- What inspired you to submit this pull request? -->

The backend does not always return skippable-suite coverage, especially when coverage report upload is disabled. The parser already handled omitted and `null` coverage as an empty coverage map, but response validation rejected `null` first with:

`Invalid skippable tests response: meta.coverage must be an object`

This prevented otherwise valid skippable suites from being fetched.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- 41 focused skippable-response and HTTP-cache tests passed.
- Added a request-level regression for `meta.coverage: null`.
- Kept regression coverage proving arrays remain invalid.
- Targeted ESLint and scoped nyc coverage passed.
