### PR TITLE
test(appsec): avoid shell execution in command injection sink tests

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.kafkajs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.kafkajs.plugin.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { testOutsideRequestHasVulnerability } = require('../utils')
+const { testOutsideRequestHasVulnerability, invokeCommandInjectionSink } = require('../utils')
 const { withVersions } = require('../../../setup/mocha')
 
 const topic = 'test-topic'
@@ -37,14 +37,8 @@ describe('command-injection-analyzer with kafkajs', () => {
 
         await consumer.run({
           eachMessage: ({ topic, message }) => {
-            try {
-              const { execSync } = require('child_process')
-
-              const command = message.value.toString()
-              execSync(command)
-            } catch {
-              // do nothing
-            }
+            const command = message.value.toString()
+            invokeCommandInjectionSink(command)
           },
         })
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { prepareTestServerForIast } = require('../utils')
+const { prepareTestServerForIast, invokeCommandInjectionSink } = require('../utils')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
@@ -12,13 +12,11 @@ describe('command injection analyzer', () => {
         const store = storage('legacy').getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const command = newTaintedString(iastContext, 'ls -la', 'param', 'Request')
-        const childProcess = require('child_process')
-        childProcess.execSync(command)
+        invokeCommandInjectionSink(command)
       }, 'COMMAND_INJECTION')
 
       testThatRequestHasNoVulnerability(() => {
-        const childProcess = require('child_process')
-        childProcess.execSync('ls -la')
+        invokeCommandInjectionSink('ls -la')
       }, 'COMMAND_INJECTION')
     })
 })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/graphql.sources.test-utils.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/graphql.sources.test-utils.js
@@ -11,6 +11,7 @@ const overheadController = require('../../../../../src/appsec/iast/overhead-cont
 const vulnerabilityReporter = require('../../../../../src/appsec/iast/vulnerability-reporter')
 const { getConfigFresh } = require('../../../../helpers/config')
 const agent = require('../../../../plugins/agent')
+const { invokeCommandInjectionSink } = require('../../utils')
 const schema = `
 type Book {
   title: String,
@@ -47,8 +48,7 @@ const books = [
 const resolvers = {
   Query: {
     books: (root, args, context) => {
-      const { execSync } = require('child_process')
-      execSync(args.title)
+      invokeCommandInjectionSink(args.title)
       return books.filter(book => {
         return book.title.includes(args.title)
       })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/sql_row.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/sql_row.pg.plugin.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { prepareTestServerForIast } = require('../../utils')
+const { prepareTestServerForIast, invokeCommandInjectionSink } = require('../../utils')
 const { withVersions } = require('../../../../setup/mocha')
 
 const connectionData = {
@@ -65,8 +65,7 @@ describe('db sources with pg', () => {
           const result = await client.query('SELECT * from examples')
           const firstItem = result.rows[0]
 
-          const childProcess = require('child_process')
-          childProcess.execSync(firstItem.command)
+          invokeCommandInjectionSink(firstItem.command)
 
           res.end('OK')
         }, 'COMMAND_INJECTION', null, 'Should not detect COMMAND_INJECTION with database source')
@@ -104,8 +103,7 @@ describe('db sources with pg', () => {
           const result = await pool.query('SELECT * from examples')
           const firstItem = result.rows[0]
 
-          const childProcess = require('child_process')
-          childProcess.execSync(firstItem.command)
+          invokeCommandInjectionSink(firstItem.command)
 
           res.end('OK')
         }, 'COMMAND_INJECTION', null, 'Should not detect COMMAND_INJECTION with database source')

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/sql_row.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/sql_row.sequelize.plugin.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { prepareTestServerForIast } = require('../../utils')
+const { prepareTestServerForIast, invokeCommandInjectionSink } = require('../../utils')
 const { withVersions } = require('../../../../setup/mocha')
 
 describe('db sources with sequelize', () => {
@@ -53,8 +53,7 @@ describe('db sources with sequelize', () => {
         testThatRequestHasNoVulnerability(async (req, res) => {
           const result = await sequelize.query('SELECT * from examples')
 
-          const childProcess = require('child_process')
-          childProcess.execSync(result[0][0].command)
+          invokeCommandInjectionSink(result[0][0].command)
 
           res.end('OK')
         }, 'COMMAND_INJECTION', null, 'Should not detect COMMAND_INJECTION with database source')
@@ -96,8 +95,7 @@ describe('db sources with sequelize', () => {
         testThatRequestHasNoVulnerability(async (req, res) => {
           const examples = await Example.findAll()
 
-          const childProcess = require('child_process')
-          childProcess.execSync(examples[0].command)
+          invokeCommandInjectionSink(examples[0].command)
 
           res.end('OK')
         }, 'COMMAND_INJECTION', null, 'Should not detect COMMAND_INJECTION with database source')


### PR DESCRIPTION
### What does this PR do?
Follow up https://github.com/DataDog/dd-trace-js/pull/9657   Extends the invokeCommandInjectionSink helper to the remaining IAST command-injection sink call sites so tests no longer spawn real shell processes just to trigger detection.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


