### PR TITLE
fix(playwright): avoid requesting page fixture in cleanup hook

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-active-test-span/no-page-fixture-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-active-test-span/no-page-fixture-test.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { test: baseTest } = require('@playwright/test')
+
+const test = baseTest.extend({
+  page: async () => {
+    throw new Error('The page fixture must not be initialized')
+  },
+})
+
+test('does not initialize the page fixture', () => {})

--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -147,6 +147,31 @@ versions.forEach((version) => {
 
         await Promise.all([once(proc, 'exit'), receiverPromise])
       })
+
+      it('does not request the page fixture from instrumented hooks', async (receiver, run) => {
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const test = events.find(event => event.type === 'test').content
+
+            assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+          })
+
+        const proc = run(
+          './node_modules/.bin/playwright test -c playwright.config.js no-page-fixture-test.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: './ci-visibility/playwright-tests-active-test-span',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), receiverPromise])
+
+        assert.strictEqual(exitCode, 0)
+      })
     })
 
     contextNewVersions('correlation between tests and RUM sessions', () => {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -67,6 +67,7 @@ const testSuiteToCtx = new Map()
 const testSuiteToTestStatuses = new Map()
 const testSuiteToErrors = new Map()
 const testsToTestStatuses = new Map()
+const activeRumPages = new Set()
 
 const RUM_FLUSH_WAIT_TIME = getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')
 const DD_PROPERTIES_TIMEOUT = 5000
@@ -1929,6 +1930,8 @@ async function handlePageGoto (page) {
     return
   }
 
+  activeRumPages.add(page)
+
   let browserVersion
   try {
     browserVersion = page.context().browser()?.version()
@@ -1962,6 +1965,54 @@ async function handlePageGoto (page) {
     }])
   } catch (error) {
     log.error('Playwright RUM correlation cookie error', error)
+  }
+}
+
+/**
+ * Stops a RUM session and expires its correlation cookie.
+ *
+ * @param {import('playwright-core').Page} page
+ * @returns {Promise<void>}
+ */
+async function cleanupRumPage (page) {
+  try {
+    const isRumActive = await page.evaluate(stopRumSession)
+
+    if (!isRumActive) {
+      return
+    }
+
+    // Give some time RUM to flush data, similar to what we do in selenium
+    await new Promise(resolve => realSetTimeout(resolve, RUM_FLUSH_WAIT_TIME))
+    const url = page.url()
+    if (url) {
+      const domain = new URL(url).hostname
+      await page.context().addCookies([{
+        name: RUM_COOKIE_NAME,
+        value: '',
+        domain,
+        path: '/',
+        expires: 0,
+      }])
+    } else {
+      log.error('RUM is active but page.url() is not available')
+    }
+  } catch (error) {
+    // Cleanup must not change the test result.
+    log.error('afterEach hook error', error)
+  }
+}
+
+/**
+ * Stops RUM sessions and expires correlation cookies for pages visited by the current test.
+ *
+ * @returns {Promise<void>}
+ */
+async function cleanupRumPages () {
+  try {
+    await Promise.all(Array.from(activeRumPages, cleanupRumPage))
+  } finally {
+    activeRumPages.clear()
   }
 }
 
@@ -2014,6 +2065,7 @@ function instrumentWorkerMainMethods (workerMain) {
     }
     test._ddStartTime = performance.now()
     steps = []
+    activeRumPages.clear()
 
     const {
       _requireFile: testSuiteAbsolutePath,
@@ -2077,34 +2129,7 @@ function instrumentWorkerMainMethods (workerMain) {
       if (!existAfterEachHook) {
         test.parent._hooks.push({
           type: 'afterEach',
-          fn: async function ({ page }) {
-            try {
-              if (page) {
-                const isRumActive = await page.evaluate(stopRumSession)
-
-                if (isRumActive) {
-                  // Give some time RUM to flush data, similar to what we do in selenium
-                  await new Promise(resolve => realSetTimeout(resolve, RUM_FLUSH_WAIT_TIME))
-                  const url = page.url()
-                  if (url) {
-                    const domain = new URL(url).hostname
-                    await page.context().addCookies([{
-                      name: RUM_COOKIE_NAME,
-                      value: '',
-                      domain,
-                      path: '/',
-                      expires: 0,
-                    }])
-                  } else {
-                    log.error('RUM is active but page.url() is not available')
-                  }
-                }
-              }
-            } catch (e) {
-              // ignore errors
-              log.error('afterEach hook error', e)
-            }
-          },
+          fn: cleanupRumPages,
           title: 'afterEach hook',
           _ddHook: true,
         })

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -2006,14 +2006,14 @@ async function cleanupRumPage (page) {
 /**
  * Stops RUM sessions and expires correlation cookies for pages visited by the current test.
  *
- * @returns {Promise<void>}
+ * @returns {Promise<void[]>|undefined}
  */
-async function cleanupRumPages () {
-  try {
-    await Promise.all(Array.from(activeRumPages, cleanupRumPage))
-  } finally {
-    activeRumPages.clear()
-  }
+function cleanupRumPages () {
+  if (activeRumPages.size === 0) return
+
+  const cleanupPromises = Array.from(activeRumPages, cleanupRumPage)
+  activeRumPages.clear()
+  return Promise.all(cleanupPromises)
 }
 
 addHook({


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stops the Playwright instrumentation's synthetic `afterEach` hook from requesting the built-in `page` fixture.
Instead, the instrumentation records pages where it detects an active RUM session and cleans those pages after the
test without declaring any fixture dependencies. The tracked pages are cleared between tests, and cleanup failures
remain isolated from the test result.

Adds an integration regression whose `page` fixture throws if Playwright initializes it. This pins that instrumented
tests which do not use a page, including Electron-only or API-only tests, remain fixture-free.

### Motivation
<!-- What inspired you to submit this pull request? -->

Playwright resolves fixture dependencies from hook parameter names. The injected `afterEach({ page })` therefore
initialized a Chromium page for every instrumented test, even when the test only used Electron. Besides requiring a
browser installation, this could leave Chromium running alongside Electron workers and contribute to startup
timeouts under constrained CI resources.

Tracking pages observed by the existing RUM navigation hook preserves RUM session and correlation-cookie cleanup
without implicitly launching a browser. It also cleans the page that generated the RUM activity rather than an
unrelated default page.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- Targeted ESLint passed for all three changed files.
- The complete latest Playwright active-test-span spec passed: 22 tests.
- The no-page fixture regression passed on Playwright 1.38.0.
- All 11 Playwright page-navigation instrumentation unit tests passed.

The existing browser-backed RUM test for Playwright 1.38.0 could not launch its Chromium 117 binary on the local
macOS arm64 host. The fixture-free regression passed on that version, and the complete RUM suite passed with the
latest Playwright version.
