### PR TITLE
ci(instrumentations): use supported Confluent Node versions

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -101,15 +101,38 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/instrumentations/test
 
+  # @confluentinc/kafka-javascript does not provide a Node 26 prebuild and its
+  # bundled librdkafka cannot build from source there. Keep this aligned with
+  # the Kafka-backed plugin matrix until upstream supports Node 26.
   instrumentation-confluentinc-kafka-javascript:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20, 22]
+        range: [">=1.0.0"]
+        include:
+          - node-version: 24
+            range: ">=1.4.0"
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     env:
       PLUGINS: confluentinc-kafka-javascript
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/instrumentations/test
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/install
+      - run: npm run test:instrumentations:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: instrumentations-${{ github.job }}-${{ matrix.node-version }}
+      - uses: ./.github/actions/upload-junit-artifacts
+        if: "!cancelled()"
+        with:
+          id: ${{ github.job }}-${{ strategy.job-index }}
 
   instrumentation-connect:
     runs-on: ubuntu-latest

--- a/scripts/group-coverage.mjs
+++ b/scripts/group-coverage.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { copyFileSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { argv } from 'node:process'
@@ -40,8 +41,28 @@ const VERSION_RE = /^(?:gte|gt|lte|lt|eq)?\.?\d+(?:\.\d+)*(?:\.(?:and|or|gte|gt|
 // of at most this many libraries, named for their members so the flag still points at a library.
 const MAX_LIBS_PER_BUCKET = 3
 // Codecov validates flags against `^[\w\.\-]{1,45}$` and silently drops any that fail. `+` is out, so
-// members join with `_`; a name longer than this falls back to a numbered bucket that stays valid.
+// members join with `_`; invalid or overlong names receive a deterministic hash suffix.
 const MAX_FLAG_LENGTH = 45
+const VALID_FLAG_RE = /^[\w.-]{1,45}$/
+const HASH_LENGTH = 8
+const INSTRUMENTATIONS_PREFIX = 'instrumentations-instrumentation-'
+
+/**
+ * Keep readable Codecov flags where possible and deterministically bound every other name.
+ *
+ * @param {string} flag
+ * @returns {string}
+ */
+function codecovFlag (flag) {
+  const readable = flag.startsWith(INSTRUMENTATIONS_PREFIX)
+    ? `instr-${flag.slice(INSTRUMENTATIONS_PREFIX.length)}`
+    : flag
+  if (VALID_FLAG_RE.test(readable)) return readable
+
+  const hash = createHash('sha256').update(flag).digest('hex').slice(0, HASH_LENGTH)
+  const sanitized = readable.replaceAll(/[^\w.-]/g, '_')
+  return `${sanitized.slice(0, MAX_FLAG_LENGTH - HASH_LENGTH - 1)}-${hash}`
+}
 
 /**
  * @param {string} token
@@ -132,7 +153,7 @@ function planGroups (cellsByIntegration) {
 
   for (const [integration, cells] of cellsByIntegration) {
     if (cells.length > 1) {
-      groups.set(integration, [integration])
+      groups.set(codecovFlag(integration), [integration])
       continue
     }
     const area = integration.split('-')[0]
@@ -148,16 +169,14 @@ function planGroups (cellsByIntegration) {
     integrations.sort()
     if (integrations.length <= 2) {
       for (const integration of integrations) {
-        groups.set(integration, [integration])
+        groups.set(codecovFlag(integration), [integration])
       }
       continue
     }
-    let bucket = 0
     for (let i = 0; i < integrations.length; i += MAX_LIBS_PER_BUCKET) {
       const chunk = integrations.slice(i, i + MAX_LIBS_PER_BUCKET)
       const named = `${area}-${chunk.map(integration => integration.slice(area.length + 1)).join('_')}`
-      groups.set(named.length <= MAX_FLAG_LENGTH ? named : `${area}-bucket-${bucket}`, chunk)
-      bucket++
+      groups.set(codecovFlag(named), chunk)
     }
   }
 

--- a/scripts/group-coverage.spec.mjs
+++ b/scripts/group-coverage.spec.mjs
@@ -77,6 +77,41 @@ describe('group-coverage', () => {
       assert.deepEqual([...groups], [['apm-integrations-next', ['apm-integrations-next']]])
     })
 
+    it('shortens the duplicated instrumentations prefix', () => {
+      const integration = 'instrumentations-instrumentation-confluentinc-kafka-javascript'
+      const groups = planGroups(new Map([[integration, ['a', 'b']]]))
+      assert.deepEqual([...groups], [['instr-confluentinc-kafka-javascript', [integration]]])
+    })
+
+    it('distinguishes overlong integration flags that share the accepted prefix', () => {
+      const accepted = `area-${'a'.repeat(40)}`
+      const longPrefix = `area-${'a'.repeat(40)}`
+      const groups = planGroups(new Map([
+        [accepted, ['a', 'b']],
+        [`${longPrefix}b`, ['c', 'd']],
+        [`${longPrefix}c`, ['e', 'f']],
+      ]))
+      const flags = [...groups.keys()]
+      assert.equal(flags[0], accepted)
+      assert.equal(flags[1].length, 45)
+      assert.equal(flags[2].length, 45)
+      assert.notEqual(flags[1], flags[2])
+      for (const flag of flags) {
+        assert.match(flag, /^[\w.-]{1,45}$/)
+      }
+    })
+
+    it('distinguishes sanitized flags from existing valid names', () => {
+      const groups = planGroups(new Map([
+        ['area-library+variant', ['a', 'b']],
+        ['area-library_variant', ['c', 'd']],
+      ]))
+      const flags = [...groups.keys()]
+      assert.match(flags[0], /^[\w.-]{1,45}$/)
+      assert.equal(flags[1], 'area-library_variant')
+      assert.notEqual(flags[0], flags[1])
+    })
+
     it('leaves a small singleton tail (<=2) standalone', () => {
       const groups = planGroups(new Map([
         ['serverless-lambda', ['a']],


### PR DESCRIPTION
### What does this PR do?

Run Confluent instrumentation on Node 18, 20, and 22 for all supported package versions, and Node 24 for `>=1.4.0`.

### Motivation

`@confluentinc/kafka-javascript` has no ABI 147 prebuild. Its source fallback fails under Node 26 because the librdkafka configuration header is not generated.

### Additional Notes

Node 26 should be added after the Kafka-backed plugin suite can install, load, and connect there.