### PR TITLE
perf(native-spans): bound exporter batching

### DIFF
--- a/benchmark/sirun/spans/README.md
+++ b/benchmark/sirun/spans/README.md
@@ -1,5 +1,2 @@
-This test initializes a tracer with the no-op scope manager. It then creates
-many spans, and depending on the variant, either finishes all of them as they
-are created, or later on once they're all created. Prior to creating any spans,
-it modifies the processor instance so that no span processing (or exporting) is
-done, and it simply stops storing the spans.
+This benchmark measures span construction and finish with the no-op scope manager. Ordinary native mutations are
+discarded before processing or export; native events are drained because libdatadog applies them directly.

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -42,7 +42,7 @@
         "DD_TRACE_SCOPE": "noop",
         "FINISH": "now",
         "SHAPE": "tags-and-otel",
-        "OPERATIONS": "100000"
+        "OPERATIONS": "50000"
       }
     }
   }

--- a/benchmark/sirun/spans/spans.js
+++ b/benchmark/sirun/spans/spans.js
@@ -9,16 +9,26 @@ const { createNativeSpanDrain } = require('../native-span-drain')
 nock.disableNetConnect()
 nock('http://127.0.0.1:8126').persist().put(/.*/).reply(200, '{}').post(/.*/).reply(200, '{}')
 
-const tracer = require('../../..').init({ hostname: '127.0.0.1', port: 8126 })
-const nativeSpanDrain = createNativeSpanDrain(tracer)
+const { FINISH, SHAPE = 'plain' } = process.env
 
+const tracer = require('../../..').init({ hostname: '127.0.0.1', port: 8126 })
+const nativeSpans = tracer._tracer._nativeSpans
+const nativeSpanDrain = SHAPE === 'tags-and-otel' ? createNativeSpanDrain(tracer) : undefined
+
+let queuedSpans = 0
+
+/** @param {import('../../../packages/dd-trace/src/opentracing/span')} span */
 tracer._tracer._processor.process = function process (span) {
   const trace = span.context()._trace
-  nativeSpanDrain.add(span)
+  if (nativeSpanDrain) {
+    nativeSpanDrain.add(span)
+  } else if (nativeSpans && ++queuedSpans === BATCH) {
+    // This benchmark excludes processing and export; discard queued native mutations before the buffer fills.
+    nativeSpans.resetChangeQueue()
+    queuedSpans = 0
+  }
   this._erase(trace, [])
 }
-
-const { FINISH, SHAPE = 'plain' } = process.env
 
 // Total spans created per process. The count stays env-driven so CI can keep
 // each native-mode variant under the job timeout while still making tracer load
