### PR TITLE
refactor(aiguard): slim down sdk file

### DIFF
--- a/packages/dd-trace/src/aiguard/client.js
+++ b/packages/dd-trace/src/aiguard/client.js
@@ -1,5 +1,27 @@
 'use strict'
 
+const tracerVersion = require('../../../../package.json').version
+const { AIGuardClientError } = require('./errors')
+const { parseEvaluationResponse } = require('./evaluation')
+const TAGS = require('./tags')
+
+/**
+ * Resolves the AI Guard host for a Datadog site.
+ *
+ * @param {string} site
+ * @returns {string}
+ */
+function aiGuardHost (site) {
+  return site.split('.').length === 2 ? `app.${site}` : site
+}
+
+/**
+ * Sends a request to the AI Guard service.
+ *
+ * @param {object} body
+ * @param {{ url: string, headers: Record<string, string>, timeout: number }} opts
+ * @returns {Promise<{ status: number, body: unknown }>}
+ */
 async function executeRequest (body, opts) {
   const postData = JSON.stringify(body)
   const headers = {
@@ -22,4 +44,81 @@ async function executeRequest (body, opts) {
   }
 }
 
-module.exports = executeRequest
+class AIGuardClient {
+  #headers
+  #evaluateUrl
+  #timeout
+
+  /**
+   * @param {import('../config/config-base')} config
+   */
+  constructor (config) {
+    this.#headers = {
+      'DD-API-KEY': config.DD_API_KEY,
+      'DD-APPLICATION-KEY': config.DD_APP_KEY,
+      'DD-AI-GUARD-VERSION': tracerVersion,
+      'DD-AI-GUARD-SOURCE': 'SDK',
+      'DD-AI-GUARD-LANGUAGE': 'nodejs',
+    }
+    const endpoint = config.experimental.aiguard.endpoint || `https://${aiGuardHost(config.site)}/api/v2/ai-guard`
+    this.#evaluateUrl = `${endpoint}/evaluate`
+    this.#timeout = config.experimental.aiguard.timeout
+  }
+
+  /**
+   * Evaluates messages and converts the service response to the internal evaluation contract.
+   *
+   * @param {import('../../../../index').aiguard.Message[]} messages
+   * @param {{ service: string, env: string }} meta
+   * @returns {Promise<NonNullable<ReturnType<typeof parseEvaluationResponse>>>}
+   */
+  evaluate (messages, meta) {
+    const payload = {
+      data: {
+        attributes: {
+          messages,
+          meta,
+        },
+      },
+    }
+    return executeRequest(
+      payload,
+      { url: this.#evaluateUrl, headers: this.#headers, timeout: this.#timeout }
+    )
+      .then(response => this.#parseResponse(response))
+      .catch(cause => {
+        if (cause instanceof AIGuardClientError) throw cause
+
+        throw new AIGuardClientError(`Unexpected error calling AI Guard service: ${cause.message}`, {
+          cause,
+          telemetryType: TAGS.ERROR_TYPE_CLIENT,
+        })
+      })
+  }
+
+  /**
+   * Validates an AI Guard HTTP response.
+   *
+   * @param {{ status: number, body: unknown }} response
+   * @returns {NonNullable<ReturnType<typeof parseEvaluationResponse>>}
+   */
+  #parseResponse (response) {
+    if (response.status !== 200) {
+      throw new AIGuardClientError(`AI Guard service call failed, status ${response.status}`, {
+        errors: response.body?.errors,
+        telemetryType: TAGS.ERROR_TYPE_STATUS,
+      })
+    }
+
+    const evaluation = parseEvaluationResponse(response.body)
+    if (!evaluation) {
+      throw new AIGuardClientError(`AI Guard service returned unexpected response : ${response.body}`, {
+        telemetryType: TAGS.ERROR_TYPE_RESPONSE,
+      })
+    }
+
+    return evaluation
+  }
+}
+
+module.exports = AIGuardClient

--- a/packages/dd-trace/src/aiguard/errors.js
+++ b/packages/dd-trace/src/aiguard/errors.js
@@ -1,0 +1,41 @@
+'use strict'
+
+class AIGuardAbortError extends Error {
+  /**
+   * @param {string|undefined} reason
+   * @param {Array<unknown>} tags
+   * @param {Record<string, unknown>} tagProbabilities
+   * @param {Array<unknown>} sds
+   */
+  constructor (reason, tags, tagProbabilities, sds) {
+    super(reason)
+    this.name = 'AIGuardAbortError'
+    this.reason = reason
+    this.tags = tags
+    this.tagProbabilities = tagProbabilities
+    this.sds = sds || []
+  }
+}
+
+class AIGuardClientError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ telemetryType: string, errors?: Array<unknown>, cause?: Error }} opts
+   */
+  constructor (message, opts) {
+    super(message)
+    this.name = 'AIGuardClientError'
+    this.telemetryType = opts.telemetryType
+    if (opts.errors) {
+      this.errors = opts.errors
+    }
+    if (opts.cause) {
+      this.cause = opts.cause
+    }
+  }
+}
+
+module.exports = {
+  AIGuardAbortError,
+  AIGuardClientError,
+}

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -1,0 +1,357 @@
+'use strict'
+
+const { HTTP_CLIENT_IP, HTTP_USERAGENT, NETWORK_CLIENT_IP } = require('../../../../ext/tags')
+const clone = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
+const { USER_ID, USER_SESSION_ID } = require('../appsec/addresses')
+const { getActiveRequest } = require('../appsec/store')
+const { keepTrace } = require('../priority_sampler')
+const { extractIp } = require('../plugins/util/ip_extractor')
+const { AI_GUARD } = require('../standalone/product')
+const telemetryMetrics = require('../telemetry/metrics')
+const TAGS = require('./tags')
+
+const ALLOW = 'ALLOW'
+
+/** @typedef {import('../../../../index').aiguard.Message} Message */
+/** @typedef {import('../opentracing/span')} Span */
+
+/**
+ * @typedef {object} EvaluationResponse
+ * @property {string} action
+ * @property {string|undefined} reason
+ * @property {Array<unknown>} tags
+ * @property {Array<unknown>} sdsFindings
+ * @property {Record<string, unknown>} tagProbabilities
+ * @property {boolean} hasTagProbabilities
+ * @property {boolean} blockingEnabled
+ */
+
+/**
+ * @typedef {object} EvaluationOutcome
+ * @property {{ action: string, reason: string|undefined, tags: Array<unknown>,
+ *   tagProbabilities: Record<string, unknown>, sds: Array<unknown> }} result
+ * @property {boolean} shouldBlock
+ * @property {boolean} hasTagProbabilities
+ */
+
+/**
+ * @typedef {object} EvaluationMetaStruct
+ * @property {Message[]} messages
+ * @property {Array<unknown>} [attack_categories]
+ * @property {Array<unknown>} [sds]
+ * @property {Record<string, unknown>} [tag_probs]
+ */
+
+/**
+ * @typedef {object} EvaluationReport
+ * @property {Span} span
+ * @property {EvaluationMetaStruct} metaStruct
+ * @property {{ source: string, integration: string }} telemetryTags
+ */
+
+/**
+ * Returns whether a value is a non-array object.
+ *
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord (value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Parses the backend evaluation response into the tracer's internal contract.
+ *
+ * @param {unknown} body
+ * @returns {EvaluationResponse|undefined}
+ */
+function parseEvaluationResponse (body) {
+  if (!isRecord(body) || !isRecord(body.data) || !isRecord(body.data.attributes)) return
+
+  const attributes = body.data.attributes
+  if (typeof attributes.action !== 'string' || attributes.action.length === 0) return
+
+  return {
+    action: attributes.action,
+    reason: typeof attributes.reason === 'string' ? attributes.reason : undefined,
+    tags: Array.isArray(attributes.tags) ? attributes.tags : [],
+    sdsFindings: Array.isArray(attributes.sds_findings) ? attributes.sds_findings : [],
+    tagProbabilities: isRecord(attributes.tag_probs) ? attributes.tag_probs : {},
+    hasTagProbabilities: isRecord(attributes.tag_probs),
+    blockingEnabled: attributes.is_blocking_enabled === true,
+  }
+}
+
+/**
+ * Determines whether the current evaluation must abort the guarded operation.
+ *
+ * @param {boolean} block
+ * @param {{ action: string, blockingEnabled: boolean }} evaluation
+ * @returns {boolean}
+ */
+function shouldBlockEvaluation (block, evaluation) {
+  return block && evaluation.blockingEnabled && evaluation.action !== ALLOW
+}
+
+/**
+ * Applies local evaluation policy and creates the result returned to the caller.
+ *
+ * @param {EvaluationResponse} evaluation
+ * @param {boolean} block
+ * @returns {EvaluationOutcome}
+ */
+function createEvaluationOutcome (evaluation, block) {
+  return {
+    result: {
+      action: evaluation.action,
+      reason: evaluation.reason,
+      tags: evaluation.tags,
+      tagProbabilities: evaluation.tagProbabilities,
+      sds: evaluation.sdsFindings,
+    },
+    shouldBlock: shouldBlockEvaluation(block, evaluation),
+    hasTagProbabilities: evaluation.hasTagProbabilities,
+  }
+}
+
+const aiguardMetrics = telemetryMetrics.manager.namespace('ai_guard')
+
+// Tags from the service entry span that must be mirrored onto every AI Guard span
+// so anomaly detection pipelines can process each span independently.
+const SERVICE_ENTRY_TAG_MAPPINGS = [
+  [HTTP_USERAGENT, TAGS.HTTP_USERAGENT_TAG_KEY],
+  [HTTP_CLIENT_IP, TAGS.HTTP_CLIENT_IP_TAG_KEY],
+  [NETWORK_CLIENT_IP, TAGS.NETWORK_CLIENT_IP_TAG_KEY],
+  [USER_ID, TAGS.USR_ID_TAG_KEY],
+  [USER_SESSION_ID, TAGS.USR_SESSION_ID_TAG_KEY],
+]
+
+class EvaluationReporter {
+  #config
+  #maxMessagesLength
+  #maxContentSize
+
+  /**
+   * @param {import('../config/config-base')} config
+   */
+  constructor (config) {
+    this.#config = config
+    this.#maxMessagesLength = config.experimental.aiguard.maxMessagesLength
+    this.#maxContentSize = config.experimental.aiguard.maxContentSize
+  }
+
+  /**
+   * Initializes span and trace reporting before the AI Guard request starts.
+   *
+   * @param {Span} span
+   * @param {Message[]} messages
+   * @param {{ source: string, integration: string }} options
+   * @returns {EvaluationReport}
+   */
+  start (span, messages, options) {
+    const telemetryTags = { source: options.source, integration: options.integration }
+    const last = messages.at(-1)
+    const target = this.#isToolCall(last) ? 'tool' : 'prompt'
+    span.setTag(TAGS.TARGET_TAG_KEY, target)
+    if (target === 'tool') {
+      const name = this.#getToolName(last, messages)
+      if (name) {
+        span.setTag(TAGS.TOOL_NAME_TAG_KEY, name)
+      }
+    }
+
+    const metaStruct = {
+      messages: this.#buildMessagesForMetaStruct(messages, telemetryTags),
+    }
+    span.meta_struct = {
+      [TAGS.META_STRUCT_KEY]: metaStruct,
+    }
+
+    const rootSpan = span.context()?._trace?.started?.[0]
+    if (rootSpan) {
+      this.#setRootSpanClientIpTags(rootSpan)
+      this.#copyServiceEntryTagsToGuardSpan(span, rootSpan)
+      // This must happen before the request so its sampling decision reaches outgoing HTTP spans.
+      keepTrace(rootSpan, AI_GUARD)
+      rootSpan.setTag(TAGS.EVENT_TAG_KEY, 'true')
+    }
+
+    return {
+      span,
+      metaStruct,
+      telemetryTags,
+    }
+  }
+
+  /**
+   * Reports a failed evaluation request.
+   *
+   * @param {EvaluationReport} report
+   * @param {string} errorType
+   * @returns {void}
+   */
+  fail (report, errorType) {
+    aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, { error: true, ...report.telemetryTags }).inc(1)
+    aiguardMetrics.count(TAGS.TELEMETRY_ERROR, { type: errorType, ...report.telemetryTags }).inc(1)
+  }
+
+  /**
+   * Reports a successful evaluation and its local policy outcome.
+   *
+   * @param {EvaluationReport} report
+   * @param {EvaluationOutcome} outcome
+   * @returns {void}
+   */
+  finish (report, outcome) {
+    const { result, shouldBlock } = outcome
+
+    if (result.tags.length > 0) report.metaStruct.attack_categories = result.tags
+    if (result.sds.length > 0) report.metaStruct.sds = result.sds
+    if (outcome.hasTagProbabilities) report.metaStruct.tag_probs = result.tagProbabilities
+
+    const requestTelemetryTags = {
+      action: result.action,
+      error: false,
+      block: shouldBlock,
+      ...report.telemetryTags,
+    }
+    aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, requestTelemetryTags).inc(1)
+
+    report.span.setTag(TAGS.ACTION_TAG_KEY, result.action)
+    if (result.reason) {
+      report.span.setTag(TAGS.REASON_TAG_KEY, result.reason)
+    }
+    if (shouldBlock) {
+      report.span.setTag(TAGS.BLOCKED_TAG_KEY, 'true')
+    }
+  }
+
+  /**
+   * Returns a safe, size-limited message copy for the span meta-struct.
+   *
+   * @param {Message[]} messages
+   * @param {{ source: string, integration: string }} telemetryTags
+   * @returns {Message[]}
+   */
+  #buildMessagesForMetaStruct (messages, telemetryTags) {
+    const size = Math.min(messages.length, this.#maxMessagesLength)
+    if (messages.length > size) {
+      aiguardMetrics.count(TAGS.TELEMETRY_TRUNCATED, { type: 'messages', ...telemetryTags }).inc(1)
+    }
+    const result = []
+    let contentTruncated = false
+    for (let i = messages.length - size; i < messages.length; i++) {
+      const message = clone(messages[i])
+      if (message.content?.length > this.#maxContentSize) {
+        contentTruncated = true
+        message.content = message.content.slice(0, this.#maxContentSize)
+      }
+      result.push(message)
+    }
+    if (contentTruncated) {
+      aiguardMetrics.count(TAGS.TELEMETRY_TRUNCATED, { type: 'content', ...telemetryTags }).inc(1)
+    }
+    return result
+  }
+
+  /**
+   * Returns whether a message represents a tool call or tool output.
+   *
+   * @param {Message} message
+   * @returns {boolean}
+   */
+  #isToolCall (message) {
+    return Boolean(message.tool_calls || message.tool_call_id)
+  }
+
+  /**
+   * Resolves the tool name associated with a tool call or output message.
+   *
+   * @param {Message} message
+   * @param {Message[]} history
+   * @returns {string|null}
+   */
+  #getToolName (message, history) {
+    if (message.tool_calls) {
+      const names = message.tool_calls.map(tool => tool.function.name)
+      return names.length === 0 ? null : names.join(',')
+    }
+
+    const id = message.tool_call_id
+    for (let i = history.length - 2; i >= 0; i--) {
+      const item = history[i]
+      if (item.tool_calls) {
+        for (const toolCall of item.tool_calls) {
+          if (toolCall.id === id) {
+            return toolCall.function.name
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  /**
+   * Adds missing client IP tags to the service entry span.
+   *
+   * @param {Span} rootSpan
+   * @returns {void}
+   */
+  #setRootSpanClientIpTags (rootSpan) {
+    const currentTags = rootSpan.context().getTags()
+    const needsHttpClientIp = !Object.hasOwn(currentTags, HTTP_CLIENT_IP)
+    const needsNetworkClientIp = !Object.hasOwn(currentTags, NETWORK_CLIENT_IP)
+
+    if (!needsHttpClientIp && !needsNetworkClientIp) return
+
+    const request = getActiveRequest()
+    if (!request) return
+
+    const newTags = {}
+    let hasNewTags = false
+
+    if (needsHttpClientIp) {
+      const clientIp = extractIp(this.#config, request)
+      if (clientIp) {
+        newTags[HTTP_CLIENT_IP] = clientIp
+        hasNewTags = true
+      }
+    }
+
+    if (needsNetworkClientIp) {
+      const networkClientIp = request.socket?.remoteAddress
+      if (networkClientIp) {
+        newTags[NETWORK_CLIENT_IP] = networkClientIp
+        hasNewTags = true
+      }
+    }
+
+    if (hasNewTags) {
+      rootSpan.addTags(newTags)
+    }
+  }
+
+  /**
+   * Copies service entry tags required by anomaly detection to the AI Guard span.
+   *
+   * @param {Span} guardSpan
+   * @param {Span} rootSpan
+   * @returns {void}
+   */
+  #copyServiceEntryTagsToGuardSpan (guardSpan, rootSpan) {
+    const rootTags = rootSpan.context().getTags()
+    for (const [sourceTag, destinationTag] of SERVICE_ENTRY_TAG_MAPPINGS) {
+      const value = rootTags[sourceTag]
+      if (value !== undefined && value !== null) {
+        guardSpan.setTag(destinationTag, value)
+      }
+    }
+  }
+}
+
+module.exports = {
+  createEvaluationOutcome,
+  EvaluationReporter,
+  parseEvaluationResponse,
+  shouldBlockEvaluation,
+}

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -1,90 +1,18 @@
 'use strict'
 
-const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
-const { HTTP_CLIENT_IP, NETWORK_CLIENT_IP, HTTP_USERAGENT } = require('../../../../ext/tags')
-const { USER_ID, USER_SESSION_ID } = require('../appsec/addresses')
-const { getActiveRequest } = require('../appsec/store')
 const log = require('../log')
-const { extractIp } = require('../plugins/util/ip_extractor')
-const telemetryMetrics = require('../telemetry/metrics')
-const tracerVersion = require('../../../../package.json').version
-const { keepTrace } = require('../priority_sampler')
-const { AI_GUARD } = require('../standalone/product')
+const AIGuardClient = require('./client')
+const { createEvaluationOutcome, EvaluationReporter } = require('./evaluation')
+const { AIGuardAbortError } = require('./errors')
 const NoopAIGuard = require('./noop')
-const executeRequest = require('./client')
 const TAGS = require('./tags')
-
-const aiguardMetrics = telemetryMetrics.manager.namespace('ai_guard')
-
-const ALLOW = 'ALLOW'
-
-// Tags from the service entry span that must be mirrored onto every AI Guard span
-// so anomaly detection pipelines can process each span independently.
-const SERVICE_ENTRY_TAG_MAPPINGS = [
-  [HTTP_USERAGENT, TAGS.HTTP_USERAGENT_TAG_KEY],
-  [HTTP_CLIENT_IP, TAGS.HTTP_CLIENT_IP_TAG_KEY],
-  [NETWORK_CLIENT_IP, TAGS.NETWORK_CLIENT_IP_TAG_KEY],
-  [USER_ID, TAGS.USR_ID_TAG_KEY],
-  [USER_SESSION_ID, TAGS.USR_SESSION_ID_TAG_KEY],
-]
-
-/**
- * Reports a telemetry error
- *
- * @param {string} errorType - The error type constant (client_error, bad_status, bad_response)
- * @param {{ source: string, integration: string }} telemetryTags - Source and integration tags
- */
-function reportTelemetryError (errorType, telemetryTags) {
-  aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, { error: true, ...telemetryTags }).inc(1)
-  aiguardMetrics.count(TAGS.TELEMETRY_ERROR, { type: errorType, ...telemetryTags }).inc(1)
-}
-
-class AIGuardAbortError extends Error {
-  constructor (reason, tags, tagProbs, sds) {
-    super(reason)
-    this.name = 'AIGuardAbortError'
-    this.reason = reason
-    this.tags = tags
-    this.tagProbabilities = tagProbs
-    this.sds = sds || []
-  }
-}
-
-class AIGuardClientError extends Error {
-  constructor (message, opts = {}) {
-    super(message)
-    this.name = 'AIGuardClientError'
-    if (opts.errors) {
-      this.errors = opts.errors
-    }
-    if (opts.cause) {
-      this.cause = opts.cause
-    }
-  }
-}
-
-/**
- * Resolves the AI Guard host for a given Datadog site. Sites with a single subdomain level
- * (e.g. `datadoghq.com`, `ddog-gov.com`) are served from the `app.` subdomain, while regional
- * sites (e.g. `us3.datadoghq.com`, `ap1.datadoghq.com`) are used as-is.
- *
- * @param {string} site - Datadog site (e.g. `datadoghq.com`, `us3.datadoghq.com`)
- * @returns {string} The host to use for the AI Guard endpoint
- */
-function aiGuardHost (site) {
-  return site.split('.').length === 2 ? `app.${site}` : site
-}
 
 class AIGuard extends NoopAIGuard {
   #initialized
   #tracer
-  #headers
-  #evaluateUrl
-  #timeout
-  #maxMessagesLength
-  #maxContentSize
+  #client
+  #reporter
   #meta
-  #config
 
   /**
    * @param {import('../tracer')} tracer - Tracer instance
@@ -99,128 +27,10 @@ class AIGuard extends NoopAIGuard {
       return
     }
     this.#tracer = tracer
-    this.#headers = {
-      'DD-API-KEY': config.DD_API_KEY,
-      'DD-APPLICATION-KEY': config.DD_APP_KEY,
-      'DD-AI-GUARD-VERSION': tracerVersion,
-      'DD-AI-GUARD-SOURCE': 'SDK',
-      'DD-AI-GUARD-LANGUAGE': 'nodejs',
-    }
-    const endpoint = config.experimental.aiguard.endpoint || `https://${aiGuardHost(config.site)}/api/v2/ai-guard`
-    this.#evaluateUrl = `${endpoint}/evaluate`
-    this.#timeout = config.experimental.aiguard.timeout
-    this.#maxMessagesLength = config.experimental.aiguard.maxMessagesLength
-    this.#maxContentSize = config.experimental.aiguard.maxContentSize
+    this.#client = new AIGuardClient(config)
+    this.#reporter = new EvaluationReporter(config)
     this.#meta = { service: config.service, env: config.env }
-    this.#config = config
     this.#initialized = true
-  }
-
-  /**
-   * Returns a safe copy of the messages to be serialized into the meta struct.
-   *
-   * - Clones each message so callers cannot mutate the data set in the meta struct.
-   * - Truncates the list of messages and `content` fields emitting metrics accordingly.
-   *
-   * @param {import('../../../../index').aiguard.Message[]} messages
-   * @param {{ source: string, integration: string }} telemetryTags
-   */
-  #buildMessagesForMetaStruct (messages, telemetryTags) {
-    const size = Math.min(messages.length, this.#maxMessagesLength)
-    if (messages.length > size) {
-      aiguardMetrics.count(TAGS.TELEMETRY_TRUNCATED, { type: 'messages', ...telemetryTags }).inc(1)
-    }
-    const result = []
-    let contentTruncated = false
-    for (let i = messages.length - size; i < messages.length; i++) {
-      const message = rfdc(messages[i])
-      if (message.content?.length > this.#maxContentSize) {
-        contentTruncated = true
-        message.content = message.content.slice(0, this.#maxContentSize)
-      }
-      result.push(message)
-    }
-    if (contentTruncated) {
-      aiguardMetrics.count(TAGS.TELEMETRY_TRUNCATED, { type: 'content', ...telemetryTags }).inc(1)
-    }
-    return result
-  }
-
-  #isToolCall (message) {
-    return message.tool_calls || message.tool_call_id
-  }
-
-  #getToolName (message, history) {
-    // 1. assistant message with tool calls
-    if (message.tool_calls) {
-      const names = message.tool_calls.map((tool) => tool.function.name)
-      return names.length === 0 ? null : names.join(',')
-    }
-    // 2. assistant message with tool output (search the linked tool call in reverse order)
-    const id = message.tool_call_id
-    for (let i = history.length - 2; i >= 0; i--) {
-      const item = history[i]
-      if (item.tool_calls) {
-        for (const toolCall of item.tool_calls) {
-          if (toolCall.id === id) {
-            return toolCall.function.name
-          }
-        }
-      }
-    }
-    return null
-  }
-
-  #setRootSpanClientIpTags (rootSpan) {
-    if (!rootSpan) return
-
-    const currentTags = rootSpan.context().getTags()
-    const needsHttpClientIp = !Object.hasOwn(currentTags, HTTP_CLIENT_IP)
-    const needsNetworkClientIp = !Object.hasOwn(currentTags, NETWORK_CLIENT_IP)
-
-    if (!needsHttpClientIp && !needsNetworkClientIp) return
-
-    const req = getActiveRequest()
-
-    if (!req) return
-
-    const newTags = {}
-
-    if (needsHttpClientIp) {
-      const clientIp = extractIp(this.#config, req)
-
-      if (clientIp) {
-        newTags[HTTP_CLIENT_IP] = clientIp
-      }
-    }
-
-    if (needsNetworkClientIp) {
-      const networkClientIp = req.socket?.remoteAddress
-
-      if (networkClientIp) {
-        newTags[NETWORK_CLIENT_IP] = networkClientIp
-      }
-    }
-
-    if (Object.keys(newTags).length > 0) {
-      rootSpan.addTags(newTags)
-    }
-  }
-
-  /**
-   * Copies service entry span tags needed by anomaly detection to the AI Guard span.
-   *
-   * @param {import('../opentracing/span')} guardSpan
-   * @param {import('../opentracing/span')} rootSpan
-   */
-  #copyServiceEntryTagsToGuardSpan (guardSpan, rootSpan) {
-    const rootTags = rootSpan.context().getTags()
-    for (const [sourceTag, destTag] of SERVICE_ENTRY_TAG_MAPPINGS) {
-      const value = rootTags[sourceTag]
-      if (value !== undefined && value !== null) {
-        guardSpan.setTag(destTag, value)
-      }
-    }
   }
 
   evaluate (messages, opts) {
@@ -228,94 +38,28 @@ class AIGuard extends NoopAIGuard {
       return super.evaluate(messages, opts)
     }
     const { block = true, source = TAGS.SOURCE_SDK, integration = TAGS.INTEGRATION_NONE, childOf } = opts ?? {}
-    const telemetryTags = { source, integration }
     // Only pass `childOf` when truthy so `tracer.trace`'s default (`scope().active()`)
     // still applies for SDK callers that don't supply an explicit parent.
     const traceOpts = childOf ? { childOf } : {}
     return this.#tracer.trace(TAGS.RESOURCE, traceOpts, async (span) => {
-      const last = messages.at(-1)
-      const target = this.#isToolCall(last) ? 'tool' : 'prompt'
-      span.setTag(TAGS.TARGET_TAG_KEY, target)
-      if (target === 'tool') {
-        const name = this.#getToolName(last, messages)
-        if (name) {
-          span.setTag(TAGS.TOOL_NAME_TAG_KEY, name)
-        }
-      }
-      const metaStruct = {
-        messages: this.#buildMessagesForMetaStruct(messages, telemetryTags),
-      }
-      span.meta_struct = {
-        [TAGS.META_STRUCT_KEY]: metaStruct,
-      }
-      const rootSpan = span.context()?._trace?.started?.[0]
-      if (rootSpan) {
-        this.#setRootSpanClientIpTags(rootSpan)
-        this.#copyServiceEntryTagsToGuardSpan(span, rootSpan)
-        // keepTrace must be called before executeRequest so the sampling decision
-        // is propagated correctly to outgoing HTTP client calls.
-        keepTrace(rootSpan, AI_GUARD)
-        rootSpan.setTag(TAGS.EVENT_TAG_KEY, 'true')
-      }
-      let response
+      const report = this.#reporter.start(span, messages, { source, integration })
+      let evaluation
       try {
-        const payload = {
-          data: {
-            attributes: {
-              messages,
-              meta: this.#meta,
-            },
-          },
-        }
-        response = await executeRequest(
-          payload,
-          { url: this.#evaluateUrl, headers: this.#headers, timeout: this.#timeout })
-      } catch (e) {
-        reportTelemetryError(TAGS.ERROR_TYPE_CLIENT, telemetryTags)
-        throw new AIGuardClientError(`Unexpected error calling AI Guard service: ${e.message}`, { cause: e })
+        evaluation = await this.#client.evaluate(messages, this.#meta)
+      } catch (error) {
+        this.#reporter.fail(report, error.telemetryType ?? TAGS.ERROR_TYPE_CLIENT)
+        throw error
       }
-      if (response.status !== 200) {
-        reportTelemetryError(TAGS.ERROR_TYPE_STATUS, telemetryTags)
-        throw new AIGuardClientError(
-          `AI Guard service call failed, status ${response.status}`,
-          { errors: response.body?.errors })
+
+      const outcome = createEvaluationOutcome(evaluation, block)
+      this.#reporter.finish(report, outcome)
+
+      if (outcome.shouldBlock) {
+        const { reason, tags, tagProbabilities, sds } = outcome.result
+        throw new AIGuardAbortError(reason, tags, tagProbabilities, sds)
       }
-      const attr = response.body?.data?.attributes
-      if (!attr?.action) {
-        reportTelemetryError(TAGS.ERROR_TYPE_RESPONSE, telemetryTags)
-        throw new AIGuardClientError(`AI Guard service returned unexpected response : ${response.body}`)
-      }
-      const action = attr.action
-      const reason = attr.reason
-      const tags = attr.tags ?? []
-      if (tags.length > 0) {
-        metaStruct.attack_categories = tags
-      }
-      const sdsFindings = attr.sds_findings ?? []
-      if (sdsFindings.length > 0) {
-        metaStruct.sds = sdsFindings
-      }
-      const tagProbabilities = attr.tag_probs ?? {}
-      if (attr.tag_probs) {
-        metaStruct.tag_probs = tagProbabilities
-      }
-      const blockingEnabled = attr.is_blocking_enabled ?? false
-      const shouldBlock = block && blockingEnabled && action !== ALLOW
-      aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, {
-        action,
-        error: false,
-        block: shouldBlock,
-        ...telemetryTags,
-      }).inc(1)
-      span.setTag(TAGS.ACTION_TAG_KEY, action)
-      if (reason) {
-        span.setTag(TAGS.REASON_TAG_KEY, reason)
-      }
-      if (shouldBlock) {
-        span.setTag(TAGS.BLOCKED_TAG_KEY, 'true')
-        throw new AIGuardAbortError(reason, tags, tagProbabilities, sdsFindings)
-      }
-      return { action, reason, tags, tagProbabilities, sds: sdsFindings }
+
+      return outcome.result
     })
   }
 }

