### PR TITLE
fix(mariadb): support 3.5.3 CommonJS bundles

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/pool-acquire.js
+++ b/packages/datadog-instrumentations/src/helpers/pool-acquire.js
@@ -621,6 +621,7 @@ module.exports = {
   clearPoolWaitTime,
   dispatchesAcquireSynchronously,
   isPoolQueryAcquire,
+  reportPoolAcquireError,
   runOutsidePoolQueryAcquire,
   runPoolAcquireError,
   runWithPoolWait,

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -164,10 +164,13 @@ function createWrapPromiseCommand (options, preparedSql, commandOwner) {
  * @param {object} options
  * @param {unknown} [preparedSql]
  * @param {object} [commandOwner]
+ * @param {number} [commandArity] Original arity when command is wrapped by a variadic forwarding function.
  * @returns {(command: Function) => Function}
  */
-function createWrapCallbackCommand (options, preparedSql, commandOwner) {
+function createWrapCallbackCommand (options, preparedSql, commandOwner, commandArity) {
   return function wrapCommand (command) {
+    const callbackIndex = (commandArity ?? command.length) - 1
+
     return function (sql) {
       if (!startCh.hasSubscribers) return command.apply(this, arguments)
 
@@ -184,8 +187,10 @@ function createWrapCallbackCommand (options, preparedSql, commandOwner) {
 
       if (typeof callback === 'function') {
         arguments[arguments.length - 1] = shimmer.wrapCallback(callback, wrapper)
+      } else if (callbackIndex >= 0 && arguments.length > callbackIndex && arguments[callbackIndex] == null) {
+        arguments[callbackIndex] = wrapper()
       } else {
-        arguments.length = Math.max(arguments.length + 1, command.length)
+        arguments.length = Math.max(arguments.length + 1, callbackIndex + 1)
         arguments[arguments.length - 1] = wrapper()
       }
 
@@ -272,7 +277,8 @@ function wrapClientCommands (client, wrapper) {
  *
  * @param {object} client
  * @param {object} options
- * @param {(options: object, sql: string) => (command: Function) => Function} createWrapper
+ * @param {(options: object, sql: string, owner?: object, commandArity?: number) =>
+ *   (command: Function) => Function} createWrapper
  * @returns {void}
  */
 function wrapTransactionMethods (client, options, createWrapper) {
@@ -286,12 +292,13 @@ function wrapTransactionMethods (client, options, createWrapper) {
  *
  * @param {object} options
  * @param {string} sql
- * @param {(options: object, sql: string) => (command: Function) => Function} createWrapper
+ * @param {(options: object, sql: string, owner?: object, commandArity?: number) =>
+ *   (command: Function) => Function} createWrapper
  * @returns {(transaction: Function) => Function}
  */
 function createWrapTransaction (options, sql, createWrapper) {
   return function wrapTransaction (transaction) {
-    const tracedTransaction = createWrapper(options, sql)(function () {
+    const tracedTransaction = createWrapper(options, sql, undefined, transaction.length)(function () {
       return skipCh.runStores({}, transaction, this, ...arguments)
     })
 
@@ -434,13 +441,14 @@ function createWrapCallbackPreparedExecute (options, sql, connection) {
  * Runs bundled pool internals in the skip store while tracing the public command.
  *
  * @param {object} options
- * @param {(options: object, sql?: unknown) => (command: Function) => Function} createWrapper
+ * @param {(options: object, sql?: unknown, owner?: object, commandArity?: number) =>
+ *   (command: Function) => Function} createWrapper
  * @param {unknown} [preparedSql]
  * @returns {(command: Function) => Function}
  */
 function createWrapPoolCommand (options, createWrapper, preparedSql) {
   return function wrapPoolCommand (command) {
-    return createWrapper(options, preparedSql)(function () {
+    return createWrapper(options, preparedSql, undefined, command.length)(function () {
       return skipCh.runStores({}, command, this, ...arguments)
     })
   }
@@ -525,16 +533,10 @@ function createWrapCallbackGetConnection (options) {
  * @returns {void}
  */
 function wrapPoolConnectionEvent (pool, options, wrapConnection) {
-  const onConnection = connection => wrapConnection(connection, options)
-
-  pool.prependListener('connection', onConnection)
-  shimmer.wrap(pool, 'emit', emit => function (event) {
+  shimmer.wrap(pool, 'emit', emit => function (event, connection) {
     if (event !== 'connection') return emit.apply(this, arguments)
+    wrapConnection(connection, options)
     return connectionFinishCh.runStores(emptyConnectionContext, emit, this, ...arguments)
-  })
-  shimmer.wrap(pool, 'end', end => function () {
-    pool.removeListener('connection', onConnection)
-    return end.apply(this, arguments)
   })
 }
 

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -1,0 +1,935 @@
+'use strict'
+
+const { errorMonitor } = require('node:events')
+
+const shimmer = require('../../datadog-shimmer')
+const { channel } = require('./helpers/instrument')
+
+const connectionStartCh = channel('apm:mariadb:connection:start')
+const connectionFinishCh = channel('apm:mariadb:connection:finish')
+const startCh = channel('apm:mariadb:query:start')
+const finishCh = channel('apm:mariadb:query:finish')
+const errorCh = channel('apm:mariadb:query:error')
+const skipCh = channel('apm:mariadb:pool:skip')
+
+const activeCommands = new WeakMap()
+const commandMethods = ['query', 'execute', 'batch']
+const emptyConnectionContext = { currentStore: {} }
+const emptyOptions = {}
+const wrappedClients = new WeakSet()
+const wrappedConnections = new WeakSet()
+const IMPORT_FILE_RESOURCE = 'IMPORT FILE'
+const noop = () => {}
+const STATUS_IN_TRANSACTION = 1
+const transactionMethods = [
+  ['beginTransaction', 'START TRANSACTION'],
+  ['commit', 'COMMIT'],
+  ['rollback', 'ROLLBACK'],
+]
+
+/** @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} Descriptor */
+
+/**
+ * Extracts SQL from MariaDB's string and object command forms.
+ *
+ * @param {unknown} command
+ * @returns {unknown}
+ */
+function normalizeSql (command) {
+  return command !== null && typeof command === 'object' ? command.sql : command
+}
+
+/**
+ * Matches MariaDB's use of the default cluster selector for every falsy pattern.
+ *
+ * @param {unknown} pattern
+ * @returns {unknown}
+ */
+function normalizeClusterPattern (pattern) {
+  return pattern || /^/
+}
+
+/**
+ * Parses connection options without allowing instrumentation to break the factory call.
+ *
+ * @param {Function} defaultOptions
+ * @param {unknown} options
+ * @returns {object}
+ */
+function normalizeOptions (defaultOptions, options) {
+  try {
+    return defaultOptions(options)
+  } catch {
+    return options !== null && typeof options === 'object' ? options : {}
+  }
+}
+
+/**
+ * Marks a command as active on its owning public connection.
+ *
+ * @param {object} owner
+ * @returns {void}
+ */
+function startCommand (owner) {
+  activeCommands.set(owner, (activeCommands.get(owner) ?? 0) + 1)
+}
+
+/**
+ * Releases one active command without clearing concurrent commands.
+ *
+ * @param {object} owner
+ * @returns {void}
+ */
+function endCommand (owner) {
+  const active = activeCommands.get(owner)
+  if (active === 1) {
+    activeCommands.delete(owner)
+  } else if (active !== undefined) {
+    activeCommands.set(owner, active - 1)
+  }
+}
+
+/**
+ * Publishes command completion state and releases its owner.
+ *
+ * @param {object} ctx
+ * @param {object} owner
+ * @param {Error} [error]
+ * @param {unknown} [result]
+ * @returns {void}
+ */
+function finishCommandState (ctx, owner, error, result) {
+  endCommand(owner)
+  if (error) {
+    ctx.error = error
+    errorCh.publish(ctx)
+  }
+  ctx.result = result
+}
+
+/**
+ * Publishes a complete command lifecycle outside a callback continuation.
+ *
+ * @param {object} ctx
+ * @param {object} owner
+ * @param {Error} [error]
+ * @param {unknown} [result]
+ * @returns {void}
+ */
+function finishCommand (ctx, owner, error, result) {
+  finishCommandState(ctx, owner, error, result)
+  finishCh.publish(ctx)
+}
+
+/**
+ * Creates a promise-returning command wrapper.
+ *
+ * @param {object} options
+ * @param {unknown} [preparedSql]
+ * @param {object} [commandOwner]
+ * @returns {(command: Function) => Function}
+ */
+function createWrapPromiseCommand (options, preparedSql, commandOwner) {
+  return function wrapCommand (command) {
+    return function (sql) {
+      if (!startCh.hasSubscribers) return command.apply(this, arguments)
+
+      const owner = commandOwner ?? this
+      const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
+
+      startCommand(owner)
+
+      let result
+      try {
+        result = startCh.runStores(ctx, command, this, ...arguments)
+      } catch (error) {
+        finishCommand(ctx, owner, error)
+        throw error
+      }
+
+      return result.then(result => {
+        finishCommand(ctx, owner, undefined, result)
+        return result
+      }, error => {
+        finishCommand(ctx, owner, error)
+        throw error
+      })
+    }
+  }
+}
+
+/**
+ * Creates a callback command wrapper and supplies a completion callback when the caller omits one.
+ *
+ * @param {object} options
+ * @param {unknown} [preparedSql]
+ * @param {object} [commandOwner]
+ * @returns {(command: Function) => Function}
+ */
+function createWrapCallbackCommand (options, preparedSql, commandOwner) {
+  return function wrapCommand (command) {
+    return function (sql) {
+      if (!startCh.hasSubscribers) return command.apply(this, arguments)
+
+      const owner = commandOwner ?? this
+      const callback = arguments[arguments.length - 1]
+      const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
+      const wrapper = callback => function (error) {
+        finishCommandState(ctx, owner, error)
+
+        return typeof callback === 'function'
+          ? finishCh.runStores(ctx, callback, this, ...arguments)
+          : finishCh.runStores(ctx, noop, this)
+      }
+
+      if (typeof callback === 'function') {
+        arguments[arguments.length - 1] = shimmer.wrapCallback(callback, wrapper)
+      } else {
+        arguments.length = Math.max(arguments.length + 1, command.length)
+        arguments[arguments.length - 1] = wrapper()
+      }
+
+      startCommand(owner)
+
+      try {
+        return startCh.runStores(ctx, command, this, ...arguments)
+      } catch (error) {
+        finishCommand(ctx, owner, error)
+        throw error
+      }
+    }
+  }
+}
+
+/**
+ * Traces a Readable-returning command without replacing the stream.
+ *
+ * @param {object} options
+ * @param {unknown} [preparedSql]
+ * @param {object} [commandOwner]
+ * @returns {(streamMethod: Function) => Function}
+ */
+function createWrapStream (options, preparedSql, commandOwner) {
+  return function wrapStream (streamMethod) {
+    return function (sql) {
+      if (!startCh.hasSubscribers) return streamMethod.apply(this, arguments)
+
+      const owner = commandOwner ?? this
+      const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
+      let stream
+
+      startCommand(owner)
+      try {
+        stream = startCh.runStores(ctx, streamMethod, this, ...arguments)
+      } catch (error) {
+        finishCommand(ctx, owner, error)
+        throw error
+      }
+
+      let finished = false
+      const cleanup = () => {
+        stream.removeListener('end', onEnd)
+        stream.removeListener('close', onClose)
+        stream.removeListener(errorMonitor, onError)
+      }
+      const complete = error => {
+        if (finished) return
+        finished = true
+        cleanup()
+        finishCommand(ctx, owner, error)
+      }
+      const onEnd = () => complete()
+      const onClose = () => complete()
+      const onError = error => complete(error)
+
+      stream.once('end', onEnd)
+      stream.once('close', onClose)
+      stream.once(errorMonitor, onError)
+
+      return stream
+    }
+  }
+}
+
+/**
+ * Wraps command methods exposed by a bundled client.
+ *
+ * @param {object} client
+ * @param {(command: Function) => Function} wrapper
+ * @returns {void}
+ */
+function wrapClientCommands (client, wrapper) {
+  if (wrappedClients.has(client)) return
+
+  wrappedClients.add(client)
+  for (const method of commandMethods) {
+    if (typeof client[method] === 'function') shimmer.wrap(client, method, wrapper)
+  }
+}
+
+/**
+ * Wraps transaction helpers whose bundled implementations bypass the public query methods.
+ *
+ * @param {object} client
+ * @param {object} options
+ * @param {(options: object, sql: string) => (command: Function) => Function} createWrapper
+ * @returns {void}
+ */
+function wrapTransactionMethods (client, options, createWrapper) {
+  for (const [method, sql] of transactionMethods) {
+    shimmer.wrap(client, method, createWrapTransaction(options, sql, createWrapper))
+  }
+}
+
+/**
+ * Traces a transaction helper only when MariaDB sends its command.
+ *
+ * @param {object} options
+ * @param {string} sql
+ * @param {(options: object, sql: string) => (command: Function) => Function} createWrapper
+ * @returns {(transaction: Function) => Function}
+ */
+function createWrapTransaction (options, sql, createWrapper) {
+  return function wrapTransaction (transaction) {
+    const tracedTransaction = createWrapper(options, sql)(function () {
+      return skipCh.runStores({}, transaction, this, ...arguments)
+    })
+
+    return function () {
+      if (!startCh.hasSubscribers) return transaction.apply(this, arguments)
+
+      if (sql !== 'START TRANSACTION' &&
+        !activeCommands.has(this) &&
+        !(this.info?.status & STATUS_IN_TRANSACTION)) {
+        return transaction.apply(this, arguments)
+      }
+
+      return tracedTransaction.apply(this, arguments)
+    }
+  }
+}
+
+/**
+ * Wraps a promise connection and the prepared statements it creates.
+ *
+ * @param {object} connection
+ * @param {object} options
+ * @returns {object}
+ */
+function wrapPromiseConnection (connection, options) {
+  wrapClientCommands(connection, createWrapPromiseCommand(options))
+  if (wrappedConnections.has(connection)) return connection
+
+  wrappedConnections.add(connection)
+  shimmer.wrap(connection, 'importFile', createWrapPromiseCommand(options, IMPORT_FILE_RESOURCE))
+  if (typeof connection.queryStream === 'function') {
+    shimmer.wrap(connection, 'queryStream', createWrapStream(options))
+  }
+  shimmer.wrap(connection, 'prepare', createWrapPromisePrepare(options))
+  wrapTransactionMethods(connection, options, createWrapPromiseCommand)
+
+  return connection
+}
+
+/**
+ * Wraps a callback connection and the prepared statements it creates.
+ *
+ * @param {object} connection
+ * @param {object} options
+ * @returns {object}
+ */
+function wrapCallbackConnection (connection, options) {
+  wrapClientCommands(connection, createWrapCallbackCommand(options))
+  if (wrappedConnections.has(connection)) return connection
+
+  wrappedConnections.add(connection)
+  shimmer.wrap(connection, 'importFile', createWrapCallbackCommand(options, IMPORT_FILE_RESOURCE))
+  if (typeof connection.queryStream === 'function') {
+    shimmer.wrap(connection, 'queryStream', createWrapStream(options))
+  }
+  shimmer.wrap(connection, 'prepare', createWrapCallbackPrepare(options))
+  wrapTransactionMethods(connection, options, createWrapCallbackCommand)
+
+  return connection
+}
+
+/**
+ * Wraps prepared statements created by a promise connection.
+ *
+ * @param {object} options
+ * @returns {(prepare: Function) => Function}
+ */
+function createWrapPromisePrepare (options) {
+  return function wrapPrepare (prepare) {
+    return function (sql) {
+      const connection = this
+      const preparedSql = normalizeSql(sql)
+      return prepare.apply(this, arguments).then(statement => {
+        shimmer.wrap(statement, 'execute', createWrapPromiseCommand(options, preparedSql, connection))
+        if (typeof statement.executeStream === 'function') {
+          shimmer.wrap(statement, 'executeStream', createWrapStream(options, preparedSql, connection))
+        }
+        return statement
+      })
+    }
+  }
+}
+
+/**
+ * Wraps prepared statements created by a callback connection.
+ *
+ * @param {object} options
+ * @returns {(prepare: Function) => Function}
+ */
+function createWrapCallbackPrepare (options) {
+  return function wrapPrepare (prepare) {
+    return function (sql) {
+      const connection = this
+      const preparedSql = normalizeSql(sql)
+      const callback = arguments[arguments.length - 1]
+      if (typeof callback !== 'function') return prepare.apply(this, arguments)
+
+      arguments[arguments.length - 1] = function () {
+        const statement = arguments[1]
+        if (statement) {
+          shimmer.wrap(
+            statement,
+            'execute',
+            createWrapCallbackPreparedExecute(options, preparedSql, connection)
+          )
+          if (typeof statement.executeStream === 'function') {
+            shimmer.wrap(statement, 'executeStream', createWrapStream(options, preparedSql, connection))
+          }
+        }
+        return callback.apply(this, arguments)
+      }
+
+      return prepare.apply(this, arguments)
+    }
+  }
+}
+
+/**
+ * Wraps callback prepared statements, which return a promise when no callback is provided.
+ *
+ * @param {object} options
+ * @param {unknown} sql
+ * @param {object} connection
+ * @returns {(execute: Function) => Function}
+ */
+function createWrapCallbackPreparedExecute (options, sql, connection) {
+  return function wrapExecute (execute) {
+    const executeWithCallback = createWrapCallbackCommand(options, sql, connection)(execute)
+    const executeWithPromise = createWrapPromiseCommand(options, sql, connection)(execute)
+
+    return function () {
+      const hasCallback = typeof arguments[1] === 'function' || typeof arguments[2] === 'function'
+      const wrappedExecute = hasCallback ? executeWithCallback : executeWithPromise
+      return wrappedExecute.apply(this, arguments)
+    }
+  }
+}
+
+/**
+ * Runs bundled pool internals in the skip store while tracing the public command.
+ *
+ * @param {object} options
+ * @param {(options: object, sql?: unknown) => (command: Function) => Function} createWrapper
+ * @param {unknown} [preparedSql]
+ * @returns {(command: Function) => Function}
+ */
+function createWrapPoolCommand (options, createWrapper, preparedSql) {
+  return function wrapPoolCommand (command) {
+    return createWrapper(options, preparedSql)(function () {
+      return skipCh.runStores({}, command, this, ...arguments)
+    })
+  }
+}
+
+/**
+ * Restores the caller context and instruments a pooled promise connection.
+ *
+ * @param {object} ctx
+ * @param {object} connection
+ * @param {object} options
+ * @returns {object}
+ */
+function finishPromiseGetConnection (ctx, connection, options) {
+  return connectionFinishCh.runStores(ctx, wrapPromiseConnection, undefined, connection, options)
+}
+
+/**
+ * Restores the caller context when a promise acquisition fails.
+ *
+ * @param {object} ctx
+ * @param {Error} error
+ * @throws {Error} The connection acquisition error.
+ */
+function finishPromiseGetConnectionError (ctx, error) {
+  return connectionFinishCh.runStores(ctx, () => { throw error })
+}
+
+/**
+ * Wraps getConnection on a bundled promise pool.
+ *
+ * @param {object} options
+ * @returns {(getConnection: Function) => Function}
+ */
+function createWrapPromiseGetConnection (options) {
+  return function wrapGetConnection (getConnection) {
+    return function () {
+      const ctx = {}
+
+      connectionStartCh.publish(ctx)
+
+      return skipCh.runStores({}, getConnection, this, ...arguments).then(
+        connection => finishPromiseGetConnection(ctx, connection, options),
+        error => finishPromiseGetConnectionError(ctx, error)
+      )
+    }
+  }
+}
+
+/**
+ * Wraps getConnection on a bundled callback pool.
+ *
+ * @param {object} options
+ * @returns {(getConnection: Function) => Function}
+ */
+function createWrapCallbackGetConnection (options) {
+  return function wrapGetConnection (getConnection) {
+    return function () {
+      const callback = arguments[arguments.length - 1]
+      if (typeof callback !== 'function') return getConnection.apply(this, arguments)
+
+      const ctx = {}
+      arguments[arguments.length - 1] = function () {
+        const connection = arguments[1]
+        if (connection) wrapCallbackConnection(connection, options)
+        return connectionFinishCh.runStores(ctx, callback, this, ...arguments)
+      }
+
+      connectionStartCh.publish(ctx)
+
+      return skipCh.runStores({}, getConnection, this, ...arguments)
+    }
+  }
+}
+
+/**
+ * Instruments connection wrappers emitted when a bundled pool creates a connection.
+ *
+ * @param {object} pool
+ * @param {object} options
+ * @param {(connection: object, options: object) => object} wrapConnection
+ * @returns {void}
+ */
+function wrapPoolConnectionEvent (pool, options, wrapConnection) {
+  const onConnection = connection => wrapConnection(connection, options)
+
+  pool.prependListener('connection', onConnection)
+  shimmer.wrap(pool, 'emit', emit => function (event) {
+    if (event !== 'connection') return emit.apply(this, arguments)
+    return connectionFinishCh.runStores(emptyConnectionContext, emit, this, ...arguments)
+  })
+  shimmer.wrap(pool, 'end', end => function () {
+    pool.removeListener('connection', onConnection)
+    return end.apply(this, arguments)
+  })
+}
+
+/**
+ * Captures the connection options registered with a pool cluster.
+ *
+ * @param {object} cluster
+ * @param {Function} defaultOptions
+ * @returns {(pattern: unknown) => object}
+ */
+function captureClusterOptions (cluster, defaultOptions) {
+  const optionsByIdentifier = new Map()
+  const optionsByPattern = new Map()
+  let nodeCounter = 0
+
+  const removeOptions = identifier => {
+    optionsByIdentifier.delete(identifier)
+    optionsByPattern.clear()
+  }
+
+  const eventEmitter = cluster.on('remove', removeOptions)
+
+  shimmer.wrap(cluster, 'add', add => function (identifier, options) {
+    const hasIdentifier = typeof identifier === 'string' ||
+      Object.prototype.toString.call(identifier) === '[object String]'
+    const generatedIdentifier = hasIdentifier ? String(identifier) : `PoolNode-${nodeCounter++}`
+    const connectionOptions = hasIdentifier ? options : identifier
+    const result = skipCh.runStores({}, add, this, ...arguments)
+    optionsByIdentifier.set(generatedIdentifier, normalizeOptions(defaultOptions, connectionOptions))
+    optionsByPattern.clear()
+    return result
+  })
+
+  shimmer.wrap(cluster, 'remove', remove => function (pattern) {
+    const result = remove.apply(this, arguments)
+    removeClusterOptions(optionsByIdentifier, pattern)
+    optionsByPattern.clear()
+    return result
+  })
+
+  shimmer.wrap(cluster, 'end', end => function () {
+    optionsByIdentifier.clear()
+    optionsByPattern.clear()
+    eventEmitter.removeListener('remove', removeOptions)
+    return end.apply(this, arguments)
+  })
+
+  return pattern => {
+    const normalizedPattern = normalizeClusterPattern(pattern)
+    const cacheKey = String(normalizedPattern)
+    const cachedOptions = optionsByPattern.get(cacheKey)
+    if (cachedOptions !== undefined) return cachedOptions
+
+    const regularExpression = new RegExp(normalizedPattern)
+    let matchedOptions
+
+    for (const [identifier, options] of optionsByIdentifier) {
+      regularExpression.lastIndex = 0
+      if (!regularExpression.test(identifier)) continue
+      if (matchedOptions !== undefined) {
+        optionsByPattern.set(cacheKey, emptyOptions)
+        return emptyOptions
+      }
+      matchedOptions = options
+    }
+
+    matchedOptions ??= emptyOptions
+    optionsByPattern.set(cacheKey, matchedOptions)
+    return matchedOptions
+  }
+}
+
+/**
+ * Removes options for every cluster node matching a selector.
+ *
+ * @param {Map<string, object>} optionsByIdentifier
+ * @param {string} pattern
+ * @returns {void}
+ */
+function removeClusterOptions (optionsByIdentifier, pattern) {
+  const regularExpression = new RegExp(pattern)
+
+  for (const identifier of optionsByIdentifier.keys()) {
+    regularExpression.lastIndex = 0
+    if (regularExpression.test(identifier)) optionsByIdentifier.delete(identifier)
+  }
+}
+
+/**
+ * Wraps promise connections acquired from a bundled pool cluster.
+ *
+ * @param {(pattern: unknown) => object} getOptions
+ * @returns {(getConnection: Function) => Function}
+ */
+function createWrapPromiseClusterGetConnection (getOptions) {
+  return function wrapGetConnection (getConnection) {
+    return function (pattern) {
+      const ctx = {}
+      const options = getOptions(pattern)
+
+      connectionStartCh.publish(ctx)
+
+      return skipCh.runStores({}, getConnection, this, ...arguments).then(
+        connection => finishPromiseGetConnection(ctx, connection, options),
+        error => finishPromiseGetConnectionError(ctx, error)
+      )
+    }
+  }
+}
+
+/**
+ * Wraps callback connections acquired from a bundled pool cluster.
+ *
+ * @param {(pattern: unknown) => object} getOptions
+ * @returns {(getConnection: Function) => Function}
+ */
+function createWrapCallbackClusterGetConnection (getOptions) {
+  return function wrapGetConnection (getConnection) {
+    return function (pattern) {
+      const callback = arguments[arguments.length - 1]
+      if (typeof callback !== 'function') return getConnection.apply(this, arguments)
+
+      const ctx = {}
+      const options = getOptions(typeof pattern === 'function' ? undefined : pattern)
+      arguments[arguments.length - 1] = function () {
+        const connection = arguments[1]
+        if (connection) wrapCallbackConnection(connection, options)
+        return connectionFinishCh.runStores(ctx, callback, this, ...arguments)
+      }
+
+      connectionStartCh.publish(ctx)
+
+      return skipCh.runStores({}, getConnection, this, ...arguments)
+    }
+  }
+}
+
+/**
+ * Wraps promise connections acquired from a bundled pool cluster.
+ *
+ * @param {object} cluster
+ * @param {Function} defaultOptions
+ * @returns {object}
+ */
+function wrapPromiseCluster (cluster, defaultOptions) {
+  const getOptions = captureClusterOptions(cluster, defaultOptions)
+
+  shimmer.wrap(cluster, 'getConnection', createWrapPromiseClusterGetConnection(getOptions))
+
+  return cluster
+}
+
+/**
+ * Wraps callback connections acquired from a bundled pool cluster.
+ *
+ * @param {object} cluster
+ * @param {Function} defaultOptions
+ * @returns {object}
+ */
+function wrapCallbackCluster (cluster, defaultOptions) {
+  const getOptions = captureClusterOptions(cluster, defaultOptions)
+
+  shimmer.wrap(cluster, 'getConnection', createWrapCallbackClusterGetConnection(getOptions))
+  // The filtered callback facade delegates to a private Cluster instance, bypassing the public method above.
+  shimmer.wrap(cluster, 'of', of => function (pattern) {
+    const filteredCluster = of.apply(this, arguments)
+    shimmer.wrap(filteredCluster, 'getConnection', createWrapCallbackClusterGetConnection(() => getOptions(pattern)))
+    return filteredCluster
+  })
+
+  return cluster
+}
+
+/**
+ * Wraps the createConnection factory from a bundled promise entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(createConnection: Function) => Function}
+ */
+function createWrapPromiseConnectionFactory (defaultOptions) {
+  return function wrapCreateConnection (createConnection) {
+    return function (options) {
+      return createConnection.apply(this, arguments).then(connection => {
+        return wrapPromiseConnection(connection, normalizeOptions(defaultOptions, options))
+      })
+    }
+  }
+}
+
+/**
+ * Wraps the createConnection factory from a bundled callback entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(createConnection: Function) => Function}
+ */
+function createWrapCallbackConnectionFactory (defaultOptions) {
+  return function wrapCreateConnection (createConnection) {
+    return function (options) {
+      const connection = createConnection.apply(this, arguments)
+      return wrapCallbackConnection(connection, normalizeOptions(defaultOptions, options))
+    }
+  }
+}
+
+/**
+ * Wraps the createPool factory from a bundled promise entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(createPool: Function) => Function}
+ */
+function createWrapPromisePoolFactory (defaultOptions) {
+  return function wrapCreatePool (createPool) {
+    return function (options) {
+      const pool = skipCh.runStores({}, createPool, this, ...arguments)
+      const normalizedOptions = normalizeOptions(defaultOptions, options)
+
+      wrapPoolConnectionEvent(pool, normalizedOptions, wrapPromiseConnection)
+      wrapClientCommands(pool, createWrapPoolCommand(normalizedOptions, createWrapPromiseCommand))
+      shimmer.wrap(
+        pool,
+        'importFile',
+        createWrapPoolCommand(normalizedOptions, createWrapPromiseCommand, IMPORT_FILE_RESOURCE)
+      )
+      shimmer.wrap(pool, 'getConnection', createWrapPromiseGetConnection(normalizedOptions))
+
+      return pool
+    }
+  }
+}
+
+/**
+ * Wraps the createPool factory from a bundled callback entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(createPool: Function) => Function}
+ */
+function createWrapCallbackPoolFactory (defaultOptions) {
+  return function wrapCreatePool (createPool) {
+    return function (options) {
+      const pool = skipCh.runStores({}, createPool, this, ...arguments)
+      const normalizedOptions = normalizeOptions(defaultOptions, options)
+
+      wrapPoolConnectionEvent(pool, normalizedOptions, wrapCallbackConnection)
+      wrapClientCommands(pool, createWrapPoolCommand(normalizedOptions, createWrapCallbackCommand))
+      shimmer.wrap(
+        pool,
+        'importFile',
+        createWrapPoolCommand(normalizedOptions, createWrapCallbackCommand, IMPORT_FILE_RESOURCE)
+      )
+      shimmer.wrap(pool, 'getConnection', createWrapCallbackGetConnection(normalizedOptions))
+
+      return pool
+    }
+  }
+}
+
+/**
+ * Wraps the createPoolCluster factory from a bundled promise entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(createPoolCluster: Function) => Function}
+ */
+function createWrapPromiseClusterFactory (defaultOptions) {
+  return function wrapCreatePoolCluster (createPoolCluster) {
+    return function () {
+      return wrapPromiseCluster(createPoolCluster.apply(this, arguments), defaultOptions)
+    }
+  }
+}
+
+/**
+ * Wraps the createPoolCluster factory from a bundled callback entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(createPoolCluster: Function) => Function}
+ */
+function createWrapCallbackClusterFactory (defaultOptions) {
+  return function wrapCreatePoolCluster (createPoolCluster) {
+    return function () {
+      return wrapCallbackCluster(createPoolCluster.apply(this, arguments), defaultOptions)
+    }
+  }
+}
+
+/**
+ * Wraps the top-level importFile helper from a bundled promise entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(importFile: Function) => Function}
+ */
+function createWrapPromiseImportFile (defaultOptions) {
+  return function wrapImportFile (importFile) {
+    return function (options) {
+      const wrapper = createWrapPromiseCommand(
+        normalizeOptions(defaultOptions, options),
+        IMPORT_FILE_RESOURCE
+      )(importFile)
+      return wrapper.apply(this, arguments)
+    }
+  }
+}
+
+/**
+ * Wraps the top-level importFile helper from a bundled callback entry.
+ *
+ * @param {Function} defaultOptions
+ * @returns {(importFile: Function) => Function}
+ */
+function createWrapCallbackImportFile (defaultOptions) {
+  return function wrapImportFile (importFile) {
+    return function (options) {
+      const wrapper = createWrapCallbackCommand(
+        normalizeOptions(defaultOptions, options),
+        IMPORT_FILE_RESOURCE
+      )(importFile)
+      return wrapper.apply(this, arguments)
+    }
+  }
+}
+
+/**
+ * Replaces a cloned export descriptor value while preserving its descriptor shape.
+ *
+ * @param {Descriptor} descriptor
+ * @param {unknown} value
+ * @returns {void}
+ */
+function replaceDescriptorValue (descriptor, value) {
+  if (descriptor.get) {
+    descriptor.get = () => value
+  } else {
+    descriptor.value = value
+  }
+}
+
+/**
+ * Clones a CommonJS bundle namespace and wraps selected factories without mutating non-configurable exports.
+ *
+ * @param {object} mariadb
+ * @param {Array<[string, (factory: Function) => Function]>} factories
+ * @returns {object}
+ */
+function wrapBundle (mariadb, factories) {
+  const descriptors = Object.getOwnPropertyDescriptors(mariadb)
+  const defaultDescriptors = Object.getOwnPropertyDescriptors(mariadb.default)
+
+  for (const [name, wrapper] of factories) {
+    const wrapped = shimmer.wrapFunction(mariadb[name], wrapper)
+    replaceDescriptorValue(descriptors[name], wrapped)
+    replaceDescriptorValue(defaultDescriptors[name], wrapped)
+  }
+
+  const defaultExport = Object.defineProperties(
+    Object.create(Object.getPrototypeOf(mariadb.default)),
+    defaultDescriptors
+  )
+  replaceDescriptorValue(descriptors.default, defaultExport)
+
+  return Object.defineProperties(Object.create(Object.getPrototypeOf(mariadb)), descriptors)
+}
+
+/**
+ * Instruments the promise API exported by MariaDB's 3.5.3+ CommonJS bundle.
+ *
+ * @param {object} mariadb
+ * @param {string} _version
+ * @param {boolean} isIitm
+ * @returns {object}
+ */
+function wrapPromiseBundle (mariadb, _version, isIitm) {
+  if (isIitm) return mariadb
+
+  const defaultOptions = mariadb.defaultOptions
+  return wrapBundle(mariadb, [
+    ['createConnection', createWrapPromiseConnectionFactory(defaultOptions)],
+    ['createPool', createWrapPromisePoolFactory(defaultOptions)],
+    ['createPoolCluster', createWrapPromiseClusterFactory(defaultOptions)],
+    ['importFile', createWrapPromiseImportFile(defaultOptions)],
+  ])
+}
+
+/**
+ * Instruments the callback API exported by MariaDB's 3.5.3+ CommonJS bundle.
+ *
+ * @param {object} mariadb
+ * @returns {object}
+ */
+function wrapCallbackBundle (mariadb) {
+  const defaultOptions = mariadb.defaultOptions
+  return wrapBundle(mariadb, [
+    ['createConnection', createWrapCallbackConnectionFactory(defaultOptions)],
+    ['createPool', createWrapCallbackPoolFactory(defaultOptions)],
+    ['createPoolCluster', createWrapCallbackClusterFactory(defaultOptions)],
+    ['importFile', createWrapCallbackImportFile(defaultOptions)],
+  ])
+}
+
+module.exports = { wrapCallbackBundle, wrapPromiseBundle }

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -412,7 +412,9 @@ function restorePoolAcquisitionObserver (pool, observer) {
  * @returns {void}
  */
 function observePoolAcquisitions (pool) {
-  const observer = () => recordPoolAcquisition(pool)
+  const observer = () => {
+    if (connectionStartCh.hasSubscribers) recordPoolAcquisition(pool)
+  }
   pool.prependListener('acquire', observer)
 
   shimmer.wrap(pool, 'removeAllListeners', removeAllListeners => function (event) {

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -335,13 +335,35 @@ function finishExplicitPoolAcquisition (acquisition, error) {
 }
 
 /**
- * Observes the public acquire event forwarded by a bundled pool.
+ * Restores the acquisition observer if application listener cleanup removed it.
+ *
+ * @param {object} pool
+ * @param {Function} observer
+ * @returns {void}
+ */
+function restorePoolAcquisitionObserver (pool, observer) {
+  const listeners = pool.listeners('acquire')
+  for (const listener of listeners) {
+    if (listener === observer) return
+  }
+  pool.prependListener('acquire', observer)
+}
+
+/**
+ * Observes public acquire events forwarded by a bundled pool.
  *
  * @param {object} pool
  * @returns {void}
  */
 function observePoolAcquisitions (pool) {
-  pool.prependListener('acquire', () => recordPoolAcquisition(pool))
+  const observer = () => recordPoolAcquisition(pool)
+  pool.prependListener('acquire', observer)
+
+  shimmer.wrap(pool, 'removeAllListeners', removeAllListeners => function (event) {
+    const result = removeAllListeners.apply(this, arguments)
+    if (event === undefined || event === 'acquire') restorePoolAcquisitionObserver(pool, observer)
+    return result
+  })
 }
 
 /**
@@ -1134,6 +1156,53 @@ function runClusterGetConnection (getConnection, receiver, args) {
 }
 
 /**
+ * Reports a failed bundled cluster node acquisition.
+ *
+ * @param {ClusterSelection} selection
+ * @param {number | undefined} start
+ * @param {unknown} error
+ * @returns {void}
+ */
+function reportBundledClusterAcquireError (selection, start, error) {
+  if (!acquireStartCh.hasSubscribers) return
+  reportPoolAcquireError(start, error, { conf: selection.options ?? emptyOptions }, poolAcquireChannels)
+}
+
+/**
+ * Restores promise caller context and reports a failed bundled cluster node acquisition.
+ *
+ * @param {object} ctx
+ * @param {ClusterSelection} selection
+ * @param {number | undefined} start
+ * @param {unknown} error
+ * @throws {unknown} The connection acquisition error.
+ */
+function finishPromiseClusterGetConnectionError (ctx, selection, start, error) {
+  return connectionFinishCh.runStores(ctx, () => {
+    reportBundledClusterAcquireError(selection, start, error)
+    throw error
+  })
+}
+
+/**
+ * Restores callback caller context and finishes a bundled cluster acquisition.
+ *
+ * @param {ClusterSelection} selection
+ * @param {number | undefined} start
+ * @param {Function} callback
+ * @param {unknown} receiver
+ * @param {ArgumentsLike} args
+ * @returns {unknown}
+ */
+function finishCallbackClusterGetConnection (selection, start, callback, receiver, args) {
+  const error = args[0]
+  const connection = args[1]
+  if (error) reportBundledClusterAcquireError(selection, start, error)
+  if (connection) wrapCallbackConnection(connection, selection.options ?? emptyOptions)
+  return callback.apply(receiver, args)
+}
+
+/**
  * Wraps promise connections acquired from a bundled pool cluster.
  *
  * @param {ClusterSelectionStorage} selectionStorage
@@ -1145,6 +1214,7 @@ function createWrapPromiseClusterGetConnection (selectionStorage) {
       const ctx = {}
       /** @type {ClusterSelection} */
       const selection = {}
+      const start = acquireStartCh.hasSubscribers ? performance.now() : undefined
 
       connectionStartCh.publish(ctx)
 
@@ -1158,7 +1228,7 @@ function createWrapPromiseClusterGetConnection (selectionStorage) {
 
       return result.then(
         connection => finishPromiseGetConnection(ctx, connection, selection.options ?? emptyOptions),
-        error => finishPromiseGetConnectionError(ctx, error)
+        error => finishPromiseClusterGetConnectionError(ctx, selection, start, error)
       )
     }
   }
@@ -1179,10 +1249,18 @@ function createWrapCallbackClusterGetConnection (selectionStorage) {
       const ctx = {}
       /** @type {ClusterSelection} */
       const selection = {}
+      const start = acquireStartCh.hasSubscribers ? performance.now() : undefined
       arguments[arguments.length - 1] = function () {
-        const connection = arguments[1]
-        if (connection) wrapCallbackConnection(connection, selection.options ?? emptyOptions)
-        return connectionFinishCh.runStores(ctx, callback, this, ...arguments)
+        return connectionFinishCh.runStores(
+          ctx,
+          finishCallbackClusterGetConnection,
+          undefined,
+          selection,
+          start,
+          callback,
+          this,
+          arguments
+        )
       }
 
       connectionStartCh.publish(ctx)

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -30,6 +30,7 @@ const wrappedClients = new WeakSet()
 const wrappedConnections = new WeakSet()
 const IMPORT_FILE_RESOURCE = 'IMPORT FILE'
 const noop = () => {}
+const POOL_ACQUISITION_COMPACTION_THRESHOLD = 1024
 const STATUS_IN_TRANSACTION = 1
 const transactionMethods = [
   ['beginTransaction', 'START TRANSACTION'],
@@ -57,7 +58,7 @@ const transactionMethods = [
  * @property {number} [start]
  */
 /** @typedef {import('node:async_hooks').AsyncLocalStorage<PoolAcquisition>} PoolAcquisitionStorage */
-/** @typedef {{ acquisitions: PoolAcquisition[], index: number }} PendingPoolAcquisitions */
+/** @typedef {{ acquisitions: Array<PoolAcquisition | undefined>, index: number }} PendingPoolAcquisitions */
 
 /** @type {ClusterSelectionStorage | undefined} */
 let clusterSelectionStorage
@@ -168,6 +169,27 @@ function isPoolAcquisitionPending (acquisition) {
 }
 
 /**
+ * Releases a consumed acquisition and periodically compacts its queue.
+ *
+ * @param {PendingPoolAcquisitions} pending
+ * @returns {void}
+ */
+function discardPoolAcquisition (pending) {
+  pending.acquisitions[pending.index++] = undefined
+
+  if (
+    pending.index < POOL_ACQUISITION_COMPACTION_THRESHOLD ||
+    pending.index * 2 < pending.acquisitions.length ||
+    pending.index === pending.acquisitions.length
+  ) {
+    return
+  }
+
+  pending.acquisitions = pending.acquisitions.slice(pending.index)
+  pending.index = 0
+}
+
+/**
  * Removes completed entries from the front of a pool's acquisition queue.
  *
  * @param {object} pool
@@ -178,9 +200,10 @@ function prunePoolAcquisitions (pool) {
   if (pending === undefined) return
 
   while (pending.index < pending.acquisitions.length) {
-    const acquisition = pending.acquisitions[pending.index]
+    const acquisition = /** @type {PoolAcquisition} */ (pending.acquisitions[pending.index])
     if (isPoolAcquisitionPending(acquisition)) return
-    pending.index++
+
+    discardPoolAcquisition(pending)
   }
 
   pendingPoolAcquisitions.delete(pool)
@@ -197,7 +220,9 @@ function takePoolAcquisition (pool) {
   if (pending === undefined) return
 
   while (pending.index < pending.acquisitions.length) {
-    const acquisition = pending.acquisitions[pending.index++]
+    const acquisition = /** @type {PoolAcquisition} */ (pending.acquisitions[pending.index])
+    discardPoolAcquisition(pending)
+
     if (isPoolAcquisitionPending(acquisition)) return acquisition
   }
 

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const { errorMonitor } = require('node:events')
+const { performance } = require('node:perf_hooks')
 
 const shimmer = require('../../datadog-shimmer')
 const { channel } = require('./helpers/instrument')
+const { acquireWait, reportPoolAcquireError } = require('./helpers/pool-acquire')
 
 const connectionStartCh = channel('apm:mariadb:connection:start')
 const connectionFinishCh = channel('apm:mariadb:connection:finish')
@@ -11,9 +13,17 @@ const startCh = channel('apm:mariadb:query:start')
 const finishCh = channel('apm:mariadb:query:finish')
 const errorCh = channel('apm:mariadb:query:error')
 const skipCh = channel('apm:mariadb:pool:skip')
+const acquireStartCh = channel('apm:mariadb:pool:acquire:start')
+const acquireFinishCh = channel('apm:mariadb:pool:acquire:finish')
+const poolAcquireChannels = {
+  connectionFinishCh,
+  acquireStartCh,
+  acquireFinishCh,
+}
 
 const activeCommands = new WeakMap()
 const commandMethods = ['query', 'execute', 'batch']
+const trackedCommandMethods = ['changeUser', 'ping', 'prepare', 'reset']
 const emptyConnectionContext = { currentStore: {} }
 const emptyOptions = {}
 const wrappedClients = new WeakSet()
@@ -27,14 +37,36 @@ const transactionMethods = [
   ['rollback', 'ROLLBACK'],
 ]
 
-/** @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} Descriptor */
 /** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
 /** @typedef {{ options: object, pendingRemovals: number }} ClusterNodeOptions */
 /** @typedef {{ options?: object }} ClusterSelection */
 /** @typedef {import('node:async_hooks').AsyncLocalStorage<ClusterSelection>} ClusterSelectionStorage */
+/**
+ * @typedef {object} PoolAcquisition
+ * @property {Record<string, unknown>} [acquireCtx]
+ * @property {boolean} [acquired]
+ * @property {object} connectionCtx
+ * @property {unknown} [error]
+ * @property {boolean} [errorReported]
+ * @property {boolean} [finished]
+ * @property {boolean} measure
+ * @property {object} options
+ * @property {object} pool
+ * @property {object} [queryCtx]
+ * @property {boolean} [ready]
+ * @property {number} [start]
+ */
+/** @typedef {import('node:async_hooks').AsyncLocalStorage<PoolAcquisition>} PoolAcquisitionStorage */
+/** @typedef {{ acquisitions: PoolAcquisition[], index: number }} PendingPoolAcquisitions */
 
 /** @type {ClusterSelectionStorage | undefined} */
 let clusterSelectionStorage
+
+/** @type {PoolAcquisitionStorage | undefined} */
+let poolAcquisitionStorage
+
+/** @type {WeakMap<object, PendingPoolAcquisitions>} */
+const pendingPoolAcquisitions = new WeakMap()
 
 /**
  * Creates cluster selection storage only when an application uses pool clusters.
@@ -50,13 +82,26 @@ function getClusterSelectionStorage () {
 }
 
 /**
+ * Creates pool acquisition storage only when an application uses a bundled pool.
+ *
+ * @returns {PoolAcquisitionStorage}
+ */
+function getPoolAcquisitionStorage () {
+  if (poolAcquisitionStorage === undefined) {
+    const { AsyncLocalStorage } = require('node:async_hooks')
+    poolAcquisitionStorage = new AsyncLocalStorage()
+  }
+  return poolAcquisitionStorage
+}
+
+/**
  * Extracts SQL from MariaDB's string and object command forms.
  *
  * @param {unknown} command
  * @returns {unknown}
  */
 function normalizeSql (command) {
-  return command !== null && typeof command === 'object' ? command.sql : command
+  return command?.sql ?? command
 }
 
 /**
@@ -72,6 +117,231 @@ function normalizeOptions (defaultOptions, options) {
   } catch {
     return options !== null && typeof options === 'object' ? options : {}
   }
+}
+
+/**
+ * Creates acquisition state while the caller context is still active.
+ *
+ * @param {object} pool
+ * @param {object} options
+ * @param {object} [queryCtx]
+ * @param {boolean} [explicit]
+ * @returns {PoolAcquisition}
+ */
+function createPoolAcquisition (pool, options, queryCtx, explicit) {
+  const measure = explicit === true || queryCtx !== undefined
+  const connectionCtx = measure ? {} : emptyConnectionContext
+  const acquisition = { connectionCtx, measure, options, pool, queryCtx }
+
+  if (measure) connectionStartCh.publish(connectionCtx)
+  if (explicit) {
+    acquisition.acquireCtx = { conf: options }
+    acquireStartCh.publish(acquisition.acquireCtx)
+  }
+
+  return acquisition
+}
+
+/**
+ * Queues a delayed acquisition for pool events that no longer carry its async-local context.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @returns {void}
+ */
+function queuePoolAcquisition (acquisition) {
+  let pending = pendingPoolAcquisitions.get(acquisition.pool)
+  if (pending === undefined) {
+    pending = { acquisitions: [], index: 0 }
+    pendingPoolAcquisitions.set(acquisition.pool, pending)
+  }
+  pending.acquisitions.push(acquisition)
+}
+
+/**
+ * Reports whether an acquisition still needs a matching pool event.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @returns {boolean}
+ */
+function isPoolAcquisitionPending (acquisition) {
+  return !acquisition.acquired && !acquisition.finished && !acquisition.errorReported
+}
+
+/**
+ * Removes completed entries from the front of a pool's acquisition queue.
+ *
+ * @param {object} pool
+ * @returns {void}
+ */
+function prunePoolAcquisitions (pool) {
+  const pending = pendingPoolAcquisitions.get(pool)
+  if (pending === undefined) return
+
+  while (pending.index < pending.acquisitions.length) {
+    const acquisition = pending.acquisitions[pending.index]
+    if (isPoolAcquisitionPending(acquisition)) return
+    pending.index++
+  }
+
+  pendingPoolAcquisitions.delete(pool)
+}
+
+/**
+ * Takes the next unfinished acquisition from a pool's public-operation queue.
+ *
+ * @param {object} pool
+ * @returns {PoolAcquisition | undefined}
+ */
+function takePoolAcquisition (pool) {
+  const pending = pendingPoolAcquisitions.get(pool)
+  if (pending === undefined) return
+
+  while (pending.index < pending.acquisitions.length) {
+    const acquisition = pending.acquisitions[pending.index++]
+    if (isPoolAcquisitionPending(acquisition)) return acquisition
+  }
+
+  pendingPoolAcquisitions.delete(pool)
+}
+
+/**
+ * Records the pool wait when MariaDB announces that the calling operation acquired a connection.
+ *
+ * @param {object} pool
+ * @returns {void}
+ */
+function recordPoolAcquisition (pool) {
+  let acquisition = poolAcquisitionStorage?.getStore()
+  if (acquisition?.pool !== pool || !isPoolAcquisitionPending(acquisition)) {
+    acquisition = takePoolAcquisition(pool)
+  }
+  if (acquisition === undefined) return
+
+  acquisition.acquired = true
+  prunePoolAcquisitions(pool)
+  if (!acquisition.measure) return
+
+  const poolWaitTime = acquireWait(acquisition.start)
+
+  if (acquisition.queryCtx !== undefined) acquisition.queryCtx.poolWaitTime = poolWaitTime
+  if (acquisition.acquireCtx !== undefined) acquisition.acquireCtx.poolWaitTime = poolWaitTime
+}
+
+/**
+ * Creates an acquire error span when a pooled query fails before receiving a connection.
+ *
+ * @param {PoolAcquisition | undefined} acquisition
+ * @param {unknown} error
+ * @returns {void}
+ */
+function reportPoolQueryAcquireError (acquisition, error) {
+  if (acquisition === undefined || acquisition.acquired || acquisition.errorReported) return
+
+  acquisition.error = error
+  if (!acquisition.ready) return
+
+  acquisition.errorReported = true
+  prunePoolAcquisitions(acquisition.pool)
+  connectionFinishCh.runStores(acquisition.connectionCtx, reportPoolAcquireError, undefined,
+    acquisition.start, error, { conf: acquisition.options }, poolAcquireChannels)
+}
+
+/**
+ * Calls a method with its original receiver and arguments.
+ *
+ * @param {Function} method
+ * @param {unknown} receiver
+ * @param {ArgumentsLike} args
+ * @returns {unknown}
+ */
+function callMethod (method, receiver, args) {
+  return method.apply(receiver, args)
+}
+
+/**
+ * Runs a public pool operation while associating its acquire event with that operation.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @param {Function} method
+ * @param {object} receiver
+ * @param {ArgumentsLike} args
+ * @returns {unknown}
+ */
+function runPoolAcquisition (acquisition, method, receiver, args) {
+  const result = getPoolAcquisitionStorage().run(acquisition, callMethod, method, receiver, args)
+
+  acquisition.ready = true
+  if (!acquisition.acquired && !acquisition.finished) {
+    queuePoolAcquisition(acquisition)
+    if (!acquisition.measure) return result
+
+    if (acquisition.error === undefined) {
+      acquisition.start = performance.now()
+    } else {
+      reportPoolQueryAcquireError(acquisition, acquisition.error)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Completes tracking for a pool command that has returned to the caller.
+ *
+ * @param {PoolAcquisition | undefined} acquisition
+ * @param {unknown} [error]
+ * @returns {void}
+ */
+function finishPoolCommandAcquisition (acquisition, error) {
+  if (acquisition === undefined) return
+  if (error && acquisition.measure) {
+    reportPoolQueryAcquireError(acquisition, error)
+    if (!acquisition.ready) return
+  }
+  if (!acquisition.acquired) acquisition.finished = true
+  prunePoolAcquisitions(acquisition.pool)
+}
+
+/**
+ * Runs a bundled pool method in the instrumentation skip context.
+ *
+ * @param {Function} method
+ * @param {unknown} receiver
+ * @param {ArgumentsLike} args
+ * @returns {unknown}
+ */
+function runSkippedPoolMethod (method, receiver, args) {
+  return skipCh.runStores({}, method, receiver, ...args)
+}
+
+/**
+ * Finishes the acquire span created for a public getConnection call.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @param {unknown} [error]
+ * @returns {void}
+ */
+function finishExplicitPoolAcquisition (acquisition, error) {
+  if (acquisition.finished) return
+  acquisition.finished = true
+  prunePoolAcquisitions(acquisition.pool)
+
+  const acquireCtx = acquisition.acquireCtx
+  if (acquireCtx === undefined) return
+
+  acquireCtx.poolWaitTime ??= acquireWait(acquisition.start)
+  if (error) acquireCtx.error = error
+  acquireFinishCh.publish(acquireCtx)
+}
+
+/**
+ * Observes the public acquire event forwarded by a bundled pool.
+ *
+ * @param {object} pool
+ * @returns {void}
+ */
+function observePoolAcquisitions (pool) {
+  pool.prependListener('acquire', () => recordPoolAcquisition(pool))
 }
 
 /**
@@ -134,6 +404,100 @@ function finishCommand (ctx, owner, error, result) {
 }
 
 /**
+ * Replaces an existing callback or inserts one in the method's declared callback slot.
+ *
+ * @param {ArgumentsLike} args
+ * @param {number} callbackIndex
+ * @param {unknown} callback
+ * @param {(callback?: Function) => Function} createCallback
+ * @returns {void}
+ */
+function setCommandCallback (args, callbackIndex, callback, createCallback) {
+  if (typeof callback === 'function') {
+    args[args.length - 1] = shimmer.wrapCallback(callback, createCallback)
+    return
+  }
+
+  const wrappedCallback = createCallback()
+  // MariaDB reads the declared callback slot, so appending after an explicit null leaves the wrapper unused.
+  if (callbackIndex >= 0 && args.length > callbackIndex && args[callbackIndex] == null) {
+    args[callbackIndex] = wrappedCallback
+    return
+  }
+
+  args.length = Math.max(args.length + 1, callbackIndex + 1)
+  args[args.length - 1] = wrappedCallback
+}
+
+/**
+ * Tracks an untraced promise command while MariaDB may have work queued for it.
+ *
+ * @param {Function} command
+ * @returns {Function}
+ */
+function createTrackPromiseCommand (command) {
+  return function () {
+    if (!startCh.hasSubscribers) return command.apply(this, arguments)
+
+    const owner = this
+    startCommand(owner)
+
+    let result
+    try {
+      result = command.apply(this, arguments)
+    } catch (error) {
+      endCommand(owner)
+      throw error
+    }
+
+    return result.then(result => {
+      endCommand(owner)
+      return result
+    }, error => {
+      endCommand(owner)
+      throw error
+    })
+  }
+}
+
+/**
+ * Tracks an untraced callback command while MariaDB may have work queued for it.
+ *
+ * @param {Function} command
+ * @returns {Function}
+ */
+function createTrackCallbackCommand (command) {
+  const callbackIndex = command.length - 1
+
+  return function () {
+    if (!startCh.hasSubscribers) return command.apply(this, arguments)
+
+    const owner = this
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      endCommand(owner)
+    }
+    const createCallback = callback => function () {
+      finish()
+      if (typeof callback === 'function') return callback.apply(this, arguments)
+    }
+
+    const callback = arguments[arguments.length - 1]
+    setCommandCallback(arguments, callbackIndex, callback, createCallback)
+    startCommand(owner)
+
+    try {
+      return command.apply(this, arguments)
+    } catch (error) {
+      finish()
+      throw error
+    }
+  }
+}
+
+/**
  * Creates a promise-returning command wrapper.
  *
  * @param {object} options
@@ -141,30 +505,45 @@ function finishCommand (ctx, owner, error, result) {
  * @param {object} [commandOwner]
  * @param {number} [_commandArity] Reserved for callback command wrappers.
  * @param {boolean} [trackActiveCommands]
+ * @param {'measure' | 'observe'} [poolAcquisition]
  * @returns {(command: Function) => Function}
  */
-function createWrapPromiseCommand (options, preparedSql, commandOwner, _commandArity, trackActiveCommands = true) {
+function createWrapPromiseCommand (
+  options,
+  preparedSql,
+  commandOwner,
+  _commandArity,
+  trackActiveCommands = true,
+  poolAcquisition
+) {
   return function wrapCommand (command) {
     return function (sql) {
       if (!startCh.hasSubscribers) return command.apply(this, arguments)
 
       const owner = trackActiveCommands ? (commandOwner ?? this) : undefined
       const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
+      const acquisition = poolAcquisition !== undefined && acquireStartCh.hasSubscribers
+        ? createPoolAcquisition(this, options, poolAcquisition === 'measure' ? ctx : undefined)
+        : undefined
 
       startCommand(owner)
 
       let result
       try {
-        result = startCh.runStores(ctx, command, this, ...arguments)
+        result = acquisition === undefined
+          ? startCh.runStores(ctx, command, this, ...arguments)
+          : startCh.runStores(ctx, runPoolAcquisition, undefined, acquisition, command, this, arguments)
       } catch (error) {
         finishCommand(ctx, owner, error)
         throw error
       }
 
       return result.then(result => {
+        finishPoolCommandAcquisition(acquisition)
         finishCommand(ctx, owner, undefined, result)
         return result
       }, error => {
+        finishPoolCommandAcquisition(acquisition, error)
         finishCommand(ctx, owner, error)
         throw error
       })
@@ -180,9 +559,17 @@ function createWrapPromiseCommand (options, preparedSql, commandOwner, _commandA
  * @param {object} [commandOwner]
  * @param {number} [commandArity] Original arity when command is wrapped by a variadic forwarding function.
  * @param {boolean} [trackActiveCommands]
+ * @param {'measure' | 'observe'} [poolAcquisition]
  * @returns {(command: Function) => Function}
  */
-function createWrapCallbackCommand (options, preparedSql, commandOwner, commandArity, trackActiveCommands = true) {
+function createWrapCallbackCommand (
+  options,
+  preparedSql,
+  commandOwner,
+  commandArity,
+  trackActiveCommands = true,
+  poolAcquisition
+) {
   return function wrapCommand (command) {
     const callbackIndex = (commandArity ?? command.length) - 1
 
@@ -192,7 +579,11 @@ function createWrapCallbackCommand (options, preparedSql, commandOwner, commandA
       const owner = trackActiveCommands ? (commandOwner ?? this) : undefined
       const callback = arguments[arguments.length - 1]
       const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
+      const acquisition = poolAcquisition !== undefined && acquireStartCh.hasSubscribers
+        ? createPoolAcquisition(this, options, poolAcquisition === 'measure' ? ctx : undefined)
+        : undefined
       const wrapper = callback => function (error) {
+        finishPoolCommandAcquisition(acquisition, error)
         finishCommandState(ctx, owner, error)
 
         return typeof callback === 'function'
@@ -200,19 +591,14 @@ function createWrapCallbackCommand (options, preparedSql, commandOwner, commandA
           : finishCh.runStores(ctx, noop, this)
       }
 
-      if (typeof callback === 'function') {
-        arguments[arguments.length - 1] = shimmer.wrapCallback(callback, wrapper)
-      } else if (callbackIndex >= 0 && arguments.length > callbackIndex && arguments[callbackIndex] == null) {
-        arguments[callbackIndex] = wrapper()
-      } else {
-        arguments.length = Math.max(arguments.length + 1, callbackIndex + 1)
-        arguments[arguments.length - 1] = wrapper()
-      }
+      setCommandCallback(arguments, callbackIndex, callback, wrapper)
 
       startCommand(owner)
 
       try {
-        return startCh.runStores(ctx, command, this, ...arguments)
+        return acquisition === undefined
+          ? startCh.runStores(ctx, command, this, ...arguments)
+          : startCh.runStores(ctx, runPoolAcquisition, undefined, acquisition, command, this, arguments)
       } catch (error) {
         finishCommand(ctx, owner, error)
         throw error
@@ -288,6 +674,27 @@ function wrapClientCommands (client, wrapper) {
 }
 
 /**
+ * Wraps commands exposed by a bundled pool and tracks acquisition for query and execute.
+ *
+ * @param {object} pool
+ * @param {object} options
+ * @param {(options: object, sql?: unknown, owner?: object, commandArity?: number,
+ *   trackActiveCommands?: boolean, poolAcquisition?: 'measure' | 'observe') =>
+ *   (command: Function) => Function} createWrapper
+ * @returns {void}
+ */
+function wrapPoolCommands (pool, options, createWrapper) {
+  if (wrappedClients.has(pool)) return
+
+  wrappedClients.add(pool)
+  for (const method of commandMethods) {
+    if (typeof pool[method] !== 'function') continue
+    const poolAcquisition = method === 'query' || method === 'execute' ? 'measure' : 'observe'
+    shimmer.wrap(pool, method, createWrapPoolCommand(options, createWrapper, undefined, poolAcquisition))
+  }
+}
+
+/**
  * Wraps transaction helpers whose bundled implementations bypass the public query methods.
  *
  * @param {object} client
@@ -313,7 +720,8 @@ function wrapTransactionMethods (client, options, createWrapper) {
  */
 function createWrapTransaction (options, sql, createWrapper) {
   return function wrapTransaction (transaction) {
-    const tracedTransaction = createWrapper(options, sql, undefined, transaction.length)(function () {
+    const wrapCommand = createWrapper(options, sql, undefined, transaction.length)
+    const tracedTransaction = wrapCommand(function () {
       return skipCh.runStores({}, transaction, this, ...arguments)
     })
 
@@ -343,6 +751,9 @@ function wrapPromiseConnection (connection, options) {
   if (wrappedConnections.has(connection)) return connection
 
   wrappedConnections.add(connection)
+  for (const method of trackedCommandMethods) {
+    if (typeof connection[method] === 'function') shimmer.wrap(connection, method, createTrackPromiseCommand)
+  }
   shimmer.wrap(connection, 'importFile', createWrapPromiseCommand(options, IMPORT_FILE_RESOURCE))
   if (typeof connection.queryStream === 'function') {
     shimmer.wrap(connection, 'queryStream', createWrapStream(options))
@@ -365,6 +776,9 @@ function wrapCallbackConnection (connection, options) {
   if (wrappedConnections.has(connection)) return connection
 
   wrappedConnections.add(connection)
+  for (const method of trackedCommandMethods) {
+    if (typeof connection[method] === 'function') shimmer.wrap(connection, method, createTrackCallbackCommand)
+  }
   shimmer.wrap(connection, 'importFile', createWrapCallbackCommand(options, IMPORT_FILE_RESOURCE))
   if (typeof connection.queryStream === 'function') {
     shimmer.wrap(connection, 'queryStream', createWrapStream(options))
@@ -441,8 +855,10 @@ function createWrapCallbackPrepare (options) {
  */
 function createWrapCallbackPreparedExecute (options, sql, connection) {
   return function wrapExecute (execute) {
-    const executeWithCallback = createWrapCallbackCommand(options, sql, connection)(execute)
-    const executeWithPromise = createWrapPromiseCommand(options, sql, connection)(execute)
+    const wrapCallbackCommand = createWrapCallbackCommand(options, sql, connection)
+    const wrapPromiseCommand = createWrapPromiseCommand(options, sql, connection)
+    const executeWithCallback = wrapCallbackCommand(execute)
+    const executeWithPromise = wrapPromiseCommand(execute)
 
     return function () {
       const hasCallback = typeof arguments[1] === 'function' || typeof arguments[2] === 'function'
@@ -457,14 +873,16 @@ function createWrapCallbackPreparedExecute (options, sql, connection) {
  *
  * @param {object} options
  * @param {(options: object, sql?: unknown, owner?: object, commandArity?: number,
- *   trackActiveCommands?: boolean) =>
+ *   trackActiveCommands?: boolean, poolAcquisition?: 'measure' | 'observe') =>
  *   (command: Function) => Function} createWrapper
  * @param {unknown} [preparedSql]
+ * @param {'measure' | 'observe'} [poolAcquisition]
  * @returns {(command: Function) => Function}
  */
-function createWrapPoolCommand (options, createWrapper, preparedSql) {
+function createWrapPoolCommand (options, createWrapper, preparedSql, poolAcquisition) {
   return function wrapPoolCommand (command) {
-    return createWrapper(options, preparedSql, undefined, command.length, false)(function () {
+    const wrapCommand = createWrapper(options, preparedSql, undefined, command.length, false, poolAcquisition)
+    return wrapCommand(function () {
       return skipCh.runStores({}, command, this, ...arguments)
     })
   }
@@ -494,6 +912,35 @@ function finishPromiseGetConnectionError (ctx, error) {
 }
 
 /**
+ * Finishes an explicit promise acquisition and instruments its connection in the caller context.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @param {object} connection
+ * @param {object} options
+ * @returns {object}
+ */
+function finishExplicitPromiseGetConnection (acquisition, connection, options) {
+  return connectionFinishCh.runStores(acquisition.connectionCtx, () => {
+    finishExplicitPoolAcquisition(acquisition)
+    return wrapPromiseConnection(connection, options)
+  })
+}
+
+/**
+ * Finishes a failed explicit promise acquisition in the caller context.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @param {Error} error
+ * @throws {Error} The connection acquisition error.
+ */
+function finishExplicitPromiseGetConnectionError (acquisition, error) {
+  return connectionFinishCh.runStores(acquisition.connectionCtx, () => {
+    finishExplicitPoolAcquisition(acquisition, error)
+    throw error
+  })
+}
+
+/**
  * Wraps getConnection on a bundled promise pool.
  *
  * @param {object} options
@@ -502,13 +949,29 @@ function finishPromiseGetConnectionError (ctx, error) {
 function createWrapPromiseGetConnection (options) {
   return function wrapGetConnection (getConnection) {
     return function () {
-      const ctx = {}
+      if (!connectionStartCh.hasSubscribers) return getConnection.apply(this, arguments)
 
-      connectionStartCh.publish(ctx)
+      if (!acquireStartCh.hasSubscribers) {
+        const ctx = {}
+        connectionStartCh.publish(ctx)
+        return skipCh.runStores({}, getConnection, this, ...arguments).then(
+          connection => finishPromiseGetConnection(ctx, connection, options),
+          error => finishPromiseGetConnectionError(ctx, error)
+        )
+      }
 
-      return skipCh.runStores({}, getConnection, this, ...arguments).then(
-        connection => finishPromiseGetConnection(ctx, connection, options),
-        error => finishPromiseGetConnectionError(ctx, error)
+      const acquisition = createPoolAcquisition(this, options, undefined, true)
+      let result
+
+      try {
+        result = runPoolAcquisition(acquisition, runSkippedPoolMethod, undefined, [getConnection, this, arguments])
+      } catch (error) {
+        return finishExplicitPromiseGetConnectionError(acquisition, error)
+      }
+
+      return result.then(
+        connection => finishExplicitPromiseGetConnection(acquisition, connection, options),
+        error => finishExplicitPromiseGetConnectionError(acquisition, error)
       )
     }
   }
@@ -526,16 +989,34 @@ function createWrapCallbackGetConnection (options) {
       const callback = arguments[arguments.length - 1]
       if (typeof callback !== 'function') return getConnection.apply(this, arguments)
 
-      const ctx = {}
-      arguments[arguments.length - 1] = function () {
-        const connection = arguments[1]
-        if (connection) wrapCallbackConnection(connection, options)
-        return connectionFinishCh.runStores(ctx, callback, this, ...arguments)
+      if (!connectionStartCh.hasSubscribers) return getConnection.apply(this, arguments)
+
+      if (!acquireStartCh.hasSubscribers) {
+        const ctx = {}
+        arguments[arguments.length - 1] = function () {
+          const connection = arguments[1]
+          if (connection) wrapCallbackConnection(connection, options)
+          return connectionFinishCh.runStores(ctx, callback, this, ...arguments)
+        }
+
+        connectionStartCh.publish(ctx)
+        return skipCh.runStores({}, getConnection, this, ...arguments)
       }
 
-      connectionStartCh.publish(ctx)
+      const acquisition = createPoolAcquisition(this, options, undefined, true)
+      arguments[arguments.length - 1] = function (error, connection) {
+        if (connection) wrapCallbackConnection(connection, options)
+        return connectionFinishCh.runStores(acquisition.connectionCtx, () => {
+          finishExplicitPoolAcquisition(acquisition, error)
+          return callback.apply(this, arguments)
+        })
+      }
 
-      return skipCh.runStores({}, getConnection, this, ...arguments)
+      try {
+        return runPoolAcquisition(acquisition, runSkippedPoolMethod, undefined, [getConnection, this, arguments])
+      } catch (error) {
+        return finishExplicitPromiseGetConnectionError(acquisition, error)
+      }
     }
   }
 }
@@ -798,12 +1279,13 @@ function createWrapPromisePoolFactory (defaultOptions) {
       const pool = skipCh.runStores({}, createPool, this, ...arguments)
       const normalizedOptions = normalizeOptions(defaultOptions, options)
 
+      observePoolAcquisitions(pool)
       wrapPoolConnectionEvent(pool, normalizedOptions, wrapPromiseConnection)
-      wrapClientCommands(pool, createWrapPoolCommand(normalizedOptions, createWrapPromiseCommand))
+      wrapPoolCommands(pool, normalizedOptions, createWrapPromiseCommand)
       shimmer.wrap(
         pool,
         'importFile',
-        createWrapPoolCommand(normalizedOptions, createWrapPromiseCommand, IMPORT_FILE_RESOURCE)
+        createWrapPoolCommand(normalizedOptions, createWrapPromiseCommand, IMPORT_FILE_RESOURCE, 'observe')
       )
       shimmer.wrap(pool, 'getConnection', createWrapPromiseGetConnection(normalizedOptions))
 
@@ -824,12 +1306,13 @@ function createWrapCallbackPoolFactory (defaultOptions) {
       const pool = skipCh.runStores({}, createPool, this, ...arguments)
       const normalizedOptions = normalizeOptions(defaultOptions, options)
 
+      observePoolAcquisitions(pool)
       wrapPoolConnectionEvent(pool, normalizedOptions, wrapCallbackConnection)
-      wrapClientCommands(pool, createWrapPoolCommand(normalizedOptions, createWrapCallbackCommand))
+      wrapPoolCommands(pool, normalizedOptions, createWrapCallbackCommand)
       shimmer.wrap(
         pool,
         'importFile',
-        createWrapPoolCommand(normalizedOptions, createWrapCallbackCommand, IMPORT_FILE_RESOURCE)
+        createWrapPoolCommand(normalizedOptions, createWrapCallbackCommand, IMPORT_FILE_RESOURCE, 'observe')
       )
       shimmer.wrap(pool, 'getConnection', createWrapCallbackGetConnection(normalizedOptions))
 
@@ -875,13 +1358,14 @@ function createWrapCallbackClusterFactory (defaultOptions) {
 function createWrapPromiseImportFile (defaultOptions) {
   return function wrapImportFile (importFile) {
     return function (options) {
-      const wrapper = createWrapPromiseCommand(
+      const wrapCommand = createWrapPromiseCommand(
         normalizeOptions(defaultOptions, options),
         IMPORT_FILE_RESOURCE,
         undefined,
         undefined,
         false
-      )(importFile)
+      )
+      const wrapper = wrapCommand(importFile)
       return wrapper.apply(this, arguments)
     }
   }
@@ -896,57 +1380,38 @@ function createWrapPromiseImportFile (defaultOptions) {
 function createWrapCallbackImportFile (defaultOptions) {
   return function wrapImportFile (importFile) {
     return function (options) {
-      const wrapper = createWrapCallbackCommand(
+      const wrapCommand = createWrapCallbackCommand(
         normalizeOptions(defaultOptions, options),
         IMPORT_FILE_RESOURCE,
         undefined,
         undefined,
         false
-      )(importFile)
+      )
+      const wrapper = wrapCommand(importFile)
       return wrapper.apply(this, arguments)
     }
   }
 }
 
 /**
- * Replaces a cloned export descriptor value while preserving its descriptor shape.
- *
- * @param {Descriptor} descriptor
- * @param {unknown} value
- * @returns {void}
- */
-function replaceDescriptorValue (descriptor, value) {
-  if (descriptor.get) {
-    descriptor.get = () => value
-  } else {
-    descriptor.value = value
-  }
-}
-
-/**
- * Clones a CommonJS bundle namespace and wraps selected factories without mutating non-configurable exports.
+ * Wraps selected CommonJS factories in the mutable default export and its non-configurable namespace getters.
  *
  * @param {object} mariadb
  * @param {Array<[string, (factory: Function) => Function]>} factories
  * @returns {object}
  */
 function wrapBundle (mariadb, factories) {
-  const descriptors = Object.getOwnPropertyDescriptors(mariadb)
-  const defaultDescriptors = Object.getOwnPropertyDescriptors(mariadb.default)
+  const defaultExport = mariadb.default
+  let wrappedBundle = mariadb
 
   for (const [name, wrapper] of factories) {
-    const wrapped = shimmer.wrapFunction(mariadb[name], wrapper)
-    replaceDescriptorValue(descriptors[name], wrapped)
-    replaceDescriptorValue(defaultDescriptors[name], wrapped)
+    wrappedBundle = shimmer.wrap(wrappedBundle, name, wrapper, { replaceGetter: true })
+  }
+  for (const [name] of factories) {
+    shimmer.wrap(defaultExport, name, () => wrappedBundle[name])
   }
 
-  const defaultExport = Object.defineProperties(
-    Object.create(Object.getPrototypeOf(mariadb.default)),
-    defaultDescriptors
-  )
-  replaceDescriptorValue(descriptors.default, defaultExport)
-
-  return Object.defineProperties(Object.create(Object.getPrototypeOf(mariadb)), descriptors)
+  return wrappedBundle
 }
 
 /**

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -54,6 +54,7 @@ const transactionMethods = [
  * @property {object} options
  * @property {object} pool
  * @property {object} [queryCtx]
+ * @property {boolean} [queryStarted]
  * @property {boolean} [ready]
  * @property {number} [start]
  */
@@ -126,15 +127,16 @@ function normalizeOptions (defaultOptions, options) {
  * @param {object} pool
  * @param {object} options
  * @param {object} [queryCtx]
- * @param {boolean} [explicit]
+ * @param {'explicit' | 'measure' | 'observe'} mode
  * @returns {PoolAcquisition}
  */
-function createPoolAcquisition (pool, options, queryCtx, explicit) {
-  const measure = explicit === true || queryCtx !== undefined
-  const connectionCtx = measure ? {} : emptyConnectionContext
+function createPoolAcquisition (pool, options, queryCtx, mode) {
+  const explicit = mode === 'explicit'
+  const measure = explicit || mode === 'measure'
+  const connectionCtx = measure || queryCtx !== undefined ? {} : emptyConnectionContext
   const acquisition = { connectionCtx, measure, options, pool, queryCtx }
 
-  if (measure) connectionStartCh.publish(connectionCtx)
+  if (connectionCtx !== emptyConnectionContext) connectionStartCh.publish(connectionCtx)
   if (explicit) {
     acquisition.acquireCtx = { conf: options }
     acquireStartCh.publish(acquisition.acquireCtx)
@@ -244,12 +246,41 @@ function recordPoolAcquisition (pool) {
 
   acquisition.acquired = true
   prunePoolAcquisitions(pool)
-  if (!acquisition.measure) return
+  if (!acquisition.measure) {
+    startPoolCommand(acquisition)
+    return
+  }
 
   const poolWaitTime = acquireWait(acquisition.start)
 
   if (acquisition.queryCtx !== undefined) acquisition.queryCtx.poolWaitTime = poolWaitTime
   if (acquisition.acquireCtx !== undefined) acquisition.acquireCtx.poolWaitTime = poolWaitTime
+
+  startPoolCommand(acquisition)
+}
+
+/**
+ * Starts a pooled command after MariaDB has acquired the connection that will execute it.
+ *
+ * @param {PoolAcquisition} acquisition
+ * @returns {void}
+ */
+function startPoolCommand (acquisition) {
+  const queryCtx = acquisition.queryCtx
+  if (queryCtx === undefined || acquisition.queryStarted) return
+
+  acquisition.queryStarted = true
+  connectionFinishCh.runStores(acquisition.connectionCtx, runCommandStart, undefined, queryCtx)
+}
+
+/**
+ * Starts a command lifecycle without running connector work inside its span store.
+ *
+ * @param {object} ctx
+ * @returns {void}
+ */
+function runCommandStart (ctx) {
+  startCh.runStores(ctx, noop)
 }
 
 /**
@@ -569,9 +600,9 @@ function createWrapPromiseCommand (
 
       const owner = trackActiveCommands ? (commandOwner ?? this) : undefined
       const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
-      const acquisition = poolAcquisition !== undefined && acquireStartCh.hasSubscribers
-        ? createPoolAcquisition(this, options, poolAcquisition === 'measure' ? ctx : undefined)
-        : undefined
+      const acquisition = poolAcquisition === undefined
+        ? undefined
+        : createPoolAcquisition(this, options, ctx, poolAcquisition)
 
       startCommand(owner)
 
@@ -579,19 +610,20 @@ function createWrapPromiseCommand (
       try {
         result = acquisition === undefined
           ? startCh.runStores(ctx, command, this, ...arguments)
-          : startCh.runStores(ctx, runPoolAcquisition, undefined, acquisition, command, this, arguments)
+          : runPoolAcquisition(acquisition, command, this, arguments)
       } catch (error) {
-        finishCommand(ctx, owner, error)
+        finishPoolCommandAcquisition(acquisition, error)
+        if (acquisition === undefined || acquisition.queryStarted) finishCommand(ctx, owner, error)
         throw error
       }
 
       return result.then(result => {
         finishPoolCommandAcquisition(acquisition)
-        finishCommand(ctx, owner, undefined, result)
+        if (acquisition === undefined || acquisition.queryStarted) finishCommand(ctx, owner, undefined, result)
         return result
       }, error => {
         finishPoolCommandAcquisition(acquisition, error)
-        finishCommand(ctx, owner, error)
+        if (acquisition === undefined || acquisition.queryStarted) finishCommand(ctx, owner, error)
         throw error
       })
     }
@@ -626,11 +658,17 @@ function createWrapCallbackCommand (
       const owner = trackActiveCommands ? (commandOwner ?? this) : undefined
       const callback = arguments[arguments.length - 1]
       const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
-      const acquisition = poolAcquisition !== undefined && acquireStartCh.hasSubscribers
-        ? createPoolAcquisition(this, options, poolAcquisition === 'measure' ? ctx : undefined)
-        : undefined
+      const acquisition = poolAcquisition === undefined
+        ? undefined
+        : createPoolAcquisition(this, options, ctx, poolAcquisition)
       const wrapper = callback => function (error) {
         finishPoolCommandAcquisition(acquisition, error)
+        if (acquisition !== undefined && !acquisition.queryStarted) {
+          return typeof callback === 'function'
+            ? connectionFinishCh.runStores(acquisition.connectionCtx, callback, this, ...arguments)
+            : undefined
+        }
+
         finishCommandState(ctx, owner, error)
 
         return typeof callback === 'function'
@@ -645,9 +683,10 @@ function createWrapCallbackCommand (
       try {
         return acquisition === undefined
           ? startCh.runStores(ctx, command, this, ...arguments)
-          : startCh.runStores(ctx, runPoolAcquisition, undefined, acquisition, command, this, arguments)
+          : runPoolAcquisition(acquisition, command, this, arguments)
       } catch (error) {
-        finishCommand(ctx, owner, error)
+        finishPoolCommandAcquisition(acquisition, error)
+        if (acquisition === undefined || acquisition.queryStarted) finishCommand(ctx, owner, error)
         throw error
       }
     }
@@ -1007,7 +1046,7 @@ function createWrapPromiseGetConnection (options) {
         )
       }
 
-      const acquisition = createPoolAcquisition(this, options, undefined, true)
+      const acquisition = createPoolAcquisition(this, options, undefined, 'explicit')
       let result
 
       try {
@@ -1050,7 +1089,7 @@ function createWrapCallbackGetConnection (options) {
         return skipCh.runStores({}, getConnection, this, ...arguments)
       }
 
-      const acquisition = createPoolAcquisition(this, options, undefined, true)
+      const acquisition = createPoolAcquisition(this, options, undefined, 'explicit')
       arguments[arguments.length - 1] = function (error, connection) {
         if (connection) wrapCallbackConnection(connection, options)
         return connectionFinishCh.runStores(acquisition.connectionCtx, () => {

--- a/packages/datadog-instrumentations/src/mariadb-bundle.js
+++ b/packages/datadog-instrumentations/src/mariadb-bundle.js
@@ -28,6 +28,26 @@ const transactionMethods = [
 ]
 
 /** @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} Descriptor */
+/** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
+/** @typedef {{ options: object, pendingRemovals: number }} ClusterNodeOptions */
+/** @typedef {{ options?: object }} ClusterSelection */
+/** @typedef {import('node:async_hooks').AsyncLocalStorage<ClusterSelection>} ClusterSelectionStorage */
+
+/** @type {ClusterSelectionStorage | undefined} */
+let clusterSelectionStorage
+
+/**
+ * Creates cluster selection storage only when an application uses pool clusters.
+ *
+ * @returns {ClusterSelectionStorage}
+ */
+function getClusterSelectionStorage () {
+  if (clusterSelectionStorage === undefined) {
+    const { AsyncLocalStorage } = require('node:async_hooks')
+    clusterSelectionStorage = new AsyncLocalStorage()
+  }
+  return clusterSelectionStorage
+}
 
 /**
  * Extracts SQL from MariaDB's string and object command forms.
@@ -37,16 +57,6 @@ const transactionMethods = [
  */
 function normalizeSql (command) {
   return command !== null && typeof command === 'object' ? command.sql : command
-}
-
-/**
- * Matches MariaDB's use of the default cluster selector for every falsy pattern.
- *
- * @param {unknown} pattern
- * @returns {unknown}
- */
-function normalizeClusterPattern (pattern) {
-  return pattern || /^/
 }
 
 /**
@@ -67,20 +77,22 @@ function normalizeOptions (defaultOptions, options) {
 /**
  * Marks a command as active on its owning public connection.
  *
- * @param {object} owner
+ * @param {object | undefined} owner
  * @returns {void}
  */
 function startCommand (owner) {
+  if (owner === undefined) return
   activeCommands.set(owner, (activeCommands.get(owner) ?? 0) + 1)
 }
 
 /**
  * Releases one active command without clearing concurrent commands.
  *
- * @param {object} owner
+ * @param {object | undefined} owner
  * @returns {void}
  */
 function endCommand (owner) {
+  if (owner === undefined) return
   const active = activeCommands.get(owner)
   if (active === 1) {
     activeCommands.delete(owner)
@@ -93,7 +105,7 @@ function endCommand (owner) {
  * Publishes command completion state and releases its owner.
  *
  * @param {object} ctx
- * @param {object} owner
+ * @param {object | undefined} owner
  * @param {Error} [error]
  * @param {unknown} [result]
  * @returns {void}
@@ -111,7 +123,7 @@ function finishCommandState (ctx, owner, error, result) {
  * Publishes a complete command lifecycle outside a callback continuation.
  *
  * @param {object} ctx
- * @param {object} owner
+ * @param {object | undefined} owner
  * @param {Error} [error]
  * @param {unknown} [result]
  * @returns {void}
@@ -127,14 +139,16 @@ function finishCommand (ctx, owner, error, result) {
  * @param {object} options
  * @param {unknown} [preparedSql]
  * @param {object} [commandOwner]
+ * @param {number} [_commandArity] Reserved for callback command wrappers.
+ * @param {boolean} [trackActiveCommands]
  * @returns {(command: Function) => Function}
  */
-function createWrapPromiseCommand (options, preparedSql, commandOwner) {
+function createWrapPromiseCommand (options, preparedSql, commandOwner, _commandArity, trackActiveCommands = true) {
   return function wrapCommand (command) {
     return function (sql) {
       if (!startCh.hasSubscribers) return command.apply(this, arguments)
 
-      const owner = commandOwner ?? this
+      const owner = trackActiveCommands ? (commandOwner ?? this) : undefined
       const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
 
       startCommand(owner)
@@ -165,16 +179,17 @@ function createWrapPromiseCommand (options, preparedSql, commandOwner) {
  * @param {unknown} [preparedSql]
  * @param {object} [commandOwner]
  * @param {number} [commandArity] Original arity when command is wrapped by a variadic forwarding function.
+ * @param {boolean} [trackActiveCommands]
  * @returns {(command: Function) => Function}
  */
-function createWrapCallbackCommand (options, preparedSql, commandOwner, commandArity) {
+function createWrapCallbackCommand (options, preparedSql, commandOwner, commandArity, trackActiveCommands = true) {
   return function wrapCommand (command) {
     const callbackIndex = (commandArity ?? command.length) - 1
 
     return function (sql) {
       if (!startCh.hasSubscribers) return command.apply(this, arguments)
 
-      const owner = commandOwner ?? this
+      const owner = trackActiveCommands ? (commandOwner ?? this) : undefined
       const callback = arguments[arguments.length - 1]
       const ctx = { sql: preparedSql ?? normalizeSql(sql), conf: options }
       const wrapper = callback => function (error) {
@@ -441,14 +456,15 @@ function createWrapCallbackPreparedExecute (options, sql, connection) {
  * Runs bundled pool internals in the skip store while tracing the public command.
  *
  * @param {object} options
- * @param {(options: object, sql?: unknown, owner?: object, commandArity?: number) =>
+ * @param {(options: object, sql?: unknown, owner?: object, commandArity?: number,
+ *   trackActiveCommands?: boolean) =>
  *   (command: Function) => Function} createWrapper
  * @param {unknown} [preparedSql]
  * @returns {(command: Function) => Function}
  */
 function createWrapPoolCommand (options, createWrapper, preparedSql) {
   return function wrapPoolCommand (command) {
-    return createWrapper(options, preparedSql, undefined, command.length)(function () {
+    return createWrapper(options, preparedSql, undefined, command.length, false)(function () {
       return skipCh.runStores({}, command, this, ...arguments)
     })
   }
@@ -545,19 +561,35 @@ function wrapPoolConnectionEvent (pool, options, wrapConnection) {
  *
  * @param {object} cluster
  * @param {Function} defaultOptions
- * @returns {(pattern: unknown) => object}
+ * @param {ClusterSelectionStorage} selectionStorage
+ * @returns {void}
  */
-function captureClusterOptions (cluster, defaultOptions) {
+function captureClusterOptions (cluster, defaultOptions, selectionStorage) {
+  /** @type {Map<string, ClusterNodeOptions>} */
   const optionsByIdentifier = new Map()
-  const optionsByPattern = new Map()
   let nodeCounter = 0
 
   const removeOptions = identifier => {
-    optionsByIdentifier.delete(identifier)
-    optionsByPattern.clear()
+    const nodeOptions = optionsByIdentifier.get(identifier)
+    if (nodeOptions?.pendingRemovals) {
+      nodeOptions.pendingRemovals--
+    } else {
+      optionsByIdentifier.delete(identifier)
+    }
   }
 
-  const eventEmitter = cluster.on('remove', removeOptions)
+  // ClusterCallback.on is bound to its private Cluster, so EventEmitter returns the internal
+  // runtime object for both APIs. MariaDB does not expose the selected node on the returned
+  // connection; capture _selectPool while the acquisition's async-local selection is active.
+  const internalCluster = cluster.on('remove', removeOptions)
+  if (typeof internalCluster._selectPool === 'function') {
+    shimmer.wrap(internalCluster, '_selectPool', selectPool => function () {
+      const identifier = selectPool.apply(this, arguments)
+      const selection = selectionStorage.getStore()
+      if (selection !== undefined) selection.options = optionsByIdentifier.get(identifier)?.options
+      return identifier
+    })
+  }
 
   shimmer.wrap(cluster, 'add', add => function (identifier, options) {
     const hasIdentifier = typeof identifier === 'string' ||
@@ -565,54 +597,37 @@ function captureClusterOptions (cluster, defaultOptions) {
     const generatedIdentifier = hasIdentifier ? String(identifier) : `PoolNode-${nodeCounter++}`
     const connectionOptions = hasIdentifier ? options : identifier
     const result = skipCh.runStores({}, add, this, ...arguments)
-    optionsByIdentifier.set(generatedIdentifier, normalizeOptions(defaultOptions, connectionOptions))
-    optionsByPattern.clear()
+    const previousNodeOptions = optionsByIdentifier.get(generatedIdentifier)
+
+    // MariaDB deletes a failed node before emitting its delayed remove event. A successful
+    // same-identifier add while options remain therefore adds one stale event to ignore.
+    const nodeOptions = {
+      options: normalizeOptions(defaultOptions, connectionOptions),
+      pendingRemovals: previousNodeOptions === undefined ? 0 : previousNodeOptions.pendingRemovals + 1,
+    }
+    optionsByIdentifier.set(generatedIdentifier, nodeOptions)
+
     return result
   })
 
   shimmer.wrap(cluster, 'remove', remove => function (pattern) {
     const result = remove.apply(this, arguments)
     removeClusterOptions(optionsByIdentifier, pattern)
-    optionsByPattern.clear()
     return result
   })
 
   shimmer.wrap(cluster, 'end', end => function () {
+    const result = end.apply(this, arguments)
     optionsByIdentifier.clear()
-    optionsByPattern.clear()
-    eventEmitter.removeListener('remove', removeOptions)
-    return end.apply(this, arguments)
+    internalCluster.removeListener('remove', removeOptions)
+    return result
   })
-
-  return pattern => {
-    const normalizedPattern = normalizeClusterPattern(pattern)
-    const cacheKey = String(normalizedPattern)
-    const cachedOptions = optionsByPattern.get(cacheKey)
-    if (cachedOptions !== undefined) return cachedOptions
-
-    const regularExpression = new RegExp(normalizedPattern)
-    let matchedOptions
-
-    for (const [identifier, options] of optionsByIdentifier) {
-      regularExpression.lastIndex = 0
-      if (!regularExpression.test(identifier)) continue
-      if (matchedOptions !== undefined) {
-        optionsByPattern.set(cacheKey, emptyOptions)
-        return emptyOptions
-      }
-      matchedOptions = options
-    }
-
-    matchedOptions ??= emptyOptions
-    optionsByPattern.set(cacheKey, matchedOptions)
-    return matchedOptions
-  }
 }
 
 /**
  * Removes options for every cluster node matching a selector.
  *
- * @param {Map<string, object>} optionsByIdentifier
+ * @param {Map<string, ClusterNodeOptions>} optionsByIdentifier
  * @param {string} pattern
  * @returns {void}
  */
@@ -626,21 +641,42 @@ function removeClusterOptions (optionsByIdentifier, pattern) {
 }
 
 /**
+ * Calls a cluster acquisition inside the pool-skip context while selection storage is active.
+ *
+ * @param {Function} getConnection
+ * @param {object} receiver
+ * @param {ArgumentsLike} args
+ * @returns {unknown}
+ */
+function runClusterGetConnection (getConnection, receiver, args) {
+  return skipCh.runStores({}, getConnection, receiver, ...args)
+}
+
+/**
  * Wraps promise connections acquired from a bundled pool cluster.
  *
- * @param {(pattern: unknown) => object} getOptions
+ * @param {ClusterSelectionStorage} selectionStorage
  * @returns {(getConnection: Function) => Function}
  */
-function createWrapPromiseClusterGetConnection (getOptions) {
+function createWrapPromiseClusterGetConnection (selectionStorage) {
   return function wrapGetConnection (getConnection) {
-    return function (pattern) {
+    return function () {
       const ctx = {}
-      const options = getOptions(pattern)
+      /** @type {ClusterSelection} */
+      const selection = {}
 
       connectionStartCh.publish(ctx)
 
-      return skipCh.runStores({}, getConnection, this, ...arguments).then(
-        connection => finishPromiseGetConnection(ctx, connection, options),
+      const result = selectionStorage.run(
+        selection,
+        runClusterGetConnection,
+        getConnection,
+        this,
+        arguments
+      )
+
+      return result.then(
+        connection => finishPromiseGetConnection(ctx, connection, selection.options ?? emptyOptions),
         error => finishPromiseGetConnectionError(ctx, error)
       )
     }
@@ -650,26 +686,33 @@ function createWrapPromiseClusterGetConnection (getOptions) {
 /**
  * Wraps callback connections acquired from a bundled pool cluster.
  *
- * @param {(pattern: unknown) => object} getOptions
+ * @param {ClusterSelectionStorage} selectionStorage
  * @returns {(getConnection: Function) => Function}
  */
-function createWrapCallbackClusterGetConnection (getOptions) {
+function createWrapCallbackClusterGetConnection (selectionStorage) {
   return function wrapGetConnection (getConnection) {
-    return function (pattern) {
+    return function () {
       const callback = arguments[arguments.length - 1]
       if (typeof callback !== 'function') return getConnection.apply(this, arguments)
 
       const ctx = {}
-      const options = getOptions(typeof pattern === 'function' ? undefined : pattern)
+      /** @type {ClusterSelection} */
+      const selection = {}
       arguments[arguments.length - 1] = function () {
         const connection = arguments[1]
-        if (connection) wrapCallbackConnection(connection, options)
+        if (connection) wrapCallbackConnection(connection, selection.options ?? emptyOptions)
         return connectionFinishCh.runStores(ctx, callback, this, ...arguments)
       }
 
       connectionStartCh.publish(ctx)
 
-      return skipCh.runStores({}, getConnection, this, ...arguments)
+      return selectionStorage.run(
+        selection,
+        runClusterGetConnection,
+        getConnection,
+        this,
+        arguments
+      )
     }
   }
 }
@@ -682,9 +725,10 @@ function createWrapCallbackClusterGetConnection (getOptions) {
  * @returns {object}
  */
 function wrapPromiseCluster (cluster, defaultOptions) {
-  const getOptions = captureClusterOptions(cluster, defaultOptions)
+  const selectionStorage = getClusterSelectionStorage()
+  captureClusterOptions(cluster, defaultOptions, selectionStorage)
 
-  shimmer.wrap(cluster, 'getConnection', createWrapPromiseClusterGetConnection(getOptions))
+  shimmer.wrap(cluster, 'getConnection', createWrapPromiseClusterGetConnection(selectionStorage))
 
   return cluster
 }
@@ -697,13 +741,14 @@ function wrapPromiseCluster (cluster, defaultOptions) {
  * @returns {object}
  */
 function wrapCallbackCluster (cluster, defaultOptions) {
-  const getOptions = captureClusterOptions(cluster, defaultOptions)
+  const selectionStorage = getClusterSelectionStorage()
+  captureClusterOptions(cluster, defaultOptions, selectionStorage)
 
-  shimmer.wrap(cluster, 'getConnection', createWrapCallbackClusterGetConnection(getOptions))
+  shimmer.wrap(cluster, 'getConnection', createWrapCallbackClusterGetConnection(selectionStorage))
   // The filtered callback facade delegates to a private Cluster instance, bypassing the public method above.
-  shimmer.wrap(cluster, 'of', of => function (pattern) {
+  shimmer.wrap(cluster, 'of', of => function () {
     const filteredCluster = of.apply(this, arguments)
-    shimmer.wrap(filteredCluster, 'getConnection', createWrapCallbackClusterGetConnection(() => getOptions(pattern)))
+    shimmer.wrap(filteredCluster, 'getConnection', createWrapCallbackClusterGetConnection(selectionStorage))
     return filteredCluster
   })
 
@@ -832,7 +877,10 @@ function createWrapPromiseImportFile (defaultOptions) {
     return function (options) {
       const wrapper = createWrapPromiseCommand(
         normalizeOptions(defaultOptions, options),
-        IMPORT_FILE_RESOURCE
+        IMPORT_FILE_RESOURCE,
+        undefined,
+        undefined,
+        false
       )(importFile)
       return wrapper.apply(this, arguments)
     }
@@ -850,7 +898,10 @@ function createWrapCallbackImportFile (defaultOptions) {
     return function (options) {
       const wrapper = createWrapCallbackCommand(
         normalizeOptions(defaultOptions, options),
-        IMPORT_FILE_RESOURCE
+        IMPORT_FILE_RESOURCE,
+        undefined,
+        undefined,
+        false
       )(importFile)
       return wrapper.apply(this, arguments)
     }

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -14,6 +14,7 @@ const {
   takePoolWaitTime,
   wrapPoolQueryMethod,
 } = require('./helpers/pool-acquire')
+const { wrapCallbackBundle, wrapPromiseBundle } = require('./mariadb-bundle')
 
 const commandAddCh = channel('apm:mariadb:command:add')
 const connectionStartCh = channel('apm:mariadb:connection:start')
@@ -443,3 +444,8 @@ addHook({ name, file: 'lib/connection.js', versions: ['>=2.0.4 <=2.5.1'] }, (Con
 addHook({ name, file: 'lib/pool-base.js', versions: ['>=2.0.4 <3'] }, (PoolBase) => {
   return shimmer.wrapFunction(PoolBase, wrapPoolBase)
 })
+
+// MariaDB 3.5.3 added minified single-file CommonJS bundles whose internal classes cannot be targeted by Orchestrion
+// or module-loader hooks, so instrument the runtime objects returned by their public factories instead.
+addHook({ name, versions: ['>=3.5.3'] }, wrapPromiseBundle)
+addHook({ name, file: 'dist/callback.cjs', versions: ['>=3.5.3'] }, wrapCallbackBundle)

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -445,7 +445,8 @@ addHook({ name, file: 'lib/pool-base.js', versions: ['>=2.0.4 <3'] }, (PoolBase)
   return shimmer.wrapFunction(PoolBase, wrapPoolBase)
 })
 
-// MariaDB 3.5.3 added minified single-file CommonJS bundles whose internal classes cannot be targeted by Orchestrion
-// or module-loader hooks, so instrument the runtime objects returned by their public factories instead.
+// MariaDB 3.5.3 added single-file CommonJS bundles that do not load the original source modules at runtime.
+// Matching their generated, minified internals would couple instrumentation to unstable bundle output, so wrap
+// the runtime objects returned by the public factories instead.
 addHook({ name, versions: ['>=3.5.3'] }, wrapPromiseBundle)
 addHook({ name, file: 'dist/callback.cjs', versions: ['>=3.5.3'] }, wrapCallbackBundle)

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -146,6 +146,18 @@ describe('register', () => {
     assert.strictEqual(result, moduleExports)
     sinon.assert.notCalled(patch)
 
+    const unsupportedModuleExports = { default: class Query {} }
+    const unsupportedVersion = hook(
+      unsupportedModuleExports,
+      'mariadb/lib/cmd/query.js',
+      '/path/to/mariadb',
+      '3.5.0',
+      true
+    )
+
+    assert.strictEqual(unsupportedVersion, unsupportedModuleExports)
+    sinon.assert.notCalled(patch)
+
     const Query = class Query {}
     patch.returns('patched')
 

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -16,6 +16,19 @@ class MariadbPlugin extends MySQLPlugin {
       ctx.parentStore = storage('legacy').getStore()
     })
   }
+
+  /**
+   * Adds pool wait time discovered after a bundled query starts, then finishes its span.
+   *
+   * @param {{ currentStore?: { span?: import('../../../..').Span }, poolWaitTime?: number }} ctx
+   * @returns {void}
+   */
+  finish (ctx) {
+    if (ctx.poolWaitTime !== undefined) {
+      ctx.currentStore?.span?.setTag(`${this.component}.pool.wait_time`, ctx.poolWaitTime)
+    }
+    super.finish(ctx)
+  }
 }
 
 module.exports = MariadbPlugin

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -16,19 +16,6 @@ class MariadbPlugin extends MySQLPlugin {
       ctx.parentStore = storage('legacy').getStore()
     })
   }
-
-  /**
-   * Adds pool wait time discovered after a bundled query starts, then finishes its span.
-   *
-   * @param {{ currentStore?: { span?: import('../../../..').Span }, poolWaitTime?: number }} ctx
-   * @returns {void}
-   */
-  finish (ctx) {
-    if (ctx.poolWaitTime !== undefined) {
-      ctx.currentStore?.span?.setTag(`${this.component}.pool.wait_time`, ctx.poolWaitTime)
-    }
-    super.finish(ctx)
-  }
 }
 
 module.exports = MariadbPlugin

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -1,0 +1,476 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { mkdtemp, rm, writeFile } = require('node:fs/promises')
+const { tmpdir } = require('node:os')
+const path = require('node:path')
+
+const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+const semver = require('semver')
+
+const { ANY_STRING } = require('../../../integration-tests/helpers')
+const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+
+const connectionOptions = {
+  host: 'localhost',
+  user: 'root',
+  database: 'db',
+}
+
+/**
+ * Resolves when a MariaDB callback reports success.
+ *
+ * @param {(callback: Function) => void} invoke
+ * @returns {Promise<Array<unknown>>}
+ */
+function callbackResult (invoke) {
+  return new Promise((resolve, reject) => {
+    invoke((error, ...results) => error ? reject(error) : resolve(results))
+  })
+}
+
+/**
+ * Resolves after a MariaDB result stream ends.
+ *
+ * @param {import('node:stream').Readable} stream
+ * @returns {Promise<void>}
+ */
+function consumeStream (stream) {
+  return new Promise((resolve, reject) => {
+    stream.once('error', reject)
+    stream.once('end', resolve)
+    stream.resume()
+  })
+}
+
+/**
+ * Asserts every expected MariaDB resource in the trace containing the named root span.
+ *
+ * @param {string} rootName
+ * @param {Array<string>} expectedResources
+ * @returns {Promise<void>}
+ */
+function assertTraceResources (rootName, expectedResources) {
+  return agent.assertSomeTraces(traces => {
+    const trace = traces.find(trace => trace.some(span => span.name === rootName))
+    assert.ok(trace, `${rootName} trace has not flushed yet`)
+
+    const resources = []
+    for (const span of trace) {
+      if (span.meta.component === 'mariadb') resources.push(span.resource)
+    }
+
+    assert.deepStrictEqual(resources.sort(), expectedResources.sort())
+  })
+}
+
+describe('Plugin', () => {
+  describe('mariadb CommonJS bundle', () => {
+    if (semver.lt(process.version, '20.0.0')) return
+
+    withVersions('mariadb', 'mariadb', '3.5.3', version => {
+      const versionModule = `../../../versions/mariadb@${version}`
+      let importFilePath
+      let temporaryDirectory
+
+      before(async () => {
+        temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'dd-trace-mariadb-'))
+        importFilePath = path.join(temporaryDirectory, 'query.sql')
+        await writeFile(importFilePath, 'SELECT 11 AS imported_statement;')
+      })
+
+      after(async () => {
+        await rm(temporaryDirectory, { recursive: true })
+      })
+
+      describe('exports', () => {
+        beforeEach(() => agent.load('mariadb'))
+        afterEach(() => agent.close())
+
+        for (const entry of ['mariadb', 'mariadb/callback']) {
+          it(`preserves the ${entry} namespace descriptors`, () => {
+            const mariadb = require(versionModule).get(entry)
+            const esModuleDescriptor = Object.getOwnPropertyDescriptor(mariadb, '__esModule')
+            const factoryDescriptor = Object.getOwnPropertyDescriptor(mariadb, 'createConnection')
+
+            assert.deepStrictEqual(esModuleDescriptor, {
+              value: true,
+              writable: false,
+              enumerable: false,
+              configurable: false,
+            })
+            assert.strictEqual(typeof factoryDescriptor.get, 'function')
+            assert.strictEqual(factoryDescriptor.set, undefined)
+            assert.strictEqual(factoryDescriptor.enumerable, true)
+            assert.strictEqual(factoryDescriptor.configurable, false)
+            assert.strictEqual(mariadb.default.createConnection, mariadb.createConnection)
+            assert.strictEqual(mariadb.default.createPool, mariadb.createPool)
+            assert.strictEqual(mariadb.default.createPoolCluster, mariadb.createPoolCluster)
+            assert.strictEqual(mariadb.default.importFile, mariadb.importFile)
+          })
+        }
+      })
+
+      describe('promise API', () => {
+        let connection
+        let mariadb
+        let tracer
+
+        beforeEach(async () => {
+          tracer = await agent.load('mariadb')
+          mariadb = require(versionModule).get('mariadb')
+          connection = await mariadb.createConnection(connectionOptions)
+        })
+
+        afterEach(async () => {
+          await connection.end()
+          await agent.close()
+        })
+
+        it('traces query, execute, prepared, and streaming commands', async () => {
+          const statement = await connection.prepare('SELECT ? AS prepared_query')
+          const assertion = assertTraceResources('bundle.promise.commands', [
+            'SELECT 1 AS object_query',
+            'SELECT ? AS execute_query',
+            'SELECT ? AS prepared_query',
+            'SELECT 2 AS query_stream',
+            'SELECT ? AS prepared_query',
+          ])
+
+          await tracer.trace('bundle.promise.commands', async () => {
+            await connection.query({ sql: 'SELECT 1 AS object_query' })
+            await connection.execute('SELECT ? AS execute_query', [2])
+            await statement.execute([3])
+            await consumeStream(connection.queryStream('SELECT 2 AS query_stream'))
+            await consumeStream(statement.executeStream([4]))
+          })
+
+          statement.close()
+          await assertion
+        })
+
+        it('traces transaction helpers only when MariaDB sends a command', async () => {
+          const assertion = assertTraceResources('bundle.promise.transactions', [
+            'START TRANSACTION',
+            'SELECT 3 AS committed_query',
+            'COMMIT',
+            'START TRANSACTION',
+            'ROLLBACK',
+          ])
+
+          await tracer.trace('bundle.promise.transactions', async () => {
+            await connection.beginTransaction()
+            await connection.query('SELECT 3 AS committed_query')
+            await connection.commit()
+            await connection.commit()
+            await connection.beginTransaction()
+            await connection.rollback()
+          })
+
+          await assertion
+        })
+
+        it('traces batch and importFile operations', async () => {
+          const assertion = assertTraceResources('bundle.promise.bulk', [
+            'INSERT INTO dd_bundle_batch VALUES (?)',
+            'IMPORT FILE',
+            'IMPORT FILE',
+          ])
+
+          await connection.query('CREATE TEMPORARY TABLE dd_bundle_batch (value INT)')
+          await tracer.trace('bundle.promise.bulk', async () => {
+            await connection.batch('INSERT INTO dd_bundle_batch VALUES (?)', [[1], [2]])
+            await connection.importFile({ file: importFilePath })
+            await mariadb.importFile({ ...connectionOptions, file: importFilePath })
+          })
+
+          await assertion
+        })
+
+        it('traces pools, acquired connections, and connection-event wrappers', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const eventQuery = new Promise((resolve, reject) => {
+            pool.once('connection', eventConnection => {
+              eventConnection.query('SELECT 4 AS event_query').then(resolve, reject)
+            })
+          })
+          const eventAssertion = agent.assertFirstTraceSpan(
+            { resource: 'SELECT 4 AS event_query' },
+            { spanResourceMatch: /event_query/ }
+          )
+          const assertion = assertTraceResources('bundle.promise.pool', [
+            'SELECT 5 AS pool_query',
+            'SELECT ? AS pool_execute',
+            'INSERT INTO dd_bundle_pool_batch VALUES (?)',
+            'IMPORT FILE',
+            'SELECT 6 AS acquired_query',
+          ])
+
+          try {
+            await pool.query('CREATE TEMPORARY TABLE dd_bundle_pool_batch (value INT)')
+            await tracer.trace('bundle.promise.pool', async () => {
+              await Promise.all([pool.query('SELECT 5 AS pool_query'), eventQuery, eventAssertion])
+              await pool.execute('SELECT ? AS pool_execute', [6])
+              await pool.batch('INSERT INTO dd_bundle_pool_batch VALUES (?)', [[1], [2]])
+              await pool.importFile({ file: importFilePath, database: 'db' })
+              const acquired = await pool.getConnection()
+              await acquired.query('SELECT 6 AS acquired_query')
+              await acquired.release()
+            })
+
+            await assertion
+          } finally {
+            await pool.end()
+          }
+        })
+
+        it('traces pool clusters, falsy selectors, and unambiguous node metadata', async () => {
+          const cluster = mariadb.createPoolCluster()
+          cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
+          const filteredAssertion = agent.assertFirstTraceSpan({
+            resource: 'SELECT 7 AS cluster_query',
+            meta: {
+              'db.name': 'db',
+              'db.user': 'root',
+            },
+          }, { spanResourceMatch: /cluster_query/ })
+          const falsyAssertion = agent.assertFirstTraceSpan({
+            resource: 'SELECT 8 AS falsy_cluster_query',
+            meta: {
+              'db.name': 'db',
+              'db.user': 'root',
+            },
+          }, { spanResourceMatch: /falsy_cluster_query/ })
+
+          try {
+            await Promise.all([
+              filteredAssertion,
+              cluster.of('primary').query('SELECT 7 AS cluster_query'),
+            ])
+            const acquired = await cluster.getConnection(false)
+            await Promise.all([
+              falsyAssertion,
+              acquired.query('SELECT 8 AS falsy_cluster_query'),
+            ])
+            await acquired.release()
+          } finally {
+            await cluster.end()
+          }
+        })
+
+        it('preserves promise continuation context and tags errors', async () => {
+          const parent = tracer.startSpan('bundle.promise.parent')
+          await tracer.scope().activate(parent, () => {
+            return connection.query('SELECT 8 AS context_query').then(() => {
+              assert.strictEqual(tracer.scope().active(), parent)
+            })
+          })
+          parent.finish()
+
+          await Promise.all([
+            agent.assertFirstTraceSpan({
+              resource: 'SELECT * FROM definitely_missing_bundle_table',
+              meta: {
+                [ERROR_TYPE]: ANY_STRING,
+                [ERROR_MESSAGE]: ANY_STRING,
+                [ERROR_STACK]: ANY_STRING,
+              },
+            }, { spanResourceMatch: /definitely_missing_bundle_table/ }),
+            connection.query('SELECT * FROM definitely_missing_bundle_table').catch(() => {}),
+          ])
+        })
+      })
+
+      describe('callback API', () => {
+        let connection
+        let mariadb
+        let tracer
+
+        beforeEach(async () => {
+          tracer = await agent.load('mariadb')
+          mariadb = require(versionModule).get('mariadb/callback')
+          connection = mariadb.createConnection(connectionOptions)
+          await callbackResult(callback => connection.connect(callback))
+        })
+
+        afterEach(async () => {
+          await callbackResult(callback => connection.end(callback))
+          await agent.close()
+        })
+
+        it('traces query, execute, prepared, and streaming commands', async () => {
+          const [statement] = await callbackResult(callback => {
+            connection.prepare('SELECT ? AS callback_prepared', callback)
+          })
+          const assertion = assertTraceResources('bundle.callback.commands', [
+            'SELECT 9 AS callback_query',
+            'SELECT ? AS callback_execute',
+            'SELECT ? AS callback_prepared',
+            'SELECT ? AS callback_prepared',
+            'SELECT 10 AS callback_stream',
+            'SELECT ? AS callback_prepared',
+          ])
+
+          await tracer.trace('bundle.callback.commands', async () => {
+            await callbackResult(callback => connection.query('SELECT 9 AS callback_query', callback))
+            await callbackResult(callback => connection.execute('SELECT ? AS callback_execute', [10], callback))
+            await callbackResult(callback => statement.execute([11], callback))
+            await statement.execute([12])
+            await consumeStream(connection.queryStream('SELECT 10 AS callback_stream'))
+            await consumeStream(statement.executeStream([13]))
+          })
+
+          statement.close()
+          await assertion
+        })
+
+        it('traces transaction helpers only when MariaDB sends a command', async () => {
+          const assertion = assertTraceResources('bundle.callback.transactions', [
+            'START TRANSACTION',
+            'SELECT 12 AS callback_committed_query',
+            'COMMIT',
+            'START TRANSACTION',
+            'ROLLBACK',
+          ])
+
+          await tracer.trace('bundle.callback.transactions', async () => {
+            await callbackResult(callback => connection.beginTransaction(callback))
+            await callbackResult(callback => connection.query('SELECT 12 AS callback_committed_query', callback))
+            await callbackResult(callback => connection.commit(callback))
+            await callbackResult(callback => connection.commit(callback))
+            await callbackResult(callback => connection.beginTransaction(callback))
+            await callbackResult(callback => connection.rollback(callback))
+          })
+
+          await assertion
+        })
+
+        it('traces batch and importFile operations', async () => {
+          const assertion = assertTraceResources('bundle.callback.bulk', [
+            'INSERT INTO dd_bundle_callback_batch VALUES (?)',
+            'IMPORT FILE',
+            'IMPORT FILE',
+          ])
+
+          await callbackResult(callback => {
+            connection.query('CREATE TEMPORARY TABLE dd_bundle_callback_batch (value INT)', callback)
+          })
+          await tracer.trace('bundle.callback.bulk', async () => {
+            await callbackResult(callback => {
+              connection.batch('INSERT INTO dd_bundle_callback_batch VALUES (?)', [[1], [2]], callback)
+            })
+            await callbackResult(callback => connection.importFile({ file: importFilePath }, callback))
+            await callbackResult(callback => {
+              mariadb.importFile({ ...connectionOptions, file: importFilePath }, callback)
+            })
+          })
+
+          await assertion
+        })
+
+        it('traces pools, acquired connections, and connection-event wrappers', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const eventQuery = new Promise((resolve, reject) => {
+            pool.once('connection', eventConnection => {
+              eventConnection.query('SELECT 13 AS callback_event_query', error => error ? reject(error) : resolve())
+            })
+          })
+          const eventAssertion = agent.assertFirstTraceSpan(
+            { resource: 'SELECT 13 AS callback_event_query' },
+            { spanResourceMatch: /callback_event_query/ }
+          )
+          const assertion = assertTraceResources('bundle.callback.pool', [
+            'SELECT 14 AS callback_pool_query',
+            'SELECT ? AS callback_pool_execute',
+            'INSERT INTO dd_bundle_callback_pool_batch VALUES (?)',
+            'IMPORT FILE',
+            'SELECT 15 AS callback_acquired_query',
+          ])
+
+          try {
+            await callbackResult(callback => {
+              pool.query('CREATE TEMPORARY TABLE dd_bundle_callback_pool_batch (value INT)', callback)
+            })
+            await tracer.trace('bundle.callback.pool', async () => {
+              await Promise.all([
+                callbackResult(callback => pool.query('SELECT 14 AS callback_pool_query', callback)),
+                eventQuery,
+                eventAssertion,
+              ])
+              await callbackResult(callback => pool.execute('SELECT ? AS callback_pool_execute', [15], callback))
+              await callbackResult(callback => {
+                pool.batch('INSERT INTO dd_bundle_callback_pool_batch VALUES (?)', [[1], [2]], callback)
+              })
+              await callbackResult(callback => pool.importFile({ file: importFilePath, database: 'db' }, callback))
+              const [acquired] = await callbackResult(callback => pool.getConnection(callback))
+              await callbackResult(callback => acquired.query('SELECT 15 AS callback_acquired_query', callback))
+              await callbackResult(callback => acquired.release(callback))
+            })
+
+            await assertion
+          } finally {
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
+        it('traces pool clusters and uses unambiguous node metadata', async () => {
+          const cluster = mariadb.createPoolCluster()
+          cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
+          const assertion = agent.assertFirstTraceSpan({
+            resource: 'SELECT 16 AS callback_cluster_query',
+            meta: {
+              'db.name': 'db',
+              'db.user': 'root',
+            },
+          })
+
+          try {
+            await Promise.all([
+              assertion,
+              callbackResult(callback => {
+                cluster.of('primary').query('SELECT 16 AS callback_cluster_query', callback)
+              }),
+            ])
+          } finally {
+            await callbackResult(callback => cluster.end(callback))
+          }
+        })
+
+        it('preserves callback context and tags errors', async () => {
+          const parent = tracer.startSpan('bundle.callback.parent')
+          await new Promise((resolve, reject) => {
+            tracer.scope().activate(parent, () => {
+              connection.query('SELECT 17 AS callback_context_query', error => {
+                if (error) return reject(error)
+                try {
+                  assert.strictEqual(tracer.scope().active(), parent)
+                  resolve()
+                } catch (assertionError) {
+                  reject(assertionError)
+                }
+              })
+            })
+          })
+          parent.finish()
+
+          const errorPromise = callbackResult(callback => {
+            connection.query('SELECT * FROM definitely_missing_callback_bundle_table', callback)
+          }).catch(() => {})
+          await Promise.all([
+            agent.assertFirstTraceSpan({
+              resource: 'SELECT * FROM definitely_missing_callback_bundle_table',
+              meta: {
+                [ERROR_TYPE]: ANY_STRING,
+                [ERROR_MESSAGE]: ANY_STRING,
+                [ERROR_STACK]: ANY_STRING,
+              },
+            }, { spanResourceMatch: /definitely_missing_callback_bundle_table/ }),
+            errorPromise,
+          ])
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -192,7 +192,7 @@ describe('Plugin', () => {
         it('traces pools, acquired connections, and connection-event wrappers', async () => {
           const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
           const eventQuery = new Promise((resolve, reject) => {
-            pool.once('connection', eventConnection => {
+            pool.prependOnceListener('connection', eventConnection => {
               eventConnection.query('SELECT 4 AS event_query').then(resolve, reject)
             })
           })
@@ -370,10 +370,37 @@ describe('Plugin', () => {
           await assertion
         })
 
+        it('replaces explicit empty callback slots', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const assertion = assertTraceResources('bundle.callback.empty_callbacks', [
+            'SELECT 18 AS callback_empty_query',
+            'IMPORT FILE',
+            'START TRANSACTION',
+            'SELECT 19 AS callback_empty_pool_query',
+            'SELECT 20 AS callback_empty_pool_barrier',
+          ])
+
+          try {
+            await tracer.trace('bundle.callback.empty_callbacks', async () => {
+              connection.query('SELECT 18 AS callback_empty_query', [], undefined)
+              connection.importFile({ file: importFilePath }, null)
+              connection.beginTransaction(undefined)
+              await callbackResult(callback => connection.ping(callback))
+
+              pool.query('SELECT 19 AS callback_empty_pool_query', [], undefined)
+              await callbackResult(callback => pool.query('SELECT 20 AS callback_empty_pool_barrier', callback))
+            })
+
+            await assertion
+          } finally {
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
         it('traces pools, acquired connections, and connection-event wrappers', async () => {
           const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
           const eventQuery = new Promise((resolve, reject) => {
-            pool.once('connection', eventConnection => {
+            pool.prependOnceListener('connection', eventConnection => {
               eventConnection.query('SELECT 13 AS callback_event_query', error => error ? reject(error) : resolve())
             })
           })

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -9,7 +9,7 @@ const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const semver = require('semver')
 
 const { ANY_STRING } = require('../../../integration-tests/helpers')
-const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
+const { CLIENT_PORT_KEY, ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
@@ -43,6 +43,15 @@ function consumeStream (stream) {
     stream.once('end', resolve)
     stream.resume()
   })
+}
+
+/**
+ * Waits for work already queued with setImmediate.
+ *
+ * @returns {Promise<void>}
+ */
+function nextImmediate () {
+  return new Promise(resolve => setImmediate(resolve))
 }
 
 /**
@@ -173,6 +182,7 @@ describe('Plugin', () => {
         })
 
         it('traces batch and importFile operations', async () => {
+          const importFile = mariadb.importFile
           const assertion = assertTraceResources('bundle.promise.bulk', [
             'INSERT INTO dd_bundle_batch VALUES (?)',
             'IMPORT FILE',
@@ -183,7 +193,7 @@ describe('Plugin', () => {
           await tracer.trace('bundle.promise.bulk', async () => {
             await connection.batch('INSERT INTO dd_bundle_batch VALUES (?)', [[1], [2]])
             await connection.importFile({ file: importFilePath })
-            await mariadb.importFile({ ...connectionOptions, file: importFilePath })
+            await importFile({ ...connectionOptions, file: importFilePath })
           })
 
           await assertion
@@ -226,28 +236,36 @@ describe('Plugin', () => {
           }
         })
 
-        it('traces pool clusters, falsy selectors, and unambiguous node metadata', async () => {
+        it('traces pool clusters, falsy selectors, and selected node metadata', async () => {
           const cluster = mariadb.createPoolCluster()
           cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
+          cluster.add('secondary', { ...connectionOptions, host: '127.0.0.1', minimumIdle: 0 })
+          const filteredCluster = cluster.of(/^(primary|secondary)$/, 'RR')
           const filteredAssertion = agent.assertFirstTraceSpan({
             resource: 'SELECT 7 AS cluster_query',
             meta: {
               'db.name': 'db',
               'db.user': 'root',
+              'out.host': '127.0.0.1',
             },
+            metrics: { [CLIENT_PORT_KEY]: 3306 },
           }, { spanResourceMatch: /cluster_query/ })
           const falsyAssertion = agent.assertFirstTraceSpan({
             resource: 'SELECT 8 AS falsy_cluster_query',
             meta: {
               'db.name': 'db',
               'db.user': 'root',
+              'out.host': 'localhost',
             },
+            metrics: { [CLIENT_PORT_KEY]: 3306 },
           }, { spanResourceMatch: /falsy_cluster_query/ })
 
           try {
+            const firstConnection = await filteredCluster.getConnection()
+            await firstConnection.release()
             await Promise.all([
               filteredAssertion,
-              cluster.of('primary').query('SELECT 7 AS cluster_query'),
+              filteredCluster.query('SELECT 7 AS cluster_query'),
             ])
             const acquired = await cluster.getConnection(false)
             await Promise.all([
@@ -255,6 +273,46 @@ describe('Plugin', () => {
               acquired.query('SELECT 8 AS falsy_cluster_query'),
             ])
             await acquired.release()
+          } finally {
+            await cluster.end()
+          }
+        })
+
+        it('retains metadata when an automatically removed node is immediately re-added', async () => {
+          const cluster = mariadb.createPoolCluster({ canRetry: false, removeNodeErrorCount: 1 })
+          cluster.add('primary', {
+            ...connectionOptions,
+            host: '127.0.0.1',
+            port: 1,
+            acquireTimeout: 100,
+            connectTimeout: 50,
+            minimumIdle: 0,
+          })
+
+          try {
+            await assert.rejects(cluster.getConnection('primary'))
+            cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
+            await nextImmediate()
+
+            const assertion = agent.assertFirstTraceSpan({
+              resource: 'SELECT 21 AS readded_cluster_query',
+              meta: {
+                'db.name': 'db',
+                'db.user': 'root',
+                'out.host': 'localhost',
+              },
+              metrics: { [CLIENT_PORT_KEY]: 3306 },
+            }, { spanResourceMatch: /readded_cluster_query/ })
+            const acquired = await cluster.getConnection('primary')
+
+            try {
+              await Promise.all([
+                assertion,
+                acquired.query('SELECT 21 AS readded_cluster_query'),
+              ])
+            } finally {
+              await acquired.release()
+            }
           } finally {
             await cluster.end()
           }
@@ -348,6 +406,7 @@ describe('Plugin', () => {
         })
 
         it('traces batch and importFile operations', async () => {
+          const importFile = mariadb.importFile
           const assertion = assertTraceResources('bundle.callback.bulk', [
             'INSERT INTO dd_bundle_callback_batch VALUES (?)',
             'IMPORT FILE',
@@ -363,7 +422,7 @@ describe('Plugin', () => {
             })
             await callbackResult(callback => connection.importFile({ file: importFilePath }, callback))
             await callbackResult(callback => {
-              mariadb.importFile({ ...connectionOptions, file: importFilePath }, callback)
+              importFile({ ...connectionOptions, file: importFilePath }, callback)
             })
           })
 
@@ -442,24 +501,72 @@ describe('Plugin', () => {
           }
         })
 
-        it('traces pool clusters and uses unambiguous node metadata', async () => {
+        it('traces pool clusters and uses selected node metadata', async () => {
           const cluster = mariadb.createPoolCluster()
           cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
+          cluster.add('secondary', { ...connectionOptions, host: '127.0.0.1', minimumIdle: 0 })
+          const filteredCluster = cluster.of(/^(primary|secondary)$/, 'RR')
           const assertion = agent.assertFirstTraceSpan({
             resource: 'SELECT 16 AS callback_cluster_query',
             meta: {
               'db.name': 'db',
               'db.user': 'root',
+              'out.host': '127.0.0.1',
             },
+            metrics: { [CLIENT_PORT_KEY]: 3306 },
           })
 
           try {
+            const [firstConnection] = await callbackResult(callback => filteredCluster.getConnection(callback))
+            await callbackResult(callback => firstConnection.release(callback))
             await Promise.all([
               assertion,
               callbackResult(callback => {
-                cluster.of('primary').query('SELECT 16 AS callback_cluster_query', callback)
+                filteredCluster.query('SELECT 16 AS callback_cluster_query', callback)
               }),
             ])
+          } finally {
+            await callbackResult(callback => cluster.end(callback))
+          }
+        })
+
+        it('retains metadata when an automatically removed node is immediately re-added', async () => {
+          const cluster = mariadb.createPoolCluster({ canRetry: false, removeNodeErrorCount: 1 })
+          cluster.add('primary', {
+            ...connectionOptions,
+            host: '127.0.0.1',
+            port: 1,
+            acquireTimeout: 100,
+            connectTimeout: 50,
+            minimumIdle: 0,
+          })
+
+          try {
+            await assert.rejects(callbackResult(callback => cluster.getConnection('primary', callback)))
+            cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
+            await nextImmediate()
+
+            const assertion = agent.assertFirstTraceSpan({
+              resource: 'SELECT 22 AS callback_readded_cluster_query',
+              meta: {
+                'db.name': 'db',
+                'db.user': 'root',
+                'out.host': 'localhost',
+              },
+              metrics: { [CLIENT_PORT_KEY]: 3306 },
+            }, { spanResourceMatch: /callback_readded_cluster_query/ })
+            const [acquired] = await callbackResult(callback => cluster.getConnection('primary', callback))
+
+            try {
+              await Promise.all([
+                assertion,
+                callbackResult(callback => {
+                  acquired.query('SELECT 22 AS callback_readded_cluster_query', callback)
+                }),
+              ])
+            } finally {
+              await callbackResult(callback => acquired.release(callback))
+            }
           } finally {
             await callbackResult(callback => cluster.end(callback))
           }

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -9,6 +9,7 @@ const { performance } = require('node:perf_hooks')
 const { setImmediate: nextImmediate } = require('node:timers/promises')
 const { inspect } = require('node:util')
 
+const dc = require('dc-polyfill')
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const semver = require('semver')
 const sinon = require('sinon')
@@ -17,6 +18,8 @@ const { ANY_STRING } = require('../../../integration-tests/helpers')
 const { CLIENT_PORT_KEY, ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
+
+const queryStartCh = dc.channel('apm:mariadb:query:start')
 
 const connectionOptions = {
   host: 'localhost',
@@ -318,6 +321,35 @@ describe('Plugin', () => {
           })
         }
 
+        it('starts a bundled pooled promise command only after acquiring its connection', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const connection = await pool.getConnection()
+          const sql = 'SELECT 38 AS bundle_delayed_pool_start'
+          let query
+          let queryStarts = 0
+          let released = false
+          const onStart = ctx => {
+            if (ctx.sql === sql) queryStarts++
+          }
+          queryStartCh.subscribe(onStart)
+
+          try {
+            query = pool.query(sql)
+            assert.strictEqual(queryStarts, 0)
+
+            await connection.release()
+            released = true
+            await query
+
+            assert.strictEqual(queryStarts, 1)
+          } finally {
+            queryStartCh.unsubscribe(onStart)
+            if (!released) await connection.release()
+            await query?.catch(noop)
+            await pool.end()
+          }
+        })
+
         it('uses zero wait without clock reads for a recent bundled pool connection', async () => {
           const pool = mariadb.createPool({
             ...connectionOptions,
@@ -477,6 +509,14 @@ describe('Plugin', () => {
             port: await getClosedPort(),
           })
           pool.on('error', noop)
+          const forbiddenResources = new Set([
+            'SELECT 29 AS bundle_query_acquire_failure',
+            'SELECT 30 AS bundle_execute_acquire_failure',
+          ])
+          const noQuerySpans = agent.assertNoTraces(traces => {
+            const span = traces.flat().find(span => forbiddenResources.has(span.resource))
+            assert.strictEqual(span, undefined, `unexpected query span for failed acquisition: ${span?.resource}`)
+          })
 
           try {
             for (const [method, args] of [
@@ -495,7 +535,9 @@ describe('Plugin', () => {
                 assert.rejects(pool[method](...args)),
               ])
             }
+            await noQuerySpans
           } finally {
+            noQuerySpans.cancel()
             await pool.end()
           }
         })
@@ -863,6 +905,35 @@ describe('Plugin', () => {
           }
         })
 
+        it('starts a bundled pooled callback command only after acquiring its connection', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const [connection] = await callbackResult(callback => pool.getConnection(callback))
+          const sql = 'SELECT 39 AS bundle_delayed_callback_pool_start'
+          let query
+          let queryStarts = 0
+          let released = false
+          const onStart = ctx => {
+            if (ctx.sql === sql) queryStarts++
+          }
+          queryStartCh.subscribe(onStart)
+
+          try {
+            query = callbackResult(callback => pool.query(sql, callback))
+            assert.strictEqual(queryStarts, 0)
+
+            await callbackResult(callback => connection.release(callback))
+            released = true
+            await query
+
+            assert.strictEqual(queryStarts, 1)
+          } finally {
+            queryStartCh.unsubscribe(onStart)
+            if (!released) await callbackResult(callback => connection.release(callback))
+            await query?.catch(noop)
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
         it('forwards bundled callback pool operations without subscribers', async () => {
           const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
 
@@ -914,6 +985,14 @@ describe('Plugin', () => {
             port: await getClosedPort(),
           })
           pool.on('error', noop)
+          const forbiddenResources = new Set([
+            'SELECT 32 AS bundle_callback_query_acquire_failure',
+            'SELECT 33 AS bundle_callback_execute_acquire_failure',
+          ])
+          const noQuerySpans = agent.assertNoTraces(traces => {
+            const span = traces.flat().find(span => forbiddenResources.has(span.resource))
+            assert.strictEqual(span, undefined, `unexpected query span for failed acquisition: ${span?.resource}`)
+          })
 
           try {
             for (const [method, args] of [
@@ -932,7 +1011,9 @@ describe('Plugin', () => {
                 assert.rejects(callbackResult(callback => pool[method](...args, callback))),
               ])
             }
+            await noQuerySpans
           } finally {
+            noQuerySpans.cancel()
             await callbackResult(callback => pool.end(callback))
           }
         })

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -183,6 +183,22 @@ describe('Plugin', () => {
           await assertion
         })
 
+        it('tags bundled stream errors', async () => {
+          const sql = 'SELECT * FROM definitely_missing_stream_table'
+
+          await Promise.all([
+            agent.assertFirstTraceSpan({
+              resource: sql,
+              meta: {
+                [ERROR_TYPE]: ANY_STRING,
+                [ERROR_MESSAGE]: ANY_STRING,
+                [ERROR_STACK]: ANY_STRING,
+              },
+            }, { spanResourceMatch: /definitely_missing_stream_table/ }),
+            assert.rejects(consumeStream(connection.queryStream(sql))),
+          ])
+        })
+
         it('traces transaction helpers only when MariaDB sends a command', async () => {
           const assertion = assertTraceResources('bundle.promise.transactions', [
             'START TRANSACTION',
@@ -408,6 +424,30 @@ describe('Plugin', () => {
               nowStub.restore()
             }
           } finally {
+            await pool.end()
+          }
+        })
+
+        it('preserves bundled pool acquisition order across queue compaction', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const connection = await pool.getConnection()
+          const queries = new Array(1025)
+          let released = false
+
+          try {
+            for (let index = 0; index < queries.length; index++) {
+              queries[index] = pool.query('SELECT 1 AS compaction_probe')
+            }
+
+            await connection.release()
+            released = true
+            const results = await Promise.all(queries)
+
+            assert.strictEqual(results.length, 1025)
+            assert.strictEqual(results[0][0].compaction_probe, 1)
+            assert.strictEqual(results[1024][0].compaction_probe, 1)
+          } finally {
+            if (!released) await connection.release()
             await pool.end()
           }
         })

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -2,11 +2,16 @@
 
 const assert = require('node:assert/strict')
 const { mkdtemp, rm, writeFile } = require('node:fs/promises')
+const net = require('node:net')
 const { tmpdir } = require('node:os')
 const path = require('node:path')
+const { performance } = require('node:perf_hooks')
+const { setImmediate: nextImmediate } = require('node:timers/promises')
+const { inspect } = require('node:util')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const semver = require('semver')
+const sinon = require('sinon')
 
 const { ANY_STRING } = require('../../../integration-tests/helpers')
 const { CLIENT_PORT_KEY, ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
@@ -18,6 +23,7 @@ const connectionOptions = {
   user: 'root',
   database: 'db',
 }
+const noop = () => {}
 
 /**
  * Resolves when a MariaDB callback reports success.
@@ -46,12 +52,29 @@ function consumeStream (stream) {
 }
 
 /**
- * Waits for work already queued with setImmediate.
- *
+ * @returns {Promise<number>}
+ */
+async function getClosedPort () {
+  const probe = net.createServer()
+  await new Promise(resolve => probe.listen(0, '127.0.0.1', resolve))
+  const port = probe.address().port
+  await new Promise(resolve => probe.close(resolve))
+  return port
+}
+
+/**
+ * @param {number} start
+ * @param {(advanceTo: (value: number) => void) => Promise<unknown>} run
  * @returns {Promise<void>}
  */
-function nextImmediate () {
-  return new Promise(resolve => setImmediate(resolve))
+async function withFakeNow (start, run) {
+  const nowStub = sinon.stub(performance, 'now').returns(start)
+
+  try {
+    await run(value => nowStub.returns(value))
+  } finally {
+    nowStub.restore()
+  }
 }
 
 /**
@@ -181,6 +204,23 @@ describe('Plugin', () => {
           await assertion
         })
 
+        it('traces transactions queued behind untraced promise commands', async () => {
+          const assertion = assertTraceResources('bundle.promise.queued_transactions', ['COMMIT', 'COMMIT'])
+
+          await tracer.trace('bundle.promise.queued_transactions', async () => {
+            const ping = connection.ping()
+            const pingCommit = connection.commit()
+            await Promise.all([ping, pingCommit])
+
+            const prepare = connection.prepare('SELECT ? AS queued_promise_prepare')
+            const prepareCommit = connection.commit()
+            const [statement] = await Promise.all([prepare, prepareCommit])
+            statement.close()
+          })
+
+          await assertion
+        })
+
         it('traces batch and importFile operations', async () => {
           const importFile = mariadb.importFile
           const assertion = assertTraceResources('bundle.promise.bulk', [
@@ -215,6 +255,7 @@ describe('Plugin', () => {
             'SELECT ? AS pool_execute',
             'INSERT INTO dd_bundle_pool_batch VALUES (?)',
             'IMPORT FILE',
+            'mariadb.pool.acquire',
             'SELECT 6 AS acquired_query',
           ])
 
@@ -231,6 +272,189 @@ describe('Plugin', () => {
             })
 
             await assertion
+          } finally {
+            await pool.end()
+          }
+        })
+
+        for (const [method, sql] of [
+          ['query', 'SELECT 23 AS bundle_pool_wait'],
+          ['execute', 'SELECT 24 AS bundle_execute_pool_wait'],
+        ]) {
+          it(`records the pool acquire wait time on the bundled ${method} span`, async () => {
+            const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+
+            try {
+              await Promise.all([
+                agent.assertSomeTraces(traces => {
+                  const span = traces[0].find(span => span.resource === sql)
+
+                  assert.ok(span, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+                  assert.strictEqual(typeof span.metrics['mariadb.pool.wait_time'], 'number')
+                  assert.ok(span.metrics['mariadb.pool.wait_time'] >= 0)
+                  assert.strictEqual(traces[0].find(span => span.name === 'mariadb.pool.acquire'), undefined)
+                }, { spanResourceMatch: new RegExp(`^${sql}$`) }),
+                pool[method](sql),
+              ])
+            } finally {
+              await pool.end()
+            }
+          })
+        }
+
+        it('uses zero wait without clock reads for a recent bundled pool connection', async () => {
+          const pool = mariadb.createPool({
+            ...connectionOptions,
+            connectionLimit: 1,
+            minDelayValidation: Number.MAX_SAFE_INTEGER,
+          })
+
+          try {
+            await pool.query('SELECT 1')
+
+            const assertion = agent.assertSomeTraces(traces => {
+              const span = traces.flat().find(span => span.resource === 'SELECT 25 AS bundle_recent_idle')
+
+              assert.ok(span, `missing query span: ${inspect(traces.flat().map(span => span.resource))}`)
+              assert.strictEqual(span.metrics['mariadb.pool.wait_time'], 0)
+            }, { spanResourceMatch: /^SELECT 25 AS bundle_recent_idle$/ })
+            const nowStub = sinon.stub(performance, 'now').returns(100)
+
+            try {
+              const query = pool.query('SELECT 25 AS bundle_recent_idle')
+
+              sinon.assert.notCalled(nowStub)
+              await Promise.all([assertion, query])
+            } finally {
+              nowStub.restore()
+            }
+          } finally {
+            await pool.end()
+          }
+        })
+
+        it('includes bundled idle validation in the pool wait time', async () => {
+          const pool = mariadb.createPool({
+            ...connectionOptions,
+            connectionLimit: 1,
+            minDelayValidation: 0,
+          })
+
+          try {
+            await pool.query('SELECT 1')
+
+            const assertion = agent.assertSomeTraces(traces => {
+              const span = traces.flat().find(span => span.resource === 'SELECT 26 AS bundle_validation')
+
+              assert.ok(span, `missing query span: ${inspect(traces.flat().map(span => span.resource))}`)
+              assert.strictEqual(span.metrics['mariadb.pool.wait_time'], 50)
+            }, { spanResourceMatch: /^SELECT 26 AS bundle_validation$/ })
+
+            await withFakeNow(100, async advanceTo => {
+              const query = pool.query('SELECT 26 AS bundle_validation')
+              advanceTo(150)
+              await Promise.all([assertion, query])
+            })
+          } finally {
+            await pool.end()
+          }
+        })
+
+        it('creates an acquire span for an explicit bundled promise getConnection', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const parent = tracer.startSpan('bundle-promise-acquire-parent')
+
+          try {
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const acquireSpan = traces[0].find(span => span.name === 'mariadb.pool.acquire')
+
+                assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+                assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
+                assert.strictEqual(typeof acquireSpan.metrics['mariadb.pool.wait_time'], 'number')
+              }, { spanResourceMatch: /^mariadb\.pool\.acquire$/ }),
+              tracer.scope().activate(parent, async () => {
+                const acquired = await pool.getConnection()
+                await acquired.release()
+                parent.finish()
+              }),
+            ])
+          } finally {
+            await pool.end()
+          }
+        })
+
+        it('does not classify reentrant bundled pool operations as each other', async () => {
+          const pool = mariadb.createPool({
+            ...connectionOptions,
+            connectionLimit: 1,
+            minDelayValidation: Number.MAX_SAFE_INTEGER,
+          })
+
+          try {
+            await pool.query('CREATE TEMPORARY TABLE dd_bundle_reentrant (value INT)')
+            let batch
+            pool.once('acquire', () => {
+              batch = pool.batch('INSERT INTO dd_bundle_reentrant VALUES (?)', [[1]])
+            })
+            const nowStub = sinon.stub(performance, 'now').returns(100)
+
+            try {
+              await pool.query('SELECT 27 AS bundle_reentrant')
+              assert.ok(batch, 'reentrant batch did not start')
+              await batch
+              sinon.assert.notCalled(nowStub)
+            } finally {
+              nowStub.restore()
+            }
+          } finally {
+            await pool.end()
+          }
+        })
+
+        it('forwards bundled pool operations without subscribers', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+
+          tracer.use('mariadb', false)
+          try {
+            const rows = await pool.query('SELECT 28 AS bundle_untraced_pool')
+            const acquired = await pool.getConnection()
+
+            await acquired.release()
+            assert.strictEqual(rows[0].bundle_untraced_pool, 28)
+          } finally {
+            tracer.use('mariadb', true)
+            await pool.end()
+          }
+        })
+
+        it('records errors for explicit and pooled bundled acquisition failures', async () => {
+          const pool = mariadb.createPool({
+            ...connectionOptions,
+            acquireTimeout: 500,
+            connectTimeout: 100,
+            host: '127.0.0.1',
+            port: await getClosedPort(),
+          })
+          pool.on('error', noop)
+
+          try {
+            for (const [method, args] of [
+              ['getConnection', []],
+              ['query', ['SELECT 29 AS bundle_query_acquire_failure']],
+              ['execute', ['SELECT 30 AS bundle_execute_acquire_failure']],
+            ]) {
+              await Promise.all([
+                agent.assertSomeTraces(traces => {
+                  const acquireSpan = traces[0].find(span => span.name === 'mariadb.pool.acquire')
+
+                  assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+                  assert.strictEqual(acquireSpan.error, 1)
+                  assert.strictEqual(typeof acquireSpan.metrics['mariadb.pool.wait_time'], 'number')
+                }),
+                assert.rejects(pool[method](...args)),
+              ])
+            }
           } finally {
             await pool.end()
           }
@@ -405,6 +629,25 @@ describe('Plugin', () => {
           await assertion
         })
 
+        it('traces transactions queued behind untraced callback commands', async () => {
+          const assertion = assertTraceResources('bundle.callback.queued_transactions', ['COMMIT', 'COMMIT'])
+
+          await tracer.trace('bundle.callback.queued_transactions', async () => {
+            const ping = callbackResult(callback => connection.ping(callback))
+            const pingCommit = callbackResult(callback => connection.commit(callback))
+            await Promise.all([ping, pingCommit])
+
+            const prepare = callbackResult(callback => {
+              connection.prepare('SELECT ? AS queued_callback_prepare', callback)
+            })
+            const prepareCommit = callbackResult(callback => connection.commit(callback))
+            const [[statement]] = await Promise.all([prepare, prepareCommit])
+            statement.close()
+          })
+
+          await assertion
+        })
+
         it('traces batch and importFile operations', async () => {
           const importFile = mariadb.importFile
           const assertion = assertTraceResources('bundle.callback.bulk', [
@@ -472,6 +715,7 @@ describe('Plugin', () => {
             'SELECT ? AS callback_pool_execute',
             'INSERT INTO dd_bundle_callback_pool_batch VALUES (?)',
             'IMPORT FILE',
+            'mariadb.pool.acquire',
             'SELECT 15 AS callback_acquired_query',
           ])
 
@@ -499,6 +743,119 @@ describe('Plugin', () => {
           } finally {
             await callbackResult(callback => pool.end(callback))
           }
+        })
+
+        it('records the pool acquire wait time on a bundled callback query span', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const sql = 'SELECT 31 AS bundle_callback_pool_wait'
+
+          try {
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const span = traces[0].find(span => span.resource === sql)
+
+                assert.ok(span, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+                assert.strictEqual(typeof span.metrics['mariadb.pool.wait_time'], 'number')
+                assert.ok(span.metrics['mariadb.pool.wait_time'] >= 0)
+                assert.strictEqual(traces[0].find(span => span.name === 'mariadb.pool.acquire'), undefined)
+              }, { spanResourceMatch: new RegExp(`^${sql}$`) }),
+              callbackResult(callback => pool.query(sql, callback)),
+            ])
+          } finally {
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
+        it('forwards bundled callback pool operations without subscribers', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+
+          tracer.use('mariadb', false)
+          try {
+            const [rows] = await callbackResult(callback => {
+              pool.query('SELECT 34 AS bundle_untraced_callback_pool', callback)
+            })
+            const [acquired] = await callbackResult(callback => pool.getConnection(callback))
+
+            await callbackResult(callback => acquired.release(callback))
+            assert.strictEqual(rows[0].bundle_untraced_callback_pool, 34)
+          } finally {
+            tracer.use('mariadb', true)
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
+        it('creates an acquire span for an explicit bundled callback getConnection', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const parent = tracer.startSpan('bundle-callback-acquire-parent')
+
+          try {
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const acquireSpan = traces[0].find(span => span.name === 'mariadb.pool.acquire')
+
+                assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+                assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
+                assert.strictEqual(typeof acquireSpan.metrics['mariadb.pool.wait_time'], 'number')
+              }, { spanResourceMatch: /^mariadb\.pool\.acquire$/ }),
+              tracer.scope().activate(parent, async () => {
+                const [acquired] = await callbackResult(callback => pool.getConnection(callback))
+                await callbackResult(callback => acquired.release(callback))
+                parent.finish()
+              }),
+            ])
+          } finally {
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
+        it('records errors for bundled callback pool acquisition failures', async () => {
+          const pool = mariadb.createPool({
+            ...connectionOptions,
+            acquireTimeout: 500,
+            connectTimeout: 100,
+            host: '127.0.0.1',
+            port: await getClosedPort(),
+          })
+          pool.on('error', noop)
+
+          try {
+            for (const [method, args] of [
+              ['getConnection', []],
+              ['query', ['SELECT 32 AS bundle_callback_query_acquire_failure']],
+              ['execute', ['SELECT 33 AS bundle_callback_execute_acquire_failure']],
+            ]) {
+              await Promise.all([
+                agent.assertSomeTraces(traces => {
+                  const acquireSpan = traces[0].find(span => span.name === 'mariadb.pool.acquire')
+
+                  assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+                  assert.strictEqual(acquireSpan.error, 1)
+                  assert.strictEqual(typeof acquireSpan.metrics['mariadb.pool.wait_time'], 'number')
+                }),
+                assert.rejects(callbackResult(callback => pool[method](...args, callback))),
+              ])
+            }
+          } finally {
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
+        it('records a synchronous bundled callback pool acquisition failure', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          await callbackResult(callback => pool.end(callback))
+
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const acquireSpan = traces[0].find(span => span.name === 'mariadb.pool.acquire')
+
+              assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+              assert.strictEqual(acquireSpan.error, 1)
+              assert.strictEqual(acquireSpan.metrics['mariadb.pool.wait_time'], 0)
+            }),
+            assert.rejects(callbackResult(callback => {
+              pool.query('SELECT 35 AS bundle_closed_pool_acquire_failure', callback)
+            })),
+          ])
         })
 
         it('traces pool clusters and uses selected node metadata', async () => {

--- a/packages/datadog-plugin-mariadb/test/bundle.spec.js
+++ b/packages/datadog-plugin-mariadb/test/bundle.spec.js
@@ -460,6 +460,63 @@ describe('Plugin', () => {
           }
         })
 
+        it('keeps bundled pool acquisition tracking after acquire listeners are removed', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const rootName = 'bundle.promise.removed_acquire_listeners'
+          const sql = 'SELECT * FROM dd_missing_bundle_listener_probe'
+
+          try {
+            await pool.query('SELECT 1')
+            pool.on('removeListener', () => {})
+            pool.removeAllListeners('acquire')
+
+            const assertion = agent.assertSomeTraces(traces => {
+              const trace = traces.find(trace => trace.some(span => span.name === rootName))
+              assert.ok(trace, `${rootName} trace has not flushed yet`)
+
+              const querySpan = trace.find(span => span.resource === sql)
+              assert.ok(querySpan, `missing query span: ${inspect(trace.map(span => span.resource))}`)
+              assert.strictEqual(typeof querySpan.metrics['mariadb.pool.wait_time'], 'number')
+              assert.strictEqual(trace.find(span => span.name === 'mariadb.pool.acquire'), undefined)
+            }, { spanResourceMatch: new RegExp(`^${rootName}$`) })
+
+            await assert.rejects(tracer.trace(rootName, () => pool.query(sql)))
+            await assertion
+          } finally {
+            await pool.end()
+          }
+        })
+
+        it('reports failed bundled promise cluster node acquisitions', async () => {
+          const cluster = mariadb.createPoolCluster({ canRetry: false })
+          const rootName = 'bundle.promise.cluster_acquire_failure'
+          cluster.add('failing', {
+            ...connectionOptions,
+            acquireTimeout: 500,
+            connectTimeout: 100,
+            host: '127.0.0.1',
+            minimumIdle: 0,
+            port: await getClosedPort(),
+          })
+
+          try {
+            const assertion = agent.assertSomeTraces(traces => {
+              const trace = traces.find(trace => trace.some(span => span.name === rootName))
+              assert.ok(trace, `${rootName} trace has not flushed yet`)
+
+              const acquireSpan = trace.find(span => span.name === 'mariadb.pool.acquire')
+              assert.ok(acquireSpan, `missing acquire span: ${inspect(trace.map(span => span.name))}`)
+              assert.strictEqual(acquireSpan.error, 1)
+              assert.strictEqual(typeof acquireSpan.metrics['mariadb.pool.wait_time'], 'number')
+            }, { spanResourceMatch: new RegExp(`^${rootName}$`) })
+
+            await assert.rejects(tracer.trace(rootName, () => cluster.of('failing').query('SELECT 36')))
+            await assertion
+          } finally {
+            await cluster.end()
+          }
+        })
+
         it('traces pool clusters, falsy selectors, and selected node metadata', async () => {
           const cluster = mariadb.createPoolCluster()
           cluster.add('primary', { ...connectionOptions, minimumIdle: 0 })
@@ -856,6 +913,58 @@ describe('Plugin', () => {
               pool.query('SELECT 35 AS bundle_closed_pool_acquire_failure', callback)
             })),
           ])
+        })
+
+        it('keeps bundled callback pool acquisition tracking after acquire listeners are removed', async () => {
+          const pool = mariadb.createPool({ ...connectionOptions, connectionLimit: 1, minimumIdle: 0 })
+          const rootName = 'bundle.callback.removed_acquire_listeners'
+          const sql = 'SELECT * FROM dd_missing_callback_listener_probe'
+
+          try {
+            await callbackResult(callback => pool.query('SELECT 1', callback))
+            pool.removeAllListeners('acquire')
+
+            const assertion = agent.assertSomeTraces(traces => {
+              const trace = traces.find(trace => trace.some(span => span.name === rootName))
+              assert.ok(trace, `${rootName} trace has not flushed yet`)
+
+              const querySpan = trace.find(span => span.resource === sql)
+              assert.ok(querySpan, `missing query span: ${inspect(trace.map(span => span.resource))}`)
+              assert.strictEqual(typeof querySpan.metrics['mariadb.pool.wait_time'], 'number')
+              assert.strictEqual(trace.find(span => span.name === 'mariadb.pool.acquire'), undefined)
+            }, { spanResourceMatch: new RegExp(`^${rootName}$`) })
+
+            await assert.rejects(tracer.trace(rootName, () => {
+              return callbackResult(callback => pool.query(sql, callback))
+            }))
+            await assertion
+          } finally {
+            await callbackResult(callback => pool.end(callback))
+          }
+        })
+
+        it('reports failed bundled callback cluster acquisitions without a matching node', async () => {
+          const cluster = mariadb.createPoolCluster({ canRetry: false })
+          const rootName = 'bundle.callback.cluster_acquire_failure'
+
+          try {
+            const assertion = agent.assertSomeTraces(traces => {
+              const trace = traces.find(trace => trace.some(span => span.name === rootName))
+              assert.ok(trace, `${rootName} trace has not flushed yet`)
+
+              const acquireSpan = trace.find(span => span.name === 'mariadb.pool.acquire')
+              assert.ok(acquireSpan, `missing acquire span: ${inspect(trace.map(span => span.name))}`)
+              assert.strictEqual(acquireSpan.error, 1)
+              assert.strictEqual(typeof acquireSpan.metrics['mariadb.pool.wait_time'], 'number')
+            }, { spanResourceMatch: new RegExp(`^${rootName}$`) })
+
+            await assert.rejects(tracer.trace(rootName, () => {
+              return callbackResult(callback => cluster.of('missing').query('SELECT 37', callback))
+            }))
+            await assertion
+          } finally {
+            await callbackResult(callback => cluster.end(callback))
+          }
         })
 
         it('traces pool clusters and uses selected node metadata', async () => {

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -56,7 +56,7 @@ describe('esm', () => {
 
     for (const variant of importVariants) {
       it(`is instrumented ${variant}`, async () => {
-        const resources = new Set()
+        const resources = []
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
           assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
@@ -64,12 +64,12 @@ describe('esm', () => {
           for (const trace of payload) {
             for (const span of trace) {
               if (span.name === 'mariadb.query' && expectedResourceSet.has(span.resource)) {
-                resources.add(span.resource)
+                resources.push(span.resource)
               }
             }
           }
 
-          assert.deepStrictEqual([...resources].sort(), expectedResources)
+          assert.deepStrictEqual(resources.sort(), expectedResources)
         })
 
         proc = await spawnPluginIntegrationTestProcAndExpectExit(sandboxCwd(), variants[variant], agent.port)

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -29,7 +29,7 @@ describe('esm', () => {
   let agent
   let proc
 
-  const range = '>=3.0.0 <3.5.3'
+  const range = semver.gte(process.version, '20.0.0') ? '>=3.0.0' : '>=3.0.0 <3.5.3'
   withVersions('mariadb', 'mariadb', range, (version, _, resolvedVersion) => {
     useSandbox([`'mariadb@${version}'`], false, [
       './packages/datadog-plugin-mariadb/test/integration-test/*'])

--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -472,6 +472,11 @@ module.exports = {
       name: 'mariadb',
       versions: ['2.5.6', '3.0.0', '3.4.0', '3.4.5', '3.5.1', '3.5.2'],
     },
+    {
+      name: 'mariadb',
+      versions: ['3.5.3'],
+      node: '>=20',
+    },
   ],
   mercurius: [
     {

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -528,7 +528,7 @@
     "dependency": "mariadb",
     "integration": "mariadb",
     "minimum_tracer_supported": "2.0.4",
-    "max_tracer_supported": "3.5.2",
+    "max_tracer_supported": "3.5.3",
     "auto-instrumented": "True"
   },
   {

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -74,7 +74,7 @@ jest-worker,jest,28.0.0,30.4.1,True
 kafkajs,kafkajs,1.4.0,2.2.4,True
 koa,koa,2.0.0,3.2.1,True
 koa-router,koa,7.0.0,14.0.0,True
-mariadb,mariadb,2.0.4,3.5.2,True
+mariadb,mariadb,2.0.4,3.5.3,True
 memcached,memcached,2.2.0,2.2.2,True
 mercurius,graphql,13.0.0,16.10.0,True
 microgateway-core,microgateway-core,2.1.0,3.3.7,True


### PR DESCRIPTION
### What does this PR do?

Restores MariaDB 3.5.3+ CommonJS tracing while preserving the ESM instrumentation introduced by #9734.

MariaDB 3.5.3 restored `require()` through generated single-file bundles. Those entry points no longer load the Query, Execute, Pool, or Cluster source modules used by the existing instrumentation, so this PR adds a CommonJS adapter around the stable exported factories and their runtime results.

The adapter covers:

- direct, pooled, acquired, pool-emitted, and clustered connections for both promise and callback APIs;
- query, execute, batch, import-file, prepared-statement, stream, and transaction operations;
- callback and promise continuation context, command errors, stream identity, and pool skip behavior;
- detached top-level `importFile` calls without treating their receiver as a connection;
- exact cluster-node metadata across broad selectors, round-robin selection, retries, and immediate remove/re-add cycles; and
- the original CommonJS namespace descriptors and named/default factory identity.

### Motivation

MariaDB 3.5.1 and 3.5.2 were ESM-only; #9734 restored tracing for those releases through ESM loader hooks. MariaDB 3.5.3 added CommonJS again, but its `dist/promise.cjs` and `dist/callback.cjs` files embed the connector internals in generated, minified bundles. Requiring MariaDB therefore never loads the original source files where the existing Query, Execute, Pool, and Cluster hooks attach.

Orchestrion cannot rewrite those original modules before bundling because bundling already happened when MariaDB published the package. Targeting the generated bundle instead would couple AST matches to generated and minified output that can change between MariaDB releases. This adapter consequently wraps the stable public factories and returned runtime methods. Cluster connections do not expose which node was selected, so cluster metadata attribution narrowly observes the retained `_selectPool` runtime method and carries the selected node through async-local context, including retries.

### Additional Notes

#9734 is now merged into `master`. Together, #9734 and this PR restore the intended support split:

- MariaDB 3.5.1-3.5.2: ESM instrumentation from #9734.
- MariaDB 3.5.3+: the same ESM path plus the CommonJS bundle adapter in this PR.

Validation:

- MariaDB 3.5.3 CommonJS promise/callback bundle suite: 40 passing.
- MariaDB 3.5.3 ESM integration matrix: 5 passing.
- MariaDB 3.4.5 CommonJS regression suite: 49 passing.
- `mariadb-bundle.js` coverage: 94.13% lines, 90.39% statements, and 95.76% functions.
- Changed-file lint: passing.
- `git diff --check`: passing.

The generated supported-version rows match MariaDB 3.5.3. Repository-wide supported-integration verification still reports unrelated generated-version drift already present on `master`; this PR does not include that unrelated churn.
