### PR TITLE
test(test-optimization): avoid duplicate WebdriverIO fixture copy

### DIFF
--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -156,7 +156,6 @@ for (const version of versions) {
       `@wdio/mocha-framework@${version}`,
     ], true, [
       './integration-tests/webdriverio/fixtures/*',
-      './integration-tests/webdriverio/fixtures/subdirectory',
       './integration-tests/ci-visibility/dynamic-instrumentation/dependency.js',
     ])
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Removes the redundant explicit WebdriverIO `fixtures/subdirectory` sandbox input. The existing `fixtures/*` input already copies that directory recursively.

### Motivation
<!-- What inspired you to submit this pull request? -->

`copyIntegrationTests()` copies every configured input concurrently. Passing both the glob and the directory caused two `cp -R` processes to race while creating the same sandbox path, intermittently failing with `File exists`.

This was observed in [PR #9730's WebdriverIO job](https://github.com/DataDog/dd-trace-js/actions/runs/31162519563/job/92815866486?pr=9730).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:
- Reproduced the GNU `cp` race locally with the original duplicate inputs.
- `WEBDRIVERIO_VERSION=latest` focused integration scenarios: 2 passing.
- ESLint and `git diff --check` pass.
