### PR TITLE
fix(test-optimization): support Jest 24 retry registration

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -262,6 +262,13 @@ jobs:
           - jest.core
           - jest.tia-efd
           - jest.test-management
+        test-pattern:
+          - ''
+        include:
+          - version: oldest
+            jest-version: 25.5.1
+            spec: jest.tia-efd
+            test-pattern: '^jest@25[.]5[.]1 commonJS early flake detection retries new tests$'
     name: integration-jest (${{ matrix.jest-version }}, node-${{ matrix.version }}, ${{ matrix.spec }})
     runs-on: ubuntu-latest
     permissions:
@@ -278,10 +285,14 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      - run: npm run test:integration:jest:coverage
+      - name: Simulate the v5 release line for Jest 25 compatibility
+        if: matrix.jest-version == '25.5.1'
+        run: npm pkg set version=5.0.0
+      - run: npm run test:integration:jest:coverage -- --grep "$JEST_TEST_PATTERN"
         env:
           NODE_OPTIONS: "-r ./ci/init"
           JEST_VERSION: ${{ matrix.jest-version }}
+          JEST_TEST_PATTERN: ${{ matrix.test-pattern }}
           SPEC: ${{ matrix.spec }}
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       - uses: ./.github/actions/coverage

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -72,6 +72,7 @@ const oldestJestVersion = DD_MAJOR >= 6 ? '28.0.0' : '24.8.0'
 const JEST_VERSION = requestedJestVersion === 'oldest' ? oldestJestVersion : requestedJestVersion
 const onlyLatestIt = JEST_VERSION === 'latest' ? it : it.skip
 const onlyBeforeJest30It = JEST_VERSION !== 'latest' && Number(JEST_VERSION.split('.')[0]) < 30 ? it : it.skip
+const onlyJest28AndLaterIt = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28 ? it : it.skip
 const shouldInstallJestEnvironmentJsdom = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
 const isJestCoverageBackfillSupported = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
 
@@ -1807,7 +1808,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       assert.strictEqual(exitCode, 0)
     })
 
