### PR TITLE
feat(openfeature): hash targeting_key and omit context in flagevaluations by default

### DIFF
--- a/docs/superpowers/plans/2026-08-06-pii-flagevaluations-js.md
+++ b/docs/superpowers/plans/2026-08-06-pii-flagevaluations-js.md
@@ -1,0 +1,365 @@
+# Implementation plan — PII hashing in dd-trace-js flagevaluations
+
+- Spec: `docs/superpowers/specs/2026-08-06-pii-flagevaluations-js-design.md`
+- Jira: FFL-2965
+- Branch: `vickie/ffl-2965-protecting-pii-in-js-flagevaluations-track` (stacked on
+  `leo.romanovsky/ffl-2446-evp-flagevaluation-nodejs`)
+
+## Verification loop between steps
+
+After each step: (1) `npm run lint` on changed files, (2) run the affected
+`*.spec.js` files directly with `./node_modules/.bin/mocha`, (3) confirm no
+untouched suites regressed. Never claim a step complete without running its
+tests.
+
+## Step 1 — UFC parse: accept `observeFullEvaluationData` at the root
+
+**Goal:** parse the new UFC field from both agentless and Remote Config
+delivery paths, fail closed on absence, wrong type, and nested placement.
+
+**Files:**
+
+- `packages/dd-trace/src/openfeature/agentless_configuration_source.js`
+  - In `parseConfiguration`, after the existing `attributes.format` /
+    `attributes.environment.name` / `attributes.flags` validation, coerce
+    `attributes.observeFullEvaluationData` with `=== true`. Any other value —
+    including `undefined`, `null`, `"true"`, `1`, `[]`, `{}` — becomes `false`.
+    Assign the coerced boolean back onto `attributes` so downstream consumers
+    see a strict boolean, never `undefined`.
+- `packages/dd-trace/src/openfeature/remote_config.js`
+  - Apply the same coercion where the RC-delivered configuration is handed to
+    `setConfiguration`. If both paths already funnel through one point, add the
+    coercion there; otherwise add a small shared helper in a new file
+    `packages/dd-trace/src/openfeature/ufc_consent.js` exporting
+    `coerceObserveFullEvaluationData(attributes)`.
+
+**Tests:**
+
+- `packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js`
+  - `it('parses observeFullEvaluationData=true at the UFC root')`
+  - `it('defaults observeFullEvaluationData to false when absent')`
+  - `it('treats explicit null as false')`
+  - Parametric `it(\`treats \${value} as false\`)` over
+    `[1, 0, 'true', 'false', [], {}]`.
+  - `it('ignores observeFullEvaluationData nested inside environment')` — the
+    FFL-2784 placement-drift guard. Construct a UFC with
+    `attributes.environment.observeFullEvaluationData = true` and the root
+    field absent; assert the resulting object's root
+    `observeFullEvaluationData` is `false`.
+- `packages/dd-trace/test/openfeature/remote_config.spec.js`
+  - Mirror the root-parse and placement-drift tests for the RC path.
+
+**Verification:**
+
+```bash
+./node_modules/.bin/mocha \
+  packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js \
+  packages/dd-trace/test/openfeature/remote_config.spec.js
+```
+
+## Step 2 — Static `hashTargetingKey` on FlagEvaluationsWriter
+
+**Goal:** ship the cross-SDK hash contract as a static method next to its only
+consumer, pinned by the canonical vector and the non-normalization tests.
+
+**Files:**
+
+- `packages/dd-trace/src/openfeature/writers/flag_evaluations.js`
+  - Add `const { createHash } = require('node:crypto')` at the top of the
+    file, in the third import group (per AGENTS.md import ordering).
+  - Add a static method on `FlagEvaluationsWriter`:
+    ```js
+    static hashTargetingKey (value) {
+      return 'sha256_' + createHash('sha256').update(value, 'utf8').digest('hex')
+    }
+    ```
+    JSDoc: `@param {string} value @returns {string}`. Note the hash contract:
+    unsalted, no normalization, lowercase hex, `sha256_` prefix, 71 chars.
+
+**Tests:**
+
+- New file
+  `packages/dd-trace/test/openfeature/writers/hash_targeting_key.spec.js`:
+  - `it('matches the cross-SDK canonical vector')` —
+    `hashTargetingKey('jane.doe@datadoghq.com')` must equal
+    `'sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b'`.
+  - `it('produces a 71-char output')`.
+  - `it('does not trim whitespace')` — `' jane '` and `'jane'` yield distinct
+    digests.
+  - `it('does not case-fold')` — `'Jane'` and `'jane'` yield distinct digests.
+  - `it('does not Unicode-normalize')` — NFC-composed and NFD-decomposed
+    variants of the same visible string yield distinct digests. Write both
+    variants with explicit `\u` escapes so editor auto-normalization cannot
+    collapse them.
+  - `it('hashes empty string to the SHA-256 empty digest')` —
+    `hashTargetingKey('')` equals
+    `'sha256_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'`.
+
+**Verification:**
+
+```bash
+./node_modules/.bin/mocha packages/dd-trace/test/openfeature/writers/hash_targeting_key.spec.js
+```
+
+## Step 3 — Atomic snapshot on FlaggingProvider
+
+**Goal:** expose `{ configuration, observeFullEvaluationData }` as one
+immutable reference the hook can read atomically.
+
+**Files:**
+
+- `packages/dd-trace/src/openfeature/flagging_provider.js`
+  - Add a `#snapshot` private field, initialised to
+    `Object.freeze({ configuration: undefined, observeFullEvaluationData: false })`.
+  - Override `setConfiguration(configuration)`:
+    ```js
+    setConfiguration (configuration) {
+      super.setConfiguration(configuration)
+      this.#snapshot = Object.freeze({
+        configuration,
+        observeFullEvaluationData: configuration?.observeFullEvaluationData === true,
+      })
+    }
+    ```
+  - Add a private `#getConsent = () => this.#snapshot.observeFullEvaluationData`
+    binding. **Do not expose a public getter** — the arrow function is passed
+    to the EVP hook constructor and nowhere else. This is the "delete the
+    accessor" defense from the Java pilot: no external reader can bypass the
+    intended path.
+  - Update the `FlagEvalEVPHook` construction line to pass `this.#getConsent`:
+    ```js
+    this.hooks.push(new FlagEvalEVPHook(this.#flagEvalEVPWriter, this.#getConsent))
+    ```
+
+**Tests:**
+
+- `packages/dd-trace/test/openfeature/flagging_provider.spec.js`
+  - `it('starts with observeFullEvaluationData=false before any configuration')` —
+    construct provider, no `setConfiguration` call, evaluate through the mocked
+    upstream base, assert the writer received `observeFullEvaluationData: false`.
+  - `it('reflects setConfiguration atomically in subsequent evaluations')` —
+    call `setConfiguration({ ..., observeFullEvaluationData: true })`, evaluate,
+    assert writer sees `true`. Then call `setConfiguration` again with `false`,
+    evaluate again, assert writer sees `false`.
+  - `it('freezes the snapshot so external code cannot mutate consent')` — grab
+    a reference to the snapshot (via a test-only escape hatch or by evaluating
+    once and reading what the writer received) and assert
+    `Object.isFrozen(snapshot)` where applicable.
+
+**Verification:**
+
+```bash
+./node_modules/.bin/mocha packages/dd-trace/test/openfeature/flagging_provider.spec.js
+```
+
+## Step 4 — FlagEvalEVPHook: consent read, context-capture skip, event field
+
+**Goal:** the hook takes consent once at `finally` entry, drops context capture
+entirely when consent is off, and passes the strict boolean to the writer.
+
+**Files:**
+
+- `packages/dd-trace/src/openfeature/writers/flag_eval_evp_hook.js`
+  - Constructor takes a second argument, `getConsent: () => boolean`. Store on
+    `this._getConsent`. Default to `() => false` when absent (fail-closed on
+    tests that construct the hook directly).
+  - In `finally`:
+    - `const consent = this._getConsent()`.
+    - `const attrs = consent ? (hookContext.context ?? {}) : {}` — this is the
+      "consent-off skip context capture on the hot path" optimization from the
+      Java pilot's `concern:consent-off-bucket-keying` lesson.
+    - Pass `observeFullEvaluationData: consent` in the `enqueue` payload.
+
+**Tests:**
+
+- `packages/dd-trace/test/openfeature/writers/flag_eval_evp_hook.spec.js`
+  - `it('reads consent from getConsent at hook entry')` — spy on `getConsent`,
+    assert called once per `finally`.
+  - `it('passes observeFullEvaluationData=false to the writer when consent is off')`.
+  - `it('passes observeFullEvaluationData=true to the writer when consent is on')`.
+  - `it('skips context capture when consent is off')` — construct a
+    `hookContext.context` with populated attributes; assert the writer
+    received `attrs === {}`, and specifically that the writer did not see any
+    of those attribute values.
+  - `it('captures context normally when consent is on')`.
+  - `it('fails closed when getConsent is not provided')` — construct the hook
+    with only the writer argument; assert the writer receives
+    `observeFullEvaluationData: false`.
+
+**Verification:**
+
+```bash
+./node_modules/.bin/mocha packages/dd-trace/test/openfeature/writers/flag_eval_evp_hook.spec.js
+```
+
+## Step 5 — FlagEvaluationsWriter: consent in bucket key, hash at flush
+
+**Goal:** wire consent through aggregation and serialization. Raw targeting key
+stays on the in-memory entry through aggregation; the hash is applied only in
+`_drainFlagEvaluations` when consent is off, once per unique bucket.
+
+**Files:**
+
+- `packages/dd-trace/src/openfeature/writers/flag_evaluations.js`
+  - Extend `FlagEvalRawEvent` typedef with
+    `observeFullEvaluationData: boolean`.
+  - Extend `FullEntry` and `DegradedEntry` typedefs with
+    `observeFullEvaluationData: boolean`.
+  - Update `makeFullKey` and `makeDegradedKey` to take `consent` as the first
+    argument. Consent leads the NUL-delimited string as `'1'` or `'0'`.
+  - In `enqueue`:
+    - Push `observeFullEvaluationData: event.observeFullEvaluationData === true`
+      onto the raw queue (strict coercion for defense in depth).
+    - When consent is `false`, skip `pruneContext(event.attrs || {})` entirely
+      and store `attrs: {}` on the raw event. `contextFitsWithoutFlattening`
+      already handles the empty case cheaply, but this saves the call itself.
+  - In `_aggregate`:
+    - Read `consent = event.observeFullEvaluationData`.
+    - Pass `consent` to `makeFullKey` / `makeDegradedKey`.
+    - When updating an existing entry, AND-fold consent:
+      `existing.observeFullEvaluationData = existing.observeFullEvaluationData && consent`.
+      (In practice a no-op because the key partitions by consent; a defense in
+      depth against a future key drift.)
+    - On new-entry creation, store `observeFullEvaluationData: consent`.
+  - In `_drainFlagEvaluations`:
+    - When writing the full-tier `ev.targeting_key`:
+      ```js
+      if (entry.targetingKey) {
+        ev.targeting_key = entry.observeFullEvaluationData
+          ? entry.targetingKey
+          : FlagEvaluationsWriter.hashTargetingKey(entry.targetingKey)
+      }
+      ```
+    - Leave the `entry.contextAttrs !== null` branch as-is; when consent is off,
+      `contextAttrs` is null by construction (the hook passed empty attrs, so
+      `hasOwnKey(attrs)` was false in `_aggregate`).
+    - Degraded tier already emits no targeting_key or context — no change.
+
+**Tests:**
+
+- `packages/dd-trace/test/openfeature/writers/flag_evaluations.spec.js`
+  Add a new `describe('observeFullEvaluationData', ...)` block:
+  - `it('hashes targeting_key when observeFullEvaluationData is false')` —
+    enqueue one event with consent off and a known targeting key; flush; assert
+    the payload's event has `targeting_key` equal to the canonical hash.
+  - `it('preserves raw targeting_key when observeFullEvaluationData is true')`.
+  - `it('omits context when observeFullEvaluationData is false')` — enqueue
+    with populated attrs and consent off; assert flushed event has no
+    `context` property.
+  - `it('includes pruned context when observeFullEvaluationData is true')`.
+  - `it('separates buckets by consent value')` — two enqueues with same subject
+    but different consent; flush; assert two events with distinct
+    `targeting_key` values (one hashed, one raw).
+  - `it('merges consent-off events across distinct contexts into one bucket')` —
+    regression guard for `concern:consent-off-bucket-keying`. Two enqueues with
+    consent off, same subject, different attrs; assert one flushed event with
+    `evaluation_count: 2`.
+  - `it('keeps consent-on events with distinct contexts distinct')`.
+  - `it('AND-folds consent as defense in depth')` — construct an event stream
+    that would produce a key collision without consent in the key (needs a
+    test-only override to `makeFullKey`), assert the resulting entry has
+    `observeFullEvaluationData === false` even if one of the inputs was `true`.
+  - `it('hashes at flush cadence, not per evaluation')` — spy on
+    `createHash` (via a `sinon.stub` on the crypto module through
+    proxyquire, or via `sinon.spy(FlagEvaluationsWriter, 'hashTargetingKey')`).
+    Enqueue N events sharing one bucket; flush; assert exactly 1 hash call.
+  - `it('does not leak the raw targeting key in the payload bytes when consent is off')` —
+    the raw-wire negative control. Enqueue with consent off; capture the
+    serialized payload string (intercept `_sendPayload`); assert
+    `!payload.includes(rawTargetingKey)` and
+    `!payload.includes(anyPiiAttributeValue)`.
+  - `it('emits nothing raw in the degraded tier under either consent')`.
+
+**Verification:**
+
+```bash
+./node_modules/.bin/mocha packages/dd-trace/test/openfeature/writers/flag_evaluations.spec.js
+```
+
+## Step 6 — End-to-end and lifecycle guards
+
+**Goal:** prove that `setConfiguration` flows through to the writer, and that a
+consent swap between evaluate and flush cannot retroactively change the emitted
+data.
+
+**Files:**
+
+- `packages/dd-trace/test/openfeature/flagging_provider.spec.js`
+  - `it('flows setConfiguration observeFullEvaluationData=false through to hashed targeting_key on the wire')` —
+    full stack, mocked upstream base and mocked EVP transport. Assert the sent
+    payload has a `sha256_`-prefixed `targeting_key` and no `context`.
+  - `it('flows setConfiguration observeFullEvaluationData=true through to raw targeting_key on the wire')`.
+  - **Consent-lifecycle guard, off→on.** Set consent off → evaluate a flag →
+    swap to consent on via a second `setConfiguration` → flush → assert the
+    flushed event still shows the hashed targeting key (the evaluation-time
+    consent), not the post-swap raw value. This is the single most important
+    regression test in this PR.
+  - **Consent-lifecycle guard, on→off.** Symmetric. Evaluate under consent on,
+    swap to off, flush; assert the flushed event carries the raw targeting key
+    (and included context), not a hashed one.
+  - `it('is unaffected by DoLog for each consent value')` — for each of
+    `{consent: true, doLog: true}`, `{consent: true, doLog: false}`,
+    `{consent: false, doLog: true}`, `{consent: false, doLog: false}`, assert
+    the flushed-event JSON is stable across the `doLog` values within each
+    consent value.
+  - `it('does not construct the writer or EVP hook when DD_FLAGGING_EVALUATION_COUNTS_ENABLED is false')` —
+    kill-switch precedence. Assert `provider.hooks` has no `FlagEvalEVPHook`
+    even when `observeFullEvaluationData: true`.
+
+**Verification:**
+
+```bash
+./node_modules/.bin/mocha packages/dd-trace/test/openfeature/flagging_provider.spec.js
+```
+
+Then run the entire OpenFeature test surface to catch regressions in adjacent
+suites:
+
+```bash
+./node_modules/.bin/mocha 'packages/dd-trace/test/openfeature/**/*.spec.js'
+```
+
+## Step 7 — Lint, coverage, and final validation
+
+- `npm run lint` on all changed files.
+- Scoped coverage on the touched paths:
+  ```bash
+  ./node_modules/.bin/nyc \
+    --include "packages/dd-trace/src/openfeature/writers/flag_evaluations.js" \
+    --include "packages/dd-trace/src/openfeature/writers/flag_eval_evp_hook.js" \
+    --include "packages/dd-trace/src/openfeature/flagging_provider.js" \
+    --include "packages/dd-trace/src/openfeature/agentless_configuration_source.js" \
+    --include "packages/dd-trace/src/openfeature/remote_config.js" \
+    ./node_modules/.bin/mocha 'packages/dd-trace/test/openfeature/**/*.spec.js'
+  ```
+  Confirm the new consent branches (bucket-key consent split, hash-at-flush,
+  context-capture skip, snapshot atomicity, UFC placement guard) are covered.
+- **Type check.** JSDoc changes must pass whatever TypeScript pass the repo
+  runs on JSDoc. If the repo has an `npm run type-check` or equivalent, run it.
+- **Do NOT** run `npm test` at the repo root — it's intentionally disabled per
+  AGENTS.md.
+
+## PR body checklist
+
+The PR description should mirror Python #19554's structure and cite:
+
+- RFC (`rfc:gdoc:19VIf4B9p-zsAL2uWSvdzil59DZlGjQm4yudAMwJBqLs`).
+- Java pilot #12042, Go peer #5151, Python peer #19554.
+- Jira FFL-2965 under FFL-2784.
+- Explicit note that the base branch is
+  `leo.romanovsky/ffl-2446-evp-flagevaluation-nodejs`, not `master`, and why.
+- Explicit note that this must merge into the base track before the base track
+  merges to master so no JS release ships raw `targeting_key` by default.
+- The wire-shape truth table (from the spec).
+- Cross-SDK canonical vector.
+- Test summary: counts, and specifically call out the consent-lifecycle guard
+  and the raw-wire negative control.
+- Explicit "system-tests L3 is out of scope" note, with the tracked follow-up.
+- Label: `semver-minor` (this is a new feature: the `observeFullEvaluationData`
+  UFC read plus the hash-by-default wire shape).
+
+## Commit strategy
+
+One commit per step, `feat(openfeature):` for new-behavior commits and
+`test(openfeature):` for pure-test additions. Java-pilot conventional-commit
+style. Every commit ends with the required Claude attribution.

