### PR TITLE
fix(serverless): retain in-flight exports on Vercel

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -6,6 +6,7 @@ const { withRequest } = require('../../dd-trace/src/appsec/store')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+const { onRequestEnd } = require('../../dd-trace/src/serverless')
 
 const legacyStorage = storage('legacy')
 
@@ -96,6 +97,7 @@ class HttpServerPlugin extends ServerPlugin {
     }
 
     web.finishAll(context)
+    onRequestEnd()
   }
 
   exit ({ req }) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -4,6 +4,7 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+const { onRequestEnd } = require('../../dd-trace/src/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
 
@@ -98,6 +99,7 @@ class NextPlugin extends ServerPlugin {
     this.config.hooks.request(span, req, res)
 
     span.finish()
+    if (!store.httpParentSpan) onRequestEnd()
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false, isFilesystemPath = isAppPath }) {

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -447,6 +447,12 @@ class Config extends ConfigBase {
       setAndTrack(this, 'flushInterval', 0)
     }
 
+    // Vercel freezes Node functions once the request completes. Flush immediately by default so
+    // the request exists before the serverless lifecycle attaches it to `waitUntil`.
+    if (getEnvironmentVariable('VERCEL') === '1' && !trackedConfigOrigins.has('flushInterval')) {
+      setAndTrack(this, 'flushInterval', 0)
+    }
+
     if (!trackedConfigOrigins.has('apmTracingEnabled') &&
         trackedConfigOrigins.has('experimental.appsec.standalone.enabled')) {
       setAndTrack(this, 'apmTracingEnabled', !this.experimental.appsec.standalone.enabled)

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -10,6 +10,7 @@ const zlib = require('zlib')
 
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
+const { trackExport } = require('../../serverless/pending_exports')
 const { isLoopbackHost, parseUrl } = require('./url')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
@@ -78,6 +79,12 @@ function request (data, options, callback) {
       })
 
     return
+  }
+
+  const finishExport = trackExport()
+  const done = (...args) => {
+    finishExport()
+    callback(...args)
   }
 
   // The timeout should be kept low to avoid excessive queueing.
