### PR TITLE
fix(next): trace compiled response lifecycles

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -267,12 +267,16 @@ addHook({
 // From Next 15.4.1, route modules execute through precompiled runtime bundles that bypass the
 // classic server hooks above. Match bundler and experimental filename variants without enumerating
 // them so App Routes, Pages APIs, and App Pages reuse the existing Next request lifecycle.
+// The route module classes and inherited methods are selected inside those bundles, so there is no
+// stable source function for Orchestrion to rewrite.
 const patchedRouteModules = new WeakSet()
+const routeResponses = new WeakMap()
+const activeRouteRequests = new WeakMap()
 const COMPILED_RUNTIME_PATH = 'dist/compiled/next-server/'
 function wrapOnRequestError (onRequestError) {
   return function (req, error) {
     if (error) {
-      errorChannel.publish({ error })
+      publishError(req, undefined, error)
     }
     return onRequestError.apply(this, arguments)
   }
@@ -302,31 +306,90 @@ function publishRoutePage (ctx, routeModule, fallbackPage, isAppPath) {
 
 function wrapAppRouteHandle (handle) {
   return function (req, context) {
-    if (!startChannel.hasSubscribers && !queryParsedChannel.hasSubscribers) {
-      return handle.apply(this, arguments)
+    if (finishChannel.hasSubscribers) {
+      const nodeRequest = activeRouteRequests.get(this)
+      if (nodeRequest) {
+        nodeNextRequestsToNextRequests.set(nodeRequest, req)
+      }
     }
 
-    const res = { statusCode: 500 }
-    nodeNextRequestsToNextRequests.set(req, req)
+    return handle.apply(this, arguments)
+  }
+}
+
+function wrapPrepare (prepare) {
+  return function (req, res) {
+    if (startChannel.hasSubscribers || queryParsedChannel.hasSubscribers) {
+      routeResponses.set(req, res)
+    }
+
+    return prepare.apply(this, arguments)
+  }
+}
+
+function wrapResponseGenerator (responseGenerator, routeModule, req) {
+  return function () {
+    // Next calls the route module before the generator's first await. Limit the association to that
+    // synchronous call so concurrent requests can share the route module instance safely.
+    activeRouteRequests.set(routeModule, req)
+    const result = responseGenerator.apply(this, arguments)
+    activeRouteRequests.delete(routeModule)
+    return result
+  }
+}
+
+function wrapHandleResponse (handleResponse, appRoute) {
+  return function (options) {
+    const req = options.req
+    const res = routeResponses.get(req)
+    routeResponses.delete(req)
+
+    if (!res || (!startChannel.hasSubscribers && !queryParsedChannel.hasSubscribers)) {
+      return handleResponse.apply(this, arguments)
+    }
+
+    if (appRoute) {
+      options.responseGenerator = wrapResponseGenerator(options.responseGenerator, this, req)
+    }
 
     return instrument(req, res, ctx => {
       publishRoutePage(ctx, this, undefined, true)
 
-      return handle.apply(this, arguments).then(response => {
-        if (ctx) ctx.res.statusCode = response?.status || 200
-        return response
+      return handleResponse.apply(this, arguments).then(result => {
+        const statusCode = result?.value?.status
+        if (ctx && typeof statusCode === 'number') {
+          ctx.res.statusCode = statusCode
+        }
+
+        return result
+      }, error => {
+        if (ctx && (typeof ctx.res.statusCode !== 'number' || ctx.res.statusCode < 400)) {
+          ctx.res.statusCode = 500
+        }
+
+        throw error
       })
     })
   }
 }
 
-function instrumentRouteModule (RouteModule, method, wrapper, handleErrors) {
+function wrapAppRouteHandleResponse (handleResponse) {
+  return wrapHandleResponse(handleResponse, true)
+}
+
+function wrapAppPageHandleResponse (handleResponse) {
+  return wrapHandleResponse(handleResponse, false)
+}
+
+function instrumentRouteModule (RouteModule, wrappers, handleErrors) {
   const proto = RouteModule?.prototype
   if (!proto || patchedRouteModules.has(RouteModule)) return
 
   patchedRouteModules.add(RouteModule)
-  if (typeof proto[method] === 'function') {
-    shimmer.wrap(proto, method, wrapper)
+  for (const [method, wrapper] of wrappers) {
+    if (typeof proto[method] === 'function') {
+      shimmer.wrap(proto, method, wrapper)
+    }
   }
   if (handleErrors && typeof proto.onRequestError === 'function') {
     shimmer.wrap(proto, 'onRequestError', wrapOnRequestError)
@@ -334,7 +397,11 @@ function instrumentRouteModule (RouteModule, method, wrapper, handleErrors) {
 }
 
 function instrumentAppRouteRuntime (runtime) {
-  instrumentRouteModule(runtime.AppRouteRouteModule, 'handle', wrapAppRouteHandle, true)
+  instrumentRouteModule(runtime.AppRouteRouteModule, [
+    ['prepare', wrapPrepare],
+    ['handleResponse', wrapAppRouteHandleResponse],
+    ['handle', wrapAppRouteHandle],
+  ], true)
   return runtime
 }
 
@@ -361,40 +428,16 @@ function wrapPagesApiRender (render) {
 
 function instrumentPagesApiRuntime (runtime) {
   const PagesAPIRouteModule = runtime.PagesAPIRouteModule || runtime.default
-  instrumentRouteModule(PagesAPIRouteModule, 'render', wrapPagesApiRender, false)
+  instrumentRouteModule(PagesAPIRouteModule, [['render', wrapPagesApiRender]], false)
   return runtime
-}
-
-function wrapAppPageRender (render) {
-  return function (req, res, context = {}) {
-    if (!startChannel.hasSubscribers && !queryParsedChannel.hasSubscribers) {
-      return render.apply(this, arguments)
-    }
-
-    return instrument(req, res, ctx => {
-      publishRoutePage(ctx, this, context.page, true)
-
-      return render.apply(this, arguments).then(result => {
-        const statusCode = result?.metadata?.statusCode
-        if (ctx && typeof statusCode === 'number') {
-          ctx.res.statusCode = statusCode
-        }
-
-        return result
-      }, error => {
-        if (ctx && (typeof ctx.res.statusCode !== 'number' || ctx.res.statusCode < 400)) {
-          ctx.res.statusCode = 500
-        }
-
-        throw error
-      })
-    })
-  }
 }
 
 function instrumentAppPageRuntime (runtime) {
   const AppPageRouteModule = runtime.AppPageRouteModule || runtime.default
-  instrumentRouteModule(AppPageRouteModule, 'render', wrapAppPageRender, true)
+  instrumentRouteModule(AppPageRouteModule, [
+    ['prepare', wrapPrepare],
+    ['handleResponse', wrapAppPageHandleResponse],
+  ], true)
   return runtime
 }
 

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -30,12 +30,17 @@ const queryParsedChannel = channel('apm:next:query-parsed')
  * @property {NextNodeRequest} req
  * @property {NextNodeResponse} res
  * @property {boolean} [finishOnResponse]
+ * @property {boolean} [handlerFinished]
+ * @property {boolean} [responseFinished]
  * @property {unknown} [error]
  * @property {NextRequest} [nextRequest]
  *
+ * @typedef {object} ResponseGeneratorContext
+ * @property {boolean} [hasResolved]
+ *
  * @typedef {object} HandleResponseOptions
  * @property {NextNodeRequest} req
- * @property {(...args: unknown[]) => Promise<unknown>} responseGenerator
+ * @property {(context?: ResponseGeneratorContext) => Promise<unknown>} responseGenerator
  *
  * @typedef {object} ResponseCacheEntry
  * @property {{ status?: number }} [value]
@@ -44,6 +49,7 @@ const queryParsedChannel = channel('apm:next:query-parsed')
 const requests = new WeakSet()
 const nodeNextRequestsToNextRequests = new WeakMap()
 const requestErrors = new WeakMap()
+const backgroundRevalidationRequests = new WeakSet()
 
 // Next.js <= 14.2.6
 const MIDDLEWARE_HEADER = 'x-middleware-invoke'
@@ -203,6 +209,16 @@ function instrument (req, res, handler, error, finishOnResponse = false) {
   requests.add(req)
 
   const ctx = finishOnResponse ? { req, res, finishOnResponse } : { req, res }
+  if (finishOnResponse) {
+    const onResponseFinish = () => {
+      res.removeListener('finish', onResponseFinish)
+      res.removeListener('close', onResponseFinish)
+      ctx.responseFinished = true
+      if (ctx.handlerFinished) publishFinish(ctx, ctx.error)
+    }
+    res.once('finish', onResponseFinish)
+    res.once('close', onResponseFinish)
+  }
   if (queryParsedChannel.hasSubscribers && req.url) {
     const queryIndex = req.url.indexOf('?')
     if (queryIndex !== -1) {
@@ -250,8 +266,8 @@ function wrapServeStatic (serveStatic) {
   }
 }
 
-function finish (ctx, result, err) {
-  publishError(ctx.req, ctx, err)
+function publishFinish (ctx, error) {
+  publishError(ctx.req, ctx, error)
   requestErrors.delete(ctx.req)
 
   const maybeNextRequest = nodeNextRequestsToNextRequests.get(ctx.req)
@@ -260,6 +276,16 @@ function finish (ctx, result, err) {
   }
 
   finishChannel.publish(ctx)
+}
+
+function finish (ctx, result, error) {
+  if (ctx.finishOnResponse) {
+    ctx.handlerFinished = true
+    if (error) ctx.error = error
+    if (!ctx.responseFinished) return
+  }
+
+  publishFinish(ctx, error)
 }
 
 /**
@@ -317,7 +343,8 @@ const activeRouteRequests = new WeakMap()
 const COMPILED_RUNTIME_PATH = 'dist/compiled/next-server/'
 function wrapOnRequestError (onRequestError) {
   return function (req, error) {
-    if (error) {
+    const nodeRequest = req.originalRequest || req
+    if (error && !backgroundRevalidationRequests.has(nodeRequest)) {
       publishError(req, undefined, error)
     }
     return onRequestError.apply(this, arguments)
@@ -370,13 +397,20 @@ function wrapPrepare (prepare) {
 }
 
 /**
- * @param {(...args: unknown[]) => unknown} responseGenerator
- * @param {object} routeModule
+ * @param {(context?: ResponseGeneratorContext) => unknown} responseGenerator
+ * @param {object | undefined} routeModule
  * @param {NextNodeRequest} req
- * @returns {(...args: unknown[]) => unknown}
+ * @returns {(context?: ResponseGeneratorContext) => unknown}
  */
 function wrapResponseGenerator (responseGenerator, routeModule, req) {
-  return function () {
+  return function (context) {
+    if (context?.hasResolved) {
+      backgroundRevalidationRequests.add(req.originalRequest || req)
+    }
+    if (!routeModule) {
+      return responseGenerator.apply(this, arguments)
+    }
+
     // Next calls the route module before the generator's first await. Limit the association to that
     // synchronous call so concurrent requests can share the route module instance safely.
     activeRouteRequests.set(routeModule, req)
@@ -403,9 +437,8 @@ function wrapHandleResponse (handleResponse, finishOnResponse) {
       return handleResponse.apply(this, arguments)
     }
 
-    if (!finishOnResponse) {
-      options.responseGenerator = wrapResponseGenerator(options.responseGenerator, this, req)
-    }
+    const routeModule = finishOnResponse ? undefined : this
+    options.responseGenerator = wrapResponseGenerator(options.responseGenerator, routeModule, req)
 
     return instrument(req, res, ctx => {
       publishRoutePage(ctx, this, undefined, true)
@@ -424,7 +457,7 @@ function wrapHandleResponse (handleResponse, finishOnResponse) {
 
         throw error
       })
-    }, undefined, finishOnResponse)
+    }, undefined, finishOnResponse && finishChannel.hasSubscribers)
   }
 }
 

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -13,6 +13,34 @@ const pageLoadChannel = channel('apm:next:page:load')
 const bodyParsedChannel = channel('apm:next:body-parsed')
 const queryParsedChannel = channel('apm:next:query-parsed')
 
+/**
+ * @typedef {import('node:http').IncomingMessage & {
+ *   error?: unknown,
+ *   originalRequest?: import('node:http').IncomingMessage
+ * }} NextNodeRequest
+ *
+ * @typedef {import('node:http').ServerResponse & {
+ *   originalResponse?: import('node:http').ServerResponse
+ * }} NextNodeResponse
+ *
+ * @typedef {object} NextRequest
+ * @property {unknown} [error]
+ *
+ * @typedef {object} NextRequestContext
+ * @property {NextNodeRequest} req
+ * @property {NextNodeResponse} res
+ * @property {boolean} [finishOnResponse]
+ * @property {unknown} [error]
+ * @property {NextRequest} [nextRequest]
+ *
+ * @typedef {object} HandleResponseOptions
+ * @property {NextNodeRequest} req
+ * @property {(...args: unknown[]) => Promise<unknown>} responseGenerator
+ *
+ * @typedef {object} ResponseCacheEntry
+ * @property {{ status?: number }} [value]
+ */
+
 const requests = new WeakSet()
 const nodeNextRequestsToNextRequests = new WeakMap()
 const requestErrors = new WeakMap()
@@ -149,7 +177,16 @@ function getRequestMeta (req, key) {
   return typeof key === 'string' ? meta[key] : meta
 }
 
-function instrument (req, res, handler, error) {
+/**
+ * @template T
+ * @param {NextNodeRequest} req
+ * @param {NextNodeResponse} res
+ * @param {(ctx: NextRequestContext) => Promise<T>} handler
+ * @param {unknown} [error]
+ * @param {boolean} [finishOnResponse]
+ * @returns {Promise<T>}
+ */
+function instrument (req, res, handler, error, finishOnResponse = false) {
   req = req.originalRequest || req
   res = res.originalResponse || res
 
@@ -165,7 +202,7 @@ function instrument (req, res, handler, error) {
 
   requests.add(req)
 
-  const ctx = { req, res }
+  const ctx = finishOnResponse ? { req, res, finishOnResponse } : { req, res }
   if (queryParsedChannel.hasSubscribers && req.url) {
     const queryIndex = req.url.indexOf('?')
     if (queryIndex !== -1) {
@@ -225,6 +262,11 @@ function finish (ctx, result, err) {
   finishChannel.publish(ctx)
 }
 
+/**
+ * @param {NextNodeRequest} req
+ * @param {NextRequestContext | undefined} ctx
+ * @param {unknown} error
+ */
 function publishError (req, ctx, error) {
   if (!error) return
 
@@ -242,7 +284,7 @@ function publishError (req, ctx, error) {
     ctx.error = error
     errorChannel.publish(ctx)
   } else {
-    errorChannel.publish({ error })
+    errorChannel.publish({ req, error })
   }
 }
 
@@ -327,18 +369,31 @@ function wrapPrepare (prepare) {
   }
 }
 
+/**
+ * @param {(...args: unknown[]) => unknown} responseGenerator
+ * @param {object} routeModule
+ * @param {NextNodeRequest} req
+ * @returns {(...args: unknown[]) => unknown}
+ */
 function wrapResponseGenerator (responseGenerator, routeModule, req) {
   return function () {
     // Next calls the route module before the generator's first await. Limit the association to that
     // synchronous call so concurrent requests can share the route module instance safely.
     activeRouteRequests.set(routeModule, req)
-    const result = responseGenerator.apply(this, arguments)
-    activeRouteRequests.delete(routeModule)
-    return result
+    try {
+      return responseGenerator.apply(this, arguments)
+    } finally {
+      activeRouteRequests.delete(routeModule)
+    }
   }
 }
 
-function wrapHandleResponse (handleResponse, appRoute) {
+/**
+ * @param {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>} handleResponse
+ * @param {boolean} finishOnResponse
+ * @returns {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>}
+ */
+function wrapHandleResponse (handleResponse, finishOnResponse) {
   return function (options) {
     const req = options.req
     const res = routeResponses.get(req)
@@ -348,7 +403,7 @@ function wrapHandleResponse (handleResponse, appRoute) {
       return handleResponse.apply(this, arguments)
     }
 
-    if (appRoute) {
+    if (!finishOnResponse) {
       options.responseGenerator = wrapResponseGenerator(options.responseGenerator, this, req)
     }
 
@@ -369,16 +424,24 @@ function wrapHandleResponse (handleResponse, appRoute) {
 
         throw error
       })
-    })
+    }, undefined, finishOnResponse)
   }
 }
 
+/**
+ * @param {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>} handleResponse
+ * @returns {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>}
+ */
 function wrapAppRouteHandleResponse (handleResponse) {
-  return wrapHandleResponse(handleResponse, true)
+  return wrapHandleResponse(handleResponse, false)
 }
 
+/**
+ * @param {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>} handleResponse
+ * @returns {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>}
+ */
 function wrapAppPageHandleResponse (handleResponse) {
-  return wrapHandleResponse(handleResponse, false)
+  return wrapHandleResponse(handleResponse, true)
 }
 
 function instrumentRouteModule (RouteModule, wrappers, handleErrors) {

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { isNativeError } = require('node:util').types
+
 const shimmer = require('../../datadog-shimmer')
 const nomenclature = require('../../dd-trace/src/service-naming')
 const spanEndingHook = require('../../dd-trace/src/opentelemetry/span-ending-hook')
@@ -50,6 +52,7 @@ const backgroundRevalidationChannel = channel('apm:next:request:background-reval
 const requests = new WeakSet()
 const nodeNextRequestsToNextRequests = new WeakMap()
 const requestErrors = new WeakMap()
+const noFallbackErrorPrototypes = new WeakSet()
 // Next.js <= 14.2.6
 const MIDDLEWARE_HEADER = 'x-middleware-invoke'
 
@@ -280,11 +283,16 @@ function publishFinish (ctx, error) {
 function finish (ctx, result, error) {
   if (ctx.finishOnResponse) {
     ctx.handlerFinished = true
-    if (error) ctx.error = error
+    if (error && !isNoFallbackError(error)) ctx.error = error
     if (!ctx.responseFinished) return
   }
 
   publishFinish(ctx, error)
+}
+
+/** @param {unknown} error */
+function isNoFallbackError (error) {
+  return isNativeError(error) && noFallbackErrorPrototypes.has(Object.getPrototypeOf(error))
 }
 
 /**
@@ -293,7 +301,9 @@ function finish (ctx, result, error) {
  * @param {unknown} error
  */
 function publishError (req, ctx, error) {
-  if (!error) return
+  if (!error || isNoFallbackError(error)) return
+
+  if (ctx) ctx.error = error
 
   req = req.originalRequest || req
   let errors = requestErrors.get(req)
@@ -306,7 +316,6 @@ function publishError (req, ctx, error) {
   errors.add(error)
 
   if (ctx) {
-    ctx.error = error
     errorChannel.publish(ctx)
   } else {
     errorChannel.publish({ req, error })
@@ -340,6 +349,20 @@ const patchedRouteModules = new WeakSet()
 const routeResponses = new WeakMap()
 const activeRouteRequests = new WeakMap()
 const COMPILED_RUNTIME_PATH = 'dist/compiled/next-server/'
+
+/** @param {{ NoFallbackError: typeof Error }} noFallbackError */
+function captureNoFallbackError (noFallbackError) {
+  noFallbackErrorPrototypes.add(noFallbackError.NoFallbackError.prototype)
+  return noFallbackError
+}
+
+// The sentinel identity only exists at runtime, so there is no source function for Orchestrion to rewrite.
+addHook({
+  name: 'next',
+  versions: ['>=15.4.1'],
+  file: 'dist/shared/lib/no-fallback-error.external.js',
+}, captureNoFallbackError)
+
 function wrapOnRequestError (onRequestError) {
   return function (req, error) {
     if (error) publishError(req, undefined, error)
@@ -430,12 +453,14 @@ function wrapHandleResponse (handleResponse, associateNextRequest) {
     const res = routeResponses.get(req)
     routeResponses.delete(req)
 
-    if (!res || (!startChannel.hasSubscribers && !queryParsedChannel.hasSubscribers)) {
+    if (!startChannel.hasSubscribers && !queryParsedChannel.hasSubscribers) {
       return handleResponse.apply(this, arguments)
     }
 
-    const routeModule = associateNextRequest ? this : undefined
+    const routeModule = res && associateNextRequest ? this : undefined
     options.responseGenerator = wrapResponseGenerator(options.responseGenerator, routeModule, req)
+
+    if (!res) return handleResponse.apply(this, arguments)
 
     return instrument(req, res, ctx => {
       publishRoutePage(ctx, this, undefined, true)

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -388,7 +388,8 @@ function publishRoutePage (ctx, routeModule, fallbackPage, isAppPath) {
 
   const pageData = getRoutePage(routeModule, fallbackPage)
   if (pageData.page) {
-    pageLoadChannel.publish(isAppPath ? { ...pageData, isAppPath: true } : pageData)
+    if (isAppPath) pageData.isAppPath = true
+    pageLoadChannel.publish(pageData)
   }
 }
 

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { AsyncLocalStorage } = require('node:async_hooks')
-
 const shimmer = require('../../datadog-shimmer')
 const nomenclature = require('../../dd-trace/src/service-naming')
 const spanEndingHook = require('../../dd-trace/src/opentelemetry/span-ending-hook')
@@ -14,6 +12,7 @@ const errorChannel = channel('apm:next:request:error')
 const pageLoadChannel = channel('apm:next:page:load')
 const bodyParsedChannel = channel('apm:next:body-parsed')
 const queryParsedChannel = channel('apm:next:query-parsed')
+const backgroundRevalidationChannel = channel('apm:next:request:background-revalidation')
 
 /**
  * @typedef {import('node:http').IncomingMessage & {
@@ -51,8 +50,6 @@ const queryParsedChannel = channel('apm:next:query-parsed')
 const requests = new WeakSet()
 const nodeNextRequestsToNextRequests = new WeakMap()
 const requestErrors = new WeakMap()
-const backgroundRevalidations = new AsyncLocalStorage()
-
 // Next.js <= 14.2.6
 const MIDDLEWARE_HEADER = 'x-middleware-invoke'
 
@@ -345,10 +342,7 @@ const activeRouteRequests = new WeakMap()
 const COMPILED_RUNTIME_PATH = 'dist/compiled/next-server/'
 function wrapOnRequestError (onRequestError) {
   return function (req, error) {
-    const nodeRequest = req.originalRequest || req
-    if (error && backgroundRevalidations.getStore() !== nodeRequest) {
-      publishError(req, undefined, error)
-    }
+    if (error) publishError(req, undefined, error)
     return onRequestError.apply(this, arguments)
   }
 }
@@ -408,7 +402,7 @@ function wrapResponseGenerator (responseGenerator, routeModule, req) {
   return function (context) {
     if (context?.hasResolved) {
       const nodeRequest = req.originalRequest || req
-      return backgroundRevalidations.run(nodeRequest, () => responseGenerator.apply(this, arguments))
+      return backgroundRevalidationChannel.runStores(nodeRequest, () => responseGenerator.apply(this, arguments))
     }
     if (!routeModule) {
       return responseGenerator.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -51,7 +51,6 @@ const backgroundRevalidationChannel = channel('apm:next:request:background-reval
 
 const requests = new WeakSet()
 const nodeNextRequestsToNextRequests = new WeakMap()
-const requestErrors = new WeakMap()
 const noFallbackErrorPrototypes = new WeakSet()
 // Next.js <= 14.2.6
 const MIDDLEWARE_HEADER = 'x-middleware-invoke'
@@ -270,7 +269,6 @@ function wrapServeStatic (serveStatic) {
 
 function publishFinish (ctx, error) {
   publishError(ctx.req, ctx, error)
-  requestErrors.delete(ctx.req)
 
   const maybeNextRequest = nodeNextRequestsToNextRequests.get(ctx.req)
   if (maybeNextRequest) {
@@ -303,21 +301,11 @@ function isNoFallbackError (error) {
 function publishError (req, ctx, error) {
   if (!error || isNoFallbackError(error)) return
 
-  if (ctx) ctx.error = error
-
-  req = req.originalRequest || req
-  let errors = requestErrors.get(req)
-  if (errors?.has(error)) return
-
-  if (!errors) {
-    errors = new Set()
-    requestErrors.set(req, errors)
-  }
-  errors.add(error)
-
   if (ctx) {
+    ctx.error = error
     errorChannel.publish(ctx)
   } else {
+    req = req.originalRequest || req
     errorChannel.publish({ req, error })
   }
 }
@@ -451,12 +439,12 @@ function wrapResponseGenerator (responseGenerator, routeModule, req) {
 function wrapHandleResponse (handleResponse, associateNextRequest) {
   return function (options) {
     const req = options.req
-    const res = routeResponses.get(req)
-    routeResponses.delete(req)
-
     if (!startChannel.hasSubscribers && !queryParsedChannel.hasSubscribers) {
       return handleResponse.apply(this, arguments)
     }
+
+    const res = routeResponses.get(req)
+    routeResponses.delete(req)
 
     const routeModule = res && associateNextRequest ? this : undefined
     options.responseGenerator = wrapResponseGenerator(options.responseGenerator, routeModule, req)

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { AsyncLocalStorage } = require('node:async_hooks')
+
 const shimmer = require('../../datadog-shimmer')
 const nomenclature = require('../../dd-trace/src/service-naming')
 const spanEndingHook = require('../../dd-trace/src/opentelemetry/span-ending-hook')
@@ -49,7 +51,7 @@ const queryParsedChannel = channel('apm:next:query-parsed')
 const requests = new WeakSet()
 const nodeNextRequestsToNextRequests = new WeakMap()
 const requestErrors = new WeakMap()
-const backgroundRevalidationRequests = new WeakSet()
+const backgroundRevalidations = new AsyncLocalStorage()
 
 // Next.js <= 14.2.6
 const MIDDLEWARE_HEADER = 'x-middleware-invoke'
@@ -344,7 +346,7 @@ const COMPILED_RUNTIME_PATH = 'dist/compiled/next-server/'
 function wrapOnRequestError (onRequestError) {
   return function (req, error) {
     const nodeRequest = req.originalRequest || req
-    if (error && !backgroundRevalidationRequests.has(nodeRequest)) {
+    if (error && backgroundRevalidations.getStore() !== nodeRequest) {
       publishError(req, undefined, error)
     }
     return onRequestError.apply(this, arguments)
@@ -405,7 +407,8 @@ function wrapPrepare (prepare) {
 function wrapResponseGenerator (responseGenerator, routeModule, req) {
   return function (context) {
     if (context?.hasResolved) {
-      backgroundRevalidationRequests.add(req.originalRequest || req)
+      const nodeRequest = req.originalRequest || req
+      return backgroundRevalidations.run(nodeRequest, () => responseGenerator.apply(this, arguments))
     }
     if (!routeModule) {
       return responseGenerator.apply(this, arguments)
@@ -424,10 +427,10 @@ function wrapResponseGenerator (responseGenerator, routeModule, req) {
 
 /**
  * @param {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>} handleResponse
- * @param {boolean} finishOnResponse
+ * @param {boolean} associateNextRequest
  * @returns {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>}
  */
-function wrapHandleResponse (handleResponse, finishOnResponse) {
+function wrapHandleResponse (handleResponse, associateNextRequest) {
   return function (options) {
     const req = options.req
     const res = routeResponses.get(req)
@@ -437,7 +440,7 @@ function wrapHandleResponse (handleResponse, finishOnResponse) {
       return handleResponse.apply(this, arguments)
     }
 
-    const routeModule = finishOnResponse ? undefined : this
+    const routeModule = associateNextRequest ? this : undefined
     options.responseGenerator = wrapResponseGenerator(options.responseGenerator, routeModule, req)
 
     return instrument(req, res, ctx => {
@@ -457,7 +460,7 @@ function wrapHandleResponse (handleResponse, finishOnResponse) {
 
         throw error
       })
-    }, undefined, finishOnResponse && finishChannel.hasSubscribers)
+    }, undefined, finishChannel.hasSubscribers)
   }
 }
 
@@ -466,7 +469,7 @@ function wrapHandleResponse (handleResponse, finishOnResponse) {
  * @returns {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>}
  */
 function wrapAppRouteHandleResponse (handleResponse) {
-  return wrapHandleResponse(handleResponse, false)
+  return wrapHandleResponse(handleResponse, true)
 }
 
 /**
@@ -474,7 +477,7 @@ function wrapAppRouteHandleResponse (handleResponse) {
  * @returns {(options: HandleResponseOptions) => Promise<ResponseCacheEntry | undefined>}
  */
 function wrapAppPageHandleResponse (handleResponse) {
-  return wrapHandleResponse(handleResponse, true)
+  return wrapHandleResponse(handleResponse, false)
 }
 
 function instrumentRouteModule (RouteModule, wrappers, handleErrors) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -14,7 +14,8 @@ const nextParentRoutes = new WeakMap()
 /**
  * @typedef {Record<string, unknown> & {
  *   span: import('../../dd-trace/src/opentracing/span'),
- *   req: import('node:http').IncomingMessage
+ *   req: import('node:http').IncomingMessage,
+ *   backgroundRevalidationRequest?: import('node:http').IncomingMessage
  * }} NextRequestStore
  *
  * @typedef {object} NextRequest
@@ -30,6 +31,7 @@ const nextParentRoutes = new WeakMap()
  * @typedef {object} NextErrorContext
  * @property {import('../../dd-trace/src/opentracing/span')} [span]
  * @property {NextRequestStore} [currentStore]
+ * @property {import('node:http').IncomingMessage} [req]
  * @property {unknown} error
  */
 
@@ -38,6 +40,10 @@ class NextPlugin extends ServerPlugin {
 
   constructor (...args) {
     super(...args)
+    this.addBind('apm:next:request:background-revalidation', req => ({
+      ...storage('legacy').getStore(),
+      backgroundRevalidationRequest: req,
+    }))
     this.addSub('apm:next:page:load', message => this.pageLoad(message))
   }
 
@@ -85,16 +91,12 @@ class NextPlugin extends ServerPlugin {
   }
 
   /** @param {NextErrorContext} ctx */
-  error ({ currentStore, span, error }) {
-    span ||= currentStore?.span
-    if (!span) {
-      const store = storage('legacy').getStore()
-      if (!store) return
+  error ({ currentStore, span, req, error }) {
+    const store = currentStore ?? storage('legacy').getStore()
+    if (req && store?.backgroundRevalidationRequest === req) return
 
-      span = store.span
-    }
-
-    this.addError(error, span)
+    span ||= store?.span
+    if (span) this.addError(error, span)
   }
 
   /** @param {NextRequestContext} ctx */

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -57,6 +57,7 @@ class NextPlugin extends ServerPlugin {
     if (parentSpan?._integrationName === this.constructor.id) {
       const reusedStore = { ...store, span: parentSpan, req }
       reusedNextRequestStores.add(reusedStore)
+      if (ctx.finishOnResponse) ctx.currentStore = reusedStore
       return reusedStore
     }
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -54,10 +54,8 @@ class NextPlugin extends ServerPlugin {
 
     analyticsSampler.sample(span, this.config.measured, true)
 
-    const isHttpParent = parentSpan?._integrationName === 'http'
-    const httpParentSpan = isHttpParent ? parentSpan : undefined
-    const httpParentReq = isHttpParent ? web.getRequest(parentSpan) : undefined
-    return { ...store, span, req, httpParentSpan, httpParentReq }
+    const httpParentSpan = parentSpan?._integrationName === 'http' ? parentSpan : undefined
+    return { ...store, span, req, httpParentSpan }
   }
 
   error ({ span, error }) {
@@ -109,7 +107,7 @@ class NextPlugin extends ServerPlugin {
 
     if (!store) return
 
-    const { span, req, httpParentReq, httpParentSpan } = store
+    const { span, req, httpParentSpan } = store
 
     // safeguard against missing req in complicated timeout scenarios
     if (!req) return
@@ -140,10 +138,9 @@ class NextPlugin extends ServerPlugin {
       'resource.name': `${req.method} ${page}`.trim(),
       'next.page': page,
     })
-    const routeRequest = httpParentReq || req
-    web.setRouteOrEndpointTag(routeRequest)
+    web.setRouteOrEndpointTag(req)
     setHttpParentRoute(httpParentSpan, req.method, page, isStatic)
-    web.setRoute(routeRequest, page)
+    web.setRoute(req, page)
   }
 
   configure (config) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -43,6 +43,7 @@ class NextPlugin extends ServerPlugin {
     super(...args)
     this.addBind('apm:next:request:background-revalidation', req => ({
       ...storage('legacy').getStore(),
+      span: undefined,
       backgroundRevalidationRequest: req,
     }))
     this.addSub('apm:next:page:load', message => this.pageLoad(message))

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -25,21 +25,16 @@ const nextParentRoutes = new WeakMap()
  * @property {import('node:http').ServerResponse} res
  * @property {NextRequest} [nextRequest]
  * @property {boolean} [finishOnResponse]
- * @property {boolean} [handlerFinished]
- * @property {boolean} [responseFinished]
  * @property {NextRequestStore} [currentStore]
  *
  * @typedef {object} NextErrorContext
  * @property {import('../../dd-trace/src/opentracing/span')} [span]
+ * @property {NextRequestStore} [currentStore]
  * @property {unknown} error
- * @property {object} [req]
  */
 
 class NextPlugin extends ServerPlugin {
   static id = 'next'
-
-  /** @type {WeakMap<import('node:http').IncomingMessage, NextRequestContext>} */
-  #deferredRequestContexts = new WeakMap()
 
   constructor (...args) {
     super(...args)
@@ -48,7 +43,7 @@ class NextPlugin extends ServerPlugin {
 
   /** @param {NextRequestContext} ctx */
   bindStart (ctx) {
-    const { req, res } = ctx
+    const { req } = ctx
     const store = storage('legacy').getStore()
     const parentSpan = store?.span
     if (parentSpan?._integrationName === this.constructor.id) {
@@ -84,31 +79,14 @@ class NextPlugin extends ServerPlugin {
     analyticsSampler.sample(span, this.config.measured, true)
 
     const httpParentSpan = parentSpan?._integrationName === 'http' ? parentSpan : undefined
-    if (ctx.finishOnResponse) {
-      const currentStore = { ...store, span, req, httpParentSpan }
-      ctx.currentStore = currentStore
-      this.#deferredRequestContexts.set(req, ctx)
-      const onResponseFinish = () => {
-        res.removeListener('finish', onResponseFinish)
-        res.removeListener('close', onResponseFinish)
-        ctx.responseFinished = true
-        if (!ctx.handlerFinished) return
-
-        this.#finishDeferred(ctx)
-      }
-      res.once('finish', onResponseFinish)
-      res.once('close', onResponseFinish)
-      return currentStore
-    }
-
-    return { ...store, span, req, httpParentSpan }
+    const currentStore = { ...store, span, req, httpParentSpan }
+    if (ctx.finishOnResponse) ctx.currentStore = currentStore
+    return currentStore
   }
 
   /** @param {NextErrorContext} ctx */
-  error ({ span, error, req }) {
-    if (!span && req) {
-      span = this.#deferredRequestContexts.get(req)?.currentStore?.span
-    }
+  error ({ currentStore, span, error }) {
+    span ||= currentStore?.span
     if (!span) {
       const store = storage('legacy').getStore()
       if (!store) return
@@ -121,25 +99,6 @@ class NextPlugin extends ServerPlugin {
 
   /** @param {NextRequestContext} ctx */
   finish (ctx) {
-    if (ctx.finishOnResponse) {
-      ctx.handlerFinished = true
-      if (!ctx.responseFinished) return
-
-      this.#finishDeferred(ctx)
-      return
-    }
-
-    this.#finish(ctx)
-  }
-
-  /** @param {NextRequestContext} ctx */
-  #finishDeferred (ctx) {
-    this.#deferredRequestContexts.delete(ctx.req)
-    this.#finish(ctx)
-  }
-
-  /** @param {NextRequestContext} ctx */
-  #finish (ctx) {
     const { req, res, nextRequest = {} } = ctx
     const store = ctx.currentStore ?? storage('legacy').getStore()
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -11,15 +11,44 @@ const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-fou
 const reusedNextRequestStores = new WeakSet()
 const nextParentRoutes = new WeakMap()
 
+/**
+ * @typedef {Record<string, unknown> & {
+ *   span: import('../../dd-trace/src/opentracing/span'),
+ *   req: import('node:http').IncomingMessage
+ * }} NextRequestStore
+ *
+ * @typedef {object} NextRequest
+ * @property {unknown} [error]
+ *
+ * @typedef {object} NextRequestContext
+ * @property {import('node:http').IncomingMessage} req
+ * @property {import('node:http').ServerResponse} res
+ * @property {NextRequest} [nextRequest]
+ * @property {boolean} [finishOnResponse]
+ * @property {boolean} [handlerFinished]
+ * @property {boolean} [responseFinished]
+ * @property {NextRequestStore} [currentStore]
+ *
+ * @typedef {object} NextErrorContext
+ * @property {import('../../dd-trace/src/opentracing/span')} [span]
+ * @property {unknown} error
+ * @property {object} [req]
+ */
+
 class NextPlugin extends ServerPlugin {
   static id = 'next'
+
+  /** @type {WeakMap<import('node:http').IncomingMessage, NextRequestContext>} */
+  #deferredRequestContexts = new WeakMap()
 
   constructor (...args) {
     super(...args)
     this.addSub('apm:next:page:load', message => this.pageLoad(message))
   }
 
-  bindStart ({ req, res }) {
+  /** @param {NextRequestContext} ctx */
+  bindStart (ctx) {
+    const { req, res } = ctx
     const store = storage('legacy').getStore()
     const parentSpan = store?.span
     if (parentSpan?._integrationName === this.constructor.id) {
@@ -55,10 +84,31 @@ class NextPlugin extends ServerPlugin {
     analyticsSampler.sample(span, this.config.measured, true)
 
     const httpParentSpan = parentSpan?._integrationName === 'http' ? parentSpan : undefined
+    if (ctx.finishOnResponse) {
+      const currentStore = { ...store, span, req, httpParentSpan }
+      ctx.currentStore = currentStore
+      this.#deferredRequestContexts.set(req, ctx)
+      const onResponseFinish = () => {
+        res.removeListener('finish', onResponseFinish)
+        res.removeListener('close', onResponseFinish)
+        ctx.responseFinished = true
+        if (!ctx.handlerFinished) return
+
+        this.#finishDeferred(ctx)
+      }
+      res.once('finish', onResponseFinish)
+      res.once('close', onResponseFinish)
+      return currentStore
+    }
+
     return { ...store, span, req, httpParentSpan }
   }
 
-  error ({ span, error }) {
+  /** @param {NextErrorContext} ctx */
+  error ({ span, error, req }) {
+    if (!span && req) {
+      span = this.#deferredRequestContexts.get(req)?.currentStore?.span
+    }
     if (!span) {
       const store = storage('legacy').getStore()
       if (!store) return
@@ -69,8 +119,29 @@ class NextPlugin extends ServerPlugin {
     this.addError(error, span)
   }
 
-  finish ({ req, res, nextRequest = {} }) {
-    const store = storage('legacy').getStore()
+  /** @param {NextRequestContext} ctx */
+  finish (ctx) {
+    if (ctx.finishOnResponse) {
+      ctx.handlerFinished = true
+      if (!ctx.responseFinished) return
+
+      this.#finishDeferred(ctx)
+      return
+    }
+
+    this.#finish(ctx)
+  }
+
+  /** @param {NextRequestContext} ctx */
+  #finishDeferred (ctx) {
+    this.#deferredRequestContexts.delete(ctx.req)
+    this.#finish(ctx)
+  }
+
+  /** @param {NextRequestContext} ctx */
+  #finish (ctx) {
+    const { req, res, nextRequest = {} } = ctx
+    const store = ctx.currentStore ?? storage('legacy').getStore()
 
     if (!store) return
     if (reusedNextRequestStores.has(store)) return

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -27,6 +27,7 @@ const nextParentRoutes = new WeakMap()
  * @property {NextRequest} [nextRequest]
  * @property {boolean} [finishOnResponse]
  * @property {NextRequestStore} [currentStore]
+ * @property {unknown} [error]
  *
  * @typedef {object} NextErrorContext
  * @property {import('../../dd-trace/src/opentracing/span')} [span]
@@ -108,7 +109,7 @@ class NextPlugin extends ServerPlugin {
     if (reusedNextRequestStores.has(store)) return
 
     const span = store.span
-    const error = span.context().getTag('error')
+    const error = ctx.error ?? span.context().getTag('error')
     const requestError = req.error || nextRequest.error
 
     if (requestError) {

--- a/packages/datadog-plugin-next/test/app/cached/page.js
+++ b/packages/datadog-plugin-next/test/app/cached/page.js
@@ -1,0 +1,5 @@
+export const revalidate = 60
+
+export default function CachedPage () {
+  return <h1>Cached App Page</h1>
+}

--- a/packages/datadog-plugin-next/test/app/cached/page.js
+++ b/packages/datadog-plugin-next/test/app/cached/page.js
@@ -1,5 +1,3 @@
-export const revalidate = 60
-
 export default function CachedPage () {
   return <h1>Cached App Page</h1>
 }

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -29,6 +29,10 @@ function getCompiledRuntimeHook (runtime) {
   return instrumentations.next.find(hook => hook.filePattern?.includes(`${runtime}[`)).hook
 }
 
+function getNoFallbackErrorHook () {
+  return instrumentations.next.find(hook => hook.file === 'dist/shared/lib/no-fallback-error.external.js').hook
+}
+
 function getDisabledRuntimeHooks () {
   const hooks = []
   const channels = new Map()
@@ -1578,12 +1582,9 @@ describe('compiled Next runtimes', () => {
       await trace
     })
 
-    it('does not record NoFallbackError when the Next 16 App Page router handles it as a 404', async () => {
-      // Next exposes this CommonJS export through Object.defineProperty.
-      // eslint-disable-next-line eslint-rules/eslint-require-export-exists
-      const { NoFallbackError } = require(
-        '../../../versions/next@16/node_modules/next/dist/shared/lib/no-fallback-error.external'
-      )
+    it('does not record NoFallbackError when the App Page router handles it as a 404', async () => {
+      class NoFallbackError extends Error {}
+      getNoFallbackErrorHook()({ NoFallbackError })
       const noFallbackError = new NoFallbackError()
 
       class AppPageRouteModule extends RouteModule {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -792,6 +792,31 @@ describe('Plugin', function () {
               ])
             })
 
+            it('should trace a cached app page through the compiled runtime', async () => {
+              const firstResponse = await axios.get(`http://127.0.0.1:${port}/cached`)
+              assert.strictEqual(firstResponse.status, 200)
+              assert.match(firstResponse.data, /<h1>Cached App Page<\/h1>/)
+
+              const tracePromise = agent.assertSomeTraces(traces => {
+                const spans = traces[0]
+                const nextRequestSpans = spans.filter(span => span.name === 'next.request')
+
+                assert.strictEqual(nextRequestSpans.length, 1)
+                assertObjectContains(nextRequestSpans[0], {
+                  resource: 'GET /cached',
+                  meta: {
+                    'http.status_code': '200',
+                  },
+                })
+              })
+
+              const [secondResponse] = await Promise.all([
+                axios.get(`http://127.0.0.1:${port}/cached`),
+                tracePromise,
+              ])
+              assert.strictEqual(secondResponse.headers['x-nextjs-cache'], 'HIT')
+            })
+
             it('should attach a thrown app page error to the request span', done => {
               agent
                 .assertSomeTraces(traces => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1337,9 +1337,7 @@ describe('compiled Next runtimes', () => {
           }
 
           [method] () {
-            return runtime === 'app-route'
-              ? Promise.reject(new Error('stale App Route revalidation error'))
-              : Promise.resolve({ metadata: { statusCode: 200 } })
+            return Promise.reject(new Error(`stale ${label} revalidation error`))
           }
 
           onRequestError () {
@@ -1351,9 +1349,17 @@ describe('compiled Next runtimes', () => {
 
         getCompiledRuntimeHook(runtime)({ [exportName]: CompiledRouteModule })
 
-        const request = { headers: {}, method: 'GET', url: pathname }
-        const response = new http.ServerResponse(request)
+        const nodeRequest = { headers: {}, method: 'GET', url: pathname }
+        const request = runtime === 'app-page' ? { ...nodeRequest, originalRequest: nodeRequest } : nodeRequest
+        const response = new http.ServerResponse(nodeRequest)
         const routeModule = new CompiledRouteModule()
+        const foregroundTrace = runtime === 'app-page'
+          ? agent.assertSomeTraces(traces => {
+            const [span] = traces[0]
+            assert.strictEqual(span.error, 0)
+            assert.strictEqual(span.meta['error.message'], undefined)
+          }, { spanResourceMatch: new RegExp(pathname) })
+          : undefined
         await routeModule.prepare(request, response, {})
         await routeModule.handleResponse({
           req: request,
@@ -1368,7 +1374,6 @@ describe('compiled Next runtimes', () => {
             }
           },
         })
-        if (runtime === 'app-page') response.emit('finish')
         assert.strictEqual(typeof responseGenerator, 'function')
 
         /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
@@ -1384,14 +1389,19 @@ describe('compiled Next runtimes', () => {
           rejectFirst: true,
           spanResourceMatch: new RegExp(parentResource),
         })
-        const revalidate = runtime === 'app-route'
-          ? () => assert.rejects(responseGenerator, /stale App Route revalidation error/)
-          : responseGenerator
+        const revalidate = () => assert.rejects(
+          () => responseGenerator({ hasResolved: true }),
+          new RegExp(`stale ${label} revalidation error`)
+        )
 
         await Promise.all([
           tracer.trace(parentResource, revalidate),
           tracePromise,
         ])
+        if (runtime === 'app-page') {
+          response.emit('finish')
+          await foregroundTrace
+        }
       })
     }
 
@@ -1460,45 +1470,6 @@ describe('compiled Next runtimes', () => {
       await trace
     })
 
-    it('records App Page errors after cache handling completes', async () => {
-      class AppPageRouteModule extends RouteModule {
-        definition = { pathname: '/post-cache-error' }
-
-        handleResponse () {
-          return Promise.resolve({ value: { status: 200 } })
-        }
-
-        onRequestError () {
-          return Promise.resolve()
-        }
-      }
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
-
-      const request = { headers: {}, method: 'GET', url: '/post-cache-error' }
-      const response = new http.ServerResponse(request)
-      const routeModule = new AppPageRouteModule()
-      const trace = agent.assertSomeTraces(traces => {
-        const [span] = traces[0]
-        assertObjectContains(span, {
-          error: 1,
-          meta: {
-            'error.message': 'post-cache App Page error',
-            'http.status_code': '500',
-          },
-        })
-      })
-
-      await routeModule.prepare(request, response, {})
-      await routeModule.handleResponse({
-        req: request,
-        responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
-      })
-      await routeModule.onRequestError(request, new Error('post-cache App Page error'))
-      response.statusCode = 500
-      response.emit('finish')
-      await trace
-    })
-
     it('records Pages API errors and status without an existing request store', async () => {
       class PagesAPIRouteModule {
         definition = { page: '/api/first-entry' }
@@ -1534,12 +1505,16 @@ describe('compiled Next runtimes', () => {
       await trace
     })
 
-    it('records App Page errors and status without an existing request store', async () => {
+    it('records App Page streaming errors after cache handling completes', async () => {
       class AppPageRouteModule extends RouteModule {
         definition = { pathname: '/first-entry' }
 
         render () {
-          return Promise.reject(new Error('App Page first-entry error'))
+          return Promise.resolve({ value: { status: 200 } })
+        }
+
+        onRequestError () {
+          return Promise.resolve()
         }
       }
       const runtimeHook = getCompiledRuntimeHook('app-page')
@@ -1564,28 +1539,36 @@ describe('compiled Next runtimes', () => {
       assert.strictEqual(storage('legacy').getStore(), undefined)
       const routeModule = new AppPageRouteModule()
       await routeModule.prepare(request, response, {})
-      await assert.rejects(
-        routeModule.handleResponse({
-          req: request,
-          responseGenerator: () => routeModule.render(request, response, { page: '/first-entry' }),
-        }),
-        /App Page first-entry error/
-      )
-      assert.strictEqual(response.statusCode, 500)
+      let reportStreamingError
+      const streamingErrorTrigger = new Promise(resolve => { reportStreamingError = resolve })
+      let streamingError
+      await routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => {
+          streamingError = streamingErrorTrigger.then(() => {
+            return routeModule.onRequestError(request, new Error('App Page first-entry error'))
+          })
+          return routeModule.render(request, response, { page: '/first-entry' })
+        },
+      })
+      reportStreamingError()
+      await streamingError
+      response.statusCode = 500
       response.emit('finish')
       await trace
     })
 
-    it('passes the Node response to App Route hooks without disabling the plugin', async () => {
+    it('passes Node responses to hooks without propagating deferred hook errors', async () => {
       const hookResponses = []
       /**
        * @param {import('../../dd-trace/src/opentracing/span')} _span
-       * @param {import('node:http').IncomingMessage} _request
+       * @param {import('node:http').IncomingMessage} request
        * @param {import('node:http').ServerResponse} response
        */
-      const requestHook = (_span, _request, response) => {
+      const requestHook = (_span, request, response) => {
         hookResponses.push(response)
         response.getHeader('content-type')
+        if (request.url === '/app-page-hook-error') throw new Error('request hook error')
       }
       agent.reload('next', { hooks: { request: requestHook } })
 
@@ -1605,8 +1588,17 @@ describe('compiled Next runtimes', () => {
         }
       }
 
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/app-page-hook-error' }
+
+        handleResponse () {
+          return Promise.reject(new Error('App Page handler error'))
+        }
+      }
+
       getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
       getCompiledRuntimeHook('pages-api')({ PagesAPIRouteModule })
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
 
       const routeRequest = { headers: {}, method: 'GET', url: '/api/response-hook' }
       const routeResponse = new http.ServerResponse(routeRequest)
@@ -1645,6 +1637,16 @@ describe('compiled Next runtimes', () => {
         tracePromise,
       ])
       assert.deepStrictEqual(hookResponses, [routeResponse, sentinelResponse])
+
+      const pageRequest = { headers: {}, method: 'GET', url: '/app-page-hook-error' }
+      const pageResponse = new http.ServerResponse(pageRequest)
+      const pageRouteModule = new AppPageRouteModule()
+      await pageRouteModule.prepare(pageRequest, pageResponse, {})
+      await assert.rejects(pageRouteModule.handleResponse({
+        req: pageRequest,
+        responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
+      }), /App Page handler error/)
+      pageResponse.emit('finish')
     })
   })
 })

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1330,6 +1330,7 @@ describe('compiled Next runtimes', () => {
 
       it(`does not create a request span for stale ${label} background revalidation`, async () => {
         let responseGenerator
+        const backgroundResource = `background-work-${runtime}`
 
         class CompiledRouteModule extends RouteModule {
           /** @param {{responseGenerator: () => Promise<unknown>}} options */
@@ -1339,6 +1340,7 @@ describe('compiled Next runtimes', () => {
           }
 
           [method] () {
+            tracer.trace(backgroundResource, () => {})
             return Promise.reject(new Error(`stale ${label} revalidation error`))
           }
 
@@ -1386,10 +1388,21 @@ describe('compiled Next runtimes', () => {
           }
           assert.strictEqual(nextRequestSpanCount, 0)
         }
+
+        /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
+        function assertBackgroundTrace (traces) {
+          const span = traces[0].find(span => span.resource === backgroundResource)
+          assert.ok(span)
+          assert.strictEqual(span.parent_id, 0n)
+        }
+
         const parentResource = `stale-revalidation-${runtime}`
         const tracePromise = agent.assertSomeTraces(assertNoNextRequestTrace, {
           rejectFirst: true,
           spanResourceMatch: new RegExp(parentResource),
+        })
+        const backgroundTrace = agent.assertSomeTraces(assertBackgroundTrace, {
+          spanResourceMatch: new RegExp(backgroundResource),
         })
         const revalidate = () => assert.rejects(
           () => responseGenerator({ hasResolved: true }),
@@ -1399,6 +1412,7 @@ describe('compiled Next runtimes', () => {
         await Promise.all([
           tracer.trace(parentResource, revalidate),
           tracePromise,
+          backgroundTrace,
         ])
         response.emit('finish')
         if (runtime === 'app-page') {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1462,6 +1462,145 @@ describe('compiled Next runtimes', () => {
       await trace
     })
 
+    it('does not attach nested fallback revalidation errors to the foreground App Page span', async () => {
+      let backgroundRevalidation
+      let continueRevalidation
+      const backgroundError = new Error('nested fallback revalidation error')
+      const revalidationContinuation = new Promise(resolve => { continueRevalidation = resolve })
+
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/nested-fallback' }
+
+        /**
+         * @param {object} options
+         * @param {boolean} [options.isFallback]
+         * @param {(context?: {hasResolved?: boolean}) => Promise<unknown>} options.responseGenerator
+         */
+        handleResponse (options) {
+          if (options.isFallback) {
+            backgroundRevalidation = options.responseGenerator({ hasResolved: true })
+            return Promise.resolve({ isMiss: false, isStale: true })
+          }
+
+          return options.responseGenerator()
+        }
+
+        onRequestError () {
+          return Promise.resolve()
+        }
+      }
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/nested-fallback' }
+      const response = new http.ServerResponse(request)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assert.strictEqual(span.error, 0)
+        assert.strictEqual(span.meta['error.message'], undefined)
+      }, { spanResourceMatch: /nested-fallback/ })
+
+      await routeModule.prepare(request, response, {})
+      await routeModule.handleResponse({
+        req: request,
+        responseGenerator: async () => {
+          await routeModule.handleResponse({
+            isFallback: true,
+            req: request,
+            responseGenerator: async () => {
+              await revalidationContinuation
+              await routeModule.onRequestError(request, backgroundError)
+              throw backgroundError
+            },
+          })
+          return { value: { status: 200 } }
+        },
+      })
+
+      const revalidation = assert.rejects(backgroundRevalidation, backgroundError)
+      continueRevalidation()
+      await revalidation
+      response.emit('finish')
+      await trace
+    })
+
+    it('retains deferred App Page handler error details after onRequestError reports the same error', async () => {
+      const handlerError = new Error('deferred App Page handler error')
+
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/deferred-handler-error' }
+
+        handleResponse () {
+          return Promise.reject(handlerError)
+        }
+
+        onRequestError () {
+          return Promise.resolve()
+        }
+      }
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/deferred-handler-error' }
+      const response = new http.ServerResponse(request)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assertObjectContains(span, {
+          error: 1,
+          meta: {
+            'error.message': handlerError.message,
+            'error.type': 'Error',
+          },
+        })
+      }, { spanResourceMatch: /deferred-handler-error/ })
+
+      await routeModule.prepare(request, response, {})
+      await assert.rejects(routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => assert.fail('a handler error should not invoke the response generator'),
+      }), handlerError)
+      await routeModule.onRequestError(request, handlerError)
+      response.emit('finish')
+      await trace
+    })
+
+    it('does not record NoFallbackError when the Next 16 App Page router handles it as a 404', async () => {
+      // Next exposes this CommonJS export through Object.defineProperty.
+      // eslint-disable-next-line eslint-rules/eslint-require-export-exists
+      const { NoFallbackError } = require(
+        '../../../versions/next@16/node_modules/next/dist/shared/lib/no-fallback-error.external'
+      )
+      const noFallbackError = new NoFallbackError()
+
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/without-fallback' }
+      }
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/without-fallback' }
+      const response = new http.ServerResponse(request)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assertObjectContains(span, {
+          error: 0,
+          meta: {
+            'http.status_code': '404',
+          },
+        })
+        assert.strictEqual(span.meta['error.message'], undefined)
+      }, { spanResourceMatch: /without-fallback/ })
+
+      await routeModule.prepare(request, response, {})
+      await assert.rejects(routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => Promise.reject(noFallbackError),
+      }), noFallbackError)
+      response.statusCode = 404
+      response.emit('finish')
+      await trace
+    })
+
     for (const { cacheStatus, label, responseStatus } of [
       { cacheStatus: 307, label: 'RSC redirect', responseStatus: 200 },
       { cacheStatus: 200, label: 'segment-prefetch miss', responseStatus: 204 },

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -25,12 +25,19 @@ const { rawExpectedSchema } = require('./naming')
 
 const min = NODE_MAJOR >= 25 ? '>=13' : '>=11.1'
 
-function getCompiledRuntimeHook (runtime) {
-  return instrumentations.next.find(hook => hook.filePattern?.includes(`${runtime}[`)).hook
+/**
+ * @param {'app-page'|'app-route'|'pages-api'} runtime
+ * @param {object} runtimeExports
+ */
+function applyCompiledRuntimeHook (runtime, runtimeExports) {
+  const hook = instrumentations.next.find(hook => hook.filePattern?.includes(`${runtime}[`)).hook
+  hook(runtimeExports)
 }
 
-function getNoFallbackErrorHook () {
-  return instrumentations.next.find(hook => hook.file === 'dist/shared/lib/no-fallback-error.external.js').hook
+/** @param {{ NoFallbackError: typeof Error }} runtimeExports */
+function applyNoFallbackErrorHook (runtimeExports) {
+  const hook = instrumentations.next.find(hook => hook.file === 'dist/shared/lib/no-fallback-error.external.js').hook
+  hook(runtimeExports)
 }
 
 function getDisabledRuntimeHooks () {
@@ -793,10 +800,6 @@ describe('Plugin', function () {
             })
 
             it('should trace a cached app page through the compiled runtime', async () => {
-              const firstResponse = await axios.get(`http://127.0.0.1:${port}/cached`)
-              assert.strictEqual(firstResponse.status, 200)
-              assert.match(firstResponse.data, /<h1>Cached App Page<\/h1>/)
-
               const tracePromise = agent.assertSomeTraces(traces => {
                 const spans = traces[0]
                 const nextRequestSpans = spans.filter(span => span.name === 'next.request')
@@ -810,11 +813,11 @@ describe('Plugin', function () {
                 })
               })
 
-              const [secondResponse] = await Promise.all([
+              const [response] = await Promise.all([
                 axios.get(`http://127.0.0.1:${port}/cached`),
                 tracePromise,
               ])
-              assert.strictEqual(secondResponse.headers['x-nextjs-cache'], 'HIT')
+              assert.strictEqual(response.headers['x-nextjs-cache'], 'HIT')
             })
 
             it('should attach a thrown app page error to the request span', done => {
@@ -1118,7 +1121,7 @@ describe('compiled Next runtimes', () => {
     }
 
     class AppPageRouteModule extends RouteModule {}
-    getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+    applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
     const startChannel = dc.channel('apm:next:request:start')
     const onStart = () => {}
@@ -1163,8 +1166,7 @@ describe('compiled Next runtimes', () => {
           return Promise.resolve({ status: 201 })
         }
       }
-      const runtimeHook = getCompiledRuntimeHook('app-route')
-      runtimeHook({ AppRouteRouteModule })
+      applyCompiledRuntimeHook('app-route', { AppRouteRouteModule })
 
       const request = {
         headers: {
@@ -1239,7 +1241,7 @@ describe('compiled Next runtimes', () => {
           return { value: { status: response.status } }
         }
       }
-      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
+      applyCompiledRuntimeHook('app-route', { AppRouteRouteModule })
 
       const request = { headers: {}, method: 'GET', url: '/api/generator-error' }
       const response = new http.ServerResponse(request)
@@ -1262,7 +1264,7 @@ describe('compiled Next runtimes', () => {
         definition = { pathname: '/without-prepare' }
       }
 
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       let starts = 0
       const onStart = () => starts++
@@ -1312,7 +1314,7 @@ describe('compiled Next runtimes', () => {
           definition = { pathname }
         }
 
-        getCompiledRuntimeHook(runtime)({ [exportName]: CompiledRouteModule })
+        applyCompiledRuntimeHook(runtime, { [exportName]: CompiledRouteModule })
 
         const request = { headers: {}, method: 'GET', url: pathname }
         const response = new http.ServerResponse(request)
@@ -1380,7 +1382,7 @@ describe('compiled Next runtimes', () => {
           definition = { pathname }
         }
 
-        getCompiledRuntimeHook(runtime)({ [exportName]: CompiledRouteModule })
+        applyCompiledRuntimeHook(runtime, { [exportName]: CompiledRouteModule })
 
         const nodeRequest = { headers: {}, method: 'GET', url: pathname }
         const request = runtime === 'app-page' ? { ...nodeRequest, originalRequest: nodeRequest } : nodeRequest
@@ -1474,7 +1476,7 @@ describe('compiled Next runtimes', () => {
           return Promise.resolve()
         }
       }
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const nodeRequest = { headers: {}, method: 'GET', url: '/interleaved-error' }
       const request = { ...nodeRequest, originalRequest: nodeRequest }
@@ -1532,7 +1534,7 @@ describe('compiled Next runtimes', () => {
           return Promise.resolve()
         }
       }
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const request = { headers: {}, method: 'GET', url: '/nested-fallback' }
       const response = new http.ServerResponse(request)
@@ -1581,7 +1583,7 @@ describe('compiled Next runtimes', () => {
           return Promise.resolve()
         }
       }
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const request = { headers: {}, method: 'GET', url: '/deferred-handler-error' }
       const response = new http.ServerResponse(request)
@@ -1609,13 +1611,13 @@ describe('compiled Next runtimes', () => {
 
     it('does not record NoFallbackError when the App Page router handles it as a 404', async () => {
       class NoFallbackError extends Error {}
-      getNoFallbackErrorHook()({ NoFallbackError })
+      applyNoFallbackErrorHook({ NoFallbackError })
       const noFallbackError = new NoFallbackError()
 
       class AppPageRouteModule extends RouteModule {
         definition = { pathname: '/without-fallback' }
       }
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const request = { headers: {}, method: 'GET', url: '/without-fallback' }
       const response = new http.ServerResponse(request)
@@ -1653,7 +1655,7 @@ describe('compiled Next runtimes', () => {
             return Promise.resolve({ value: { status: cacheStatus } })
           }
         }
-        getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+        applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
         const request = { headers: {}, method: 'GET', url: '/cached-status' }
         const response = new http.ServerResponse(request)
@@ -1685,7 +1687,7 @@ describe('compiled Next runtimes', () => {
           return handleResponseResult
         }
       }
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const request = { headers: {}, method: 'GET', url: '/closed-response' }
       const response = new http.ServerResponse(request)
@@ -1716,8 +1718,7 @@ describe('compiled Next runtimes', () => {
           return Promise.resolve()
         }
       }
-      const runtimeHook = getCompiledRuntimeHook('pages-api')
-      runtimeHook({ PagesAPIRouteModule })
+      applyCompiledRuntimeHook('pages-api', { PagesAPIRouteModule })
 
       const response = { statusCode: 200 }
       const trace = agent.assertSomeTraces(traces => {
@@ -1753,8 +1754,7 @@ describe('compiled Next runtimes', () => {
           return Promise.resolve()
         }
       }
-      const runtimeHook = getCompiledRuntimeHook('app-page')
-      runtimeHook({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const request = { headers: {}, method: 'GET', url: '/first-entry' }
       const response = new http.ServerResponse(request)
@@ -1834,9 +1834,9 @@ describe('compiled Next runtimes', () => {
         }
       }
 
-      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
-      getCompiledRuntimeHook('pages-api')({ PagesAPIRouteModule })
-      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+      applyCompiledRuntimeHook('app-route', { AppRouteRouteModule })
+      applyCompiledRuntimeHook('pages-api', { PagesAPIRouteModule })
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
       const routeRequest = { headers: {}, method: 'GET', url: '/api/response-hook' }
       const routeResponse = new http.ServerResponse(routeRequest)

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -877,12 +877,7 @@ describe('Plugin', function () {
             .catch(done)
         })
 
-        // From next 15.4.1 the app-route handler builds its NextRequest from a copy of
-        // `NextRequestAdapter.fromNodeNextRequest` that next bundles into the app build
-        // (dist/build/templates/app-route.js), so the file hook that maps the node request to
-        // the NextRequest never fires and a user-set `req.error` cannot reach the span. Capturing
-        // it again needs the runtime `onRequestError` hook rather than file instrumentation.
-        if (satisfies(pkg.version, '>=13.3.0 <15.4.1')) {
+        if (satisfies(pkg.version, '>=13.3.0')) {
           it('should attach the error to the span from a NextRequest', done => {
             agent
               .assertSomeTraces(traces => {
@@ -908,7 +903,9 @@ describe('Plugin', function () {
                 if (err.response.status !== 500) done(err)
               })
           })
-        } else if (satisfies(pkg.version, '>=15.4.1')) {
+        }
+
+        if (satisfies(pkg.version, '>=15.4.1')) {
           it('should attach a thrown app-route error to the span via onRequestError', done => {
             agent
               .assertSomeTraces(traces => {
@@ -1042,12 +1039,28 @@ describe('compiled Next runtimes', () => {
     ]
 
     for (const [runtime, exportName, method, args] of cases) {
-      const returned = {}
+      const returned = {
+        handleResponse: {},
+        prepare: {},
+        route: {},
+      }
       class RouteModule {
+        prepare (...received) {
+          assert.strictEqual(this, routeModule)
+          assert.deepStrictEqual(received, args)
+          return returned.prepare
+        }
+
+        handleResponse (...received) {
+          assert.strictEqual(this, routeModule)
+          assert.deepStrictEqual(received, args)
+          return returned.handleResponse
+        }
+
         [method] (...received) {
           assert.strictEqual(this, routeModule)
           assert.deepStrictEqual(received, args)
-          return returned
+          return returned.route
         }
       }
       const routeModule = new RouteModule()
@@ -1055,19 +1068,66 @@ describe('compiled Next runtimes', () => {
       const hook = getHook(runtime)
       hook({ [exportName]: RouteModule })
 
-      assert.strictEqual(routeModule[method](...args), returned)
+      if (runtime !== 'pages-api') {
+        assert.strictEqual(routeModule.prepare(...args), returned.prepare)
+        assert.strictEqual(routeModule.handleResponse(...args), returned.handleResponse)
+      }
+      assert.strictEqual(routeModule[method](...args), returned.route)
     }
   })
 
+  it('bypasses the shared lifecycle when the last subscriber is removed after prepare', async () => {
+    class RouteModule {
+      prepare () {
+        return Promise.resolve({})
+      }
+
+      /** @param {{responseGenerator: () => Promise<unknown>}} options */
+      handleResponse ({ responseGenerator }) {
+        return responseGenerator()
+      }
+    }
+
+    class AppPageRouteModule extends RouteModule {}
+    getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+    const startChannel = dc.channel('apm:next:request:start')
+    const onStart = () => {}
+    startChannel.subscribe(onStart)
+    const routeModule = new AppPageRouteModule()
+    const request = { headers: {}, method: 'GET', url: '/disabled-after-prepare' }
+    await routeModule.prepare(request, new http.ServerResponse(request), {})
+    startChannel.unsubscribe(onStart)
+
+    const result = await routeModule.handleResponse({
+      req: request,
+      responseGenerator: () => Promise.resolve('response'),
+    })
+    assert.strictEqual(result, 'response')
+  })
+
   describe('as the first tracing entrypoint', () => {
+    let tracer
+
+    class RouteModule {
+      prepare () {
+        return Promise.resolve({})
+      }
+
+      /** @param {{responseGenerator: () => Promise<unknown>}} options */
+      handleResponse ({ responseGenerator }) {
+        return responseGenerator()
+      }
+    }
+
     before(async () => {
-      await agent.load('next')
+      tracer = await agent.load('next')
       dc.channel('dd-trace:instrumentation:load').publish({ name: 'next' })
     })
     after(() => agent.close())
 
     it('traces an App Route lifecycle with status and incoming context', async () => {
-      class AppRouteRouteModule {
+      class AppRouteRouteModule extends RouteModule {
         definition = { pathname: '/api/first-entry' }
 
         handle () {
@@ -1108,14 +1168,186 @@ describe('compiled Next runtimes', () => {
       })
 
       assert.strictEqual(storage('legacy').getStore(), undefined)
-      const response = await new AppRouteRouteModule().handle(request, {})
-      assert.strictEqual(response.status, 201)
+      const nodeResponse = new http.ServerResponse(request)
+      const routeModule = new AppRouteRouteModule()
+      const nextRequest = { headers: {}, method: 'GET', url: '/api/first-entry' }
+      await routeModule.prepare(request, nodeResponse, {})
+      const response = await routeModule.handleResponse({
+        req: request,
+        responseGenerator: async () => {
+          const response = await routeModule.handle(nextRequest, {})
+          return { value: { status: response.status } }
+        },
+      })
+      assert.strictEqual(response.value.status, 201)
       await trace
       assert.deepStrictEqual(lifecycle, ['start', 'page', 'finish'])
       dc.channel('apm:next:request:start').unsubscribe(onStart)
       dc.channel('apm:next:page:load').unsubscribe(onPage)
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
     })
+
+    it('bypasses the shared lifecycle when prepare was not called', async () => {
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/without-prepare' }
+      }
+
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      let starts = 0
+      const onStart = () => starts++
+      dc.channel('apm:next:request:start').subscribe(onStart)
+      const result = await new AppPageRouteModule().handleResponse({
+        req: { headers: {}, method: 'GET', url: '/without-prepare' },
+        responseGenerator: () => Promise.resolve('response'),
+      })
+      dc.channel('apm:next:request:start').unsubscribe(onStart)
+
+      assert.strictEqual(result, 'response')
+      assert.strictEqual(starts, 0)
+    })
+
+    const cachedRuntimeCases = [
+      {
+        exportName: 'AppRouteRouteModule',
+        label: 'App Route',
+        method: 'handle',
+        pathname: '/api/cached',
+        runtime: 'app-route',
+      },
+      {
+        exportName: 'AppPageRouteModule',
+        label: 'App Page',
+        method: 'render',
+        pathname: '/cached',
+        runtime: 'app-page',
+      },
+    ]
+
+    for (const { exportName, label, method, pathname, runtime } of cachedRuntimeCases) {
+      it(`traces a cached ${label} response`, async () => {
+        class CompiledRouteModule extends RouteModule {
+          handleResponse () {
+            return Promise.resolve({
+              isMiss: false,
+              isStale: false,
+              value: { status: 202 },
+            })
+          }
+
+          [method] () {
+            assert.fail('a cache hit should not invoke the response generator')
+          }
+
+          definition = { pathname }
+        }
+
+        getCompiledRuntimeHook(runtime)({ [exportName]: CompiledRouteModule })
+
+        const request = { headers: {}, method: 'GET', url: pathname }
+        const response = new http.ServerResponse(request)
+        const routeModule = new CompiledRouteModule()
+        const parentResource = `cache-hit-${runtime}`
+        /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
+        function assertNextRequestTrace (traces) {
+          let nextRequestSpan
+          let nextRequestSpanCount = 0
+
+          for (const span of traces[0]) {
+            if (span.name === 'next.request') {
+              nextRequestSpan = span
+              nextRequestSpanCount++
+            }
+          }
+
+          assert.strictEqual(nextRequestSpanCount, 1)
+          assert.strictEqual(nextRequestSpan.resource, `GET ${pathname}`)
+          assert.strictEqual(nextRequestSpan.meta['http.status_code'], '202')
+        }
+        const tracePromise = agent.assertSomeTraces(assertNextRequestTrace, {
+          rejectFirst: true,
+          spanResourceMatch: new RegExp(pathname),
+        })
+
+        await Promise.all([
+          tracer.trace(parentResource, async () => {
+            await routeModule.prepare(request, response, {})
+            return routeModule.handleResponse({
+              req: request,
+              responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
+            })
+          }),
+          tracePromise,
+        ])
+      })
+
+      it(`does not create a request span for stale ${label} background revalidation`, async () => {
+        let responseGenerator
+
+        class CompiledRouteModule extends RouteModule {
+          /** @param {{responseGenerator: () => Promise<unknown>}} options */
+          handleResponse (options) {
+            responseGenerator = options.responseGenerator
+            return Promise.resolve({ isMiss: false, isStale: true })
+          }
+
+          [method] () {
+            return runtime === 'app-route'
+              ? Promise.reject(new Error('stale App Route revalidation error'))
+              : Promise.resolve({ metadata: { statusCode: 200 } })
+          }
+
+          onRequestError () {
+            return Promise.resolve()
+          }
+
+          definition = { pathname }
+        }
+
+        getCompiledRuntimeHook(runtime)({ [exportName]: CompiledRouteModule })
+
+        const request = { headers: {}, method: 'GET', url: pathname }
+        const response = new http.ServerResponse(request)
+        const routeModule = new CompiledRouteModule()
+        await routeModule.prepare(request, response, {})
+        await routeModule.handleResponse({
+          req: request,
+          responseGenerator: async () => {
+            try {
+              return runtime === 'app-route'
+                ? await routeModule[method]({ headers: {}, method: 'GET' }, {})
+                : await routeModule[method](request, response, { page: pathname })
+            } catch (error) {
+              await routeModule.onRequestError(request, error)
+              throw error
+            }
+          },
+        })
+        assert.strictEqual(typeof responseGenerator, 'function')
+
+        /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
+        function assertNoNextRequestTrace (traces) {
+          let nextRequestSpanCount = 0
+          for (const span of traces[0]) {
+            if (span.name === 'next.request') nextRequestSpanCount++
+          }
+          assert.strictEqual(nextRequestSpanCount, 0)
+        }
+        const parentResource = `stale-revalidation-${runtime}`
+        const tracePromise = agent.assertSomeTraces(assertNoNextRequestTrace, {
+          rejectFirst: true,
+          spanResourceMatch: new RegExp(parentResource),
+        })
+        const revalidate = runtime === 'app-route'
+          ? () => assert.rejects(responseGenerator, /stale App Route revalidation error/)
+          : responseGenerator
+
+        await Promise.all([
+          tracer.trace(parentResource, revalidate),
+          tracePromise,
+        ])
+      })
+    }
 
     it('records Pages API errors and status without an existing request store', async () => {
       class PagesAPIRouteModule {
@@ -1153,7 +1385,7 @@ describe('compiled Next runtimes', () => {
     })
 
     it('records App Page errors and status without an existing request store', async () => {
-      class AppPageRouteModule {
+      class AppPageRouteModule extends RouteModule {
         definition = { pathname: '/first-entry' }
 
         render () {
@@ -1179,14 +1411,89 @@ describe('compiled Next runtimes', () => {
       })
 
       assert.strictEqual(storage('legacy').getStore(), undefined)
+      const request = { headers: {}, method: 'GET', url: '/first-entry' }
+      const routeModule = new AppPageRouteModule()
+      await routeModule.prepare(request, response, {})
       await assert.rejects(
-        new AppPageRouteModule().render({ headers: {}, method: 'GET', url: '/first-entry' }, response, {
-          page: '/first-entry',
+        routeModule.handleResponse({
+          req: request,
+          responseGenerator: () => routeModule.render(request, response, { page: '/first-entry' }),
         }),
         /App Page first-entry error/
       )
       assert.strictEqual(response.statusCode, 500)
       await trace
+    })
+
+    it('passes the Node response to App Route hooks without disabling the plugin', async () => {
+      const hookResponses = []
+      /**
+       * @param {import('../../dd-trace/src/opentracing/span')} _span
+       * @param {import('node:http').IncomingMessage} _request
+       * @param {import('node:http').ServerResponse} response
+       */
+      const requestHook = (_span, _request, response) => {
+        hookResponses.push(response)
+        response.getHeader('content-type')
+      }
+      agent.reload('next', { hooks: { request: requestHook } })
+
+      class AppRouteRouteModule extends RouteModule {
+        definition = { pathname: '/api/response-hook' }
+
+        handle () {
+          return Promise.resolve({ status: 200 })
+        }
+      }
+
+      class PagesAPIRouteModule {
+        definition = { page: '/api/response-hook-sentinel' }
+
+        render () {
+          return Promise.resolve()
+        }
+      }
+
+      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
+      getCompiledRuntimeHook('pages-api')({ PagesAPIRouteModule })
+
+      const routeRequest = { headers: {}, method: 'GET', url: '/api/response-hook' }
+      const routeResponse = new http.ServerResponse(routeRequest)
+      const routeModule = new AppRouteRouteModule()
+      await routeModule.prepare(routeRequest, routeResponse, {})
+      await routeModule.handleResponse({
+        req: routeRequest,
+        responseGenerator: () => routeModule.handle({ headers: {}, method: 'GET' }, {}),
+      })
+
+      const sentinelRequest = { headers: {}, method: 'GET', url: '/api/response-hook-sentinel' }
+      const sentinelResponse = new http.ServerResponse(sentinelRequest)
+      /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
+      function assertNextRequestTrace (traces) {
+        let nextRequestSpan
+        for (const span of traces[0]) {
+          if (span.name === 'next.request') {
+            nextRequestSpan = span
+            break
+          }
+        }
+
+        assert.ok(nextRequestSpan, 'next.request span should exist after the App Route hook')
+      }
+      const tracePromise = agent.assertSomeTraces(assertNextRequestTrace, {
+        rejectFirst: true,
+        spanResourceMatch: /response-hook-sentinel/,
+      })
+
+      await Promise.all([
+        tracer.trace('response-hook-sentinel', () => {
+          return new PagesAPIRouteModule().render(sentinelRequest, sentinelResponse, {
+            page: '/api/response-hook-sentinel',
+          })
+        }),
+        tracePromise,
+      ])
+      assert.deepStrictEqual(hookResponses, [routeResponse, sentinelResponse])
     })
   })
 })

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1138,8 +1138,13 @@ describe('compiled Next runtimes', () => {
     assert.strictEqual(result, 'response')
   })
 
-  describe('as the first tracing entrypoint', () => {
+  describe('with tracing enabled', () => {
     let tracer
+    let requestHookCalls = 0
+
+    function countRequestHook () {
+      requestHookCalls++
+    }
 
     class RouteModule {
       prepare () {
@@ -1153,7 +1158,11 @@ describe('compiled Next runtimes', () => {
     }
 
     before(async () => {
-      tracer = await agent.load('next')
+      tracer = await agent.load('next', {
+        hooks: {
+          request: countRequestHook,
+        },
+      })
       dc.channel('dd-trace:instrumentation:load').publish({ name: 'next' })
     })
     after(() => agent.close())
@@ -1218,6 +1227,52 @@ describe('compiled Next runtimes', () => {
       dc.channel('apm:next:page:load').unsubscribe(onPage)
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
     })
+
+    for (const responseBeforeHandler of [false, true]) {
+      const completionOrder = responseBeforeHandler ? 'response-first' : 'handler-first'
+
+      it(`does not finish a reused App Page lifecycle for ${completionOrder} completion`, async () => {
+        const pathname = `/reused-app-page-${completionOrder}`
+
+        class AppPageRouteModule extends RouteModule {
+          definition = { pathname }
+
+          handleResponse () {
+            if (responseBeforeHandler) response.emit('finish')
+            return Promise.resolve({ value: { status: 200 } })
+          }
+        }
+
+        applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
+
+        const request = { headers: {}, method: 'GET', url: pathname }
+        const response = new http.ServerResponse(request)
+        const routeModule = new AppPageRouteModule()
+        const parentResource = `reused-app-page-${completionOrder}`
+        /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
+        function assertParentTrace (traces) {
+          const [span] = traces[0]
+          assert.strictEqual(requestHookCalls, 0)
+          assert.strictEqual(span.name, parentResource)
+          assert.strictEqual(span.resource, `GET ${pathname}`)
+        }
+        const tracePromise = agent.assertSomeTraces(assertParentTrace, { spanResourceMatch: new RegExp(pathname) })
+        requestHookCalls = 0
+
+        await Promise.all([
+          tracer.trace(parentResource, { integrationName: 'next' }, async () => {
+            await routeModule.prepare(request, response, {})
+            const result = await routeModule.handleResponse({
+              req: request,
+              responseGenerator: () => Promise.resolve(),
+            })
+            if (!responseBeforeHandler) response.emit('finish')
+            return result
+          }),
+          tracePromise,
+        ])
+      })
+    }
 
     it('clears the App Route request association after a synchronous generator error', async () => {
       const nextRequest = {
@@ -1452,60 +1507,74 @@ describe('compiled Next runtimes', () => {
       })
     }
 
-    it('records a foreground App Page error while stale revalidation is pending', async () => {
-      let responseGenerator
-      let continueRevalidation
-      let reportForegroundError
-      let foregroundErrorReported
-      const foregroundError = new Error('foreground postponed render error')
-      const backgroundError = new Error('stale revalidation error')
-      const foregroundErrorTrigger = new Promise(resolve => { reportForegroundError = resolve })
-      const revalidationContinuation = new Promise(resolve => { continueRevalidation = resolve })
+    for (const { foregroundAfterRevalidation, label, reuseError } of [
+      { foregroundAfterRevalidation: false, label: 'while stale revalidation is pending', reuseError: false },
+      { foregroundAfterRevalidation: true, label: 'after stale revalidation reports the same error', reuseError: true },
+    ]) {
+      it(`records a foreground App Page error ${label}`, async () => {
+        let responseGenerator
+        let continueRevalidation
+        let reportForegroundError
+        let foregroundErrorReported
+        const foregroundError = new Error('foreground postponed render error')
+        const backgroundError = reuseError ? foregroundError : new Error('stale revalidation error')
+        const foregroundErrorTrigger = new Promise(resolve => { reportForegroundError = resolve })
+        const revalidationContinuation = new Promise(resolve => { continueRevalidation = resolve })
 
-      class AppPageRouteModule extends RouteModule {
-        definition = { pathname: '/interleaved-error' }
+        class AppPageRouteModule extends RouteModule {
+          definition = { pathname: '/interleaved-error' }
 
-        /** @param {{responseGenerator: () => Promise<unknown>}} options */
-        handleResponse (options) {
-          responseGenerator = options.responseGenerator
-          foregroundErrorReported = foregroundErrorTrigger.then(() => this.onRequestError(options.req, foregroundError))
-          return Promise.resolve({ isMiss: false, isStale: true })
+          /** @param {{responseGenerator: () => Promise<unknown>}} options */
+          handleResponse (options) {
+            responseGenerator = options.responseGenerator
+            foregroundErrorReported = (async () => {
+              await foregroundErrorTrigger
+              await this.onRequestError(options.req, foregroundError)
+            })()
+            return Promise.resolve({ isMiss: false, isStale: true })
+          }
+
+          onRequestError () {
+            return Promise.resolve()
+          }
         }
+        applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
 
-        onRequestError () {
-          return Promise.resolve()
+        const nodeRequest = { headers: {}, method: 'GET', url: '/interleaved-error' }
+        const request = { ...nodeRequest, originalRequest: nodeRequest }
+        const response = new http.ServerResponse(nodeRequest)
+        const routeModule = new AppPageRouteModule()
+        const trace = agent.assertSomeTraces(traces => {
+          const [span] = traces[0]
+          assert.strictEqual(span.error, 1)
+          assert.strictEqual(span.meta['error.message'], foregroundError.message)
+        })
+
+        await routeModule.prepare(request, response, {})
+        await routeModule.handleResponse({
+          req: request,
+          responseGenerator: async () => {
+            await revalidationContinuation
+            await routeModule.onRequestError(request, backgroundError)
+            throw backgroundError
+          },
+        })
+
+        const revalidation = responseGenerator({ hasResolved: true })
+        if (!foregroundAfterRevalidation) {
+          reportForegroundError()
+          await foregroundErrorReported
         }
-      }
-      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
-
-      const nodeRequest = { headers: {}, method: 'GET', url: '/interleaved-error' }
-      const request = { ...nodeRequest, originalRequest: nodeRequest }
-      const response = new http.ServerResponse(nodeRequest)
-      const routeModule = new AppPageRouteModule()
-      const trace = agent.assertSomeTraces(traces => {
-        const [span] = traces[0]
-        assert.strictEqual(span.error, 1)
-        assert.strictEqual(span.meta['error.message'], foregroundError.message)
+        continueRevalidation()
+        await assert.rejects(revalidation, backgroundError)
+        if (foregroundAfterRevalidation) {
+          reportForegroundError()
+          await foregroundErrorReported
+        }
+        response.emit('finish')
+        await trace
       })
-
-      await routeModule.prepare(request, response, {})
-      await routeModule.handleResponse({
-        req: request,
-        responseGenerator: async () => {
-          await revalidationContinuation
-          await routeModule.onRequestError(request, backgroundError)
-          throw backgroundError
-        },
-      })
-
-      const revalidation = responseGenerator({ hasResolved: true })
-      reportForegroundError()
-      await foregroundErrorReported
-      continueRevalidation()
-      await assert.rejects(revalidation, backgroundError)
-      response.emit('finish')
-      await trace
-    })
+    }
 
     it('does not attach nested fallback revalidation errors to the foreground App Page span', async () => {
       let backgroundRevalidation
@@ -1704,6 +1773,47 @@ describe('compiled Next runtimes', () => {
       })
       response.emit('close')
       finishHandleResponse({ value: { status: 503 } })
+      await result
+      await trace
+    })
+
+    it('records App Page handler errors after the response closes', async () => {
+      let finishHandleResponse
+      const handlerError = new Error('closed response handler error')
+      const handleResponseResult = new Promise(resolve => { finishHandleResponse = resolve })
+
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/closed-response-error' }
+
+        async handleResponse () {
+          await handleResponseResult
+          throw handlerError
+        }
+      }
+      applyCompiledRuntimeHook('app-page', { AppPageRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/closed-response-error' }
+      const response = new http.ServerResponse(request)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assertObjectContains(span, {
+          error: 1,
+          meta: {
+            'error.message': handlerError.message,
+            'error.type': 'Error',
+          },
+        })
+        assert.ok(span.meta['error.stack'])
+      }, { spanResourceMatch: /closed-response-error/ })
+
+      await routeModule.prepare(request, response, {})
+      const result = assert.rejects(routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
+      }), handlerError)
+      response.emit('close')
+      finishHandleResponse()
       await result
       await trace
     })

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1187,6 +1187,45 @@ describe('compiled Next runtimes', () => {
       dc.channel('apm:next:request:finish').unsubscribe(onFinish)
     })
 
+    it('clears the App Route request association after a synchronous generator error', async () => {
+      const nextRequest = {
+        error: new Error('unrelated Next request error'),
+        headers: {},
+        method: 'GET',
+        url: '/api/generator-error',
+      }
+
+      class AppRouteRouteModule extends RouteModule {
+        definition = { pathname: '/api/generator-error' }
+
+        handle () {
+          return Promise.resolve({ status: 200 })
+        }
+
+        /** @param {{responseGenerator: () => Promise<unknown>}} options */
+        async handleResponse ({ responseGenerator }) {
+          assert.throws(responseGenerator, /synchronous generator error/)
+          const response = await this.handle(nextRequest, {})
+          return { value: { status: response.status } }
+        }
+      }
+      getCompiledRuntimeHook('app-route')({ AppRouteRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/api/generator-error' }
+      const response = new http.ServerResponse(request)
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assert.strictEqual(span.error, 0)
+      })
+      const routeModule = new AppRouteRouteModule()
+      await routeModule.prepare(request, response, {})
+      await routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => { throw new Error('synchronous generator error') },
+      })
+      await trace
+    })
+
     it('bypasses the shared lifecycle when prepare was not called', async () => {
       class AppPageRouteModule extends RouteModule {
         definition = { pathname: '/without-prepare' }
@@ -1250,16 +1289,20 @@ describe('compiled Next runtimes', () => {
         const parentResource = `cache-hit-${runtime}`
         /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
         function assertNextRequestTrace (traces) {
+          let httpParentSpan
           let nextRequestSpan
           let nextRequestSpanCount = 0
 
           for (const span of traces[0]) {
+            if (span.name === parentResource) httpParentSpan = span
             if (span.name === 'next.request') {
               nextRequestSpan = span
               nextRequestSpanCount++
             }
           }
 
+          assert.strictEqual(httpParentSpan.resource, `GET ${pathname}`)
+          assert.strictEqual(httpParentSpan.meta['http.route'], pathname)
           assert.strictEqual(nextRequestSpanCount, 1)
           assert.strictEqual(nextRequestSpan.resource, `GET ${pathname}`)
           assert.strictEqual(nextRequestSpan.meta['http.status_code'], '202')
@@ -1270,12 +1313,14 @@ describe('compiled Next runtimes', () => {
         })
 
         await Promise.all([
-          tracer.trace(parentResource, async () => {
+          tracer.trace(parentResource, { integrationName: 'http' }, async () => {
             await routeModule.prepare(request, response, {})
-            return routeModule.handleResponse({
+            const result = await routeModule.handleResponse({
               req: request,
               responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
             })
+            if (runtime === 'app-page') response.emit('finish')
+            return result
           }),
           tracePromise,
         ])
@@ -1323,6 +1368,7 @@ describe('compiled Next runtimes', () => {
             }
           },
         })
+        if (runtime === 'app-page') response.emit('finish')
         assert.strictEqual(typeof responseGenerator, 'function')
 
         /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
@@ -1348,6 +1394,110 @@ describe('compiled Next runtimes', () => {
         ])
       })
     }
+
+    for (const { cacheStatus, label, responseStatus } of [
+      { cacheStatus: 307, label: 'RSC redirect', responseStatus: 200 },
+      { cacheStatus: 200, label: 'segment-prefetch miss', responseStatus: 204 },
+    ]) {
+      it(`records the final App Page status for a cached ${label}`, async () => {
+        class AppPageRouteModule extends RouteModule {
+          definition = { pathname: '/cached-status' }
+
+          handleResponse () {
+            return Promise.resolve({ value: { status: cacheStatus } })
+          }
+        }
+        getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+        const request = { headers: {}, method: 'GET', url: '/cached-status' }
+        const response = new http.ServerResponse(request)
+        const routeModule = new AppPageRouteModule()
+        const trace = agent.assertSomeTraces(traces => {
+          const [span] = traces[0]
+          assert.strictEqual(span.meta['http.status_code'], String(responseStatus))
+        })
+
+        await routeModule.prepare(request, response, {})
+        await routeModule.handleResponse({
+          req: request,
+          responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
+        })
+        response.statusCode = responseStatus
+        response.emit('finish')
+        await trace
+      })
+    }
+
+    it('waits for App Page response handling after the response closes', async () => {
+      let finishHandleResponse
+      const handleResponseResult = new Promise(resolve => { finishHandleResponse = resolve })
+
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/closed-response' }
+
+        handleResponse () {
+          return handleResponseResult
+        }
+      }
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/closed-response' }
+      const response = new http.ServerResponse(request)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assert.strictEqual(span.meta['http.status_code'], '503')
+      })
+
+      await routeModule.prepare(request, response, {})
+      const result = routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
+      })
+      response.emit('close')
+      finishHandleResponse({ value: { status: 503 } })
+      await result
+      await trace
+    })
+
+    it('records App Page errors after cache handling completes', async () => {
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/post-cache-error' }
+
+        handleResponse () {
+          return Promise.resolve({ value: { status: 200 } })
+        }
+
+        onRequestError () {
+          return Promise.resolve()
+        }
+      }
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      const request = { headers: {}, method: 'GET', url: '/post-cache-error' }
+      const response = new http.ServerResponse(request)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assertObjectContains(span, {
+          error: 1,
+          meta: {
+            'error.message': 'post-cache App Page error',
+            'http.status_code': '500',
+          },
+        })
+      })
+
+      await routeModule.prepare(request, response, {})
+      await routeModule.handleResponse({
+        req: request,
+        responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
+      })
+      await routeModule.onRequestError(request, new Error('post-cache App Page error'))
+      response.statusCode = 500
+      response.emit('finish')
+      await trace
+    })
 
     it('records Pages API errors and status without an existing request store', async () => {
       class PagesAPIRouteModule {
@@ -1395,7 +1545,8 @@ describe('compiled Next runtimes', () => {
       const runtimeHook = getCompiledRuntimeHook('app-page')
       runtimeHook({ AppPageRouteModule })
 
-      const response = { statusCode: 200 }
+      const request = { headers: {}, method: 'GET', url: '/first-entry' }
+      const response = new http.ServerResponse(request)
       const trace = agent.assertSomeTraces(traces => {
         const [span] = traces[0]
         assertObjectContains(span, {
@@ -1411,7 +1562,6 @@ describe('compiled Next runtimes', () => {
       })
 
       assert.strictEqual(storage('legacy').getStore(), undefined)
-      const request = { headers: {}, method: 'GET', url: '/first-entry' }
       const routeModule = new AppPageRouteModule()
       await routeModule.prepare(request, response, {})
       await assert.rejects(
@@ -1422,6 +1572,7 @@ describe('compiled Next runtimes', () => {
         /App Page first-entry error/
       )
       assert.strictEqual(response.statusCode, 500)
+      response.emit('finish')
       await trace
     })
 

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1180,6 +1180,7 @@ describe('compiled Next runtimes', () => {
         },
       })
       assert.strictEqual(response.value.status, 201)
+      nodeResponse.emit('finish')
       await trace
       assert.deepStrictEqual(lifecycle, ['start', 'page', 'finish'])
       dc.channel('apm:next:request:start').unsubscribe(onStart)
@@ -1223,6 +1224,7 @@ describe('compiled Next runtimes', () => {
         req: request,
         responseGenerator: () => { throw new Error('synchronous generator error') },
       })
+      response.emit('finish')
       await trace
     })
 
@@ -1319,7 +1321,7 @@ describe('compiled Next runtimes', () => {
               req: request,
               responseGenerator: () => assert.fail('a cache hit should not invoke the response generator'),
             })
-            if (runtime === 'app-page') response.emit('finish')
+            response.emit('finish')
             return result
           }),
           tracePromise,
@@ -1398,12 +1400,67 @@ describe('compiled Next runtimes', () => {
           tracer.trace(parentResource, revalidate),
           tracePromise,
         ])
+        response.emit('finish')
         if (runtime === 'app-page') {
-          response.emit('finish')
           await foregroundTrace
         }
       })
     }
+
+    it('records a foreground App Page error while stale revalidation is pending', async () => {
+      let responseGenerator
+      let continueRevalidation
+      let reportForegroundError
+      let foregroundErrorReported
+      const foregroundError = new Error('foreground postponed render error')
+      const backgroundError = new Error('stale revalidation error')
+      const foregroundErrorTrigger = new Promise(resolve => { reportForegroundError = resolve })
+      const revalidationContinuation = new Promise(resolve => { continueRevalidation = resolve })
+
+      class AppPageRouteModule extends RouteModule {
+        definition = { pathname: '/interleaved-error' }
+
+        /** @param {{responseGenerator: () => Promise<unknown>}} options */
+        handleResponse (options) {
+          responseGenerator = options.responseGenerator
+          foregroundErrorReported = foregroundErrorTrigger.then(() => this.onRequestError(options.req, foregroundError))
+          return Promise.resolve({ isMiss: false, isStale: true })
+        }
+
+        onRequestError () {
+          return Promise.resolve()
+        }
+      }
+      getCompiledRuntimeHook('app-page')({ AppPageRouteModule })
+
+      const nodeRequest = { headers: {}, method: 'GET', url: '/interleaved-error' }
+      const request = { ...nodeRequest, originalRequest: nodeRequest }
+      const response = new http.ServerResponse(nodeRequest)
+      const routeModule = new AppPageRouteModule()
+      const trace = agent.assertSomeTraces(traces => {
+        const [span] = traces[0]
+        assert.strictEqual(span.error, 1)
+        assert.strictEqual(span.meta['error.message'], foregroundError.message)
+      })
+
+      await routeModule.prepare(request, response, {})
+      await routeModule.handleResponse({
+        req: request,
+        responseGenerator: async () => {
+          await revalidationContinuation
+          await routeModule.onRequestError(request, backgroundError)
+          throw backgroundError
+        },
+      })
+
+      const revalidation = responseGenerator({ hasResolved: true })
+      reportForegroundError()
+      await foregroundErrorReported
+      continueRevalidation()
+      await assert.rejects(revalidation, backgroundError)
+      response.emit('finish')
+      await trace
+    })
 
     for (const { cacheStatus, label, responseStatus } of [
       { cacheStatus: 307, label: 'RSC redirect', responseStatus: 200 },
@@ -1558,8 +1615,9 @@ describe('compiled Next runtimes', () => {
       await trace
     })
 
-    it('passes Node responses to hooks without propagating deferred hook errors', async () => {
+    it('passes final Node responses to hooks without propagating deferred hook errors', async () => {
       const hookResponses = []
+      const hookCacheStatuses = []
       /**
        * @param {import('../../dd-trace/src/opentracing/span')} _span
        * @param {import('node:http').IncomingMessage} request
@@ -1567,6 +1625,7 @@ describe('compiled Next runtimes', () => {
        */
       const requestHook = (_span, request, response) => {
         hookResponses.push(response)
+        hookCacheStatuses.push(response.getHeader('x-nextjs-cache'))
         response.getHeader('content-type')
         if (request.url === '/app-page-hook-error') throw new Error('request hook error')
       }
@@ -1608,6 +1667,8 @@ describe('compiled Next runtimes', () => {
         req: routeRequest,
         responseGenerator: () => routeModule.handle({ headers: {}, method: 'GET' }, {}),
       })
+      routeResponse.setHeader('x-nextjs-cache', 'HIT')
+      routeResponse.emit('finish')
 
       const sentinelRequest = { headers: {}, method: 'GET', url: '/api/response-hook-sentinel' }
       const sentinelResponse = new http.ServerResponse(sentinelRequest)
@@ -1637,6 +1698,7 @@ describe('compiled Next runtimes', () => {
         tracePromise,
       ])
       assert.deepStrictEqual(hookResponses, [routeResponse, sentinelResponse])
+      assert.deepStrictEqual(hookCacheStatuses, ['HIT', undefined])
 
       const pageRequest = { headers: {}, method: 'GET', url: '/app-page-hook-error' }
       const pageResponse = new http.ServerResponse(pageRequest)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -35,7 +35,6 @@ const HTTP_CLIENT_IP = tags.HTTP_CLIENT_IP
 const MANUAL_DROP = tags.MANUAL_DROP
 
 const contexts = new WeakMap()
-const requests = new WeakMap()
 
 // TODO: change this to no longer rely on creating a dummy plugin to be able to access startSpan
 function createWebPlugin (tracer, config = {}) {
@@ -129,7 +128,6 @@ const web = {
     context.tracer = tracer
     context.span = span
     context.res = res
-    requests.set(span, req)
 
     this.setConfig(req, config)
     addRequestTags(context, this.TYPE)
@@ -314,7 +312,6 @@ const web = {
     web.finishMiddleware(context)
 
     web.finishSpan(context, spanType)
-    requests.delete(context.span)
 
     finishInferredProxySpan(context)
   },
@@ -343,9 +340,6 @@ const web = {
   },
   getContext (req) {
     return contexts.get(req)
-  },
-  getRequest (span) {
-    return requests.get(span)
   },
   setRouteOrEndpointTag (req) {
     const context = contexts.get(req)


### PR DESCRIPTION
## Summary

Compiled App Route and App Page request spans started inside response generators, so cache hits had no span, stale background revalidations created request spans, and App Route hooks received a synthetic response. Starting at the shared RouteModule response boundary covers the foreground request once and passes the Node response through unchanged.

Refs: https://github.com/DataDog/dd-trace-js/pull/9627
Refs: https://github.com/DataDog/dd-trace-js/pull/9682