### PR TITLE
fix(test-optimization): preserve Jest parameters across retries

### DIFF
--- a/integration-tests/ci-visibility/jest-flaky/parameterized-fails.js
+++ b/integration-tests/ci-visibility/jest-flaky/parameterized-fails.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+describe('test-flaky-test-retries', () => {
+  test.each([
+    ['passing row', true],
+    ['failing row', false],
+  ])('preserves parameters between retries', (row, shouldPass) => {
+    assert.strictEqual(shouldPass, true, row)
+  })
+})

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -33,6 +33,7 @@ const {
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
   TEST_NAME,
+  TEST_PARAMETERS,
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_RETRY_REASON,
   DI_ERROR_DEBUG_INFO_CAPTURED,
@@ -4280,6 +4281,73 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           done()
         }).catch(done)
       })
+    })
+
+    it('preserves parameterized test identity between automatic retries', async () => {
+      receiver.setSettings({
+        itr_enabled: false,
+        code_coverage: false,
+        tests_skipping: false,
+        flaky_test_retries_enabled: true,
+        early_flake_detection: {
+          enabled: false,
+        },
+      })
+
+      const testSuite = 'ci-visibility/jest-flaky/parameterized-fails.js'
+      const testName = 'test-flaky-test-retries preserves parameters between retries'
+      const passingAttempt = {
+        isRetry: false,
+        parameters: { arguments: ['passing row', true], metadata: {} },
+        retryReason: undefined,
+        status: 'pass',
+      }
+      const failingAttempt = {
+        isRetry: false,
+        parameters: { arguments: ['failing row', false], metadata: {} },
+        retryReason: undefined,
+        status: 'fail',
+      }
+      const retryAttempt = {
+        isRetry: true,
+        parameters: { arguments: ['failing row', false], metadata: {} },
+        retryReason: TEST_RETRY_REASON_TYPES.atr,
+        status: 'fail',
+      }
+      const expectedAttempts = JEST_VERSION === 'latest'
+        ? [failingAttempt, passingAttempt, retryAttempt]
+        : [passingAttempt, failingAttempt, retryAttempt]
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events
+            .filter(event => event.type === 'test')
+            .map(event => event.content)
+            .filter(test => test.meta[TEST_SUITE] === testSuite && test.meta[TEST_NAME] === testName)
+            .sort((a, b) => a.start < b.start ? -1 : a.start > b.start ? 1 : 0)
+
+          assert.deepStrictEqual(tests.map(test => ({
+            isRetry: test.meta[TEST_IS_RETRY] === 'true',
+            parameters: JSON.parse(test.meta[TEST_PARAMETERS]),
+            retryReason: test.meta[TEST_RETRY_REASON],
+            status: test.meta[TEST_STATUS],
+          })), expectedAttempts)
+        })
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisEvpProxyConfig(receiver.port),
+            TESTS_TO_RUN: 'jest-flaky/parameterized-fails',
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            ...(JEST_VERSION === 'latest' ? { JEST_RANDOMIZE: '1', JEST_SEED: '4' } : {}),
+          },
+        }
+      )
+
+      await Promise.all([once(childProcess, 'exit'), eventsPromise])
     })
 
     it('is disabled if DD_CIVISIBILITY_FLAKY_RETRY_ENABLED is false', (done) => {

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -4314,9 +4314,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         retryReason: TEST_RETRY_REASON_TYPES.atr,
         status: 'fail',
       }
-      const expectedAttempts = JEST_VERSION === 'latest'
-        ? [failingAttempt, passingAttempt, retryAttempt]
-        : [passingAttempt, failingAttempt, retryAttempt]
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
@@ -4324,14 +4321,24 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             .filter(event => event.type === 'test')
             .map(event => event.content)
             .filter(test => test.meta[TEST_SUITE] === testSuite && test.meta[TEST_NAME] === testName)
-            .sort((a, b) => a.start < b.start ? -1 : a.start > b.start ? 1 : 0)
 
-          assert.deepStrictEqual(tests.map(test => ({
+          const attempts = tests.map(test => ({
             isRetry: test.meta[TEST_IS_RETRY] === 'true',
             parameters: JSON.parse(test.meta[TEST_PARAMETERS]),
             retryReason: test.meta[TEST_RETRY_REASON],
             status: test.meta[TEST_STATUS],
-          })), expectedAttempts)
+          }))
+
+          assert.strictEqual(attempts.length, 3)
+          assert.deepStrictEqual(
+            attempts.find(({ isRetry, status }) => !isRetry && status === 'pass'),
+            passingAttempt
+          )
+          assert.deepStrictEqual(
+            attempts.find(({ isRetry, status }) => !isRetry && status === 'fail'),
+            failingAttempt
+          )
+          assert.deepStrictEqual(attempts.find(({ isRetry }) => isRetry), retryAttempt)
         })
 
       childProcess = exec(

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -632,6 +632,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       this.concurrentTestContexts = new Map()
       this.concurrentTestStates = new WeakMap()
       this.concurrentTestSourceFns = new WeakMap()
+      this.testParametersByFunction = new WeakMap()
       this.wrappedConcurrentTestFunctions = new WeakSet()
       this.jestEachBind = undefined
       this.#activeDetachedEfdRetries = 0
@@ -708,6 +709,53 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         }
         this.wrapCustomHandleTestEvent(DatadogEnvironment.prototype.handleTestEvent)
         return result