@@ -171,7 +178,7 @@ function request (data, options, callback) {
   const attempt = attemptIndex => {
     if (!request.writable) {
       log.debug('Maximum number of active requests reached: payload is discarded.')
-      return callback(null)
+      return done(null)
     }
 
     activeBufferSize += options.headers['Content-Length'] ?? 0
@@ -195,7 +202,7 @@ function request (data, options, callback) {
         if (settled) return
         settled = true
         finalize()
-        callback(error, result, statusCode, headers)
+        done(error, result, statusCode, headers)
       }
 
       /**
@@ -241,7 +248,12 @@ function request (data, options, callback) {
     })
   }
 
-  attempt(1)
+  try {
+    attempt(1)
+  } catch (error) {
+    finishExport()
+    throw error
+  }
 }
 
 function byteLength (data) {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -1,6 +1,12 @@
 'use strict'
 
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
+const { waitForPendingExports } = require('./serverless/pending_exports')
+
+const VERCEL_REQUEST_CONTEXTS = [
+  Symbol.for('@next/request-context'),
+  Symbol.for('@vercel/request-context'),
+]
 
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
@@ -42,10 +48,33 @@ function isInServerlessEnvironment () {
   return inAWSLambda || isGCPFunction || isAzureFunction
 }
 
+function retainVercelRequest (promise) {
+  if (getEnvironmentVariable('VERCEL') !== '1') return false
+
+  for (const requestContext of VERCEL_REQUEST_CONTEXTS) {
+    try {
+      const waitUntil = globalThis[requestContext]?.get?.()?.waitUntil
+      if (typeof waitUntil !== 'function') continue
+      waitUntil(promise)
+      return true
+    } catch {
+      // The other request-context implementation may still be available.
+    }
+  }
+
+  return false
+}
+
+function onRequestEnd () {
+  return retainVercelRequest(waitForPendingExports())
+}
+
 module.exports = {
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  retainVercelRequest,
+  onRequestEnd,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -66,6 +66,7 @@ function retainVercelRequest (promise) {
 }
 
 function onRequestEnd () {
+  if (getEnvironmentVariable('VERCEL') !== '1') return false
   return retainVercelRequest(waitForPendingExports())
 }
 

--- a/packages/dd-trace/src/serverless/pending_exports.js
+++ b/packages/dd-trace/src/serverless/pending_exports.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const pending = new Set()
+
+function trackExport () {
+  let resolve
+  const exportPromise = new Promise((_resolve) => { resolve = _resolve })
+  pending.add(exportPromise)
+
+  return () => {
+    pending.delete(exportPromise)
+    resolve()
+  }
+}
+
+function waitForPendingExports () {
+  return Promise.allSettled(pending)
+}
+
+module.exports = { trackExport, waitForPendingExports }

--- a/packages/dd-trace/src/serverless/pending_exports.js
+++ b/packages/dd-trace/src/serverless/pending_exports.js
@@ -1,8 +1,13 @@
 'use strict'
 
+const { getEnvironmentVariable } = require('../config/helper')
+
 const pending = new Set()
+const noop = () => {}
 
 function trackExport () {
+  if (getEnvironmentVariable('VERCEL') !== '1') return noop
+
   let resolve
   const exportPromise = new Promise((_resolve) => { resolve = _resolve })
   pending.add(exportPromise)
@@ -13,8 +18,10 @@ function trackExport () {
   }
 }
 
-function waitForPendingExports () {
-  return Promise.allSettled(pending)
+async function waitForPendingExports () {
+  while (pending.size) {
+    await Promise.allSettled([...pending])
+  }
 }
 
 module.exports = { trackExport, waitForPendingExports }

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -3159,6 +3159,25 @@ describe('Config', () => {
     })
   })
 
+  describe('flushInterval in Vercel', () => {
+    it('should set the default flush interval to 0', () => {
+      process.env.VERCEL = '1'
+
+      const config = getConfig()
+
+      assert.strictEqual(config.flushInterval, 0)
+    })
+
+    it('should preserve an explicit flush interval', () => {
+      process.env.VERCEL = '1'
+      process.env.DD_TRACE_FLUSH_INTERVAL = '1234'
+
+      const config = getConfig()
+
+      assert.strictEqual(config.flushInterval, 1234)
+    })
+  })
+
   it('should not set DD_REMOTE_CONFIGURATION_ENABLED if FUNCTION_NAME and GCP_PROJECT are present', () => {
     process.env.FUNCTION_NAME = 'function_name'
     process.env.GCP_PROJECT = 'project_name'

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -61,6 +61,7 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'FUNCTIONS_WORKER_RUNTIME',
   'GCP_PROJECT',
   'K_SERVICE',
+  'VERCEL',
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -71,6 +71,28 @@ describe('retainVercelRequest', () => {
     assert.strictEqual(completed, true)
   })
 
+  it('retains exports started by completion callbacks', async () => {
+    process.env.VERCEL = '1'
+    let retained
+    const finishInitialExport = trackExport()
+    globalThis[requestContext] = {
+      get: () => ({ waitUntil: promise => { retained = promise } }),
+    }
+
+    assert.strictEqual(onRequestEnd(), true)
+    finishInitialExport()
+
+    const finishFallbackExport = trackExport()
+    let completed = false
+    retained.then(() => { completed = true })
+    await Promise.resolve()
+    assert.strictEqual(completed, false)
+
+    finishFallbackExport()
+    await retained
+    assert.strictEqual(completed, true)
+  })
+
   it('does nothing outside Vercel', () => {
     delete process.env.VERCEL
     assert.strictEqual(retainVercelRequest(Promise.resolve()), false)

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -6,7 +6,8 @@ const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { enableGCPPubSubPushSubscription, onRequestEnd, retainVercelRequest } = require('../src/serverless')
+const { trackExport } = require('../src/serverless/pending_exports')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -34,5 +35,44 @@ describe('enableGCPPubSubPushSubscription', () => {
     process.env.K_SERVICE = 'svc'
     process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED = 'false'
     assert.strictEqual(enableGCPPubSubPushSubscription(), false)
+  })
+})
+
+describe('retainVercelRequest', () => {
+  const requestContext = Symbol.for('@vercel/request-context')
+  const originalVercel = process.env.VERCEL
+  const originalRequestContext = globalThis[requestContext]
+
+  afterEach(() => {
+    if (originalVercel === undefined) delete process.env.VERCEL
+    else process.env.VERCEL = originalVercel
+
+    if (originalRequestContext === undefined) delete globalThis[requestContext]
+    else globalThis[requestContext] = originalRequestContext
+  })
+
+  it('retains globally pending exports until they complete', async () => {
+    process.env.VERCEL = '1'
+    let retained
+    const finishExport = trackExport()
+    globalThis[requestContext] = {
+      get: () => ({ waitUntil: promise => { retained = promise } }),
+    }
+
+    assert.strictEqual(onRequestEnd(), true)
+
+    let completed = false
+    retained.then(() => { completed = true })
+    await Promise.resolve()
+    assert.strictEqual(completed, false)
+
+    finishExport()
+    await retained
+    assert.strictEqual(completed, true)
+  })
+
+  it('does nothing outside Vercel', () => {
+    delete process.env.VERCEL
+    assert.strictEqual(retainVercelRequest(Promise.resolve()), false)
   })
 })


### PR DESCRIPTION
## Summary
- retain existing outbound telemetry requests through Vercel `waitUntil`
- do not change exporter or `forceFlush()` contracts
- hook normal HTTP and Next request completion after spans finish

## Verification
- `npx mocha packages/dd-trace/test/serverless.spec.js`
- deployed Vercel control: five normal requests exported all request/manual spans and metric points without customer-side flush code