### PR TITLE
feat(instrumentation): add awaited context callbacks to conditional branches

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -7,7 +7,7 @@ const log = require('../../../../dd-trace/src/log')
 const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
 const instrumentations = require('./instrumentations')
 const { getRewriteTarget } = require('./targets')
-const { waitForAsyncEnd } = require('./transforms')
+const { awaitContextCallback, waitForAsyncEnd } = require('./transforms')
 
 // `dc-polyfill` is referenced from injected `require()` (CJS) and `import`
 // (ESM) statements that the transformer splices into the rewritten module.
@@ -35,6 +35,7 @@ const matcherCjs = create(instrumentations, dcPolyfillCjs)
 const matcherEsm = create(instrumentations, dcPolyfillEsm)
 
 for (const matcher of [matcherCjs, matcherEsm]) {
+  matcher.addTransform('awaitContextCallback', awaitContextCallback)
   matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
 }
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -14,7 +14,89 @@ const clone = require('../../../../../vendor/dist/rfdc')({ proto: false, circles
 
 const { parse, query } = require('./compiler')
 
-module.exports = { waitForAsyncEnd }
+const functionTypes = new Set(['ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression'])
+const identifierPattern = /^[$A-Z_a-z][$\w]*$/
+
+module.exports = { awaitContextCallback, waitForAsyncEnd }
+
+/**
+ * Awaits an optional context callback before continuing through a matched conditional branch.
+ *
+ * The branch condition is checked again after the callback settles so the
+ * original body does not run against state that changed while awaiting.
+ *
+ * @param {{
+ *   transformOptions?: {
+ *     callbackArgumentNames?: string[],
+ *     callbackName?: string
+ *   }
+ * }} state
+ * @param {import('estree').IfStatement} node
+ * @param {import('estree').Node} _parent
+ * @param {import('estree').Node[]} ancestry
+ * @returns {void}
+ */
+function awaitContextCallback (state, node, _parent, ancestry) {
+  assert(node.type === 'IfStatement' && node.consequent?.type === 'BlockStatement',
+    'awaitContextCallback: expected an if statement with a block body')
+
+  const { callbackArgumentNames = [], callbackName } = state.transformOptions ?? {}
+
+  assert(identifierPattern.test(callbackName), 'awaitContextCallback: callbackName must be an identifier')
+  assert(callbackArgumentNames.every(name => identifierPattern.test(name)),
+    'awaitContextCallback: callbackArgumentNames must be identifiers')
+
+  let enclosingFunction
+  let hasTraceWrapper = false
+  for (const ancestor of ancestry) {
+    if (!functionTypes.has(ancestor.type)) continue
+
+    enclosingFunction ??= ancestor
+    if (ancestor.body?.type !== 'BlockStatement') continue
+
+    let hasContextBinding = false
+    let hasTracedBinding = false
+    for (const statement of ancestor.body.body) {
+      if (statement.type !== 'VariableDeclaration') continue
+
+      for (const declaration of statement.declarations) {
+        hasContextBinding ||= declaration.id?.name === '__apm$ctx'
+        hasTracedBinding ||= declaration.id?.name === '__apm$traced'
+      }
+    }
+    hasTraceWrapper ||= hasContextBinding && hasTracedBinding
+  }
+
+  assert(enclosingFunction?.async, 'awaitContextCallback: expected an enclosing async function')
+  assert(hasTraceWrapper, 'awaitContextCallback: expected an enclosing trace wrapper')
+
+  const callbackVariable = `__apm$${callbackName}`
+  if (query(node, `[id.name="${callbackVariable}"]`).length > 0) {
+    return
+  }
+
+  const originalStatements = node.consequent.body
+  const callbackStatements = parse(`
+    async function wrapper () {
+      const ${callbackVariable} = __apm$ctx.${callbackName};
+      if (typeof ${callbackVariable} === 'function') {
+        try {
+          await ${callbackVariable}(${callbackArgumentNames.join(', ')});
+        } catch {}
+        if (true) {}
+      } else {
+      }
+    }
+  `).body[0].body.body
+
+  const callbackBranch = callbackStatements[1]
+  const recheckedBranch = callbackBranch.consequent.body[1]
+  recheckedBranch.test = clone(node.test)
+  recheckedBranch.consequent.body.push(...clone(originalStatements))
+  recheckedBranch.alternate = clone(node.alternate)
+  callbackBranch.alternate.body.push(...originalStatements)
+  node.consequent.body = callbackStatements
+}
 
 /**
  * Injects settlement-specific asyncEnd waits into a generated `tracePromise`

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -301,6 +301,112 @@ describe('check-require-cache', () => {
         },
         {
           module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          functionQuery: {
+            functionName: 'runWithRetry',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="runWithRetry"] CatchClause ' +
+            'IfStatement[test.operator=">"][test.left.object.name="state"]' +
+            '[test.left.property.name="remaining"]',
+          channelName: 'trace_await_context_callback',
+          transform: 'awaitContextCallback',
+          transformOptions: {
+            callbackArgumentNames: ['error'],
+            callbackName: 'beforeContinue',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          functionQuery: {
+            functionName: 'consumeFirst',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback_side_effect',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="consumeFirst"] ' +
+            'IfStatement[test.callee.object.name="queue"][test.callee.property.name="shift"]',
+          channelName: 'trace_await_context_callback_side_effect',
+          transform: 'awaitContextCallback',
+          transformOptions: {
+            callbackName: 'beforeContinue',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          functionQuery: {
+            functionName: 'chooseBranch',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback_alternate',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="chooseBranch"] ' +
+            'IfStatement[test.object.name="state"][test.property.name="usePrimary"]',
+          channelName: 'trace_await_context_callback_alternate',
+          transform: 'awaitContextCallback',
+          transformOptions: {
+            callbackName: 'beforeContinue',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback-sync.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="runSynchronously"] IfStatement',
+          channelName: 'trace_await_context_callback_sync',
+          transform: 'awaitContextCallback',
+          transformOptions: {
+            callbackName: 'beforeContinue',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback-unwrapped.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="runUnwrapped"] IfStatement',
+          channelName: 'trace_await_context_callback_unwrapped',
+          transform: 'awaitContextCallback',
+          transformOptions: {
+            callbackName: 'beforeContinue',
+          },
+        },
+        {
+          module: {
             name: 'test-esm',
             versionRange: '>=0.1',
             filePath: 'pregel-class.js',
@@ -664,6 +770,158 @@ describe('check-require-cache', () => {
     ])
 
     assert.equal(result, 'result')
+  })
+
+  it('should await a context callback before continuing through a conditional branch', async () => {
+    const { runWithRetry } = compileFile('trace-await-context-callback')
+    const callbackError = new Error('first attempt failed')
+    const steps = []
+    let finishCallback
+    let startCallback
+    const callbackStarted = new Promise(resolve => {
+      startCallback = resolve
+    })
+    const callbackFinished = new Promise(resolve => {
+      finishCallback = resolve
+    })
+    let attempts = 0
+
+    subs = {
+      start (ctx) {
+        ctx.beforeContinue = error => {
+          steps.push(error)
+          startCallback()
+          return callbackFinished
+        }
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback')
+    ch.subscribe(subs)
+
+    const resultPromise = runWithRetry(() => {
+      attempts++
+      if (attempts === 1) throw callbackError
+      return 'passed'
+    }, { remaining: 1 })
+
+    await callbackStarted
+
+    assert.equal(attempts, 1)
+    assert.deepStrictEqual(steps, [callbackError])
+
+    finishCallback()
+
+    assert.equal(await resultPromise, 'passed')
+    assert.equal(attempts, 2)
+  })
+
+  it('should recheck the condition after the context callback settles', async () => {
+    const { runWithRetry } = compileFile('trace-await-context-callback')
+    const callbackError = new Error('do not retry')
+    const state = { remaining: 1 }
+    let attempts = 0
+
+    subs = {
+      start (ctx) {
+        ctx.beforeContinue = () => {
+          state.remaining = 0
+        }
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback')
+    ch.subscribe(subs)
+
+    await assert.rejects(runWithRetry(() => {
+      attempts++
+      throw callbackError
+    }, state), error => error === callbackError)
+
+    assert.equal(attempts, 1)
+    assert.equal(state.remaining, 0)
+  })
+
+  it('should preserve the conditional branch when the context callback rejects', async () => {
+    const { runWithRetry } = compileFile('trace-await-context-callback')
+    let attempts = 0
+
+    subs = {
+      start (ctx) {
+        ctx.beforeContinue = () => Promise.reject(new Error('observability callback failed'))
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback')
+    ch.subscribe(subs)
+
+    const result = await runWithRetry(() => {
+      attempts++
+      if (attempts === 1) throw new Error('first attempt failed')
+      return 'passed'
+    }, { remaining: 1 })
+
+    assert.equal(result, 'passed')
+    assert.equal(attempts, 2)
+  })
+
+  it('should not recheck a side-effectful condition when no context callback exists', async () => {
+    const { consumeFirst } = compileFile('trace-await-context-callback')
+    const queue = [true, 'remaining']
+
+    subs = { start: sinon.spy() }
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_side_effect')
+    ch.subscribe(subs)
+
+    assert.equal(await consumeFirst(queue), 1)
+    assert.deepStrictEqual(queue, ['remaining'])
+  })
+
+  it('should use the alternate branch when the rechecked condition changes', async () => {
+    const { chooseBranch } = compileFile('trace-await-context-callback')
+    const state = { usePrimary: true }
+
+    subs = {
+      start (ctx) {
+        ctx.beforeContinue = () => {
+          state.usePrimary = false
+        }
+      },
+    }
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_alternate')
+    ch.subscribe(subs)
+
+    assert.equal(await chooseBranch(state), 'fallback')
+  })
+
+  it('should leave synchronous callback targets untouched', () => {
+    const filename = resolve(__dirname, 'node_modules', 'test', 'trace-await-context-callback-sync.js')
+    const source = readFileSync(filename, 'utf8')
+
+    subs = { start: sinon.spy() }
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_sync')
+    ch.subscribe(subs)
+
+    const { runSynchronously } = compileFile('trace-await-context-callback-sync')
+
+    assert.strictEqual(content, source)
+    assert.equal(runSynchronously({ shouldContinue: true }), 'continued')
+    assert.equal(subs.start.callCount, 0)
+  })
+
+  it('should leave targets without a trace wrapper untouched', async () => {
+    const filename = resolve(__dirname, 'node_modules', 'test', 'trace-await-context-callback-unwrapped.js')
+    const source = readFileSync(filename, 'utf8')
+
+    subs = { start: sinon.spy() }
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_unwrapped')
+    ch.subscribe(subs)
+
+    const { runUnwrapped } = compileFile('trace-await-context-callback-unwrapped')
+
+    assert.strictEqual(content, source)
+    assert.equal(await runUnwrapped({ shouldContinue: true }), 'continued')
+    assert.equal(subs.start.callCount, 0)
   })
 
   it('should leave dependencies without a rewrite target untouched', () => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback-sync.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback-sync.js
@@ -1,0 +1,10 @@
+'use strict'
+
+function runSynchronously (state) {
+  if (state.shouldContinue) {
+    return 'continued'
+  }
+  return 'stopped'
+}
+
+module.exports = { runSynchronously }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback-unwrapped.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback-unwrapped.js
@@ -1,0 +1,10 @@
+'use strict'
+
+async function runUnwrapped (state) {
+  if (state.shouldContinue) {
+    return 'continued'
+  }
+  return 'stopped'
+}
+
+module.exports = { runUnwrapped }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
@@ -1,0 +1,30 @@
+'use strict'
+
+async function runWithRetry (task, state) {
+  try {
+    return await task()
+  } catch (error) {
+    if (state.remaining > 0) {
+      state.remaining--
+      return runWithRetry(task, state)
+    }
+    throw error
+  }
+}
+
+async function consumeFirst (queue) {
+  if (queue.shift()) {
+    return queue.length
+  }
+  return -1
+}
+
+async function chooseBranch (state) {
+  if (state.usePrimary) {
+    return 'primary'
+  } else {
+    return 'fallback'
+  }
+}
+
+module.exports = { chooseBranch, consumeFirst, runWithRetry }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a generic `awaitContextCallback` rewriter transform. An instrumentation selects a conditional with its own `astQuery` and provides the context callback name and argument identifiers through `transformOptions`.

When the callback is present, the transform awaits it before continuing through the branch, rechecks the condition after the await, and suppresses callback failures so observability code cannot change the instrumented application's error behavior. When no callback is present, it executes the original branch directly without evaluating the condition a second time.

### Motivation
<!-- What inspired you to submit this pull request? -->

The existing Orchestrion operators expose function entry and completion. Instrumenting a function that contains internal retries therefore produces one lifecycle around the entire operation:

```js
async function runWithRetry (attempt) {
  while (true) {
    try {
      return await attempt()
    } catch (error) {
      if (shouldRetry(error)) {
        attempts++
        continue
      }
      throw error
    }
  }
}
```

The outer instrumentation sees `runWithRetry` start and eventually finish. It does not see the caught error or expose an awaitable boundary between the two loop iterations.

When the next operation is a separate, statically targetable function, instrumenting that function may be sufficient. It is not sufficient when the operation is supplied dynamically, when instrumentation needs the error and retry decision held by the caller, or when asynchronous setup must finish before the branch continues. A normal `start` subscriber is synchronous and cannot provide that pause.

Recursion is another instance of the same problem:

```js
if (shouldRetry) {
  attempts++
  return runWithRetry()
}
```

Instrumenting `runWithRetry` observes the recursive invocation, but the original invocation remains active, its caught error is not reported as a function error, and the recursive `start` event cannot await work before the next attempt executes.

`awaitContextCallback` exposes the missing internal boundary. Conceptually, an instrumentation can turn a selected branch into:

```js
if (shouldRetry) {
  const callback = context.beforeContinue
  if (typeof callback === 'function') {
    try {
      await callback(error)
    } catch {}

    if (shouldRetry) {
      attempts++
      return runWithRetry()
    }
  } else {
    attempts++
    return runWithRetry()
  }
}
```

The condition is checked again only after a callback runs because state may change while awaiting. If that recheck becomes false, the original `else` branch is preserved. Callback failures are ignored so instrumentation cannot change the application's error behavior.

The generic transform does not encode retry logic, a framework, an AST selector, or a callback name. Each consumer supplies its own conditional query and callback options. The stacked WebdriverIO PR (#9668) is the first consumer and owns all WebdriverIO-specific choices.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR contains only the generic transform registration and neutral rewriter coverage. No production instrumentation references the transform in this PR, so it does not change existing instrumentation behavior by itself.

Because the transform injects both `await` and access to the trace context, it validates that the selected conditional is inside an async function with the paired trace wrapper. If either precondition is missing, rewriting fails safely and the original source is retained.

Validation:

- `./node_modules/.bin/mocha packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js` — 34 passing
- targeted ESLint for all changed JavaScript files
- `npm run verify:rewriter:targets`
