### PR TITLE
feat(llmobs): support opt-out for all integrations

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,11 +21,13 @@ tracer.use('pg', {
 })
 ```
 
-The `langchain` and `modelcontextprotocol-sdk` integrations accept an `llmobs` option. Setting it to `false` stops LLM Observability span capture for that integration only — APM spans and distributed trace context propagation are unaffected. This is useful when another enabled integration already captures the same operation and the input/output payloads would otherwise be stored twice:
+LLM Observability integrations accept an `llmobs` option. Setting it to `false` stops LLM Observability span capture for that integration only — APM spans and distributed trace context propagation are unaffected. This is useful when another enabled integration already captures the same operation and the input/output payloads would otherwise be stored twice.
+
+The option is supported by `ai`, `anthropic`, `aws-sdk` (Bedrock Runtime only), `claude-agent-sdk`, `google-cloud-vertexai`, `google-genai`, `langchain`, `langgraph`, `modelcontextprotocol-sdk`, `openai`, and `openai-agents`.
 
 ```javascript
-// Keep APM tracing for MCP, but let LangChain own the LLM Observability spans.
-tracer.use('modelcontextprotocol-sdk', {
+// Keep APM tracing for OpenAI, but let another integration own the LLM Observability spans.
+tracer.use('openai', {
   llmobs: false
 })
 ```

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -294,12 +294,16 @@ const openSearchOptions: plugins.opensearch = {
 };
 
 tracer.use('ai', true)
+tracer.use('ai', { llmobs: false })
 tracer.use('amqp10');
 tracer.use('amqplib');
 tracer.use('anthropic');
+tracer.use('anthropic', { llmobs: false });
 tracer.use('claude-agent-sdk');
+tracer.use('claude-agent-sdk', { llmobs: false });
 tracer.use('avsc');
 tracer.use('aws-sdk');
+tracer.use('aws-sdk', { llmobs: false });
 tracer.use('aws-sdk', awsSdkOptions);
 tracer.use('aws-sdk', awsSdkServiceFunctionOptions);
 tracer.use('azure-cosmos');
@@ -331,7 +335,9 @@ tracer.use('fetch');
 tracer.use('fetch', httpClientOptions);
 tracer.use('google-cloud-pubsub');
 tracer.use('google-cloud-vertexai');
+tracer.use('google-cloud-vertexai', { llmobs: false });
 tracer.use('google-genai');
+tracer.use('google-genai', { llmobs: false });
 tracer.use('graphql');
 tracer.use('graphql', graphqlOptions);
 tracer.use('graphql', { variables: ['foo', 'bar'] });
@@ -376,6 +382,7 @@ tracer.use('langchain');
 tracer.use('langchain', { llmobs: false });
 tracer.use('mariadb', { service: () => `my-custom-mariadb` })
 tracer.use('langgraph');
+tracer.use('langgraph', { llmobs: false });
 tracer.use('memcached');
 tracer.use('microgateway-core');
 tracer.use('microgateway-core', httpServerOptions);
@@ -395,6 +402,8 @@ tracer.use('net');
 tracer.use('next');
 tracer.use('next', nextOptions);
 tracer.use('openai-agents');
+tracer.use('openai-agents', { llmobs: false });
+tracer.use('openai', { llmobs: false });
 tracer.use('opensearch');
 tracer.use('opensearch', openSearchOptions);
 tracer.use('oracledb');

--- a/index.d.ts
+++ b/index.d.ts
@@ -2240,7 +2240,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [Vercel AI SDK](https://ai-sdk.dev/docs/introduction) module.
      */
-    interface ai extends Instrumentation {}
+    interface ai extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
@@ -2258,13 +2258,13 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [anthropic](https://www.npmjs.com/package/@anthropic-ai/sdk) module.
      */
-    interface anthropic extends Instrumentation {}
+    interface anthropic extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
      * [@anthropic-ai/claude-agent-sdk](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) module.
      */
-    interface claude_agent_sdk extends Instrumentation {}
+    interface claude_agent_sdk extends Instrumentation, LLMObsIntegration {}
 
     /**
      * Currently this plugin automatically instruments
@@ -2325,7 +2325,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [aws-sdk](https://github.com/aws/aws-sdk-js) module.
      */
-    interface aws_sdk extends Instrumentation {
+    interface aws_sdk extends Instrumentation, LLMObsIntegration {
       /**
        * The service name to be used for this plugin. When a function is used it is called with the AWS
        * request parameters (e.g. `{ TableName }` for DynamoDB, `{ Bucket }` for S3) and its return value
@@ -2554,13 +2554,13 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [@google-cloud/vertexai](https://github.com/googleapis/nodejs-vertexai) module.
     */
-  interface google_cloud_vertexai extends Integration {}
+  interface google_cloud_vertexai extends Integration, LLMObsIntegration {}
 
   /**
     * This plugin automatically instruments the
     * [@google-genai](https://github.com/googleapis/js-genai) module.
     */
-  interface google_genai extends Integration {}
+  interface google_genai extends Integration, LLMObsIntegration {}
 
   /** @hidden */
   interface ExecutionArgs {
@@ -2882,7 +2882,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [langgraph](https://github.com/npmjs/package/langgraph) library.
      */
-    interface langgraph extends Instrumentation {}
+    interface langgraph extends Instrumentation, LLMObsIntegration {}
 
       /**
      * This plugin automatically instruments the
@@ -3042,13 +3042,13 @@ declare namespace tracer {
      * [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent#setup)
      * in the agent.
      */
-    interface openai extends Instrumentation {}
+    interface openai extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
      * [@openai/agents](https://www.npmjs.com/package/@openai/agents) library.
      */
-    interface openai_agents extends Instrumentation {}
+    interface openai_agents extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -2368,7 +2368,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [Vercel AI SDK](https://ai-sdk.dev/docs/introduction) module.
      */
-    interface ai extends Instrumentation {}
+    interface ai extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
@@ -2386,13 +2386,13 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [@anthropic-ai/claude-agent-sdk](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) module.
      */
-    interface claude_agent_sdk extends Instrumentation {}
+    interface claude_agent_sdk extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
      * [anthropic](https://www.npmjs.com/package/@anthropic-ai/sdk) module.
      */
-    interface anthropic extends Instrumentation {}
+    interface anthropic extends Instrumentation, LLMObsIntegration {}
 
     /**
      * Currently this plugin automatically instruments
@@ -2453,7 +2453,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [aws-sdk](https://github.com/aws/aws-sdk-js) module.
      */
-    interface aws_sdk extends Instrumentation {
+    interface aws_sdk extends Instrumentation, LLMObsIntegration {
       /**
        * The service name to be used for this plugin. When a function is used it is called with the AWS
        * request parameters (e.g. `{ TableName }` for DynamoDB, `{ Bucket }` for S3) and its return value
@@ -2688,13 +2688,13 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [@google-cloud/vertexai](https://github.com/googleapis/nodejs-vertexai) module.
     */
-  interface google_cloud_vertexai extends Integration {}
+  interface google_cloud_vertexai extends Integration, LLMObsIntegration {}
 
   /**
     * This plugin automatically instruments the
     * [@google-genai](https://github.com/googleapis/js-genai) module.
     */
-  interface google_genai extends Integration {}
+  interface google_genai extends Integration, LLMObsIntegration {}
 
   /** @hidden */
   interface ExecutionArgs {
@@ -3052,7 +3052,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [langgraph](https://github.com/npmjs/package/langgraph) library.
      */
-    interface langgraph extends Instrumentation {}
+    interface langgraph extends Instrumentation, LLMObsIntegration {}
 
       /**
      * This plugin automatically instruments the
@@ -3212,13 +3212,13 @@ declare namespace tracer {
      * [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent#setup)
      * in the agent.
      */
-    interface openai extends Instrumentation {}
+    interface openai extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the
      * [@openai/agents](https://www.npmjs.com/package/@openai/agents) library.
      */
-    interface openai_agents extends Instrumentation {}
+    interface openai_agents extends Instrumentation, LLMObsIntegration {}
 
     /**
      * This plugin automatically instruments the

--- a/packages/datadog-plugin-openai-agents/src/integration.js
+++ b/packages/datadog-plugin-openai-agents/src/integration.js
@@ -63,6 +63,7 @@ class OpenAIAgentsIntegration {
   #tracer
   #config
   #enabled = false
+  #llmobsEnabled = true
   #service
   /**
    * LLMObs is gated independently of APM tracing: when DD_LLMOBS_ENABLED is
@@ -95,10 +96,11 @@ class OpenAIAgentsIntegration {
   /**
    * Apply plugin lifecycle configuration.
    *
-   * @param {{ enabled?: boolean, service?: string }} [config]
+   * @param {{ enabled?: boolean, llmobs?: boolean, service?: string }} [config]
    */
   configure (config) {
     this.#enabled = !!config?.enabled
+    this.#llmobsEnabled = config?.llmobs !== false
     this.#service = config?.service
   }
 
@@ -210,15 +212,17 @@ class OpenAIAgentsIntegration {
       completionRequested: false,
     })
 
-    this.#tagger.registerLLMObsSpan(ddSpan, {
-      kind: 'workflow',
-      name,
-      integration: COMPONENT,
-      parent: llmobsParentStore?.span,
-      sessionId: oaiTrace.groupId || undefined,
-    })
-    if (LLMObsTagger.tagMap.has(ddSpan)) {
-      llmobsStorage.enterWith({ ...llmobsParentStore, span: ddSpan })
+    if (this.#isLLMObsEnabled()) {
+      this.#tagger.registerLLMObsSpan(ddSpan, {
+        kind: 'workflow',
+        name,
+        integration: COMPONENT,
+        parent: llmobsParentStore?.span,
+        sessionId: oaiTrace.groupId || undefined,
+      })
+      if (LLMObsTagger.tagMap.has(ddSpan)) {
+        llmobsStorage.enterWith({ ...llmobsParentStore, span: ddSpan })
+      }
     }
   }
 
@@ -680,7 +684,7 @@ class OpenAIAgentsIntegration {
    * @returns {boolean}
    */
   #isLLMObsEnabled () {
-    return !!this.#config.llmobs?.DD_LLMOBS_ENABLED
+    return this.#llmobsEnabled && !!this.#config.llmobs?.DD_LLMOBS_ENABLED
   }
 
   /**

--- a/packages/datadog-plugin-openai-agents/test/integration.spec.js
+++ b/packages/datadog-plugin-openai-agents/test/integration.spec.js
@@ -62,6 +62,26 @@ describe('OpenAIAgentsIntegration', () => {
       integration.configure({ enabled: false })
       assert.strictEqual(integration.enabled, false)
     })
+
+    it('keeps APM tracing enabled while opting out of LLM Observability', () => {
+      const workflowSpan = makeFakeSpan('workflow')
+      const { integration, tracer } = build({
+        tracerSpans: [workflowSpan],
+        config: {
+          llmobs: {
+            DD_LLMOBS_ENABLED: true,
+            mlApp: 'test',
+            sampleRate: 1,
+          },
+        },
+      })
+
+      integration.configure({ enabled: true, llmobs: false })
+      integration.startTrace({ traceId: 't1' })
+
+      sinon.assert.calledOnce(tracer.startSpan)
+      assert.strictEqual(LLMObsTagger.tagMap.get(workflowSpan), undefined)
+    })
   })
 
   describe('startTrace', () => {


### PR DESCRIPTION
## Summary

Follow-up to #9733.

- Extends `llmobs: false` to every remaining LLM Observability integration while preserving APM spans and trace-context propagation.
- Adds the missing per-integration gate for OpenAI Agents and exposes the option in public types and API documentation.
- AWS SDK support applies to Bedrock Runtime LLM Observability only.

## Testing

- `./node_modules/.bin/mocha packages/datadog-plugin-openai-agents/test/integration.spec.js`
- `./node_modules/.bin/tsc --noEmit --skipLibCheck --target es2022 --module node16 --moduleResolution node16 --types node docs/test.ts`
- `./node_modules/.bin/eslint packages/datadog-plugin-openai-agents/src/integration.js packages/datadog-plugin-openai-agents/test/integration.spec.js`