### PR TITLE
feat(serverless): add AWS MicroVM support

### DIFF
--- a/benchmark/sirun/test-optimization/index.js
+++ b/benchmark/sirun/test-optimization/index.js
@@ -128,7 +128,7 @@ assert.ok(shape, `unknown VARIANT: ${VARIANT}`)
 const trace = buildTrace(shape.tests, shape.suites, shape.wide)
 const encoder = new AgentlessCiVisibilityEncoder(
   { flush () {} },
-  { runtimeId: 'a1b2c3d4-0000-0000-0000-000000000000', service: 'my-service', env: 'ci' }
+  { tags: { 'runtime-id': 'a1b2c3d4-0000-0000-0000-000000000000', service: 'my-service', env: 'ci' } }
 )
 
 // Preflight: encode once and confirm the encoder buffered bytes and counted the

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -26,9 +26,8 @@ class Writer extends BaseWriter {
   constructor ({ url, tags, evpProxyPrefix = '' }) {
     super(...arguments)
     this.#requestTracker = new TestOptimizationRequestTracker(this)
-    const { 'runtime-id': runtimeId, env, service } = tags
     this._url = url
-    this._encoder = new AgentlessCiVisibilityEncoder(this, { runtimeId, env, service })
+    this._encoder = new AgentlessCiVisibilityEncoder(this, { tags })
     this._evpProxyPrefix = evpProxyPrefix
   }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-validation/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-validation/writer.js
@@ -11,9 +11,8 @@ class CiValidationWriter {
    * @param {object} options.tags tracer tags
    */
   constructor ({ sink, tags }) {
-    const { 'runtime-id': runtimeId, env, service } = tags
     this._sink = sink
-    this._encoder = new AgentlessCiVisibilityEncoder(this, { runtimeId, env, service })
+    this._encoder = new AgentlessCiVisibilityEncoder(this, { tags })
   }
 
   /**

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -4,6 +4,8 @@ const fs = require('node:fs')
 const os = require('node:os')
 const { URL, format } = require('node:url')
 
+const { channel } = require('dc-polyfill')
+
 const exporters = require('../../../../ext/exporters')
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
 const uuid = require('../../../../vendor/dist/crypto-randomuuid') // we need to keep the old uuid dep because of cypress
@@ -42,7 +44,6 @@ const {
 const { normalizeService } = require('./normalize-service')
 const { programmaticTypeCoercions, transformers } = require('./parsers')
 
-const RUNTIME_ID = uuid()
 const TEST_OPTIMIZATION_WORKER_EXPORTERS = new Set([
   exporters.CUCUMBER_WORKER,
   exporters.JEST_WORKER,
@@ -50,6 +51,21 @@ const TEST_OPTIMIZATION_WORKER_EXPORTERS = new Set([
   exporters.PLAYWRIGHT_WORKER,
   exporters.VITEST_WORKER,
 ])
+
+let runtimeId
+
+channel('datadog:identity:update').subscribe(refreshRuntimeId)
+
+/**
+ * Lazily generates the process-wide runtime ID on first access instead of at module load,
+ * so modules that merely require this file without constructing a Config never pay for it.
+ *
+ * @returns {string}
+ */
+function getRuntimeId () {
+  runtimeId ??= uuid()
+  return runtimeId
+}
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
 
@@ -602,7 +618,7 @@ class Config extends ConfigBase {
     if (this.version) {
       this.tags.version = this.version
     }
-    this.tags['runtime-id'] = RUNTIME_ID
+    this.tags['runtime-id'] = getRuntimeId()
     const platformTags = getServerlessPlatformTags()
     if (platformTags) {
       for (let i = 0; i < platformTags.length; i += 2) {
@@ -787,4 +803,16 @@ function getConfig (options) {
     configInstance = new Config(options)
   }
   return configInstance
+}
+
+/**
+ * Regenerates the runtime ID.
+ *
+ * Used for Lambda MicroVM `/run` lifecycle hooks, giving each clone a distinct runtime identity.
+ *
+ * @param {import('./config-base')} config
+ */
+function refreshRuntimeId (config) {
+  runtimeId = uuid()
+  config.tags['runtime-id'] = runtimeId
 }

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -6,9 +6,12 @@ const { EOL, platform } = require('node:os')
 const libdatadog = require('@datadog/libdatadog')
 const binding = libdatadog.load('crashtracker')
 
+const { channel } = require('dc-polyfill')
 const log = require('../log')
 const pkg = require('../../../../package.json')
 const processTags = require('../process-tags')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 class Crashtracker {
   #started = false
@@ -38,6 +41,7 @@ class Crashtracker {
       )
       this.#started = true
       this.#trackUnhandledExceptions()
+      identityRefreshChannel.subscribe((config) => this.configure(config))
     } catch (e) {
       log.error('Error initializing crashtracker', e)
     }

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -4,6 +4,8 @@ const dgram = require('dgram')
 const isIP = require('net').isIP
 const { performance } = require('node:perf_hooks')
 
+const { channel } = require('dc-polyfill')
+
 const tracerVersion = require('../../../package.json').version
 const { storage } = require('../../datadog-core')
 const request = require('./exporters/common/request')
@@ -76,6 +78,8 @@ const TYPE_LABELS = ['count', 'gauge', 'distribution', 'histogram']
  * @returns {void}
  */
 
+const identityRefreshChannel = channel('datadog:identity:refresh')
+
 /**
  * @import { DogStatsD } from "../../../index.d.ts"
  * @implements {DogStatsD}
@@ -115,7 +119,6 @@ class DogStatsDClient {
     this.#family = isIP(options.host)
     this.#host = options.host
     this.#port = options.port
-    this.#tagsPrefix = options.tags?.length ? `|#${options.tags.join(',')}` : ''
     this.#serverlessDeliveryTracker = createServerlessDeliveryTracker()
 
     if (telemetryEnabled) {
@@ -129,15 +132,56 @@ class DogStatsDClient {
         packetsSent: 0,
         payload: { message: '', offset: 0, queue: [] },
       }
-
-      const separator = this.#tagsPrefix ? ',' : '|#'
-      const prefix = `${this.#tagsPrefix}${separator}client:nodejs,client_version:${tracerVersion},client_transport:`
-      this.#telemetryHttpTagsPrefix = `${prefix}http`
-      this.#telemetryUdpTagsPrefix = `${prefix}udp`
     }
+
+    this.#updateTagPrefixes(options.tags.length ? `|#${options.tags.join(',')}` : '')
 
     this.#udp4 = this._socket('udp4')
     this.#udp6 = this._socket('udp6')
+  }
+
+  /**
+   * Recomputes the cached tags and tag-prefix (mirrors the constructor) after a `config.tags`
+   * change, e.g. a MicroVM clone resume.
+   *
+   * Buffered lines have the old prefix baked in, and on a clone resume they were produced during
+   * the image build, so every clone holds the same bytes — flushing them would submit one identical
+   * copy per clone. Dropping is right here for that reason only: for a tag change on a live process
+   * the buffer holds unique data whose old tags are still correct, so that case wants a flush
+   * before the swap.
+   *
+   * @param {string[]} tags - DogStatsD-formatted tags (e.g. `['key:value']`)
+   */
+  updateTags (tags) {
+    const tagsPrefix = tags.length ? `|#${tags.join(',')}` : ''
+    if (tagsPrefix === this.#tagsPrefix) return
+
+    this.#updateTagPrefixes(tagsPrefix)
+    this.#metrics.queue = []
+    this.#metrics.message = ''
+    this.#metrics.offset = 0
+
+    const payload = this.telemetry?.payload
+    if (payload) {
+      payload.queue = []
+      payload.message = ''
+      payload.offset = 0
+    }
+  }
+
+  /**
+   * Updates the prefixes used for application metrics and client telemetry.
+   * @param {string} tagsPrefix - Serialized global DogStatsD tags
+   */
+  #updateTagPrefixes (tagsPrefix) {
+    this.#tagsPrefix = tagsPrefix
+
+    if (!this.telemetry) return
+
+    const separator = tagsPrefix ? ',' : '|#'
+    const prefix = `${tagsPrefix}${separator}client:nodejs,client_version:${tracerVersion},client_transport:`
+    this.#telemetryHttpTagsPrefix = `${prefix}http`
+    this.#telemetryUdpTagsPrefix = `${prefix}udp`
   }
 
   increment (stat, value, tags) {
@@ -551,6 +595,14 @@ class MetricsAggregationClient {
   }
 
   /**
+   * Recomputes the wrapped client's cached tags (e.g. after a MicroVM clone resume).
+   * @param {string[]} tags - DogStatsD-formatted tags (e.g. `['key:value']`)
+   */
+  updateTags (tags) {
+    this._client.updateTags(tags)
+  }
+
+  /**
    * @param {boolean|(() => void)} [forceTelemetry] - Whether to ignore the telemetry interval, or completion callback
    * @param {() => void} [done] - Called after serverless deliveries complete
    * @returns {void}
@@ -765,6 +817,11 @@ class CustomMetrics {
   constructor (config) {
     const clientConfig = DogStatsDClient.generateClientConfig(config)
     this.#client = createMetricsAggregationClient(clientConfig)
+
+    // CustomMetrics has process-lifetime flush handlers and no stop hook, so this shares that lifetime.
+    identityRefreshChannel.subscribe(() => {
+      this.#client.updateTags(DogStatsDClient.generateClientConfig(config).tags)
+    })
 
     const flush = this.flush.bind(this)
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -69,11 +69,11 @@ function truncateTestLevelMetadataTags (tags) {
 }
 
 class AgentlessCiVisibilityEncoder extends AgentEncoder {
-  constructor (writer, { runtimeId, service, env }) {
+  constructor (writer, { tags }) {
     super(writer, INTAKE_SOFT_LIMIT)
-    this.runtimeId = runtimeId
-    this.service = service
-    this.env = env
+    // Holds a reference to the live `tags` object (instead of copying `env`/`runtime-id` out of it)
+    // so a later change (e.g. a MicroVM clone resume) is picked up at flush time.
+    this.tags = tags
 
     // Used to keep track of the number of encoded events to update the
     // length of `payload.events` when calling `makePayload`
@@ -406,11 +406,12 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       events: [],
     }
 
-    if (this.env) {
-      payload.metadata['*'].env = this.env
+    if (this.tags.env) {
+      payload.metadata['*'].env = this.tags.env
     }
-    if (this.runtimeId) {
-      payload.metadata['*']['runtime-id'] = this.runtimeId
+    const runtimeId = this.tags['runtime-id']
+    if (runtimeId) {
+      payload.metadata['*']['runtime-id'] = runtimeId
     }
 
     bytes.writeMapPrefix(Object.keys(payload).length)

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -23,7 +23,7 @@ class AgentlessExporter {
    * @param {string} [config.site] - The Datadog site. Defaults to 'datadoghq.com'.
    * @param {number} [config.flushInterval] - Batch flush interval in ms
    * @param {string} [config.env] - Environment name
-   * @param {object} [config.tags] - Tags including runtime-id
+   * @param {object} config.tags - Tags including runtime-id
    */
   constructor (config) {
     this.#config = config
@@ -40,11 +40,13 @@ class AgentlessExporter {
 
     const metadata = {
       hostname: os.hostname(),
-      env: config.env,
       languageName: 'nodejs',
       languageVersion: process.version,
       tracerVersion,
-      runtimeID: config.tags?.['runtime-id'],
+      // Read live off `config` (instead of copying the value) so a later change
+      // (e.g. a MicroVM clone resume) is picked up by the next `JSON.stringify` in the encoder.
+      get env () { return config.env },
+      get runtimeID () { return config.tags['runtime-id'] },
       ...(entityId ? { containerID: entityId } : {}),
     }
 

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -2,12 +2,16 @@
 
 const { randomFillSync } = require('crypto')
 
+const { channel } = require('dc-polyfill')
+
 const UINT_MAX = 4_294_967_296
 
 const data = new Uint8Array(8 * 8192)
 const zeroId = new Uint8Array(8)
 
 let batch = 0
+
+channel('datadog:identity:update').subscribe(reseed)
 
 // Internal representation of a trace or span ID.
 class Identifier {
@@ -252,6 +256,16 @@ function writeUInt32BE (buffer, value, offset) {
   buffer[1 + offset] = value & 255
   value >>= 8
   buffer[0 + offset] = value & 255
+}
+
+/**
+ * Resets the batch cursor, forcing the next ID batch to draw a fresh
+ * randomFillSync() call on MicroVM clone resume. Node's crypto RNG is
+ * re-seeded from the kernel CSPRNG on snapshot resume, so re-invoking it
+ * is sufficient — no need to read /dev/urandom directly.
+ */
+function reseed () {
+  batch = 0
 }
 
 /**

--- a/packages/dd-trace/src/opentelemetry/logs/index.js
+++ b/packages/dd-trace/src/opentelemetry/logs/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const os = require('os')
+const { buildResourceAttributes, registerResourceAttributeRefresh } = require('../resource-attributes')
 
 /**
  * @typedef {import('../../config')} Config
@@ -37,35 +37,13 @@ const OtlpHttpLogExporter = require('./otlp_http_log_exporter')
  * @param {import('../../config/config-base')} config - Tracer configuration instance
  */
 function initializeOpenTelemetryLogs (config) {
-  // Build resource attributes
-  const resourceAttributes = {
-    'service.name': config.service,
-    'service.version': config.version,
-    'deployment.environment': config.env,
-  }
-
-  // Add all tracer tags (includes DD_TAGS, OTEL_RESOURCE_ATTRIBUTES, DD_TRACE_TAGS, etc.)
-  // Exclude Datadog-style keys that duplicate OpenTelemetry standard keys
-  if (config.tags) {
-    const filteredTags = { ...config.tags }
-    delete filteredTags.service
-    delete filteredTags.version
-    delete filteredTags.env
-    Object.assign(resourceAttributes, filteredTags)
-  }
-
-  // Add host.name if reportHostname is enabled
-  if (config.reportHostname) {
-    resourceAttributes['host.name'] = os.hostname()
-  }
-
   // Create OTLP exporter using resolved config values
   const exporter = new OtlpHttpLogExporter(
     config.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     config.OTEL_EXPORTER_OTLP_LOGS_HEADERS,
     config.OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
     config.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
-    resourceAttributes
+    buildResourceAttributes(config)
   )
 
   // Create batch processor for exporting logs to Datadog Agent
@@ -80,8 +58,11 @@ function initializeOpenTelemetryLogs (config) {
 
   // Expose this provider to application calls through the OpenTelemetry Logs API.
   loggerProvider.register()
+
   // Include final log batches in lifecycle retention with trace delivery.
   registerTelemetryFlusher(done => loggerProvider.forceFlush(done))
+
+  registerResourceAttributeRefresh(exporter, () => buildResourceAttributes(config))
 }
 
 module.exports = {

--- a/packages/dd-trace/src/opentelemetry/logs/otlp_http_log_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/logs/otlp_http_log_exporter.js
@@ -4,7 +4,7 @@ const OtlpHttpExporterBase = require('../otlp/otlp_http_exporter_base')
 const OtlpTransformer = require('./otlp_transformer')
 
 /**
- * @typedef {import('@opentelemetry/resources').Resource} Resource
+ * @typedef {import('@opentelemetry/api').Attributes} Attributes
  * @typedef {import('@opentelemetry/api-logs').LogRecord} LogRecord
  */
 
@@ -26,11 +26,21 @@ class OtlpHttpLogExporter extends OtlpHttpExporterBase {
    *   corresponding `OTEL_EXPORTER_OTLP_*_HEADERS` env by the MAP parser.
    * @param {number} timeout - Request timeout in milliseconds
    * @param {string} protocol - OTLP protocol (http/protobuf or http/json)
-   * @param {Resource} resource - Resource attributes
+   * @param {Attributes} resourceAttributes - Resource attributes
    */
-  constructor (url, headers, timeout, protocol, resource) {
+  constructor (url, headers, timeout, protocol, resourceAttributes) {
     super(url, headers, timeout, protocol, 'logs')
-    this.transformer = new OtlpTransformer(resource, protocol)
+    this.transformer = new OtlpTransformer(resourceAttributes, protocol)
+  }
+
+  /**
+   * Recomputes the resource attributes baked into the transformer (e.g. after a MicroVM clone
+   * resume regenerates `runtime-id`).
+   *
+   * @param {Attributes} resourceAttributes - Resource attributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.transformer.updateResourceAttributes(resourceAttributes)
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/metrics/index.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/index.js
@@ -7,6 +7,10 @@ const { metrics } = require('@opentelemetry/api')
 const { VERSION } = require('../../../../../version')
 const processTags = require('../../process-tags')
 const { registerTelemetryFlusher } = require('../../flush')
+const {
+  buildResourceAttributes: buildGeneralResourceAttributes,
+  registerResourceAttributeRefresh,
+} = require('../resource-attributes')
 const MeterProvider = require('./meter_provider')
 const PeriodicMetricReader = require('./periodic_metric_reader')
 const OtlpHttpMetricExporter = require('./otlp_http_metric_exporter')
@@ -43,30 +47,12 @@ const RESERVED_TRACER_TAGS = new Set(['service', 'env', 'version', 'runtime_id',
  * @param {import('../../config/config-base')} config - Tracer configuration instance
  */
 function initializeOpenTelemetryMetrics (config) {
-  const resourceAttributes = {
-    'service.name': config.service,
-    'service.version': config.version,
-    'deployment.environment': config.env,
-  }
-
-  if (config.tags) {
-    const filteredTags = { ...config.tags }
-    delete filteredTags.service
-    delete filteredTags.version
-    delete filteredTags.env
-    Object.assign(resourceAttributes, filteredTags)
-  }
-
-  if (config.reportHostname) {
-    resourceAttributes['host.name'] = os.hostname()
-  }
-
   const exporter = new OtlpHttpMetricExporter(
     config.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     config.OTEL_EXPORTER_OTLP_METRICS_HEADERS,
     config.OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
     config.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
-    resourceAttributes
+    buildGeneralResourceAttributes(config)
   )
 
   const reader = new PeriodicMetricReader(
@@ -78,8 +64,11 @@ function initializeOpenTelemetryMetrics (config) {
 
   const meterProvider = new MeterProvider({ reader })
   metrics.setGlobalMeterProvider(meterProvider)
+
   // Include the final metric collection and export in lifecycle retention.
   registerTelemetryFlusher(done => meterProvider.forceFlush(done))
+
+  registerResourceAttributeRefresh(exporter, () => buildGeneralResourceAttributes(config))
 }
 
 /**
@@ -122,19 +111,23 @@ function buildResourceAttributes (tags, { reportHostname, service, env, serviceV
 function createOtlpSpanStatsExporter (config) {
   const { OtlpStatsExporter } = require('./otlp_span_stats_exporter')
   const protocol = config.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL || 'http/json'
-  const resourceAttributes = buildResourceAttributes(config.tags, {
+  const buildSpanStatsResourceAttributes = () => buildResourceAttributes(config.tags, {
     reportHostname: config.reportHostname,
     service: config.service,
     env: config.env,
     serviceVersion: config.version,
   })
-  return new OtlpStatsExporter(
+  const exporter = new OtlpStatsExporter(
     config.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     protocol,
-    resourceAttributes,
+    buildSpanStatsResourceAttributes(),
     config.OTEL_EXPORTER_OTLP_METRICS_HEADERS,
     config.OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
   )
+
+  registerResourceAttributeRefresh(exporter, buildSpanStatsResourceAttributes)
+
+  return exporter
 }
 
 module.exports = {

--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_http_metric_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_http_metric_exporter.js
@@ -4,7 +4,7 @@ const OtlpHttpExporterBase = require('../otlp/otlp_http_exporter_base')
 const OtlpTransformer = require('./otlp_transformer')
 
 /**
- * @typedef {import('@opentelemetry/resources').Resource} Resource
+ * @typedef {import('@opentelemetry/api').Attributes} Attributes
  * @typedef {import('./periodic_metric_reader').AggregatedMetric} AggregatedMetric
  */
 
@@ -22,11 +22,21 @@ class OtlpHttpMetricExporter extends OtlpHttpExporterBase {
    *   corresponding `OTEL_EXPORTER_OTLP_*_HEADERS` env by the MAP parser.
    * @param {number} timeout - Request timeout in milliseconds
    * @param {string} protocol - OTLP protocol (http/protobuf or http/json)
-   * @param {Resource} resource - Resource attributes
+   * @param {Attributes} resourceAttributes - Resource attributes
    */
-  constructor (url, headers, timeout, protocol, resource) {
+  constructor (url, headers, timeout, protocol, resourceAttributes) {
     super(url, headers, timeout, protocol, 'metrics')
-    this.transformer = new OtlpTransformer(resource, protocol)
+    this.transformer = new OtlpTransformer(resourceAttributes, protocol)
+  }
+
+  /**
+   * Recomputes the resource attributes baked into the transformer (e.g. after a MicroVM clone
+   * resume regenerates `runtime-id`). Leaves the reader's export interval untouched.
+   *
+   * @param {Attributes} resourceAttributes - Resource attributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.transformer.updateResourceAttributes(resourceAttributes)
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_span_stats_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_span_stats_exporter.js
@@ -20,6 +20,16 @@ class OtlpStatsExporter extends OtlpHttpExporterBase {
   }
 
   /**
+   * Recomputes the resource attributes baked into the transformer (e.g. after a MicroVM clone
+   * resume regenerates `runtime-id`).
+   *
+   * @param {import('@opentelemetry/api').Attributes} resourceAttributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.#transformer.updateResourceAttributes(resourceAttributes)
+  }
+
+  /**
    * @param {Array<{timeNs: number, bucket: import('../../span_stats').SpanBuckets}>} drained
    * @param {number} bucketSizeNs
    * @param {Function} [done] Called after the HTTP export completes

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
@@ -76,6 +76,16 @@ class OtlpTransformerBase {
   }
 
   /**
+   * Recomputes the cached OTLP resource attributes (e.g. after `config.tags` changes post-
+   * construction, such as a MicroVM clone resume regenerating its runtime-id). Leaves the
+   * reader/exporter/protocol otherwise untouched.
+   * @param {Attributes} resourceAttributes - Resource attributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.#resourceAttributes = this.transformAttributes(resourceAttributes)
+  }
+
+  /**
    * Transforms attributes to OTLP KeyValue format.
    * @param {Attributes} attributes - Attributes to transform
    * @returns {object[]} Array of OTLP KeyValue objects

--- a/packages/dd-trace/src/opentelemetry/resource-attributes.js
+++ b/packages/dd-trace/src/opentelemetry/resource-attributes.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const os = require('node:os')
+
+const { channel } = require('dc-polyfill')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
+const resourceAttributeRefreshers = new Map()
+
+function refreshActiveResourceAttributes () {
+  for (const refreshResourceAttributes of resourceAttributeRefreshers.values()) {
+    refreshResourceAttributes()
+  }
+}
+
+/**
+ * @typedef {import('@opentelemetry/api').Attributes} Attributes
+ * @typedef {{
+ *   signalType: string,
+ *   updateResourceAttributes: (resourceAttributes: Attributes) => void
+ * }} ResourceAttributeExporter
+ */
+
+/**
+ * @param {import('../config/config-base')} config
+ * @returns {Attributes}
+ */
+function buildResourceAttributes (config) {
+  const { service, version, env, ...tags } = config.tags
+  const resourceAttributes = {
+    'service.name': config.service,
+    'service.version': config.version,
+    'deployment.environment': config.env,
+    ...tags,
+  }
+
+  if (config.reportHostname) resourceAttributes['host.name'] = os.hostname()
+
+  return resourceAttributes
+}
+
+/**
+ * @param {ResourceAttributeExporter} exporter
+ * @param {() => Attributes} buildResourceAttributes
+ */
+function registerResourceAttributeRefresh (exporter, buildResourceAttributes) {
+  if (resourceAttributeRefreshers.size === 0) {
+    identityRefreshChannel.subscribe(refreshActiveResourceAttributes)
+  }
+  resourceAttributeRefreshers.set(exporter.signalType, () => {
+    exporter.updateResourceAttributes(buildResourceAttributes())
+  })
+}
+
+module.exports = { buildResourceAttributes, registerResourceAttributeRefresh }

--- a/packages/dd-trace/src/opentelemetry/trace/index.js
+++ b/packages/dd-trace/src/opentelemetry/trace/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { VERSION } = require('../../../../../version')
+const { registerResourceAttributeRefresh } = require('../resource-attributes')
 const OtlpHttpTraceExporter = require('./otlp_http_trace_exporter')
 
 /**
@@ -59,13 +60,17 @@ function buildResourceAttributes (config) {
  * @returns {OtlpHttpTraceExporter} The OTLP HTTP/JSON exporter
  */
 function createOtlpTraceExporter (config) {
-  return new OtlpHttpTraceExporter(
+  const exporter = new OtlpHttpTraceExporter(
     config.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
     config.OTEL_EXPORTER_OTLP_TRACES_HEADERS,
     config.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
     buildResourceAttributes(config),
     config.DD_TRACE_OTEL_SEMANTICS_ENABLED
   )
+
+  registerResourceAttributeRefresh(exporter, () => buildResourceAttributes(config))
+
+  return exporter
 }
 
 module.exports = {

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_http_trace_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_http_trace_exporter.js
@@ -44,6 +44,16 @@ class OtlpHttpTraceExporter extends OtlpHttpExporterBase {
   }
 
   /**
+   * Recomputes the resource attributes baked into the transformer (e.g. after a MicroVM clone
+   * resume regenerates `runtime-id`).
+   *
+   * @param {import('@opentelemetry/api').Attributes} resourceAttributes - Resource attributes
+   */
+  updateResourceAttributes (resourceAttributes) {
+    this.#transformer.updateResourceAttributes(resourceAttributes)
+  }
+
+  /**
    * Exports DD-formatted spans via OTLP over HTTP.
    *
    * @param {import('./otlp_transformer').DDFormattedSpan[]} spans - Array of DD-formatted spans to export

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -222,4 +222,5 @@ function buildProfilingRuntime (config) {
 
 module.exports = {
   buildProfilingRuntime,
+  getProfilingTags,
 }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -4,7 +4,7 @@ const { EventEmitter } = require('events')
 const dc = require('dc-polyfill')
 const crashtracker = require('../crashtracking')
 const log = require('../log')
-const { buildProfilingRuntime } = require('./config')
+const { buildProfilingRuntime, getProfilingTags } = require('./config')
 const { snapshotKinds } = require('./constants')
 const { threadNamePrefix } = require('./profilers/shared')
 const { isWebServerSpan, endpointNameFromTags, getStartedSpans } = require('./webspan-utils')
@@ -54,6 +54,7 @@ class Profiler extends EventEmitter {
   #compressionFn
   #compressionFnInitialized = false
   #compressionOptions
+  #config
   #customLabelKeys = new Set()
   #enabled = false
   #endpointCounts = new Map()
@@ -64,7 +65,7 @@ class Profiler extends EventEmitter {
   #profilers
   #spanFinishListener
   #systemInfoReport
-  #tags
+  #currentSnapshotTags
   #timer
   #uploadCompression
 
@@ -176,12 +177,13 @@ class Profiler extends EventEmitter {
     if (this.enabled) return true
     this.#enabled = true
 
-    const { tags, exporters, flushInterval, profilers, uploadCompression, systemInfoReport } =
+    const { tags: snapshotTags, exporters, flushInterval, profilers, uploadCompression, systemInfoReport } =
       buildProfilingRuntime(config)
-    this.#tags = tags
+    this.#config = config
     this.#exporters = exporters
     this.#flushInterval = flushInterval
     this.#profilers = profilers
+    this.#currentSnapshotTags = snapshotTags
     this.#uploadCompression = uploadCompression
     this.#systemInfoReport = systemInfoReport
     if (this.#customLabelKeys.size > 0) {
@@ -248,7 +250,7 @@ class Profiler extends EventEmitter {
     processInfo(infos, info, profileType)
     this.#submit({
       [profileType]: encodedProfile,
-    }, infos, start, end, snapshotKinds.ON_OUT_OF_MEMORY)
+    }, infos, start, end, this.#currentSnapshotTags, snapshotKinds.ON_OUT_OF_MEMORY)
   }
 
   _setInterval () {
@@ -332,6 +334,7 @@ class Profiler extends EventEmitter {
 
       const startDate = this.#lastStart
       const endDate = new Date()
+      const snapshotTags = this.#currentSnapshotTags
       const profiles = []
 
       crashtracker.withProfilerSerializing(() => {
@@ -348,6 +351,7 @@ class Profiler extends EventEmitter {
       })
 
       if (restart) {
+        this.#currentSnapshotTags = getProfilingTags(this.#config)
         this._capture(this._timeoutInterval, endDate)
       }
 
@@ -385,7 +389,7 @@ class Profiler extends EventEmitter {
       }))
 
       if (hasEncoded) {
-        await this.#submit(encodedProfiles, infos, startDate, endDate, snapshotKind)
+        await this.#submit(encodedProfiles, infos, startDate, endDate, snapshotTags, snapshotKind)
         profileSubmittedChannel.publish()
         log.debug('Submitted profiles')
       }
@@ -395,9 +399,15 @@ class Profiler extends EventEmitter {
     }
   }
 
-  #submit (profiles, infos, start, end, snapshotKind) {
-    const tags = this.#tags
-
+  /**
+   * @param {Record<string, Buffer|string>} profiles
+   * @param {Record<string, unknown>} infos
+   * @param {Date} start
+   * @param {Date} end
+   * @param {Record<string, string|number|boolean|undefined>} snapshotTags
+   * @param {string} snapshotKind
+   */
+  #submit (profiles, infos, start, end, snapshotTags, snapshotKind) {
     // Flatten endpoint counts
     const endpointCounts = {}
     for (const [endpoint, { count }] of this.#endpointCounts) {
@@ -405,12 +415,12 @@ class Profiler extends EventEmitter {
     }
     this.#endpointCounts.clear()
 
-    tags.snapshot = snapshotKind
-    tags.profile_seq = this.#profileSeq++
+    snapshotTags.snapshot = snapshotKind
+    snapshotTags.profile_seq = this.#profileSeq++
     const customAttributes = this.#customLabelKeys.size > 0
       ? [...this.#customLabelKeys]
       : undefined
-    const exportSpec = { profiles, infos, start, end, tags, endpointCounts, customAttributes }
+    const exportSpec = { profiles, infos, start, end, tags: snapshotTags, endpointCounts, customAttributes }
     const tasks = this.#exporters.map(exporter =>
       exporter.export(exportSpec).catch(error => {
         log.warn(error)

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const { channel } = require('dc-polyfill')
+
+const log = require('../../log')
 const { oomExportStrategies, ensureOOMExportStrategies, strategiesToCallbackMode, buildExportCommand } =
   require('../oom')
 const { encodeProfileAsync, getThreadLabels } = require('./shared')
@@ -11,10 +14,12 @@ const { encodeProfileAsync, getThreadLabels } = require('./shared')
  */
 
 const STACK_DEPTH = 64
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 class NativeSpaceProfiler {
   #config
   #exporters
+  #identityRefreshListener
   #mapper
   #pprof
   #samplingInterval
@@ -39,20 +44,36 @@ class NativeSpaceProfiler {
   start ({ mapper, nearOOMCallback } = {}) {
     if (this.#started) return
 
-    const config = this.#config
     this.#mapper = mapper
     this.#pprof = require('@datadog/pprof')
-    this.#pprof.heap.start(this.#samplingInterval, STACK_DEPTH, config.DD_PROFILING_ALLOCATION_ENABLED)
-    if (config.DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED) {
+    this.#pprof.heap.start(this.#samplingInterval, STACK_DEPTH, this.#config.DD_PROFILING_ALLOCATION_ENABLED)
+
+    if (this.#config.DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED) {
+      const config = this.#config
       const strategies = ensureOOMExportStrategies(config.DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES)
-      this.#pprof.heap.monitorOutOfMemory(
-        config.DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE,
-        config.DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT,
-        strategies.includes(oomExportStrategies.LOGS),
-        strategies.includes(oomExportStrategies.PROCESS) ? buildExportCommand(this.#exporters, this.#tags) : [],
-        (profile) => nearOOMCallback(this.type, this.#pprof.encodeSync(profile), this.getInfo()),
-        strategiesToCallbackMode(strategies, this.#pprof.heap.CallbackMode)
-      )
+      const monitorOutOfMemory = () => {
+        this.#pprof.heap.monitorOutOfMemory(
+          config.DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE,
+          config.DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT,
+          strategies.includes(oomExportStrategies.LOGS),
+          strategies.includes(oomExportStrategies.PROCESS) ? buildExportCommand(this.#exporters, this.#tags) : [],
+          (profile) => nearOOMCallback(this.type, this.#pprof.encodeSync(profile), this.getInfo()),
+          strategiesToCallbackMode(strategies, this.#pprof.heap.CallbackMode)
+        )
+      }
+      monitorOutOfMemory()
+
+      if (strategies.includes(oomExportStrategies.PROCESS)) {
+        this.#identityRefreshListener = () => {
+          try {
+            Object.assign(this.#tags, config.tags)
+            monitorOutOfMemory()
+          } catch (error) {
+            log.error(error)
+          }
+        }
+        identityRefreshChannel.subscribe(this.#identityRefreshListener)
+      }
     }
 
     this.#started = true
@@ -74,6 +95,12 @@ class NativeSpaceProfiler {
 
   stop () {
     if (!this.#started) return
+
+    if (this.#identityRefreshListener !== undefined) {
+      identityRefreshChannel.unsubscribe(this.#identityRefreshListener)
+      this.#identityRefreshListener = undefined
+    }
+
     this.#pprof.heap.stop()
     this.#started = false
   }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { channel } = require('dc-polyfill')
+const uuid = require('../../../vendor/dist/crypto-randomuuid')
 const NoopProxy = require('./noop/proxy')
 const DatadogTracer = require('./tracer')
 const getConfig = require('./config')
@@ -11,7 +13,13 @@ const telemetry = require('./telemetry')
 const nomenclature = require('./service-naming')
 const PluginManager = require('./plugin_manager')
 const NoopDogStatsDClient = require('./noop/dogstatsd')
-const { IS_SERVERLESS, initializeServerlessTelemetry, supportsServerlessTelemetryRetention } = require('./serverless')
+const {
+  IS_AWS_LAMBDA_MICROVM,
+  IS_SERVERLESS,
+  NODE_BUNDLES_OPENSSL,
+  initializeServerlessTelemetry,
+  supportsServerlessTelemetryRetention,
+} = require('./serverless')
 const { flushServerlessTelemetry, registerTelemetryFlusher } = require('./flush')
 const processTags = require('./process-tags')
 const { isTrue } = require('./util')
@@ -47,6 +55,13 @@ function getDynamicInstrumentation () {
   dynamicInstrumentation ??= require('./debugger')
   return dynamicInstrumentation
 }
+
+const UUID_POOL_SIZE = 128
+
+const BUNDLED_OPENSSL_WARNING = 'This Node.js build bundles its own OpenSSL, so its random number ' +
+  'generator is not reseeded when a MicroVM clone resumes and trace IDs may repeat across clones. ' +
+  'Install Node.js from the Amazon Linux 2023 repositories (for example `dnf install nodejs22`) so it ' +
+  'links the base image\'s snapsafe OpenSSL.'
 
 class LazyModule {
   constructor (provider) {
@@ -149,6 +164,10 @@ class Tracer extends NoopProxy {
 
     try {
       const config = getConfig(options) // TODO: support dynamic code config
+
+      if (IS_AWS_LAMBDA_MICROVM) {
+        this.#registerMicroVmRunHook(config)
+      }
 
       // Add config dependent process tags
       processTags.initialize(config)
@@ -316,6 +335,41 @@ class Tracer extends NoopProxy {
     }
 
     return this
+  }
+
+  /**
+   * Listens for the MicroVM /run lifecycle event and triggers a one-time
+   * identity reset on first fire.
+   *
+   * @param {import('./config/config-base')} config
+   */
+  #registerMicroVmRunHook (config) {
+    // Node reseeds its CSPRNG from the kernel on clone resume only when it links the base image's
+    // snapsafe libcrypto; a bundled OpenSSL keeps the snapshot's DRBG state, so the refresh below
+    // cannot produce distinct IDs. Logged at registration, during the image build, where the
+    // Dockerfile can still be fixed — not once per clone.
+    if (NODE_BUNDLES_OPENSSL) {
+      log.error(BUNDLED_OPENSSL_WARNING)
+    }
+
+    const ch = channel('http.server.request.start')
+
+    const onHttpRequest = ({ request }) => {
+      if (request.method === 'POST' && request.url === '/aws/lambda-microvms/runtime/v1/run') {
+        ch.unsubscribe(onHttpRequest)
+        drainUuidPool()
+        channel('datadog:identity:update').publish(config)
+        if (this._tracingInitialized) {
+          const metadata = require('./tracer_metadata')(config)
+          if (metadata === undefined) {
+            log.warn('Could not store tracer configuration for service discovery')
+          }
+        }
+        channel('datadog:identity:refresh').publish(config)
+      }
+    }
+
+    ch.subscribe(onHttpRequest)
   }
 
   /**
@@ -513,6 +567,21 @@ function isOfflineTestOptimizationValidation () {
  */
 function isOfflineValidationExporter (options) {
   return OFFLINE_VALIDATION_EXPORTERS.has(options?.experimental?.exporter)
+}
+
+/**
+ * Discards Node's buffered UUID entropy, so the identity subscribers draw from bytes generated
+ * after the clone resumed.
+ *
+ * `crypto.randomUUID()` serves `kBatchSize` (128, see `lib/internal/crypto/random.js`) UUIDs from one
+ * process-wide pool and refills it only when its cursor wraps back to 0. A full cycle crosses the
+ * cursor exactly once from any starting position, and the position is not observable, so the count
+ * has to be the batch size rather than the number of UUIDs we need.
+ */
+function drainUuidPool () {
+  for (let index = 0; index < UUID_POOL_SIZE; index++) {
+    uuid()
+  }
 }
 
 module.exports = Tracer

--- a/packages/dd-trace/src/remote_config/index.js
+++ b/packages/dd-trace/src/remote_config/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { channel } = require('dc-polyfill')
+
 const uuid = require('../../../../vendor/dist/crypto-randomuuid')
 const tracerVersion = require('../../../../package.json').version
 const request = require('../exporters/common/request')
@@ -12,7 +14,11 @@ const processTags = require('../process-tags')
 const Scheduler = require('./scheduler')
 const { UNACKNOWLEDGED, ACKNOWLEDGED, ERROR } = require('./apply_states')
 
-const clientId = uuid()
+let clientId = uuid()
+/** @type {{ id: string, client_tracer: { runtime_id: string, tags: string[] } } | undefined} */
+let client
+
+channel('datadog:identity:update').subscribe(refreshIdentity)
 
 const DEFAULT_CAPABILITY = Buffer.alloc(1).toString('base64') // 0x00
 
@@ -38,13 +44,6 @@ class RemoteConfig {
     })
 
     const { commitSHA, repositoryUrl } = getGitMetadata(config)
-    const tags = repositoryUrl
-      ? {
-          ...config.tags,
-          [GIT_REPOSITORY_URL]: repositoryUrl,
-          [GIT_COMMIT_SHA]: commitSHA,
-        }
-      : config.tags
 
     const appliedConfigs = this.appliedConfigs = new Map()
 
@@ -84,13 +83,15 @@ class RemoteConfig {
           env: config.env,
           app_version: config.version,
           extra_services: /** @type {string[]} */ ([]),
-          tags: Object.entries(tags).map((pair) => pair.join(':')),
+          tags: getTagsString(config, repositoryUrl, commitSHA),
           [processTags.REMOTE_CONFIG_FIELD_NAME]: processTags.tagsArray,
         },
         capabilities: DEFAULT_CAPABILITY, // updated by `updateCapabilities()`
       },
       cached_target_files: /** @type {RcCachedTargetFile[]} */ ([]), // updated by `parseConfig()`
     }
+
+    client = this.state.client
   }
 
   /**
@@ -573,6 +574,40 @@ function supportsAckCallback (handler) {
   handler[kSupportsAckCallback] = result
 
   return result
+}
+
+/**
+ * @param {import('../config/config-base')} config
+ * @param {string} repositoryUrl
+ * @param {string} commitSHA
+ * @returns {string[]}
+ */
+function getTagsString (config, repositoryUrl, commitSHA) {
+  const tags = repositoryUrl
+    ? {
+        ...config.tags,
+        [GIT_REPOSITORY_URL]: repositoryUrl,
+        [GIT_COMMIT_SHA]: commitSHA,
+      }
+    : config.tags
+  return Object.entries(tags).map((pair) => pair.join(':'))
+}
+
+/**
+ * Regenerates the RC client ID and rebuilds the RC tag list, so subsequent RC polls report the
+ * clone's identity. No-ops on the tags before the first `RemoteConfig` is constructed.
+ *
+ * @param {import('../config/config-base')} config
+ */
+function refreshIdentity (config) {
+  clientId = uuid()
+  if (client !== undefined) {
+    config.tags['_dd.rc.client_id'] = clientId
+    client.id = clientId
+    client.client_tracer.runtime_id = config.tags['runtime-id']
+    const { commitSHA, repositoryUrl } = getGitMetadata(config)
+    client.client_tracer.tags = getTagsString(config, repositoryUrl, commitSHA)
+  }
 }
 
 module.exports = RemoteConfig

--- a/packages/dd-trace/src/runtime_metrics/client.js
+++ b/packages/dd-trace/src/runtime_metrics/client.js
@@ -1,21 +1,24 @@
 'use strict'
 
+const { channel } = require('dc-polyfill')
 const { DogStatsDClient, createMetricsAggregationClient } = require('../dogstatsd')
 const processTags = require('../process-tags')
 
+const identityRefreshChannel = channel('datadog:identity:refresh')
+
 /**
- * Builds the aggregating DogStatsD client used to emit DD-proprietary tracer
- * metrics (runtime.node.*, datadog.tracer.*). Shared by both runtime-metrics
- * paths (DogStatsD and OTLP) so their client construction can't drift apart.
+ * Builds the DogStatsD tags (with process tags applied) for the runtime-metrics client.
+ * Shared by `createMetricsClient()` and `subscribeToIdentityRefresh()` so their tag
+ * composition can't drift apart.
  *
  * Process tags are applied here, not via config/generateClientConfig, so they only
  * reach this bounded set of runtime metrics. Putting them on the global tags would
  * also tag user-facing custom metrics, inflating their cardinality (and billing).
  *
  * @param {import('../config/config-base')} config - Tracer configuration
- * @returns {ReturnType<typeof createMetricsAggregationClient>}
+ * @returns {{ host: string, port: number, tags: string[], lookup: Function, metricsProxyUrl?: URL }}
  */
-function createMetricsClient (config) {
+function buildClientConfig (config) {
   const clientConfig = DogStatsDClient.generateClientConfig(config)
 
   if (config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED) {
@@ -24,7 +27,33 @@ function createMetricsClient (config) {
     }
   }
 
-  return createMetricsAggregationClient(clientConfig)
+  return clientConfig
 }
 
-module.exports = { createMetricsClient }
+/**
+ * Builds the aggregating DogStatsD client used to emit DD-proprietary tracer
+ * metrics (runtime.node.*, datadog.tracer.*). Shared by both runtime-metrics
+ * paths (DogStatsD and OTLP) so their client construction can't drift apart.
+ *
+ * @param {import('../config/config-base')} config - Tracer configuration
+ * @returns {ReturnType<typeof createMetricsAggregationClient>}
+ */
+function createMetricsClient (config) {
+  return createMetricsAggregationClient(buildClientConfig(config))
+}
+
+/**
+ * Subscribes a runtime-metrics client to the identity-refresh channel so its DogStatsD tags
+ * (runtime-id, RC client id) reflect `config.tags` after a MicroVM clone resume.
+ *
+ * @param {ReturnType<typeof createMetricsAggregationClient>} client - The client returned by `createMetricsClient()`
+ * @param {import('../config/config-base')} config - Tracer configuration
+ * @returns {() => void} Unsubscribe function; call it from the owning module's `stop()`
+ */
+function subscribeToIdentityRefresh (client, config) {
+  const onIdentityRefresh = () => client.updateTags(buildClientConfig(config).tags)
+  identityRefreshChannel.subscribe(onIdentityRefresh)
+  return () => identityRefreshChannel.unsubscribe(onIdentityRefresh)
+}
+
+module.exports = { createMetricsClient, subscribeToIdentityRefresh }

--- a/packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js
@@ -5,7 +5,7 @@ const process = require('node:process')
 const { performance, monitorEventLoopDelay, PerformanceObserver, constants } = require('node:perf_hooks')
 const { metrics } = require('@opentelemetry/api')
 const log = require('../log')
-const { createMetricsClient } = require('./client')
+const { createMetricsClient, subscribeToIdentityRefresh } = require('./client')
 
 const METER_NAME = 'datadog.runtime_metrics'
 
@@ -53,6 +53,7 @@ const registeredBatchCallbacks = []
 // equivalent; keep a DogStatsD client so OTLP-path customers don't lose them.
 let client = null
 let flushInterval = null
+let unsubscribeIdentityRefresh = null
 
 module.exports = {
   /**
@@ -62,6 +63,7 @@ module.exports = {
     this.stop()
 
     client = createMetricsClient(config)
+    unsubscribeIdentityRefresh = subscribeToIdentityRefresh(client, config)
     flushInterval = setInterval(() => {
       client.flush()
     }, config.DD_RUNTIME_METRICS_FLUSH_INTERVAL ?? 10_000)
@@ -221,6 +223,8 @@ module.exports = {
       clearInterval(flushInterval)
       flushInterval = null
     }
+    unsubscribeIdentityRefresh?.()
+    unsubscribeIdentityRefresh = null
     client = null
   },
 

--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -8,7 +8,7 @@ const process = require('process')
 const { performance, PerformanceObserver, monitorEventLoopDelay } = require('perf_hooks')
 const log = require('../log')
 const { NODE_MAJOR, NODE_MINOR } = require('../../../../version')
-const { createMetricsClient } = require('./client')
+const { createMetricsClient, subscribeToIdentityRefresh } = require('./client')
 
 const eventLoopDelayResolution = 4
 const EVENT_LOOP_SAMPLE_PER_ITERATION_AVAILABLE = NODE_MAJOR > 26 ||
@@ -28,6 +28,7 @@ let lastTime = 0
 let lastCpuUsage = null
 let eventLoopDelayObserver = null
 let capture = null
+let unsubscribeIdentityRefresh = null
 
 // !!!!!!!!!!!
 //  IMPORTANT
@@ -49,6 +50,7 @@ module.exports = {
     const trackGc = config.runtimeMetrics.gc !== false
 
     client = createMetricsClient(config)
+    unsubscribeIdentityRefresh = subscribeToIdentityRefresh(client, config)
 
     if (trackGc) {
       startGCObserver()
@@ -117,6 +119,8 @@ module.exports = {
     clearInterval(interval)
     interval = null
 
+    unsubscribeIdentityRefresh?.()
+    unsubscribeIdentityRefresh = null
     client = null
     capture = null
     lastCpuUsage = null

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -2,6 +2,8 @@
 
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
 
+const IS_AWS_LAMBDA_MICROVM = getEnvironmentVariable('AWS_LAMBDA_MICROVM_IMAGE_ARN') !== undefined
+
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
     getEnvironmentVariable('FUNCTION_NAME') !== undefined &&
@@ -39,7 +41,7 @@ function isInServerlessEnvironment () {
   const isGCPFunction = getIsGCPFunction()
   const isAzureFunction = getIsAzureFunction()
 
-  return inAWSLambda || isGCPFunction || isAzureFunction
+  return IS_AWS_LAMBDA_MICROVM || inAWSLambda || isGCPFunction || isAzureFunction
 }
 
 /**
@@ -101,5 +103,9 @@ module.exports = {
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
   initializeServerlessTelemetry,
+  IS_AWS_LAMBDA_MICROVM,
+  // true only for a Node that bundles its own OpenSSL, whose CSPRNG keeps the snapshot's DRBG
+  // state across a MicroVM clone resume
+  NODE_BUNDLES_OPENSSL: process.config.variables.node_shared_openssl === false,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -201,19 +201,26 @@ class TimeBuckets extends Map {
 }
 
 class SpanStatsProcessor {
-  constructor ({
-    stats: {
-      DD_TRACE_STATS_COMPUTATION_ENABLED: enabled = false,
-      interval = 10,
-    } = {},
-    hostname,
-    port,
-    url,
-    env,
-    tags,
-    version: appVersion,
-    _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL: flushIntervalMs,
-  } = {}, otlpExporter) {
+  #config
+
+  /**
+   * @param {import('./config/config-base')} config
+   * @param {import('./opentelemetry/metrics/otlp_span_stats_exporter').OtlpStatsExporter} [otlpExporter]
+   */
+  constructor (config, otlpExporter) {
+    const {
+      stats: {
+        DD_TRACE_STATS_COMPUTATION_ENABLED: enabled = false,
+        interval = 10,
+      } = {},
+      hostname,
+      port,
+      url,
+      env,
+      tags,
+      version: appVersion,
+      _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL: flushIntervalMs,
+    } = config
     if (!otlpExporter) {
       this.exporter = new SpanStatsExporter({ hostname, port, tags, url })
     }
@@ -225,7 +232,7 @@ class SpanStatsProcessor {
     this.enabled = enabled
     this.otlpExporter = otlpExporter || null
     this.env = env
-    this.tags = tags || {}
+    this.#config = config
     this.sequence = 0
     this.version = appVersion
 
@@ -258,7 +265,7 @@ class SpanStatsProcessor {
         Stats: this.#toV06Payload(drained),
         Lang: 'javascript',
         TracerVersion: pkg.version,
-        RuntimeID: this.tags['runtime-id'],
+        RuntimeID: this.#config.tags['runtime-id'],
         Sequence: ++this.sequence,
         ProcessTags: processTags.serialized,
       }, done)

--- a/packages/dd-trace/src/telemetry/session-propagation.js
+++ b/packages/dd-trace/src/telemetry/session-propagation.js
@@ -4,13 +4,14 @@ const dc = /** @type {typeof import('diagnostics_channel')} */ (require('dc-poly
 const childProcessChannel = dc.tracingChannel('datadog:child_process:execution')
 
 let subscribed = false
-let runtimeId
+let savedConfig
 
 function isOptionsObject (value) {
   return value != null && typeof value === 'object' && !Array.isArray(value) && value
 }
 
 function getEnvWithRuntimeId (env) {
+  const runtimeId = savedConfig.DD_ROOT_JS_SESSION_ID || savedConfig.tags['runtime-id']
   // eslint-disable-next-line eslint-rules/eslint-process-env
   return { ...(env ?? process.env), DD_ROOT_JS_SESSION_ID: runtimeId }
 }
@@ -43,7 +44,7 @@ function start (config) {
   if (!config.telemetry.DD_INSTRUMENTATION_TELEMETRY_ENABLED || subscribed) return
   subscribed = true
 
-  runtimeId = config.DD_ROOT_JS_SESSION_ID || config.tags['runtime-id']
+  savedConfig = config
 
   childProcessChannel.subscribe(
     /** @type {import('diagnostics_channel').TracingChannelSubscribers<object>} */ ({ start: onChildProcessStart })

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -43,13 +43,10 @@ class DatadogTracer extends Tracer {
 
     if (!IS_SERVERLESS) {
       const storeConfig = require('./tracer_metadata')
-      // Keep a reference to the handle, to keep the memfd alive in memory.
-      // It is read by the service discovery feature.
       const metadata = storeConfig(config)
       if (metadata === undefined) {
         log.warn('Could not store tracer configuration for service discovery')
       }
-      this._inmem_cfg = metadata
     }
   }
 

--- a/packages/dd-trace/src/tracer_metadata.js
+++ b/packages/dd-trace/src/tracer_metadata.js
@@ -2,6 +2,13 @@
 
 const tracerVersion = require('../../../version').VERSION
 
+// Service discovery reads this metadata after tracer initialization; retaining the handle keeps
+// the backing memfd open for the process lifetime.
+let metadataHandle
+
+/**
+ * @param {import('./config/config-base')} config
+ */
 function storeConfig (config) {
   try {
     // Load binding first to not import other modules if it throws
@@ -42,7 +49,8 @@ function storeConfig (config) {
       threadlocalMetadata
     )
 
-    return processDiscovery.storeMetadata(metadata)
+    metadataHandle = processDiscovery.storeMetadata(metadata)
+    return metadataHandle
   } catch {
     // Either libdatadog or process-discovery is unavailable.
   }

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const assert = require('node:assert/strict')
+
 const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
@@ -11,12 +13,14 @@ let writer
 let span
 let request
 let encoder
+let encoderArgs
 let coverageEncoder
 let url
 let log
 let incrementCountMetric
 let agent
 let getAgent
+let tags
 
 describe('CI Visibility Writer', () => {
   beforeEach(() => {
@@ -42,7 +46,8 @@ describe('CI Visibility Writer', () => {
     agent = {}
     getAgent = sinon.stub().returns(agent)
 
-    const AgentlessCiVisibilityEncoder = function () {
+    const AgentlessCiVisibilityEncoder = function (...args) {
+      encoderArgs = args
       return encoder
     }
 
@@ -64,7 +69,14 @@ describe('CI Visibility Writer', () => {
       '../../../ci-visibility/telemetry': { incrementCountMetric },
       '../../../log': log,
     })
-    writer = new Writer({ url, tags: { 'runtime-id': 'runtime-id' }, coverageUrl: url })
+    tags = { 'runtime-id': 'runtime-id' }
+    writer = new Writer({ url, tags, coverageUrl: url })
+  })
+
+  describe('constructor', () => {
+    it('should pass the live tags object (not a copied runtime-id) to the encoder', () => {
+      assert.strictEqual(encoderArgs[1].tags, tags)
+    })
   })
 
   describe('append', () => {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -12,6 +12,7 @@ const sinon = require('sinon')
 const { it, describe, beforeEach, afterEach } = require('mocha')
 const context = describe
 const proxyquire = require('proxyquire')
+const { channel } = require('dc-polyfill')
 
 require('../setup/core')
 const exporters = require('../../../../ext/exporters')
@@ -5432,6 +5433,95 @@ rules:
       const config = getConfig()
       assert.strictEqual(config.isServiceNameInferred, true)
       assert.strictEqual(config.service, 'node')
+    })
+  })
+
+  describe('refreshRuntimeId', () => {
+    const loadConfigModule = (overrides = {}) => {
+      const uuid = overrides.uuid || require('../../../../vendor/dist/crypto-randomuuid')
+      const parsers = proxyquire.noPreserveCache()('../../src/config/parsers', {})
+      const supportedConfigurations = proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
+      const configDefaults = proxyquire.noPreserveCache()('../../src/config/defaults', {
+        './supported-configurations.json': supportedConfigurations,
+        '../log': log,
+        './parsers': parsers,
+        '../../../../version': { DD_MAJOR },
+      })
+      const configHelper = proxyquire.noPreserveCache()('../../src/config/helper', {
+        './supported-configurations.json': supportedConfigurations,
+      })
+      const serverless = proxyquire.noPreserveCache()('../../src/serverless', {})
+      return proxyquire.noPreserveCache()('../../src/config', {
+        './defaults': configDefaults,
+        '../log': log,
+        '../telemetry': { updateConfig },
+        '../serverless': serverless,
+        'node:fs': fs,
+        './helper': configHelper,
+        '../pkg': pkg,
+        '../../../../version': { DD_MAJOR },
+        '../../../../vendor/dist/crypto-randomuuid': uuid,
+      })
+    }
+
+    beforeEach(() => {
+      log = proxyquire('../../src/log', {})
+      sinon.spy(log, 'info')
+      sinon.spy(log, 'warn')
+      sinon.spy(log, 'error')
+    })
+
+    it('should not generate a runtime id until a Config is constructed', () => {
+      const uuid = sinon.stub().returns('11111111-2222-4333-8444-555555555555')
+      const configModule = loadConfigModule({ uuid })
+
+      sinon.assert.notCalled(uuid)
+
+      configModule()
+
+      sinon.assert.calledOnce(uuid)
+    })
+
+    it('should update config.tags[runtime-id] to a new UUID', () => {
+      const configModule = loadConfigModule()
+      const config = configModule()
+      const originalId = config.tags['runtime-id']
+
+      channel('datadog:identity:update').publish(config)
+
+      assert.ok(config.tags['runtime-id'])
+      assert.strictEqual(typeof config.tags['runtime-id'], 'string')
+      // runtime-id should have been set
+      assert.notStrictEqual(config.tags['runtime-id'], originalId)
+    })
+
+    it('should call uuid again to regenerate the runtime id', () => {
+      const uuid = sinon.stub().returns('11111111-2222-4333-8444-555555555555')
+      const configModule = loadConfigModule({ uuid })
+      const config = configModule()
+
+      channel('datadog:identity:update').publish(config)
+
+      // once at module load for the initial runtimeId, once on refresh
+      sinon.assert.calledTwice(uuid)
+      // the buffered pool is drained by the publisher, so the refresh must not opt out of it
+      assert.deepStrictEqual(uuid.secondCall.args, [])
+    })
+
+    it('should store new value that differs from original runtimeId', () => {
+      const uuid = sinon.stub()
+      uuid.onFirstCall().returns('00000000-0000-4000-8000-000000000001')
+      uuid.onSecondCall().returns('00000000-0000-4000-8000-000000000002')
+      const configModule = loadConfigModule({ uuid })
+      const config = configModule()
+
+      channel('datadog:identity:update').publish(config)
+      const firstRefresh = config.tags['runtime-id']
+
+      channel('datadog:identity:update').publish(config)
+      const secondRefresh = config.tags['runtime-id']
+
+      assert.notStrictEqual(firstRefresh, secondRefresh)
     })
   })
 })

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -14,6 +14,7 @@ describeNotWindows('crashtracker', () => {
   let crashtracker
   let binding
   let config
+  let identityRefreshChannel
   let libdatadog
   let log
 
@@ -36,6 +37,9 @@ describeNotWindows('crashtracker', () => {
     log = {
       error: sinon.stub(),
     }
+    identityRefreshChannel = {
+      subscribe: sinon.stub(),
+    }
 
     sinon.stub(binding, 'init')
     sinon.stub(binding, 'updateConfig')
@@ -43,6 +47,7 @@ describeNotWindows('crashtracker', () => {
     sinon.stub(binding, 'reportUncaughtExceptionMonitor')
 
     crashtracker = proxyquire('../../src/crashtracking/crashtracker', {
+      'dc-polyfill': { channel: sinon.stub().returns(identityRefreshChannel) },
       '../log': log,
     })
   })
@@ -131,6 +136,27 @@ describeNotWindows('crashtracker', () => {
       crashtracker.configure(null)
 
       crashtracker.configure(config)
+    })
+  })
+
+  describe('identity refresh', () => {
+    it('should reconfigure the binding with refreshed tags when the identity-refresh channel fires', () => {
+      crashtracker.start(config)
+
+      const refreshedConfig = { ...config, tags: { foo: 'baz' } }
+      identityRefreshChannel.subscribe.firstCall.args[0](refreshedConfig)
+
+      sinon.assert.called(binding.updateMetadata)
+      const metadata = binding.updateMetadata.lastCall.args[0]
+      assert.ok(metadata.tags.includes('foo:baz'), `Expected tags to include foo:baz, got ${inspect(metadata.tags)}`)
+    })
+
+    it('should subscribe only after successful initialization', () => {
+      binding.init.throws(new Error('init failed'))
+
+      crashtracker.start(config)
+
+      sinon.assert.notCalled(identityRefreshChannel.subscribe)
     })
   })
 

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -9,11 +9,14 @@ const { performance } = require('node:perf_hooks')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { channel } = require('dc-polyfill')
 
 const datadogCore = require('../../datadog-core')
 
 require('./setup/core')
 const TelemetryDeliveryTracker = require('../src/serverless/telemetry-delivery-tracker')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 describe('dogstatsd', () => {
   let client
@@ -207,6 +210,26 @@ describe('dogstatsd', () => {
   }
 
   describe('client telemetry', () => {
+    it('uses refreshed global tags for client telemetry', async () => {
+      const now = sinon.stub(performance, 'now').returns(0)
+      const completions = stubUdpSend()
+
+      try {
+        client = createTelemetryClient({ tags: ['runtime-id:initial-id'] })
+        client.updateTags(['runtime-id:refreshed-id'])
+
+        now.returns(10_000)
+        client.flush()
+        await Promise.all(completions)
+
+        const telemetry = getUdpPayload(0)
+        assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics:0\|c\|#runtime-id:refreshed-id,/)
+        assert.doesNotMatch(telemetry, /runtime-id:initial-id/)
+      } finally {
+        now.restore()
+      }
+    })
+
     it('emits the client and aggregation metrics every 10 seconds with common UDP tags', async () => {
       const now = sinon.stub(performance, 'now').returns(0)
       const completions = stubUdpSend()
@@ -1315,6 +1338,58 @@ describe('dogstatsd', () => {
 
       sinon.assert.called(udp4.send)
       assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:10|g|#foo:bar|c:ci-1234\n')
+    })
+
+    it('should refresh its tags when the identity-refresh channel fires', () => {
+      const config = {
+        dogstatsd: {
+          hostname: '127.0.0.1',
+          port: 8125,
+        },
+        lookup: dns.lookup,
+        runtimeMetricsRuntimeId: true,
+        tags: { 'runtime-id': 'initial-id' },
+      }
+
+      client = new CustomMetrics(config)
+      client.distribution('test.stale', 1)
+
+      config.tags['runtime-id'] = 'refreshed-id'
+      identityRefreshChannel.publish(config)
+
+      client.gauge('test.avg', 10)
+      client.flush()
+
+      assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:10|g|#runtime-id:refreshed-id\n')
+
+      udp4.send.resetHistory()
+      config.tags = {}
+      identityRefreshChannel.publish(config)
+
+      client.gauge('test.avg', 20)
+      client.flush()
+
+      assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:20|g\n')
+    })
+
+    it('should preserve buffered metrics when an identity refresh does not change its tags', () => {
+      const config = {
+        dogstatsd: {
+          hostname: '127.0.0.1',
+          port: 8125,
+        },
+        lookup: dns.lookup,
+        runtimeMetricsRuntimeId: true,
+        tags: { 'runtime-id': 'initial-id' },
+      }
+
+      client = new CustomMetrics(config)
+      client.distribution('test.buffered', 1)
+
+      identityRefreshChannel.publish(config)
+      client.flush()
+
+      assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.buffered:1|d|#runtime-id:initial-id\n')
     })
   })
 

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -29,16 +29,17 @@ describe('agentless-ci-visibility-encode', () => {
   let writer
   let logger
   let trace
+  let AgentlessCiVisibilityEncoder
 
   beforeEach(() => {
     logger = {
       debug: sinon.stub(),
     }
-    const { AgentlessCiVisibilityEncoder } = proxyquire('../../src/encode/agentless-ci-visibility', {
+    AgentlessCiVisibilityEncoder = proxyquire('../../src/encode/agentless-ci-visibility', {
       '../log': logger,
-    })
+    }).AgentlessCiVisibilityEncoder
     writer = { flush: sinon.spy() }
-    encoder = new AgentlessCiVisibilityEncoder(writer, {})
+    encoder = new AgentlessCiVisibilityEncoder(writer, { tags: {} })
 
     trace = [{
       trace_id: id('1234abcd1234abcd'),
@@ -110,6 +111,36 @@ describe('agentless-ci-visibility-encode', () => {
 
     assert.strictEqual(spanEvent.content.metrics.positive, 123456712345)
     assert.strictEqual(spanEvent.content.metrics.negative, -123456712345)
+  })
+
+  it('should encode runtime-id from tags, reflecting a mutation made after construction', () => {
+    const tags = { 'runtime-id': 'initial-id' }
+    const localEncoder = new AgentlessCiVisibilityEncoder(writer, { tags })
+
+    localEncoder.encode(trace)
+    const firstDecoded = msgpack.decode(localEncoder.makePayload(), { useBigInt64: true })
+    assert.strictEqual(firstDecoded.metadata['*']['runtime-id'], 'initial-id')
+
+    tags['runtime-id'] = 'refreshed-id'
+
+    localEncoder.encode(trace)
+    const secondDecoded = msgpack.decode(localEncoder.makePayload(), { useBigInt64: true })
+    assert.strictEqual(secondDecoded.metadata['*']['runtime-id'], 'refreshed-id')
+  })
+
+  it('should encode env from tags, reflecting a mutation made after construction', () => {
+    const tags = { env: 'initial-env' }
+    const localEncoder = new AgentlessCiVisibilityEncoder(writer, { tags })
+
+    localEncoder.encode(trace)
+    const firstDecoded = msgpack.decode(localEncoder.makePayload(), { useBigInt64: true })
+    assert.strictEqual(firstDecoded.metadata['*'].env, 'initial-env')
+
+    tags.env = 'refreshed-env'
+
+    localEncoder.encode(trace)
+    const secondDecoded = msgpack.decode(localEncoder.makePayload(), { useBigInt64: true })
+    assert.strictEqual(secondDecoded.metadata['*'].env, 'refreshed-env')
   })
 
   it('should report its count', () => {

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -120,6 +120,54 @@ describe('AgentlessExporter', () => {
         languageName: 'nodejs',
       })
     })
+
+    it('should reflect a runtime id updated on config after construction', () => {
+      const writerOptions = {}
+      const Writer = function (opts) {
+        Object.assign(writerOptions, opts)
+        return writer
+      }
+
+      Exporter = proxyquire('../../../src/exporters/agentless', {
+        './writer': Writer,
+      })
+
+      const config = {
+        site: 'datadoghq.com',
+        env: 'production',
+        tags: { 'runtime-id': 'test-uuid' },
+      }
+
+      exporter = new Exporter(config)
+
+      config.tags['runtime-id'] = 'new-uuid'
+
+      assert.strictEqual(writerOptions.metadata.runtimeID, 'new-uuid')
+    })
+
+    it('should reflect an env updated on config after construction', () => {
+      const writerOptions = {}
+      const Writer = function (opts) {
+        Object.assign(writerOptions, opts)
+        return writer
+      }
+
+      Exporter = proxyquire('../../../src/exporters/agentless', {
+        './writer': Writer,
+      })
+
+      const config = {
+        site: 'datadoghq.com',
+        env: 'production',
+        tags: { 'runtime-id': 'test-uuid' },
+      }
+
+      exporter = new Exporter(config)
+
+      config.env = 'staging'
+
+      assert.strictEqual(writerOptions.metadata.env, 'staging')
+    })
   })
 
   describe('export', () => {

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { channel } = require('dc-polyfill')
 
 require('./setup/core')
 
@@ -154,5 +155,76 @@ describe('id', () => {
 
     assert.strictEqual(spanId.toString(16), '000000000000abcd')
     assert.strictEqual(spanId.toString(10), '43981')
+  })
+
+  describe('reseed()', () => {
+    let freshId
+    let randomFillSyncStub
+
+    beforeEach(() => {
+      // Fill with a value that increments per call, so IDs drawn from different
+      // randomFillSync() fills are distinguishable instead of all looking alike.
+      let fillByte = 0
+      randomFillSyncStub = sinon.stub().callsFake(buf => {
+        fillByte++
+        buf.fill(fillByte)
+      })
+
+      freshId = proxyquire('../src/id', {
+        crypto: { randomFillSync: randomFillSyncStub },
+      })
+    })
+
+    it('should generate a different id after reseed', () => {
+      const before = freshId().toString()
+
+      channel('datadog:identity:update').publish({ tags: {} })
+      const after = freshId().toString()
+
+      assert.notStrictEqual(after, before)
+    })
+
+    it('should reset the batch cursor to 0', () => {
+      // Call id() several times to advance the batch counter
+      freshId()
+      freshId()
+      freshId()
+      randomFillSyncStub.resetHistory()
+
+      channel('datadog:identity:update').publish({ tags: {} })
+      // After reseed, batch = 0, so the next call must refill from randomFillSync
+      freshId()
+
+      sinon.assert.called(randomFillSyncStub)
+    })
+
+    it('should force a fresh randomFillSync() call on the very next id() after reseed', () => {
+      channel('datadog:identity:update').publish({ tags: {} })
+      randomFillSyncStub.resetHistory()
+
+      freshId()
+
+      sinon.assert.calledOnce(randomFillSyncStub)
+    })
+
+    it('should be safe to call repeatedly', () => {
+      channel('datadog:identity:update').publish({ tags: {} })
+      channel('datadog:identity:update').publish({ tags: {} })
+      randomFillSyncStub.resetHistory()
+
+      freshId()
+
+      sinon.assert.calledOnce(randomFillSyncStub)
+    })
+
+    it('should reseed when datadog:identity:update is published', () => {
+      freshId()
+      randomFillSyncStub.resetHistory()
+
+      channel('datadog:identity:update').publish({ tags: {} })
+      freshId()
+
+      sinon.assert.calledOnce(randomFillSyncStub)
+    })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/logs.spec.js
+++ b/packages/dd-trace/test/opentelemetry/logs.spec.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const { logs } = require('@opentelemetry/api-logs')
 const { trace, context } = require('@opentelemetry/api')
+const { channel } = require('dc-polyfill')
 const { timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/core')
 
 require('../setup/core')
@@ -16,6 +17,8 @@ const { protoLogsService } = require('../../src/opentelemetry/otlp/protobuf_load
 const { getConfigFresh } = require('../helpers/config')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 const BatchLogRecordProcessor = require('../../src/opentelemetry/logs/batch_log_processor')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 /**
  * @param {object} type protobufjs Type instance for the OTLP service message
@@ -919,6 +922,24 @@ describe('OpenTelemetry Logs', () => {
       exporter.export([{ body: 'test', severityNumber: 9, timestamp: [1700000000, 0] }], () => {})
 
       assert(telemetryMetrics.manager.namespace().count().inc.calledWith(1))
+    })
+  })
+
+  describe('Identity refresh', () => {
+    it('exports resource attributes rebuilt after identity refresh', () => {
+      const validator = mockOtlpExport((decoded) => {
+        const runtimeId = decoded.resourceLogs[0].resource.attributes.find(
+          attribute => attribute.key === 'runtime-id'
+        )
+        assert.strictEqual(runtimeId.value.stringValue, 'refreshed-id')
+      })
+      const { config, logs } = setupLogs()
+
+      config.tags['runtime-id'] = 'refreshed-id'
+      identityRefreshChannel.publish(config)
+      logs.getLogger('test-logger').emit({ body: 'test' })
+
+      validator()
     })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -8,6 +8,7 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const { metrics } = require('@opentelemetry/api')
+const { channel } = require('dc-polyfill')
 
 require('../setup/core')
 const { protoMetricsService } = require('../../src/opentelemetry/otlp/protobuf_loader').getProtobufTypes()
@@ -15,6 +16,8 @@ const { getConfigFresh } = require('../helpers/config')
 const { DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE } = require('../../src/opentelemetry/metrics/constants')
 const MeterProvider = require('../../src/opentelemetry/metrics/meter_provider')
 const PeriodicMetricReader = require('../../src/opentelemetry/metrics/periodic_metric_reader')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 /**
  * @param {object} type protobufjs Type instance for the OTLP service message
@@ -1282,6 +1285,42 @@ describe('OpenTelemetry Meter Provider', () => {
       } finally {
         clock.restore()
       }
+    })
+  })
+
+  describe('Identity refresh', () => {
+    it('exports refreshed resources without resetting the ObservableCounter delta baseline', () => {
+      const clock = sinon.useFakeTimers()
+      const exportedMetrics = []
+      mockOtlpExport((decoded) => {
+        const resourceAttributes = decoded.resourceMetrics[0].resource.attributes
+        const runtimeId = resourceAttributes.find(attribute => attribute.key === 'runtime-id')
+        const counter = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
+        exportedMetrics.push({
+          runtimeId: runtimeId.value.stringValue,
+          value: counter.sum.dataPoints[0].asInt,
+        })
+      })
+
+      const { config } = setupMetrics()
+      const initialRuntimeId = config.tags['runtime-id']
+      const meter = metrics.getMeter('app')
+      let value = 20
+      meter.createObservableCounter('obs').addCallback((result) => result.observe(value))
+
+      clock.tick(100)
+
+      // Refresh happens after the first export already established a baseline of 20.
+      config.tags['runtime-id'] = 'refreshed-id'
+      identityRefreshChannel.publish(config)
+      value = 25
+
+      clock.tick(100)
+
+      assert.deepStrictEqual(exportedMetrics, [
+        { runtimeId: initialRuntimeId, value: 20 },
+        { runtimeId: 'refreshed-id', value: 5 },
+      ])
     })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_exporter.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_exporter.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const http = require('node:http')
 const { describe, it, before, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
+const { channel } = require('dc-polyfill')
 
 require('../../setup/core')
 
@@ -12,6 +13,8 @@ const { buildResourceAttributes, createOtlpSpanStatsExporter } = require('../../
 const { SpanBuckets } = require('../../../src/span_stats')
 const { HTTP_STATUS_CODE } = require('../../../../../ext/tags')
 const processTags = require('../../../src/process-tags')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 const RESOURCE_ATTRS = { 'service.name': 'svc' }
 const BUCKET_SIZE_NS = 10 * 1e9
@@ -117,6 +120,34 @@ describe('createOtlpSpanStatsExporter', () => {
       tags: {},
     })
     assert.ok(exporter instanceof OtlpStatsExporter)
+  })
+
+  it('exports resource attributes rebuilt after identity refresh', () => {
+    const config = {
+      OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: 'http://localhost:4318/v1/metrics',
+      service: 'svc',
+      version: '1.0.0',
+      env: 'prod',
+      tags: { 'runtime-id': 'initial-id' },
+    }
+    const exporter = createOtlpSpanStatsExporter(config)
+
+    config.tags['runtime-id'] = 'refreshed-id'
+    identityRefreshChannel.publish(config)
+    exporter.export(makeDrained([makeSpan()]), BUCKET_SIZE_NS)
+
+    const request = httpStub.firstCall.returnValue
+    const payload = JSON.parse(request.write.firstCall.args[0].toString())
+    const resourceAttributes = Object.fromEntries(
+      payload.resourceMetrics[0].resource.attributes.map(attribute => [attribute.key, attribute.value.stringValue])
+    )
+    assert.strictEqual(resourceAttributes['telemetry.sdk.name'], 'datadog')
+    assert.strictEqual(resourceAttributes['telemetry.sdk.language'], 'nodejs')
+    assert.strictEqual(typeof resourceAttributes['telemetry.sdk.version'], 'string')
+    assert.strictEqual(resourceAttributes['service.name'], 'svc')
+    assert.strictEqual(resourceAttributes['service.version'], '1.0.0')
+    assert.strictEqual(resourceAttributes['deployment.environment.name'], 'prod')
+    assert.strictEqual(resourceAttributes['datadog.runtime_id'], 'refreshed-id')
   })
 })
 

--- a/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_transformer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_transformer.spec.js
@@ -310,6 +310,20 @@ describe('OtlpStatsTransformer', () => {
       assert.strictEqual(resourceAttrs['deployment.environment.name'], 'test')
     })
 
+    it('replaces cached resource attributes', () => {
+      const localTransformer = new OtlpStatsTransformer({ 'datadog.runtime_id': 'initial-id' }, 'http/json')
+
+      localTransformer.updateResourceAttributes({ 'datadog.runtime_id': 'refreshed-id' })
+
+      const payload = JSON.parse(
+        localTransformer.transform(makeDrained(12340000000000, [makeSpan()]), BUCKET_SIZE_NS)
+      )
+      assert.deepStrictEqual(payload.resourceMetrics[0].resource.attributes, [{
+        key: 'datadog.runtime_id',
+        value: { stringValue: 'refreshed-id' },
+      }])
+    })
+
     it('emits a single scopeMetrics and tags every data point with service.name, including the default service', () => {
       const drained = makeDrained(12340000000000, [
         makeSpan({ service: 'svc', resource: 'GET /foo' }),

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -7,12 +7,19 @@ const https = require('node:https')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { channel } = require('dc-polyfill')
 
 require('../setup/core')
+const { HTTP_STATUS_CODE } = require('../../../../ext/tags')
 const { getConfigFresh } = require('../helpers/config')
 const id = require('../../src/id')
+const { createOtlpSpanStatsExporter } = require('../../src/opentelemetry/metrics')
 const OtlpHttpTraceExporter = require('../../src/opentelemetry/trace/otlp_http_trace_exporter')
 const { createOtlpTraceExporter } = require('../../src/opentelemetry/trace')
+const processTags = require('../../src/process-tags')
+const { SpanBuckets } = require('../../src/span_stats')
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 const OTEL_ENV_KEYS = [
   'OTEL_TRACES_EXPORTER',
@@ -57,6 +64,23 @@ describe('OpenTelemetry Traces', () => {
       duration: 50000000, // 50ms in nanoseconds
       ...overrides,
     }
+  }
+
+  function createSpanStatsDrain () {
+    const span = {
+      startTime: 12345 * 1e9,
+      duration: 1000,
+      error: 0,
+      name: 'op',
+      service: 'svc',
+      resource: 'res',
+      type: 'web',
+      meta: { [HTTP_STATUS_CODE]: 200 },
+      metrics: {},
+    }
+    const bucket = new SpanBuckets()
+    bucket.forSpan(span).record(span)
+    return [{ timeNs: 12340000000000, bucket }]
   }
 
   function mockOtlpExport (validator) {
@@ -943,6 +967,96 @@ describe('OpenTelemetry Traces', () => {
       exporter.sendPayload(Buffer.from('{}'), () => {})
 
       assert.ok(httpsStub.calledOnce, 'https.request should have been called after switching to https')
+    })
+  })
+
+  describe('Identity refresh', () => {
+    it('exports resource attributes rebuilt after identity refresh', () => {
+      const validator = mockOtlpExport((decoded) => {
+        const runtimeId = decoded.resourceSpans[0].resource.attributes.find(
+          attribute => attribute.key === 'runtime-id'
+        )
+        assert.strictEqual(runtimeId.value.stringValue, 'refreshed-id')
+      })
+      const config = getConfigFresh()
+      const exporter = createOtlpTraceExporter(config)
+
+      config.tags['runtime-id'] = 'refreshed-id'
+      identityRefreshChannel.publish(config)
+      exporter.export([createMockSpan()])
+
+      validator()
+    })
+
+    it('updates only the active exporter after identity refresh', () => {
+      const runtimeIds = []
+      const validator = mockOtlpExport((decoded) => {
+        const runtimeId = decoded.resourceSpans[0].resource.attributes.find(
+          attribute => attribute.key === 'runtime-id'
+        )
+        runtimeIds.push(runtimeId.value.stringValue)
+      })
+      const firstConfig = getConfigFresh()
+      firstConfig.tags['runtime-id'] = 'first-initial-id'
+      const firstExporter = createOtlpTraceExporter(firstConfig)
+
+      const secondConfig = getConfigFresh()
+      secondConfig.tags['runtime-id'] = 'second-initial-id'
+      const secondExporter = createOtlpTraceExporter(secondConfig)
+
+      firstConfig.tags['runtime-id'] = 'stale-first-id'
+      secondConfig.tags['runtime-id'] = 'second-refreshed-id'
+      identityRefreshChannel.publish(secondConfig)
+      firstExporter.export([createMockSpan()])
+      secondExporter.export([createMockSpan()])
+
+      assert.deepStrictEqual(runtimeIds, ['first-initial-id', 'second-refreshed-id'])
+      validator()
+    })
+
+    it('refreshes every active signal exporter', () => {
+      const payloads = new Map()
+      sinon.stub(http, 'request').callsFake((options, callback) => {
+        const response = {
+          statusCode: 200,
+          on: () => response,
+          once: () => response,
+        }
+        const request = {
+          write: data => payloads.set(options.path, JSON.parse(data.toString())),
+          end: () => {},
+          on: () => request,
+          once: () => request,
+        }
+        callback(response)
+        return request
+      })
+
+      const traceConfig = getConfigFresh()
+      traceConfig.tags['runtime-id'] = 'initial-trace-id'
+      const traceExporter = createOtlpTraceExporter(traceConfig)
+      const statsConfig = {
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: 'http://localhost:4318/v1/metrics',
+        service: 'svc',
+        tags: { 'runtime-id': 'initial-stats-id' },
+      }
+      processTags.initialize(statsConfig)
+      const statsExporter = createOtlpSpanStatsExporter(statsConfig)
+
+      traceConfig.tags['runtime-id'] = 'refreshed-trace-id'
+      statsConfig.tags['runtime-id'] = 'refreshed-stats-id'
+      identityRefreshChannel.publish(traceConfig)
+      traceExporter.export([createMockSpan()])
+      statsExporter.export(createSpanStatsDrain(), 10 * 1e9)
+
+      const traceRuntimeId = payloads.get('/v1/traces').resourceSpans[0].resource.attributes.find(
+        attribute => attribute.key === 'runtime-id'
+      )
+      const statsRuntimeId = payloads.get('/v1/metrics').resourceMetrics[0].resource.attributes.find(
+        attribute => attribute.key === 'datadog.runtime_id'
+      )
+      assert.strictEqual(traceRuntimeId.value.stringValue, 'refreshed-trace-id')
+      assert.strictEqual(statsRuntimeId.value.stringValue, 'refreshed-stats-id')
     })
   })
 })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -70,6 +70,8 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',
+  // MicroVM clone-resume identity reseed hook registration
+  'AWS_LAMBDA_MICROVM_IMAGE_ARN',
   // serverless service-name fallbacks (Config singleton)
   'WEBSITE_SITE_NAME',
   // azure metadata payload (cached at first build)

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -4,8 +4,8 @@ const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire').noCallThru()
 const sinon = require('sinon')
-const proxyquire = require('proxyquire')
 
 require('../setup/core')
 
@@ -47,6 +47,7 @@ describe('profiler', function () {
         systemInfoReport: { oomMonitoring: { enabled: false } },
       }
     },
+    getProfilingTags: (config) => ({ ...config.tags }),
   }
 
   async function waitForExport () {
@@ -573,6 +574,45 @@ describe('profiler', function () {
       const { infos } = await exporterPromise
 
       assert.strictEqual(infos.hasMissingSourceMaps, false)
+    })
+
+    it('uses the tags captured at each snapshot start', async () => {
+      const exportSpecs = []
+      exporter.export = sinon.stub().callsFake((exportSpec) => {
+        exportSpecs.push(exportSpec)
+        return Promise.resolve()
+      })
+      const startOptions = makeStartOptions({ tags: { 'runtime-id': 'initial-id' } })
+      await profiler.start(startOptions)
+
+      startOptions.tags['runtime-id'] = 'refreshed-id'
+
+      await clock.tickAsync(interval)
+
+      assert.strictEqual(exportSpecs.length, 1)
+      assert.strictEqual(exportSpecs[0].tags['runtime-id'], 'initial-id')
+
+      await clock.tickAsync(interval)
+
+      assert.strictEqual(exportSpecs.length, 2)
+      assert.strictEqual(exportSpecs[1].tags['runtime-id'], 'refreshed-id')
+    })
+
+    it('uses the current snapshot tags for near-OOM exports', async () => {
+      exporterPromise = new Promise(resolve => {
+        exporter.export = (exportSpec) => {
+          resolve(exportSpec)
+          return Promise.resolve()
+        }
+      })
+      const startOptions = makeStartOptions({ tags: { 'runtime-id': 'initial-id' } })
+      await profiler.start(startOptions)
+
+      startOptions.tags['runtime-id'] = 'refreshed-id'
+      wallProfiler.start.firstCall.args[0].nearOOMCallback('wall', wallProfile, {})
+
+      const { tags } = await exporterPromise
+      assert.strictEqual(tags['runtime-id'], 'initial-id')
     })
   })
 

--- a/packages/dd-trace/test/profiling/profilers/space.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/space.spec.js
@@ -4,17 +4,19 @@ const assert = require('node:assert/strict')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 
-const { describe, it, beforeEach } = require('mocha')
-const proxyquire = require('proxyquire')
+const { channel } = require('dc-polyfill')
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire').noCallThru()
 const sinon = require('sinon')
 
 require('../../setup/core')
 const { AgentExporter } = require('../../../src/profiling/exporters/agent')
 const { FileExporter } = require('../../../src/profiling/exporters/file')
 
-// Test adapter: the space profiler reads the canonical DD_PROFILING_* names (allocation and OOM
-// monitoring included) straight off the tracer config; only tags and exporters are passed through.
-// Map the legacy flat option names onto a config-shaped object.
+// Map the legacy flat test options onto the production constructor shape.
+const identityRefreshChannel = channel('datadog:identity:refresh')
+const activeProfilers = []
+
 function makeSpace (Cls, {
   allocationProfilingEnabled = false,
   heapSamplingInterval = 512 * 1024,
@@ -25,24 +27,30 @@ function makeSpace (Cls, {
   tags = {},
   exporters = [],
 } = {}) {
-  return new Cls({
+  const profiler = new Cls({
     DD_PROFILING_HEAP_SAMPLING_INTERVAL: heapSamplingInterval,
     DD_PROFILING_ALLOCATION_ENABLED: allocationProfilingEnabled,
     DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: oomMonitoringEnabled,
     DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: heapLimitExtensionSize,
     DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: maxHeapExtensionCount,
     DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: exportStrategies,
-  }, { tags, exporters })
+    tags,
+  }, { tags: { ...tags }, exporters })
+  activeProfilers.push(profiler)
+  return profiler
 }
 
 const exporterCliPath = path.join(__dirname, '../../../src/profiling', 'exporter_cli.js')
 
 describe('profilers/native/space', () => {
   let NativeSpaceProfiler
+  let logger
   let pprof
   let profile0
 
   beforeEach(() => {
+    activeProfilers.length = 0
+    logger = { error: sinon.stub() }
     profile0 = {
       encodeAsync: sinon.stub().returns(Promise.resolve('encoded')),
     }
@@ -58,7 +66,14 @@ describe('profilers/native/space', () => {
 
     NativeSpaceProfiler = proxyquire('../../../src/profiling/profilers/space', {
       '@datadog/pprof': pprof,
+      '../../log': logger,
     })
+  })
+
+  afterEach(() => {
+    for (const profiler of activeProfilers) {
+      profiler.stop()
+    }
   })
 
   it('should start the internal space profiler', () => {
@@ -220,5 +235,50 @@ describe('profilers/native/space', () => {
     const [, , logsEnabled, exportCommand] = pprof.heap.monitorOutOfMemory.firstCall.args
     assert.strictEqual(logsEnabled, true)
     assert.deepStrictEqual(exportCommand, [])
+  })
+
+  it('should re-register the OOM export command with refreshed tags', () => {
+    const url = new URL('http://127.0.0.1:8126/')
+    const tags = { 'runtime-id': 'initial-id' }
+    const profiler = makeSpace(NativeSpaceProfiler, {
+      oomMonitoringEnabled: true,
+      exportStrategies: ['process'],
+      tags,
+      exporters: [new AgentExporter({ url, DD_PROFILING_UPLOAD_TIMEOUT: 60_000 })],
+    })
+
+    profiler.start()
+    tags['runtime-id'] = 'refreshed-id'
+    identityRefreshChannel.publish()
+
+    sinon.assert.calledTwice(pprof.heap.monitorOutOfMemory)
+    const exportCommand = pprof.heap.monitorOutOfMemory.secondCall.args[3]
+    assert.deepStrictEqual(exportCommand, [
+      process.execPath,
+      exporterCliPath,
+      'http://127.0.0.1:8126/',
+      'runtime-id:refreshed-id,snapshot:on_oom',
+      'space',
+    ])
+
+    profiler.stop()
+    tags['runtime-id'] = 'another-id'
+    identityRefreshChannel.publish()
+
+    sinon.assert.calledTwice(pprof.heap.monitorOutOfMemory)
+  })
+
+  it('should contain OOM export refresh failures', () => {
+    const error = new Error('boom')
+    const profiler = makeSpace(NativeSpaceProfiler, {
+      oomMonitoringEnabled: true,
+      exportStrategies: ['process'],
+    })
+
+    profiler.start()
+    pprof.heap.monitorOutOfMemory.onSecondCall().throws(error)
+
+    identityRefreshChannel.publish()
+    sinon.assert.calledOnceWithExactly(logger.error, error)
   })
 })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -2,15 +2,21 @@
 
 const assert = require('node:assert/strict')
 const { spawnSync } = require('node:child_process')
+const { once } = require('node:events')
+const http = require('node:http')
 const path = require('node:path')
 const { inspect } = require('node:util')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+
+const { storage } = require('../../datadog-core')
 const RemoteConfigCapabilities = require('../src/remote_config/capabilities')
 
 require('./setup/core')
+
+const legacyStorage = storage('legacy')
 
 describe('TracerProxy', () => {
   let ProxyClass
@@ -143,6 +149,7 @@ describe('TracerProxy', () => {
 
     log = {
       error: sinon.spy(),
+      warn: sinon.spy(),
     }
 
     DatadogTracer = sinon.stub().returns(tracer)
@@ -1317,7 +1324,351 @@ describe('TracerProxy', () => {
       })
     })
   })
+
+  describe('MicroVM identity reset', () => {
+    let channelMock
+    let diagnosticsChannelMock
+    let microProxy
+    let storeConfig
+    let uuidStub
+    let buildProxy
+
+    beforeEach(() => {
+      uuidStub = sinon.stub().returns('00000000-0000-4000-8000-000000000000')
+
+      channelMock = {
+        subscribe: sinon.stub(),
+        unsubscribe: sinon.stub(),
+        publish: sinon.stub(),
+      }
+
+      diagnosticsChannelMock = {
+        channel: sinon.stub().returns(channelMock),
+      }
+      storeConfig = sinon.stub().returns({})
+
+      buildProxy = (nodeBundlesOpenssl = false) => new (proxyquire('../src/proxy', {
+        './tracer': DatadogTracer,
+        './noop/proxy': NoopProxy,
+        './config': Config,
+        './plugin_manager': PluginManager,
+        './runtime_metrics': runtimeMetrics,
+        './log': log,
+        './profiler': profiler,
+        './tracer_metadata': storeConfig,
+        './serverless': {
+          IS_AWS_LAMBDA_MICROVM: true,
+          IS_SERVERLESS: true,
+          NODE_BUNDLES_OPENSSL: nodeBundlesOpenssl,
+        },
+        './appsec': appsec,
+        './appsec/iast': iast,
+        './telemetry': telemetry,
+        './remote_config': RemoteConfig,
+        './aiguard/sdk': AIGuardSdk,
+        './appsec/sdk': AppsecSdk,
+        './dogstatsd': dogStatsD,
+        './noop/dogstatsd': NoopDogStatsDClient,
+        './flare': flare,
+        './openfeature': openfeature,
+        './openfeature/flagging_provider': OpenFeatureProvider,
+        'dc-polyfill': diagnosticsChannelMock,
+        '../../../vendor/dist/crypto-randomuuid': uuidStub,
+      }))()
+
+      microProxy = buildProxy()
+    })
+
+    it('should register the MicroVM hook when env var is set', () => {
+      microProxy.init()
+
+      sinon.assert.calledWith(diagnosticsChannelMock.channel, 'http.server.request.start')
+      sinon.assert.calledOnce(channelMock.subscribe)
+    })
+
+    it('should keep the MicroVM identity refresh when tracer initialization fails', () => {
+      const error = new Error('tracer initialization failed')
+      DatadogTracer.throws(error)
+
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.calledTwice(channelMock.publish)
+      sinon.assert.alwaysCalledWithExactly(channelMock.publish, config)
+      sinon.assert.notCalled(storeConfig)
+      sinon.assert.calledOnceWithExactly(log.error, 'Error initializing tracer', error)
+    })
+
+    it('should not store tracer metadata when tracing is disabled', () => {
+      config.DD_TRACE_ENABLED = false
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.notCalled(storeConfig)
+      sinon.assert.calledTwice(channelMock.publish)
+    })
+
+    it('should publish datadog:identity:update with the tracer config on POST .../run', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      sinon.assert.notCalled(channelMock.publish)
+
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.calledWith(diagnosticsChannelMock.channel, 'datadog:identity:update')
+      sinon.assert.calledWith(diagnosticsChannelMock.channel, 'datadog:identity:refresh')
+      sinon.assert.calledTwice(channelMock.publish)
+      sinon.assert.alwaysCalledWithExactly(channelMock.publish, config)
+    })
+
+    it('should update identity, store metadata, and then refresh consumers', () => {
+      // Core identity producers (id/config/remote_config) self-subscribe to identity:update and
+      // must finish reseeding before identity:refresh notifies downstream cache-holders
+      // (dogstatsd, otel metrics, debugger); otherwise those subsystems would refresh from the
+      // pre-reseed identity.
+      storeConfig.returns(undefined)
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      const channelNames = diagnosticsChannelMock.channel.getCalls().map(call => call.args[0])
+      const updateIndex = channelNames.indexOf('datadog:identity:update')
+      const refreshIndex = channelNames.indexOf('datadog:identity:refresh')
+
+      assert.notStrictEqual(updateIndex, -1)
+      assert.notStrictEqual(refreshIndex, -1)
+
+      const updateCall = diagnosticsChannelMock.channel.getCall(updateIndex)
+      const refreshCall = diagnosticsChannelMock.channel.getCall(refreshIndex)
+      assert.ok(updateCall.callId < storeConfig.firstCall.callId)
+      assert.ok(storeConfig.firstCall.callId < refreshCall.callId)
+      sinon.assert.calledOnceWithExactly(log.warn, 'Could not store tracer configuration for service discovery')
+    })
+
+    it('should NOT fire refreshIdentity on GET /aws/lambda-microvms/runtime/v1/run', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'GET', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.notCalled(channelMock.publish)
+    })
+
+    it('should NOT fire refreshIdentity on POST /other', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/other' } })
+
+      sinon.assert.notCalled(channelMock.publish)
+    })
+
+    it('should log an error at registration when Node bundles its own OpenSSL', () => {
+      buildProxy(true).init()
+
+      sinon.assert.calledOnce(log.error)
+      assert.match(log.error.firstCall.args[0], /bundles its own OpenSSL/)
+    })
+
+    it('should not log an error when Node links a shared OpenSSL', () => {
+      microProxy.init()
+
+      sinon.assert.notCalled(log.error)
+    })
+
+    it('should drain a full UUID batch before publishing datadog:identity:update', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      sinon.assert.notCalled(uuidStub)
+
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      // a full batch, so the pool's cursor wraps and refills wherever the snapshot froze it
+      sinon.assert.callCount(uuidStub, 128)
+
+      const updateIndex = diagnosticsChannelMock.channel.getCalls()
+        .findIndex(call => call.args[0] === 'datadog:identity:update')
+      const updateCall = diagnosticsChannelMock.channel.getCall(updateIndex)
+
+      assert.ok(uuidStub.lastCall.callId < updateCall.callId)
+    })
+
+    it('should not drain the UUID pool when the request is not the run hook', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'GET', url: '/aws/lambda-microvms/runtime/v1/run' } })
+      subscriber({ request: { method: 'POST', url: '/other' } })
+
+      sinon.assert.notCalled(uuidStub)
+    })
+
+    it('should unsubscribe HTTP channel after first fire', () => {
+      microProxy.init()
+
+      const subscriber = channelMock.subscribe.firstCall.args[0]
+      subscriber({ request: { method: 'POST', url: '/aws/lambda-microvms/runtime/v1/run' } })
+
+      sinon.assert.calledOnceWithExactly(channelMock.unsubscribe, subscriber)
+    })
+  })
+
+  describe('MicroVM identity refresh (real modules)', () => {
+    let RealConfig
+    let RealRemoteConfig
+    let udp4Send
+    let MicroVmProxy
+    let microProxy
+    let capturedConfig
+    let storedRuntimeId
+    let storeConfig
+    let server
+
+    beforeEach(async () => {
+      // Real (not proxied) config/remote_config/dogstatsd modules, so this test proves the
+      // actual production wiring — not that mocks were called correctly.
+      RealConfig = proxyquire.noPreserveCache()('../src/config', {})
+      RealRemoteConfig = proxyquire.noPreserveCache()('../src/remote_config', {})
+
+      udp4Send = sinon.spy()
+      const udp4 = { send: udp4Send, on: sinon.stub(), unref: sinon.stub() }
+      udp4.on.returns(udp4)
+      udp4.unref.returns(udp4)
+      const dgram = { createSocket: sinon.stub().returns(udp4) }
+      const dns = { lookup: sinon.stub().callsFake((hostname, callback) => callback(null, hostname, 4)) }
+      const RealCustomMetrics = proxyquire.noPreserveCache()('../src/dogstatsd', { dgram }).CustomMetrics
+
+      storeConfig = sinon.stub().callsFake(metadataConfig => {
+        storedRuntimeId = metadataConfig.tags['runtime-id']
+        return {}
+      })
+
+      capturedConfig = null
+      const CapturingConfig = (...args) => {
+        capturedConfig = RealConfig(...args)
+        capturedConfig.lookup = dns.lookup
+        capturedConfig.runtimeMetricsRuntimeId = true
+        // Force the UDP send path so this test can observe the outgoing packet directly,
+        // instead of going through the HTTP-proxy-to-agent path config.url otherwise selects.
+        capturedConfig.url = undefined
+        return capturedConfig
+      }
+
+      MicroVmProxy = proxyquire('../src/proxy', {
+        './tracer': DatadogTracer,
+        './noop/proxy': NoopProxy,
+        './config': CapturingConfig,
+        './plugin_manager': PluginManager,
+        './runtime_metrics': runtimeMetrics,
+        './log': log,
+        './profiler': profiler,
+        './tracer_metadata': storeConfig,
+        './serverless': {
+          IS_AWS_LAMBDA_MICROVM: true,
+          IS_SERVERLESS: true,
+        },
+        './appsec': appsec,
+        './appsec/iast': iast,
+        './telemetry': telemetry,
+        './remote_config': RemoteConfig,
+        './aiguard/sdk': AIGuardSdk,
+        './appsec/sdk': AppsecSdk,
+        './dogstatsd': { CustomMetrics: RealCustomMetrics },
+        './noop/dogstatsd': NoopDogStatsDClient,
+        './flare': flare,
+        './openfeature': openfeature,
+        './openfeature/flagging_provider': OpenFeatureProvider,
+        // dc-polyfill intentionally NOT mocked — this test exercises the real shared channel.
+      })
+
+      microProxy = new MicroVmProxy()
+
+      server = http.createServer((request, response) => {
+        assert.strictEqual(request.method, 'POST')
+        assert.strictEqual(request.url, '/aws/lambda-microvms/runtime/v1/run')
+        response.end()
+      })
+      server.listen(0)
+      await once(server, 'listening')
+    })
+
+    afterEach(async () => {
+      const closed = once(server, 'close')
+      server.close()
+      await closed
+    })
+
+    it('refreshes config, remote config, and dogstatsd tags together on a real /run request', async () => {
+      microProxy.init()
+
+      // Constructed independently from the same real remote_config module proxy.js uses
+      // internally — refreshClientId() mutates module-scoped state shared by every instance.
+      const rc = new RealRemoteConfig(capturedConfig)
+      const originalRuntimeId = capturedConfig.tags['runtime-id']
+      const originalClientId = rc.state.client.id
+
+      const customMetrics = microProxy.dogstatsd
+
+      await triggerMicroVmRun(server)
+
+      assert.notStrictEqual(capturedConfig.tags['runtime-id'], originalRuntimeId)
+      assert.notStrictEqual(rc.state.client.id, originalClientId)
+
+      customMetrics.gauge('test.metric', 1)
+      customMetrics.flush()
+
+      sinon.assert.called(udp4Send)
+      const payload = udp4Send.firstCall.args[0].toString()
+      assert.ok(
+        payload.includes(`runtime-id:${capturedConfig.tags['runtime-id']}`),
+        `expected refreshed runtime-id in payload, got: ${payload}`
+      )
+    })
+
+    it('stores process metadata once with the refreshed /run identity', async () => {
+      microProxy.init()
+
+      const originalRuntimeId = capturedConfig.tags['runtime-id']
+      sinon.assert.notCalled(storeConfig)
+
+      await triggerMicroVmRun(server)
+      await triggerMicroVmRun(server)
+
+      sinon.assert.calledOnceWithExactly(storeConfig, capturedConfig)
+      assert.notStrictEqual(storedRuntimeId, originalRuntimeId)
+      assert.strictEqual(storedRuntimeId, capturedConfig.tags['runtime-id'])
+    })
+  })
 })
+
+/**
+ * @param {import('node:http').Server} server
+ */
+async function triggerMicroVmRun (server) {
+  await legacyStorage.run({ noop: true }, async () => {
+    const { address, port } = server.address()
+    const request = http.request({
+      hostname: address === '::' ? '::1' : address,
+      method: 'POST',
+      path: '/aws/lambda-microvms/runtime/v1/run',
+      port,
+    })
+    const responsePromise = once(request, 'response')
+    request.end()
+
+    const [response] = await responsePromise
+    const end = once(response, 'end')
+    response.resume()
+    await end
+  })
+}
 
 // Helper function to create APM_TRACING batch transaction objects
 function createApmTracingTransaction (configId, libConfig, action = 'apply') {

--- a/packages/dd-trace/test/remote_config/index.spec.js
+++ b/packages/dd-trace/test/remote_config/index.spec.js
@@ -6,6 +6,7 @@ const { inspect } = require('node:util')
 const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { channel } = require('dc-polyfill')
 
 require('../setup/core')
 const Capabilities = require('../../src/remote_config/capabilities')
@@ -818,6 +819,163 @@ describe('RemoteConfig', () => {
 
       sinon.assert.calledOnceWithExactly(handler, 'unapply', { asm: { enabled: true } }, 'asm_data')
       assert.strictEqual(rc.appliedConfigs.size, 0)
+    })
+  })
+
+  describe('identity state refresh', () => {
+    it('should replace state.client.id when identity is updated', () => {
+      const originalId = rc.state.client.id
+
+      uuid.returns('refreshed-client-id')
+      channel('datadog:identity:update').publish(config)
+
+      assert.strictEqual(rc.state.client.id, 'refreshed-client-id')
+      assert.notStrictEqual(rc.state.client.id, originalId)
+    })
+
+    it('should replace client_tracer.runtime_id when identity is updated', () => {
+      assert.strictEqual(rc.state.client.client_tracer.runtime_id, 'runtimeId')
+
+      config.tags['runtime-id'] = 'refreshed-runtime-id'
+      channel('datadog:identity:update').publish(config)
+
+      assert.strictEqual(rc.state.client.client_tracer.runtime_id, 'refreshed-runtime-id')
+
+      config.tags['runtime-id'] = 'runtimeId' // restore for other tests
+    })
+
+    it('should include refreshed runtime_id and id in the JSON payload', () => {
+      uuid.returns('refreshed-client-id')
+      config.tags['runtime-id'] = 'live-runtime-id'
+      channel('datadog:identity:update').publish(config)
+      const payload = JSON.parse(rc.getPayload())
+
+      assert.strictEqual(payload.client.client_tracer.runtime_id, 'live-runtime-id')
+      assert.strictEqual(payload.client.id, 'refreshed-client-id')
+
+      config.tags['runtime-id'] = 'runtimeId'
+    })
+
+    it('should cache client_tracer.tags and only refresh it on datadog:identity:update', () => {
+      const originalTags = rc.state.client.client_tracer.tags
+
+      config.tags['new-tag'] = 'new-value'
+
+      // unlike runtime_id, tags is a cached string, so a direct config mutation isn't picked up
+      assert.strictEqual(rc.state.client.client_tracer.tags, originalTags)
+
+      channel('datadog:identity:update').publish(config)
+
+      assert.notStrictEqual(rc.state.client.client_tracer.tags, originalTags)
+      assert.ok(rc.state.client.client_tracer.tags.includes('new-tag:new-value'))
+
+      delete config.tags['new-tag']
+    })
+  })
+
+  describe('refreshClientId', () => {
+    let refreshIdentity
+    let uuidStub
+    let RemoteConfigWithId
+
+    beforeEach(() => {
+      uuidStub = sinon.stub()
+      // first call is the module-load-time `let clientId = uuid()`, second is the refresh
+      uuidStub.onFirstCall().returns('1234-5678')
+      uuidStub.onSecondCall().returns('new-client-id-uuid')
+
+      RemoteConfigWithId = proxyquire('../../src/remote_config', {
+        'dc-polyfill': {
+          channel: sinon.stub().returns({
+            subscribe: (listener) => { refreshIdentity = listener },
+          }),
+        },
+        '../../../../vendor/dist/crypto-randomuuid': uuidStub,
+        './scheduler': Scheduler,
+        '../../../../package.json': { version: '3.0.0' },
+        '../exporters/common/request': request,
+        '../log': log,
+        '../tagger': tagger,
+        '../git_metadata': getGitMetadata,
+        '../service-naming/extra-services': {
+          getExtraServices: () => extraServices,
+        },
+      })
+    })
+
+    it('should update state.client.id on the existing instance after refresh', () => {
+      const rcInstance = new RemoteConfigWithId(config)
+      assert.strictEqual(rcInstance.state.client.id, '1234-5678')
+
+      refreshIdentity(config)
+
+      assert.strictEqual(rcInstance.state.client.id, 'new-client-id-uuid')
+    })
+
+    it('should rebuild client_tracer.tags to reflect the refreshed _dd.rc.client_id', () => {
+      const rcConfig = {
+        url: new URL('http://127.0.0.1:1337'),
+        tags: { 'runtime-id': 'runtimeId', '_dd.rc.client_id': 'old-client-id' },
+        service: 'serviceName',
+        env: 'serviceEnv',
+        version: 'appVersion',
+        remoteConfig: { pollInterval: 5 },
+      }
+      const rcInstance = new RemoteConfigWithId(rcConfig)
+      assert.deepStrictEqual(rcInstance.state.client.client_tracer.tags, [
+        'runtime-id:runtimeId',
+        '_dd.rc.client_id:old-client-id',
+      ])
+
+      delete rcConfig.tags['_dd.rc.client_id']
+      refreshIdentity(rcConfig)
+
+      assert.strictEqual(rcConfig.tags['_dd.rc.client_id'], 'new-client-id-uuid')
+      const refreshedTags = rcInstance.state.client.client_tracer.tags
+      assert.deepStrictEqual(refreshedTags, [
+        'runtime-id:runtimeId',
+        '_dd.rc.client_id:new-client-id-uuid',
+      ])
+    })
+
+    it('should set clientId to the value returned by uuid after a client exists', () => {
+      const rcConfig = {
+        url: new URL('http://127.0.0.1:1337'),
+        tags: { 'runtime-id': 'runtimeId', '_dd.rc.client_id': 'old' },
+        service: 'serviceName',
+        env: 'serviceEnv',
+        version: 'appVersion',
+        remoteConfig: { pollInterval: 5 },
+      }
+      const rcInstance = new RemoteConfigWithId(rcConfig)
+      assert.strictEqual(rcInstance.state.client.id, '1234-5678')
+
+      refreshIdentity(rcConfig)
+
+      assert.strictEqual(rcConfig.tags['_dd.rc.client_id'], 'new-client-id-uuid')
+    })
+
+    it('should not add config.tags[_dd.rc.client_id] before a client exists', () => {
+      const rcConfig = {
+        url: new URL('http://127.0.0.1:1337'),
+        tags: { 'runtime-id': 'runtimeId' },
+        service: 'serviceName',
+        env: 'serviceEnv',
+        version: 'appVersion',
+        remoteConfig: { pollInterval: 5 },
+      }
+      refreshIdentity(rcConfig)
+
+      assert.strictEqual(rcConfig.tags['_dd.rc.client_id'], undefined)
+    })
+
+    it('should call uuid again to generate the new ID', () => {
+      refreshIdentity(config)
+
+      // once at module load for the initial clientId, once on refresh
+      sinon.assert.calledTwice(uuidStub)
+      // the buffered pool is drained by the publisher, so the refresh must not opt out of it
+      assert.deepStrictEqual(uuidStub.secondCall.args, [])
     })
   })
 })

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -10,6 +10,7 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { metrics } = require('@opentelemetry/api')
+const { channel } = require('dc-polyfill')
 
 require('./setup/core')
 const { NODE_MAJOR, NODE_MINOR } = require('../../../version')
@@ -42,6 +43,8 @@ function proxyMetricsClient (Client) {
     },
   })
 }
+
+const identityRefreshChannel = channel('datadog:identity:refresh')
 
 function createGarbage (count = 50) {
   let last = {}
@@ -205,6 +208,7 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
             increment: wrapSpy(client, client.increment),
             histogram: wrapSpy(client, client.histogram),
             flush: client.flush.bind(client),
+            updateTags: client.updateTags,
           }
         })
 
@@ -215,6 +219,7 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
           increment: sinon.spy(),
           histogram: sinon.spy(),
           flush: sinon.stub().callsFake(done => done?.()),
+          updateTags: sinon.spy(),
         }
 
         const proxiedObject = {
@@ -338,6 +343,32 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
           const call = Client.lastCall
           const tags = call.args[0].tags
           assert.ok(!tags.some(tag => tag.startsWith('entrypoint.')), 'expected no entrypoint tags')
+        })
+
+        it('should refresh the DogStatsD client tags when the identity-refresh channel fires', () => {
+          config.tags['runtime-id'] = 'initial-id'
+          config.runtimeMetricsRuntimeId = true
+          runtimeMetrics.stop()
+          runtimeMetrics.start(config)
+          client.updateTags.resetHistory()
+
+          // Simulates `proxy.js#refreshIdentity` mutating `config.tags['runtime-id']` in place
+          // and then publishing to the shared identity-refresh channel (MicroVM clone resume).
+          config.tags['runtime-id'] = 'refreshed-id'
+          identityRefreshChannel.publish(config)
+
+          sinon.assert.calledOnce(client.updateTags)
+          const tags = client.updateTags.lastCall.args[0]
+          assert.ok(tags.includes('runtime-id:refreshed-id'), `expected tags to include refreshed-id: ${tags}`)
+        })
+
+        it('should stop reacting to identity refresh after stop', () => {
+          runtimeMetrics.stop()
+          client.updateTags.resetHistory()
+
+          identityRefreshChannel.publish(config)
+
+          sinon.assert.notCalled(client.updateTags)
         })
 
         it('should start collecting runtimeMetrics every 10 seconds', async () => {
@@ -1084,6 +1115,7 @@ FakePerformanceObserverForOtlp.instances = []
  *   batchCallbacks: Array<{ cb: Function, observables: object[] }>,
  *   fireBatchCallbacks: () => Map<object, Array<{ v: number, a: object }>>,
  *   fakeMetricsClient: object,
+ *   identityRefreshCalls: Array<{ client: object, config: object, unsubscribe: Function }>,
  * }}
  */
 function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
@@ -1092,6 +1124,7 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
   const records = {}
   const batchCallbacks = []
   const statsdCalls = []
+  const identityRefreshCalls = []
   FakePerformanceObserverForOtlp.instances = []
 
   function makeFactory (type) {
@@ -1159,6 +1192,11 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
     },
     './client': {
       createMetricsClient: () => fakeMetricsClient,
+      subscribeToIdentityRefresh: (client, config) => {
+        const unsubscribe = sinon.spy()
+        identityRefreshCalls.push({ client, config, unsubscribe })
+        return unsubscribe
+      },
     },
   })
 
@@ -1186,6 +1224,7 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
     fireBatchCallbacks,
     fakeMetricsClient,
     statsdCalls,
+    identityRefreshCalls,
   }
 }
 
@@ -1461,6 +1500,7 @@ describe('otlp_runtime_metrics', () => {
       '../log': { debug () {}, error: errorLog },
       './client': {
         createMetricsClient: () => ({ flush () {} }),
+        subscribeToIdentityRefresh: () => () => {},
       },
     })
     const dispatcher = proxyquire.noCallThru()('../src/runtime_metrics', {
@@ -1515,6 +1555,22 @@ describe('otlp_runtime_metrics', () => {
     otlpMetrics.start({ runtimeMetrics: { eventLoop: true } })
     assert.strictEqual(Object.keys(createdInstruments).length, Object.keys(SPEC).length,
       'should register every metric again after stop')
+  })
+
+  it('subscribes the DogStatsD client to identity refresh on start and unsubscribes on stop', () => {
+    const ctx = loadOtlpRuntimeMetricsTestModule()
+    const config = { runtimeMetrics: { eventLoop: true } }
+
+    ctx.otlpMetrics.start(config)
+
+    assert.strictEqual(ctx.identityRefreshCalls.length, 1)
+    assert.strictEqual(ctx.identityRefreshCalls[0].client, ctx.fakeMetricsClient)
+    assert.strictEqual(ctx.identityRefreshCalls[0].config, config)
+    sinon.assert.notCalled(ctx.identityRefreshCalls[0].unsubscribe)
+
+    ctx.otlpMetrics.stop()
+
+    sinon.assert.calledOnce(ctx.identityRefreshCalls[0].unsubscribe)
   })
 })
 

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -3,11 +3,13 @@
 const assert = require('node:assert/strict')
 const { hostname } = require('os')
 
+const { channel } = require('dc-polyfill')
 const { describe, it } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
 require('./setup/core')
+
 const { LogCollapsingLowestDenseDDSketch } = require('../../../vendor/dist/@datadog/sketches-js')
 const { version } = require('../src/pkg')
 const pkg = require('../../../package.json')
@@ -27,6 +29,7 @@ const {
   DEFAULT_SERVICE_NAME,
 } = require('../src/encode/tags-processors')
 const processTags = require('../src/process-tags')
+const { getConfigFresh } = require('./helpers/config')
 
 // Mock spans use the post-format field name `start` (nanoseconds), matching
 // what `SpanProcessor.process` hands to `onSpanFinished` via the formatted
@@ -446,7 +449,6 @@ describe('SpanStatsProcessor', () => {
     assert.strictEqual(processor.hostname, hostname())
     assert.strictEqual(processor.enabled, config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED)
     assert.strictEqual(processor.env, config.env)
-    assert.deepStrictEqual(processor.tags, config.tags)
     assert.strictEqual(processor.version, config.version)
   })
 
@@ -559,10 +561,29 @@ describe('SpanStatsProcessor', () => {
       }],
       Lang: 'javascript',
       TracerVersion: pkg.version,
-      RuntimeID: processor.tags['runtime-id'],
+      RuntimeID: config.tags['runtime-id'],
       Sequence: processor.sequence,
       ProcessTags: processTags.serialized,
     })
+  })
+
+  it('should export the current runtime ID after remote config replaces tags', () => {
+    const config = getConfigFresh({ stats: true })
+    const processor = new SpanStatsProcessor(config)
+    clearTimeout(processor.timer)
+    const originalTags = config.tags
+    const originalRuntimeId = originalTags['runtime-id']
+
+    processor.onInterval()
+    assert.strictEqual(exporter.export.lastCall.args[0].RuntimeID, originalRuntimeId)
+
+    config.setRemoteConfig({ tags: { team: 'backend' } })
+    assert.notStrictEqual(config.tags, originalTags)
+    channel('datadog:identity:update').publish(config)
+    processor.onInterval()
+
+    assert.notStrictEqual(config.tags['runtime-id'], originalRuntimeId)
+    assert.strictEqual(exporter.export.lastCall.args[0].RuntimeID, config.tags['runtime-id'])
   })
 
   it('should export on interval with default version', () => {
@@ -578,7 +599,7 @@ describe('SpanStatsProcessor', () => {
       Stats: [],
       Lang: 'javascript',
       TracerVersion: pkg.version,
-      RuntimeID: processor.tags['runtime-id'],
+      RuntimeID: versionlessConfig.tags['runtime-id'],
       Sequence: processor.sequence,
       ProcessTags: processTags.serialized,
     })

--- a/packages/dd-trace/test/telemetry/session-propagation.spec.js
+++ b/packages/dd-trace/test/telemetry/session-propagation.spec.js
@@ -228,6 +228,21 @@ describe('session-propagation', () => {
       ])
     })
 
+    it('reflects a runtime id updated on config after start (e.g. MicroVM identity refresh)', () => {
+      const config = createConfig()
+      sessionPropagation.start(config)
+
+      config.tags['runtime-id'] = 'refreshed-id'
+
+      const context = publishStart({ callArgs: ['node', ['test.js'], {}], shell: false })
+
+      assert.deepStrictEqual(context.callArgs, [
+        'node',
+        ['test.js'],
+        { env: createExpectedEnv({ DD_ROOT_JS_SESSION_ID: 'refreshed-id' }) },
+      ])
+    })
+
     it('ignores execution contexts without call arguments', () => {
       sessionPropagation.start(createConfig())
 

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -560,4 +560,21 @@ describe('Tracer', () => {
         'expected service discovery warning to be emitted at log level warn')
     })
   })
+
+  describe('MicroVM service discovery metadata', () => {
+    it('should defer storing metadata while a MicroVM image is being built', () => {
+      const storeConfig = sinon.stub()
+      const PatchedTracer = proxyquire('../src/tracer', {
+        './serverless': {
+          IS_SERVERLESS: true,
+        },
+        './tracer_metadata': storeConfig,
+      })
+
+      // eslint-disable-next-line no-new
+      new PatchedTracer(getConfig({ service: 'service' }))
+
+      sinon.assert.notCalled(storeConfig)
+    })
+  })
 })


### PR DESCRIPTION
…VM clone resume

Firecracker snapshots a process's full memory — including OpenSSL's DRBG
state, the id.js batch buffer and its cursor, and the uuid() call's
internal buffer. Every clone that resumes from the same snapshot starts
from the identical PRNG state, so all clones produce the same trace/span
IDs, runtime-id, and RC client ID until those states happen to diverge.

Root cause: three independent entropy consumers are all frozen in the snapshot:
  1. id.js pseudoRandom() — batch-fills 8192 IDs from randomFillSync (OpenSSL DRBG)
  2. runtimeId in config/index.js — uuid() at module load (OpenSSL DRBG)
  3. clientId in remote_config/index.js — uuid() at module load (OpenSSL DRBG)