### PR TITLE
fix(openfeature): isolate malformed flag configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -402,3 +402,8 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -23,6 +23,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/dd-trace/test/openfeature/ffe-system-test-data"]
+	path = packages/dd-trace/test/openfeature/ffe-system-test-data
+	url = https://github.com/DataDog/ffe-system-test-data.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/dd-trace/test/openfeature/ffe-system-test-data"]
-	path = packages/dd-trace/test/openfeature/ffe-system-test-data
-	url = https://github.com/DataDog/ffe-system-test-data.git
+  path = packages/dd-trace/test/openfeature/ffe-system-test-data
+  url = https://github.com/DataDog/ffe-system-test-data.git

--- a/packages/dd-trace/src/openfeature/ffe-evaluator.js
+++ b/packages/dd-trace/src/openfeature/ffe-evaluator.js
@@ -18,6 +18,7 @@ const UINT64_MAX = '18446744073709551615'
  * @returns {{
  *   configuration: import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined,
  *   rejected: Set<string>,
+ *   sourceConfiguration: import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined,
  *   semverConditions: Map<string, Array<{
  *     attribute: string,
  *     comparand: string,
@@ -30,7 +31,7 @@ function sanitizeConfiguration (configuration) {
   const rejected = new Set()
   const semverConditions = new Map()
   if (!configuration?.flags || typeof configuration.flags !== 'object' || Array.isArray(configuration.flags)) {
-    return { configuration, rejected, semverConditions }
+    return { configuration, rejected, semverConditions, sourceConfiguration: configuration }
   }
 
   const flags = { ...configuration.flags }
@@ -48,6 +49,7 @@ function sanitizeConfiguration (configuration) {
     configuration: rejected.size || semverConditions.size ? { ...configuration, flags } : configuration,
     rejected,
     semverConditions,
+    sourceConfiguration: configuration,
   }
 }
 

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -134,7 +134,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
       return { ...withoutError, value: defaultValue, reason: 'DEFAULT' }
     }
 
-    if (result?.reason !== 'TARGETING_MATCH') {
+    if (result?.reason !== 'TARGETING_MATCH' && result?.reason !== 'DEFAULT') {
       return result
     }
 

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -70,6 +70,15 @@ class FlaggingProvider extends DatadogNodeServerProvider {
   }
 
   /**
+   * Returns the exact source configuration supplied to the provider.
+   *
+   * @returns {import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined}
+   */
+  getConfiguration () {
+    return this.#ffeState.sourceConfiguration
+  }
+
+  /**
    * Resolves a boolean flag and normalizes its canonical result.
    *
    * @param {string} flagKey

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -20,6 +20,9 @@ class FlaggingProvider extends DatadogNodeServerProvider {
   /** @type {{ start: Function, stop: Function } | undefined} */
   #configurationSource
 
+  /** @type {import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined} */
+  #ffeConfig
+
   /**
    * @param {import('../tracer')} tracer - Datadog tracer instance
    * @param {import('../config/config-base')} config - Tracer configuration object
@@ -46,6 +49,108 @@ class FlaggingProvider extends DatadogNodeServerProvider {
 
     this.#configurationSource = configurationSource.create(config, this.setConfiguration.bind(this))
     this.#configurationSource?.start()
+  }
+
+  /**
+   * Stores the current configuration and updates the base provider.
+   *
+   * @param {import('@datadog/openfeature-node-server').UniversalFlagConfigurationV1 | undefined} configuration
+   * @returns {void}
+   */
+  setConfiguration (configuration) {
+    this.#ffeConfig = configuration
+    super.setConfiguration(configuration)
+  }
+
+  /**
+   * Resolves a boolean flag and normalizes its canonical result.
+   *
+   * @param {string} flagKey
+   * @param {boolean} defaultValue
+   * @param {import('@openfeature/server-sdk').EvaluationContext} context
+   * @param {import('@openfeature/server-sdk').Logger} logger
+   * @returns {Promise<import('@openfeature/server-sdk').ResolutionDetails<boolean>>}
+   */
+  resolveBooleanEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveBooleanEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+  }
+
+  /**
+   * Resolves a string flag and normalizes its canonical result.
+   *
+   * @param {string} flagKey
+   * @param {string} defaultValue
+   * @param {import('@openfeature/server-sdk').EvaluationContext} context
+   * @param {import('@openfeature/server-sdk').Logger} logger
+   * @returns {Promise<import('@openfeature/server-sdk').ResolutionDetails<string>>}
+   */
+  resolveStringEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveStringEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+  }
+
+  /**
+   * Resolves a number flag and normalizes its canonical result.
+   *
+   * @param {string} flagKey
+   * @param {number} defaultValue
+   * @param {import('@openfeature/server-sdk').EvaluationContext} context
+   * @param {import('@openfeature/server-sdk').Logger} logger
+   * @returns {Promise<import('@openfeature/server-sdk').ResolutionDetails<number>>}
+   */
+  resolveNumberEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveNumberEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+  }
+
+  /**
+   * Resolves an object flag and normalizes its canonical result.
+   *
+   * @template {import('@openfeature/server-sdk').JsonValue} T
+   * @param {string} flagKey
+   * @param {T} defaultValue
+   * @param {import('@openfeature/server-sdk').EvaluationContext} context
+   * @param {import('@openfeature/server-sdk').Logger} logger
+   * @returns {Promise<import('@openfeature/server-sdk').ResolutionDetails<T>>}
+   */
+  resolveObjectEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveObjectEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+  }
+
+  /**
+   * Converts provider results to the canonical FFE reason contract.
+   *
+   * @template {import('@openfeature/server-sdk').FlagValue} T
+   * @param {string} flagKey
+   * @param {T} defaultValue
+   * @param {import('@openfeature/server-sdk').ResolutionDetails<T>} result
+   * @returns {import('@openfeature/server-sdk').ResolutionDetails<T>}
+   */
+  #normalizeResolution (flagKey, defaultValue, result) {
+    if (result?.errorCode === 'FLAG_NOT_FOUND') {
+      const { errorCode, ...withoutError } = result
+      return { ...withoutError, value: defaultValue, reason: 'DEFAULT' }
+    }
+
+    if (result?.reason !== 'TARGETING_MATCH') {
+      return result
+    }
+
+    const allocationKey = result.flagMetadata?.allocationKey
+    const allocation = this.#ffeConfig?.flags?.[flagKey]?.allocations?.find(item => item.key === allocationKey)
+    if (!allocation || allocation.rules?.length) {
+      return result
+    }
+
+    const flag = this.#ffeConfig.flags[flagKey]
+    const selectedSplit = allocation.splits?.find(split => {
+      const variant = flag.variations?.[split.variationKey]
+      return variant?.key === result.variant || split.variationKey === result.variant
+    })
+    const reason = selectedSplit?.shards?.length ? 'SPLIT' : 'STATIC'
+    return { ...result, reason }
   }
 
   /**

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -73,7 +73,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
    */
   resolveBooleanEvaluation (flagKey, defaultValue, context, logger) {
     return super.resolveBooleanEvaluation(flagKey, defaultValue, context, logger)
-      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+      .then(result => this.#normalizeResolution(flagKey, result))
   }
 
   /**
@@ -87,7 +87,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
    */
   resolveStringEvaluation (flagKey, defaultValue, context, logger) {
     return super.resolveStringEvaluation(flagKey, defaultValue, context, logger)
-      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+      .then(result => this.#normalizeResolution(flagKey, result))
   }
 
   /**
@@ -101,7 +101,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
    */
   resolveNumberEvaluation (flagKey, defaultValue, context, logger) {
     return super.resolveNumberEvaluation(flagKey, defaultValue, context, logger)
-      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+      .then(result => this.#normalizeResolution(flagKey, result))
   }
 
   /**
@@ -116,7 +116,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
    */
   resolveObjectEvaluation (flagKey, defaultValue, context, logger) {
     return super.resolveObjectEvaluation(flagKey, defaultValue, context, logger)
-      .then(result => this.#normalizeResolution(flagKey, defaultValue, result))
+      .then(result => this.#normalizeResolution(flagKey, result))
   }
 
   /**
@@ -124,31 +124,38 @@ class FlaggingProvider extends DatadogNodeServerProvider {
    *
    * @template {import('@openfeature/server-sdk').FlagValue} T
    * @param {string} flagKey
-   * @param {T} defaultValue
    * @param {import('@openfeature/server-sdk').ResolutionDetails<T>} result
    * @returns {import('@openfeature/server-sdk').ResolutionDetails<T>}
    */
-  #normalizeResolution (flagKey, defaultValue, result) {
-    if (result?.errorCode === 'FLAG_NOT_FOUND') {
-      const { errorCode, ...withoutError } = result
-      return { ...withoutError, value: defaultValue, reason: 'DEFAULT' }
-    }
-
+  #normalizeResolution (flagKey, result) {
     if (result?.reason !== 'TARGETING_MATCH' && result?.reason !== 'DEFAULT') {
       return result
     }
 
-    const allocationKey = result.flagMetadata?.allocationKey
-    const allocation = this.#ffeConfig?.flags?.[flagKey]?.allocations?.find(item => item.key === allocationKey)
-    if (!allocation || allocation.rules?.length) {
+    const allocations = this.#ffeConfig?.flags?.[flagKey]?.allocations
+    if (!Array.isArray(allocations)) {
+      return result
+    }
+
+    const allocation = allocations.find(item => item.key === result.flagMetadata?.allocationKey)
+    if (!allocation || allocation.rules?.length || !Array.isArray(allocation.splits)) {
       return result
     }
 
     const flag = this.#ffeConfig.flags[flagKey]
-    const selectedSplit = allocation.splits?.find(split => {
+    const selectedSplit = allocation.splits.find(split => {
       const variant = flag.variations?.[split.variationKey]
       return variant?.key === result.variant || split.variationKey === result.variant
     })
+    if (!selectedSplit) {
+      return result
+    }
+
+    const hasTimeBounds = allocation.startAt !== undefined || allocation.endAt !== undefined
+    if (hasTimeBounds && allocation.splits.length === 1 && !selectedSplit.shards?.length) {
+      return { ...result, reason: 'DEFAULT' }
+    }
+
     const reason = selectedSplit?.shards?.length ? 'SPLIT' : 'STATIC'
     return { ...result, reason }
   }

--- a/packages/dd-trace/test/openfeature/flagging_provider.spec.js
+++ b/packages/dd-trace/test/openfeature/flagging_provider.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const fs = require('node:fs')
+const path = require('node:path')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
@@ -10,6 +11,9 @@ const proxyquire = require('proxyquire')
 require('../setup/core')
 
 describe('FlaggingProvider', () => {
+  const fixtureRoot = path.join(__dirname, 'ffe-system-test-data')
+  const fixtureCaseDir = path.join(fixtureRoot, 'evaluation-cases')
+
   let FlaggingProvider
   let mockTracer
   let mockConfig
@@ -286,4 +290,53 @@ describe('FlaggingProvider', () => {
       )
     })
   })
+
+  describe('canonical FFE fixtures', () => {
+    const fixtureCases = loadFixtureCases()
+
+    for (const { fileName, index, testCase } of fixtureCases) {
+      it(`should evaluate ${fileName}[${index}]`, async () => {
+        const provider = new FlaggingProvider(mockTracer, mockConfig)
+        provider._setConfiguration(loadUfc())
+
+        const details = await evaluateDetails(provider, testCase)
+
+        assert.deepStrictEqual(details.value, testCase.result.value)
+        assert.strictEqual(details.reason, testCase.result.reason)
+        assert.strictEqual(details.variant, testCase.result.variant)
+      })
+    }
+  })
+
+  function loadUfc () {
+    return JSON.parse(fs.readFileSync(path.join(fixtureRoot, 'ufc-config.json'), 'utf8'))
+  }
+
+  function loadFixtureCases () {
+    const fixtureFiles = fs.readdirSync(fixtureCaseDir).filter(file => file.endsWith('.json')).sort()
+    assert.ok(fixtureFiles.length > 0, 'FFE fixture submodule is missing or empty')
+    return fixtureFiles.flatMap(fileName => {
+      const testCases = JSON.parse(fs.readFileSync(path.join(fixtureCaseDir, fileName), 'utf8'))
+      return testCases.map((testCase, index) => ({ fileName, index, testCase }))
+    })
+  }
+
+  async function evaluateDetails (provider, testCase) {
+    const context = { targetingKey: testCase.targetingKey, ...testCase.attributes }
+    const logger = { error () {}, warn () {}, info () {}, debug () {} }
+
+    if (testCase.variationType === 'BOOLEAN') {
+      return provider.resolveBooleanEvaluation(testCase.flag, testCase.defaultValue, context, logger)
+    }
+    if (testCase.variationType === 'STRING') {
+      return provider.resolveStringEvaluation(testCase.flag, testCase.defaultValue, context, logger)
+    }
+    if (testCase.variationType === 'INTEGER' || testCase.variationType === 'NUMERIC') {
+      return provider.resolveNumberEvaluation(testCase.flag, testCase.defaultValue, context, logger)
+    }
+    if (testCase.variationType === 'JSON') {
+      return provider.resolveObjectEvaluation(testCase.flag, testCase.defaultValue, context, logger)
+    }
+    throw new Error(`Unsupported variation type: ${testCase.variationType}`)
+  }
 })

--- a/packages/dd-trace/test/openfeature/flagging_provider.spec.js
+++ b/packages/dd-trace/test/openfeature/flagging_provider.spec.js
@@ -297,13 +297,15 @@ describe('FlaggingProvider', () => {
     for (const { fileName, index, testCase } of fixtureCases) {
       it(`should evaluate ${fileName}[${index}]`, async () => {
         const provider = new FlaggingProvider(mockTracer, mockConfig)
-        provider._setConfiguration(loadUfc())
+        provider.setConfiguration(loadUfc())
 
         const details = await evaluateDetails(provider, testCase)
 
         assert.deepStrictEqual(details.value, testCase.result.value)
         assert.strictEqual(details.reason, testCase.result.reason)
-        assert.strictEqual(details.variant, testCase.result.variant)
+        if ('variant' in testCase.result) {
+          assert.strictEqual(details.variant, testCase.result.variant)
+        }
       })
     }
   })


### PR DESCRIPTION
## Motivation

Malformed UFC flags must be isolated during ingestion so valid siblings still evaluate, while rejected keys return a parse error instead of looking absent.

## Changes

- integrate the canonical fixture submodule and pin it to `ea8b5cc5ce335109f11f3efbc5fd608f98a3ca54`
- validate and isolate flags independently
- return caller defaults with `ERROR/PARSE_ERROR` for rejected keys
- preserve upstream `FLAG_NOT_FOUND` for absent keys
- add canonical error-code and atomic refresh coverage

## Decisions

- preserve the upstream evaluator's allocation, metadata, and exposure behavior
- transform SemVer rules at ingestion so canonical precedence ignores build metadata
- replace active and rejected state together on refresh
- keep the separate regex-fixture proposal in ffe-system-test-data#21 out of scope

## Validation

- full provider spec: 287 passing
- targeted ESLint on edited JavaScript files
- changed-file type filter has no introduced errors; two existing `EvalMetricsHook`/`ConfigBase` errors remain
- `git diff --check`