### PR TITLE
fix(debugger): redact sensitive data in log probe messages

### DIFF
--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const { once } = require('node:events')
+const { NODE_MAJOR } = require('../../version')
 const { assertObjectContains } = require('../helpers')
 const { setup } = require('./utils')
 
@@ -135,6 +136,71 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
       assert.doesNotMatch(message, /shh!/)
     })
 
+    it('should redact own properties attached to a Map', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{mapWithProp}',
+        segments: [{ dsl: 'mapWithProp', json: { ref: 'mapWithProp' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, "Map(1) { 'username' => 'alice', password: '[redacted]' }")
+      assert.doesNotMatch(message, /shh!/)
+    })
+
+    it('should redact own properties attached to a function', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{fnWithSecret}',
+        segments: [{ dsl: 'fnWithSecret', json: { ref: 'fnWithSecret' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, "[Function: handler] { password: '[redacted]', username: 'alice' }")
+      assert.doesNotMatch(message, /shh!/)
+    })
+
+    it('should not invoke Proxy traps or leak a proxied function', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{fnProxy}',
+        segments: [{ dsl: 'fnProxy', json: { ref: 'fnProxy' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, '[Proxy]')
+      assert.doesNotMatch(message, /shh!/)
+    })
+
+    it('should redact a Map subclass without invoking its overridden keys()', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{mapWithOverriddenKeys}',
+        segments: [{ dsl: 'mapWithOverriddenKeys', json: { ref: 'mapWithOverriddenKeys' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, "Map(1) { 'password' => '[redacted]' }")
+      assert.doesNotMatch(message, /shh!/)
+      assert.doesNotMatch(message, /must not be called/)
+    })
+
     it('should not leak a redacted key beyond the rendered window of a large Map', async function () {
       t.triggerBreakpoint()
 
@@ -147,7 +213,32 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
 
       const [{ payload: [{ message }] }] = await promise
 
-      assert.strictEqual(message, "Map(5) { 'k0' => 0, 'k1' => 1, 'k2' => 2, ... 2 more items }")
+      // On Node.js <= 18 util.inspect renders every Map entry, so the redacted key at position 5
+      // is displayed and must be redacted; on Node.js > 18 only the first 3 entries render, so it
+      // falls outside the window and is never displayed.
+      assert.strictEqual(
+        message,
+        NODE_MAJOR > 18
+          ? "Map(5) { 'k0' => 0, 'k1' => 1, 'k2' => 2, ... 2 more items }"
+          : "Map(5) { 'k0' => 0, 'k1' => 1, 'k2' => 2, 'k3' => 3, 'password' => '[redacted]' }"
+      )
+      assert.doesNotMatch(message, /shh!/)
+    })
+
+    it('should still redact when intrinsics are shadowed in the paused scope', async function () {
+      const breakpoint = t.breakpoints[1]
+      breakpoint.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(breakpoint.generateRemoteConfig({
+        template: '{shadowObj}',
+        segments: [{ dsl: 'shadowObj', json: { ref: 'shadowObj' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, "{ username: 'alice', password: '[redacted]' }")
       assert.doesNotMatch(message, /shh!/)
     })
   })

--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -79,8 +79,8 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
 
       assert.strictEqual(
         message,
-        "obj={ username: 'alice', password: '[redacted]' };" +
-          "map=Map(2) { 'username' => 'alice', 'password' => '[redacted]' }"
+        "obj={ username: 'alice', password: '[redacted]', Symbol(password): '[redacted]' };" +
+          "map=Map(3) { 'username' => 'alice', 'password' => '[redacted]', Symbol(password) => '[redacted]' }"
       )
     })
   })

--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -2,9 +2,16 @@
 
 const assert = require('node:assert/strict')
 const { once } = require('node:events')
+const { inspect } = require('node:util')
 const { NODE_MAJOR } = require('../../version')
 const { assertObjectContains } = require('../helpers')
 const { setup } = require('./utils')
+
+// util.inspect renders an object's own symbol key as `[Symbol(x)]:` on Node <= 20 and
+// `Symbol(x):` on Node >= 22; derive the form so message assertions track the runtime.
+const objectSymbolKey = inspect({ [Symbol('password')]: 0 }, { breakLength: Infinity }).includes('[Symbol(')
+  ? '[Symbol(password)]'
+  : 'Symbol(password)'
 
 // Default settings is tested in unit tests, so we only need to test the env vars here
 describe('Dynamic Instrumentation snapshot PII redaction', function () {
@@ -80,7 +87,7 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
 
       assert.strictEqual(
         message,
-        "obj={ username: 'alice', password: '[redacted]', Symbol(password): '[redacted]' };" +
+        `obj={ username: 'alice', password: '[redacted]', ${objectSymbolKey}: '[redacted]' };` +
           "map=Map(3) { 'username' => 'alice', 'password' => '[redacted]', Symbol(password) => '[redacted]' }"
       )
     })

--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('node:assert/strict')
 const { once } = require('node:events')
 const { assertObjectContains } = require('../helpers')
 const { setup } = require('./utils')
@@ -53,6 +54,34 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
         secret: { type: 'string', value: 'shh!' },
         password: { type: 'string', notCapturedReason: 'redactedIdent' },
       })
+    })
+  })
+
+  describe('log probe message', function () {
+    const t = setup({ dependencies: ['fastify'] })
+
+    it('should redact sensitive identifiers when a template interpolates an object or map', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: 'obj={obj};map={map}',
+        segments: [
+          { str: 'obj=' },
+          { dsl: 'obj', json: { ref: 'obj' } },
+          { str: ';map=' },
+          { dsl: 'map', json: { ref: 'map' } },
+        ],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(
+        message,
+        "obj={ username: 'alice', password: '[redacted]' };" +
+          "map=Map(2) { 'username' => 'alice', 'password' => '[redacted]' }"
+      )
     })
   })
 })

