### PR TITLE
fix(appsec): bump @datadog/wasm-js-rewriter to 5.0.2 to resolve js-yaml vulnerability (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,5 +253,8 @@
     "workerpool": "^10.0.3",
     "yaml": "^2.9.0",
     "yarn-deduplicate": "^6.0.2"
+  },
+  "resolutions": {
+    "@datadog/wasm-js-rewriter/js-yaml": "^4.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@datadog/native-metrics": "3.1.2",
     "@datadog/openfeature-node-server": "2.0.2",
     "@datadog/pprof": "5.17.0",
-    "@datadog/wasm-js-rewriter": "5.0.1",
+    "@datadog/wasm-js-rewriter": "5.0.2",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/api-logs": "<1.0.0",
     "oxc-parser": "^0.132.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,12 +295,12 @@
     pprof-format "^2.2.1"
     source-map "^0.8.0"
 
-"@datadog/wasm-js-rewriter@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz#f227d2e3eb0f83b8a37f190a9ff8fdbde5955782"
-  integrity sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==
+"@datadog/wasm-js-rewriter@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.2.tgz#f7cb491d02a0ce54429ca732f3dba5436b5e9271"
+  integrity sha512-ffv9TqdtuE8XnZgaGnmMIU1A+t+eaHIEbdVpV5elijq1dKK03OqFb+Xo4ojTbgCwxIYDA1zmA8TnZJBjtzuVuw==
   dependencies:
-    js-yaml "^4.1.0"
+    js-yaml "^4.1.1"
     lru-cache "^7.14.0"
     module-details-from-path "^1.0.3"
     node-gyp-build "^4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,10 +2854,10 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary
- Bumps `@datadog/wasm-js-rewriter` from `5.0.1` to `5.0.2`
- `5.0.2` tightens its own `js-yaml` dependency range from `^4.1.0` to `^4.1.1`, resolving the transitive vulnerability reported in `js-yaml@4.3.0` (GHSA-5p4m-2wfm-xmqj, CVSS 7.5), affecting `dd-trace` v5.114.0–v5.121.0 and v6.10.0.

## Test plan
- [x] `yarn install` run locally against the updated `package.json`; lockfile regenerated identically to the hand-edited version (no unrelated drift)
- [x] Verified `node_modules/@datadog/wasm-js-rewriter/package.json` resolves to `5.0.2`
- [x] Verified resolved `node_modules/js-yaml/package.json` version is no longer the vulnerable `4.3.0`

Reported by a customer via support; requests a release on both the v5 maintenance and v6 current lines once merged.