### PR TITLE
chore(release): keep contributor footer avatar-only

### DIFF
--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -14,7 +14,6 @@ const CONVENTIONAL_PATTERN = new RegExp(
 )
 const PULL_REQUEST_PATTERN = /\s+\(#([0-9]+)\)$/
 const REFERENCE_PATTERN = /#([0-9]+)/g
-const MARKDOWN_PUNCTUATION_PATTERN = /[\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E]/g
 const GITHUB_URL = 'https://github.com'
 const REPO_URL = `${GITHUB_URL}/DataDog/dd-trace-js`
 const UNCATEGORIZED_PRODUCT = 'Other'
@@ -466,8 +465,16 @@ function renderMarkdown (sections, contributors, breakingChanges) {
   }
 
   if (contributors.size > 0) {
-    const badges = [...contributors.values()].sort(compareContributors).map(renderContributor)
-    lines.push('### Contributors', '', badges.join(' '), '')
+    const iconContributors = []
+    for (const contributor of contributors.values()) {
+      if (contributor.login) iconContributors.push(contributor)
+    }
+    if (iconContributors.length > 0) {
+      iconContributors.sort(compareContributors)
+      const avatars = []
+      for (const contributor of iconContributors) avatars.push(renderContributor(contributor))
+      lines.push('### Contributors', '', avatars.join(' '), '')
+    }
   }
 
   return lines.join('\n')
@@ -509,8 +516,6 @@ function compareContributors (a, b) {
  * @param {Contributor} contributor
  */
 function renderContributor (contributor) {
-  if (!contributor.login) return escapeMarkdown(contributor.name)
-
   const { login, name } = contributor
   return `[<img src="${GITHUB_URL}/${login}.png?size=48" width="24" height="24" ` +
     `alt="${name}" title="${name}" />](${GITHUB_URL}/${login})`
@@ -521,32 +526,12 @@ function renderContributor (contributor) {
  */
 function renderChange (change) {
   const subject = linkifyReferences(change.subject)
-  let suffix = change.pr ? ` ${renderPullRequest(change.pr)}` : ''
-  if (change.contributors.length > 0) {
-    suffix += ` — by ${change.contributors.map(renderContributorLink).join(', ')}`
-  }
+  const suffix = change.pr ? ` ${renderPullRequest(change.pr)}` : ''
   if (change.product === UNCATEGORIZED_PRODUCT) {
     return `- ${subject}${suffix}`
   }
 
   return `- **${change.product}:** ${subject}${suffix}`
-}
-
-/**
- * @param {Contributor} contributor
- * @returns {string}
- */
-function renderContributorLink (contributor) {
-  if (!contributor.login) return escapeMarkdown(contributor.name)
-
-  return `[${contributor.name}](${GITHUB_URL}/${contributor.login})`
-}
-
-/**
- * @param {string} text
- */
-function escapeMarkdown (text) {
-  return text.replaceAll(MARKDOWN_PUNCTUATION_PATTERN, String.raw`\$&`)
 }
 
 /**

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -295,7 +295,10 @@ function isInternalOnly (files) {
 function addContributors (contributors, additions) {
   for (const contributor of additions) {
     const identity = contributor.login?.toLowerCase() ?? contributor.name.toLowerCase()
-    if (!contributors.has(identity)) contributors.set(identity, contributor)
+    const existing = contributors.get(identity)
+    if (existing === undefined || (existing.login === undefined && contributor.login !== undefined)) {
+      contributors.set(identity, contributor)
+    }
   }
 }
 

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -509,12 +509,15 @@ describe('release changelog', () => {
     ))
   })
 
-  it('renders only contributor avatars in the footer', () => {
+  it('renders only linked contributors and prefers them over name-only duplicates', () => {
     const changelog = createReleaseChangelog([
       {
         sha: 'abc001',
         subject: 'feat(appsec): add thing (#1)',
-        contributors: [{ name: '@Zoe', login: 'Zoe' }],
+        contributors: [
+          { name: 'alice' },
+          { name: '@Zoe', login: 'Zoe' },
+        ],
       },
       {
         sha: 'abc002',
@@ -523,6 +526,7 @@ describe('release changelog', () => {
           { name: '@alice', login: 'alice' },
           { name: '@bob', login: 'bob' },
           { name: '@Zoe', login: 'Zoe' },
+          { name: 'bob' },
           { name: 'Jane Doe' },
         ],
       },

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -14,12 +14,6 @@ const prLink = (number) => `[#${number}](https://github.com/DataDog/dd-trace-js/
  * @param {string} login
  * @returns {string}
  */
-const contributorLink = (login) => `[@${login}](https://github.com/${login})`
-
-/**
- * @param {string} login
- * @returns {string}
- */
 const avatar = (login) => `[<img src="https://github.com/${login}.png?size=48" width="24" height="24" ` +
   `alt="@${login}" title="@${login}" />](https://github.com/${login})`
 
@@ -181,10 +175,10 @@ describe('release changelog', () => {
     assert.strictEqual(changelog.markdown, [
       '### Breaking Changes',
       `- **Dependencies:** Bump eslint from 9.0.0 to 10.0.0 ${prLink(9003)}`,
-      `- **OpenTelemetry:** Remove legacy propagation mode ${prLink(9002)} — by ${contributorLink('bob')}`,
+      `- **OpenTelemetry:** Remove legacy propagation mode ${prLink(9002)}`,
       '',
       '### Fixes',
-      `- **General:** Keep existing behavior stable ${prLink(9001)} — by ${contributorLink('alice')}`,
+      `- **General:** Keep existing behavior stable ${prLink(9001)}`,
       '',
       '### Contributors',
       '',
@@ -515,7 +509,7 @@ describe('release changelog', () => {
     ))
   })
 
-  it('credits authors and co-authors on each change and in the contributor footer', () => {
+  it('renders only contributor avatars in the footer', () => {
     const changelog = createReleaseChangelog([
       {
         sha: 'abc001',
@@ -536,20 +530,19 @@ describe('release changelog', () => {
 
     assert.strictEqual(changelog.markdown, [
       '### Features',
-      `- **AppSec:** Add thing ${prLink(1)} — by ${contributorLink('Zoe')}`,
+      `- **AppSec:** Add thing ${prLink(1)}`,
       '',
       '### Fixes',
-      `- **Profiling:** Fix thing ${prLink(2)} — by ${contributorLink('alice')}, ${contributorLink('bob')}, ` +
-        `${contributorLink('Zoe')}, Jane Doe`,
+      `- **Profiling:** Fix thing ${prLink(2)}`,
       '',
       '### Contributors',
       '',
-      `${avatar('alice')} ${avatar('bob')} ${avatar('Zoe')} Jane Doe`,
+      `${avatar('alice')} ${avatar('bob')} ${avatar('Zoe')}`,
       '',
     ].join('\n'))
   })
 
-  it('escapes Markdown in contributors without GitHub accounts', () => {
+  it('omits the contributor footer without GitHub accounts', () => {
     const changelog = createReleaseChangelog([
       {
         sha: 'abc001',
@@ -558,14 +551,9 @@ describe('release changelog', () => {
       },
     ])
 
-    const contributor = String.raw`\[Jane\]\(https\:\/\/example\.com\)`
     assert.strictEqual(changelog.markdown, [
       '### Fixes',
-      `- **General:** Fix thing ${prLink(1)} — by ${contributor}`,
-      '',
-      '### Contributors',
-      '',
-      contributor,
+      `- **General:** Fix thing ${prLink(1)}`,
       '',
     ].join('\n'))
   })

--- a/scripts/release/metadata.js
+++ b/scripts/release/metadata.js
@@ -40,6 +40,7 @@ const NON_HUMAN_EMAILS = new Set([
  * @typedef {object} GitHubContributor
  * @property {string} [name]
  * @property {string} [email]
+ * @property {string} [__typename]
  * @property {string} [login]
  * @property {{ login?: string }} [user]
  */
@@ -127,7 +128,7 @@ function readGitHubMetadata (shas, pullRequestNumbers) {
       const pullRequestNumber = pullRequestNumbers[i]
       if (pullRequestNumber !== undefined) {
         fields += `pullRequest${i}: issueOrPullRequest(number: ${pullRequestNumber}) { __typename ` +
-          '... on PullRequest { number title author { login } ' +
+          '... on PullRequest { number title author { __typename login } ' +
           'labels(first: 100) { nodes { name } pageInfo { hasNextPage } } ' +
           'files(first: 100) { nodes { path changeType } pageInfo { hasNextPage } } } } '
       }
@@ -197,6 +198,8 @@ function readFiles (pullRequest) {
  * @param {GitHubContributor} contributor
  */
 function addContributor (contributors, contributor) {
+  if (contributor.__typename === 'Bot') return
+
   const login = contributor.user?.login ?? contributor.login
   const normalizedLogin = login?.toLowerCase()
   if ((normalizedLogin && (normalizedLogin.endsWith('[bot]') || NON_HUMAN_LOGINS.has(normalizedLogin))) ||

--- a/scripts/release/metadata.spec.js
+++ b/scripts/release/metadata.spec.js
@@ -51,7 +51,7 @@ describe('release metadata', () => {
             __typename: 'PullRequest',
             number: 123,
             title: 'fix(core): preserve the complete pull request context',
-            author: { login: 'pull-request-author' },
+            author: { __typename: 'User', login: 'pull-request-author' },
             labels: {
               nodes: [{ name: 'appsec' }, { name: 'ai-guard' }],
               pageInfo: { hasNextPage: false },
@@ -214,7 +214,7 @@ describe('release metadata', () => {
     }])
   })
 
-  it('hydrates pull request metadata without a merge commit', () => {
+  it('omits bot pull request authors without a merge commit', () => {
     const capture = sinon.stub().returns(JSON.stringify({
       data: {
         repository: {
@@ -222,7 +222,7 @@ describe('release metadata', () => {
             __typename: 'PullRequest',
             number: 123,
             title: 'feat(core)!: remove legacy context',
-            author: { login: 'pull-request-author' },
+            author: { __typename: 'Bot', login: 'gh-worker-campaigns-3e9aa4' },
             labels: { nodes: [{ name: 'appsec' }], pageInfo: { hasNextPage: false } },
             files: {
               nodes: [{ path: 'packages/dd-trace/src/index.js', changeType: 'MODIFIED' }],
@@ -241,11 +241,12 @@ describe('release metadata', () => {
     assert.deepStrictEqual(entries, [{
       sha: 'pull-request-123',
       subject: 'feat(core)!: remove legacy context (#123)',
-      contributors: [{ name: '@pull-request-author', login: 'pull-request-author' }],
+      contributors: [],
       labels: ['appsec'],
       files: ['packages/dd-trace/src/index.js'],
     }])
     assert.doesNotMatch(capture.firstCall.args[0], /commit0:/)
+    assert.match(capture.firstCall.args[0], /author \{ __typename login \}/)
   })
 
   it('rejects truncated contributor and label metadata', () => {


### PR DESCRIPTION
Remove per-entry contributor attribution so release notes only show GitHub avatar icons in the Contributors footer.