--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -83,5 +83,72 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
           "map=Map(3) { 'username' => 'alice', 'password' => '[redacted]', Symbol(password) => '[redacted]' }"
       )
     })
+
+    it('should redact a template that references a sensitive identifier directly', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: 'local={password};member={obj.password}',
+        segments: [
+          { str: 'local=' },
+          { dsl: 'password', json: { ref: 'password' } },
+          { str: ';member=' },
+          { dsl: 'obj.password', json: { getmember: [{ ref: 'obj' }, 'password'] } },
+        ],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, 'local=[redacted];member=[redacted]')
+    })
+
+    it('should redact a Map created in another realm', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{vmMap}',
+        segments: [{ dsl: 'vmMap', json: { ref: 'vmMap' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, "Map(1) { 'password' => '[redacted]' }")
+    })
+
+    it('should not invoke Proxy traps or leak a proxied value', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{proxy}',
+        segments: [{ dsl: 'proxy', json: { ref: 'proxy' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, '[Proxy]')
+      assert.doesNotMatch(message, /shh!/)
+    })
+
+    it('should not leak a redacted key beyond the rendered window of a large Map', async function () {
+      t.triggerBreakpoint()
+
+      const promise = once(t.agent, 'debugger-input')
+
+      t.agent.addRemoteConfig(t.generateRemoteConfig({
+        template: '{bigMap}',
+        segments: [{ dsl: 'bigMap', json: { ref: 'bigMap' } }],
+      }))
+
+      const [{ payload: [{ message }] }] = await promise
+
+      assert.strictEqual(message, "Map(5) { 'k0' => 0, 'k1' => 1, 'k2' => 2, ... 2 more items }")
+      assert.doesNotMatch(message, /shh!/)
+    })
   })
 })

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -14,8 +14,9 @@ fastify.get('/', function () {
   const baz = 'c'
   const secret = 'shh!'
   const password = 'shh!'
-  const obj = { username: 'alice', password: 'shh!' }
-  const map = new Map([['username', 'alice'], ['password', 'shh!']])
+  const secretSymbol = Symbol('password')
+  const obj = { username: 'alice', password: 'shh!', [secretSymbol]: 'shh!' }
+  const map = new Map([['username', 'alice'], ['password', 'shh!'], [secretSymbol, 'shh!']])
   /* eslint-enable no-unused-vars */
 
   return { hello: 'world' } // BREAKPOINT: /

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -8,7 +8,7 @@ const Fastify = require('fastify')
 const fastify = Fastify({ logger: { level: 'error' } })
 
 fastify.get('/', function () {
-  /* eslint-disable no-unused-vars */
+  /* eslint-disable no-unused-vars, sonarjs/no-unused-collection */
   const foo = 'a'
   const bar = 'b'
   const baz = 'c'
@@ -20,9 +20,32 @@ fastify.get('/', function () {
   const vmMap = require('node:vm').runInNewContext("new Map([['password', 'shh!']])")
   const proxy = new Proxy({ password: 'shh!' }, {})
   const bigMap = new Map([['k0', 0], ['k1', 1], ['k2', 2], ['k3', 3], ['password', 'shh!']])
-  /* eslint-enable no-unused-vars */
+  const mapWithProp = new Map([['username', 'alice']])
+  mapWithProp.password = 'shh!'
+  const fnWithSecret = function handler () {}
+  fnWithSecret.password = 'shh!'
+  fnWithSecret.username = 'alice'
+  class MapWithCustomKeys extends Map { keys () { throw new Error('keys() must not be called during redaction') } }
+  const mapWithOverriddenKeys = new MapWithCustomKeys([['password', 'shh!']])
+  const fnProxy = new Proxy(fnWithSecret, {})
+  /* eslint-enable no-unused-vars, sonarjs/no-unused-collection */
 
   return { hello: 'world' } // BREAKPOINT: /
+})
+
+fastify.get('/shadow', function () {
+  // Shadow the intrinsics the redaction setup relies on. If the setup resolved them from the
+  // paused call frame instead of the global object, `new Set(...)` would throw and every log
+  // probe at this pause would be sent with an empty message.
+  /* eslint-disable no-unused-vars, sonarjs/no-globals-shadowing */
+  const Set = 'shadow'
+  const Map = 'shadow'
+  const Object = 'shadow'
+  const Reflect = 'shadow'
+  const shadowObj = { username: 'alice', password: 'shh!' }
+  /* eslint-enable no-unused-vars, sonarjs/no-globals-shadowing */
+
+  return { hello: 'world' } // BREAKPOINT: /shadow
 })
 
 fastify.listen({ port: process.env.APP_PORT || 0 }, (err) => {

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -14,6 +14,8 @@ fastify.get('/', function () {
   const baz = 'c'
   const secret = 'shh!'
   const password = 'shh!'
+  const obj = { username: 'alice', password: 'shh!' }
+  const map = new Map([['username', 'alice'], ['password', 'shh!']])
   /* eslint-enable no-unused-vars */
 
   return { hello: 'world' } // BREAKPOINT: /

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -17,6 +17,9 @@ fastify.get('/', function () {
   const secretSymbol = Symbol('password')
   const obj = { username: 'alice', password: 'shh!', [secretSymbol]: 'shh!' }
   const map = new Map([['username', 'alice'], ['password', 'shh!'], [secretSymbol, 'shh!']])
+  const vmMap = require('node:vm').runInNewContext("new Map([['password', 'shh!']])")
+  const proxy = new Proxy({ password: 'shh!' }, {})
+  const bigMap = new Map([['k0', 0], ['k1', 1], ['k2', 2], ['k3', 3], ['password', 'shh!']])
   /* eslint-enable no-unused-vars */
 
   return { hello: 'world' } // BREAKPOINT: /

--- a/integration-tests/debugger/template.spec.js
+++ b/integration-tests/debugger/template.spec.js
@@ -49,7 +49,7 @@ describe('Dynamic Instrumentation', function () {
         assert.strictEqual(messages.shift(), '[ [Object], 2, 3, ... 2 more items ]')
         assert.strictEqual(messages.shift(), '{}')
         const obj = messages.shift()
-        let expectedObjectShape = '{ ' +
+        const expectedObjectShape = '{ ' +
           'foo: [Object], ' +
           'bar: true, ' +
           'baz: [Getter], ' +
@@ -58,11 +58,8 @@ describe('Dynamic Instrumentation', function () {
             : '[Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]] ') +
         '}'
         assert.strictEqual(obj, expectedObjectShape)
-        if (NODE_MAJOR >= 26) {
-          // A proxy should be stringified to the wrapped object plus the proxy type in newer Node.js versions
-          expectedObjectShape = `Proxy(${expectedObjectShape})`
-        }
-        assert.strictEqual(messages.shift(), expectedObjectShape)
+        // A Proxy is rendered as a fixed token so its traps are never invoked during redaction.
+        assert.strictEqual(messages.shift(), '[Proxy]')
         assert.strictEqual(messages.shift(), '<ref *1> { circular: [Circular *1] }')
         assert.strictEqual(messages.shift(), '[class CustomClass]')
         // Notice execution of `Symbol.toStringTag` getter (`foo`). There's nothing we can do about it when using

--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -55,7 +55,7 @@ function compileSegments (segments) {
       ? `(() => {
           try {
             const result = ${compile(json)}
-            return typeof result === 'string' ? result : $dd_inspect(result, $dd_segmentInspectOptions)
+            return $dd_inspectSegment(result)
           } catch (e) {
             return { expr: ${JSON.stringify(dsl)}, message: \`\${e.name}: \${e.message}\` }
           }

--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -51,21 +51,40 @@ function compileSegments (segments) {
   let result = '['
   for (let i = 0; i < segments.length; i++) {
     const { str, dsl, json } = segments[i]
-    result += str === undefined
-      ? `(() => {
+    if (str === undefined) {
+      // The direct-reference identifier (e.g. 'password' for `{password}` or `{user.password}`)
+      // is passed to $dd_inspectSegment so it can redact by name, matching the snapshot path;
+      // it is undefined when the segment is not a statically-named reference.
+      result += `(() => {
           try {
             const result = ${compile(json)}
-            return $dd_inspectSegment(result)
+            return $dd_inspectSegment(result, ${JSON.stringify(directReferenceIdentifier(json))})
           } catch (e) {
             return { expr: ${JSON.stringify(dsl)}, message: \`\${e.name}: \${e.message}\` }
           }
         })()`
-      : JSON.stringify(str)
+    } else {
+      result += JSON.stringify(str)
+    }
     if (i !== segments.length - 1) {
       result += ','
     }
   }
   return `${result}]`
+}
+
+// Returns the terminal identifier a segment references directly, or undefined when the segment
+// is not a direct reference with a statically-known name. `{ref: 'x'}` yields 'x';
+// `{getmember: [obj, 'x']}` and `{index: [obj, 'x']}` yield 'x'; computed or dynamic terminals
+// (e.g. `obj[k]`, method calls) yield undefined and fall through to value serialization.
+function directReferenceIdentifier (json) {
+  if (json === null || typeof json !== 'object') return
+  const [type, value] = Object.entries(json)[0]
+  if (type === 'ref') {
+    if (typeof value === 'string') return value
+  } else if ((type === 'getmember' || type === 'index') && Array.isArray(value) && typeof value[1] === 'string') {
+    return value[1]
+  }
 }
 
 // TODO: Consider storing some of these functions that doesn't require closure access to the current scope on `process`

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -103,9 +103,9 @@ const templateExpressionSetupCode = `
       const $dd_ownKeys = $dd_Reflect.ownKeys(value);
       const $dd_ownKeysRedacted = $dd_hasRedactedKey($dd_ownKeys);
       if (!$dd_hasRenderedRedactedKey && !$dd_ownKeysRedacted) return value;
-      // A full copy keeps the rendered Map(N) size and "... K more items" marker matching the
-      // original; only entries inside the rendered window can be displayed, so entry values are
-      // redacted only within that window (entries beyond it are copied by reference, never shown).
+      // util.inspect prints Map(N) and "... K more items" from the entry count, so the copy must
+      // hold every entry. Only the first maxArrayLength entries render, so redact within that
+      // window and pass the rest through unchanged.
       const redacted = new $dd_Map();
       $dd_index = 0;
       for (const [key, val] of $dd_Map.prototype.entries.call(value)) {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -27,6 +27,7 @@ require('./remote_config')
 // Expression to run on a call frame of the paused thread to get its active trace and span id.
 const templateExpressionSetupCode = `
   const $dd_inspect = global.require('node:util').inspect;
+  const $dd_types = global.require('node:util').types;
   const $dd_segmentInspectOptions = {
     depth: 0,
     customInspect: false,
@@ -52,8 +53,18 @@ const templateExpressionSetupCode = `
   };
   const $dd_redactSegmentValue = (value) => {
     if (value === null || typeof value !== 'object') return value;
-    if (value instanceof Map) {
-      if (!$dd_hasRedactedKey(value.keys())) return value;
+    if ($dd_types.isMap(value)) {
+      // Only the first maxArrayLength entries are rendered, so scanning past that
+      // window cannot affect the output. Bounding the scan keeps the common
+      // large-Map case constant-time on the paused application thread.
+      const $dd_max = $dd_segmentInspectOptions.maxArrayLength;
+      let $dd_index = 0;
+      let $dd_hasRenderedRedactedKey = false;
+      for (const key of value.keys()) {
+        if ($dd_index++ >= $dd_max) break;
+        if ($dd_isRedactedIdentifier(key)) { $dd_hasRenderedRedactedKey = true; break; }
+      }
+      if (!$dd_hasRenderedRedactedKey) return value;
       const redacted = new Map();
       for (const [key, val] of value) redacted.set(key, $dd_isRedactedIdentifier(key) ? '[redacted]' : val);
       return redacted;
@@ -72,8 +83,18 @@ const templateExpressionSetupCode = `
     }
     return redacted;
   };
-  const $dd_inspectSegment = (value) =>
-    typeof value === 'string' ? value : $dd_inspect($dd_redactSegmentValue(value), $dd_segmentInspectOptions);
+  const $dd_inspectSegment = (value, directRefIdentifier) => {
+    // A template that references a sensitive identifier directly (e.g. the password
+    // local, or user.password) yields a primitive with no key context, so redact by
+    // the reference name the compiler passed in, matching the snapshot path.
+    if (directRefIdentifier !== undefined && $dd_isRedactedIdentifier(directRefIdentifier)) return '[redacted]';
+    if (typeof value === 'string') return value;
+    // Proxies are rendered as a fixed token: enumerating one via Reflect.ownKeys
+    // would run its traps (customer code) in the paused frame, and letting
+    // util.inspect render the target would leak a proxy-wrapped secret.
+    if (value !== null && typeof value === 'object' && $dd_types.isProxy(value)) return '[Proxy]';
+    return $dd_inspect($dd_redactSegmentValue(value), $dd_segmentInspectOptions);
+  };
 `
 const getDDTagsExpression = `(() => {
   const context = global.require('dd-trace').scope().active()?.context();

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -35,8 +35,17 @@ const templateExpressionSetupCode = `
     breakLength: Infinity
   };
   const $dd_redactedIdentifiers = new Set(${JSON.stringify([...REDACTED_IDENTIFIERS])});
-  const $dd_isRedactedIdentifier = (key) =>
-    typeof key === 'string' && $dd_redactedIdentifiers.has(key.toLowerCase().replace(/[-_@$.]/g, ''));
+  const $dd_normalizeIdentifier = (key) => {
+    if (typeof key === 'string') return key.toLowerCase().replace(/[-_@$.]/g, '');
+    // Symbol('x').toString() is 'Symbol(x)'; slice(7, -1) yields 'x', matching
+    // normalizeName(name, isSymbol) in snapshot/redaction.js.
+    if (typeof key === 'symbol') return key.toString().slice(7, -1).toLowerCase().replace(/[-_@$.]/g, '');
+    return undefined;
+  };
+  const $dd_isRedactedIdentifier = (key) => {
+    const $dd_normalized = $dd_normalizeIdentifier(key);
+    return $dd_normalized !== undefined && $dd_redactedIdentifiers.has($dd_normalized);
+  };
   const $dd_hasRedactedKey = (keys) => {
     for (const key of keys) if ($dd_isRedactedIdentifier(key)) return true;
     return false;

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -25,10 +25,6 @@ require('./remote_config')
 /** @typedef {import('node:inspector').Debugger.EvaluateOnCallFrameReturnType} EvaluateOnCallFrameResult */
 
 // Expression to run on a call frame of the paused thread to get its active trace and span id.
-// Redaction of log-probe messages runs inside the paused application process, so the redacted-identifier
-// set is embedded into the evaluated code. Values are redacted before interpolation, matching the snapshot
-// path (see snapshot/processor.js) so that a template referencing an object or map (e.g. `{user}`) does not
-// leak sensitive fields the snapshot would redact.
 const templateExpressionSetupCode = `
   const $dd_inspect = global.require('node:util').inspect;
   const $dd_segmentInspectOptions = {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -13,6 +13,7 @@ const {
 const { breakpointToProbes, samplingIndexToProbe } = require('./state')
 const session = require('./session')
 const { getLocalStateForCallFrame, evaluateCaptureExpressions } = require('./snapshot')
+const { REDACTED_IDENTIFIERS } = require('./snapshot/redaction')
 const send = require('./send')
 const { getStackFromCallFrames } = require('./state')
 const { ackEmitting } = require('./status')
@@ -24,6 +25,10 @@ require('./remote_config')
 /** @typedef {import('node:inspector').Debugger.EvaluateOnCallFrameReturnType} EvaluateOnCallFrameResult */
 
 // Expression to run on a call frame of the paused thread to get its active trace and span id.
+// Redaction of log-probe messages runs inside the paused application process, so the redacted-identifier
+// set is embedded into the evaluated code. Values are redacted before interpolation, matching the snapshot
+// path (see snapshot/processor.js) so that a template referencing an object or map (e.g. `{user}`) does not
+// leak sensitive fields the snapshot would redact.
 const templateExpressionSetupCode = `
   const $dd_inspect = global.require('node:util').inspect;
   const $dd_segmentInspectOptions = {
@@ -33,6 +38,37 @@ const templateExpressionSetupCode = `
     maxStringLength: 8 * 1024,
     breakLength: Infinity
   };
+  const $dd_redactedIdentifiers = new Set(${JSON.stringify([...REDACTED_IDENTIFIERS])});
+  const $dd_isRedactedIdentifier = (key) =>
+    typeof key === 'string' && $dd_redactedIdentifiers.has(key.toLowerCase().replace(/[-_@$.]/g, ''));
+  const $dd_hasRedactedKey = (keys) => {
+    for (const key of keys) if ($dd_isRedactedIdentifier(key)) return true;
+    return false;
+  };
+  const $dd_redactSegmentValue = (value) => {
+    if (value === null || typeof value !== 'object') return value;
+    if (value instanceof Map) {
+      if (!$dd_hasRedactedKey(value.keys())) return value;
+      const redacted = new Map();
+      for (const [key, val] of value) redacted.set(key, $dd_isRedactedIdentifier(key) ? '[redacted]' : val);
+      return redacted;
+    }
+    const keys = Reflect.ownKeys(value);
+    if (!$dd_hasRedactedKey(keys)) return value;
+    const redacted = Object.create(Object.getPrototypeOf(value));
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if ($dd_isRedactedIdentifier(key)) {
+        Object.defineProperty(redacted, key,
+          { value: '[redacted]', writable: true, enumerable: descriptor.enumerable, configurable: true });
+      } else {
+        Object.defineProperty(redacted, key, descriptor);
+      }
+    }
+    return redacted;
+  };
+  const $dd_inspectSegment = (value) =>
+    typeof value === 'string' ? value : $dd_inspect($dd_redactSegmentValue(value), $dd_segmentInspectOptions);
 `
 const getDDTagsExpression = `(() => {
   const context = global.require('dd-trace').scope().active()?.context();

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -3,6 +3,7 @@
 const { randomUUID } = require('crypto')
 const { workerData: { probeSamplerBuffer } } = require('worker_threads')
 const { version } = require('../../../../../package.json')
+const { NODE_MAJOR } = require('../../../../../version')
 const processTags = require('../../process-tags')
 const {
   MAX_SAMPLED_PROBES_PER_PAUSE,
@@ -28,6 +29,14 @@ require('./remote_config')
 const templateExpressionSetupCode = `
   const $dd_inspect = global.require('node:util').inspect;
   const $dd_types = global.require('node:util').types;
+  // Intrinsics are captured from the global object rather than resolved against the paused
+  // call frame, so an application local named Set/Map/Object/Reflect cannot shadow them and
+  // turn the whole setup into a TypeError (which would send every log probe at that pause
+  // with an empty message).
+  const $dd_Object = global.Object;
+  const $dd_Reflect = global.Reflect;
+  const $dd_Map = global.Map;
+  const $dd_Set = global.Set;
   const $dd_segmentInspectOptions = {
     depth: 0,
     customInspect: false,
@@ -35,7 +44,12 @@ const templateExpressionSetupCode = `
     maxStringLength: 8 * 1024,
     breakLength: Infinity
   };
-  const $dd_redactedIdentifiers = new Set(${JSON.stringify([...REDACTED_IDENTIFIERS])});
+  // On Node.js <= 18, util.inspect does not apply maxArrayLength to Maps, so every entry is
+  // rendered; on Node.js > 18 only the first maxArrayLength entries render. The redaction
+  // window must follow the runtime so a sensitive key that is actually rendered on Node.js 18
+  // is not missed by the bounded pre-scan.
+  const $dd_boundMapRendering = ${NODE_MAJOR > 18};
+  const $dd_redactedIdentifiers = new $dd_Set(${JSON.stringify([...REDACTED_IDENTIFIERS])});
   const $dd_normalizeIdentifier = (key) => {
     if (typeof key === 'string') return key.toLowerCase().replace(/[-_@$.]/g, '');
     // Symbol('x').toString() is 'Symbol(x)'; slice(7, -1) yields 'x', matching
@@ -51,36 +65,73 @@ const templateExpressionSetupCode = `
     for (const key of keys) if ($dd_isRedactedIdentifier(key)) return true;
     return false;
   };
+  const $dd_enumerableOwnKeys = (value) => {
+    const keys = [];
+    for (const key of $dd_Reflect.ownKeys(value)) {
+      if ($dd_Object.getOwnPropertyDescriptor(value, key).enumerable) keys.push(key);
+    }
+    return keys;
+  };
+  // Copies own properties, substituting '[redacted]' for values whose key is a redacted
+  // identifier. Descriptors are copied verbatim for non-redacted keys so getters remain
+  // getters (util.inspect renders them as [Getter] without invoking them in the paused frame).
+  const $dd_redactOwnPropertiesInto = (target, source, keys) => {
+    for (const key of keys) {
+      const descriptor = $dd_Object.getOwnPropertyDescriptor(source, key);
+      if ($dd_isRedactedIdentifier(key)) {
+        $dd_Object.defineProperty(target, key,
+          { value: '[redacted]', writable: true, enumerable: descriptor.enumerable, configurable: true });
+      } else {
+        $dd_Object.defineProperty(target, key, descriptor);
+      }
+    }
+  };
   const $dd_redactSegmentValue = (value) => {
-    if (value === null || typeof value !== 'object') return value;
+    if (value === null) return value;
+    const $dd_type = typeof value;
+    if ($dd_type !== 'object' && $dd_type !== 'function') return value;
     if ($dd_types.isMap(value)) {
-      // Only the first maxArrayLength entries are rendered, so scanning past that
-      // window cannot affect the output. Bounding the scan keeps the common
-      // large-Map case constant-time on the paused application thread.
+      // Iterate via the intrinsic Map.prototype so a Map subclass that overrides keys()/entries()
+      // cannot run its own code (or mutate state, or throw) while the application thread is paused.
       const $dd_max = $dd_segmentInspectOptions.maxArrayLength;
       let $dd_index = 0;
       let $dd_hasRenderedRedactedKey = false;
-      for (const key of value.keys()) {
-        if ($dd_index++ >= $dd_max) break;
+      for (const key of $dd_Map.prototype.keys.call(value)) {
+        if ($dd_boundMapRendering && $dd_index++ >= $dd_max) break;
         if ($dd_isRedactedIdentifier(key)) { $dd_hasRenderedRedactedKey = true; break; }
       }
-      if (!$dd_hasRenderedRedactedKey) return value;
-      const redacted = new Map();
-      for (const [key, val] of value) redacted.set(key, $dd_isRedactedIdentifier(key) ? '[redacted]' : val);
+      const $dd_ownKeys = $dd_Reflect.ownKeys(value);
+      const $dd_ownKeysRedacted = $dd_hasRedactedKey($dd_ownKeys);
+      if (!$dd_hasRenderedRedactedKey && !$dd_ownKeysRedacted) return value;
+      // A full copy keeps the rendered Map(N) size and "... K more items" marker matching the
+      // original; only entries inside the rendered window can be displayed, so entry values are
+      // redacted only within that window (entries beyond it are copied by reference, never shown).
+      const redacted = new $dd_Map();
+      $dd_index = 0;
+      for (const [key, val] of $dd_Map.prototype.entries.call(value)) {
+        const $dd_withinWindow = !$dd_boundMapRendering || $dd_index++ < $dd_max;
+        redacted.set(key, $dd_withinWindow && $dd_isRedactedIdentifier(key) ? '[redacted]' : val);
+      }
+      // A Map can also carry its own string/symbol properties, which util.inspect renders
+      // alongside its entries; redact those the same way as plain object properties.
+      if ($dd_ownKeysRedacted) $dd_redactOwnPropertiesInto(redacted, value, $dd_ownKeys);
       return redacted;
     }
-    const keys = Reflect.ownKeys(value);
-    if (!$dd_hasRedactedKey(keys)) return value;
-    const redacted = Object.create(Object.getPrototypeOf(value));
-    for (const key of keys) {
-      const descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if ($dd_isRedactedIdentifier(key)) {
-        Object.defineProperty(redacted, key,
-          { value: '[redacted]', writable: true, enumerable: descriptor.enumerable, configurable: true });
-      } else {
-        Object.defineProperty(redacted, key, descriptor);
-      }
+    if ($dd_type === 'function') {
+      // Functions render as \`[Function: name] { ...own props... }\`, so a sensitive own property
+      // leaks unless redacted. Clone into a same-named function to preserve that rendering (an
+      // async/generator function degrades to the plain [Function: name] tag in this rare case,
+      // but the value is still redacted).
+      const $dd_ownKeys = $dd_enumerableOwnKeys(value);
+      if (!$dd_hasRedactedKey($dd_ownKeys)) return value;
+      const redacted = ({ [value.name]: function () {} })[value.name];
+      $dd_redactOwnPropertiesInto(redacted, value, $dd_ownKeys);
+      return redacted;
     }
+    const $dd_keys = $dd_Reflect.ownKeys(value);
+    if (!$dd_hasRedactedKey($dd_keys)) return value;
+    const redacted = $dd_Object.create($dd_Object.getPrototypeOf(value));
+    $dd_redactOwnPropertiesInto(redacted, value, $dd_keys);
     return redacted;
   };
   const $dd_inspectSegment = (value, directRefIdentifier) => {
@@ -89,10 +140,12 @@ const templateExpressionSetupCode = `
     // the reference name the compiler passed in, matching the snapshot path.
     if (directRefIdentifier !== undefined && $dd_isRedactedIdentifier(directRefIdentifier)) return '[redacted]';
     if (typeof value === 'string') return value;
-    // Proxies are rendered as a fixed token: enumerating one via Reflect.ownKeys
-    // would run its traps (customer code) in the paused frame, and letting
+    // Proxies (of objects or functions) are rendered as a fixed token: enumerating one via
+    // Reflect.ownKeys would run its traps (customer code) in the paused frame, and letting
     // util.inspect render the target would leak a proxy-wrapped secret.
-    if (value !== null && typeof value === 'object' && $dd_types.isProxy(value)) return '[Proxy]';
+    if (value !== null && (typeof value === 'object' || typeof value === 'function') && $dd_types.isProxy(value)) {
+      return '[Proxy]';
+    }
     return $dd_inspect($dd_redactSegmentValue(value), $dd_segmentInspectOptions);
   };
 `

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -126,7 +126,7 @@ describe('Expression language', function () {
         `[(() => {
           try {
             const result = foo
-            return $dd_inspectSegment(result)
+            return $dd_inspectSegment(result, "foo")
           } catch (e) {
             return { expr: "foo", message: \`\${e.name}: \${e.message}\` }
           }
@@ -146,12 +146,29 @@ describe('Expression language', function () {
         `["foo: ",(() => {
           try {
             const result = foo
-            return $dd_inspectSegment(result)
+            return $dd_inspectSegment(result, "foo")
           } catch (e) {
             return { expr: "foo", message: \`\${e.name}: \${e.message}\` }
           }
         })()]`
       )
+    })
+
+    it('should thread the direct-reference identifier to $dd_inspectSegment', function () {
+      assert.deepStrictEqual(compileSegments([{ dsl: 'password', json: { ref: 'password' } }]),
+        `[(() => {
+          try {
+            const result = password
+            return $dd_inspectSegment(result, "password")
+          } catch (e) {
+            return { expr: "password", message: \`\${e.name}: \${e.message}\` }
+          }
+        })()]`
+      )
+      // getmember compiles to a guarded accessor, so assert only that the terminal member
+      // name is threaded as the direct-reference identifier.
+      const memberResult = compileSegments([{ dsl: 'user.password', json: { getmember: [{ ref: 'user' }, 'password'] } }])
+      assert.match(memberResult, /return \$dd_inspectSegment\(result, "password"\)/)
     })
   })
 })

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -126,7 +126,7 @@ describe('Expression language', function () {
         `[(() => {
           try {
             const result = foo
-            return typeof result === 'string' ? result : $dd_inspect(result, $dd_segmentInspectOptions)
+            return $dd_inspectSegment(result)
           } catch (e) {
             return { expr: "foo", message: \`\${e.name}: \${e.message}\` }
           }
@@ -146,7 +146,7 @@ describe('Expression language', function () {
         `["foo: ",(() => {
           try {
             const result = foo
-            return typeof result === 'string' ? result : $dd_inspect(result, $dd_segmentInspectOptions)
+            return $dd_inspectSegment(result)
           } catch (e) {
             return { expr: "foo", message: \`\${e.name}: \${e.message}\` }
           }

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -167,7 +167,9 @@ describe('Expression language', function () {
       )
       // getmember compiles to a guarded accessor, so assert only that the terminal member
       // name is threaded as the direct-reference identifier.
-      const memberResult = compileSegments([{ dsl: 'user.password', json: { getmember: [{ ref: 'user' }, 'password'] } }])
+      const memberResult = compileSegments(
+        [{ dsl: 'user.password', json: { getmember: [{ ref: 'user' }, 'password'] } }]
+      )
       assert.match(memberResult, /return \$dd_inspectSegment\(result, "password"\)/)
     })
   })

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -117,6 +117,7 @@ describe('onPause', function () {
       './session': session,
       './state': state,
       './snapshot': snapshot,
+      './snapshot/redaction': redaction,
       './log': log,
       './send': send,
       './status': { ackEmitting },


### PR DESCRIPTION
### What does this PR do?

Makes the Dynamic Instrumentation log-probe **message** path honor the same redaction the snapshot path applies.

Log probe template segments were rendered with `util.inspect` (`$dd_inspect`) and no redaction. A template that references an object or map (e.g. `{user}`, `{params}`) interpolated every own property / entry verbatim, so sensitive identifiers (`password`, `api_key`, `session`, …) were emitted in plaintext to the debugger intake — even though the snapshot path (`snapshot/processor.js`) already redacts them.

The fix injects a redaction-aware segment serializer into the code evaluated in the paused process:
- `$dd_redactSegmentValue` replaces a property/entry value with `[redacted]` when its key matches a redacted identifier, for plain objects, class instances, and `Map`s;
- objects/maps whose own keys are all non-redacted are passed to `util.inspect` untouched, so the existing message format (including `[Object]`, `[Getter]`, circular/proxy rendering) is preserved;

### Motivation

APMSP-3552 audited across all tracers - Node is the only one lacking redaction besides Ruby.

### Additional Notes

Ruby fix: https://github.com/DataDog/dd-trace-rb/pull/6155

