### PR TITLE
fix(datastreams): reset edge start per hop so edge latency is not cumulative

### DIFF
--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -338,14 +338,7 @@ class DataStreamsProcessor {
     const pathwayLatencyNs = nowNs - pathwayStartNs
     const dataStreamsContext = {
       hash,
-      // Reset the edge start to now: the edge latency emitted above is measured
-      // from the *previous* checkpoint, but the context we hand to the next hop
-      // must start its edge clock here so the next hop's edge latency is per-hop.
-      // Inheriting the parent's edgeStartNs (the old behavior) pins it at the
-      // pathway origin, making every hop's edge latency cumulative (edge latency
-      // == pathway latency) and double-counting when per-hop latencies are summed
-      // (e.g. the Measure tab). This matches dd-trace-go, which stores
-      // edgeStart: now on the child pathway.
+      // start the next hop's edge clock here so edge latency stays per-hop
       edgeStartNs: nowNs,
       pathwayStartNs,
       previousDirection: direction,

--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -338,7 +338,15 @@ class DataStreamsProcessor {
     const pathwayLatencyNs = nowNs - pathwayStartNs
     const dataStreamsContext = {
       hash,
-      edgeStartNs,
+      // Reset the edge start to now: the edge latency emitted above is measured
+      // from the *previous* checkpoint, but the context we hand to the next hop
+      // must start its edge clock here so the next hop's edge latency is per-hop.
+      // Inheriting the parent's edgeStartNs (the old behavior) pins it at the
+      // pathway origin, making every hop's edge latency cumulative (edge latency
+      // == pathway latency) and double-counting when per-hop latencies are summed
+      // (e.g. the Measure tab). This matches dd-trace-go, which stores
+      // edgeStart: now on the child pathway.
+      edgeStartNs: nowNs,
       pathwayStartNs,
       previousDirection: direction,
       closestOppositeDirectionHash,

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -363,6 +363,44 @@ describe('DataStreamsProcessor', () => {
 
     assert.strictEqual(payload.ProcessTags, undefined, 'ProcessTags should not be present')
   })
+
+  it('resets the edge start per hop so edge latency is per-hop, not cumulative', () => {
+    // Serial pipeline reported by real tracers: produce(topic-a) ->
+    // consume(topic-a) -> produce(topic-b) -> consume(topic-b), with a 1s
+    // processing gap at the middle service and near-zero queue waits.
+    //
+    // Each hop's edge latency must be measured from the *previous* checkpoint
+    // (per-hop). If the context handed to the next hop keeps the parent's
+    // edgeStartNs (the pre-fix behavior), edgeStart stays pinned at the pathway
+    // origin and every hop's edge latency becomes cumulative (== pathway
+    // latency), which double-counts when per-hop latencies are summed (e.g. the
+    // DSM Measure tab). Here the downstream topic-b edge must be the ~3ms queue
+    // wait, not the cumulative ~1008ms.
+    //
+    // A small fake epoch is used so Date.now() * 1e6 stays within safe-integer
+    // range and the nanosecond deltas are exact.
+    const recorded = []
+    sinon.stub(processor, 'recordCheckpoint').callsFake((checkpoint) => recorded.push(checkpoint))
+    const clock = sinon.useFakeTimers({ now: 1000, toFake: ['Date'] })
+    const MS = 1e6 // nanoseconds per millisecond
+    try {
+      const produceA = processor.setCheckpoint(['direction:out', 'topic:a', 'type:kafka'], null, null)
+      clock.tick(5) // topic-a queue wait
+      const consumeA = processor.setCheckpoint(['direction:in', 'group:g2', 'topic:a', 'type:kafka'], null, produceA)
+      clock.tick(1000) // in-service processing at the middle service
+      const produceB = processor.setCheckpoint(['direction:out', 'topic:b', 'type:kafka'], null, consumeA)
+      clock.tick(3) // topic-b queue wait
+      processor.setCheckpoint(['direction:in', 'group:g3', 'topic:b', 'type:kafka'], null, produceB)
+    } finally {
+      clock.restore()
+    }
+
+    const [, consumeACp, produceBCp, consumeBCp] = recorded
+    assert.strictEqual(consumeACp.edgeLatencyNs, 5 * MS, 'topic-a edge latency should be the queue wait')
+    assert.strictEqual(produceBCp.edgeLatencyNs, 1000 * MS, 'middle service internal latency should be the processing time')
+    assert.strictEqual(consumeBCp.edgeLatencyNs, 3 * MS, 'topic-b edge latency should be the queue wait, not cumulative')
+    assert.strictEqual(consumeBCp.pathwayLatencyNs, 1008 * MS, 'pathway latency should remain cumulative (end-to-end)')
+  })
 })
 
 describe('CheckpointRegistry', () => {

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -397,8 +397,8 @@ describe('DataStreamsProcessor', () => {
 
     const [, consumeACp, produceBCp, consumeBCp] = recorded
     assert.strictEqual(consumeACp.edgeLatencyNs, 5 * MS, 'topic-a edge latency should be the queue wait')
-    assert.strictEqual(produceBCp.edgeLatencyNs, 1000 * MS, 'middle service internal latency should be the processing time')
-    assert.strictEqual(consumeBCp.edgeLatencyNs, 3 * MS, 'topic-b edge latency should be the queue wait, not cumulative')
+    assert.strictEqual(produceBCp.edgeLatencyNs, 1000 * MS, 'middle service internal latency = processing time')
+    assert.strictEqual(consumeBCp.edgeLatencyNs, 3 * MS, 'topic-b edge = queue wait, not cumulative')
     assert.strictEqual(consumeBCp.pathwayLatencyNs, 1008 * MS, 'pathway latency should remain cumulative (end-to-end)')
   })
 })

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -364,42 +364,77 @@ describe('DataStreamsProcessor', () => {
     assert.strictEqual(payload.ProcessTags, undefined, 'ProcessTags should not be present')
   })
 
-  it('resets the edge start per hop so edge latency is per-hop, not cumulative', () => {
-    // Serial pipeline reported by real tracers: produce(topic-a) ->
-    // consume(topic-a) -> produce(topic-b) -> consume(topic-b), with a 1s
-    // processing gap at the middle service and near-zero queue waits.
-    //
-    // Each hop's edge latency must be measured from the *previous* checkpoint
-    // (per-hop). If the context handed to the next hop keeps the parent's
-    // edgeStartNs (the pre-fix behavior), edgeStart stays pinned at the pathway
-    // origin and every hop's edge latency becomes cumulative (== pathway
-    // latency), which double-counts when per-hop latencies are summed (e.g. the
-    // DSM Measure tab). Here the downstream topic-b edge must be the ~3ms queue
-    // wait, not the cumulative ~1008ms.
-    //
-    // A small fake epoch is used so Date.now() * 1e6 stays within safe-integer
-    // range and the nanosecond deltas are exact.
+  // A small fake epoch keeps Date.now() * 1e6 within safe-integer range so the
+  // nanosecond deltas are exact.
+  const MS = 1e6
+
+  const captureCheckpoints = () => {
     const recorded = []
     sinon.stub(processor, 'recordCheckpoint').callsFake((checkpoint) => recorded.push(checkpoint))
+    return recorded
+  }
+
+  it('resets the edge start per hop so edge latency is per-hop, not cumulative', () => {
+    // produce(a) -> consume(a) -> produce(b) -> consume(b), 1s processing at the
+    // middle hop. The downstream topic-b edge must be the 3ms queue wait, not
+    // the cumulative 1008ms.
+    const recorded = captureCheckpoints()
     const clock = sinon.useFakeTimers({ now: 1000, toFake: ['Date'] })
-    const MS = 1e6 // nanoseconds per millisecond
     try {
       const produceA = processor.setCheckpoint(['direction:out', 'topic:a', 'type:kafka'], null, null)
-      clock.tick(5) // topic-a queue wait
+      clock.tick(5)
       const consumeA = processor.setCheckpoint(['direction:in', 'group:g2', 'topic:a', 'type:kafka'], null, produceA)
-      clock.tick(1000) // in-service processing at the middle service
+      clock.tick(1000)
       const produceB = processor.setCheckpoint(['direction:out', 'topic:b', 'type:kafka'], null, consumeA)
-      clock.tick(3) // topic-b queue wait
+      clock.tick(3)
       processor.setCheckpoint(['direction:in', 'group:g3', 'topic:b', 'type:kafka'], null, produceB)
     } finally {
       clock.restore()
     }
 
     const [, consumeACp, produceBCp, consumeBCp] = recorded
-    assert.strictEqual(consumeACp.edgeLatencyNs, 5 * MS, 'topic-a edge latency should be the queue wait')
-    assert.strictEqual(produceBCp.edgeLatencyNs, 1000 * MS, 'middle service internal latency = processing time')
-    assert.strictEqual(consumeBCp.edgeLatencyNs, 3 * MS, 'topic-b edge = queue wait, not cumulative')
-    assert.strictEqual(consumeBCp.pathwayLatencyNs, 1008 * MS, 'pathway latency should remain cumulative (end-to-end)')
+    assert.strictEqual(consumeACp.edgeLatencyNs, 5 * MS)
+    assert.strictEqual(produceBCp.edgeLatencyNs, 1000 * MS)
+    assert.strictEqual(consumeBCp.edgeLatencyNs, 3 * MS)
+    assert.strictEqual(consumeBCp.pathwayLatencyNs, 1008 * MS)
+  })
+
+  it('measures same-direction (fan-out) hops from the closest opposite-direction checkpoint', () => {
+    // consume -> produce(a), produce(b): both fan-out produces measure their
+    // edge from the shared consume, not from each other.
+    const recorded = captureCheckpoints()
+    const clock = sinon.useFakeTimers({ now: 1000, toFake: ['Date'] })
+    try {
+      const origin = processor.setCheckpoint(['direction:out', 'topic:in', 'type:kafka'], null, null)
+      clock.tick(5)
+      const consume = processor.setCheckpoint(['direction:in', 'group:g', 'topic:in', 'type:kafka'], null, origin)
+      clock.tick(2)
+      const fanoutA = processor.setCheckpoint(['direction:out', 'topic:a', 'type:kafka'], null, consume)
+      clock.tick(3)
+      processor.setCheckpoint(['direction:out', 'topic:b', 'type:kafka'], null, fanoutA)
+    } finally {
+      clock.restore()
+    }
+
+    const [, , fanoutACp, fanoutBCp] = recorded
+    assert.strictEqual(fanoutACp.edgeLatencyNs, 2 * MS)
+    assert.strictEqual(fanoutBCp.edgeLatencyNs, 5 * MS)
+  })
+
+  it('restarts the pathway for a produce loop with no consume (same direction, entry parent)', () => {
+    const recorded = captureCheckpoints()
+    const clock = sinon.useFakeTimers({ now: 1000, toFake: ['Date'] })
+    try {
+      const p1 = processor.setCheckpoint(['direction:out', 'topic:a', 'type:kafka'], null, null)
+      clock.tick(4)
+      processor.setCheckpoint(['direction:out', 'topic:b', 'type:kafka'], null, p1)
+    } finally {
+      clock.restore()
+    }
+
+    const [, loop] = recorded
+    assert.strictEqual(loop.edgeLatencyNs, 0)
+    assert.strictEqual(loop.pathwayLatencyNs, 0)
   })
 })
 


### PR DESCRIPTION
### What / why

DSM `setCheckpoint` returns a pathway context for the next hop that keeps the **parent's** `edgeStartNs`. On a normal alternating `consume → produce` chain (the opposite-direction branch), that value is never reset, so `edgeStartNs` stays pinned at the **pathway origin**. As a result every hop's `edgeLatencyNs = nowNs - edgeStartNs` is measured from the origin rather than from the previous checkpoint — i.e. **edge latency becomes cumulative and effectively equals pathway latency**.

Anything that consumes per-hop latencies and sums them then double-counts upstream time. The clearest symptom is the **DSM Measure tab**: its "Avg Latency" / "Top latency contributors" is a per-hop sum, so it reports roughly **2× the true end-to-end latency**, while the topology map (which reads the single `pathway_type:full` value) stays correct.

### Reproduction

A serial pipeline `produce(topic-a) → consume(topic-a) → produce(topic-b) → consume(topic-b)` with a 1s processing gap at the middle service and ~0 queue waits. Running the exact `setCheckpoint` edge/pathway state machine before vs. after this change:

| | topic-a edge | middle internal | **topic-b edge** | full (map) | **per-hop sum (Measure)** |
|---|---|---|---|---|---|
| **before** | 5ms | 1005ms | **1008ms** | 1008ms | **2018ms** |
| **after**  | 5ms | 1000ms | **3ms** | 1008ms | **1008ms** |

`topic-b`'s edge should be the ~3ms queue wait, but before the fix it absorbs the middle service's 1s of processing (already counted as "internal"), so the sum doubles. `pathway_type:full` is correct in both cases.

This was also confirmed empirically end-to-end: a Kafka serial lab instrumented with **dd-trace-go** (which does not have this bug) shows Measure ≈ map ≈ 1s, whereas the same topology under dd-trace-js shows map ≈ 1s but Measure ≈ 2s.

### The fix

Store `edgeStartNs = nowNs` on the returned context so each hop measures its edge from the previous checkpoint (per-hop). `pathwayStartNs` is left unchanged, so end-to-end pathway latency is unaffected. This matches **dd-trace-go**, which stores `edgeStart: now` on the child pathway (`internal/datastreams/processor.go`). The fan-out / loop-protection path (`closestOppositeDirection*`) is preserved and still measures fan-out branches from the shared upstream checkpoint.

### Tests

Adds a regression test (`processor.spec.js`) that drives the serial scenario with fake timers and asserts per-hop edge latencies (topic-b edge = queue wait, not cumulative) while pathway latency stays cumulative.

### Scope / risk

- Only `edgeLatencyNs` values change (they become per-hop). `pathwayLatencyNs` and hashes are unchanged, so topology and end-to-end latency are unaffected.
- Existing `data_streams.latency{pathway_type:edge}` / `internal` monitors will report smaller, correct per-hop values after rollout — worth a heads-up in release notes.

### Cross-tracer audit

I checked the equivalent DSM checkpoint code in the other tracers to see whether the same "edge start never resets" mistake exists elsewhere. **It does not — this bug is unique to dd-trace-js.** Every other tracer resets the edge start to `now` for the next hop (either by mutating the context in place after computing the edge latency, or by storing `now` on a newly built context).

| Tracer | Resets edge start per hop? | Verdict | Evidence |
|---|---|---|---|
| **Node (this PR)** | ❌ stored the inherited `edgeStartNs` on the returned context | **buggy → fixed here** | `packages/dd-trace/src/datastreams/processor.js` (`edgeStartNs,` → `edgeStartNs: nowNs`) |
| **Go** | ✅ `edgeStart: now` on the child pathway (latency from `parent.EdgeStart()`) | correct | `internal/datastreams/processor.go` (`SetCheckpointWithParams`) |
| **Java** | ✅ mutates in place: `edgeStartNanoTicks = nanoTicks` after computing edge latency | correct | `dd-trace-core/.../datastreams/DefaultPathwayContext.java` (`setCheckpoint`) |
| **.NET** | ✅ new context `edgeStart = nowNs`; latency from `previousContext.EdgeStart` | correct | `tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs` (`SetCheckpoint`) |
| **Python** | ✅ `self.current_edge_start_sec = now_sec` after computing edge latency | correct | `ddtrace/internal/datastreams/processor.py` (`DataStreamsCtx.set_checkpoint`) |
| **Ruby** | ✅ `current_context.current_edge_start = now` at end of checkpoint | correct | `lib/datadog/data_streams/processor.rb` (`set_checkpoint`) |

Why dd-trace-js was the only one affected: Python/Ruby/Java mutate the pathway context in place (read the edge latency from the field, then overwrite it with `now`), and Go/.NET build a new context but explicitly set its edge start to `now`. dd-trace-js builds a new context (functional style) but copied the *inherited* `edgeStartNs` into it instead of `nowNs`. This change brings dd-trace-js in line with all five other tracers.

### Validation

I re-ran the "serial" example using the patched JS tracer: https://github.com/DataDog/data-streams-dev/pull/478. See the correct E2E latency numbers here ([reference link in DSM IBM MQ org](https://app.datadoghq.com/data-streams/measure?query=start%3Ajsfix-serial-1%20end%3Ajsfix-serial-3&collapse_pipeline=false&fromUser=true&start=1786482957865&end=1786483450000&paused=true)): 

<img width="1912" height="1242" alt="Screenshot 2026-08-11 at 5 23 01 PM" src="https://github.com/user-attachments/assets/ed97a485-f4c1-4dd9-8727-ea7fd5a3b697" />

