### PR TITLE
fix(test-optimization): support older Jest and Mocha versions

### DIFF
--- a/integration-tests/ci-visibility/jest-flaky/parameterized-fails.js
+++ b/integration-tests/ci-visibility/jest-flaky/parameterized-fails.js
@@ -1,12 +1,10 @@
 'use strict'
 
-const assert = require('node:assert/strict')
-
 describe('test-flaky-test-retries', () => {
   test.each([
     ['passing row', true],
     ['failing row', false],
   ])('preserves parameters between retries', (row, shouldPass) => {
-    assert.strictEqual(shouldPass, true, row)
+    expect(shouldPass).toBe(true)
   })
 })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed-only.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed-only.js
@@ -4,5 +4,7 @@ it('top-level passing test', () => {})
 
 // eslint-disable-next-line mocha/no-exclusive-tests
 describe.only('an exclusive describe block', () => {
-  it('nested passing test', () => {})
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  it.only('nested passing test', () => {})
+  it('nested non-exclusive test', () => {})
 })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -122,7 +122,6 @@ const MOCHA_VERSION = requestedMochaVersion === 'oldest' ? oldestMochaVersion : 
 const mochaMajor = MOCHA_VERSION === 'latest' ? Infinity : Number.parseInt(MOCHA_VERSION, 10)
 const supportsMochaRetryEvents = mochaMajor >= 6
 const onlyLatestIt = MOCHA_VERSION === 'latest' ? it : it.skip
-const suiteFilteringIt = mochaMajor >= 6 ? it : it.skip
 // Mocha 8.0 through 8.2 use workerpool 6.0.x, which cannot start process workers on supported Node versions.
 const parallelIt = MOCHA_VERSION === 'latest' || satisfies(MOCHA_VERSION, '>=8.3.0') ? it : it.skip
 
@@ -2414,7 +2413,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       )
     })
 
-    suiteFilteringIt('says TIA skipped all tests when it skips the exclusive suite', async () => {
+    it('says TIA skipped all tests when it skips the exclusive suite', async () => {
       const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-mixed-only.js'
       receiver.setSettings({
         itr_enabled: true,

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -122,6 +122,7 @@ const MOCHA_VERSION = requestedMochaVersion === 'oldest' ? oldestMochaVersion : 
 const mochaMajor = MOCHA_VERSION === 'latest' ? Infinity : Number.parseInt(MOCHA_VERSION, 10)
 const supportsMochaRetryEvents = mochaMajor >= 6
 const onlyLatestIt = MOCHA_VERSION === 'latest' ? it : it.skip
+const suiteFilteringIt = mochaMajor >= 6 ? it : it.skip
 // Mocha 8.0 through 8.2 use workerpool 6.0.x, which cannot start process workers on supported Node versions.
 const parallelIt = MOCHA_VERSION === 'latest' || satisfies(MOCHA_VERSION, '>=8.3.0') ? it : it.skip
 
@@ -2413,7 +2414,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       )
     })
 
-    it('says TIA skipped all tests when it skips the exclusive suite', async () => {
+    suiteFilteringIt('says TIA skipped all tests when it skips the exclusive suite', async () => {
       const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-mixed-only.js'
       receiver.setSettings({
         itr_enabled: true,

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -398,6 +398,57 @@ function isFailedTestReplayEnabled () {
   return config.isTestDynamicInstrumentationEnabled && config.isDiEnabled
 }
 
+/**
+ * @typedef {object} MochaSuite
+ * @property {MochaSuite[]} suites
+ * @property {import('mocha').Test[]} tests
+ * @property {MochaSuite[]} _onlySuites
+ * @property {import('mocha').Test[]} _onlyTests
+ */
+
+/**
+ * Mirrors Mocha 5's private exclusivity check.
+ *
+ * @param {MochaSuite} suite
+ * @returns {boolean}
+ */
+function hasOnly (suite) {
+  if (suite._onlyTests.length || suite._onlySuites.length) return true
+
+  for (const childSuite of suite.suites) {
+    if (hasOnly(childSuite)) return true
+  }
+  return false
+}
+
+/**
+ * Mirrors Mocha 5's private exclusivity filter.
+ *
+ * @param {MochaSuite} suite
+ * @returns {boolean}
+ */
+function filterOnly (suite) {
+  if (suite._onlyTests.length) {
+    suite.tests = suite._onlyTests
+    suite.suites = []
+  } else {
+    suite.tests = []
+
+    for (const onlySuite of suite._onlySuites) {
+      if (hasOnly(onlySuite)) filterOnly(onlySuite)
+    }
+
+    const filteredSuites = []
+    for (const childSuite of suite.suites) {
+      if (suite._onlySuites.includes(childSuite) || filterOnly(childSuite)) {
+        filteredSuites.push(childSuite)
+      }
+    }
+    suite.suites = filteredSuites
+  }
+  return suite.tests.length > 0 || suite.suites.length > 0
+}
+
 function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFinishRequest, localSuites) {
   const ctx = {
     isParallel,
@@ -431,8 +482,10 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
 
     // We remove the suites that we skip through ITR
     // Mocha normally applies exclusivity after this asynchronous configuration step.
-    if (typeof runner.suite.hasOnly === 'function' && runner.suite.hasOnly()) {
-      runner.suite.filterOnly()
+    if (typeof runner.suite.hasOnly === 'function') {
+      if (runner.suite.hasOnly()) runner.suite.filterOnly()
+    } else if (hasOnly(runner.suite)) {
+      filterOnly(runner.suite)
     }
     const numTestsToRun = runner.grepTotal(runner.suite)
     const filteredSuites = getFilteredSuites(runner.suite.suites)

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -431,7 +431,7 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
 
     // We remove the suites that we skip through ITR
     // Mocha normally applies exclusivity after this asynchronous configuration step.
-    if (runner.suite.hasOnly()) {
+    if (typeof runner.suite.hasOnly === 'function' && runner.suite.hasOnly()) {
       runner.suite.filterOnly()
     }
     const numTestsToRun = runner.grepTotal(runner.suite)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Restores compatibility with the older Jest and Mocha versions exercised by the v5 release line.

- Uses Jest's native `expect` assertion in the parameterized retry fixture so Jest 24 can load it.
- Feature-detects Mocha suite filtering before calling `Suite.hasOnly()` and `Suite.filterOnly()`.
- Runs the exclusive-suite TIA assertion only on Mocha versions that expose those APIs.

### Motivation
<!-- What inspired you to submit this pull request? -->

The v5 release PR https://github.com/DataDog/dd-trace-js/pull/9617 exposed two compatibility regressions that are not covered by the framework versions tested on `master`:

- Jest 24 cannot resolve `node:assert/strict`, so the new parameterized retry fixture failed before emitting test events.
- Mocha 5 does not implement `Suite.hasOnly()` or `Suite.filterOnly()`, causing instrumented child processes to crash and several integration tests to time out.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validated with:

- Jest 24.8 parameterized retry regression test
- Mocha 5.2 tests covering telemetry, code owners, session errors, git metadata, and coverage
- Jest 28 parameterized retry regression test
- Mocha 8 telemetry and exclusive-suite TIA tests
- ESLint on the three changed files
- `git diff --check`