+      }
+    }
+
+    /**
+     * Rebuilds serial `test.each` so every generated row function keeps its parameters.
+     *
+     * @param {Function|undefined} test
+     * @returns {void}
+     */
+    bindTestEach (test) {
+      if (typeof test?.each !== 'function') return
+
+      const bind = this.getJestEachBind()
+      if (typeof bind !== 'function') {
+        const environment = this
+        shimmer.wrap(test, 'each', each => function (...args) {
+          const testParameters = getFormattedJestTestParameters(args)
+          const eachBind = each.apply(this, args)
+          return function (...args) {
+            const [testName] = args
+            environment.setNameToParams(testName, testParameters)
+            return eachBind.apply(this, args)
+          }
+        })
+        return
+      }
+
+      // Jest creates each row function at runtime, so Orchestrion cannot associate parameters statically.
+      const environment = this
+      test.each = function wrappedTestEach (...eachArgs) {
+        const testParameters = getFormattedJestTestParameters(eachArgs)
+        return function (...testArgs) {
+          let parameterIndex = 0
+          const eachTest = function (testName, testFn, ...callArgs) {
+            const parameters = testParameters?.[parameterIndex++]
+            if (parameters !== undefined && typeof testFn === 'function') {
+              environment.appendNameToParams(testName, parameters)
+              environment.testParametersByFunction.set(
+                testFn,
+                getTestParametersString(environment.nameToParams, testName)
+              )
+            }
+            return test.call(this, testName, testFn, ...callArgs)
+          }
+          const eachBind = bind(eachTest).apply(this, eachArgs)
+          return eachBind.apply(this, testArgs)
+        }
       }
     }
 
@@ -1816,18 +1864,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
       if (event.name === 'setup') {
         this.wrapConcurrentTest(state)
-      }
-      if (event.name === 'setup' && this.global.test) {
-        const environment = this
-        shimmer.wrap(this.global.test, 'each', each => function (...args) {
-          const testParameters = getFormattedJestTestParameters(args)
-          const eachBind = each.apply(this, args)
-          return function (...args) {
-            const [testName] = args
-            environment.setNameToParams(testName, testParameters)
-            return eachBind.apply(this, args)
-          }
-        })
+        this.bindTestEach(this.global.test)
       }
       if (
         event.name === 'run_describe_start' &&
@@ -1888,6 +1925,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         let numOfAttemptsToFixRetries = null
         const testParameters = concurrentCtx?.testParameters ||
           concurrentTestState?.ctx?.testParameters ||
+          this.testParametersByFunction.get(event.test.fn) ||
           getTestParametersString(this.nameToParams, event.test.name)
 
         if (isAttemptToFix) {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Associates serial Jest `test.each` parameters with each generated row function instead of consuming a name-keyed queue at execution time. Automatic retries and randomized execution now retain the same `test.parameters` as the original attempt.

Adds an end-to-end Jest regression covering duplicate parameterized test names, randomized ordering, and an all-failing automatic retry.

### Motivation
The Jest instrumentation stored `test.each` row parameters in a FIFO queue keyed by the expanded test name, then destructively consumed the next entry whenever Jest emitted `test_start`. This assumed that rows would execute in registration order and that each row would execute only once.

Jest can randomize the initial row order and defers automatic retries until the other rows have run. Randomization could therefore associate an initial attempt with a sibling row's parameters. By the time a retry started, the name-keyed queue was exhausted, so the retry was reported with `test.parameters` containing only empty metadata instead of the failed row's arguments.

The retry event was still emitted and tagged as an automatic retry, but its parameter-based test identity no longer matched the original failed attempt. As a result, Test Optimization could show a failed parameterized test without an associated retry, making it appear that automatic retry had not occurred.

### Additional Notes
Validation:
- Jest 30.4.2 regression with randomized execution
- Jest 28.0.0 regression
- Existing Jest parameterized reporting and EFD parameterized tests
- Focused Jest integration coverage
- `npm run lint`
