### PR TITLE
fix(debugger): limit and safely stringify template log message values

### DIFF
--- a/integration-tests/debugger/target-app/template.js
+++ b/integration-tests/debugger/target-app/template.js
@@ -24,6 +24,8 @@ fastify.get('/:name', function (request) {
   const emptyArr = []
   const arr = [{ a: 1 }, 2, 3, 4, 5]
   const emptyObj = {}
+  const maxObj = { a: 1, b: 2, c: 3, d: 4, e: 5 }
+  Object.defineProperty(maxObj, 'hidden', { value: 6 })
   const obj = {
     foo: {
       baz: 42,
@@ -35,6 +37,8 @@ fastify.get('/:name', function (request) {
     get baz () {
       return 'This is a getter!'
     },
+    qux: 42,
+    quux: false,
     [inspect.custom] () {
       return 'This is a custom inspect!'
     },
@@ -44,8 +48,31 @@ fastify.get('/:name', function (request) {
       return 'This is a proxy!'
     },
   })
+  const objectWithProxyPrototype = Object.create(new Proxy({}, {
+    getPrototypeOf () {
+      throw new Error('Proxy prototype trap should not run')
+    },
+  }))
+  Object.defineProperties(objectWithProxyPrototype, {
+    a: { value: 1, enumerable: true },
+    b: { value: 2, enumerable: true },
+    c: { value: 3, enumerable: true },
+    d: { value: 4, enumerable: true },
+    e: { value: 5, enumerable: true },
+    f: { value: 6, enumerable: true },
+  })
+  const sideEffectfulObject = {
+    a: 1,
+    b: 2,
+    get [Symbol.toStringTag] () {
+      throw new Error('Symbol.toStringTag getter should not run')
+    },
+    [Symbol('extra')]: 4,
+  }
   const circular = {}
   circular.circular = circular
+  const wideCircular = { circular: undefined, a: 1, b: 2, c: 3, d: 4, e: 5 }
+  wideCircular.circular = wideCircular
   const ins = new CustomClass()
   const p = Promise.resolve(42)
   const arrowFn = () => {}
@@ -80,6 +107,10 @@ class CustomClass {
 
   constructor () {
     this.c = 3
+    this.d = 4
+    this.e = 5
+    this.f = 6
+    this.g = 7
   }
 
   get [Symbol.toStringTag] () {

--- a/integration-tests/debugger/template.spec.js
+++ b/integration-tests/debugger/template.spec.js
@@ -48,27 +48,22 @@ describe('Dynamic Instrumentation', function () {
         assert.strictEqual(messages.shift(), '[]')
         assert.strictEqual(messages.shift(), '[ [Object], 2, 3, ... 2 more items ]')
         assert.strictEqual(messages.shift(), '{}')
+        assert.strictEqual(messages.shift(), '{ a: 1, b: 2, c: 3, d: 4, e: 5 }')
         const obj = messages.shift()
-        let expectedObjectShape = '{ ' +
-          'foo: [Object], ' +
-          'bar: true, ' +
-          'baz: [Getter], ' +
-          (NODE_MAJOR >= 24
-            ? 'Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]] '
-            : '[Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]] ') +
+        const expectedObjectShape = '{ ' +
+          'foo: [Object], bar: true, baz: [Getter], qux: 42, quux: false, ... 1 more property ' +
         '}'
         assert.strictEqual(obj, expectedObjectShape)
-        if (NODE_MAJOR >= 26) {
-          // A proxy should be stringified to the wrapped object plus the proxy type in newer Node.js versions
-          expectedObjectShape = `Proxy(${expectedObjectShape})`
-        }
-        assert.strictEqual(messages.shift(), expectedObjectShape)
+        assert.strictEqual(messages.shift(), '[Proxy]')
+        assert.strictEqual(messages.shift(), '{ a: 1, b: 2, c: 3, d: 4, e: 5, ... 1 more property }')
+        assert.strictEqual(messages.shift(), '[Value omitted: inspection may execute user code]')
         assert.strictEqual(messages.shift(), '<ref *1> { circular: [Circular *1] }')
+        assert.strictEqual(
+          messages.shift(),
+          '<ref *1> { circular: [Circular *1], a: 1, b: 2, c: 3, d: 4, ... 1 more property }'
+        )
         assert.strictEqual(messages.shift(), '[class CustomClass]')
-        // Notice execution of `Symbol.toStringTag` getter (`foo`). There's nothing we can do about it when using
-        // `util.inspect`, but it has not been considered a big side-effects issue, as anyone implementing this
-        // function is doing so with the explicit intent of modifying the string representation of instances.
-        assert.strictEqual(messages.shift(), 'CustomClass [foo] { b: 2, c: 3 }')
+        assert.strictEqual(messages.shift(), '{ b: 2, c: 3, d: 4, e: 5, f: 6, ... 1 more property }')
         if (NODE_MAJOR >= 24) {
           assert.strictEqual(messages.shift(), 'Promise { 42 }')
         } else {
@@ -83,18 +78,8 @@ describe('Dynamic Instrumentation', function () {
         }
         assert.strictEqual(messages.shift(), '[Function: arrowFn]')
         assert.strictEqual(messages.shift(), '[Function: fn]')
-        assert.strictEqual(
-          messages.shift(),
-          NODE_MAJOR > 18
-            ? 'Set(5) { 1, 2, 3, ... 2 more items }'
-            : 'Set(5) { 1, 2, 3, 4, 5 }'
-        )
-        assert.strictEqual(
-          messages.shift(),
-          NODE_MAJOR > 18
-            ? 'Map(5) { 1 => 2, 3 => 4, 5 => 6, ... 2 more items }'
-            : 'Map(5) { 1 => 2, 3 => 4, 5 => 6, 7 => 8, 9 => 10 }'
-        )
+        assert.strictEqual(messages.shift(), 'Set(5) { 1, 2, 3, ... 2 more items }')
+        assert.strictEqual(messages.shift(), 'Map(5) { 1 => 2, 3 => 4, 5 => 6, ... 2 more items }')
         assert.strictEqual(messages.shift(), 'WeakSet { <items unknown> }')
         assert.strictEqual(messages.shift(), 'WeakMap { <items unknown> }')
         assert.strictEqual(messages.shift(), 'Buffer(6) [Uint8Array] [ 102, 111, 111, ... 3 more items ]')
@@ -138,11 +123,19 @@ describe('Dynamic Instrumentation', function () {
           { str: ';' },
           { dsl: 'emptyObj', json: { ref: 'emptyObj' } },
           { str: ';' },
+          { dsl: 'maxObj', json: { ref: 'maxObj' } },
+          { str: ';' },
           { dsl: 'obj', json: { ref: 'obj' } },
           { str: ';' },
           { dsl: 'proxy', json: { ref: 'proxy' } },
           { str: ';' },
+          { dsl: 'objectWithProxyPrototype', json: { ref: 'objectWithProxyPrototype' } },
+          { str: ';' },
+          { dsl: 'sideEffectfulObject', json: { ref: 'sideEffectfulObject' } },
+          { str: ';' },
           { dsl: 'circular', json: { ref: 'circular' } },
+          { str: ';' },
+          { dsl: 'wideCircular', json: { ref: 'wideCircular' } },
           { str: ';' },
           { dsl: 'CustomClass', json: { ref: 'CustomClass' } },
           { str: ';' },

--- a/packages/dd-trace/src/debugger/constants.js
+++ b/packages/dd-trace/src/debugger/constants.js
@@ -4,4 +4,5 @@ module.exports = {
   DEBUGGER_DIAGNOSTICS_V1: '/debugger/v1/diagnostics',
   DEBUGGER_INPUT_V1: '/debugger/v1/input',
   DEBUGGER_INPUT_V2: '/debugger/v2/input',
+  INSPECT_SEGMENT_GLOBAL_PROPERTY: 'debuggerInspectSegment',
 }

--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -55,7 +55,7 @@ function compileSegments (segments) {
       ? `(() => {
           try {
             const result = ${compile(json)}
-            return typeof result === 'string' ? result : $dd_inspect(result, $dd_segmentInspectOptions)
+            return typeof result === 'string' ? result : $dd_inspectSegment(result)
           } catch (e) {
             return { expr: ${JSON.stringify(dsl)}, message: \`\${e.name}: \${e.message}\` }
           }

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -4,6 +4,7 @@ const { randomUUID } = require('crypto')
 const { workerData: { probeSamplerBuffer } } = require('worker_threads')
 const { version } = require('../../../../../package.json')
 const processTags = require('../../process-tags')
+const { INSPECT_SEGMENT_GLOBAL_PROPERTY } = require('../constants')
 const {
   MAX_SAMPLED_PROBES_PER_PAUSE,
   SAMPLED_PROBE_COUNT_INDEX,
@@ -23,16 +24,8 @@ require('./remote_config')
 
 /** @typedef {import('node:inspector').Debugger.EvaluateOnCallFrameReturnType} EvaluateOnCallFrameResult */
 
-const templateExpressionSetupCode = `
-  const $dd_inspect = global.require('node:util').inspect;
-  const $dd_segmentInspectOptions = {
-    depth: 0,
-    customInspect: false,
-    maxArrayLength: 3,
-    maxStringLength: 8 * 1024,
-    breakLength: Infinity
-  };
-`
+const templateExpressionSetupCode = 'const $dd_inspectSegment = ' +
+  `globalThis[Symbol.for('dd-trace')][${JSON.stringify(INSPECT_SEGMENT_GLOBAL_PROPERTY)}];`
 
 // Expression to run on a call frame of the paused thread to get its active trace and span id.
 const getDDTagsExpression = `(() => {

--- a/packages/dd-trace/src/debugger/index.js
+++ b/packages/dd-trace/src/debugger/index.js
@@ -7,7 +7,7 @@ const { Worker, MessageChannel, threadId: parentThreadId } = require('worker_thr
 const log = require('../log')
 const { fetchAgentInfo } = require('../agent/info')
 const getDebuggerConfig = require('./config')
-const { DEBUGGER_DIAGNOSTICS_V1, DEBUGGER_INPUT_V2 } = require('./constants')
+const { DEBUGGER_DIAGNOSTICS_V1, DEBUGGER_INPUT_V2, INSPECT_SEGMENT_GLOBAL_PROPERTY } = require('./constants')
 const { installProbeSampler, uninstallProbeSampler } = require('./probe_sampler')
 
 /**
@@ -64,7 +64,9 @@ function start (config, rcInstance) {
   const logChannel = new MessageChannel()
   configChannel = new MessageChannel()
 
-  globalThis[Symbol.for('dd-trace')].utilTypes = types
+  const debuggerGlobals = globalThis[Symbol.for('dd-trace')]
+  debuggerGlobals.utilTypes = types
+  debuggerGlobals[INSPECT_SEGMENT_GLOBAL_PROPERTY] = require('./inspect-segment')
 
   const probeSamplerBuffer = installProbeSampler()
 

--- a/packages/dd-trace/src/debugger/inspect-segment.js
+++ b/packages/dd-trace/src/debugger/inspect-segment.js
@@ -3,15 +3,30 @@
 const { inspect, types } = require('node:util')
 
 /** @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} PropertyDescriptor */
+/** @typedef {Map<unknown, unknown> | Set<unknown>} Collection */
 
+const mapEntries = Map.prototype.entries
+const mapSet = Map.prototype.set
+const mapSizeGetter = Object.getOwnPropertyDescriptor(Map.prototype, 'size').get
+const setAdd = Set.prototype.add
+const setSizeGetter = Object.getOwnPropertyDescriptor(Set.prototype, 'size').get
+const setValues = Set.prototype.values
+const mapIteratorNext = Object.getPrototypeOf(mapEntries.call(new Map())).next
+const setIteratorNext = Object.getPrototypeOf(setValues.call(new Set())).next
+
+const maxCollectionEntries = 3
 const maxProperties = 5
 const segmentInspectOptions = {
   depth: 0,
   customInspect: false,
-  maxArrayLength: 3,
+  maxArrayLength: maxCollectionEntries,
   maxStringLength: 8 * 1024,
   breakLength: Infinity,
 }
+const collectionLimitSupported = inspect(
+  new Set([1, 2, 3, 4]),
+  segmentInspectOptions
+).includes('... 1 more item')
 
 module.exports = inspectSegment
 
@@ -28,13 +43,13 @@ function inspectSegment (value) {
     return inspect(value, segmentInspectOptions)
   }
   if (types.isProxy(value)) return '[Proxy]'
+  if (types.isMap(value)) return inspectCollection(value, true)
+  if (types.isSet(value)) return inspectCollection(value, false)
   if (
     Array.isArray(value) ||
     types.isTypedArray(value) ||
     types.isAnyArrayBuffer(value) ||
     types.isDataView(value) ||
-    types.isMap(value) ||
-    types.isSet(value) ||
     types.isWeakMap(value) ||
     types.isWeakSet(value) ||
     types.isMapIterator(value) ||
@@ -79,6 +94,45 @@ function inspectSegment (value) {
   const omitted = propertyCount - maxProperties
   const inspected = inspect(truncated, segmentInspectOptions)
   return `${inspected.slice(0, -2)}, ... ${omitted} more ${omitted === 1 ? 'property' : 'properties'} }`
+}
+
+/**
+ * Inspect a Map or Set while bounding the number of entries on runtimes where `util.inspect` does not.
+ *
+ * @param {Collection} value
+ * @param {boolean} isMap
+ * @returns {string}
+ */
+function inspectCollection (value, isMap) {
+  if (collectionLimitSupported) return inspect(value, segmentInspectOptions)
+
+  const size = (isMap ? mapSizeGetter : setSizeGetter).call(value)
+  if (size <= maxCollectionEntries) return inspect(value, segmentInspectOptions)
+
+  const truncated = isMap ? new Map() : new Set()
+  const iterator = (isMap ? mapEntries : setValues).call(value)
+  const iteratorNext = isMap ? mapIteratorNext : setIteratorNext
+
+  for (let i = 0; i < maxCollectionEntries; i++) {
+    const result = iteratorNext.call(iterator)
+    if (result.done) break
+
+    if (isMap) {
+      const entry = result.value
+      const key = entry[0] === value ? truncated : entry[0]
+      const entryValue = entry[1] === value ? truncated : entry[1]
+      mapSet.call(truncated, key, entryValue)
+    } else {
+      const entryValue = result.value === value ? truncated : result.value
+      setAdd.call(truncated, entryValue)
+    }
+  }
+
+  const type = isMap ? 'Map' : 'Set'
+  const inspected = inspect(truncated, segmentInspectOptions)
+  const normalized = inspected.replace(`${type}(${maxCollectionEntries})`, `${type}(${size})`)
+  const remaining = size - maxCollectionEntries
+  return `${normalized.slice(0, -2)}, ... ${remaining} more item${remaining === 1 ? '' : 's'} }`
 }
 
 /**

--- a/packages/dd-trace/src/debugger/inspect-segment.js
+++ b/packages/dd-trace/src/debugger/inspect-segment.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const { inspect, types } = require('node:util')
+
+/** @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} PropertyDescriptor */
+
+const maxProperties = 5
+const segmentInspectOptions = {
+  depth: 0,
+  customInspect: false,
+  maxArrayLength: 3,
+  maxStringLength: 8 * 1024,
+  breakLength: Infinity,
+}
+
+module.exports = inspectSegment
+
+/**
+ * Inspect a dynamic-instrumentation template value without invoking user code.
+ * Unlike collections, `util.inspect` has no option for limiting the number of object properties, so this function
+ * truncates objects before inspecting them.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+function inspectSegment (value) {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function')) {
+    return inspect(value, segmentInspectOptions)
+  }
+  if (types.isProxy(value)) return '[Proxy]'
+  if (
+    Array.isArray(value) ||
+    types.isTypedArray(value) ||
+    types.isAnyArrayBuffer(value) ||
+    types.isDataView(value) ||
+    types.isMap(value) ||
+    types.isSet(value) ||
+    types.isWeakMap(value) ||
+    types.isWeakSet(value) ||
+    types.isMapIterator(value) ||
+    types.isSetIterator(value)
+  ) {
+    return inspect(value, segmentInspectOptions)
+  }
+
+  /** @type {(string | symbol)[]} */
+  const keys = Object.keys(value)
+  let propertyCount = keys.length
+  const symbols = Object.getOwnPropertySymbols(value)
+  for (let i = 0; i < symbols.length; i++) {
+    if (Object.getOwnPropertyDescriptor(value, symbols[i])?.enumerable === true) {
+      propertyCount++
+      if (keys.length < maxProperties) keys.push(symbols[i])
+    }
+  }
+
+  if (propertyCount <= maxProperties) {
+    // TODO: Decide whether allowing util.inspect to invoke Symbol.toStringTag getters is acceptable. If it is,
+    // remove inspectionCanRunUserCode and the related omission paths.
+    if (inspectionCanRunUserCode(value)) {
+      return '[Value omitted: inspection may execute user code]'
+    }
+    return inspect(value, segmentInspectOptions)
+  }
+
+  const truncated = {}
+  for (let i = 0; i < maxProperties; i++) {
+    const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(value, keys[i]))
+    if (
+      (keys[i] === Symbol.toStringTag && descriptor.get !== undefined) ||
+      (descriptor.value !== value && inspectionCanRunUserCode(descriptor.value))
+    ) {
+      return '[Value omitted: inspection may execute user code]'
+    }
+    if (descriptor.value === value) descriptor.value = truncated
+    Object.defineProperty(truncated, keys[i], descriptor)
+  }
+
+  const omitted = propertyCount - maxProperties
+  const inspected = inspect(truncated, segmentInspectOptions)
+  return `${inspected.slice(0, -2)}, ... ${omitted} more ${omitted === 1 ? 'property' : 'properties'} }`
+}
+
+/**
+ * Determine whether inspecting a value could invoke a proxy trap or toStringTag getter.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function inspectionCanRunUserCode (value) {
+  const type = typeof value
+  if (value === null || (type !== 'object' && type !== 'function')) return false
+  if (types.isProxy(value)) return true
+
+  let current = value
+  while (current !== null) {
+    if (Object.getOwnPropertyDescriptor(current, Symbol.toStringTag)?.get !== undefined) return true
+    current = Object.getPrototypeOf(current)
+    if (types.isProxy(current)) return true
+  }
+  return false
+}

--- a/packages/dd-trace/src/debugger/inspect-segment.js
+++ b/packages/dd-trace/src/debugger/inspect-segment.js
@@ -2,6 +2,8 @@
 
 const { inspect, types } = require('node:util')
 
+const { NODE_MAJOR } = require('../../../../version')
+
 /** @typedef {NonNullable<ReturnType<typeof globalThis.Object.getOwnPropertyDescriptor>>} PropertyDescriptor */
 /** @typedef {Map<unknown, unknown> | Set<unknown>} Collection */
 
@@ -23,10 +25,6 @@ const segmentInspectOptions = {
   maxStringLength: 8 * 1024,
   breakLength: Infinity,
 }
-const collectionLimitSupported = inspect(
-  new Set([1, 2, 3, 4]),
-  segmentInspectOptions
-).includes('... 1 more item')
 
 module.exports = inspectSegment
 
@@ -97,14 +95,14 @@ function inspectSegment (value) {
 }
 
 /**
- * Inspect a Map or Set while bounding the number of entries on runtimes where `util.inspect` does not.
+ * Inspect a Map or Set while bounding the number of entries on Node.js 18, where `util.inspect` does not.
  *
  * @param {Collection} value
  * @param {boolean} isMap
  * @returns {string}
  */
 function inspectCollection (value, isMap) {
-  if (collectionLimitSupported) return inspect(value, segmentInspectOptions)
+  if (NODE_MAJOR !== 18) return inspect(value, segmentInspectOptions)
 
   const size = (isMap ? mapSizeGetter : setSizeGetter).call(value)
   if (size <= maxCollectionEntries) return inspect(value, segmentInspectOptions)

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -126,7 +126,7 @@ describe('Expression language', function () {
         `[(() => {
           try {
             const result = foo
-            return typeof result === 'string' ? result : $dd_inspect(result, $dd_segmentInspectOptions)
+            return typeof result === 'string' ? result : $dd_inspectSegment(result)
           } catch (e) {
             return { expr: "foo", message: \`\${e.name}: \${e.message}\` }
           }
@@ -146,7 +146,7 @@ describe('Expression language', function () {
         `["foo: ",(() => {
           try {
             const result = foo
-            return typeof result === 'string' ? result : $dd_inspect(result, $dd_segmentInspectOptions)
+            return typeof result === 'string' ? result : $dd_inspectSegment(result)
           } catch (e) {
             return { expr: "foo", message: \`\${e.name}: \${e.message}\` }
           }

--- a/packages/dd-trace/test/debugger/devtools_client/inspect-segment.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/inspect-segment.spec.js
@@ -17,6 +17,18 @@ describe('inspectSegment', function () {
 
     assert.strictEqual(inspectSegment(42), '42')
     assert.strictEqual(inspectSegment([1, 2, 3, 4]), '[ 1, 2, 3, ... 1 more item ]')
+    assert.strictEqual(inspectSegment(new Set([1, 2, 3])), 'Set(3) { 1, 2, 3 }')
+    assert.strictEqual(inspectSegment(new Set([1, 2, 3, 4])), 'Set(4) { 1, 2, 3, ... 1 more item }')
+    assert.strictEqual(inspectSegment(new Set([1, 2, 3, 4, 5])), 'Set(5) { 1, 2, 3, ... 2 more items }')
+    assert.strictEqual(inspectSegment(new Map([[1, 2], [3, 4], [5, 6]])), 'Map(3) { 1 => 2, 3 => 4, 5 => 6 }')
+    assert.strictEqual(
+      inspectSegment(new Map([[1, 2], [3, 4], [5, 6], [7, 8]])),
+      'Map(4) { 1 => 2, 3 => 4, 5 => 6, ... 1 more item }'
+    )
+    assert.strictEqual(
+      inspectSegment(new Map([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])),
+      'Map(5) { 1 => 2, 3 => 4, 5 => 6, ... 2 more items }'
+    )
     assert.strictEqual(inspectSegment(fiveProperties), '{ a: 1, b: 2, c: 3, d: 4, e: 5 }')
     assert.strictEqual(
       inspectSegment(sixProperties),
@@ -78,6 +90,22 @@ describe('inspectSegment', function () {
     assert.strictEqual(
       inspectSegment(value),
       '<ref *1> { circular: [Circular *1], a: 1, b: 2, c: 3, d: 4, ... 1 more property }'
+    )
+  })
+
+  it('preserves direct circular references when limiting collections', function () {
+    const set = new Set()
+    set.add(set).add(1).add(2).add(3)
+    const map = new Map()
+    map.set(map, map).set(1, 2).set(3, 4).set(5, 6)
+
+    assert.strictEqual(
+      inspectSegment(set),
+      '<ref *1> Set(4) { [Circular *1], 1, 2, ... 1 more item }'
+    )
+    assert.strictEqual(
+      inspectSegment(map),
+      '<ref *1> Map(4) { [Circular *1] => [Circular *1], 1 => 2, 3 => 4, ... 1 more item }'
     )
   })
 })

--- a/packages/dd-trace/test/debugger/devtools_client/inspect-segment.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/inspect-segment.spec.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { inspect } = require('node:util')
+
+const { describe, it } = require('mocha')
+
+require('../../setup/mocha')
+
+const inspectSegment = require('../../../src/debugger/inspect-segment')
+
+describe('inspectSegment', function () {
+  it('limits collections and enumerable object properties', function () {
+    const fiveProperties = { a: 1, b: 2, c: 3, d: 4, e: 5 }
+    Object.defineProperty(fiveProperties, 'hidden', { value: 6 })
+    const sixProperties = { ...fiveProperties, f: 6 }
+
+    assert.strictEqual(inspectSegment(42), '42')
+    assert.strictEqual(inspectSegment([1, 2, 3, 4]), '[ 1, 2, 3, ... 1 more item ]')
+    assert.strictEqual(inspectSegment(fiveProperties), '{ a: 1, b: 2, c: 3, d: 4, e: 5 }')
+    assert.strictEqual(
+      inspectSegment(sixProperties),
+      '{ a: 1, b: 2, c: 3, d: 4, e: 5, ... 1 more property }'
+    )
+  })
+
+  it('does not invoke proxy traps', function () {
+    const proxy = new Proxy({}, {
+      ownKeys () {
+        throw new Error('Proxy trap should not run')
+      },
+    })
+    const objectWithProxyPrototype = Object.create(new Proxy({}, {
+      getPrototypeOf () {
+        throw new Error('Proxy prototype trap should not run')
+      },
+    }))
+    Object.assign(objectWithProxyPrototype, { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 })
+
+    assert.strictEqual(inspectSegment(proxy), '[Proxy]')
+    assert.strictEqual(
+      inspectSegment(objectWithProxyPrototype),
+      '{ a: 1, b: 2, c: 3, d: 4, e: 5, ... 1 more property }'
+    )
+  })
+
+  it('does not invoke Symbol.toStringTag getters or custom inspection functions', function () {
+    let customInspectCalled = false
+    const value = {
+      get [Symbol.toStringTag] () {
+        throw new Error('Symbol.toStringTag getter should not run')
+      },
+      [inspect.custom] () {
+        customInspectCalled = true
+        return 'custom'
+      },
+    }
+
+    assert.strictEqual(inspectSegment(value), '[Value omitted: inspection may execute user code]')
+    assert.strictEqual(customInspectCalled, false)
+  })
+
+  it('omits wide objects containing values whose inspection may run user code', function () {
+    const sideEffectfulValue = {
+      get [Symbol.toStringTag] () {
+        throw new Error('Symbol.toStringTag getter should not run')
+      },
+    }
+    const value = { a: sideEffectfulValue, b: 2, c: 3, d: 4, e: 5, f: 6 }
+
+    assert.strictEqual(inspectSegment(value), '[Value omitted: inspection may execute user code]')
+  })
+
+  it('preserves circular references when truncating objects', function () {
+    const value = { circular: undefined, a: 1, b: 2, c: 3, d: 4, e: 5 }
+    value.circular = value
+
+    assert.strictEqual(
+      inspectSegment(value),
+      '<ref *1> { circular: [Circular *1], a: 1, b: 2, c: 3, d: 4, ... 1 more property }'
+    )
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds a dedicated `inspectSegment` helper for Debugger log template expressions. It limits enumerable object properties to five, omits values that could run user code during inspection, and renders direct proxies as `[Proxy]`. The devtools client now calls this helper via a dd-trace global instead of inlining `util.inspect` options.

### Motivation

Template log messages could stringify objects with unbounded property counts. Inspection can also invoke user code when walking a prototype-chain proxy (`getPrototypeOf` traps) or formatting values with `Symbol.toStringTag` getters (notably class instances). Note that `util.inspect` on a direct `Proxy` value generally does not exercise `ownKeys`/`get` traps on current Node; the `[Proxy]` label is mainly for predictable, bounded output rather than trap avoidance alone. DEBUG-5974.

### Additional Notes

- Small objects with a `Symbol.toStringTag` getter are fully omitted rather than partially inspected; a TODO in `inspect-segment.js` tracks whether that trade-off should change.