### PR TITLE
chore(test-optimization): log Vitest known tests

### DIFF
--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -681,7 +681,11 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
       },
       known_tests_enabled: true,
     })
-    receiver.setKnownTests({ vitest: {} })
+    receiver.setKnownTests({
+      vitest: {
+        'known-suite.mjs': ['known test'],
+      },
+    })
 
     const payloadsPromise = gatherEvents(events => {
       const tests = getEventContents(events, 'test')
@@ -700,11 +704,15 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
     })
 
     const [exitCode] = await Promise.all([
-      runVitest('browser-efd.mjs'),
+      runVitest('browser-efd.mjs', { DD_TRACE_DEBUG: 'true' }),
       payloadsPromise,
     ])
 
     assert.strictEqual(exitCode, 0, testOutput)
+    assert.match(
+      testOutput,
+      /Known tests received by Vitest: {"vitest":{"known-suite.mjs":\["known test"\]}}/
+    )
   })
 
   it('uses an unmocked clock for browser attempt durations and EFD retries', async () => {

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -729,6 +729,7 @@ async function runMainProcessSetup (
       isEarlyFlakeDetectionEnabled = false
     } else {
       knownTests = currentKnownTestsResponse.knownTests
+      log.debug('Known tests received by Vitest: %j', knownTests)
       const currentTestFilepaths = await getCurrentTestFilepaths()
 
       if (isValidKnownTests(knownTests)) {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Logs the complete parsed Known Tests object during Vitest setup when debug logging is enabled. It also verifies the diagnostic output in the existing Browser Mode EFD integration test.

### Motivation
<!-- What inspired you to submit this pull request? -->

A Vitest Browser Mode session is disabling Early Flake Detection because too many discovered suites appear new. The complete Known Tests payload is needed to compare backend module/suite identities with Vitest's discovered suite paths.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Diagnostic draft only; this PR is not intended to be merged.

Verification:
- `npm exec -- eslint packages/datadog-instrumentations/src/vitest-main.js integration-tests/vitest/vitest.browser.spec.js --max-warnings 0`
- `./node_modules/.bin/mocha --timeout 180000 integration-tests/vitest/vitest.browser.spec.js --grep "applies Early Flake Detection repetitions to new browser tests"`