### PR TITLE
test(test-optimization): stabilize output file limit test

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-validation.spec.js
@@ -31,6 +31,25 @@ const { createWindowsFileReferenceFs } = require('../validation-test-helpers')
 
 const VALIDATION_MANIFEST_ENV = '_DD_TEST_OPTIMIZATION_VALIDATION_MANIFEST_FILE'
 const VALIDATION_OUTPUT_ENV = '_DD_TEST_OPTIMIZATION_VALIDATION_OUTPUT_DIR'
+const IN_MEMORY_DIRECTORY_STAT = {
+  dev: 1n,
+  ino: 1n,
+  isDirectory: () => true,
+  isSymbolicLink: () => false,
+}
+const IN_MEMORY_FILE_STAT = {
+  isFile: () => true,
+  nlink: 1,
+}
+const IN_MEMORY_OUTPUT_FS = {
+  closeSync: () => {},
+  fstatSync: () => IN_MEMORY_FILE_STAT,
+  lstatSync: () => IN_MEMORY_DIRECTORY_STAT,
+  mkdirSync: () => {},
+  openSync: () => 1,
+  renameSync: () => {},
+  writeFileSync: () => {},
+}
 
 describe('CI validation offline output', () => {
   let outputRoot
@@ -230,7 +249,11 @@ describe('CI validation offline output', () => {
   })
 
   it('accepts the last output file and rejects the first file beyond the limit', () => {
-    const sink = new CiValidationSink(outputRoot)
+    const { CiValidationSink: InMemoryCiValidationSink } =
+      proxyquire('../../../src/ci-visibility/exporters/ci-validation/sink', {
+        'node:fs': IN_MEMORY_OUTPUT_FS,
+      })
+    const sink = new InMemoryCiValidationSink(outputRoot)
     const payload = Buffer.from(msgpack.encode({ version: 1, events: [] }))
     for (let index = 0; index <= MAX_OUTPUT_FILES; index++) sink.writeTestCycle(payload)
     sink.writeSummary()


### PR DESCRIPTION
## Summary

The output file boundary test opens and later removes 10,000 real files. Windows CI exceeded Mocha's 30-second timeout; profiling attributes 73.6% of local sampled time to `open` and recursive cleanup.

The count-boundary test now uses an in-memory filesystem backend while preserving all 10,001 production sink calls. Locally, the focused test drops from 832 ms to 38 ms; neighboring tests keep real filesystem coverage.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/31020866970/job/92356909914?pr=9631