### PR TITLE
test(test-optimization): respect v5 Cypress support range

### DIFF
--- a/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
+++ b/packages/dd-trace/test/ci-visibility/manifest-scaffold.spec.js
@@ -18,12 +18,16 @@ const {
   getManifestInputFiles,
 } = require('../../../../ci/test-optimization-validation/runner-command')
 const { getRunnerContract } = require('../../../../ci/test-optimization-validation/runner-contract')
+const { DD_MAJOR } = require('../../../../version')
 const {
   FRAMEWORKS,
   createRepositoryFixture,
   removeFixture,
   withRepositoryFixture,
 } = require('./validation-test-helpers')
+
+const CYPRESS_UNSUPPORTED_VERSION = DD_MAJOR >= 6 ? '11.2.0' : '6.6.0'
+const CYPRESS_MINIMUM_VERSION = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
 
 function scaffoldFramework (fixture, framework) {
   return createManifestScaffold({ root: fixture.root, frameworks: new Set([framework]) }).frameworks[0]
@@ -2085,16 +2089,16 @@ describe('test optimization validation manifest scaffold', () => {
       const installedPackageJsonPath = path.join(fixture.root, 'node_modules', 'cypress', 'package.json')
       for (const filename of [packageJsonPath, installedPackageJsonPath]) {
         const packageJson = JSON.parse(fs.readFileSync(filename))
-        packageJson.version = filename === installedPackageJsonPath ? '11.2.0' : packageJson.version
-        if (filename === packageJsonPath) packageJson.devDependencies.cypress = '11.2.0'
+        packageJson.version = filename === installedPackageJsonPath ? CYPRESS_UNSUPPORTED_VERSION : packageJson.version
+        if (filename === packageJsonPath) packageJson.devDependencies.cypress = CYPRESS_UNSUPPORTED_VERSION
         fs.writeFileSync(filename, `${JSON.stringify(packageJson)}\n`)
       }
       const framework = scaffoldFramework(fixture, 'cypress')
 
       assert.strictEqual(framework.status, 'detected_not_runnable')
       assert.strictEqual(framework.blockerCategory, 'UNSUPPORTED_VERSION')
-      assert.match(framework.notes[0], /Cypress 11\.2\.0 was detected/)
-      assert.match(framework.notes[0], /live validation requires >=12\.0\.0/)
+      assert.ok(framework.notes[0].includes(`Cypress ${CYPRESS_UNSUPPORTED_VERSION} was detected`))
+      assert.ok(framework.notes[0].includes(`live validation requires >=${CYPRESS_MINIMUM_VERSION}`))
       assert.match(framework.notes[0], /normal dependency workflow/)
     })
   })

--- a/packages/dd-trace/test/ci-visibility/validation-cli.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-cli.spec.js
@@ -18,6 +18,7 @@ const {
   EXECUTION_LOCK_FILENAME,
 } = require('../../../../ci/test-optimization-validation/execution-lock')
 const { createManifestScaffold } = require('../../../../ci/test-optimization-validation/manifest-scaffold')
+const { DD_MAJOR } = require('../../../../version')
 const {
   createRepositoryFixture,
   removeFixture,
@@ -26,6 +27,7 @@ const {
 
 const PACKAGE_ROOT = path.resolve(__dirname, '../../../..')
 const VALIDATOR = path.join(PACKAGE_ROOT, 'ci', 'validate-test-optimization.js')
+const CYPRESS_UNSUPPORTED_VERSION = DD_MAJOR >= 6 ? '11.2.0' : '6.6.0'
 
 describe('test optimization validation CLI', () => {
   it('uses only published files and runtime dependencies', () => {
@@ -172,8 +174,8 @@ describe('test optimization validation CLI', () => {
       const installedPackageJsonPath = path.join(fixture.root, 'node_modules', 'cypress', 'package.json')
       for (const filename of [packageJsonPath, installedPackageJsonPath]) {
         const packageJson = JSON.parse(fs.readFileSync(filename))
-        if (filename === packageJsonPath) packageJson.devDependencies.cypress = '11.2.0'
-        else packageJson.version = '11.2.0'
+        if (filename === packageJsonPath) packageJson.devDependencies.cypress = CYPRESS_UNSUPPORTED_VERSION
+        else packageJson.version = CYPRESS_UNSUPPORTED_VERSION
         fs.writeFileSync(filename, `${JSON.stringify(packageJson)}\n`)
       }
       assert.strictEqual(runCli(fixture.root, ['--init-manifest', '--framework', 'cypress']).status, 0)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Makes the Cypress validation fixtures select an unsupported version for the active dd-trace release line:

- Cypress 6.6.0 for v5 (minimum supported version: 6.7.0)
- Cypress 11.2.0 for v6+ (minimum supported version: 12.0.0)

### Motivation
<!-- Explain the motivation behind the change. -->

PR #9617 exposed that Cypress 11.2.0 is intentionally runnable on v5, while the new validation tests assumed the v6+ support floor. This caused the manifest assertion to fail and the CLI test to cascade because a final static-only report was not produced.

### Additional Notes
<!-- Any additional information that might be useful to reviewers. -->

Validated with:

- Targeted manifest and CLI tests on the normal master package version (`7.0.0-pre`)
- The same targeted tests with the package version temporarily set to `5.120.0`
- ESLint on both changed files
- `git diff --check`