@@ -104,13 +114,17 @@ function startOne () {
 }
 
 async function main () {
-  await nativeSpanDrain.drain()
+  await nativeSpanDrain?.drain()
 
   guard.loopStart()
-  if (FINISH === 'now') {
+  if (FINISH === 'now' && nativeSpanDrain) {
     for (let iteration = 0; iteration < OPERATIONS; iteration++) {
       startOne().finish()
       if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+    }
+  } else if (FINISH === 'now') {
+    for (let iteration = 0; iteration < OPERATIONS; iteration++) {
+      startOne().finish()
     }
   } else {
     // Deferred finish in batches: start BATCH spans, finish them after the batch is
@@ -126,10 +140,11 @@ async function main () {
       }
       spans.length = 0
       remaining -= size
-      if (nativeSpanDrain.needsDrain()) await nativeSpanDrain.drain()
+      if (nativeSpanDrain?.needsDrain()) await nativeSpanDrain.drain()
     }
   }
-  await nativeSpanDrain.drain()
+  await nativeSpanDrain?.drain()
+  nativeSpans?.resetChangeQueue()
   // Native-mode CI counts are intentionally lower than the old JS-only counts so
   // the candidate shard finishes before the job timeout. The older baseline source
   // can run those counts in under a second, so allow a higher startup share there

--- a/packages/dd-trace/src/exporters/native/index.js
+++ b/packages/dd-trace/src/exporters/native/index.js
@@ -10,6 +10,9 @@ const runtimeMetrics = require('../../runtime_metrics')
 const { fetchAgentInfo } = require('../../agent/info')
 
 const firstFlushChannel = channel('dd-trace:exporter:first-flush')
+// The JS encoder flushes at 8 MiB; libdatadog exposes no pre-serialization byte
+// count. Bound the full span objects retained during the batching window instead.
+const MAX_PENDING_SPANS = 2000
 
 // Mirrors the legacy AgentWriter so operators see the same tracer-health
 // metrics on the native export path. The native `sendPreparedChunk` does not
@@ -309,7 +312,7 @@ class NativeExporter {
 
     const { flushInterval } = this._config
 
-    if (flushInterval === 0) {
+    if (flushInterval === 0 || this._pendingSpans.length >= MAX_PENDING_SPANS) {
       this.flush()
     } else if (this.#timer === undefined) {
       this.#timer = setTimeout(() => {
@@ -385,12 +388,15 @@ class NativeExporter {
   }
 
   #finishSend () {
-    if (this._pendingSpanChunks.length > 0) {
-      this.flush()
-    } else {
+    if (this._pendingSpanChunks.length === 0) {
       this.#finishFlushCallbacks()
       this.#finishUrlUpdateCallbacks()
+      return
     }
+
+    // Explicit and elapsed flushes clear the timer. Ordinary traffic keeps its
+    // existing timer so a send completion does not bypass the batching window.
+    if (this.#timer === undefined) this.flush()
   }
 
   #handleSendError (err) {
@@ -520,9 +526,8 @@ class NativeExporter {
       .then((response) => {
         this.#flushInFlight = false
         runtimeMetrics.increment(`${METRIC_PREFIX}.responses`, true)
-        // Drain any spans that arrived while the send was in flight. Flush
-        // callbacks wait until the exporter is idle so explicit flush endpoints
-        // only acknowledge once all queued sends have reached the agent.
+        // Flush callbacks wait until the exporter is idle so explicit flush
+        // endpoints only acknowledge once all queued sends have reached the agent.
         this.#finishSend()
       }, (err) => {
         this.#handleSendError(err)

--- a/packages/dd-trace/src/native/span.js
+++ b/packages/dd-trace/src/native/span.js
@@ -258,7 +258,6 @@ class NativeDatadogSpan extends DatadogSpan {
 
     let spanContext
     let startTime
-    let traceId
     let parentId
 
     let baggage = {}
@@ -290,7 +289,6 @@ class NativeDatadogSpan extends DatadogSpan {
       })
 
       if (!spanContext._trace.startTime) startTime = dateNow()
-      traceId = buildNativeTraceId(existingContext._traceId, spanContext._trace.tags['_dd.p.tid'])
       parentId = existingContext._parentId
     } else if (parent) {
       const spanId = id()
@@ -307,7 +305,6 @@ class NativeDatadogSpan extends DatadogSpan {
       })
 
       if (!spanContext._trace.startTime) startTime = dateNow()
-      traceId = buildNativeTraceId(parent._traceId, spanContext._trace.tags['_dd.p.tid'])
       parentId = parent._spanId
     } else {
       // Root span - generate new trace ID and span ID.
@@ -327,9 +324,6 @@ class NativeDatadogSpan extends DatadogSpan {
           .padStart(8, '0')
           .padEnd(16, '0')
         spanContext._trace.tags['_dd.p.tid'] = tidHex
-        traceId = buildNativeTraceId(spanId, tidHex)
-      } else {
-        traceId = spanId
       }
       parentId = null
 
@@ -373,6 +367,13 @@ class NativeDatadogSpan extends DatadogSpan {
     const nativeType = typeof fields.tags?.['span.type'] === 'string'
       ? fields.tags['span.type']
       : ''
+    // A trace ID is immutable and the trace object is shared by every local
+    // span. Reuse the full 128-bit byte representation instead of rebuilding
+    // its high half and allocating a 16-entry array for every child.
+    const traceId = (spanContext._trace._nativeTraceId ??= buildNativeTraceId(
+      spanContext._traceId,
+      spanContext._trace.tags['_dd.p.tid']
+    ))
 
     nativeSpans.queueCreateSpanFull(
       spanContext._nativeSpanId,

--- a/packages/dd-trace/src/native/span.js
+++ b/packages/dd-trace/src/native/span.js
@@ -176,14 +176,6 @@ function encodeSpanEventAttrs (attributes) {
 // guard below).
 let pendingNativeSpans = null
 
-// Shadows `NativeSpanContext.prototype._syncNameToNative` on the
-// instance during construction so the parent's
-// `this._spanContext._name = operationName` line (opentracing/span.js)
-// does not emit a redundant SetName WASM op alongside the combined
-// CreateSpan op we queue ourselves. The subclass constructor deletes
-// the shadow once super() returns.
-const noopSyncName = () => {}
-
 /**
  * NativeDatadogSpan stores span data in native Rust storage via
  * NativeSpansInterface, replacing the JS-side trace buffer. It inherits
@@ -217,11 +209,6 @@ class NativeDatadogSpan extends DatadogSpan {
 
     this._nativeSpans = nativeSpans
 
-    // Restore the prototype `_syncNameToNative` (shadowed in
-    // `_createContext`) so later `setOperationName` calls reach the
-    // real WASM-syncing method.
-    delete this._spanContext._syncNameToNative
-
     // Parent wrote initial tags via `Object.assign(getTags(), tags)`,
     // which bypasses NativeSpanContext.setTag's native-sync path. Push
     // them to WASM now (no JS-cache write — the parent already did it).
@@ -235,9 +222,8 @@ class NativeDatadogSpan extends DatadogSpan {
   /**
    * Allocate a native slot, build a NativeSpanContext, queue the
    * combined CreateSpan op (Create + SetName + SetStart in one WASM
-   * call), and silently set the initial name. The subclass constructor
-   * (after super) restores the prototype `_syncNameToNative` so future
-   * name changes reach WASM normally.
+   * call). The inherited constructor stores the initial name locally after
+   * this returns; final synchronization owns subsequent name changes.
    *
    * @param {object|null} parent
    * @param {object} fields
@@ -351,9 +337,6 @@ class NativeDatadogSpan extends DatadogSpan {
     // CreateSpanFull carries the common immutable/default core fields natively
     // (name, service, resource, type, start), so final sync can skip no-op
     // overwrites unless user tags changed them.
-    spanContext._setNameLocal(operationName)
-    spanContext._syncNameToNative = noopSyncName
-
     // One segment id per local trace, shared by all its spans via the
     // shared `_trace` object (the local root allocates; children reuse).
     // Required by the native chunk flush, which keys a chunk by segment.

--- a/packages/dd-trace/src/native/span.js
+++ b/packages/dd-trace/src/native/span.js
@@ -270,7 +270,6 @@ class NativeDatadogSpan extends DatadogSpan {
         tags: { ...existingContext.getTags() },
         trace: existingContext._trace,
         tracestate: existingContext._tracestate,
-        tracerService,
         tracerServiceLower,
       })
 
@@ -286,7 +285,6 @@ class NativeDatadogSpan extends DatadogSpan {
         baggageItems: { ...parent._baggageItems },
         trace: parent._trace,
         tracestate: parent._tracestate,
-        tracerService,
         tracerServiceLower,
       })
 
@@ -300,7 +298,6 @@ class NativeDatadogSpan extends DatadogSpan {
       spanContext = new NativeSpanContext(nativeSpans, {
         traceId: spanId,
         spanId,
-        tracerService,
         tracerServiceLower,
       })
       spanContext._trace.startTime = startTime

--- a/packages/dd-trace/src/native/span_context.js
+++ b/packages/dd-trace/src/native/span_context.js
@@ -22,7 +22,6 @@ const {
   MAX_NAME_LENGTH,
   MAX_SERVICE_LENGTH,
   MAX_TYPE_LENGTH,
-  MAX_RESOURCE_NAME_LENGTH,
   DEFAULT_SPAN_NAME,
   DEFAULT_SERVICE_NAME,
 } = require('../encode/tags-processors')
@@ -64,8 +63,7 @@ function normalizeService (service) {
 }
 
 function normalizeResource (resource, name) {
-  resource ||= name
-  return resource.length > MAX_RESOURCE_NAME_LENGTH ? resource.slice(0, MAX_RESOURCE_NAME_LENGTH) : resource
+  return resource || name
 }
 
 function normalizeType (type) {

--- a/packages/dd-trace/src/native/span_context.js
+++ b/packages/dd-trace/src/native/span_context.js
@@ -41,7 +41,7 @@ const PROCESS_TAGS_META_KEY = '_dd.tags.process'
  * - Has a `_nativeSpanId` (byte buffer) for native operations
  * - `syncFinalTagsToNative()` materializes the final JS wire state into WASM
  */
-const { MEASURED } = tags
+const { BASE_SERVICE, MEASURED } = tags
 const ERROR_META_KEYS = new Set(['error.type', 'error.message', 'error.stack'])
 
 function truncateWithEllipsis (value, max) {
@@ -103,8 +103,7 @@ class NativeSpanContext extends DatadogSpanContext {
    * @param {object} [props.baggageItems] - Baggage items
    * @param {object} [props.trace] - Shared trace object
    * @param {object} [props.tracestate] - W3C tracestate
-   * @param {string} [props.tracerService] - Tracer's configured service name (for BASE_SERVICE)
-   * @param {string} [props.tracerServiceLower] - Lowercase tracer service for extra-service registration
+   * @param {string} [props.tracerServiceLower] - Lowercase tracer service for base-service inference
    */
   constructor (nativeSpans, props) {
     // During super(props), the `_name` setter stores the value locally. Native
@@ -126,7 +125,6 @@ class NativeSpanContext extends DatadogSpanContext {
     leId[6] = beBuf[1]
     leId[7] = beBuf[0]
     this._nativeSpanId = leId
-    this._tracerService = props.tracerService // Store for BASE_SERVICE check
     this._tracerServiceLower = props.tracerServiceLower || ''
   }
 
@@ -230,6 +228,7 @@ class NativeSpanContext extends DatadogSpanContext {
     let service
     let type = ''
     let extraService
+    let baseService
 
     for (const key of Object.keys(tags)) {
       const value = tags[key]
@@ -248,6 +247,9 @@ class NativeSpanContext extends DatadogSpanContext {
         case 'resource.name':
           if (typeof value !== 'string') return false
           resource = truncateWithEllipsis(value, MAX_META_VALUE_LENGTH)
+          break
+        case BASE_SERVICE:
+          baseService = value
           break
         case 'span.type':
           if (typeof value !== 'string') return false
@@ -296,7 +298,15 @@ class NativeSpanContext extends DatadogSpanContext {
     service = normalizeService(service)
     type = normalizeType(type)
 
-    if (extraService !== undefined) registerExtraService(extraService)
+    if (extraService !== undefined) {
+      baseService = this._tracerServiceLower
+      this.setTag(BASE_SERVICE, baseService)
+      registerExtraService(extraService)
+    }
+    if (baseService !== undefined) {
+      if (typeof baseService !== 'string') return false
+      metaBatch.push(BASE_SERVICE, truncateWithEllipsis(baseService, MAX_META_VALUE_LENGTH))
+    }
     this.#syncCoreFields(name, resource, service, type, 0)
     const spanId = this._nativeSpanId
     if (metaBatch.length > 0) this.#nativeSpans.queueBatchMetaFlat(spanId, metaBatch)

--- a/packages/dd-trace/src/native/span_context.js
+++ b/packages/dd-trace/src/native/span_context.js
@@ -455,30 +455,6 @@ class NativeSpanContext extends DatadogSpanContext {
   }
 
   /**
-   * Set the name locally without syncing to native storage.
-   * Used during construction when CreateSpan already set the name natively.
-   * @param {string} name - Span name
-   */
-  _setNameLocal (name) {
-    this[NAME_VALUE] = name
-  }
-
-  /**
-   * Sync the span name to native storage.
-   * Called from NativeDatadogSpan.
-   * @param {string} name - Span name
-   */
-  _syncNameToNative (name) {
-    const stringName = String(name)
-    this.#nativeSpans.queueOp(
-      OpCode.SetName,
-      this._nativeSpanId,
-      stringName
-    )
-    this.#nativeName = stringName
-  }
-
-  /**
    * Apply the OpenTelemetry HTTP semantic-convention remap to this span's
    * native output at finish. Datadog HTTP tags are skipped by
    * syncFinalTagsToNative(), so build a formatted view from the JS tag cache,

--- a/packages/dd-trace/test/native/exporter.spec.js
+++ b/packages/dd-trace/test/native/exporter.spec.js
@@ -306,6 +306,17 @@ describe('NativeExporter', () => {
       sinon.assert.calledOnce(nativeSpans.flushSpansGrouped)
     })
 
+    it('flushes when the pending span cap is reached', () => {
+      const spans = []
+      for (let i = 1; i < 2000; i++) spans.push(createMockSpan(BigInt(i)))
+
+      exporter.export(spans)
+      sinon.assert.notCalled(nativeSpans.flushSpansGrouped)
+
+      exporter.export([createMockSpan(2000n)])
+      sinon.assert.calledOnce(nativeSpans.flushSpansGrouped)
+    })
+
     it('resets native state immediately when explicitly requested while idle', () => {
       exporter._resetNativeStateWhenIdle()
 
@@ -607,8 +618,7 @@ describe('NativeExporter', () => {
       resolveSend('unchanged')
     })
 
-    it('should re-flush queued spans after in-flight settles', async () => {
-      // Spans queued during a send should drain on settle, not stay buffered.
+    it('waits for the scheduled flush when an in-flight send settles before the interval', async () => {
       let resolveSend
       nativeSpans.flushSpansGrouped
         .onFirstCall().callsFake(() => new Promise(resolve => { resolveSend = resolve }))
@@ -617,12 +627,36 @@ describe('NativeExporter', () => {
       exporter.export([createMockSpan(1n)])
       exporter.flush()
       exporter.export([createMockSpan(2n)])
-      exporter.flush()
       assert.strictEqual(exporter._pendingSpans.length, 1)
 
       resolveSend('unchanged')
-      // Drain the .then chain on the first send and the chained re-flush.
       await clock.tickAsync(0)
+
+      sinon.assert.calledOnce(nativeSpans.flushSpansGrouped)
+      assert.strictEqual(exporter._pendingSpans.length, 1)
+
+      await clock.tickAsync(config.flushInterval)
+
+      sinon.assert.calledTwice(nativeSpans.flushSpansGrouped)
+      assert.strictEqual(exporter._pendingSpans.length, 0)
+    })
+
+    it('re-flushes queued spans when their scheduled interval elapsed during an in-flight send', async () => {
+      let resolveSend
+      nativeSpans.flushSpansGrouped
+        .onFirstCall().callsFake(() => new Promise(resolve => { resolveSend = resolve }))
+        .onSecondCall().resolves('unchanged')
+
+      exporter.export([createMockSpan(1n)])
+      exporter.flush()
+      exporter.export([createMockSpan(2n)])
+
+      await clock.tickAsync(config.flushInterval)
+
+      sinon.assert.calledOnce(nativeSpans.flushSpansGrouped)
+      assert.strictEqual(exporter._pendingSpans.length, 1)
+
+      resolveSend('unchanged')
       await clock.tickAsync(0)
 
       sinon.assert.calledTwice(nativeSpans.flushSpansGrouped)

--- a/packages/dd-trace/test/native/span.spec.js
+++ b/packages/dd-trace/test/native/span.spec.js
@@ -101,9 +101,8 @@ describe('NativeDatadogSpan', () => {
     }
 
     // Create a mock NativeSpanContext that tracks tags. The real
-    // class adds syncToNativeOnly / syncOneTagToNative /
-    // _setNameLocal — provide stubs so the production span code can call
-    // them without TypeErrors.
+    // class adds syncToNativeOnly / syncOneTagToNative — provide stubs so the
+    // production span code can call them without TypeErrors.
     NativeSpanContext = function (ns, props) {
       this._nativeSpans = ns
       this._nativeSpanId = props.spanId.toBuffer()
@@ -120,29 +119,10 @@ describe('NativeDatadogSpan', () => {
       // Backing store renamed away from `_tags` so the
       // `eslint-no-private-tags-access` rule does not flag mock-internal access.
       this.tagStore = { ...(props.tags || {}) }
-      // Mirror the production NativeSpanContext shape: `_name` is a getter/setter
-      // pair, and the setter fires `_syncNameToNative` once the context is
-      // `[NATIVE_READY]`. The mock starts ready so `setOperationName` writes
-      // are observed via the stub.
-      let nameValue
-      Object.defineProperty(this, '_name', {
-        configurable: true,
-        get () { return nameValue },
-        set (v) {
-          nameValue = v
-          this._syncNameToNative(v)
-        },
-      })
+      // Production keeps `_name` local until the final snapshot is synchronized.
+      this._name = undefined
       this._hostname = undefined
       this._isFinished = false
-      // Per-instance call tracker. The production NativeDatadogSpan
-      // shadows the prototype's `_syncNameToNative` with a no-op on
-      // the instance during construction (to suppress the parent's
-      // double-SetName), then deletes the shadow once super() returns.
-      // We keep the underlying tracker as `_syncNameToNativeStub` so
-      // tests can still assert against it post-construction.
-      this._syncNameToNativeStub = sinon.stub()
-      this._setNameLocal = (name) => { nameValue = name }
       // Initial tags are seeded into `_tags` by the parent
       // DatadogSpanContext via Object.assign in `getTags()`; the native
       // span constructor then calls `syncToNativeOnly(fields.tags)` to
@@ -170,14 +150,6 @@ describe('NativeDatadogSpan', () => {
         return this.tagStore
       }
     }
-    // `_syncNameToNative` lives on the prototype so the production
-    // `delete spanContext._syncNameToNative` (which removes only the
-    // instance shadow installed during construction) leaves a usable
-    // method behind for post-construction `setOperationName` calls.
-    NativeSpanContext.prototype._syncNameToNative = function (v) {
-      this._syncNameToNativeStub(v)
-    }
-
     // Mock DatadogSpan parent — exercises the relevant constructor
     // surface (calls `_createContext`, sets `_spanContext`, `_name`,
     // tags, hostname, trace.started.push, `_startTime`, `_links`),
@@ -390,12 +362,8 @@ describe('NativeDatadogSpan', () => {
     })
 
     it('should NOT also issue a separate SetName op on init', () => {
-      // CreateSpan already carries the name; the subclass shadows
-      // `_syncNameToNative` with a no-op so the parent constructor's
-      // `_spanContext._name = operationName` line doesn't double-emit.
-      // We assert at the WASM-op level (no SetName op queued) rather
-      // than against the `_syncNameToNative` stub directly, since the
-      // shadow replaces the instance property during construction.
+      // CreateSpan already carries the name. The parent constructor stores it
+      // locally, so construction must not also queue a SetName operation.
       span = new NativeDatadogSpan(tracer, processor, prioritySampler, {
         operationName: 'test-operation',
       }, false, nativeSpans)
@@ -424,7 +392,7 @@ describe('NativeDatadogSpan', () => {
   })
 
   describe('setOperationName', () => {
-    it('should update operation name and sync to native', () => {
+    it('should update operation name locally for final synchronization', () => {
       span = new NativeDatadogSpan(tracer, processor, prioritySampler, {
         operationName: 'original-name',
       }, false, nativeSpans)
@@ -432,10 +400,7 @@ describe('NativeDatadogSpan', () => {
       span.setOperationName('new-name')
 
       assert.strictEqual(span.context()._name, 'new-name')
-      // The prototype `_syncNameToNative` delegates to the per-instance
-      // `_syncNameToNativeStub` (so the construction-time shadow doesn't
-      // erase call history). See the NativeSpanContext mock definition.
-      sinon.assert.calledWith(span.context()._syncNameToNativeStub, 'new-name')
+      sinon.assert.notCalled(nativeSpans.queueOp)
     })
   })
 

--- a/packages/dd-trace/test/native/span.spec.js
+++ b/packages/dd-trace/test/native/span.spec.js
@@ -360,8 +360,8 @@ describe('NativeDatadogSpan', () => {
         traceId128BitGenerationEnabled: true,
       }, false, nativeSpans)
       const childTraceId = nativeSpans.queueCreateSpanFull.getCall(0).args[1]
-      // Child must carry the SAME full 128-bit id, not a high-bits-zeroed one.
-      assert.deepStrictEqual(childTraceId, rootTraceId)
+      // Child reuses the SAME full 128-bit id, not a rebuilt or high-bits-zeroed one.
+      assert.strictEqual(childTraceId, rootTraceId)
     })
 
     it('builds the full 128-bit id for a child of a propagated (16-byte) trace id', () => {

--- a/packages/dd-trace/test/native/span_context.spec.js
+++ b/packages/dd-trace/test/native/span_context.spec.js
@@ -267,6 +267,19 @@ describe('NativeSpanContext', () => {
       sinon.assert.notCalled(nativeSpans.queueBatchMetricsFlat)
     })
 
+    it('preserves resource names longer than the agent normalization threshold', () => {
+      const resource = 'r'.repeat(5_001)
+
+      spanContext._name = 'operation'
+      spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')
+      spanContext.setTag('service.name', 'svc')
+      spanContext.setTag('resource.name', resource)
+
+      assert.strictEqual(spanContext.tryFastFinalTagsToNative(), true)
+
+      sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetResourceName, leSpanId, resource)
+    })
+
     it('falls back without writing for unsupported final tags', () => {
       spanContext._name = 'operation'
       spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')

--- a/packages/dd-trace/test/native/span_context.spec.js
+++ b/packages/dd-trace/test/native/span_context.spec.js
@@ -255,6 +255,7 @@ describe('NativeSpanContext', () => {
       spanContext.setTag('service.name', 'api')
       spanContext.setTag('resource.name', 'GET /users')
       spanContext.setTag('span.type', 'web')
+      spanContext.setTag('_dd.base_service', 'stale')
 
       assert.strictEqual(spanContext.tryFastFinalTagsToNative(), true)
 
@@ -263,6 +264,20 @@ describe('NativeSpanContext', () => {
       sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetServiceName, leSpanId, 'api')
       sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetType, leSpanId, 'web')
       sinon.assert.calledOnceWithExactly(registerExtraService, 'api')
+      assert.strictEqual(spanContext.getTag('_dd.base_service'), 'svc')
+      sinon.assert.calledWith(nativeSpans.queueBatchMetaFlat, leSpanId, ['_dd.base_service', 'svc'])
+      sinon.assert.notCalled(nativeSpans.queueBatchMetricsFlat)
+    })
+
+    it('falls back for a non-string explicit base service', () => {
+      spanContext._name = 'operation'
+      spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')
+      spanContext.setTag('service.name', 'svc')
+      spanContext.setTag('_dd.base_service', 1)
+
+      assert.strictEqual(spanContext.tryFastFinalTagsToNative(), false)
+
+      sinon.assert.notCalled(nativeSpans.queueOp)
       sinon.assert.notCalled(nativeSpans.queueBatchMetaFlat)
       sinon.assert.notCalled(nativeSpans.queueBatchMetricsFlat)
     })

--- a/packages/dd-trace/test/native/span_context.spec.js
+++ b/packages/dd-trace/test/native/span_context.spec.js
@@ -224,7 +224,7 @@ describe('NativeSpanContext', () => {
     })
 
     it('fast-syncs primitive tags without a formatted snapshot', () => {
-      spanContext._setNameLocal('operation')
+      spanContext._name = 'operation'
       spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')
       spanContext.setTag('service.name', 'svc')
       spanContext._sampling.priority = 1
@@ -250,14 +250,15 @@ describe('NativeSpanContext', () => {
     })
 
     it('fast-syncs supported core tag changes', () => {
-      spanContext._setNameLocal('operation')
       spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')
+      spanContext._name = 'renamed-operation'
       spanContext.setTag('service.name', 'api')
       spanContext.setTag('resource.name', 'GET /users')
       spanContext.setTag('span.type', 'web')
 
       assert.strictEqual(spanContext.tryFastFinalTagsToNative(), true)
 
+      sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetName, leSpanId, 'renamed-operation')
       sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetResourceName, leSpanId, 'GET /users')
       sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetServiceName, leSpanId, 'api')
       sinon.assert.calledWith(nativeSpans.queueOp, OpCode.SetType, leSpanId, 'web')
@@ -267,7 +268,7 @@ describe('NativeSpanContext', () => {
     })
 
     it('falls back without writing for unsupported final tags', () => {
-      spanContext._setNameLocal('operation')
+      spanContext._name = 'operation'
       spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')
       spanContext.setTag('object.tag', { nested: true })
 
@@ -280,7 +281,7 @@ describe('NativeSpanContext', () => {
 
     it('falls back before DD HTTP tags when OTel remapping is enabled', () => {
       nativeSpans.otelSemanticsEnabled = true
-      spanContext._setNameLocal('operation')
+      spanContext._name = 'operation'
       spanContext._recordNativeCoreFields('operation', 'operation', 'svc', '')
       spanContext.setTag('http.method', 'GET')
 
@@ -311,26 +312,6 @@ describe('NativeSpanContext', () => {
   // covered by `packages/dd-trace/test/opentracing/span_context.spec.js`. The
   // native subclass adds native-storage sync on setTag (tested above) but
   // doesn't override the read-side accessors, so we don't re-test them here.
-
-  describe('_syncNameToNative', () => {
-    beforeEach(() => {
-      spanContext = new NativeSpanContext(nativeSpans, {
-        traceId: id,
-        spanId: id,
-      })
-    })
-
-    it('should queue SetName operation', () => {
-      spanContext._syncNameToNative('my-operation')
-
-      sinon.assert.calledWith(
-        nativeSpans.queueOp,
-        OpCode.SetName,
-        leSpanId,
-        'my-operation'
-      )
-    })
-  })
 
   describe('OTEL semantics (DD_TRACE_OTEL_SEMANTICS_ENABLED)', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary

Keep the existing flush timer authoritative after an in-flight native send and flush early at 2,000 pending spans. This draft is stacked on #9139.

## Why

The stacked base waits up to two seconds before its first send, then bypasses batching after every settlement. Preserving the timer without a bound retained 1,269–1,773 MiB RSS. Libdatadog does not expose the pre-serialization payload size, so this uses a span-count bound.

The 2,000-span cap was the measured tradeoff. Raising it to 4,000 gained 0.4% CPU while adding 8.9% RSS. Raising it to 8,000 regressed CPU and averaged 633 MiB RSS.

Across three rotated Express/PostgreSQL trials with 50,000 requests each:

- CPU/request: 143.9 → 114.2 µs (-20.7%)
- Throughput: 8,440 → 10,820 requests/s (+28.2%)
- RSS: 1,344 → 371 MiB (-72.4%)
- Agent requests: 1,103 → 175 (-84.1%)

Every trial delivered 50,000 traces and executed 50,000 PostgreSQL queries.

## Test plan

- Run all 53 native exporter unit tests.
- Verify every changed production branch with c8.
- Run the full repository lint.
- Run the fresh-process Express/PostgreSQL benchmark at the default two-second flush interval.
