### PR TITLE
fix(http): allow W3C tracing headers in CORS preflight

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -376,6 +376,9 @@ function addAllowHeaders (req, res, headers) {
   const allowHeaders = splitHeader(headers['access-control-allow-headers'])
   const requestHeaders = splitHeader(req.headers['access-control-request-headers'])
   const contextHeaders = [
+    'baggage',
+    'traceparent',
+    'tracestate',
     'x-datadog-origin',
     'x-datadog-parent-id',
     'x-datadog-sampled', // Deprecated, but still accept it in case it's sent.

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -862,6 +862,22 @@ describe('plugins/util/web', () => {
       )
     })
 
+    it('merges W3C tracing allow-headers on OPTIONS when allow-origin is *', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'baggage, traceparent, tracestate, x-other'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'baggage,traceparent,tracestate']
+      )
+    })
+
     it('honours headers passed as the second writeHead argument', () => {
       req.method = 'OPTIONS'
       req.headers.origin = 'https://example.com'
@@ -929,7 +945,7 @@ describe('plugins/util/web', () => {
       )
     })
 
-    it('leaves allow-headers untouched when no datadog header was requested', () => {
+    it('leaves allow-headers untouched when no supported tracing header was requested', () => {
       req.method = 'OPTIONS'
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'content-type, x-other'


### PR DESCRIPTION
What does this PR do?

Adds baggage, traceparent, and tracestate to dd-trace-js automatic CORS preflight responses. It also forwards the merged allow-list into explicit second- and third-argument writeHead() calls, and adds regression coverage through the real HTTP plugin/server path.

Motivation

RUM Browser SDK v7 propagates baggage by default on cross-origin traced requests. The browser sends these tracing headers in the CORS preflight request, but addAllowHeaders() previously only allowed the legacy x-datadog-* headers. The browser therefore blocked the actual request before dd-trace-js could extract the tracing context. Datadog documents Datadog, W3C Trace Context, and W3C Baggage as supported propagation formats.

Motivation also includes a Node.js writeHead() precedence issue: explicit header objects override values previously set through res.setHeader(), so the merged CORS value must be written back into the explicit argument.

Notes

Targeted validation: packages/dd-trace/test/plugins/util/web.spec.js (78 passing), packages/datadog-plugin-http/test/server.spec.js (52 passing), and git diff --check. Targeted ESLint could not run because the installed ESLint 10 and unicorn plugin versions are incompatible in this checkout.