### PR TITLE
test(appsec): expect Fastify QUERY endpoints

### DIFF
--- a/integration-tests/appsec/endpoints-collection.spec.js
+++ b/integration-tests/appsec/endpoints-collection.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const path = require('node:path')
 
 const { before, describe, it } = require('mocha')
+const semver = require('semver')
 
 const { assertObjectContains, sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 
@@ -50,6 +51,8 @@ describe('Endpoints collection', () => {
     ]
 
     if (framework === 'fastify') {
+      const { version } = require(path.join(cwd, 'node_modules', 'fastify', 'package.json'))
+
       expectedEndpoints.push(
         // Route with regex - not supported in express5
         { method: 'DELETE', path: '/regex/:hour(^\\d{2})h:minute(^\\d{2})m' },
@@ -74,6 +77,10 @@ describe('Endpoints collection', () => {
         { method: 'GET', path: '*' },
         { method: 'HEAD', path: '*' }
       )
+
+      if (semver.gte(version, '5.11.0')) {
+        expectedEndpoints.push({ method: 'QUERY', path: '/all-methods' })
+      }
     }
 
     if (framework === 'express') {


### PR DESCRIPTION
## Summary

Fastify 5.11 adds `QUERY` to the methods registered by `app.all()`. Account for that endpoint when the sandbox uses Fastify 5.11 or newer.

## Why

Endpoint collection intentionally rejects unexpected routes. Keeping the expectation version-aware preserves that check for older Fastify releases while accepting the new standard method.

Refs: https://github.com/fastify/fastify/pull/6832