-    it('keeps concurrent originals and EFD retries concurrent', async () => {
+    onlyJest28AndLaterIt('keeps concurrent originals and EFD retries concurrent', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       const testSuite = 'ci-visibility/test-early-flake-detection/concurrent-sibling-test.js'
       const newTestName = 'early flake detection concurrent siblings new test waits for its known sibling'

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -70,11 +70,12 @@ const runTestsCommand = 'node ./ci-visibility/run-jest.js'
 const requestedJestVersion = process.env.JEST_VERSION || 'latest'
 const oldestJestVersion = DD_MAJOR >= 6 ? '28.0.0' : '24.8.0'
 const JEST_VERSION = requestedJestVersion === 'oldest' ? oldestJestVersion : requestedJestVersion
+const jestMajor = JEST_VERSION === 'latest' ? Infinity : Number(JEST_VERSION.split('.')[0])
 const onlyLatestIt = JEST_VERSION === 'latest' ? it : it.skip
-const onlyBeforeJest30It = JEST_VERSION !== 'latest' && Number(JEST_VERSION.split('.')[0]) < 30 ? it : it.skip
-const onlyJest28AndLaterIt = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28 ? it : it.skip
-const shouldInstallJestEnvironmentJsdom = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
-const isJestCoverageBackfillSupported = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
+const onlyJest28Before30It = jestMajor >= 28 && jestMajor < 30 ? it : it.skip
+const onlyJest28AndLaterIt = jestMajor >= 28 ? it : it.skip
+const shouldInstallJestEnvironmentJsdom = jestMajor >= 28
+const isJestCoverageBackfillSupported = jestMajor >= 28
 
 function assertItrSkippingEnabledTags (events, expected) {
   const testSuite = events.find(event => event.type === 'test_suite_end').content
@@ -1902,7 +1903,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       assert.strictEqual(exitCode, 0)
     })
 
-    it('retries a concurrent test after its original times out', async () => {
+    onlyJest28AndLaterIt('retries a concurrent test after its original times out', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       const testSuite = 'ci-visibility/test-early-flake-detection/concurrent-timeout-test.js'
       receiver.setKnownTests({ jest: {} })
@@ -1956,7 +1957,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       assert.strictEqual(exitCode, 0)
     })
 
-    onlyBeforeJest30It('applies the Jest timeout to concurrent EFD retry bodies', async () => {
+    onlyJest28Before30It('applies the Jest timeout to concurrent EFD retry bodies', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       const testSuite = 'ci-visibility/test-early-flake-detection/concurrent-retry-timeout-test.js'
       receiver.setKnownTests({ jest: {} })
@@ -2060,7 +2061,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       assert.strictEqual(exitCode, 0)
     })
 
-    it('retries a concurrent test after its original throws synchronously', async () => {
+    onlyJest28AndLaterIt('retries a concurrent test after its original throws synchronously', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       const testSuite = 'ci-visibility/test-early-flake-detection/concurrent-throw-test.js'
       receiver.setKnownTests({ jest: {} })
@@ -3988,7 +3989,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       await Promise.all([once(childProcess, 'exit'), eventsPromise])
     })
 
-    it('picks the retry budget of a concurrent test from its own execution time', async () => {
+    onlyJest28AndLaterIt('picks the retry budget of a concurrent test from its own execution time', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       receiver.setKnownTests({ jest: {} })
       receiver.setSettings({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "7.0.0-pre",
+  "version": "5.120.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.120.0",
+  "version": "7.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -585,6 +585,15 @@ function isJestTestSkipped (test, hasFocusedTests, testNamePattern) {
 
 function getWrappedEnvironment (BaseEnvironment, jestVersion) {
   const hasConcurrentTestsStartEvent = satisfies(jestVersion, '>=30.0.0')
+  const hasTestsInChildren = satisfies(jestVersion, '>=25.0.0')
+
+  /**
+   * @param {object} describeBlock
+   * @returns {object[]|undefined}
+   */
+  function getTestEntries (describeBlock) {
+    return hasTestsInChildren ? describeBlock?.children : describeBlock?.tests
+  }
 
   return class DatadogEnvironment extends BaseEnvironment {
     #activeDetachedEfdRetries
@@ -1467,7 +1476,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       const concurrentTestState = registeredConcurrentTestState || this.concurrentTestStates.get(fn)
       let originalTest
       if (isEfdRetry && !efdRetryGates) {
-        originalTest = state.currentDescribeBlock?.children?.at(-1)
+        originalTest = getTestEntries(state.currentDescribeBlock)?.at(-1)
         if (originalTest?.fn !== fn) {
           log.error('%s could not retain its original Jest test', retryType)
           return 0
@@ -1475,8 +1484,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       }
       let registeredRetryCount = 0
       for (let retryIndex = 1; retryIndex <= retryCount; retryIndex++) {
-        const children = state.currentDescribeBlock?.children
-        const initialChildCount = children?.length
+        const testEntries = getTestEntries(state.currentDescribeBlock)
+        const initialTestCount = testEntries?.length
         let retryFn
         if (concurrentTestState) {
           const test = concurrentTestState.concurrentTest ??
@@ -1515,7 +1524,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         }
 
         if (isEfdRetry) {
-          const retryTest = children?.length === initialChildCount + 1 ? children.at(-1) : undefined
+          const retryTest = testEntries?.length === initialTestCount + 1 ? testEntries.at(-1) : undefined
           if (retryTest?.fn !== retryFn) {
             log.error('%s could not retain its pre-registered Jest retry', retryType)
             continue
@@ -1545,8 +1554,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         return false
       }
 
-      const children = retryOptions.state.currentDescribeBlock?.children
-      const initialChildCount = children?.length
+      const testEntries = getTestEntries(retryOptions.state.currentDescribeBlock)
+      const initialTestCount = testEntries?.length
       try {
         const registeredRetryCount = this.retryTest(retryOptions)
         if (registeredRetryCount === retryOptions.retryCount) return true
@@ -1554,8 +1563,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         log.error('%s could not register retries', retryOptions.retryType, error)
       }
 
-      if (children && initialChildCount !== undefined) {
-        const retryTests = children.splice(initialChildCount)
+      if (testEntries && initialTestCount !== undefined) {
+        const retryTests = testEntries.splice(initialTestCount)
         for (const retryTest of retryTests) {
           removedRetryTests.add(retryTest)
           const retryCtx = this.concurrentTestStates.get(retryTest.fn)?.ctx
@@ -1588,7 +1597,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
      * @returns {number} Retries left to run.
      */
     discardEfdRetries (testName, executedTest, retryCount = 0) {
-      const siblings = executedTest.parent?.children
+      const siblings = getTestEntries(executedTest.parent)
       const executedTestIndex = siblings ? siblings.indexOf(executedTest) : -1
       if (executedTestIndex === -1) return 0
 
@@ -1732,7 +1741,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       if (!this.#discardedEfdRetryTests) return
 
       for (const retryTest of this.#discardedEfdRetryTests) {
-        const siblings = retryTest.parent?.children
+        const siblings = getTestEntries(retryTest.parent)
         const retryTestIndex = siblings?.indexOf(retryTest) ?? -1
         if (retryTestIndex !== -1) {
           siblings.splice(retryTestIndex, 1)
@@ -1767,7 +1776,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       const concurrentTestContexts = this.concurrentTestContexts.get(testFullName)
       const concurrentTestState = this.concurrentTestStates.get(event.fn) ||
         concurrentTestContexts?.at(-1)?.concurrentTestState
-      const registeredTest = state.currentDescribeBlock?.children?.at(-1)
+      const registeredTest = getTestEntries(state.currentDescribeBlock)?.at(-1)
       if (concurrentTestState && registeredTest?.fn === event.fn) {
         testContexts.set(registeredTest, concurrentTestState.ctx)
       }

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -585,7 +585,7 @@ function isJestTestSkipped (test, hasFocusedTests, testNamePattern) {
 
 function getWrappedEnvironment (BaseEnvironment, jestVersion) {
   const hasConcurrentTestsStartEvent = satisfies(jestVersion, '>=30.0.0')
-  const hasTestsInChildren = satisfies(jestVersion, '>=25.0.0')
+  const hasTestsInChildren = satisfies(jestVersion, '>=26.0.0')
 
   /**
    * @param {object} describeBlock


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Restores Early Flake Detection retry registration for Jest 24:

- Reads registered tests from Jest 24's separate `describeBlock.tests` list.
- Keeps using the unified `describeBlock.children` tree on Jest 25 and later.
- Runs concurrent-retry lifecycle assertions only on Jest 28 and later.

### Motivation
<!-- Explain the motivation behind the change. -->

The v5 release line tests Jest 24.8.0. Its Circus tree stores tests separately from child describe blocks, while newer Jest versions include tests in `children`. The duration-based EFD retry implementation assumed the newer tree, could not retain the original Jest 24 test node, and therefore registered no EFD retries.

Jest 24 also does not expose the modern concurrent-test lifecycle used by the newer EFD concurrency fixtures. Those assertions are now consistently scoped to the Jest versions that support them.

This is a follow-up to #9697, which was merged before the Jest failures were identified.

### Additional Notes
<!-- Any additional information that might be useful to reviewers. -->

Validated locally and in the complete v5 release-line CI matrix by temporarily using package version `5.120.0`:

- Jest 24.8.0 TIA/EFD: 66 passing, 22 version-gated pending, 0 failing
- Jest 24.8.0 Test Management: 63 passing, 16 version-gated pending, 0 failing
- Jest 28.0.0 reported TIA/EFD scenarios: 7 passing
- Jest 28.0.0 EFD plus quarantine scenario: 1 passing
- ESLint on the changed Jest files
- `git diff --check`
