### PR TITLE
feat(browser-bunyan): Add new browser-bunyan integration

### DIFF
--- a/.agents/skills/apm-integrations/references/reference-plugins.md
+++ b/.agents/skills/apm-integrations/references/reference-plugins.md
@@ -52,6 +52,7 @@ packages/datadog-plugin-graphql/
 ```
 packages/datadog-plugin-winston/
 packages/datadog-plugin-bunyan/
+packages/datadog-plugin-browser-bunyan/
 packages/datadog-plugin-pino/
 ```
 

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -197,6 +197,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/plugins/test-and-upstream
 
+  browser-bunyan:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: browser-bunyan
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/plugins/test-and-upstream
+
   cassandra:
     runs-on: ubuntu-latest
     permissions:

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,7 @@ tracer.use('pg', {
 <h5 id="azure-durable-functions"></h5>
 <h5 id="bullmq"></h5>
 <h5 id="bunyan"></h5>
+<h5 id="browser-bunyan"></h5>
 <h5 id="cassandra-driver"></h5>
 <h5 id="child_process"></h5>
 <h5 id="confluentinc-kafka-javascript"></h5>
@@ -125,6 +126,7 @@ tracer.use('pg', {
 * [azure-durable-functions](./interfaces/export_.plugins.azure_durable_functions.html)
 * [bullmq](./interfaces/export_.plugins.bullmq.html)
 * [bunyan](./interfaces/export_.plugins.bunyan.html)
+* [browser-bunyan](./interfaces/export_.plugins.browser_bunyan.html)
 * [cassandra-driver](./interfaces/export_.plugins.cassandra_driver.html)
 * [child_process](./interfaces/export_.plugins.child_process.html)
 * [confluentinc-kafka-javascript](./interfaces/export_.plugins.confluentinc_kafka_javascript.html)

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -308,6 +308,7 @@ tracer.use('azure-functions');
 tracer.use('bullmq');
 tracer.use('bullmq', bullmqOptions);
 tracer.use('bunyan');
+tracer.use('browser-bunyan');
 tracer.use('couchbase');
 tracer.use('cassandra-driver');
 tracer.use('child_process');

--- a/index.d.ts
+++ b/index.d.ts
@@ -245,6 +245,7 @@ interface Plugins {
   "azure-durable-functions": tracer.plugins.azure_durable_functions
   "bullmq": tracer.plugins.bullmq;
   "bunyan": tracer.plugins.bunyan;
+  "browser-bunyan": tracer.plugins.browser_bunyan;
   "cassandra-driver": tracer.plugins.cassandra_driver;
   "child_process": tracer.plugins.child_process;
   "confluentinc-kafka-javascript": tracer.plugins.confluentinc_kafka_javascript;
@@ -2333,12 +2334,6 @@ declare namespace tracer {
       interface azure_durable_functions extends Integration {}
 
     /**
-     * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
-     * to automatically inject trace identifiers in log records when the
-     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
-     * on the tracer.
-     */
-    /**
      * This plugin automatically instruments the
      * [bullmq](https://github.com/npmjs/package/bullmq) message queue library.
      */
@@ -2358,7 +2353,21 @@ declare namespace tracer {
       producerFilter?: (job: { name?: string; data?: unknown; opts?: unknown; queueName?: string }) => boolean;
     }
 
+    /**
+     * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
     interface bunyan extends Integration {}
+
+    /**
+     * This plugin patches the [browser-bunyan](https://github.com/philmander/browser-bunyan)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
+    interface browser_bunyan extends Integration {}
 
     /**
      * This plugin automatically instruments the

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -245,6 +245,7 @@ interface Plugins {
   "azure-durable-functions": tracer.plugins.azure_durable_functions
   "bullmq": tracer.plugins.bullmq;
   "bunyan": tracer.plugins.bunyan;
+  "browser-bunyan": tracer.plugins.browser_bunyan;
   "cassandra-driver": tracer.plugins.cassandra_driver;
   "child_process": tracer.plugins.child_process;
   "confluentinc-kafka-javascript": tracer.plugins.confluentinc_kafka_javascript;
@@ -2461,12 +2462,6 @@ declare namespace tracer {
       interface azure_durable_functions extends Integration {}
 
     /**
-     * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
-     * to automatically inject trace identifiers in log records when the
-     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
-     * on the tracer.
-     */
-    /**
      * This plugin automatically instruments the
      * [bullmq](https://github.com/npmjs/package/bullmq) message queue library.
      */
@@ -2486,7 +2481,21 @@ declare namespace tracer {
       producerFilter?: (job: { name?: string; data?: unknown; opts?: unknown; queueName?: string }) => boolean;
     }
 
+    /**
+     * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
     interface bunyan extends Integration {}
+
+    /**
+     * This plugin patches the [browser-bunyan](https://github.com/philmander/browser-bunyan)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
+    interface browser_bunyan extends Integration {}
 
     /**
      * This plugin automatically instruments the

--- a/packages/datadog-instrumentations/src/browser-bunyan.js
+++ b/packages/datadog-instrumentations/src/browser-bunyan.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const shimmer = require('../../datadog-shimmer')
+const {
+  channel,
+  addHook,
+} = require('./helpers/instrument')
+
+addHook({ name: 'browser-bunyan', versions: ['>=1'] }, def => {
+  const logCh = channel('apm:browser-bunyan:log')
+  shimmer.wrap(def.Logger.prototype, '_emit', emit => {
+    return function wrappedEmit (rec) {
+      if (logCh.hasSubscribers) {
+        const payload = { message: rec }
+        logCh.publish(payload)
+        arguments[0] = payload.message
+      }
+      return emit.apply(this, arguments)
+    }
+  })
+  return def
+})

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -72,6 +72,7 @@ module.exports = {
   'body-parser': () => require('../body-parser'),
   bullmq: () => require('../bullmq'),
   bunyan: () => require('../bunyan'),
+  'browser-bunyan': () => require('../browser-bunyan'),
   'cassandra-driver': () => require('../cassandra-driver'),
   connect: () => require('../connect'),
   cookie: () => require('../cookie'),

--- a/packages/datadog-plugin-browser-bunyan/src/index.js
+++ b/packages/datadog-plugin-browser-bunyan/src/index.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const { buildLogHolder } = require('../../dd-trace/src/plugins/log_injection')
+const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
+
+class BrowserBunyanPlugin extends LogPlugin {
+  static id = 'browser-bunyan'
+
+  constructor (...args) {
+    super(...args)
+    this.addSub('apm:browser-bunyan:log', (arg) => this.handleLog(arg))
+  }
+
+  /**
+   * Inject `dd` directly on the record browser-bunyan hands us. browser-bunyan builds the
+   * record inside `mkRecord` via `objCopy(log.fields)` and then copies the
+   * caller's fields onto the result, so the `rec` object that flows
+   * through `_emit` is always browser-bunyan-owned, has `Object.prototype` for its
+   * prototype, and is never the caller's input directly. Mutating it adds
+   * `dd` for every consumer (JSON streams via `JSON.stringify(rec)`, raw
+   * streams via the record reference) without paying for a Proxy view.
+   *
+   * @param {{ message: object }} arg
+   */
+  handleLog (arg) {
+    const rec = arg.message
+    if (rec === null || typeof rec !== 'object' || Object.hasOwn(rec, 'dd')) return
+
+    const logHolder = buildLogHolder(this.tracer)
+    if (!logHolder) return
+
+    rec.dd = logHolder.dd
+  }
+}
+
+module.exports = BrowserBunyanPlugin

--- a/packages/datadog-plugin-browser-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-browser-bunyan/test/index.spec.js
@@ -1,0 +1,124 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { Writable } = require('node:stream')
+const { inspect } = require('node:util')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
+
+describe('Plugin', () => {
+  let logger
+  let tracer
+  let stream
+  let span
+
+  class JsonStream {
+    constructor (stream) {
+      this._stream = stream
+    }
+
+    write (rec) {
+      this._stream.write(JSON.stringify(rec))
+    }
+  }
+
+  function setupTest (version) {
+    const bunyan = require(`../../../versions/browser-bunyan@${version}`).get()
+
+    span = tracer.startSpan('test')
+
+    stream = new Writable()
+    stream._write = () => {}
+
+    sinon.spy(stream, 'write')
+
+    logger = bunyan.createLogger({ name: 'test', stream: new JsonStream(stream) })
+  }
+
+  describe('browser-bunyan', () => {
+    withVersions('browser-bunyan', 'browser-bunyan', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load('browser-bunyan')
+        })
+
+        beforeEach(() => {
+          setupTest(version)
+        })
+
+        it('should not alter the default behavior', () => {
+          tracer.scope().activate(span, () => {
+            logger.info('message')
+
+            sinon.assert.called(stream.write)
+
+            const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+            assert.ok(Object.hasOwn(record, 'dd'), `Available keys: ${inspect(Object.keys(record))}`)
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        beforeEach(() => {
+          return agent.load('browser-bunyan', { logInjection: true })
+        })
+
+        beforeEach(() => {
+          setupTest(version)
+        })
+
+        it('should add the trace identifiers to logger instances', () => {
+          tracer.scope().activate(span, () => {
+            logger.info('message')
+
+            sinon.assert.called(stream.write)
+
+            const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+            assertObjectContains(record.dd, {
+              trace_id: span.context().toTraceId(true),
+              span_id: span.context().toSpanId(),
+            })
+          })
+        })
+
+        it('should not mutate the original record', () => {
+          tracer.scope().activate(span, () => {
+            const record = { foo: 'bar' }
+
+            logger.info(record)
+
+            sinon.assert.called(stream.write)
+            assert.ok(!('dd' in record))
+          })
+        })
+
+        it('should not inject trace_id or span_id without an active span', () => {
+          logger.info('message')
+
+          sinon.assert.called(stream.write)
+
+          const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+          assert.ok(Object.hasOwn(record, 'dd'), `Available keys: ${inspect(Object.keys(record))}`)
+          assert.ok(!('trace_id' in record.dd))
+          assert.ok(!('span_id' in record.dd))
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-browser-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-browser-bunyan/test/integration-test/client.spec.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { inspect } = require('node:util')
+const {
+  FakeAgent,
+  spawnPluginIntegrationTestProcAndExpectExit,
+  sandboxCwd,
+  useSandbox,
+  varySandbox,
+  stopProc,
+} = require('../../../../integration-tests/helpers')
+const { withVersions } = require('../../../dd-trace/test/setup/mocha')
+
+describe('esm', () => {
+  let agent
+  let proc
+
+  withVersions('browser-bunyan', 'browser-bunyan', version => {
+    useSandbox([`'browser-bunyan@${version}'`], false,
+      ['./packages/datadog-plugin-browser-bunyan/test/integration-test/*'])
+
+    const variants = varySandbox('server.mjs', {
+      bindingName: 'bunyan',
+      packageName: 'browser-bunyan',
+      defaultExport: true,
+      namedExports: ['createLogger'],
+      namedExportBinding: 'namespace',
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      await stopProc(proc)
+      await agent.stop()
+    })
+    for (const variant of Object.keys(variants)) {
+      it(`is instrumented loaded with ${variant}`, async () => {
+        proc = await spawnPluginIntegrationTestProcAndExpectExit(
+          sandboxCwd(),
+          variants[variant],
+          agent.port,
+          undefined,
+          undefined,
+          (data) => {
+            const jsonObject = JSON.parse(data.toString())
+            assert.ok(Object.hasOwn(jsonObject, 'dd'), `Available keys: ${inspect(Object.keys(jsonObject))}`)
+          }
+        )
+      }).timeout(20000)
+    }
+  })
+})

--- a/packages/datadog-plugin-browser-bunyan/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-browser-bunyan/test/integration-test/server.mjs
@@ -1,0 +1,16 @@
+import ddtrace from 'dd-trace'
+import bunyan from 'browser-bunyan'
+
+ddtrace.init({
+  logInjection: true,
+})
+
+class ConsoleJsonStream {
+  write (rec) {
+    console.log(JSON.stringify(rec)) // eslint-disable-line no-console
+  }
+}
+
+const logger = bunyan.createLogger({ name: 'test-logger', stream: new ConsoleJsonStream() })
+
+logger.info('test xyz')

--- a/packages/datadog-plugin-browser-bunyan/test/suite.js
+++ b/packages/datadog-plugin-browser-bunyan/test/suite.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const suiteTest = require('../../dd-trace/test/plugins/suite')
+
+suiteTest('browser-bunyan', 'philmander/browser-bunyan', 'latest')

--- a/packages/datadog-plugin-browser-bunyan/test/unit.spec.js
+++ b/packages/datadog-plugin-browser-bunyan/test/unit.spec.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+const { channel } = require('dc-polyfill')
+const { storage } = require('../../datadog-core')
+
+require('../../dd-trace/test/setup/core')
+const BrowserBunyanPlugin = require('../src')
+const Tracer = require('../../dd-trace/src/tracer')
+const getConfig = require('../../dd-trace/src/config')
+
+const logCh = channel('apm:browser-bunyan:log')
+
+const tracer = new Tracer(getConfig({
+  enabled: true,
+  logInjection: true,
+  env: 'my-env',
+  service: 'my-service',
+  version: '1.2.3',
+}))
+
+const plugin = new BrowserBunyanPlugin({
+  _tracer: tracer,
+})
+plugin.configure({
+  logInjection: true,
+  enabled: true,
+})
+
+describe('BrowserBunyanPlugin', () => {
+  it('injects dd onto the record browser-bunyan passes through _emit', () => {
+    const record = { foo: 'bar', msg: 'hello' }
+    logCh.publish({ message: record })
+    assert.strictEqual(record.dd.service, 'my-service')
+    assert.strictEqual(record.dd.version, '1.2.3')
+    assert.strictEqual(record.dd.env, 'my-env')
+  })
+
+  it('preserves a caller-provided dd field', () => {
+    const record = { foo: 'bar', dd: { custom: true } }
+    logCh.publish({ message: record })
+    assert.deepStrictEqual(record.dd, { custom: true })
+  })
+
+  it('adds trace_id and span_id when a span is active', () => {
+    const span = tracer.startSpan('test')
+
+    storage('legacy').run({ span }, () => {
+      const record = { foo: 'bar' }
+      logCh.publish({ message: record })
+      assert.strictEqual(record.dd.trace_id, span.context().toTraceId(true))
+      assert.strictEqual(record.dd.span_id, span.context().toSpanId())
+    })
+  })
+
+  it('does not mutate a caller-set dd even when a span is active', () => {
+    const span = tracer.startSpan('test')
+
+    storage('legacy').run({ span }, () => {
+      const record = { foo: 'bar', dd: { custom: true } }
+      logCh.publish({ message: record })
+      assert.deepStrictEqual(record.dd, { custom: true })
+    })
+  })
+
+  it('does not run on non-object messages', () => {
+    const payload = { message: 'just a string' }
+    logCh.publish(payload)
+    assert.strictEqual(payload.message, 'just a string')
+  })
+
+  it('leaves the record untouched when the propagator emits no dd', () => {
+    const originalInject = tracer.inject
+    tracer.inject = () => {}
+    try {
+      const record = { foo: 'bar' }
+      logCh.publish({ message: record })
+      assert.strictEqual(record.dd, undefined)
+    } finally {
+      tracer.inject = originalInject
+    }
+  })
+})

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -2473,6 +2473,13 @@
         "default": "true"
       }
     ],
+    "DD_TRACE_BROWSER_BUNYAN_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "true"
+      }
+    ],
     "DD_TRACE_CASSANDRA_DRIVER_ENABLED": [
       {
         "implementation": "A",

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -48,6 +48,7 @@ const plugins = {
   get 'aws-sdk' () { return require('../../../datadog-plugin-aws-sdk/src') },
   get bullmq () { return require('../../../datadog-plugin-bullmq/src') },
   get bunyan () { return require('../../../datadog-plugin-bunyan/src') },
+  get 'browser-bunyan' () { return require('../../../datadog-plugin-browser-bunyan/src') },
   get 'cassandra-driver' () { return require('../../../datadog-plugin-cassandra-driver/src') },
   get child_process () { return require('../../../datadog-plugin-child_process/src') },
   get 'claude-agent-sdk' () { return require('../../../datadog-plugin-claude-agent-sdk/src') },

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -113,6 +113,7 @@
     "bson": "7.3.1",
     "bullmq": "5.81.2",
     "bunyan": "2.0.5",
+    "browser-bunyan": "1.8.0",
     "cassandra-driver": "4.9.0",
     "collections": "5.1.13",
     "connect": "3.7.0",

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -301,6 +301,13 @@
     "auto-instrumented": "True"
   },
   {
+    "dependency": "browser-bunyan",
+    "integration": "browser-bunyan",
+    "minimum_tracer_supported": "1.0.0",
+    "max_tracer_supported": "1.8.0",
+    "auto-instrumented": "True"
+  },
+  {
     "dependency": "cassandra-driver",
     "integration": "cassandra-driver",
     "minimum_tracer_supported": "3.0.0",

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -42,6 +42,7 @@ avsc,avsc,5.0.0,5.7.9,True
 aws-sdk,aws-sdk,2.1.35,2.1693.0,True
 bullmq,bullmq,5.66.0,5.80.9,True
 bunyan,bunyan,1.0.0,2.0.5,True
+browser-bunyan,browser-bunyan,1.0.0,1.8.0,True
 cassandra-driver,cassandra-driver,3.0.0,4.9.0,True
 child_process,child_process,22.0.0,26.4.0,True
 connect,connect,2.2.2,3.7.0,True


### PR DESCRIPTION
### What does this PR do?
This pull requests integrates `dd-trace` with the logging library `browser-bunyan`, when it is running on the server-side in Node.js.

### Motivation
As frameworks such as Next.js and Remix focus on isomorphic React, the logging library should be isomorphic. I've found `browser-bunyan` to fit the bill of something lightweight and very usable.

For example, if a web app is attempting to follow the twelve-factor methodology, then it only needs to write its event stream, unbuffered, to stdout, so a simpler the logging library is better.

### Additional Notes
I previously submitted #1935 in 2022 but without it getting merged I continued using this integration via a local patch. Now I've re-built it with the current state of the `dd-trace` library and am re-submitting.

The tests are very similar to the `bunyan` integration tests, with some minor differences to convert the console output to JSON. The user would be expected to do the same in their Node.js application.