### PR TITLE
fix(next): preserve http endpoint for parent spans

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -5,7 +5,7 @@ const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
-const { HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
+const { HTTP_ENDPOINT, HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
 
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
 const reusedNextRequestStores = new WeakSet()
@@ -171,6 +171,7 @@ function setHttpParentRoute (span, method, page, isStatic) {
   if (currentRoute && (nextParentRoutes.get(span) !== currentRoute || isStatic)) return
 
   span.setTag(HTTP_ROUTE, page)
+  span.setTag(HTTP_ENDPOINT, page)
   span.setTag(RESOURCE_NAME, `${method} ${page}`.trim())
   nextParentRoutes.set(span, page)
 }

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -136,7 +136,7 @@ class NextPlugin extends ServerPlugin {
       'resource.name': `${req.method} ${page}`.trim(),
       'next.page': page,
     })
-    setHttpParentRoute(httpParentSpan, req.method, page, isStatic)
+    setHttpParentRoute(httpParentSpan, req.method, page, isStatic, this.config.resourceRenamingEnabled)
     web.setRoute(req, page)
   }
 
@@ -163,7 +163,7 @@ function normalizeAppPath (page) {
   return page
 }
 
-function setHttpParentRoute (span, method, page, isStatic) {
+function setHttpParentRoute (span, method, page, isStatic, resourceRenamingEnabled) {
   if (!span) return
   const currentRoute = span.context().getTag(HTTP_ROUTE)
 
@@ -171,7 +171,7 @@ function setHttpParentRoute (span, method, page, isStatic) {
   if (currentRoute && (nextParentRoutes.get(span) !== currentRoute || isStatic)) return
 
   span.setTag(HTTP_ROUTE, page)
-  span.setTag(HTTP_ENDPOINT, page)
+  if (resourceRenamingEnabled) span.setTag(HTTP_ENDPOINT, page)
   span.setTag(RESOURCE_NAME, `${method} ${page}`.trim())
   nextParentRoutes.set(span, page)
 }

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -5,7 +5,7 @@ const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
-const { HTTP_ENDPOINT, HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
+const { HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
 
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
 const reusedNextRequestStores = new WeakSet()
@@ -136,7 +136,8 @@ class NextPlugin extends ServerPlugin {
       'resource.name': `${req.method} ${page}`.trim(),
       'next.page': page,
     })
-    setHttpParentRoute(httpParentSpan, req.method, page, isStatic, this.config.resourceRenamingEnabled)
+    web.setRouteOrEndpointTag(req)
+    setHttpParentRoute(httpParentSpan, req.method, page, isStatic)
     web.setRoute(req, page)
   }
 
@@ -163,7 +164,7 @@ function normalizeAppPath (page) {
   return page
 }
 
-function setHttpParentRoute (span, method, page, isStatic, resourceRenamingEnabled) {
+function setHttpParentRoute (span, method, page, isStatic) {
   if (!span) return
   const currentRoute = span.context().getTag(HTTP_ROUTE)
 
@@ -171,7 +172,6 @@ function setHttpParentRoute (span, method, page, isStatic, resourceRenamingEnabl
   if (currentRoute && (nextParentRoutes.get(span) !== currentRoute || isStatic)) return
 
   span.setTag(HTTP_ROUTE, page)
-  if (resourceRenamingEnabled) span.setTag(HTTP_ENDPOINT, page)
   span.setTag(RESOURCE_NAME, `${method} ${page}`.trim())
   nextParentRoutes.set(span, page)
 }

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -52,8 +52,10 @@ class NextPlugin extends ServerPlugin {
 
     analyticsSampler.sample(span, this.config.measured, true)
 
-    const httpParentSpan = parentSpan?._integrationName === 'http' ? parentSpan : undefined
-    return { ...store, span, req, httpParentSpan }
+    const isHttpParent = parentSpan?._integrationName === 'http'
+    const httpParentSpan = isHttpParent ? parentSpan : undefined
+    const httpParentReq = isHttpParent ? store.req : undefined
+    return { ...store, span, req, httpParentSpan, httpParentReq }
   }
 
   error ({ span, error }) {
@@ -105,7 +107,7 @@ class NextPlugin extends ServerPlugin {
 
     if (!store) return
 
-    const { span, req, httpParentSpan } = store
+    const { span, req, httpParentReq, httpParentSpan } = store
 
     // safeguard against missing req in complicated timeout scenarios
     if (!req) return
@@ -136,9 +138,10 @@ class NextPlugin extends ServerPlugin {
       'resource.name': `${req.method} ${page}`.trim(),
       'next.page': page,
     })
-    web.setRouteOrEndpointTag(req)
+    const routeRequest = httpParentReq || req
+    web.setRouteOrEndpointTag(routeRequest)
     setHttpParentRoute(httpParentSpan, req.method, page, isStatic)
-    web.setRoute(req, page)
+    web.setRoute(routeRequest, page)
   }
 
   configure (config) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -54,7 +54,7 @@ class NextPlugin extends ServerPlugin {
 
     const isHttpParent = parentSpan?._integrationName === 'http'
     const httpParentSpan = isHttpParent ? parentSpan : undefined
-    const httpParentReq = isHttpParent ? store.req : undefined
+    const httpParentReq = isHttpParent ? web.getRequest(parentSpan) : undefined
     return { ...store, span, req, httpParentSpan, httpParentReq }
   }
 

--- a/packages/datadog-plugin-next/test/datadog.js
+++ b/packages/datadog-plugin-next/test/datadog.js
@@ -22,7 +22,10 @@ const tracer = require('../../..').init({
 }).use('next', process.env.WITH_CONFIG ? config : true)
 
 if (process.env.WITH_HTTP !== 'false') {
-  tracer.use('http')
+  const httpConfig = process.env.WITH_HTTP_RESOURCE_RENAMING === 'true'
+    ? { resourceRenamingEnabled: true }
+    : true
+  tracer.use('http', httpConfig)
 }
 
 module.exports = tracer

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -85,7 +85,7 @@ describe('Plugin', function () {
       after(done => downstreamServer.close(done))
 
       const startServer = (
-        { withConfig, standalone, withHttp = true, serverFile = 'server' },
+        { withConfig, standalone, withHttp = true, httpResourceRenamingEnabled = false, serverFile = 'server' },
         schemaVersion = 'v0',
         defaultToGlobalService = false
       ) => {
@@ -110,6 +110,7 @@ describe('Plugin', function () {
               DD_TRACE_AGENT_PORT: agent.server.address().port,
               WITH_CONFIG: withConfig,
               WITH_HTTP: String(withHttp),
+              WITH_HTTP_RESOURCE_RENAMING: String(httpResourceRenamingEnabled),
               DD_TRACE_SPAN_ATTRIBUTE_SCHEMA: schemaVersion,
               DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED: defaultToGlobalService,
               // eslint-disable-next-line n/no-path-concat
@@ -364,6 +365,7 @@ describe('Plugin', function () {
 
                 assert.strictEqual(spans[0].name, 'web.request')
                 assert.strictEqual(spans[0].resource, 'GET /api/hello/[name]')
+                assert.strictEqual(spans[0].meta['http.endpoint'], undefined)
                 assert.strictEqual(spans[1].name, 'next.request')
                 assert.strictEqual(spans[1].parent_id.toString(), spans[0].span_id.toString())
               })
@@ -694,7 +696,7 @@ describe('Plugin', function () {
 
       if (satisfies(pkg.version, '>=13.4.0')) {
         describe('with app directory', () => {
-          startServer({ withConfig: false, standalone: false })
+          startServer({ withConfig: false, standalone: false, httpResourceRenamingEnabled: true })
 
           it('should infer the correct resource path for appDir routes', done => {
             agent

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1021,7 +1021,10 @@ describe('compiled Next runtimes', () => {
     let tracer
 
     before(async () => {
-      tracer = await agent.load('next')
+      tracer = await agent.load(
+        ['next', 'http'],
+        [{ resourceRenamingEnabled: false }, { client: false, resourceRenamingEnabled: true }]
+      )
       dc.channel('dd-trace:instrumentation:load').publish({ name: 'next' })
     })
     after(() => agent.close())
@@ -1077,9 +1080,6 @@ describe('compiled Next runtimes', () => {
     })
 
     it('uses HTTP resource renaming for dynamic App Routes', async () => {
-      agent.reload('next', { resourceRenamingEnabled: false })
-      agent.reload('http', { client: false, resourceRenamingEnabled: true })
-
       class AppRouteRouteModule {
         definition = { pathname: '/api/users/[id]' }
 
@@ -1091,7 +1091,11 @@ describe('compiled Next runtimes', () => {
 
       const routeModule = new AppRouteRouteModule()
       const routeServer = http.createServer(async (req, res) => {
-        const response = await routeModule.handle(req, {})
+        const request = new Request(`http://127.0.0.1${req.url}`, {
+          headers: req.headers,
+          method: req.method,
+        })
+        const response = await routeModule.handle(request, {})
         res.writeHead(response.status)
         res.end()
       })

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1076,9 +1076,12 @@ describe('compiled Next runtimes', () => {
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
     })
 
-    it('does not add an HTTP endpoint when resource renaming is disabled', async () => {
+    it('uses HTTP resource renaming for dynamic App Routes', async () => {
+      agent.reload('next', { resourceRenamingEnabled: false })
+      agent.reload('http', { client: false, resourceRenamingEnabled: true })
+
       class AppRouteRouteModule {
-        definition = { pathname: '/api/http-parent' }
+        definition = { pathname: '/api/users/[id]' }
 
         handle () {
           return Promise.resolve({ status: 200 })
@@ -1086,56 +1089,29 @@ describe('compiled Next runtimes', () => {
       }
       getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
 
-      const httpParentSpan = tracer.startSpan('web.request', {
-        integrationName: 'http',
-        tags: { 'http.method': 'GET' },
+      const routeModule = new AppRouteRouteModule()
+      const routeServer = http.createServer(async (req, res) => {
+        const response = await routeModule.handle(req, {})
+        res.writeHead(response.status)
+        res.end()
       })
+      await new Promise(resolve => routeServer.listen(0, '127.0.0.1', resolve))
+      const routePort = routeServer.address().port
       const trace = agent.assertSomeTraces(traces => {
         const httpSpan = traces[0].find(span => span.name === 'web.request')
         assert.ok(httpSpan)
-        assert.strictEqual(httpSpan.resource, 'GET /api/http-parent')
-        assert.strictEqual(httpSpan.meta['http.route'], '/api/http-parent')
-        assert.strictEqual(httpSpan.meta['http.endpoint'], undefined)
+        assert.strictEqual(httpSpan.resource, 'GET /api/users/[id]')
+        assert.strictEqual(httpSpan.meta['http.route'], '/api/users/[id]')
+        assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/users/{param:int}')
       })
 
-      await storage('legacy').run(
-        { span: httpParentSpan },
-        () => new AppRouteRouteModule().handle({ headers: {}, method: 'GET', url: '/api/http-parent' }, {})
-      )
-      httpParentSpan.finish()
-      await trace
-    })
-
-    it('preserves the HTTP endpoint when resource renaming is enabled', async () => {
-      agent.reload('next', { resourceRenamingEnabled: true })
-
-      class AppRouteRouteModule {
-        definition = { pathname: '/api/http-parent-enabled' }
-
-        handle () {
-          return Promise.resolve({ status: 200 })
-        }
+      try {
+        const response = await axios.get(`http://127.0.0.1:${routePort}/api/users/123`)
+        assert.strictEqual(response.status, 200)
+        await trace
+      } finally {
+        await new Promise(resolve => routeServer.close(resolve))
       }
-      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
-
-      const httpParentSpan = tracer.startSpan('web.request', {
-        integrationName: 'http',
-        tags: { 'http.method': 'GET' },
-      })
-      const trace = agent.assertSomeTraces(traces => {
-        const httpSpan = traces[0].find(span => span.name === 'web.request')
-        assert.ok(httpSpan)
-        assert.strictEqual(httpSpan.resource, 'GET /api/http-parent-enabled')
-        assert.strictEqual(httpSpan.meta['http.route'], '/api/http-parent-enabled')
-        assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/http-parent-enabled')
-      })
-
-      await storage('legacy').run(
-        { span: httpParentSpan },
-        () => new AppRouteRouteModule().handle({ headers: {}, method: 'GET', url: '/api/http-parent-enabled' }, {})
-      )
-      httpParentSpan.finish()
-      await trace
     })
 
     it('records Pages API errors and status without an existing request store', async () => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1023,10 +1023,8 @@ describe('compiled Next runtimes', () => {
   })
 
   describe('as the first tracing entrypoint', () => {
-    let tracer
-
     before(async () => {
-      tracer = await agent.load('next')
+      await agent.load('next')
       dc.channel('dd-trace:instrumentation:load').publish({ name: 'next' })
     })
     after(() => agent.close())

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -18,7 +18,6 @@ const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { storage } = require('../../datadog-core')
 const instrumentations = require('../../datadog-instrumentations/src/helpers/instrumentations')
 require('../../datadog-instrumentations/src/next')
-const web = require('../../dd-trace/src/plugins/util/web')
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { NODE_MAJOR } = require('../../../version')
@@ -734,17 +733,22 @@ describe('Plugin', function () {
                 const spans = traces[0]
                 const requestSpans = spans.filter(span => span.name === 'next.request')
                 const routeSpan = requestSpans.find(span => span.resource === 'GET /api/appRouteTrace/[name]')
+                const httpSpan = spans.find(span => span.name === 'web.request')
                 const downstreamSpan = spans.find(span => span.name === 'http.request' &&
                   span.meta['http.url'] === `http://127.0.0.1:${downstreamPort}/downstream`)
 
                 assert.strictEqual(requestSpans.length, 1)
                 assert.ok(routeSpan)
+                assert.ok(httpSpan)
+                assert.strictEqual(httpSpan.resource, 'GET /api/appRouteTrace/[name]')
+                assert.strictEqual(httpSpan.meta['http.route'], '/api/appRouteTrace/[name]')
+                assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/appRouteTrace/{param:int}')
                 assert.ok(downstreamSpan)
                 assert.strictEqual(downstreamSpan.parent_id.toString(), routeSpan.span_id.toString())
               })
 
               return Promise.all([
-                axios.get(`http://127.0.0.1:${port}/api/appRouteTrace/hello`),
+                axios.get(`http://127.0.0.1:${port}/api/appRouteTrace/123`),
                 tracePromise,
               ])
             })
@@ -1075,43 +1079,6 @@ describe('compiled Next runtimes', () => {
       dc.channel('apm:next:request:start').unsubscribe(onStart)
       dc.channel('apm:next:page:load').unsubscribe(onPage)
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
-    })
-
-    it('uses HTTP resource renaming for dynamic App Routes', async () => {
-      class AppRouteRouteModule {
-        definition = { pathname: '/api/users/[id]' }
-
-        handle () {
-          return Promise.resolve({ status: 200 })
-        }
-      }
-      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
-
-      const routeModule = new AppRouteRouteModule()
-      const nodeRequest = { headers: {}, method: 'GET', url: '/api/users/123' }
-      const nodeResponse = {
-        getHeader: () => undefined,
-        getHeaders: () => ({}),
-        statusCode: 200,
-      }
-      const httpParentSpan = web.startSpan(
-        tracer,
-        web.normalizeConfig({ resourceRenamingEnabled: true }),
-        nodeRequest,
-        nodeResponse,
-        'web.request'
-      )
-      httpParentSpan._integrationName = 'http'
-
-      await storage('legacy').run({ span: httpParentSpan }, () => {
-        const request = new Request('http://127.0.0.1/api/users/123', { method: 'GET' })
-        return routeModule.handle(request, {})
-      })
-
-      assert.strictEqual(httpParentSpan.context().getTag('resource.name'), 'GET /api/users/[id]')
-      assert.strictEqual(httpParentSpan.context().getTag('http.route'), '/api/users/[id]')
-      assert.strictEqual(httpParentSpan.context().getTag('http.endpoint'), '/api/users/{param:int}')
-      web.finishAll(web.getContext(nodeRequest))
     })
 
     it('records Pages API errors and status without an existing request store', async () => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1076,7 +1076,7 @@ describe('compiled Next runtimes', () => {
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
     })
 
-    it('preserves the HTTP endpoint when an App Route resolves an HTTP parent', async () => {
+    it('does not add an HTTP endpoint when resource renaming is disabled', async () => {
       class AppRouteRouteModule {
         definition = { pathname: '/api/http-parent' }
 
@@ -1095,12 +1095,44 @@ describe('compiled Next runtimes', () => {
         assert.ok(httpSpan)
         assert.strictEqual(httpSpan.resource, 'GET /api/http-parent')
         assert.strictEqual(httpSpan.meta['http.route'], '/api/http-parent')
-        assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/http-parent')
+        assert.strictEqual(httpSpan.meta['http.endpoint'], undefined)
       })
 
       await storage('legacy').run(
         { span: httpParentSpan },
         () => new AppRouteRouteModule().handle({ headers: {}, method: 'GET', url: '/api/http-parent' }, {})
+      )
+      httpParentSpan.finish()
+      await trace
+    })
+
+    it('preserves the HTTP endpoint when resource renaming is enabled', async () => {
+      agent.reload('next', { resourceRenamingEnabled: true })
+
+      class AppRouteRouteModule {
+        definition = { pathname: '/api/http-parent-enabled' }
+
+        handle () {
+          return Promise.resolve({ status: 200 })
+        }
+      }
+      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
+
+      const httpParentSpan = tracer.startSpan('web.request', {
+        integrationName: 'http',
+        tags: { 'http.method': 'GET' },
+      })
+      const trace = agent.assertSomeTraces(traces => {
+        const httpSpan = traces[0].find(span => span.name === 'web.request')
+        assert.ok(httpSpan)
+        assert.strictEqual(httpSpan.resource, 'GET /api/http-parent-enabled')
+        assert.strictEqual(httpSpan.meta['http.route'], '/api/http-parent-enabled')
+        assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/http-parent-enabled')
+      })
+
+      await storage('legacy').run(
+        { span: httpParentSpan },
+        () => new AppRouteRouteModule().handle({ headers: {}, method: 'GET', url: '/api/http-parent-enabled' }, {})
       )
       httpParentSpan.finish()
       await trace

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1018,8 +1018,10 @@ describe('compiled Next runtimes', () => {
   })
 
   describe('as the first tracing entrypoint', () => {
+    let tracer
+
     before(async () => {
-      await agent.load('next')
+      tracer = await agent.load('next')
       dc.channel('dd-trace:instrumentation:load').publish({ name: 'next' })
     })
     after(() => agent.close())
@@ -1072,6 +1074,36 @@ describe('compiled Next runtimes', () => {
       dc.channel('apm:next:request:start').unsubscribe(onStart)
       dc.channel('apm:next:page:load').unsubscribe(onPage)
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
+    })
+
+    it('preserves the HTTP endpoint when an App Route resolves an HTTP parent', async () => {
+      class AppRouteRouteModule {
+        definition = { pathname: '/api/http-parent' }
+
+        handle () {
+          return Promise.resolve({ status: 200 })
+        }
+      }
+      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
+
+      const httpParentSpan = tracer.startSpan('web.request', {
+        integrationName: 'http',
+        tags: { 'http.method': 'GET' },
+      })
+      const trace = agent.assertSomeTraces(traces => {
+        const httpSpan = traces[0].find(span => span.name === 'web.request')
+        assert.ok(httpSpan)
+        assert.strictEqual(httpSpan.resource, 'GET /api/http-parent')
+        assert.strictEqual(httpSpan.meta['http.route'], '/api/http-parent')
+        assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/http-parent')
+      })
+
+      await storage('legacy').run(
+        { span: httpParentSpan },
+        () => new AppRouteRouteModule().handle({ headers: {}, method: 'GET', url: '/api/http-parent' }, {})
+      )
+      httpParentSpan.finish()
+      await trace
     })
 
     it('records Pages API errors and status without an existing request store', async () => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -18,6 +18,7 @@ const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { storage } = require('../../datadog-core')
 const instrumentations = require('../../datadog-instrumentations/src/helpers/instrumentations')
 require('../../datadog-instrumentations/src/next')
+const web = require('../../dd-trace/src/plugins/util/web')
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { NODE_MAJOR } = require('../../../version')
@@ -1021,10 +1022,7 @@ describe('compiled Next runtimes', () => {
     let tracer
 
     before(async () => {
-      tracer = await agent.load(
-        ['next', 'http'],
-        [{ resourceRenamingEnabled: false }, { client: false, resourceRenamingEnabled: true }]
-      )
+      tracer = await agent.load('next')
       dc.channel('dd-trace:instrumentation:load').publish({ name: 'next' })
     })
     after(() => agent.close())
@@ -1090,32 +1088,30 @@ describe('compiled Next runtimes', () => {
       getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
 
       const routeModule = new AppRouteRouteModule()
-      const routeServer = http.createServer(async (req, res) => {
-        const request = new Request(`http://127.0.0.1${req.url}`, {
-          headers: req.headers,
-          method: req.method,
-        })
-        const response = await routeModule.handle(request, {})
-        res.writeHead(response.status)
-        res.end()
-      })
-      await new Promise(resolve => routeServer.listen(0, '127.0.0.1', resolve))
-      const routePort = routeServer.address().port
-      const trace = agent.assertSomeTraces(traces => {
-        const httpSpan = traces[0].find(span => span.name === 'web.request')
-        assert.ok(httpSpan)
-        assert.strictEqual(httpSpan.resource, 'GET /api/users/[id]')
-        assert.strictEqual(httpSpan.meta['http.route'], '/api/users/[id]')
-        assert.strictEqual(httpSpan.meta['http.endpoint'], '/api/users/{param:int}')
+      const nodeRequest = { headers: {}, method: 'GET', url: '/api/users/123' }
+      const nodeResponse = {
+        getHeader: () => undefined,
+        getHeaders: () => ({}),
+        statusCode: 200,
+      }
+      const httpParentSpan = web.startSpan(
+        tracer,
+        web.normalizeConfig({ resourceRenamingEnabled: true }),
+        nodeRequest,
+        nodeResponse,
+        'web.request'
+      )
+      httpParentSpan._integrationName = 'http'
+
+      await storage('legacy').run({ span: httpParentSpan }, () => {
+        const request = new Request('http://127.0.0.1/api/users/123', { method: 'GET' })
+        return routeModule.handle(request, {})
       })
 
-      try {
-        const response = await axios.get(`http://127.0.0.1:${routePort}/api/users/123`)
-        assert.strictEqual(response.status, 200)
-        await trace
-      } finally {
-        await new Promise(resolve => routeServer.close(resolve))
-      }
+      assert.strictEqual(httpParentSpan.context().getTag('resource.name'), 'GET /api/users/[id]')
+      assert.strictEqual(httpParentSpan.context().getTag('http.route'), '/api/users/[id]')
+      assert.strictEqual(httpParentSpan.context().getTag('http.endpoint'), '/api/users/{param:int}')
+      web.finishAll(web.getContext(nodeRequest))
     })
 
     it('records Pages API errors and status without an existing request store', async () => {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -313,6 +313,7 @@ const web = {
     web.finishMiddleware(context)
 
     web.finishSpan(context, spanType)
+    requests.delete(context.span)
 
     finishInferredProxySpan(context)
   },

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -34,6 +34,7 @@ const HTTP_CLIENT_IP = tags.HTTP_CLIENT_IP
 const MANUAL_DROP = tags.MANUAL_DROP
 
 const contexts = new WeakMap()
+const requests = new WeakMap()
 
 // TODO: change this to no longer rely on creating a dummy plugin to be able to access startSpan
 function createWebPlugin (tracer, config = {}) {
@@ -127,6 +128,7 @@ const web = {
     context.tracer = tracer
     context.span = span
     context.res = res
+    requests.set(span, req)
 
     this.setConfig(req, config)
     addRequestTags(context, this.TYPE)
@@ -339,6 +341,9 @@ const web = {
   },
   getContext (req) {
     return contexts.get(req)
+  },
+  getRequest (span) {
+    return requests.get(span)
   },
   setRouteOrEndpointTag (req) {
     const context = contexts.get(req)


### PR DESCRIPTION
## Summary
- preserve the legacy `http.endpoint` tag when compiled Next runtimes refine the HTTP parent route
- restores the resource-renaming contract regressed by #9627

## Verification
- system-tests `TRACING_CONFIG_NONDEFAULT_3` / `test_http_endpoint_root` against the real Next 14.0.4 app
  - pre-#9627 tracer: passes
  - #9627 tracer: fails with `assert None == "/"`
  - this branch: passes and emits both `http.endpoint: "/"` and `http.route: "/"`

Focused ESLint could not run locally because the shared dependency tree has an incompatible `eslint-plugin-unicorn` version for the current config; CI will validate lint.