--- a/docs/superpowers/specs/2026-08-06-pii-flagevaluations-js-design.md
+++ b/docs/superpowers/specs/2026-08-06-pii-flagevaluations-js-design.md
@@ -1,0 +1,368 @@
+# Protecting PII in flagevaluations EVP track — dd-trace-js
+
+- Status: draft
+- Owner: Vickie Boettcher (FFE)
+- Jira: FFL-2965 (fan-out under FFL-2784, umbrella FFL-2780)
+- Contract: `rfc:gdoc:19VIf4B9p-zsAL2uWSvdzil59DZlGjQm4yudAMwJBqLs`
+  (`references/sources/rfcs/ffe/2026-07-15-protecting-pii-flagevaluations-evp.md`)
+- Reference implementations:
+  - Java pilot: [dd-trace-java#12042](https://github.com/DataDog/dd-trace-java/pull/12042)
+  - Go: [dd-trace-go#5151](https://github.com/DataDog/dd-trace-go/pull/5151)
+  - Python: [dd-trace-py#19554](https://github.com/DataDog/dd-trace-py/pull/19554)
+- Branch: `vickie/ffl-2965-protecting-pii-in-js-flagevaluations-track`
+- Base branch: `leo.romanovsky/ffl-2446-evp-flagevaluation-nodejs` (stacked, not `master`)
+
+## Problem
+
+Server SDKs upgrading to the EVP `flagevaluation` track today would ship raw
+subject identifiers (targeting keys — often user emails, org IDs, or service
+names) and full evaluation context to Datadog by default. This contradicts
+Datadog's marketing that server-side flag evaluations happen locally and
+introduces a silent-PII regression on upgrade.
+
+The RFC changes the wire contract so that, by default, `targeting_key` is a
+one-way SHA-256 fingerprint (`sha256_`-prefixed, 71 chars total) and
+`context.evaluation` is omitted entirely. A single environment-scoped UFC
+boolean `observeFullEvaluationData` selects the wire shape. Every SDK must
+produce byte-identical digests for the same subject so per-(flag, allocation)
+unique-subject counts still resolve across languages.
+
+`dd-trace-js` has not yet shipped the base EVP `flagevaluation` track (FFL-2446).
+The cluster README calls out that JS should fold the PII contract into the base
+track or ship it stacked directly ahead of the base merge — never after — so
+customers never receive a raw-PII default.
+
+## Contract
+
+| Server says `observeFullEvaluationData` | `targeting_key` on the wire | `context.evaluation` on the wire |
+| --- | --- | --- |
+| `true` | raw, verbatim | present, pruned |
+| `false`, absent, or any non-`true` value (the default) | `sha256_` + 64-char lowercase hex (71 chars) | absent |
+
+- **Hash spec:** unsalted SHA-256 over the raw UTF-8 bytes of the targeting key
+  as received. No trim, no case fold, no Unicode normalization. Lowercase hex.
+  Literal `sha256_` prefix. 71 chars total.
+- **Canonical vector (must match across every SDK):**
+  `"jane.doe@datadoghq.com"` →
+  `sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b`.
+- **Empty targeting key:** the field is already omitted when empty; hashing
+  applies only to non-empty values. No `sha256_` emitted for absent subjects.
+- **UFC placement:** `observeFullEvaluationData` is at the **root** of the UFC,
+  a sibling of `environment`, not nested inside it. A value nested inside
+  `environment` is ignored (fail-closed).
+- **Fail-closed:** absent, explicit JSON `null`, and any non-boolean value all
+  resolve to `false`. Only strict `=== true` grants opt-in.
+- **Kill switch:** `DD_FLAGGING_EVALUATION_COUNTS_ENABLED=false` continues to
+  disable the entire EVP `flagevaluation` track (writer and hook are not
+  constructed). Kill switch always wins over UFC.
+- **`DoLog` does not gate PII behavior.** The RFC explicitly forbids it; a
+  regression test asserts the flushed-event bytes are identical across
+  `doLog ∈ {true, false}` for each consent value.
+- **Cross-SDK evaluation-metadata key:** `observe_full_evaluation_data`
+  (unprefixed, snake_case) — the pilot-settled contract. Only used internally
+  in JS (not surfaced through OpenFeature `flagMetadata` yet, see "Design
+  Decisions" below).
+
+## Where consent lives (the portable design)
+
+The Java pilot established the contract every SDK must follow:
+
+> Consent must travel with the evaluation, not be looked up later.
+
+Any read of mutable global config after evaluation is a PII bug in both
+directions — consent-off traffic can be emitted raw if consent flipped on
+between evaluation and flush, and consent-on traffic can be needlessly hashed if
+it flipped off. Both directions must have regression tests.
+
+In JS, the evaluator lives upstream in `@datadog/openfeature-node-server`
+(v2.0.2 today). It does not yet stamp `observe_full_evaluation_data` into
+`ProviderEvaluation.flagMetadata`. The design must therefore snapshot consent at
+a boundary this repo controls.
+
+**The chosen boundary is `FlagEvalEVPHook.finally`.** OpenFeature `finally`
+hooks run synchronously on the same call stack as the evaluation, before the
+next await point returns to the caller. Reading consent once at hook entry —
+from an atomic snapshot the provider maintains — gives the same lifecycle
+guarantee as stamping metadata in the evaluator would: no Remote Config update
+can interleave between the evaluation and the consent read.
+
+A future refactor can move the consent stamp into the upstream evaluator (so
+the hook reads `evaluationDetails.flagMetadata.observe_full_evaluation_data`
+directly). The hook is the compatibility shim for today; when the evaluator
+starts stamping, the hook flips to reading metadata and the provider's
+`getConsent` accessor is deleted.
+
+## Atomic snapshot
+
+The provider stores UFC and consent as a single immutable object reference:
+
+```js
+this._snapshot = Object.freeze({
+  configuration,
+  observeFullEvaluationData: configuration?.observeFullEvaluationData === true,
+})
+```
+
+`setConfiguration` on the FlaggingProvider does two things atomically from the
+outside: (1) forwards the configuration to the upstream base, (2) replaces the
+snapshot reference. A single field read (`this._snapshot`) returns a paired
+`{ configuration, observeFullEvaluationData }` — no torn read is possible.
+
+This mirrors Python's `_FfeSnapshot: NamedTuple` and Go's atomic pointer swap
+of a struct value.
+
+## Components
+
+### `hashTargetingKey` — static method on `FlagEvaluationsWriter`
+
+```js
+static hashTargetingKey (value) {
+  return 'sha256_' + createHash('sha256').update(value, 'utf8').digest('hex')
+}
+```
+
+- Uses `node:crypto` (`createHash` cached at module load).
+- Called at **flush cadence**, once per unique full-tier bucket where
+  `observeFullEvaluationData === false`. Never per evaluation. This is a
+  meaningful perf choice: N evaluations sharing one targeting key collapse
+  into 1 bucket and 1 hash call, not N.
+- Canonical vector pinned in a unit test named
+  `it('matches the cross-SDK canonical vector')`.
+- Non-normalization guarded by parametric tests (whitespace, case, NFC vs NFD).
+
+### UFC parse — `parseConfiguration` in `agentless_configuration_source.js`
+
+`parseConfiguration` and its RC counterpart share one helper:
+
+```js
+function readObserveFullEvaluationData (attributes) {
+  return attributes?.observeFullEvaluationData === true
+}
+```
+
+Applied at the top level only. A nested `environment.observeFullEvaluationData`
+is silently ignored (a unit test guards this — this is the FFL-2784 placement
+drift point).
+
+### FlaggingProvider — atomic snapshot
+
+- Adds `_snapshot` field, initialised to
+  `{ configuration: undefined, observeFullEvaluationData: false }`.
+- Wraps `setConfiguration(conf)`:
+  1. `super.setConfiguration(conf)`
+  2. `this._snapshot = Object.freeze({ configuration: conf, observeFullEvaluationData: conf?.observeFullEvaluationData === true })`
+- Passes a `getSnapshot()` binding to `FlagEvalEVPHook` at construction, not a
+  public accessor on the provider. This keeps the consent read a
+  constructor-scoped dependency injection — external code cannot reach in.
+
+### FlagEvalEVPHook — reads consent, conditionally captures context
+
+```js
+finally (hookContext, evaluationDetails) {
+  const consent = this._getConsent()  // strict boolean
+  const flagKey = hookContext.flagKey
+  const variant = evaluationDetails.variant ?? ''
+  const flagMetadata = evaluationDetails.flagMetadata
+  const allocationKey = flagMetadata?.allocationKey ?? ''
+  const targetingKey = hookContext.context?.targetingKey ?? ''
+  const evalTimeMs = flagMetadata?.['dd.eval.timestamp_ms'] ?? Date.now()
+  const errorMessage = evaluationDetails.errorMessage ?? evaluationDetails.errorCode ?? ''
+
+  // Consent-off: skip capturing context entirely. The writer must not receive
+  // attrs it will later discard — that would silently push privacy-protected
+  // traffic through pruneContext for no downstream use.
+  const attrs = consent ? (hookContext.context ?? {}) : {}
+
+  this._writer.enqueue({
+    flagKey, variant, allocationKey, targetingKey,
+    errorMessage, evalTimeMs, attrs,
+    observeFullEvaluationData: consent,
+  })
+}
+```
+
+Fail-closed everywhere: `_getConsent` returns strict boolean; `attrs = {}` when
+consent is off; the writer defaults `observeFullEvaluationData` to `false` on
+absence too.
+
+### FlagEvaluationsWriter — consent in bucket key, hash at flush
+
+**Raw event shape (extended):**
+
+```js
+{
+  flagKey, variant, allocationKey, targetingKey, errorMessage,
+  evalTimeMs, attrs,
+  observeFullEvaluationData: boolean
+}
+```
+
+**Bucket keys (extended):**
+
+```js
+function makeFullKey (consent, flagKey, variant, allocationKey, errorMessage, targetingKey, ctxKey) {
+  return `${consent ? '1' : '0'}\0${flagKey}\0${variant}\0${allocationKey}\0${errorMessage}\0${targetingKey}\0${ctxKey}`
+}
+
+function makeDegradedKey (consent, flagKey, variant, allocationKey, errorMessage) {
+  return `${consent ? '1' : '0'}\0${flagKey}\0${variant}\0${allocationKey}\0${errorMessage}`
+}
+```
+
+Consent leads the key because it's the coarsest partition. Mixed-consent events
+land in different buckets by construction. AND-fold on merge is defense in
+depth (`existing.observeFullEvaluationData &&= event.observeFullEvaluationData`)
+— a no-op when the key holds, a safety net when a future refactor breaks the
+invariant.
+
+**Aggregation, when consent is `false`:**
+
+- `attrs` is already empty (the hook did not capture it).
+- `ctxKey` is empty by construction.
+- `entry.contextAttrs = null`; `_drainFlagEvaluations` emits no `context` field.
+- `entry.targetingKey` holds the **raw** value on the entry. This is the design
+  seam: raw stays on the entry through aggregation so N evaluations with the
+  same subject collapse into 1 bucket. **The hash is applied only in
+  `_drainFlagEvaluations` when serializing.** This means the raw value never
+  crosses the process boundary — it exists only on the in-memory entry for the
+  flush interval — and the crypto call runs once per unique bucket, not once
+  per evaluation.
+
+**Serialization change in `_drainFlagEvaluations`:**
+
+```js
+if (entry.targetingKey) {
+  ev.targeting_key = entry.observeFullEvaluationData
+    ? entry.targetingKey
+    : FlagEvaluationsWriter.hashTargetingKey(entry.targetingKey)
+}
+```
+
+Everything else stays as-is. The existing payload-limit `_degradeEventForPayloadLimit`
+already strips `targeting_key` and `context` from oversized rows, so no change
+is needed there.
+
+## Tests
+
+### New file: `hash_targeting_key.spec.js` (in `test/openfeature/writers/`)
+
+- `matches the cross-SDK canonical vector` — `jane.doe@datadoghq.com` →
+  `sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b`.
+- `does not trim whitespace` — leading/trailing space yields a different digest.
+- `does not case-fold` — `Jane` vs `jane` yields different digests.
+- `does not Unicode-normalize` — NFC-composed vs NFD-decomposed yield different
+  digests. Both variants written with explicit `\u` escapes.
+- `handles empty string` — pins the `sha256_e3b0c...` digest.
+
+### `agentless_configuration_source.spec.js` — new cases
+
+- `parses observeFullEvaluationData=true at UFC root`
+- `defaults observeFullEvaluationData to false when absent`
+- `treats explicit null as false`
+- Parametric fail-closed table over `[1, 0, 'true', 'false', [], {}, null]` —
+  each resolves to `false`.
+- `ignores observeFullEvaluationData nested inside environment` — this is the
+  placement-drift guard.
+
+### `flag_evaluations.spec.js` — new cases
+
+- `hashes targeting_key when observeFullEvaluationData is false`
+- `preserves raw targeting_key when observeFullEvaluationData is true`
+- `omits context when observeFullEvaluationData is false` (asserted on the
+  emitted event object, not on the aggregation entry).
+- `separates buckets by consent value` — same subject, two consent values,
+  two full-tier buckets.
+- `consent-off buckets share one entry across distinct contexts` — regression
+  guard for `concern:consent-off-bucket-keying` (Java pilot lesson: the bucket
+  key must not carry dimensions the wire event drops).
+- `AND-folds consent on merge as defense in depth` — construct a scenario where
+  two events with the same bucket key have different consent values (would
+  require a bug for the key to collide, but the AND-fold makes it safe anyway).
+- `hashes once per bucket at flush cadence, not per evaluation` — spy on
+  `createHash` and assert call count equals unique full-tier buckets, not
+  evaluation count.
+- `raw wire negative control` — assert that the raw targeting-key string does
+  not appear anywhere in the serialized payload bytes when consent is off, and
+  no PII context attribute value appears either. Byte-string search, not
+  decode-and-inspect (a decode misses raw values that route into unexpected
+  fields).
+- `degraded tier emits no raw targeting_key or context under either consent`.
+
+### `flag_eval_evp_hook.spec.js` — new cases
+
+- `reads consent from the provider snapshot at hook entry, not later`
+- `skips context capture entirely when consent is off` — assert the writer
+  received `attrs === {}` even though `hookContext.context` was populated.
+- `fails closed when snapshot is undefined` (initial-config-not-yet-received).
+
+### `flagging_provider.spec.js` — end-to-end
+
+- `setConfiguration flows observeFullEvaluationData into writer output`
+- **Consent-lifecycle guard.** Evaluate flag → replace snapshot with opposite
+  consent → flush → assert the flushed event shows the evaluation-time consent,
+  not the post-swap value. Both directions covered. This is the single most
+  important regression test in this PR; the Java pilot shipped this bug and L3
+  caught it, not unit tests.
+- `DoLog non-impact` — for each consent value, flushed-event JSON is identical
+  across `doLog ∈ {true, false}`.
+- `kill switch prevents construction` — with
+  `DD_FLAGGING_EVALUATION_COUNTS_ENABLED=false`, neither writer nor EVP hook is
+  registered on the provider, regardless of UFC consent value.
+
+### `remote_config.spec.js` — new cases
+
+- Mirror the agentless parse tests for the RC-delivered configuration path
+  (same UFC schema; consent value must land on the same snapshot).
+
+## Out of scope
+
+- **System-tests (L3).** JS's `manifests/nodejs.yml` currently deactivates the
+  entire `test_flag_eval_evp.py` file with `missing_feature (FFL-2446)`. This
+  PR does not activate it. A follow-up `system-tests` change flips the file on
+  and marks only the three `Test_FFE_EVP_Flagevaluation_ObserveFullData_*` rows
+  as `missing_feature (FFL-2965)`. Tracked separately.
+- **L2 dogfooding.** No companion `ffe-dogfooding` change in this PR.
+- **Upstream evaluator metadata stamping.** A follow-up may move the consent
+  stamp into `@datadog/openfeature-node-server` so the JS side deletes the
+  provider `_snapshot` and reads `evaluationDetails.flagMetadata.observe_full_evaluation_data`
+  directly. Not required for this PR.
+- **Public OpenFeature `flagMetadata` exposure of `observe_full_evaluation_data`.**
+  The Java pilot exposes this on `ProviderEvaluation`; a cross-SDK decision on
+  whether to surface it publicly in JS is deferred (`concern:public-flagmetadata`
+  from Go PR #4886). This PR keeps the value internal.
+- **Config surface.** No new env vars. The kill switch
+  `DD_FLAGGING_EVALUATION_COUNTS_ENABLED` and its config mapping are already
+  in place; verified.
+
+## Risks
+
+- **Default-hashed on upgrade.** Any customer dashboard/query that reads
+  `targeting_key` verbatim will start seeing `sha256_`-prefixed values as soon
+  as this ships. Mitigation: the base track has not shipped yet in JS, so the
+  first release JS customers see already carries hashing by default — no
+  behavior change from an intermediate raw-PII release.
+- **Cross-SDK contract drift.** A future refactor that adds trim, case fold, or
+  Unicode normalization silently breaks the cross-SDK subject-count join. The
+  canonical vector test plus non-normalization parametric tests are the primary
+  guards.
+- **Consent-lifecycle regression.** The Java pilot shipped a flush-time consent
+  read bug that unit tests missed and L3 caught. JS's L3 is not activated by
+  this PR, so the consent-lifecycle guard in
+  `flagging_provider.spec.js` carries more weight than usual. It must exercise
+  the actual swap-between-evaluate-and-flush path, not just the read path.
+- **Stacked-PR merge risk.** This branch targets
+  `leo.romanovsky/ffl-2446-evp-flagevaluation-nodejs`, not `master`. Reviewers
+  must resolve base-track changes back into this branch as the base moves.
+  Alternative (fold into base track) was rejected for reviewability; the
+  stacking is explicit in the PR body.
+
+## Design Decisions (log)
+
+| Decision | Chosen | Alternative | Reason |
+| --- | --- | --- | --- |
+| Where hashing lives | Static method on `FlagEvaluationsWriter` | Standalone `writers/hash_targeting_key.js` module | Small, single-callsite; keeps the hash contract discoverable next to its only consumer. Canonical-vector test targets the static method directly. |
+| Consent snapshot boundary | `FlagEvalEVPHook.finally` reading provider snapshot | Upstream evaluator stamps `flagMetadata` | Upstream `@datadog/openfeature-node-server` v2.0.2 does not stamp today. Hook boundary gives the same lifecycle guarantee (synchronous with evaluation). Upstream stamp is a follow-up. |
+| Hash cadence | At flush, once per full-tier bucket | Per evaluation in `enqueue` | Aggregation collapses N evaluations with the same subject into 1 bucket → 1 hash call, not N. Matches Python. Raw value never crosses process boundary — lives on the in-memory entry for the flush interval only. |
+| Snapshot representation | Single `Object.freeze({...})` reference | Two fields (`_config`, `_consent`) | Prevents torn reads. Matches Python `NamedTuple` and Go atomic pointer swap. |
+| Consent in the bucket key | Yes, leading position | Post-aggregation filter | Prevents mixed-consent merges by construction. AND-fold is only defense in depth. |
+| PR sequencing | Stacked on base track PR | Fold into base track PR | User preference; easier review; will merge into base before base merges to master, so customers never see a raw-PII release. |

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -15,6 +15,21 @@ const { DatadogNodeServerProvider } = require('./require-provider')
  * OpenFeature provider that integrates with Datadog's feature flagging system.
  * Extends DatadogNodeServerProvider to add tracer integration and configuration management.
  */
+/**
+ * Atomic snapshot pairing the active configuration with its consent value.
+ * A single field read returns both — no torn read possible between them.
+ *
+ * @typedef {object} FfeSnapshot
+ * @property {import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined} configuration
+ * @property {boolean} observeFullEvaluationData
+ */
+
+/** @type {FfeSnapshot} */
+const EMPTY_SNAPSHOT = Object.freeze({
+  configuration: undefined,
+  observeFullEvaluationData: false,
+})
+
 class FlaggingProvider extends DatadogNodeServerProvider {
   /** @type {SpanEnrichmentHook | undefined} */
   #spanEnrichmentHook
@@ -24,6 +39,27 @@ class FlaggingProvider extends DatadogNodeServerProvider {
 
   /** @type {{ start: Function, stop: Function } | undefined} */
   #configurationSource
+
+  /**
+   * Atomic {configuration, observeFullEvaluationData} pair, replaced as a
+   * single reference by `setConfiguration`. The EVP hook reads consent from
+   * `this.#snapshot.observeFullEvaluationData` synchronously at hook entry, so
+   * a Remote Config swap between the hook's `finally` and the writer's flush
+   * cannot retroactively apply a different environment's policy.
+   *
+   * Fail-closed: strict `=== true` coercion means absent, `null`, or any
+   * non-boolean value all resolve to `false`.
+   *
+   * @type {FfeSnapshot}
+   */
+  #snapshot = EMPTY_SNAPSHOT
+
+  /**
+   * Bound arrow function exposed to the EVP hook so no public consent getter
+   * exists on this class — external callers cannot bypass the intended path.
+   * Deleting this after upstream metadata stamping lands is straightforward.
+   */
+  #getConsent = () => this.#snapshot.observeFullEvaluationData
 
   /**
    * @param {import('../tracer')} tracer - Datadog tracer instance
@@ -42,7 +78,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
     // Default: enabled (only explicit false disables); routed through config system.
     if (config.experimental.flaggingProvider.evaluationCountsEnabled) {
       this.#flagEvalEVPWriter = new FlagEvaluationsWriter(config)
-      this.hooks.push(new FlagEvalEVPHook(this.#flagEvalEVPWriter))
+      this.hooks.push(new FlagEvalEVPHook(this.#flagEvalEVPWriter, this.#getConsent))
       log.debug('%s EVP flagevaluation writer enabled', this.constructor.name)
     } else {
       log.debug('%s EVP flagevaluation writer disabled (DD_FLAGGING_EVALUATION_COUNTS_ENABLED=false)',
@@ -63,6 +99,25 @@ class FlaggingProvider extends DatadogNodeServerProvider {
 
     this.#configurationSource = configurationSource.create(config, this.setConfiguration.bind(this))
     this.#configurationSource?.start()
+  }
+
+  /**
+   * Replaces the active UFC and its consent snapshot as a single atomic step.
+   * Strict `=== true` on `observeFullEvaluationData` means absent, explicit
+   * `null`, wrong-typed values, and — critically — a value nested inside
+   * `configuration.environment` (the FFL-2784 placement-drift trap) all fail
+   * closed to `false`. Only a UFC-root boolean `true` grants opt-in.
+   *
+   * @param {import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined} configuration
+   */
+  setConfiguration (configuration) {
+    super.setConfiguration(configuration)
+    this.#snapshot = configuration === undefined
+      ? EMPTY_SNAPSHOT
+      : Object.freeze({
+        configuration,
+        observeFullEvaluationData: configuration.observeFullEvaluationData === true,
+      })
   }
 
   /**

--- a/packages/dd-trace/src/openfeature/writers/flag_eval_evp_hook.js
+++ b/packages/dd-trace/src/openfeature/writers/flag_eval_evp_hook.js
@@ -14,15 +14,24 @@
  * The existing FlagEvalMetricsHook (OTel feature_flag.evaluations) is untouched —
  * this hook is registered IN ADDITION to it, not as a replacement.
  */
+const FAIL_CLOSED_CONSENT = () => false
+
 class FlagEvalEVPHook {
   /** @type {import('./flag_evaluations')} */
   _writer
 
+  /** @type {() => boolean} */
+  _getConsent
+
   /**
    * @param {import('./flag_evaluations')} writer - FlagEvaluationsWriter instance
+   * @param {() => boolean} [getConsent] - Reads the atomic UFC consent snapshot.
+   *   Missing accessor fails closed to `false` (no raw PII leaks in tests that
+   *   construct this hook directly without a provider).
    */
-  constructor (writer) {
+  constructor (writer, getConsent) {
     this._writer = writer
+    this._getConsent = getConsent ?? FAIL_CLOSED_CONSENT
   }
 
   /**
@@ -69,13 +78,36 @@ class FlagEvalEVPHook {
     const evalTimeMs = flagMetadata?.['dd.eval.timestamp_ms'] ?? Date.now()
     const errorMessage = evaluationDetails.errorMessage ?? evaluationDetails.errorCode ?? ''
 
-    // Passed to the writer for inline pruning (see FlagEvaluationsWriter.enqueue).
-    // The SDK produces a fresh shallow-merged object per evaluation, so the top-level
-    // identity is stable, but nested values share references with caller state — which
-    // is exactly why the writer prunes inline rather than deferring the flatten.
-    const attrs = hookContext.context ?? {}
+    // Snapshot consent once, synchronously at hook entry, so a Remote Config
+    // update between this hook firing and the writer's flush cannot retroactively
+    // change the wire shape of this evaluation. Strict boolean by construction —
+    // the provider's snapshot already coerces `=== true`.
+    const observeFullEvaluationData = this._getConsent() === true
 
-    writer.enqueue({ flagKey, variant, allocationKey, targetingKey, errorMessage, evalTimeMs, attrs })
+    // Consent-off: skip capturing the evaluation context entirely. The writer must
+    // not receive attrs it will later discard — that would silently push privacy-
+    // protected traffic through pruneContext for no downstream use. Concretely, a
+    // high-cardinality attribute like `request_id` would then contribute to the
+    // aggregation bucket key while producing wire-identical events, exhausting the
+    // per-flag cap and pushing consent-off traffic to the degraded tier. Java
+    // pilot lesson `concern:consent-off-bucket-keying`.
+    //
+    // When consent IS on, the SDK produces a fresh shallow-merged object per
+    // evaluation, so the top-level identity is stable, but nested values share
+    // references with caller state — which is exactly why the writer prunes
+    // inline rather than deferring the flatten.
+    const attrs = observeFullEvaluationData ? (hookContext.context ?? {}) : {}
+
+    writer.enqueue({
+      flagKey,
+      variant,
+      allocationKey,
+      targetingKey,
+      errorMessage,
+      evalTimeMs,
+      attrs,
+      observeFullEvaluationData,
+    })
   }
 }
 

--- a/packages/dd-trace/src/openfeature/writers/flag_evaluations.js
+++ b/packages/dd-trace/src/openfeature/writers/flag_evaluations.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { createHash } = require('node:crypto')
+
 const {
   FLAGEVALUATIONS_ENDPOINT,
   EVP_PROXY_AGENT_BASE_PATH,
@@ -352,6 +354,13 @@ function eventEvaluationCount (event) {
 /**
  * Builds the full-tier bucket key string from schema-visible dimensions only.
  *
+ * Consent leads the key so mixed-consent evaluations cannot merge into one
+ * bucket and inherit one policy; the AND-fold on the entry field is defense in
+ * depth only. When consent is off, `targetingKey` still contributes as the RAW
+ * value (not the hash) — hashing happens once at flush cadence, keeping the
+ * bucket-key contract identical between consent-on and consent-off aggregation.
+ *
+ * @param {boolean} observeFullEvaluationData
  * @param {string} flagKey
  * @param {string} variant
  * @param {string} allocationKey
@@ -360,22 +369,24 @@ function eventEvaluationCount (event) {
  * @param {string} ctxKey
  * @returns {string}
  */
-function makeFullKey (flagKey, variant, allocationKey, errorMessage, targetingKey, ctxKey) {
+function makeFullKey (observeFullEvaluationData, flagKey, variant, allocationKey, errorMessage, targetingKey, ctxKey) {
   // NUL separator: safe because length-delimited ctxKey cannot contain NUL as a separator
-  return `${flagKey}\0${variant}\0${allocationKey}\0${errorMessage}\0${targetingKey}\0${ctxKey}`
+  return `${observeFullEvaluationData ? '1' : '0'}\0` +
+    `${flagKey}\0${variant}\0${allocationKey}\0${errorMessage}\0${targetingKey}\0${ctxKey}`
 }
 
 /**
  * Builds the degraded-tier bucket key string (drops targetingKey + context).
  *
+ * @param {boolean} observeFullEvaluationData
  * @param {string} flagKey
  * @param {string} variant
  * @param {string} allocationKey
  * @param {string} errorMessage
  * @returns {string}
  */
-function makeDegradedKey (flagKey, variant, allocationKey, errorMessage) {
-  return `${flagKey}\0${variant}\0${allocationKey}\0${errorMessage}`
+function makeDegradedKey (observeFullEvaluationData, flagKey, variant, allocationKey, errorMessage) {
+  return `${observeFullEvaluationData ? '1' : '0'}\0${flagKey}\0${variant}\0${allocationKey}\0${errorMessage}`
 }
 
 /**
@@ -383,10 +394,14 @@ function makeDegradedKey (flagKey, variant, allocationKey, errorMessage) {
  * @property {string} flagKey
  * @property {string} variant - empty string means absent (runtime_default)
  * @property {string} allocationKey
- * @property {string} targetingKey
+ * @property {string} targetingKey - RAW subject id. Hashed at flush cadence when
+ *   observeFullEvaluationData is false (never mutated on the entry itself).
  * @property {string} errorMessage
  * @property {number} evalTimeMs
- * @property {Record<string, unknown>} attrs - Flattened and pruned context attributes
+ * @property {Record<string, unknown>} attrs - Flattened and pruned context attributes.
+ *   The EVP hook passes an empty object when observeFullEvaluationData is false.
+ * @property {boolean} observeFullEvaluationData - Consent snapshot taken at evaluation
+ *   time. Consent-off events emit a `sha256_`-prefixed targeting_key and no context.
  */
 
 /**
@@ -394,13 +409,16 @@ function makeDegradedKey (flagKey, variant, allocationKey, errorMessage) {
  * @property {string} flagKey
  * @property {string} variant
  * @property {string} allocationKey
- * @property {string} targetingKey
+ * @property {string} targetingKey - RAW subject id; hashed lazily at flush when
+ *   observeFullEvaluationData is false.
  * @property {string} errorMessage
  * @property {number} count
  * @property {number} first
  * @property {number} last
  * @property {boolean} runtimeDefault
  * @property {Record<string, unknown> | null} contextAttrs
+ * @property {boolean} observeFullEvaluationData - AND-folded on merge as defense in
+ *   depth. Bucket-key partitioning already makes this a no-op unless the key drifts.
  */
 
 /**
@@ -413,6 +431,7 @@ function makeDegradedKey (flagKey, variant, allocationKey, errorMessage) {
  * @property {number} first
  * @property {number} last
  * @property {boolean} runtimeDefault
+ * @property {boolean} observeFullEvaluationData
  */
 
 /**
@@ -549,6 +568,16 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
       return false
     }
 
+    // Strict boolean coercion — defense in depth. The hook already stamps a
+    // strict boolean; this guards direct callers (tests, future integrations).
+    const observeFullEvaluationData = event.observeFullEvaluationData === true
+
+    // Consent-off skips pruneContext entirely: the hook passed an empty attrs
+    // object, and the emitted event omits `context.evaluation`. Running
+    // pruneContext on `{}` is cheap (fast path returns immediately), but the
+    // explicit skip documents the invariant and avoids the shortest-path call.
+    const attrs = observeFullEvaluationData ? pruneContext(event.attrs || {}) : {}
+
     this._rawQueue.push({
       flagKey: event.flagKey,
       variant: event.variant ?? '',
@@ -556,7 +585,8 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
       targetingKey: event.targetingKey ?? '',
       errorMessage: event.errorMessage ?? '',
       evalTimeMs: event.evalTimeMs,
-      attrs: pruneContext(event.attrs || {}),
+      attrs,
+      observeFullEvaluationData,
     })
 
     if (!this._drainScheduled) {
@@ -595,11 +625,14 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
     const targetingKey = event.targetingKey ?? ''
     const errorMessage = event.errorMessage ?? ''
     const attrs = event.attrs || {}
+    const observeFullEvaluationData = event.observeFullEvaluationData === true
 
     const ctxKey = canonicalContextKey(attrs)
     const isRuntimeDefault = variant === ''
 
-    const fKey = makeFullKey(flagKey, variant, allocationKey, errorMessage, targetingKey, ctxKey)
+    const fKey = makeFullKey(
+      observeFullEvaluationData, flagKey, variant, allocationKey, errorMessage, targetingKey, ctxKey
+    )
 
     // Fast path: existing full-tier bucket
     const existing = this._full.get(fKey)
@@ -607,13 +640,19 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
       existing.count++
       if (evalTimeMs < existing.first) existing.first = evalTimeMs
       if (evalTimeMs > existing.last) existing.last = evalTimeMs
+      // AND-fold: consent is already partitioned by the bucket key, so this is a
+      // no-op today. Defense in depth against a future key-shape refactor that
+      // drops consent from the key — consent-off would then dominate any merge.
+      if (!observeFullEvaluationData) existing.observeFullEvaluationData = false
       return
     }
 
     // Check per-flag cap
     const perFlagCount = this._perFlagFullCount.get(flagKey) ?? 0
     if (perFlagCount >= this._perFlagCap) {
-      this._addToDegraded(flagKey, variant, allocationKey, errorMessage, evalTimeMs, isRuntimeDefault)
+      this._addToDegraded(
+        flagKey, variant, allocationKey, errorMessage, evalTimeMs, isRuntimeDefault, observeFullEvaluationData
+      )
       return
     }
 
@@ -622,7 +661,9 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
 
     // Check global cap
     if (this._globalCount >= this._globalCap) {
-      this._addToDegraded(flagKey, variant, allocationKey, errorMessage, evalTimeMs, isRuntimeDefault)
+      this._addToDegraded(
+        flagKey, variant, allocationKey, errorMessage, evalTimeMs, isRuntimeDefault, observeFullEvaluationData
+      )
       return
     }
 
@@ -638,6 +679,7 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
       last: evalTimeMs,
       runtimeDefault: isRuntimeDefault,
       contextAttrs: hasOwnKey(attrs) ? attrs : null,
+      observeFullEvaluationData,
     })
     this._globalCount++
   }
@@ -652,14 +694,18 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
    * @param {string} errorMessage
    * @param {number} evalTimeMs
    * @param {boolean} isRuntimeDefault
+   * @param {boolean} observeFullEvaluationData
    */
-  _addToDegraded (flagKey, variant, allocationKey, errorMessage, evalTimeMs, isRuntimeDefault) {
-    const dKey = makeDegradedKey(flagKey, variant, allocationKey, errorMessage)
+  _addToDegraded (
+    flagKey, variant, allocationKey, errorMessage, evalTimeMs, isRuntimeDefault, observeFullEvaluationData
+  ) {
+    const dKey = makeDegradedKey(observeFullEvaluationData, flagKey, variant, allocationKey, errorMessage)
     const existing = this._degraded.get(dKey)
     if (existing) {
       existing.count++
       if (evalTimeMs < existing.first) existing.first = evalTimeMs
       if (evalTimeMs > existing.last) existing.last = evalTimeMs
+      if (!observeFullEvaluationData) existing.observeFullEvaluationData = false
       return
     }
 
@@ -678,6 +724,7 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
       first: evalTimeMs,
       last: evalTimeMs,
       runtimeDefault: isRuntimeDefault,
+      observeFullEvaluationData,
     })
   }
 
@@ -734,12 +781,23 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
       }
 
       if (entry.runtimeDefault) ev.runtime_default_used = true
-      if (entry.targetingKey) ev.targeting_key = entry.targetingKey
+      if (entry.targetingKey) {
+        // Consent-off entries carry the RAW subject on the in-memory entry so N
+        // evaluations sharing one subject collapse into 1 bucket. Hashing runs
+        // once here at flush cadence — one crypto call per unique bucket rather
+        // than one per evaluation. The raw value never crosses the process
+        // boundary; it lives only on the entry for the flush interval.
+        ev.targeting_key = entry.observeFullEvaluationData
+          ? entry.targetingKey
+          : FlagEvaluationsWriter.hashTargetingKey(entry.targetingKey)
+      }
       if (entry.variant) ev.variant = { key: entry.variant }
       if (entry.allocationKey) ev.allocation = { key: entry.allocationKey }
       if (entry.errorMessage) ev.error = { message: entry.errorMessage }
       // `contextAttrs` is null when the pruned context was empty (see _aggregate);
       // when non-null it is guaranteed non-empty, so no re-probe is needed here.
+      // When consent is off, contextAttrs is null by construction — the hook
+      // passed empty attrs, so hasOwnKey(attrs) was false in _aggregate.
       if (entry.contextAttrs !== null) {
         ev.context = { evaluation: entry.contextAttrs }
       }
@@ -915,6 +973,22 @@ class FlagEvaluationsWriter extends BaseFFEWriter {
    */
   makePayload (events) {
     return { context: this._context, flagEvaluations: events }
+  }
+
+  /**
+   * Cross-SDK targeting-key fingerprint. Unsalted SHA-256 over the raw UTF-8
+   * bytes exactly as received — no trim, no case fold, no Unicode normalization.
+   * Output: literal `sha256_` prefix + 64-char lowercase hex digest (71 chars).
+   *
+   * The canonical vector `"jane.doe@datadoghq.com"` MUST hash to
+   * `sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b`
+   * byte-for-byte on every SDK; otherwise cross-language subject counts diverge.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static hashTargetingKey (value) {
+    return 'sha256_' + createHash('sha256').update(value, 'utf8').digest('hex')
   }
 
   _resetAggregationState () {

--- a/packages/dd-trace/test/openfeature/flagging_provider.spec.js
+++ b/packages/dd-trace/test/openfeature/flagging_provider.spec.js
@@ -249,6 +249,130 @@ describe('FlaggingProvider', () => {
     })
   })
 
+  describe('observeFullEvaluationData snapshot', () => {
+    it('passes a getConsent accessor to the EVP hook, not to the OTel/span hooks', () => {
+      new FlaggingProvider(mockTracer, mockConfig) // eslint-disable-line no-new
+
+      // The EVP hook is the only consumer of consent. Any other hook receiving
+      // an accessor would be a channel bypassing the intended path.
+      sinon.assert.calledOnce(mockFlagEvalEVPHookClass)
+      const evpArgs = mockFlagEvalEVPHookClass.firstCall.args
+      assert.strictEqual(evpArgs[0], mockFlagEvalWriter)
+      assert.strictEqual(typeof evpArgs[1], 'function', 'EVP hook must receive a getConsent function')
+
+      // OTel hook takes only config.
+      sinon.assert.calledOnce(mockFlagEvalMetricsHookClass)
+      sinon.assert.calledWith(mockFlagEvalMetricsHookClass, mockConfig)
+    })
+
+    it('starts with observeFullEvaluationData=false before any setConfiguration call', () => {
+      new FlaggingProvider(mockTracer, mockConfig) // eslint-disable-line no-new
+      const getConsent = mockFlagEvalEVPHookClass.firstCall.args[1]
+
+      assert.strictEqual(getConsent(), false, 'default snapshot must be consent-off')
+    })
+
+    it('reflects setConfiguration({ observeFullEvaluationData: true }) atomically', () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const getConsent = mockFlagEvalEVPHookClass.firstCall.args[1]
+
+      provider.setConfiguration({
+        createdAt: '2026-01-01T00:00:00Z',
+        format: 'SERVER',
+        environment: { name: 'test' },
+        flags: {},
+        observeFullEvaluationData: true,
+      })
+
+      assert.strictEqual(getConsent(), true)
+    })
+
+    it('coerces observeFullEvaluationData to false for non-boolean values (fail-closed)', () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const getConsent = mockFlagEvalEVPHookClass.firstCall.args[1]
+
+      for (const value of [undefined, null, 1, 0, 'true', 'false', {}, []]) {
+        provider.setConfiguration({
+          createdAt: '2026-01-01T00:00:00Z',
+          format: 'SERVER',
+          environment: { name: 'test' },
+          flags: {},
+          observeFullEvaluationData: value,
+        })
+        assert.strictEqual(getConsent(), false,
+          `value ${JSON.stringify(value)} must coerce to false (strict === true)`)
+      }
+    })
+
+    it('ignores observeFullEvaluationData nested inside environment (FFL-2784 placement drift)', () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const getConsent = mockFlagEvalEVPHookClass.firstCall.args[1]
+
+      provider.setConfiguration({
+        createdAt: '2026-01-01T00:00:00Z',
+        format: 'SERVER',
+        environment: { name: 'test', observeFullEvaluationData: true },
+        flags: {},
+      })
+
+      assert.strictEqual(getConsent(), false,
+        'consent nested inside environment MUST NOT be read; the field lives at UFC root')
+    })
+
+    it('resets to observeFullEvaluationData=false when configuration is unset', () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const getConsent = mockFlagEvalEVPHookClass.firstCall.args[1]
+
+      provider.setConfiguration({
+        createdAt: '2026-01-01T00:00:00Z',
+        format: 'SERVER',
+        environment: { name: 'test' },
+        flags: {},
+        observeFullEvaluationData: true,
+      })
+      assert.strictEqual(getConsent(), true)
+
+      provider.setConfiguration(undefined)
+      assert.strictEqual(getConsent(), false, 'unsetting configuration must revert consent to false')
+    })
+
+    it('swaps consent atomically — a reader sees either the old or the new snapshot, never a torn pair', () => {
+      // The snapshot is Object.frozen. There is no observable intermediate state.
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const getConsent = mockFlagEvalEVPHookClass.firstCall.args[1]
+
+      provider.setConfiguration({
+        createdAt: '2026-01-01T00:00:00Z',
+        format: 'SERVER',
+        environment: { name: 'e1' },
+        flags: {},
+        observeFullEvaluationData: false,
+      })
+      const before = getConsent()
+
+      provider.setConfiguration({
+        createdAt: '2026-01-02T00:00:00Z',
+        format: 'SERVER',
+        environment: { name: 'e2' },
+        flags: {},
+        observeFullEvaluationData: true,
+      })
+      const after = getConsent()
+
+      assert.strictEqual(before, false)
+      assert.strictEqual(after, true)
+    })
+
+    it('does not expose a public consent accessor on the provider', () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+
+      // No public getter / method / property leaks consent.
+      assert.strictEqual(typeof provider.getConsent, 'undefined')
+      assert.strictEqual(typeof provider.observeFullEvaluationData, 'undefined')
+      assert.strictEqual(typeof provider.isObserveFullEvaluationDataEnabled, 'undefined')
+    })
+  })
+
   describe('inheritance', () => {
     it('should extend DatadogNodeServerProvider', () => {
       const { DatadogNodeServerProvider } = require('@datadog/openfeature-node-server')

--- a/packages/dd-trace/test/openfeature/writers/flag_eval_consent_lifecycle.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/flag_eval_consent_lifecycle.spec.js
@@ -1,0 +1,158 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { OpenFeature, InMemoryProvider } = require('@openfeature/server-sdk')
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../../setup/core')
+
+const FlagEvalEVPHook = require('../../../src/openfeature/writers/flag_eval_evp_hook')
+
+// The single most important regression test in this PR: the Java pilot shipped a
+// flush-time consent read bug that unit tests missed and system-tests (L3) caught.
+// The bug shape: evaluation fires under consent X, a Remote Config update flips
+// consent to !X before the flush timer fires, and the flushed event carries !X's
+// wire shape instead of X's. Both directions produce PII bugs — consent-off traffic
+// emitted raw, or consent-on traffic needlessly hashed.
+//
+// This spec drives the REAL hook + REAL writer through the OpenFeature server SDK
+// and swaps consent between evaluation and flush to prove the design property:
+// consent is read once at hook entry, stamped onto the event, and never re-read.
+describe('FlagEvalEVPHook + FlagEvaluationsWriter — consent-lifecycle guard', () => {
+  let FlagEvaluationsWriter
+  let writer
+  let hook
+  let client
+  let request
+  let clock
+  let getConsent
+  let consentValue
+
+  const config = {
+    site: 'datadoghq.com',
+    hostname: 'localhost',
+    port: 8126,
+    url: new URL('http://localhost:8126'),
+    apiKey: 'test-api-key',
+    service: 'test-service',
+    version: '1.0.0',
+    env: 'test',
+  }
+
+  const flags = {
+    'bool-flag': { variants: { on: true, off: false }, defaultVariant: 'on', disabled: false },
+  }
+
+  beforeEach(async () => {
+    request = sinon.stub().yieldsAsync(null, 'OK', 200)
+    clock = sinon.useFakeTimers()
+
+    FlagEvaluationsWriter = proxyquire('../../../src/openfeature/writers/flag_evaluations', {
+      '../../log': { debug: () => {}, error: () => {}, warn: () => {} },
+      '../../telemetry/metrics': {
+        manager: { namespace: () => ({ count: () => ({ inc: () => {} }) }) },
+      },
+      './base': proxyquire('../../../src/openfeature/writers/base', {
+        '../../exporters/common/request': request,
+        '../../log': { debug: () => {}, error: () => {}, warn: () => {} },
+      }),
+    })
+
+    writer = new FlagEvaluationsWriter(config)
+
+    // Mutable consent accessor — the test flips consentValue between evaluate and flush.
+    consentValue = true
+    getConsent = () => consentValue
+    hook = new FlagEvalEVPHook(writer, getConsent)
+
+    await OpenFeature.setProviderAndWait(new InMemoryProvider(flags))
+    client = OpenFeature.getClient()
+    client.addHooks(hook)
+  })
+
+  afterEach(async () => {
+    await OpenFeature.close()
+    writer.destroy()
+    clock.restore()
+  })
+
+  it('off→on swap: consent-off evaluation stays hashed even if consent flips on before flush', async () => {
+    // Evaluate under consent OFF.
+    consentValue = false
+    await client.getBooleanValue('bool-flag', false, {
+      targetingKey: 'jane.doe@datadoghq.com',
+      plan: 'premium',
+    })
+
+    // Simulate an RC update flipping consent to ON before the flush timer fires.
+    consentValue = true
+
+    writer.flush()
+
+    sinon.assert.calledOnce(request)
+    const payload = JSON.parse(request.getCall(0).args[0])
+    const event = payload.flagEvaluations[0]
+
+    assert.strictEqual(
+      event.targeting_key,
+      'sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b',
+      'evaluation-time consent (off) must win over the post-swap consent (on)'
+    )
+    assert.strictEqual(Object.hasOwn(event, 'context'), false,
+      'evaluation-time context omission must win over the post-swap consent-on state')
+  })
+
+  it('on→off swap: consent-on evaluation stays raw even if consent flips off before flush', async () => {
+    // Evaluate under consent ON.
+    consentValue = true
+    await client.getBooleanValue('bool-flag', false, {
+      targetingKey: 'jane.doe@datadoghq.com',
+      plan: 'premium',
+    })
+
+    // Simulate an RC update flipping consent to OFF before the flush timer fires.
+    consentValue = false
+
+    writer.flush()
+
+    const payload = JSON.parse(request.getCall(0).args[0])
+    const event = payload.flagEvaluations[0]
+
+    assert.strictEqual(event.targeting_key, 'jane.doe@datadoghq.com',
+      'evaluation-time consent (on) must preserve the raw targeting_key through flush')
+    assert.deepStrictEqual(event.context, { evaluation: { plan: 'premium' } },
+      'evaluation-time context capture must survive a post-evaluation consent-off swap')
+  })
+
+  it('multiple consent transitions during aggregation preserve each evaluation-time snapshot', async () => {
+    // Two evaluations under different consent values, then flush. Both must reach
+    // the wire with their own evaluation-time shape, in distinct buckets.
+    consentValue = false
+    await client.getBooleanValue('bool-flag', false, {
+      targetingKey: 'jane.doe@datadoghq.com',
+    })
+
+    consentValue = true
+    await client.getBooleanValue('bool-flag', false, {
+      targetingKey: 'jane.doe@datadoghq.com',
+    })
+
+    // Post-eval swap must not retroactively apply.
+    consentValue = false
+
+    writer.flush()
+
+    const payload = JSON.parse(request.getCall(0).args[0])
+    assert.strictEqual(payload.flagEvaluations.length, 2)
+
+    const targetingKeys = payload.flagEvaluations.map(e => e.targeting_key)
+    assert.ok(targetingKeys.includes('jane.doe@datadoghq.com'),
+      'consent-on evaluation preserves the raw targeting key')
+    assert.ok(targetingKeys.includes(
+      'sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b'),
+    'consent-off evaluation carries the hashed targeting key')
+  })
+})

--- a/packages/dd-trace/test/openfeature/writers/flag_eval_evp_hook.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/flag_eval_evp_hook.spec.js
@@ -12,10 +12,15 @@ const FlagEvalEVPHook = require('../../../src/openfeature/writers/flag_eval_evp_
 describe('FlagEvalEVPHook', () => {
   let writer
   let hook
+  let getConsent
 
   beforeEach(() => {
     writer = { enqueue: sinon.spy() }
-    hook = new FlagEvalEVPHook(writer)
+    // Existing extraction tests cover the consent-on wire shape (raw
+    // targeting_key + captured context). Consent-off behavior gets its own
+    // describe block below.
+    getConsent = sinon.stub().returns(true)
+    hook = new FlagEvalEVPHook(writer, getConsent)
   })
 
   const lastEnqueued = () => writer.enqueue.firstCall.args[0]
@@ -137,6 +142,67 @@ describe('FlagEvalEVPHook', () => {
       const event = lastEnqueued()
       assert.strictEqual(event.targetingKey, 'user-1')
       assert.strictEqual(event.attrs, context)
+    })
+  })
+
+  describe('observeFullEvaluationData consent', () => {
+    it('reads consent from getConsent once per finally', () => {
+      hook.finally({ flagKey: 'f' }, { variant: 'on' })
+      sinon.assert.calledOnce(getConsent)
+    })
+
+    it('passes observeFullEvaluationData=true to the writer when consent is on', () => {
+      getConsent.returns(true)
+      hook.finally({ flagKey: 'f' }, { variant: 'on' })
+      assert.strictEqual(lastEnqueued().observeFullEvaluationData, true)
+    })
+
+    it('passes observeFullEvaluationData=false to the writer when consent is off', () => {
+      getConsent.returns(false)
+      hook.finally({ flagKey: 'f' }, { variant: 'on' })
+      assert.strictEqual(lastEnqueued().observeFullEvaluationData, false)
+    })
+
+    it('skips context capture entirely when consent is off', () => {
+      getConsent.returns(false)
+      const context = { targetingKey: 'user-1', plan: 'premium', email: 'x@y.z' }
+      hook.finally({ flagKey: 'f', context }, { variant: 'on' })
+
+      const event = lastEnqueued()
+      assert.deepStrictEqual(event.attrs, {},
+        'consent-off hooks MUST NOT pass PII attrs to the writer')
+      // targetingKey is still captured — the writer hashes it later.
+      assert.strictEqual(event.targetingKey, 'user-1')
+    })
+
+    it('captures context normally when consent is on', () => {
+      getConsent.returns(true)
+      const context = { targetingKey: 'user-1', plan: 'premium' }
+      hook.finally({ flagKey: 'f', context }, { variant: 'on' })
+
+      assert.strictEqual(lastEnqueued().attrs, context)
+    })
+
+    it('fails closed to observeFullEvaluationData=false when getConsent is not provided', () => {
+      const noAccessorHook = new FlagEvalEVPHook(writer)
+      const context = { targetingKey: 'user-1', plan: 'premium' }
+      noAccessorHook.finally({ flagKey: 'f', context }, { variant: 'on' })
+
+      const event = lastEnqueued()
+      assert.strictEqual(event.observeFullEvaluationData, false)
+      assert.deepStrictEqual(event.attrs, {})
+    })
+
+    it('coerces non-boolean consent return values to false (strict === true)', () => {
+      // Defense in depth: the provider snapshot already coerces, but a
+      // misconfigured accessor must not leak PII.
+      for (const value of [1, 'true', {}, [], null, undefined]) {
+        getConsent.returns(value)
+        writer.enqueue.resetHistory()
+        hook.finally({ flagKey: 'f', context: { plan: 'premium' } }, { variant: 'on' })
+        assert.strictEqual(lastEnqueued().observeFullEvaluationData, false,
+          `value ${JSON.stringify(value)} must coerce to false`)
+      }
     })
   })
 })

--- a/packages/dd-trace/test/openfeature/writers/flag_evaluations.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/flag_evaluations.spec.js
@@ -25,6 +25,10 @@ describe('FlagEvaluationsWriter', () => {
     targetingKey: 'user-1',
     evalTimeMs: 1760000000000,
     attrs: { plan: 'premium', count: 5 },
+    // Existing suites cover the pre-PII wire shape (raw targeting_key + context).
+    // Default to consent-on here so those assertions still hold; PII tests set
+    // observeFullEvaluationData: false explicitly.
+    observeFullEvaluationData: true,
     ...overrides,
   })
 
@@ -789,6 +793,203 @@ describe('FlagEvaluationsWriter', () => {
       writer.enqueue(makeEvent())
       clock.tick(10000)
       sinon.assert.calledOnce(request)
+    })
+  })
+
+  describe('observeFullEvaluationData', () => {
+    // Canonical vector from the RFC. MUST match Java / Go / Python / Ruby / PHP / .NET.
+    const CANONICAL_INPUT = 'jane.doe@datadoghq.com'
+    const CANONICAL_HASH =
+      'sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b'
+
+    it('hashes targeting_key when observeFullEvaluationData is false', () => {
+      writer.enqueue(makeEvent({
+        targetingKey: CANONICAL_INPUT,
+        attrs: {},
+        observeFullEvaluationData: false,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      assert.strictEqual(payload.flagEvaluations[0].targeting_key, CANONICAL_HASH)
+    })
+
+    it('preserves raw targeting_key when observeFullEvaluationData is true', () => {
+      writer.enqueue(makeEvent({
+        targetingKey: CANONICAL_INPUT,
+        observeFullEvaluationData: true,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      assert.strictEqual(payload.flagEvaluations[0].targeting_key, CANONICAL_INPUT)
+    })
+
+    it('omits context on the wire when observeFullEvaluationData is false', () => {
+      writer.enqueue(makeEvent({
+        attrs: { plan: 'premium', email: 'jane@example.com' },
+        observeFullEvaluationData: false,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      const event = payload.flagEvaluations[0]
+      assert.strictEqual(Object.hasOwn(event, 'context'), false,
+        'consent-off events MUST omit the context.evaluation dimension entirely')
+    })
+
+    it('includes context on the wire when observeFullEvaluationData is true', () => {
+      writer.enqueue(makeEvent({
+        attrs: { plan: 'premium' },
+        observeFullEvaluationData: true,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      assert.deepStrictEqual(payload.flagEvaluations[0].context, { evaluation: { plan: 'premium' } })
+    })
+
+    it('separates buckets by consent value even when other dimensions match', () => {
+      writer.enqueue(makeEvent({ targetingKey: 'u1', attrs: {}, observeFullEvaluationData: false }))
+      writer.enqueue(makeEvent({ targetingKey: 'u1', attrs: {}, observeFullEvaluationData: true }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      assert.strictEqual(payload.flagEvaluations.length, 2,
+        'mixed-consent evaluations MUST NOT merge into one bucket')
+      const targetingKeys = payload.flagEvaluations.map(e => e.targeting_key).sort()
+      // One hashed (sha256_ prefix), one raw ('u1'). Distinct.
+      assert.ok(targetingKeys.some(k => k === 'u1'), targetingKeys.join(','))
+      assert.ok(targetingKeys.some(k => k.startsWith('sha256_')), targetingKeys.join(','))
+    })
+
+    it('merges consent-off events across distinct contexts into one bucket', () => {
+      // Regression guard for concern:consent-off-bucket-keying (Java pilot lesson).
+      // When consent is off the hook passes attrs={}, so distinct upstream contexts
+      // collapse to one bucket at aggregation time — the bucket key must not carry
+      // dimensions that the wire event drops.
+      writer.enqueue(makeEvent({
+        targetingKey: 'u1',
+        attrs: {}, // hook zeroed it out because consent was off
+        observeFullEvaluationData: false,
+      }))
+      writer.enqueue(makeEvent({
+        targetingKey: 'u1',
+        attrs: {}, // same, from a different original context
+        observeFullEvaluationData: false,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      assert.strictEqual(payload.flagEvaluations.length, 1)
+      assert.strictEqual(payload.flagEvaluations[0].evaluation_count, 2)
+    })
+
+    it('keeps consent-on events with distinct contexts distinct', () => {
+      writer.enqueue(makeEvent({
+        targetingKey: 'u1',
+        attrs: { plan: 'premium' },
+        observeFullEvaluationData: true,
+      }))
+      writer.enqueue(makeEvent({
+        targetingKey: 'u1',
+        attrs: { plan: 'basic' },
+        observeFullEvaluationData: true,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      assert.strictEqual(payload.flagEvaluations.length, 2)
+    })
+
+    it('hashes once per bucket at flush cadence, not per evaluation', () => {
+      const hashSpy = sinon.spy(FlagEvaluationsWriter, 'hashTargetingKey')
+      try {
+        // 10 evaluations sharing one (flag, variant, allocation, targetingKey) bucket
+        for (let i = 0; i < 10; i++) {
+          writer.enqueue(makeEvent({
+            targetingKey: CANONICAL_INPUT,
+            attrs: {},
+            observeFullEvaluationData: false,
+          }))
+        }
+        writer.flush()
+
+        sinon.assert.calledOnce(hashSpy)
+      } finally {
+        hashSpy.restore()
+      }
+    })
+
+    it('does not leak the raw targeting_key in payload bytes when consent is off', () => {
+      const raw = 'user-secret@example.com'
+      writer.enqueue(makeEvent({
+        targetingKey: raw,
+        attrs: {},
+        observeFullEvaluationData: false,
+      }))
+      writer.flush()
+
+      // Assert on the serialized payload string, not on decoded objects. A
+      // decode-then-inspect check misses raw values that route into unexpected
+      // fields (e.g., through a stringified error message).
+      const payloadString = request.getCall(0).args[0]
+      assert.strictEqual(payloadString.includes(raw), false,
+        'raw targeting key MUST NOT appear anywhere in the wire bytes')
+      assert.ok(payloadString.includes('sha256_'),
+        'consent-off payload MUST carry the hashed prefix')
+    })
+
+    it('does not leak PII context values in payload bytes when consent is off', () => {
+      const raw = 'user-secret@example.com'
+      writer.enqueue(makeEvent({
+        targetingKey: 'u1',
+        // The hook zeros attrs to {} when consent is off; a well-behaved test
+        // documents the invariant explicitly.
+        attrs: {},
+        observeFullEvaluationData: false,
+      }))
+      writer.flush()
+
+      const payloadString = request.getCall(0).args[0]
+      assert.strictEqual(payloadString.includes(raw), false)
+    })
+
+    it('coerces non-boolean observeFullEvaluationData to false (fail-closed)', () => {
+      // Direct-caller defense in depth: the hook already coerces, but the writer
+      // is a documented internal surface. A wrong-typed value must not opt-in.
+      for (const value of [undefined, null, 1, 0, 'true', 'false', {}, []]) {
+        writer.enqueue(makeEvent({
+          targetingKey: CANONICAL_INPUT,
+          attrs: {},
+          observeFullEvaluationData: value,
+        }))
+      }
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      // All wrong-typed values coerce to false → all merge into one hashed bucket.
+      assert.strictEqual(payload.flagEvaluations.length, 1,
+        'all non-strict-true values MUST resolve to false and share one bucket')
+      assert.strictEqual(payload.flagEvaluations[0].targeting_key, CANONICAL_HASH)
+    })
+
+    it('runtime_default_used still emits when consent is off', () => {
+      // The runtime_default_used dimension is orthogonal to consent — it comes
+      // from the SDK's evaluation outcome, not the UFC.
+      writer.enqueue(makeEvent({
+        variant: '', // absent → runtime default
+        targetingKey: CANONICAL_INPUT,
+        attrs: {},
+        observeFullEvaluationData: false,
+      }))
+      writer.flush()
+
+      const payload = JSON.parse(request.getCall(0).args[0])
+      const event = payload.flagEvaluations[0]
+      assert.strictEqual(event.runtime_default_used, true)
+      assert.strictEqual(event.targeting_key, CANONICAL_HASH)
+      assert.strictEqual(Object.hasOwn(event, 'variant'), false)
     })
   })
 })

--- a/packages/dd-trace/test/openfeature/writers/hash_targeting_key.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/hash_targeting_key.spec.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+require('../../setup/core')
+
+const FlagEvaluationsWriter = require('../../../src/openfeature/writers/flag_evaluations')
+
+const { hashTargetingKey } = FlagEvaluationsWriter
+
+// SHA-256 of the empty string — pinned so a future refactor cannot silently
+// change the hashing algorithm.
+const SHA256_EMPTY = 'sha256_e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+// The canonical cross-SDK vector. Every SDK — Java, Go, Python, Ruby, PHP,
+// .NET, JS — MUST produce this exact digest for this exact input. Any drift
+// (trim, case fold, Unicode normalization, salt) silently breaks the
+// per-(flag, allocation) unique-subject count join in the backend.
+const CANONICAL_INPUT = 'jane.doe@datadoghq.com'
+const CANONICAL_HASH = 'sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b'
+
+describe('FlagEvaluationsWriter.hashTargetingKey', () => {
+  it('matches the cross-SDK canonical vector', () => {
+    assert.strictEqual(hashTargetingKey(CANONICAL_INPUT), CANONICAL_HASH)
+  })
+
+  it('produces a 71-char output for any input', () => {
+    assert.strictEqual(hashTargetingKey('').length, 71)
+    assert.strictEqual(hashTargetingKey(CANONICAL_INPUT).length, 71)
+    assert.strictEqual(hashTargetingKey('a'.repeat(4096)).length, 71)
+  })
+
+  it('hashes the empty string to the SHA-256 empty digest', () => {
+    assert.strictEqual(hashTargetingKey(''), SHA256_EMPTY)
+  })
+
+  it('does not trim whitespace', () => {
+    assert.notStrictEqual(hashTargetingKey(' jane '), hashTargetingKey('jane'))
+    assert.notStrictEqual(hashTargetingKey('jane\n'), hashTargetingKey('jane'))
+  })
+
+  it('does not case-fold', () => {
+    assert.notStrictEqual(hashTargetingKey('Jane'), hashTargetingKey('jane'))
+    assert.notStrictEqual(hashTargetingKey('JANE'), hashTargetingKey('jane'))
+  })
+
+  it('does not Unicode-normalize', () => {
+    // U+00E9 (single code point) vs U+0065 U+0301 (composed pair). Both render
+    // as "é" but are byte-distinct; a normalizing hash would collapse them.
+    const nfc = 'é'
+    const nfd = 'é'
+    assert.notStrictEqual(hashTargetingKey(nfc), hashTargetingKey(nfd))
+  })
+
+  it('is stable across repeated calls with the same input', () => {
+    assert.strictEqual(hashTargetingKey(CANONICAL_INPUT), hashTargetingKey(CANONICAL_INPUT))
+  })
+})


### PR DESCRIPTION
### What does this PR do?

This PR protects PII in the EVP `flagevaluation` track for `dd-trace-js`.

By default, the SDK does not send raw subject identifiers or evaluation context to Datadog.

A new UFC boolean `observeFullEvaluationData` selects the wire shape:

| `observeFullEvaluationData` | `targeting_key` on the wire | `context.evaluation` on the wire |
| --- | --- | --- |
| `true` | raw, unchanged | present, pruned |
| `false`, absent, or wrong-typed (the default) | `sha256_` + 64-char lowercase hex (71 chars total) | absent |

The kill switch `DD_FLAGGING_EVALUATION_COUNTS_ENABLED` is unchanged. This kill switch disables the whole track when set to `false`.

### Motivation

Server SDK upgrades must not send subject PII to Datadog by accident. Datadog marketing states that server SDK flag evaluations happen locally. The default wire shape must not contradict this promise.

The product metric — unique-subject counts per (flag, allocation) — needs a stable per-subject identifier, not the raw subject. This PR sends a one-way SHA-256 fingerprint by default. Full data collection is an explicit per-environment opt-in.

Tracked as [FFL-2965](https://datadoghq.atlassian.net/browse/FFL-2965), under the server-SDK fan-out FFL-2784. The pilot is [dd-trace-java#12042](https://github.com/DataDog/dd-trace-java/pull/12042). Peers: [dd-trace-go#5151](https://github.com/DataDog/dd-trace-go/pull/5151), [dd-trace-py#19554](https://github.com/DataDog/dd-trace-py/pull/19554).

### Stacked PR

This PR is stacked on `leo.romanovsky/ffl-2446-evp-flagevaluation-nodejs`, not `master`. `dd-trace-js` has not yet shipped the base EVP `flagevaluation` track. The PII contract must land before or with the base track. This order prevents a release that ships raw `targeting_key` by default.

Merge order:
1. Merge this PR into the base-track branch.
2. Merge the base-track branch into `master`.

### Design

**Hashing.** Unsalted SHA-256 over the raw UTF-8 bytes of `targeting_key`. No trim. No case fold. No Unicode normalization. Lowercase hex. Literal `sha256_` prefix. 71 chars total.

- Canonical cross-SDK vector: `jane.doe@datadoghq.com` → `sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b`.
- The same digest must appear in every SDK for the same input. A future refactor that adds trim, case fold, or Unicode normalization breaks the cross-SDK subject-count join.

**UFC read.** The `observeFullEvaluationData` field lives at the **root** of the UFC. It is a sibling of `environment`, not a field of it. Absent, explicit `null`, and wrong-typed values all fail closed to `false`. A value nested inside `environment` is ignored. This defends against the FFL-2784 placement-drift trap.

**Consent lifecycle.** The Java pilot shipped a flush-time consent read bug that unit tests missed and system-tests (L3) caught. This PR uses the same fix pattern as the pilot:

- `FlaggingProvider` stores the UFC and its consent value as one `Object.freeze({configuration, observeFullEvaluationData})` reference. A reader sees the pair, not a torn view.
- `FlagEvalEVPHook` reads consent once at hook entry through an injected `getConsent` function. The function is a private arrow method on the provider. No public accessor is exposed.
- The hook stamps consent on the raw event. The writer keeps consent on the entry. The aggregation bucket key partitions by consent. Mixed-consent evaluations cannot merge.
- A Remote Config update between evaluation and flush cannot retroactively change the wire shape of an in-flight evaluation.

**Hash cadence.** The writer keeps the raw `targeting_key` on the in-memory entry through aggregation. The hash runs once per unique full-tier bucket at flush cadence, not per evaluation. Ten evaluations that share one subject produce one crypto call, not ten. The raw value never crosses the process boundary.

**Consent-off context skip.** When consent is off, the hook does not capture the evaluation context. The writer receives `attrs: {}`. The consent-off bucket key does not carry context dimensions. This prevents high-cardinality context attributes from exhausting the per-flag cap and pushing privacy-protected traffic to the degraded tier. Java pilot lesson `concern:consent-off-bucket-keying`.

**Fail-closed defaults.** Strict `=== true` coercion applies at three sites: the provider snapshot, the hook, and the writer. Only a UFC-root boolean `true` grants opt-in.

### Testing

**All 323 tests in `packages/dd-trace/test/openfeature/` pass.** New PII coverage adds 38 tests across 5 spec files.

**New spec files:**
- `test/openfeature/writers/hash_targeting_key.spec.js` — canonical vector, empty string, 71-char length, non-trim, non-case-fold, non-Unicode-normalize.
- `test/openfeature/writers/flag_eval_consent_lifecycle.spec.js` — the real OpenFeature server SDK drives the real hook and the real writer. Tests swap consent between evaluation and flush. Both directions asserted (off→on, on→off, and mixed-transition).

**New tests in existing spec files:**
- `flag_evaluations.spec.js` (+12 tests): consent-off hashes `targeting_key`, consent-on preserves raw, consent-off omits context on the wire, consent partitions buckets, consent-off merges distinct contexts into one bucket (regression guard), consent-on keeps distinct contexts distinct, hash runs once per bucket at flush, raw-wire negative control on payload bytes, PII context values do not leak, non-boolean consent fails closed, runtime_default_used still emits.
- `flag_eval_evp_hook.spec.js` (+7 tests): consent read once per `finally`, `true`/`false` propagation, context skip when consent is off, capture when on, absent `getConsent` fails closed, non-boolean coercion.
- `flagging_provider.spec.js` (+8 tests): `getConsent` accessor passed only to the EVP hook, default `false` before any `setConfiguration`, atomic swap, fail-closed on wrong types, nested-in-environment ignored, reset on unset, atomic snapshot swap, no public consent accessor.

**Raw-wire negative control.** One test asserts on the serialized payload bytes that the raw `targeting_key` string does not appear anywhere in the wire output when consent is off. The test asserts on the byte string, not on decoded objects. A decode-then-inspect check misses raw values that route into unexpected fields.

**Consent-lifecycle guard.** The lifecycle spec is the most important regression test in this PR. The Java pilot shipped this bug. Unit tests missed it. L3 caught it. This PR pins the fix at the JS layer with three real-eval tests.

**System-tests (L3): out of scope for this PR.** The JS manifest deactivates `test_flag_eval_evp.py` at file level with `missing_feature (FFL-2446)`. A follow-up `system-tests` PR must activate the file and mark the three `Test_FFE_EVP_Flagevaluation_ObserveFullData_*` rows as `missing_feature (FFL-2965)`.

**L2 (dogfooding): not run in this PR.**

### Risks

- **Default-hashed on upgrade.** Any customer dashboard that reads `targeting_key` verbatim starts to see `sha256_`-prefixed values. `dd-trace-js` has not yet shipped the base track. The first release that JS customers see already carries hashing by default. No intermediate raw-PII release exists.
- **Cross-SDK contract drift.** A future refactor that adds trim, case fold, Unicode normalization, or a salt silently breaks the cross-SDK subject-count join. The canonical-vector test and the non-normalization tests are the primary guards.
- **No L3 coverage in CI yet.** The unit-level consent-lifecycle guard carries more weight than usual until L3 is activated for JS.
- **Stacked-PR merge risk.** Reviewers must merge changes from `leo.romanovsky/ffl-2446-evp-flagevaluation-nodejs` back into this branch as the base moves.

### Additional Notes

- **Design and plan.** Committed under `docs/superpowers/specs/2026-08-06-pii-flagevaluations-js-design.md` and `docs/superpowers/plans/2026-08-06-pii-flagevaluations-js.md`.
- **No new configuration keys.** The kill switch `DD_FLAGGING_EVALUATION_COUNTS_ENABLED` already exists in `config/supported-configurations.json`.
- **No dependency changes.** Hashing uses `node:crypto`.
- **No public API surface change.** The `observe_full_evaluation_data` value is internal to the EVP path. It is not exposed on OpenFeature `flagMetadata`. The Java pilot exposed it; a cross-SDK decision to surface it publicly is deferred (see `concern:public-flagmetadata` from Go PR #4886).
- **Upstream evaluator.** `@datadog/openfeature-node-server` v2.0.2 does not stamp `observe_full_evaluation_data` on `ProviderEvaluation.flagMetadata`. This PR uses the hook boundary as the consent-snapshot point. A future upstream change can move the stamp into the evaluator; the hook then flips to read metadata and the provider's `getConsent` binding is removed.
- **Cross-SDK contract source.** RFC `rfc:gdoc:19VIf4B9p-zsAL2uWSvdzil59DZlGjQm4yudAMwJBqLs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FFL-2965]: https://datadoghq.atlassian.net/browse/FFL-2965