### PR TITLE
perf(serverless): optimize Vercel platform tags

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -598,8 +598,11 @@ class Config extends ConfigBase {
       this.tags.version = this.version
     }
     this.tags['runtime-id'] = RUNTIME_ID
-    for (const [name, value] of Object.entries(getPlatformTags())) {
-      this.tags[name] ??= value
+    const platformTags = getPlatformTags()
+    if (platformTags) {
+      for (let i = 0; i < platformTags.length; i += 2) {
+        this.tags[platformTags[i]] ??= platformTags[i + 1]
+      }
     }
 
     if (IS_SERVERLESS) {

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -15,7 +15,7 @@ const { isTrue } = require('../util')
 const telemetry = require('../telemetry')
 const telemetryMetrics = require('../telemetry/metrics')
 const {
-  getPlatformTags,
+  getServerlessPlatformTags,
   IS_SERVERLESS,
   getIsGCPFunction,
   getIsAzureFunction,
@@ -598,7 +598,7 @@ class Config extends ConfigBase {
       this.tags.version = this.version
     }
     this.tags['runtime-id'] = RUNTIME_ID
-    const platformTags = getPlatformTags()
+    const platformTags = getServerlessPlatformTags()
     if (platformTags) {
       for (let i = 0; i < platformTags.length; i += 2) {
         this.tags[platformTags[i]] ??= platformTags[i + 1]

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -45,26 +45,27 @@ function isInServerlessEnvironment () {
 /**
  * Gets tags describing the platform where the tracer is running.
  *
- * @returns {Record<string, string>}
+ * @returns {string[]|undefined}
  */
 function getPlatformTags () {
-  return getVercelTags()
-}
+  if (getEnvironmentVariable('VERCEL') !== '1') return
 
-/**
- * @returns {Record<string, string>}
- */
-function getVercelTags () {
-  if (getEnvironmentVariable('VERCEL') !== '1') return {}
-
-  const tags = {
-    'vercel.project_id': getEnvironmentVariable('VERCEL_PROJECT_ID'),
-    'vercel.environment': getEnvironmentVariable('VERCEL_ENV'),
-    'vercel.region': getEnvironmentVariable('VERCEL_REGION'),
+  let tags
+  const projectId = getEnvironmentVariable('VERCEL_PROJECT_ID')
+  if (projectId) {
+    tags = ['vercel.project_id', projectId]
   }
 
-  for (const [name, value] of Object.entries(tags)) {
-    if (!value) delete tags[name]
+  const environment = getEnvironmentVariable('VERCEL_ENV')
+  if (environment) {
+    tags ??= []
+    tags.push('vercel.environment', environment)
+  }
+
+  const region = getEnvironmentVariable('VERCEL_REGION')
+  if (region) {
+    tags ??= []
+    tags.push('vercel.region', region)
   }
 
   return tags

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -43,13 +43,20 @@ function isInServerlessEnvironment () {
 }
 
 /**
- * Gets tags describing the platform where the tracer is running.
+ * Gets tags describing the serverless platform where the tracer is running.
  *
  * @returns {string[]|undefined}
  */
-function getPlatformTags () {
-  if (getEnvironmentVariable('VERCEL') !== '1') return
+function getServerlessPlatformTags () {
+  if (getEnvironmentVariable('VERCEL') === '1') {
+    return getVercelPlatformTags()
+  }
+}
 
+/**
+ * @returns {string[]|undefined}
+ */
+function getVercelPlatformTags () {
   let tags
   const projectId = getEnvironmentVariable('VERCEL_PROJECT_ID')
   if (projectId) {
@@ -72,7 +79,7 @@ function getPlatformTags () {
 }
 
 module.exports = {
-  getPlatformTags,
+  getServerlessPlatformTags,
   getIsGCPFunction,
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -104,9 +104,21 @@ describe('Vercel span metadata', () => {
       VERCEL_PROJECT_ID: 'prj_123',
     }
 
-    assert.deepStrictEqual(getPlatformTags(), {
-      'vercel.project_id': 'prj_123',
-      'vercel.environment': 'preview',
-    })
+    assert.deepStrictEqual(getPlatformTags(), [
+      'vercel.project_id', 'prj_123',
+      'vercel.environment', 'preview',
+    ])
+  })
+
+  it('discovers Vercel metadata when project ID is missing', () => {
+    process.env = {
+      ...environment,
+      VERCEL: '1',
+      VERCEL_ENV: 'preview',
+    }
+
+    assert.deepStrictEqual(getPlatformTags(), [
+      'vercel.environment', 'preview',
+    ])
   })
 })

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -6,7 +6,7 @@ const { describe, it, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { getPlatformTags, enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { getServerlessPlatformTags, enableGCPPubSubPushSubscription } = require('../src/serverless')
 const agent = require('./plugins/agent')
 
 describe('enableGCPPubSubPushSubscription', () => {
@@ -104,7 +104,7 @@ describe('Vercel span metadata', () => {
       VERCEL_PROJECT_ID: 'prj_123',
     }
 
-    assert.deepStrictEqual(getPlatformTags(), [
+    assert.deepStrictEqual(getServerlessPlatformTags(), [
       'vercel.project_id', 'prj_123',
       'vercel.environment', 'preview',
     ])
@@ -117,7 +117,7 @@ describe('Vercel span metadata', () => {
       VERCEL_ENV: 'preview',
     }
 
-    assert.deepStrictEqual(getPlatformTags(), [
+    assert.deepStrictEqual(getServerlessPlatformTags(), [
       'vercel.environment', 'preview',
     ])
   })


### PR DESCRIPTION
### What does this PR do?

Replaces the Vercel platform-tag object and `Object.entries()` iteration with a compact flat key/value array and indexed application loop. It preserves user-supplied tag precedence and avoids allocations and deletion work during tracer configuration.

### Motivation

Follow-up to the performance optimization suggested in the review on #9660 after its Vercel runtime-tag feature merged.

### Additional Notes

Validation:

- `packages/dd-trace/test/serverless.spec.js` — 7 passing, including mock-agent encoded-span assertions and the missing-project-ID edge case.
- ESLint and `git diff --check` passed for all changed files.
- Microbenchmark, two fresh runs with five trials after a one-second warmup: flat array averaged 54,147 and 54,685 calls/ms vs. 7,946 and 8,168 calls/ms for the object implementation (about 6.7x faster).