--- a/packages/dd-trace/test/aiguard/evaluation.spec.js
+++ b/packages/dd-trace/test/aiguard/evaluation.spec.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const {
+  createEvaluationOutcome,
+  parseEvaluationResponse,
+  shouldBlockEvaluation,
+} = require('../../src/aiguard/evaluation')
+
+describe('AI Guard evaluation response', () => {
+  it('parses the backend response into the internal evaluation contract', () => {
+    const sdsFindings = [{ category: 'ssn' }]
+    const tagProbabilities = { jailbreak: 0.8 }
+    const response = {
+      data: {
+        attributes: {
+          action: 'DENY',
+          reason: 'Sensitive data detected.',
+          tags: ['jailbreak'],
+          sds_findings: sdsFindings,
+          tag_probs: tagProbabilities,
+          is_blocking_enabled: true,
+        },
+      },
+    }
+
+    assert.deepStrictEqual(parseEvaluationResponse(response), {
+      action: 'DENY',
+      reason: 'Sensitive data detected.',
+      tags: ['jailbreak'],
+      sdsFindings,
+      tagProbabilities,
+      hasTagProbabilities: true,
+      blockingEnabled: true,
+    })
+  })
+
+  it('uses safe defaults for optional backend fields', () => {
+    assert.deepStrictEqual(parseEvaluationResponse({ data: { attributes: { action: 'ALLOW' } } }), {
+      action: 'ALLOW',
+      reason: undefined,
+      tags: [],
+      sdsFindings: [],
+      tagProbabilities: {},
+      hasTagProbabilities: false,
+      blockingEnabled: false,
+    })
+  })
+
+  for (const response of [
+    undefined,
+    {},
+    { data: {} },
+    { data: { attributes: {} } },
+    { data: { attributes: { action: '' } } },
+    { data: { attributes: { action: 42 } } },
+  ]) {
+    it('rejects an invalid backend response', () => {
+      assert.strictEqual(parseEvaluationResponse(response), undefined)
+    })
+  }
+
+  it('creates a blocked outcome', () => {
+    const evaluation = parseEvaluationResponse({
+      data: {
+        attributes: {
+          action: 'DENY',
+          reason: 'Sensitive data detected.',
+          tags: ['prompt-injection'],
+          sds_findings: [{ category: 'email_address' }],
+          tag_probs: { 'prompt-injection': 0.9 },
+          is_blocking_enabled: true,
+        },
+      },
+    })
+
+    assert.ok(evaluation)
+    const outcome = createEvaluationOutcome(evaluation, true)
+
+    assert.deepStrictEqual(outcome, {
+      result: {
+        action: 'DENY',
+        reason: 'Sensitive data detected.',
+        tags: ['prompt-injection'],
+        tagProbabilities: { 'prompt-injection': 0.9 },
+        sds: [{ category: 'email_address' }],
+      },
+      shouldBlock: true,
+      hasTagProbabilities: true,
+    })
+  })
+
+  for (const testCase of [
+    { block: false, action: 'DENY', blockingEnabled: true, expected: false },
+    { block: true, action: 'DENY', blockingEnabled: false, expected: false },
+    { block: true, action: 'ALLOW', blockingEnabled: true, expected: false },
+    { block: true, action: 'DENY', blockingEnabled: true, expected: true },
+  ]) {
+    it(`returns ${testCase.expected} when block=${testCase.block}, action=${testCase.action}, and ` +
+      `blockingEnabled=${testCase.blockingEnabled}`, () => {
+      const evaluation = {
+        action: testCase.action,
+        blockingEnabled: testCase.blockingEnabled,
+      }
+
+      assert.strictEqual(shouldBlockEvaluation(testCase.block, evaluation), testCase.expected)
+    })
+  }
+})


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Refactors the AI Guard SDK without intentionally changing its public behavior:

  - Keeps sdk.evaluate() focused on orchestration.
  - Moves HTTP requests and response validation into client.js.
  - Moves evaluation decisions, span reporting, meta-struct handling, and telemetry into evaluation.js.
  - Moves AI Guard error classes into errors.js.
  - Adds focused tests for response parsing and blocking decisions.

### Motivation

evaluate() previously handled transport, response parsing, blocking decisions, tracing, telemetry, message truncation, and error construction in one large function. This made the lifecycle difficult to understand, test, and safely extend.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


