### PR TITLE
test(test-optimization): avoid Playwright payload timeout race

### DIFF
--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -198,8 +198,21 @@ versions.forEach((version) => {
             ? '/api/v2/citestcycle'
             : '/evp_proxy/v2/api/v2/citestcycle'
 
+          const proc = run(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...envVars,
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2',
+                DD_TEST_SESSION_NAME: 'my-test-session',
+                DD_SERVICE: undefined,
+              },
+            }
+          )
           const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === reportUrl, payloads => {
+            .gatherPayloadsUntilChildExit(proc, ({ url }) => url === reportUrl, payloads => {
               const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
 
               metadataDicts.forEach(metadata => {
@@ -324,22 +337,9 @@ versions.forEach((version) => {
                 },
               })
               assert.ok(!('test.invalid' in annotatedTest.content.meta))
-            })
+            }, { hardTimeout: 60000 })
 
-          const proc = run(
-            './node_modules/.bin/playwright test -c playwright.config.js',
-            {
-              cwd,
-              env: {
-                ...envVars,
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2',
-                DD_TEST_SESSION_NAME: 'my-test-session',
-                DD_SERVICE: undefined,
-              },
-            }
-          )
-          await Promise.all([eventsPromise, once(proc, 'exit')])
+          await eventsPromise
         })
       })
     })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Waits for the Playwright child process to exit and the intake to drain before asserting the complete reporting payload. A 60-second hard timeout remains as a backstop for genuinely hung child processes.

This is a test-only change with no production or user-facing impact.

### Motivation
<!-- What inspired you to submit this pull request? -->

The reporting integration test used a fixed 15-second payload-gathering window. Under CI load, the test events could arrive before the session and module end events, especially when Test Optimization finalization used its bounded flush window. The assertion then dereferenced a missing session event even though the child process was still completing normally.

This caused both the agentless and EVP variants to fail intermittently in https://github.com/DataDog/dd-trace-js/actions/runs/31170048451/job/92839690876, while the run-level retry passed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- `npm exec -- eslint integration-tests/playwright/playwright-reporting.spec.js --max-warnings 0`
- `PLAYWRIGHT_VERSION=latest OPTIONS_OVERRIDE=1 SPEC=playwright-reporting NODE_OPTIONS='-r ./ci/init' npm run test:integration:playwright:coverage -- --grep 'can run and report tests'` (2 passing: agentless and EVP proxy)
