### PR TITLE
fix(test-optimization): parse rate-limit reset delays

### DIFF
--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -15,10 +15,45 @@ const {
 const { parseUrl } = require('../../exporters/common/url')
 
 const legacyStorage = storage('legacy')
+const EPOCH_SECONDS_THRESHOLD = 1_000_000_000
+
+/**
+ * Returns the delay requested by a Test Optimization intake rate-limit response.
+ *
+ * @param {import('node:http').IncomingHttpHeaders} [headers]
+ * @returns {number}
+ */
+function getRateLimitResetDelay (headers) {
+  let retryAfter = headers?.['retry-after']
+  if (Array.isArray(retryAfter)) retryAfter = retryAfter[0]
+  if (typeof retryAfter === 'string' && retryAfter.trim() !== '') {
+    const delaySeconds = Number(retryAfter)
+    if (Number.isFinite(delaySeconds)) {
+      if (delaySeconds >= 0) return delaySeconds * 1000
+    } else {
+      const resetTimestamp = Date.parse(retryAfter)
+      if (Number.isFinite(resetTimestamp)) return Math.max(0, resetTimestamp - Date.now())
+    }
+  }
+
+  let reset = headers?.['x-ratelimit-reset']
+  if (Array.isArray(reset)) reset = reset[0]
+  if (typeof reset !== 'string' || reset.trim() === '') return NaN
+
+  const resetSeconds = Number(reset)
+  if (!Number.isFinite(resetSeconds) || resetSeconds < 0) return NaN
+
+  // Datadog defines this header as delay seconds. Preserve compatibility with
+  // realistic Unix timestamps without confusing ordinary durations with epochs.
+  if (resetSeconds >= EPOCH_SECONDS_THRESHOLD) {
+    return Math.max(0, resetSeconds * 1000 - Date.now())
+  }
+  return resetSeconds * 1000
+}
 
 /**
  * Simplified HTTP request for test optimization (library config). Uses common HTTP agents.
- * Retries: 429 (with X-ratelimit-reset, max 30s wait),
+ * Retries: 429 (with Retry-After or X-RateLimit-Reset, max 30s wait),
  * >=500 and transient network errors (5–7.5s delay with jitter). Max one retry.
  * Destroys connections on errors to prevent reuse of bad connections. Preserves
  * original status code across retries for telemetry.
@@ -98,11 +133,7 @@ function request (data, options, callback) {
           }
 
           if (res.statusCode === 429 && !hasRetried) {
-            const resetHeader = res.headers['x-ratelimit-reset']
-            const resetTs = (resetHeader === null || resetHeader === undefined)
-              ? NaN
-              : Number.parseInt(resetHeader, 10)
-            const waitMs = Number.isFinite(resetTs) ? Math.max(0, resetTs * 1000 - Date.now()) : NaN
+            const waitMs = getRateLimitResetDelay(res.headers)
 
             if (Number.isFinite(waitMs) && waitMs <= RATE_LIMIT_MAX_WAIT_MS) {
               hasRetried = true

--- a/packages/dd-trace/test/ci-visibility/requests/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/request.spec.js
@@ -12,9 +12,12 @@ require('../../setup/core')
 const request = require('../../../src/ci-visibility/requests/request')
 
 describe('ci-visibility/requests/request', () => {
+  let clock
   let timeoutStub
 
   beforeEach(() => {
+    clock = sinon.useFakeTimers({ now: 1_700_000_000_000, toFake: ['Date'] })
+
     // Collapse retry delays (5–7.5 s) to 0 ms so tests don't wait for real time,
     // while leaving small delays (res.setTimeout, 0-ms retries) unchanged.
     const realSetTimeout = setTimeout
@@ -25,6 +28,7 @@ describe('ci-visibility/requests/request', () => {
 
   afterEach(() => {
     timeoutStub.restore()
+    clock.restore()
     nock.cleanAll()
   })
 
@@ -76,6 +80,105 @@ describe('ci-visibility/requests/request', () => {
       assert.strictEqual(err, null)
       assert.strictEqual(res, 'ok')
       assert.strictEqual(statusCode, 200)
+      done()
+    })
+  })
+
+  it('treats X-RateLimit-Reset as a duration in seconds', (done) => {
+    nock('http://localhost:8126')
+      .post('/path')
+      .reply(429, 'rate limited', { 'x-ratelimit-reset': '5' })
+      .post('/path')
+      .reply(200, 'ok')
+
+    request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
+      try {
+        assert.strictEqual(err, null)
+        assert.strictEqual(res, 'ok')
+        assert.strictEqual(statusCode, 200)
+        assert.strictEqual(timeoutStub.calledWith(sinon.match.func, 5000), true)
+      } catch (error) {
+        return done(error)
+      }
+      done()
+    })
+  })
+
+  for (const { name, getHeaders, expectedDelay } of [
+    {
+      name: 'uses Retry-After delay seconds',
+      getHeaders: () => ({ 'retry-after': '3', 'x-ratelimit-reset': '5' }),
+      expectedDelay: 3000,
+    },
+    {
+      name: 'supports Retry-After HTTP dates',
+      getHeaders: () => ({ 'retry-after': new Date(Date.now() + 5000).toUTCString() }),
+      expectedDelay: 5000,
+    },
+    {
+      name: 'supports legacy absolute X-RateLimit-Reset timestamps',
+      getHeaders: () => ({ 'x-ratelimit-reset': String(Date.now() / 1000 + 5) }),
+      expectedDelay: 5000,
+    },
+  ]) {
+    it(name, (done) => {
+      nock('http://localhost:8126')
+        .post('/path')
+        .reply(429, 'rate limited', getHeaders())
+        .post('/path')
+        .reply(200, 'ok')
+
+      request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
+        try {
+          assert.strictEqual(err, null)
+          assert.strictEqual(res, 'ok')
+          assert.strictEqual(statusCode, 200)
+          assert.strictEqual(timeoutStub.calledWith(sinon.match.func, expectedDelay), true)
+        } catch (error) {
+          return done(error)
+        }
+        done()
+      })
+    })
+  }
+
+  it('falls back to X-RateLimit-Reset when Retry-After is negative', (done) => {
+    nock('http://localhost:8126')
+      .post('/path')
+      .reply(429, 'rate limited', {
+        'retry-after': '-1',
+        'x-ratelimit-reset': '5',
+      })
+      .post('/path')
+      .reply(200, 'ok')
+
+    request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
+      try {
+        assert.strictEqual(err, null)
+        assert.strictEqual(res, 'ok')
+        assert.strictEqual(statusCode, 200)
+        assert.strictEqual(timeoutStub.calledWith(sinon.match.func, 5000), true)
+      } catch (error) {
+        return done(error)
+      }
+      done()
+    })
+  })
+
+  it('does not retry a negative X-RateLimit-Reset delay', (done) => {
+    nock('http://localhost:8126')
+      .post('/path')
+      .reply(429, 'rate limited', { 'x-ratelimit-reset': '-1' })
+
+    request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
+      try {
+        assert.ok(err)
+        assert.strictEqual(res, null)
+        assert.strictEqual(statusCode, 429)
+        assert.strictEqual(timeoutStub.called, false)
+      } catch (error) {
+        return done(error)
+      }
       done()
     })
   })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Corrects Test Optimization rate-limit reset parsing in its existing request client:

- Treats `X-RateLimit-Reset` as Datadog's documented duration in seconds.
- Preserves compatibility with realistic Unix epoch values by distinguishing them explicitly.
- Prefers valid `Retry-After` values, including both delay seconds and HTTP dates.
- Rejects negative retry delays and falls back to a valid `X-RateLimit-Reset` value.

### Motivation
<!-- What inspired you to submit this pull request? -->

The request client treated `X-RateLimit-Reset: 5` as an epoch timestamp, producing a zero-delay retry instead of waiting approximately five seconds. It also accepted a negative `Retry-After` as a zero-delay retry, masking a valid reset-header fallback.

This is stack 1 of 3 extracted from #9732:

1. This PR — Test Optimization rate-limit reset parsing
2. #9789 — bounded Test Optimization final-flush lifecycle
3. #9790 — deferred hierarchy preservation and framework terminal errors

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR is entirely scoped to the existing `ci-visibility/requests/request.js`; it does not modify the shared exporter request, retry, or writer implementations, and it does not add a new production module boundary.

Validation:

- 10 focused Test Optimization request tests pass.
- Full `npm run lint` passes on the complete stack.
