### PR TITLE
fix(iast): compile module body exactly once in rewriter _compile hook

### DIFF
--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -97,15 +97,15 @@ function getPrepareStackTraceAccessor () {
 
 function getCompileMethodFn (compileMethod) {
   let delegate = function (content, filename) {
+    if (isDdTrace(filename) || !isPrivateModule(filename) || !config.iast?.enabled) {
+      return compileMethod.apply(this, [content, filename])
+    }
+
+    let contentToCompile = content
+
+    // TODO when we have CJS support for orchestrion and taint-tracking, add
+    // them here as appropriate
     try {
-      if (isDdTrace(filename)) {
-        return compileMethod.apply(this, [content, filename])
-      }
-      if (!isPrivateModule(filename) || !config.iast?.enabled) {
-        return compileMethod.apply(this, [content, filename])
-      }
-      // TODO when we have CJS support for orchestrion and taint-tracking, add
-      // them here as appropriate
       const rewritten = rewriter.rewrite(content, filename, ['iast'])
 
       incrementTelemetryIfNeeded(rewritten.metrics)
@@ -115,12 +115,12 @@ function getCompileMethodFn (compileMethod) {
       }
 
       if (rewritten?.content) {
-        return compileMethod.apply(this, [rewritten.content, filename])
+        contentToCompile = rewritten.content
       }
     } catch (e) {
       log.error('Error rewriting file %s', filename, e)
     }
-    return compileMethod.apply(this, [content, filename])
+    return compileMethod.apply(this, [contentToCompile, filename])
   }
 
   const shim = function (...args) {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -101,10 +101,9 @@ function getCompileMethodFn (compileMethod) {
       return compileMethod.apply(this, [content, filename])
     }
 
-    let contentToCompile = content
-
     // TODO when we have CJS support for orchestrion and taint-tracking, add
     // them here as appropriate
+    let rewrittenContent
     try {
       const rewritten = rewriter.rewrite(content, filename, ['iast'])
 
@@ -114,13 +113,11 @@ function getCompileMethodFn (compileMethod) {
         hardcodedSecretCh.publish(rewritten.literalsResult)
       }
 
-      if (rewritten?.content) {
-        contentToCompile = rewritten.content
-      }
+      rewrittenContent = rewritten?.content
     } catch (e) {
       log.error('Error rewriting file %s', filename, e)
     }
-    return compileMethod.apply(this, [contentToCompile, filename])
+    return compileMethod.apply(this, [rewrittenContent || content, filename])
   }
 
   const shim = function (...args) {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -424,14 +424,19 @@ describe('IAST Rewriter', () => {
     it('should compile a module body only once when its first execution throws', () => {
       realRewriter.enable(iastEnabledConfig)
 
-      const filename = '/tmp/node_modules/graphql/index.js'
       const source = "Object.defineProperty(exports, 'BREAK', { enumerable: true, get () { return {} } })\n" +
         "throw new Error('original module error')\n"
-
-      const module = new RealModule(filename, null)
-      module.filename = filename
-
-      assert.throws(() => module._compile(source, filename), /original module error/)
+      for (const filename of [
+        '/tmp/node_modules/graphql/index.js',
+        '/tmp/app/index.js',
+      ]) {
+        const module = new RealModule(filename)
+        module.filename = filename
+        assert.throws(
+          () => module._compile(source, filename),
+          { message: 'original module error' }
+        )
+      }
     })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -406,4 +406,32 @@ describe('IAST Rewriter', () => {
       process.env.NODE_OPTIONS = origNodeOptions
     })
   })
+
+  describe('Compiling wrapped modules', () => {
+    const RealModule = require('module')
+    const realRewriter = require('../../../../src/appsec/iast/taint-tracking/rewriter')
+
+    afterEach(() => {
+      realRewriter.disable()
+    })
+
+    // with IAST enabled, requiring graphql/@apollo threw "TypeError: Cannot redefine property: BREAK" at load time.
+    // The compile wrapper executed the module body inside a try/catch and, on any throw,
+    // re-executed the same body on the already-initialized `exports`. graphql's
+    // `Object.defineProperty(exports, 'BREAK', ...)` omits `configurable` (so it
+    // defaults to false), so the second pass could not redefine it and masked the
+    // module's real error. The body must be compiled/executed exactly once.
+    it('should compile a module body only once when its first execution throws', () => {
+      realRewriter.enable(iastEnabledConfig)
+
+      const filename = '/tmp/node_modules/graphql/index.js'
+      const source = "Object.defineProperty(exports, 'BREAK', { enumerable: true, get () { return {} } })\n" +
+        "throw new Error('original module error')\n"
+
+      const module = new RealModule(filename, null)
+      module.filename = filename
+
+      assert.throws(() => module._compile(source, filename), /original module error/)
+    })
+  })
 })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Move `compileMethod.apply` out of the try so the body is compiled/executed exactly once; only the rewrite step is guarded.
```
  // Before (buggy): compile runs inside the try
  try {
    ...
    return compileMethod.apply(...)   // executes body; may throw after partial init
  } catch (e) { log.error(...) }      // swallows it
  return compileMethod.apply(...)     // ← re-executes body on same exports → redefine error

  // After (fixed): compile runs once, outside the try
  try {
    rewriter.rewrite(...)             // only the rewrite is guarded
  } catch (e) { log.error(...) }
  return compileMethod.apply(...)     // executes body exactly once; real error propagates

```

### Motivation
With IAST enabled, requiring graphql could crash at load time with `TypeError: Cannot redefine property: BREAK`. 
The `_compile` wrapper executed the module body inside a try/catch; when a module threw at runtime after partially initializing its exports, the error was swallowed and the fallback re-ran the body on the same exports. graphql defines `Object.defineProperty(exports, 'BREAK', …)`  so the second pass threw the redefine error and masked the module's real error.

### Additional Notes

https://datadoghq.atlassian.net/browse/APPSEC-69594


