### PR TITLE
fix(debugger): reuse loaded tracer for trace context in devtools client

### DIFF
--- a/benchmark/sirun/debugger/start-devtools-client.js
+++ b/benchmark/sirun/debugger/start-devtools-client.js
@@ -2,7 +2,6 @@
 
 const assert = require('node:assert/strict')
 const fs = require('node:fs')
-const Module = require('node:module')
 
 // Point the tracer at this variant's per-core agent (port matches `agent.js`)
 // before `getConfig()` reads the URL. Set it unconditionally so a globally
@@ -10,15 +9,9 @@ const Module = require('node:module')
 // another parallel variant owns.
 process.env.DD_TRACE_AGENT_URL = `http://127.0.0.1:${8080 + Number(process.env.CPU_AFFINITY || 0)}`
 
-// The trace-context expression the devtools client evaluates on the paused frame
-// for every hit does `global.require('dd-trace')`. This bench loads the tracer by
-// relative path, so the bare specifier would otherwise throw MODULE_NOT_FOUND on
-// every hit and skew the measurement. Resolve it to this checkout's entry point.
-const ddTraceEntry = require.resolve('../../..')
-const originalResolveFilename = Module._resolveFilename
-Module._resolveFilename = function (request, ...rest) {
-  return originalResolveFilename.call(this, request === 'dd-trace' ? ddTraceEntry : request, ...rest)
-}
+// Production initializes the tracer before starting Dynamic Instrumentation. This benchmark imports the debugger
+// internals directly, so initialize the tracer explicitly before the paused-frame expression reads global._ddtrace.
+require('../../..')
 
 // The global snapshot cap (MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) is read in the
 // devtools worker thread at module load, with no config or env path to override
@@ -26,9 +19,6 @@ Module._resolveFilename = function (request, ...rest) {
 // variants measure capture cost on every hit instead of the rate-limited path.
 // No-op unless the variant opts in via the env var.
 patchGlobalSnapshotCap(process.env.MAX_SNAPSHOTS_PER_SECOND_GLOBALLY)
-
-// Entry point normally primes this; bench imports src directly.
-globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
 
 const getConfig = require('../../../packages/dd-trace/src/config')
 const { start } = require('../../../packages/dd-trace/src/debugger')

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -23,7 +23,6 @@ require('./remote_config')
 
 /** @typedef {import('node:inspector').Debugger.EvaluateOnCallFrameReturnType} EvaluateOnCallFrameResult */
 
-// Expression to run on a call frame of the paused thread to get its active trace and span id.
 const templateExpressionSetupCode = `
   const $dd_inspect = global.require('node:util').inspect;
   const $dd_segmentInspectOptions = {
@@ -34,8 +33,10 @@ const templateExpressionSetupCode = `
     breakLength: Infinity
   };
 `
+
+// Expression to run on a call frame of the paused thread to get its active trace and span id.
 const getDDTagsExpression = `(() => {
-  const context = global.require('dd-trace').scope().active()?.context();
+  const context = globalThis._ddtrace.scope().active()?.context();
   return { trace_id: context?.toTraceId(), span_id: context?.toSpanId() }
 })()`
 


### PR DESCRIPTION
### What does this PR do?

Updates the trace-context expression evaluated by the Debugger devtools client on each paused call frame to read the active span from `globalThis._ddtrace` instead of `global.require('dd-trace')`.

It also updates the Debugger sirun benchmark to initialize the tracer through the package entry point before starting the Debugger directly, replacing the now-obsolete module-resolution shim and manual shared-global initialization.

### Motivation

Every debugger pause runs an inspector expression to attach trace and span IDs to snapshots. The previous expression re-required `dd-trace` on each hit via `global.require('dd-trace')`, adding module resolution to the hot path and potentially resolving a tracer other than the singleton already used by the application.

`globalThis._ddtrace` is the singleton tracer proxy installed by `bootstrap.js` when dd-trace is first loaded, so reusing it provides the correct active scope without per-hit module resolution.

Production initializes that proxy before starting Dynamic Instrumentation, but the sirun benchmark imports and starts the Debugger internals directly. The benchmark now explicitly loads the package entry point first so its hit variants exercise the successful trace-context path instead of measuring repeated evaluation failures.