### PR TITLE
fix(llmobs): add per-integration opt-out

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,15 @@ tracer.use('pg', {
 })
 ```
 
+The `langchain` and `modelcontextprotocol-sdk` integrations accept an `llmobs` option. Setting it to `false` stops LLM Observability span capture for that integration only — APM spans and distributed trace context propagation are unaffected. This is useful when another enabled integration already captures the same operation and the input/output payloads would otherwise be stored twice:
+
+```javascript
+// Keep APM tracing for MCP, but let LangChain own the LLM Observability spans.
+tracer.use('modelcontextprotocol-sdk', {
+  llmobs: false
+})
+```
+
 <h5 id="amqplib"></h5>
 <h5 id="amqplib-tags"></h5>
 <h5 id="amqplib-config"></h5>

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -372,6 +372,7 @@ tracer.use('kafkajs');
 tracer.use('koa');
 tracer.use('koa', httpServerOptions);
 tracer.use('langchain');
+tracer.use('langchain', { llmobs: false });
 tracer.use('mariadb', { service: () => `my-custom-mariadb` })
 tracer.use('langgraph');
 tracer.use('memcached');
@@ -381,6 +382,7 @@ tracer.use('mocha');
 tracer.use('mocha', { service: 'mocha-service' });
 tracer.use('moleculer', moleculerOptions);
 tracer.use('modelcontextprotocol-sdk');
+tracer.use('modelcontextprotocol-sdk', { llmobs: false });
 tracer.use('mongodb-core');
 tracer.use('mongoose');
 tracer.use('mysql');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1941,6 +1941,18 @@ declare namespace tracer {
     interface Instrumentation extends Integration, Analyzable {}
 
     /** @hidden */
+    interface LLMObsIntegration extends Integration {
+      /**
+       * Whether to capture LLM Observability spans for this integration. When set to `false`,
+       * the integration keeps emitting APM spans and propagating trace context, but no LLM
+       * Observability spans are produced. Useful when another integration already captures the
+       * same operation and the payloads would otherwise be stored twice.
+       * @default true
+       */
+      llmobs?: boolean;
+    }
+
+    /** @hidden */
     interface DatabaseInstrumentation extends Instrumentation {
       /**
        * Truncate the resource name (e.g. the query) to the given length.
@@ -2804,7 +2816,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [langchain](https://js.langchain.com/) module
      */
-    interface langchain extends Instrumentation {}
+    interface langchain extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
@@ -2846,7 +2858,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [modelcontextprotocol-sdk](https://github.com/npmjs/package/@modelcontextprotocol/sdk) library.
      */
-    interface modelcontextprotocol_sdk extends Instrumentation {}
+    interface modelcontextprotocol_sdk extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -2053,6 +2053,18 @@ declare namespace tracer {
     interface Instrumentation extends Integration, Analyzable {}
 
     /** @hidden */
+    interface LLMObsIntegration extends Integration {
+      /**
+       * Whether to capture LLM Observability spans for this integration. When set to `false`,
+       * the integration keeps emitting APM spans and propagating trace context, but no LLM
+       * Observability spans are produced. Useful when another integration already captures the
+       * same operation and the payloads would otherwise be stored twice.
+       * @default true
+       */
+      llmobs?: boolean;
+    }
+
+    /** @hidden */
     interface DatabaseInstrumentation extends Instrumentation {
       /**
        * Truncate the resource name (e.g. the query) to the given length.
@@ -2974,7 +2986,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [langchain](https://js.langchain.com/) module
      */
-    interface langchain extends Instrumentation {}
+    interface langchain extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
@@ -3016,7 +3028,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [modelcontextprotocol-sdk](https://github.com/npmjs/package/@modelcontextprotocol/sdk) library.
      */
-    interface modelcontextprotocol_sdk extends Instrumentation {}
+    interface modelcontextprotocol_sdk extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the

--- a/packages/datadog-plugin-modelcontextprotocol-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-modelcontextprotocol-sdk/test/index.spec.js
@@ -10,6 +10,7 @@ const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
 const TestSetup = require('./test-setup')
 
 const testSetup = new TestSetup()
+const llmobsDisabledTestSetup = new TestSetup()
 const legacyStorage = storage('legacy')
 
 describe('plugin lifecycle', () => {
@@ -551,6 +552,73 @@ createIntegrationTestSuite('modelcontextprotocol-sdk', '@modelcontextprotocol/sd
       } finally {
         testSetup.renameTestTool('test-tool')
       }
+
+      return traceAssertion
+    })
+  })
+})
+
+// `llmobs: false` opts the integration out of LLM Observability span capture only: APM tracing and
+// the client -> server trace context propagation must keep working.
+createIntegrationTestSuite('modelcontextprotocol-sdk', '@modelcontextprotocol/sdk', {
+  subModule: '@modelcontextprotocol/sdk/client',
+  pluginConfig: { llmobs: false },
+}, (meta) => {
+  const { agent } = meta
+
+  before(async () => {
+    await llmobsDisabledTestSetup.setup(meta.mod, meta.versionMod)
+  })
+
+  after(async () => {
+    await llmobsDisabledTestSetup.teardown()
+  })
+
+  describe('with llmobs disabled', () => {
+    it('should still generate the client tool call span', async () => {
+      const traceAssertion = expectSomeSpan(agent, {
+        name: 'mcp.request',
+        type: 'mcp',
+        resource: 'client_tool_call',
+        meta: {
+          component: 'modelcontextprotocol_client',
+          '_dd.integration': 'modelcontextprotocol_client',
+          'span.kind': 'client',
+        },
+      })
+
+      const result = await llmobsDisabledTestSetup.clientCallTool()
+      assert.equal(result.content[0].text, 'Result from test-tool')
+
+      return traceAssertion
+    })
+
+    it('should still generate the client list tools span', async () => {
+      const traceAssertion = expectSomeSpan(agent, {
+        name: 'mcp.request',
+        type: 'mcp',
+        resource: 'ClientSession.list_tools',
+        meta: {
+          component: 'modelcontextprotocol_list_tools',
+          '_dd.integration': 'modelcontextprotocol_list_tools',
+          'span.kind': 'client',
+        },
+      })
+
+      const result = await llmobsDisabledTestSetup.clientListTools()
+      assert.equal(result.tools.length, 2)
+
+      return traceAssertion
+    })
+
+    it('should still parent the server request span to the client tool call span', async () => {
+      const spans = []
+      const traceAssertion = agent.assertSomeTraces(traces => {
+        spans.push(...traces.flatMap(trace => trace))
+        assertClientServerParenting(spans, 'client_tool_call')
+      })
+
+      await llmobsDisabledTestSetup.clientCallTool()
 
       return traceAssertion
     })

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -84,9 +84,11 @@ class LLMObsPlugin extends TracingPlugin {
   }
 
   configure (config) {
-    // we do not want to enable any LLMObs plugins if it is disabled on the tracer
+    // we do not want to enable any LLMObs plugins if it is disabled on the tracer, or if the
+    // integration opted out via `tracer.use(<name>, { llmobs: false })`. Opting out only disables
+    // the LLMObs layer: the integration keeps emitting APM spans and propagating trace context.
     const llmobsEnabled = this._tracerConfig.llmobs.DD_LLMOBS_ENABLED
-    if (llmobsEnabled === false) {
+    if (llmobsEnabled === false || config?.llmobs === false) {
       config = typeof config === 'boolean' ? false : { ...config, enabled: false } // override to false
     }
     super.configure(config)

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -121,6 +121,44 @@ describe('integrations', () => {
     })
   })
 
+  describe('langchain with llmobs disabled', () => {
+    const { assertNoLlmObsSpans } = useLlmObs({
+      plugin: 'langchain',
+      pluginConfig: { llmobs: false },
+    })
+
+    withVersions('langchain', ['@langchain/core'], (version) => {
+      let disabledTool
+
+      beforeEach(() => {
+        disabledTool = require(`../../../../../../versions/@langchain/core@${version}`)
+          .get('@langchain/core/tools')
+          .tool
+      })
+
+      it('does not create an LLMObs span for a tool invocation', async function () {
+        if (!disabledTool) this.skip()
+
+        const add = disabledTool(
+          ({ a, b }) => a + b,
+          {
+            name: 'add',
+            description: 'A tool that adds two numbers',
+            schema: {
+              a: { type: 'number' },
+              b: { type: 'number' },
+            },
+          }
+        )
+
+        const result = await add.invoke({ a: 1, b: 2 })
+        assert.equal(result, 3)
+
+        await assertNoLlmObsSpans()
+      })
+    })
+  })
+
   describe('langchain', () => {
     const { getEvents } = useLlmObs({ plugin: 'langchain' })
 

--- a/packages/dd-trace/test/llmobs/plugins/modelcontextprotocol-sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/modelcontextprotocol-sdk/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert')
+const path = require('node:path')
 const { inspect } = require('node:util')
 const { describe, it, before, after } = require('mocha')
 const { withVersions } = require('../../../setup/mocha')
@@ -11,11 +12,40 @@ const {
   useLlmObs,
 } = require('../../util')
 
-describe('integrations', () => {
-  let Client
-  let McpServer
-  let InMemoryTransport
+/**
+ * Connects an in-memory MCP client/server pair for the given SDK version.
+ *
+ * @param {string} version
+ * @param {(server: object) => void} registerTools
+ * @returns {Promise<{ client: object, server: object }>}
+ */
+async function connectClientAndServer (version, registerTools) {
+  const versionModule = require(`../../../../../../versions/@modelcontextprotocol/sdk@${version}`)
 
+  // Require the client submodule first so RITM patches it before the server loads it transitively
+  const { Client } = versionModule.get('@modelcontextprotocol/sdk/client')
+
+  // The package exports map remaps package.json to dist/cjs/package.json, so navigate
+  // up from the resolved client entry path to find the SDK root directory
+  const clientEntryPath = versionModule.getPath('@modelcontextprotocol/sdk/client')
+  const sdkDir = path.resolve(path.dirname(clientEntryPath), '..', '..', '..')
+  const { McpServer } = require(path.join(sdkDir, 'dist/cjs/server/mcp.js'))
+
+  const { InMemoryTransport } = versionModule.get('@modelcontextprotocol/sdk/inMemory.js')
+
+  const server = new McpServer({ name: 'test-server', version: '1.0.0' })
+  registerTools(server)
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' })
+  await client.connect(clientTransport)
+
+  return { client, server }
+}
+
+describe('integrations', () => {
   let client
   let server
 
@@ -24,54 +54,34 @@ describe('integrations', () => {
 
     withVersions('modelcontextprotocol-sdk', '@modelcontextprotocol/sdk', (version) => {
       before(async () => {
-        const path = require('path')
-        const versionModule = require(`../../../../../../versions/@modelcontextprotocol/sdk@${version}`)
+        ;({ client, server } = await connectClientAndServer(version, (mcpServer) => {
+          mcpServer.registerTool(
+            'test-tool',
+            { description: 'A test tool', inputSchema: {} },
+            async () => ({
+              content: [{ type: 'text', text: 'Result from test-tool' }],
+            })
+          )
 
-        // Require the client submodule first so RITM patches it before the server loads it transitively
-        Client = versionModule.get('@modelcontextprotocol/sdk/client').Client
+          mcpServer.registerTool(
+            'error-tool',
+            { description: 'A tool that errors', inputSchema: {} },
+            async () => {
+              throw new Error('Intentional test error')
+            }
+          )
 
-        // The package exports map remaps package.json to dist/cjs/package.json, so navigate
-        // up from the resolved client entry path to find the SDK root directory
-        const clientEntryPath = versionModule.getPath('@modelcontextprotocol/sdk/client')
-        const sdkDir = path.resolve(path.dirname(clientEntryPath), '..', '..', '..')
-        McpServer = require(path.join(sdkDir, 'dist/cjs/server/mcp.js')).McpServer
-
-        InMemoryTransport = versionModule.get('@modelcontextprotocol/sdk/inMemory.js').InMemoryTransport
-
-        server = new McpServer({ name: 'test-server', version: '1.0.0' })
-
-        server.registerTool(
-          'test-tool',
-          { description: 'A test tool', inputSchema: {} },
-          async () => ({
-            content: [{ type: 'text', text: 'Result from test-tool' }],
-          })
-        )
-
-        server.registerTool(
-          'error-tool',
-          { description: 'A tool that errors', inputSchema: {} },
-          async () => {
-            throw new Error('Intentional test error')
-          }
-        )
-
-        server.registerTool(
-          'multi-content-tool',
-          { description: 'Returns multiple content parts', inputSchema: {} },
-          async () => ({
-            content: [
-              { type: 'text', text: 'First part' },
-              { type: 'text', text: 'Second part' },
-            ],
-          })
-        )
-
-        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
-        await server.connect(serverTransport)
-
-        client = new Client({ name: 'test-client', version: '1.0.0' })
-        await client.connect(clientTransport)
+          mcpServer.registerTool(
+            'multi-content-tool',
+            { description: 'Returns multiple content parts', inputSchema: {} },
+            async () => ({
+              content: [
+                { type: 'text', text: 'First part' },
+                { type: 'text', text: 'Second part' },
+              ],
+            })
+          )
+        }))
       })
 
       after(async () => {
@@ -218,6 +228,52 @@ describe('integrations', () => {
             tags: { ml_app: 'test', integration: 'modelcontextprotocol-sdk' },
           })
         })
+      })
+    })
+  })
+
+  describe('modelcontextprotocol-sdk with llmobs disabled', () => {
+    const { assertNoLlmObsSpans } = useLlmObs({
+      plugin: 'modelcontextprotocol-sdk',
+      pluginConfig: { llmobs: false },
+    })
+
+    withVersions('modelcontextprotocol-sdk', '@modelcontextprotocol/sdk', (version) => {
+      let disabledClient
+      let disabledServer
+
+      before(async () => {
+        ({ client: disabledClient, server: disabledServer } = await connectClientAndServer(version, (mcpServer) => {
+          mcpServer.registerTool(
+            'test-tool',
+            { description: 'A test tool', inputSchema: {} },
+            async () => ({
+              content: [{ type: 'text', text: 'Result from test-tool' }],
+            })
+          )
+        }))
+      })
+
+      after(async () => {
+        if (disabledClient) await disabledClient.close()
+        if (disabledServer) await disabledServer.close()
+      })
+
+      it('does not create an LLMObs span for Client.callTool', async () => {
+        const result = await disabledClient.callTool({ name: 'test-tool', arguments: {} })
+        assert.equal(result.content[0].text, 'Result from test-tool')
+
+        // assertNoLlmObsSpans awaits the APM traces first, so this also pins that APM
+        // tracing for the integration survives the LLM Obs opt-out.
+        await assertNoLlmObsSpans()
+      })
+
+      it('does not create an LLMObs span for Client.listTools', async () => {
+        const result = await disabledClient.listTools()
+        assert.equal(result.tools.length, 1)
+        assert.equal(result.tools[0].name, 'test-tool')
+
+        await assertNoLlmObsSpans()
       })
     })
   })

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -406,6 +406,7 @@ function fromBuffer (spanProperty, isNumber = false) {
 /**
  * @param {object} options
  * @param {string} options.plugin
+ * @param {object} [options.pluginConfig] - config passed to `tracer.use(plugin, ...)`
  * @param {object} options.tracerConfigOptions
  * @returns {{
  *   getEvents: (numLlmObsSpans?: number) => Promise<{ apmSpans: Array<object>, llmobsSpans: Array<object> }>,
@@ -415,6 +416,7 @@ function fromBuffer (spanProperty, isNumber = false) {
  */
 function useLlmObs ({
   plugin,
+  pluginConfig = {},
   tracerConfigOptions = {},
 } = {}) {
   /** @type {ReturnType<typeof agent.assertSomeTraces>} */
@@ -436,7 +438,7 @@ function useLlmObs ({
   })
 
   before(async () => {
-    await agent.load(plugin, {}, {
+    await agent.load(plugin, pluginConfig, {
       llmobs: {
         mlApp: 'test',
         agentlessEnabled: false,


### PR DESCRIPTION
## Summary

Closes [#9416](https://github.com/DataDog/dd-trace-js/issues/9416), add a documented and typed `llmobs: false` per-integration option for `langchain` and `modelcontextprotocol-sdk`.

- Disables only LLM Observability span capture for the selected integration.
- Preserves APM spans and distributed trace-context propagation.
- Lets the LangChain integration own LLM Observability spans while MCP tool calls and list-tools operations retain normal APM tracing.

The implementation uses shared LLM Observability plugin plumbing, so other integrations could adopt the pattern later. This PR deliberately scopes its public API and documentation to the LangChain/MCP pairing raised in #9416; broader support belongs in a follow-up PR.

## Testing

- `PLUGINS=modelcontextprotocol-sdk npm run test:plugins:ci` — 57 passing
- `git diff --check`
