### PR TITLE
fix(msgpack): omit undefined map entries

### DIFF
--- a/packages/dd-trace/src/msgpack/index.js
+++ b/packages/dd-trace/src/msgpack/index.js
@@ -88,12 +88,18 @@ function writeArray (bytes, value) {
  */
 function writeMap (bytes, value) {
   const keys = Object.keys(value)
+  let size = keys.length
+  for (const key of keys) {
+    if (value[key] === undefined) size--
+  }
 
-  bytes.writeMapPrefix(keys.length)
+  bytes.writeMapPrefix(size)
 
   for (const key of keys) {
+    const item = value[key]
+    if (item === undefined) continue
     bytes.write(key)
-    writeValue(bytes, value[key])
+    writeValue(bytes, item)
   }
 }
 

--- a/packages/dd-trace/test/msgpack/encode.spec.js
+++ b/packages/dd-trace/test/msgpack/encode.spec.js
@@ -107,15 +107,16 @@ describe('msgpack/encode', () => {
     assert.strictEqual(msgpack.decode(buffer), 'Symbol(pipeline)')
   })
 
-  it('falls back to msgpack null for unsupported value types (functions, undefined)', () => {
-    // `typeof undefined === 'undefined'` and `typeof () => {} === 'function'`
-    // both hit the dispatcher's `default` arm. Encoding them as `nil` keeps
-    // the surrounding payload well-formed instead of letting the chunk
-    // emit zero bytes for the value, which would desync the map header
-    // count from the actual entries.
-    const buffer = encode({ fn: () => {}, missing: undefined })
+  it('omits undefined-valued keys and falls back to null for other unsupported types (functions)', () => {
+    // msgpack has no `undefined`; encoding it as `nil` would diverge from JSON
+    // semantics and from the legacy v0.4 encoder (which omits such keys), and
+    // it corrupts meta_struct payloads such as AppSec's truncated request body
+    // where a dropped child is left as an `undefined`-valued key. So undefined
+    // keys are omitted (with the map header counting only the kept entries),
+    // while a function still falls back to `nil` rather than emitting nothing.
+    const buffer = encode({ fn: () => {}, missing: undefined, kept: 1 })
 
-    assert.deepStrictEqual(msgpack.decode(buffer), { fn: null, missing: null })
+    assert.deepStrictEqual(msgpack.decode(buffer), { fn: null, kept: 1 })
   })
 
   it('emits an array32 header for arrays with 16 or more entries', () => {


### PR DESCRIPTION
## What does this PR do?

Omits object keys whose value is `undefined` from the shared msgpack encoder. Msgpack has no `undefined` value; encoding it as `nil` changes the semantic value from absent to explicit `null`.

The map prefix is computed without allocating a filtered keys array. Other unsupported values, such as functions, continue to encode as `nil`.

## Motivation

Structured payloads can retain an `undefined`-valued property after a child is intentionally dropped. The current encoder turns that into `null`, diverging from JSON and the v0.4 trace encoder and changing the payload observed by the backend.

## Verification

- `./node_modules/.bin/mocha packages/dd-trace/test/msgpack/encode.spec.js` — 6 passing
- ESLint on changed files — clean
- two fresh microbenchmark runs, 1s warmup and 5 trials each:
  - all-defined maps: count-and-skip was 8.9% and 10.4% faster than `filter`
  - maps with undefined values: count-and-skip was 4.9% and 1.4% slower

All-defined maps are the common path; count-and-skip also avoids the extra filtered-array allocation.