### PR TITLE
fix(test-optimization): bound final flush lifecycle

### DIFF
--- a/packages/dd-trace/src/agent/info.js
+++ b/packages/dd-trace/src/agent/info.js
@@ -17,8 +17,10 @@ module.exports = {
  * Fetches agent information from the /info endpoint
  * @param {URL} url - The agent URL
  * @param {Function} callback - Callback function with signature (err, agentInfo)
+ * @param {{ deadline?: number, signal?: AbortSignal }} [options] - Request finalization options
+ * @param {Function} [makeRequest] - Request implementation
  */
-function fetchAgentInfo (url, callback) {
+function fetchAgentInfo (url, callback, options = {}, makeRequest = request) {
   const urlKey = url.href
 
   if (cachedUrl !== null && cachedUrl !== urlKey) {
@@ -29,10 +31,9 @@ function fetchAgentInfo (url, callback) {
     return process.nextTick(callback, null, cachedData)
   }
 
-  request('', {
-    path: '/info',
-    url,
-  }, (err, res) => {
+  options.path = '/info'
+  options.url = url
+  makeRequest('', options, (err, res) => {
     if (err) {
       return callback(err)
     }

--- a/packages/dd-trace/src/bootstrap.js
+++ b/packages/dd-trace/src/bootstrap.js
@@ -17,15 +17,7 @@ if (!global._ddtrace) {
   process.once('beforeExit', function mainBeforeExit () {
     if (globalThis[ddTraceSymbol]?.beforeExitHandlers) {
       for (const handler of globalThis[ddTraceSymbol].beforeExitHandlers) {
-        try {
-          handler()
-        } catch (error) {
-          try {
-            require('./log').error('Error running a beforeExit handler', error)
-          } catch {
-            // Never let one shutdown handler prevent the remaining handlers.
-          }
-        }
+        handler()
       }
     }
   })

--- a/packages/dd-trace/src/bootstrap.js
+++ b/packages/dd-trace/src/bootstrap.js
@@ -17,7 +17,15 @@ if (!global._ddtrace) {
   process.once('beforeExit', function mainBeforeExit () {
     if (globalThis[ddTraceSymbol]?.beforeExitHandlers) {
       for (const handler of globalThis[ddTraceSymbol].beforeExitHandlers) {
-        handler()
+        try {
+          handler()
+        } catch (error) {
+          try {
+            require('./log').error('Error running a beforeExit handler', error)
+          } catch {
+            // Never let one shutdown handler prevent the remaining handlers.
+          }
+        }
       }
     }
   })

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -4,6 +4,7 @@ const AgentWriter = require('../../../exporters/agent/writer')
 const AgentlessWriter = require('../agentless/writer')
 const CoverageWriter = require('../agentless/coverage-writer')
 const CiVisibilityExporter = require('../ci-visibility-exporter')
+const request = require('../request')
 const { fetchAgentInfo } = require('../../../agent/info')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
 
@@ -43,9 +44,20 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       testOptimization,
     } = config
 
+    const initializationController = new AbortController()
+    const initializationOptions = { signal: initializationController.signal }
+    this._initializationRequest = {
+      controller: initializationController,
+      options: initializationOptions,
+    }
+
     fetchAgentInfo(this._url, (err, agentInfo) => {
+      this._initializationRequest = undefined
+      const initializationAborted = initializationController.signal.aborted
+      const agentInfoError = err || (initializationAborted ? initializationController.signal.reason : undefined)
+
       this._isInitialized = true
-      let latestEvpProxyVersion = getLatestEvpProxyVersion(err, agentInfo)
+      let latestEvpProxyVersion = getLatestEvpProxyVersion(agentInfoError, agentInfo)
       const isEvpCompatible = latestEvpProxyVersion >= 2
       this._isGzipCompatible = latestEvpProxyVersion >= 4
 
@@ -72,7 +84,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
         // path with evpProxyPrefix and sets X-Datadog-EVP-Subdomain: api (see uploadTestScreenshot).
         this._testScreenshotUploadUrl = this._url
         if (testOptimization.DD_TEST_FAILED_TEST_REPLAY_ENABLED) {
-          const canFowardLogs = getCanForwardDebuggerLogs(err, agentInfo)
+          const canFowardLogs = getCanForwardDebuggerLogs(agentInfoError, agentInfo)
           if (canFowardLogs) {
             const DynamicInstrumentationLogsWriter = require('../agentless/di-logs-writer')
             this._logsWriter = new DynamicInstrumentationLogsWriter({
@@ -89,14 +101,19 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
           lookup,
           protocolVersion,
           headers,
+          isTestOptimization: true,
         })
         // coverages will never be used, so we discard them
         this._coverageBuffer = []
       }
       this._resolveCanUseCiVisProtocol(isEvpCompatible)
+      if (initializationAborted) {
+        this.resetUncodedTraces()
+        return
+      }
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
-    })
+    }, initializationOptions, request)
   }
 
   setUrl (url, coverageUrl) {

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -73,16 +73,13 @@ class Writer extends BaseWriter {
         Date.now() - startRequestTime
       )
       if (err) {
-        const reason = err.code === 'ABORT_ERR' || err.code === 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
-          ? 'final_flush_timeout'
-          : (statusCode ? 'http_error' : 'network_error')
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
           { endpoint: 'code_coverage', statusCode }
         )
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
-          { endpoint: 'code_coverage', reason }
+          { endpoint: 'code_coverage' }
         )
         log.error('Error sending CI coverage payload', err)
         done(err)

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -1,11 +1,8 @@
 'use strict'
 const getConfig = require('../../../config')
-const request = require('../../../exporters/common/request')
 const log = require('../../../log')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 
-const { CoverageCIVisibilityEncoder } = require('../../../encode/coverage-ci-visibility')
-const BaseWriter = require('../../../exporters/common/writer')
 const {
   incrementCountMetric,
   distributionMetric,
@@ -15,16 +12,34 @@ const {
   TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
   TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
 } = require('../../../ci-visibility/telemetry')
+const { CoverageCIVisibilityEncoder } = require('../../../encode/coverage-ci-visibility')
+const BaseWriter = require('../../../exporters/common/writer')
+const request = require('../request')
+const TestOptimizationRequestTracker = require('./request-tracker')
 
 class Writer extends BaseWriter {
+  #requestTracker
+
   constructor ({ url, evpProxyPrefix = '' }) {
     super(...arguments)
+    this.#requestTracker = new TestOptimizationRequestTracker(this)
     this._url = url
     this._encoder = new CoverageCIVisibilityEncoder(this)
     this._evpProxyPrefix = evpProxyPrefix
   }
 
-  _sendPayload (form, _, done) {
+  /**
+   * Flushes buffered coverage, waiting for tracked requests during finalization.
+   *
+   * @param {(error?: Error) => void} [done]
+   * @param {{ deadline?: number }} [options]
+   * @returns {void}
+   */
+  flush (done, options) {
+    this.#requestTracker.flush(done, options)
+  }
+
+  _sendPayload (form, _, done, flushOptions) {
     const options = {
       path: '/api/v2/citestcov',
       method: 'POST',
@@ -34,6 +49,7 @@ class Writer extends BaseWriter {
       },
       timeout: 15_000,
       url: this._url,
+      deadline: flushOptions?.deadline,
     }
 
     if (this._evpProxyPrefix) {
@@ -50,23 +66,26 @@ class Writer extends BaseWriter {
     incrementCountMetric(TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS, { endpoint: 'code_coverage' })
     distributionMetric(TELEMETRY_ENDPOINT_PAYLOAD_BYTES, { endpoint: 'code_coverage' }, form.size())
 
-    request(form, options, (err, res, statusCode) => {
+    this.#requestTracker.send(request, form, options, (err, res, statusCode) => {
       distributionMetric(
         TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_MS,
         { endpoint: 'code_coverage' },
         Date.now() - startRequestTime
       )
       if (err) {
+        const reason = err.code === 'ABORT_ERR' || err.code === 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
+          ? 'final_flush_timeout'
+          : (statusCode ? 'http_error' : 'network_error')
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
           { endpoint: 'code_coverage', statusCode }
         )
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
-          { endpoint: 'code_coverage' }
+          { endpoint: 'code_coverage', reason }
         )
         log.error('Error sending CI coverage payload', err)
-        done()
+        done(err)
         return
       }
       log.debug('Response from the intake:', res)

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
@@ -1,27 +1,42 @@
 'use strict'
 const getConfig = require('../../../config')
-const request = require('../../../exporters/common/request')
 const log = require('../../../log')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 const { JSONEncoder } = require('../../encode/json-encoder')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
-
 const BaseWriter = require('../../../exporters/common/writer')
+
+const request = require('../request')
+const TestOptimizationRequestTracker = require('./request-tracker')
 
 // Writer used by the integration between Dynamic Instrumentation and Test Visibility
 // It is used to encode and send logs to both the logs intake directly and the
 // `/debugger/v1/input` endpoint in the agent, which is a proxy to the logs intake.
 class DynamicInstrumentationLogsWriter extends BaseWriter {
+  #requestTracker
+
   // TODO: what's a good value for timeout for the logs intake?
   constructor ({ url, timeout = 15_000, isAgentProxy = false }) {
     super(...arguments)
+    this.#requestTracker = new TestOptimizationRequestTracker(this)
     this._url = url
     this._encoder = new JSONEncoder()
     this._isAgentProxy = isAgentProxy
     this.timeout = timeout
   }
 
-  _sendPayload (data, _, done) {
+  /**
+   * Flushes buffered logs, waiting for tracked requests during finalization.
+   *
+   * @param {(error?: Error) => void} [done]
+   * @param {{ deadline?: number }} [options]
+   * @returns {void}
+   */
+  flush (done, options) {
+    this.#requestTracker.flush(done, options)
+  }
+
+  _sendPayload (data, _, done, flushOptions) {
     const options = {
       path: '/api/v2/logs',
       method: 'POST',
@@ -31,6 +46,7 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
       },
       timeout: this.timeout,
       url: this._url,
+      deadline: flushOptions?.deadline,
     }
 
     if (this._isAgentProxy) {
@@ -41,10 +57,10 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Request to the logs intake: ${safeJSONStringify(options)}`)
 
-    request(data, options, (err, res) => {
+    this.#requestTracker.send(request, data, options, (err, res) => {
       if (err) {
         log.error('Error sending DI logs payload', err)
-        done()
+        done(err)
         return
       }
       log.debug('Response from the logs intake:', res)

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/request-tracker.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/request-tracker.js
@@ -1,0 +1,164 @@
+'use strict'
+
+const BaseWriter = require('../../../exporters/common/writer')
+
+const FINAL_FLUSH_TIMEOUT_CODE = 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
+
+class TestOptimizationRequestTracker {
+  #writer
+  #pendingRequests = new Set()
+  #finalFlushes = new Set()
+  #activeFinalFlush
+
+  /**
+   * Creates request tracking for a Test Optimization writer.
+   *
+   * @param {BaseWriter} writer
+   */
+  constructor (writer) {
+    this.#writer = writer
+  }
+
+  /**
+   * Flushes queued payloads and, for a final flush, waits for requests that were
+   * already in flight. The absolute deadline prevents Test Optimization from
+   * keeping the test process alive indefinitely.
+   *
+   * @param {(error?: Error) => void} [done]
+   * @param {{ deadline?: number }} [options]
+   * @returns {void}
+   */
+  flush (done, options) {
+    if (options?.deadline === undefined) {
+      BaseWriter.prototype.flush.call(this.#writer, done, options)
+      return
+    }
+
+    const finalFlush = {
+      deadline: options.deadline,
+      done: done || (() => {}),
+      error: undefined,
+      requests: new Set(),
+      timeoutId: undefined,
+      writerDone: false,
+    }
+    this.#finalFlushes.add(finalFlush)
+
+    for (const pendingRequest of this.#pendingRequests) {
+      this.#attachRequest(finalFlush, pendingRequest)
+    }
+
+    const remaining = Math.max(0, options.deadline - Date.now())
+    finalFlush.timeoutId = setTimeout(() => {
+      const error = new Error('Timed out flushing Test Optimization data')
+      error.code = FINAL_FLUSH_TIMEOUT_CODE
+
+      finalFlush.error ||= error
+      finalFlush.writerDone = true
+
+      for (const pendingRequest of finalFlush.requests) {
+        pendingRequest.finalFlushes.delete(finalFlush)
+        if (pendingRequest.finalFlushes.size === 0) {
+          pendingRequest.controller.abort(error)
+          this.#pendingRequests.delete(pendingRequest)
+        } else {
+          this.#updateRequestDeadline(pendingRequest)
+        }
+      }
+      finalFlush.requests.clear()
+      this.#finishFinalFlush(finalFlush)
+    }, remaining)
+
+    const previousFinalFlush = this.#activeFinalFlush
+    this.#activeFinalFlush = finalFlush
+    try {
+      BaseWriter.prototype.flush.call(this.#writer, (error) => {
+        finalFlush.error ||= error
+        finalFlush.writerDone = true
+        this.#finishFinalFlush(finalFlush)
+      }, options)
+    } finally {
+      this.#activeFinalFlush = previousFinalFlush
+    }
+    this.#finishFinalFlush(finalFlush)
+  }
+
+  /**
+   * Sends and tracks a request so a later final flush can wait for or abort it.
+   *
+   * @param {Function} request
+   * @param {Buffer|string|object} data
+   * @param {object} options
+   * @param {(error: Error|null, result?: string|null, statusCode?: number,
+   *   headers?: import('node:http').IncomingHttpHeaders) => void} callback
+   * @returns {void}
+   */
+  send (request, data, options, callback) {
+    const controller = new AbortController()
+    const requestOptions = { ...options, signal: controller.signal }
+    const pendingRequest = { controller, finalFlushes: new Set(), options: requestOptions }
+    this.#pendingRequests.add(pendingRequest)
+    if (this.#activeFinalFlush) this.#attachRequest(this.#activeFinalFlush, pendingRequest)
+
+    request(data, requestOptions, (error, result, statusCode, headers) => {
+      if (error) {
+        for (const finalFlush of pendingRequest.finalFlushes) finalFlush.error ||= error
+      }
+
+      try {
+        callback(error, result, statusCode, headers)
+      } finally {
+        this.#pendingRequests.delete(pendingRequest)
+        for (const finalFlush of pendingRequest.finalFlushes) {
+          finalFlush.requests.delete(pendingRequest)
+          this.#finishFinalFlush(finalFlush)
+        }
+        pendingRequest.finalFlushes.clear()
+      }
+    })
+  }
+
+  /**
+   * Associates a request with the final flush boundary that must wait for it.
+   *
+   * @param {object} finalFlush
+   * @param {object} pendingRequest
+   * @returns {void}
+   */
+  #attachRequest (finalFlush, pendingRequest) {
+    finalFlush.requests.add(pendingRequest)
+    pendingRequest.finalFlushes.add(finalFlush)
+    this.#updateRequestDeadline(pendingRequest)
+  }
+
+  /**
+   * Gives a shared request the latest deadline of the flushes waiting for it.
+   *
+   * @param {object} pendingRequest
+   * @returns {void}
+   */
+  #updateRequestDeadline (pendingRequest) {
+    let deadline = 0
+    for (const finalFlush of pendingRequest.finalFlushes) {
+      deadline = Math.max(deadline, finalFlush.deadline)
+    }
+    pendingRequest.options.deadline = deadline
+  }
+
+  /**
+   * Completes a final flush callback once its writer and associated requests
+   * have settled.
+   *
+   * @param {object} finalFlush
+   * @returns {void}
+   */
+  #finishFinalFlush (finalFlush) {
+    if (!this.#finalFlushes.has(finalFlush) || !finalFlush.writerDone || finalFlush.requests.size !== 0) return
+
+    this.#finalFlushes.delete(finalFlush)
+    clearTimeout(finalFlush.timeoutId)
+    finalFlush.done(finalFlush.error)
+  }
+}
+
+module.exports = TestOptimizationRequestTracker

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -1,11 +1,8 @@
 'use strict'
 const getConfig = require('../../../config')
-const request = require('../../../exporters/common/request')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 const log = require('../../../log')
 
-const { AgentlessCiVisibilityEncoder } = require('../../../encode/agentless-ci-visibility')
-const BaseWriter = require('../../../exporters/common/writer')
 const {
   incrementCountMetric,
   distributionMetric,
@@ -15,17 +12,35 @@ const {
   TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
   TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
 } = require('../../../ci-visibility/telemetry')
+const { AgentlessCiVisibilityEncoder } = require('../../../encode/agentless-ci-visibility')
+const BaseWriter = require('../../../exporters/common/writer')
+const request = require('../request')
+const TestOptimizationRequestTracker = require('./request-tracker')
 
 class Writer extends BaseWriter {
+  #requestTracker
+
   constructor ({ url, tags, evpProxyPrefix = '' }) {
     super(...arguments)
+    this.#requestTracker = new TestOptimizationRequestTracker(this)
     const { 'runtime-id': runtimeId, env, service } = tags
     this._url = url
     this._encoder = new AgentlessCiVisibilityEncoder(this, { runtimeId, env, service })
     this._evpProxyPrefix = evpProxyPrefix
   }
 
-  _sendPayload (data, _, done) {
+  /**
+   * Flushes buffered events, waiting for tracked requests during finalization.
+   *
+   * @param {(error?: Error) => void} [done]
+   * @param {{ deadline?: number }} [options]
+   * @returns {void}
+   */
+  flush (done, options) {
+    this.#requestTracker.flush(done, options)
+  }
+
+  _sendPayload (data, _, done, flushOptions) {
     const options = {
       path: '/api/v2/citestcycle',
       method: 'POST',
@@ -35,6 +50,7 @@ class Writer extends BaseWriter {
       },
       timeout: 15_000,
       url: this._url,
+      deadline: flushOptions?.deadline,
     }
 
     if (this._evpProxyPrefix) {
@@ -51,23 +67,26 @@ class Writer extends BaseWriter {
     incrementCountMetric(TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS, { endpoint: 'test_cycle' })
     distributionMetric(TELEMETRY_ENDPOINT_PAYLOAD_BYTES, { endpoint: 'test_cycle' }, Buffer.byteLength(data))
 
-    request(data, options, (err, res, statusCode) => {
+    this.#requestTracker.send(request, data, options, (err, res, statusCode) => {
       distributionMetric(
         TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_MS,
         { endpoint: 'test_cycle' },
         Date.now() - startRequestTime
       )
       if (err) {
+        const reason = err.code === 'ABORT_ERR' || err.code === 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
+          ? 'final_flush_timeout'
+          : (statusCode ? 'http_error' : 'network_error')
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
           { endpoint: 'test_cycle', statusCode }
         )
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
-          { endpoint: 'test_cycle' }
+          { endpoint: 'test_cycle', reason }
         )
         log.error('Error sending CI agentless payload', err)
-        done()
+        done(err)
         return
       }
       log.debug('Response from the intake:', res)

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -74,16 +74,13 @@ class Writer extends BaseWriter {
         Date.now() - startRequestTime
       )
       if (err) {
-        const reason = err.code === 'ABORT_ERR' || err.code === 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
-          ? 'final_flush_timeout'
-          : (statusCode ? 'http_error' : 'network_error')
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
           { endpoint: 'test_cycle', statusCode }
         )
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
-          { endpoint: 'test_cycle', reason }
+          { endpoint: 'test_cycle' }
         )
         log.error('Error sending CI agentless payload', err)
         done(err)

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -99,7 +99,7 @@ function getLogTags (logMessage, { env, version }, gitRepositoryUrl, gitCommitSh
 
 class CiVisibilityExporter extends BufferingExporter {
   #finalFlush
-  #deferredHierarchyTraces = []
+  #deferredTestSessionTraces = []
 
   constructor (config, options = {}) {
     super(config)
@@ -407,7 +407,7 @@ class CiVisibilityExporter extends BufferingExporter {
   }
 
   /**
-   * Exports spans that are not retained for late hierarchy updates.
+   * Exports spans that are not retained for late updates to session, module, or suite events.
    *
    * @param {Array<object>} trace
    * @returns {void}
@@ -418,32 +418,32 @@ class CiVisibilityExporter extends BufferingExporter {
       this._traceBuffer.push(trace)
       return
     }
-    const isHierarchyTrace = getIsTestSessionTrace(trace)
-    if (!this.canReportSessionTraces() && isHierarchyTrace) {
+    const isTestSessionTrace = getIsTestSessionTrace(trace)
+    if (!this.canReportSessionTraces() && isTestSessionTrace) {
       return
     }
-    if (this._export(trace, undefined, undefined, isHierarchyTrace) === false && isHierarchyTrace) {
-      this.#deferredHierarchyTraces.push(trace)
+    if (this._export(trace, undefined, undefined, isTestSessionTrace) === false && isTestSessionTrace) {
+      this.#deferredTestSessionTraces.push(trace)
     }
   }
 
   /**
-   * Retries hierarchy traces rejected by writer backpressure within the final deadline.
+   * Retries session, module, and suite traces rejected by writer backpressure within the final deadline.
    *
    * @param {{ deadline?: number }} options final-flush options
    * @returns {void}
    */
-  #exportDeferredHierarchyTraces (options) {
+  #exportDeferredTestSessionTraces (options) {
     if (!this._writer || !this.canReportSessionTraces()) return
 
     let retainedCount = 0
 
-    for (const trace of this.#deferredHierarchyTraces) {
+    for (const trace of this.#deferredTestSessionTraces) {
       if (this._writer.append(trace, options) === false) {
-        this.#deferredHierarchyTraces[retainedCount++] = trace
+        this.#deferredTestSessionTraces[retainedCount++] = trace
       }
     }
-    this.#deferredHierarchyTraces.length = retainedCount
+    this.#deferredTestSessionTraces.length = retainedCount
   }
 
   exportCoverage (formattedCoverage) {
@@ -514,7 +514,7 @@ class CiVisibilityExporter extends BufferingExporter {
 
     if (isFinalFlush && !this._isInitialized &&
       this._traceBuffer.length === 0 && this._coverageBuffer.length === 0 &&
-      this.#deferredHierarchyTraces.length === 0) {
+      this.#deferredTestSessionTraces.length === 0) {
       onDone()
       return
     }
@@ -559,7 +559,7 @@ class CiVisibilityExporter extends BufferingExporter {
     const flushWriters = () => {
       const options = deadline === undefined ? undefined : { deadline }
       if (isFinalFlush) {
-        this.#exportDeferredHierarchyTraces(options)
+        this.#exportDeferredTestSessionTraces(options)
       }
 
       const writers = [

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -57,6 +57,17 @@ function getIsTestSessionTrace (trace) {
 const GIT_UPLOAD_TIMEOUT = 60_000 // 60 seconds
 const CAN_USE_CI_VIS_PROTOCOL_TIMEOUT = GIT_UPLOAD_TIMEOUT
 const MAX_COVERAGE_REPORT_FLAGS = 32
+const FINAL_FLUSH_TIMEOUT = 10_000
+const FINAL_FLUSH_FALLBACK_DELAY = 100
+
+/**
+ * @returns {Error}
+ */
+function createFinalFlushTimeoutError () {
+  const error = new Error('Timed out waiting for Test Optimization to flush')
+  error.code = 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
+  return error
+}
 
 function appendLogTag (tags, key, value) {
   if (value !== undefined) {
@@ -87,6 +98,9 @@ function getLogTags (logMessage, { env, version }, gitRepositoryUrl, gitCommitSh
 }
 
 class CiVisibilityExporter extends BufferingExporter {
+  #finalFlush
+  #deferredHierarchyTraces = []
+
   constructor (config, options = {}) {
     super(config)
     this._timer = undefined
@@ -137,18 +151,7 @@ class CiVisibilityExporter extends BufferingExporter {
       }
     })
 
-    const flush = () => {
-      if (this._writer) {
-        this._writer.flush()
-      }
-      if (this._coverageWriter) {
-        this._coverageWriter.flush()
-      }
-      if (this._logsWriter) {
-        this._logsWriter.flush()
-      }
-    }
-    globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(flush.bind(this))
+    globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(() => this.flush(() => {}))
   }
 
   shouldRequestSkippableSuites () {
@@ -399,18 +402,53 @@ class CiVisibilityExporter extends BufferingExporter {
   }
 
   export (trace) {
+    this.#resetFinalFlush()
+    this.#exportTrace(trace)
+  }
+
+  /**
+   * Exports spans that are not retained for late hierarchy updates.
+   *
+   * @param {Array<object>} trace
+   * @returns {void}
+   */
+  #exportTrace (trace) {
     // Until it's initialized, we just store the traces as is
     if (!this._isInitialized) {
       this._traceBuffer.push(trace)
       return
     }
-    if (!this.canReportSessionTraces() && getIsTestSessionTrace(trace)) {
+    const isHierarchyTrace = getIsTestSessionTrace(trace)
+    if (!this.canReportSessionTraces() && isHierarchyTrace) {
       return
     }
-    this._export(trace)
+    if (this._export(trace, undefined, undefined, isHierarchyTrace) === false && isHierarchyTrace) {
+      this.#deferredHierarchyTraces.push(trace)
+    }
+  }
+
+  /**
+   * Retries hierarchy traces rejected by writer backpressure within the final deadline.
+   *
+   * @param {{ deadline?: number }} options final-flush options
+   * @returns {void}
+   */
+  #exportDeferredHierarchyTraces (options) {
+    if (!this._writer || !this.canReportSessionTraces()) return
+
+    let retainedCount = 0
+
+    for (const trace of this.#deferredHierarchyTraces) {
+      if (this._writer.append(trace, options) === false) {
+        this.#deferredHierarchyTraces[retainedCount++] = trace
+      }
+    }
+    this.#deferredHierarchyTraces.length = retainedCount
   }
 
   exportCoverage (formattedCoverage) {
+    this.#resetFinalFlush()
+
     // Until it's initialized, we just store the coverages as is
     if (!this._isInitialized) {
       this._coverageBuffer.push(formattedCoverage)
@@ -455,6 +493,7 @@ class CiVisibilityExporter extends BufferingExporter {
       return
     }
 
+    this.#resetFinalFlush()
     this._export(
       this.formatLogMessage(testEnvironmentMetadata, logMessage),
       this._logsWriter,
@@ -462,32 +501,126 @@ class CiVisibilityExporter extends BufferingExporter {
     )
   }
 
-  flush (done = () => {}) {
-    if (!this._isInitialized) {
-      return done()
+  flush (done) {
+    const isFinalFlush = typeof done === 'function'
+    const onDone = done || (() => {})
+    let finalFlush
+
+    if (isFinalFlush && this.#finalFlush) {
+      if (this.#finalFlush.completed) onDone(this.#finalFlush.error)
+      else this.#finalFlush.callbacks.push(onDone)
+      return
     }
 
-    // TODO: safe to do them at once? Or do we want to do them one by one?
-    const writers = [
-      this._writer,
-      this._coverageWriter,
-      this._logsWriter,
-    ].filter(Boolean)
-
-    let remaining = writers.length
-
-    if (remaining === 0) {
-      return done()
+    if (isFinalFlush && !this._isInitialized &&
+      this._traceBuffer.length === 0 && this._coverageBuffer.length === 0 &&
+      this.#deferredHierarchyTraces.length === 0) {
+      onDone()
+      return
     }
 
-    const onFlushComplete = () => {
-      remaining -= 1
-      if (remaining === 0) {
-        done()
+    if (isFinalFlush) {
+      finalFlush = {
+        callbacks: [onDone],
+        completed: false,
+        error: undefined,
       }
+      this.#finalFlush = finalFlush
     }
 
-    for (const writer of writers) writer.flush(onFlushComplete)
+    const deadline = isFinalFlush ? Date.now() + FINAL_FLUSH_TIMEOUT : undefined
+    let hasCompleted = false
+    let initializationTimeoutId
+
+    const fallbackTimeoutId = isFinalFlush
+      ? setTimeout(() => {
+        complete(createFinalFlushTimeoutError())
+      }, FINAL_FLUSH_TIMEOUT + FINAL_FLUSH_FALLBACK_DELAY)
+      : undefined
+
+    const complete = (error) => {
+      if (hasCompleted) return
+      hasCompleted = true
+      clearTimeout(fallbackTimeoutId)
+      clearTimeout(initializationTimeoutId)
+      if (error) log.error('Error flushing Test Optimization data', error)
+      if (!isFinalFlush) {
+        onDone(error)
+        return
+      }
+
+      finalFlush.completed = true
+      finalFlush.error = error
+      const callbacks = finalFlush.callbacks
+      finalFlush.callbacks = []
+      for (const callback of callbacks) callback(error)
+    }
+
+    const flushWriters = () => {
+      const options = deadline === undefined ? undefined : { deadline }
+      if (isFinalFlush) {
+        this.#exportDeferredHierarchyTraces(options)
+      }
+
+      const writers = [
+        this._writer,
+        this._coverageWriter,
+        this._logsWriter,
+      ].filter(Boolean)
+
+      let remaining = writers.length
+      let flushError
+
+      if (remaining === 0) {
+        complete()
+        return
+      }
+
+      const onFlushComplete = (error) => {
+        flushError ||= error
+        remaining -= 1
+        if (remaining === 0) complete(flushError)
+      }
+
+      for (const writer of writers) writer.flush(onFlushComplete, options)
+    }
+
+    if (isFinalFlush && this._initializationRequest) {
+      const initializationRequest = this._initializationRequest
+      const { controller, options } = initializationRequest
+      initializationRequest.finalFlush = finalFlush
+      options.deadline = deadline
+      initializationTimeoutId = setTimeout(() => {
+        const error = createFinalFlushTimeoutError()
+        if (initializationRequest.finalFlush === finalFlush) controller.abort(error)
+        complete(error)
+      }, Math.max(0, deadline - Date.now()))
+    }
+
+    if (!isFinalFlush) {
+      if (this._isInitialized) flushWriters()
+      else complete()
+      return
+    }
+
+    if (this._isInitialized) {
+      flushWriters()
+      return
+    }
+
+    this._canUseCiVisProtocolPromise.then(() => {
+      clearTimeout(initializationTimeoutId)
+      if (!hasCompleted) flushWriters()
+    })
+  }
+
+  /**
+   * Allows later test activity to establish a new finalization boundary.
+   *
+   * @returns {void}
+   */
+  #resetFinalFlush () {
+    this.#finalFlush = undefined
   }
 
   exportUncodedCoverages () {
@@ -572,9 +705,10 @@ class CiVisibilityExporter extends BufferingExporter {
    * @param {string} options.traceId - Test trace id used as the screenshot key
    * @param {string} options.idempotencyKey - Stable per-artifact key, reused on retry
    * @param {number} options.capturedAtMs - Capture time in epoch milliseconds
+   * @param {AbortSignal} [options.signal] - Signal used to cancel the upload
    * @param {Function} callback - Callback function (err)
    */
-  uploadTestScreenshot ({ filePath, traceId, idempotencyKey, capturedAtMs }, callback) {
+  uploadTestScreenshot ({ filePath, traceId, idempotencyKey, capturedAtMs, signal }, callback) {
     if (!this._testScreenshotUploadUrl) {
       return callback(new Error('Test screenshot upload URL not configured'))
     }
@@ -587,6 +721,7 @@ class CiVisibilityExporter extends BufferingExporter {
       url: this._testScreenshotUploadUrl,
       isEvpProxy: !!this._isUsingEvpProxy,
       evpProxyPrefix: this.evpProxyPrefix,
+      signal,
     }, callback)
   }
 }

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -100,6 +100,8 @@ function getLogTags (logMessage, { env, version }, gitRepositoryUrl, gitCommitSh
 class CiVisibilityExporter extends BufferingExporter {
   #finalFlush
   #deferredTestSessionTraces = []
+  #pendingScreenshotUploads = new Set()
+  #screenshotFlushWaiters = new Set()
 
   constructor (config, options = {}) {
     super(config)
@@ -514,7 +516,7 @@ class CiVisibilityExporter extends BufferingExporter {
 
     if (isFinalFlush && !this._isInitialized &&
       this._traceBuffer.length === 0 && this._coverageBuffer.length === 0 &&
-      this.#deferredTestSessionTraces.length === 0) {
+      this.#deferredTestSessionTraces.length === 0 && this.#pendingScreenshotUploads.size === 0) {
       onDone()
       return
     }
@@ -543,6 +545,7 @@ class CiVisibilityExporter extends BufferingExporter {
       hasCompleted = true
       clearTimeout(fallbackTimeoutId)
       clearTimeout(initializationTimeoutId)
+      this.#screenshotFlushWaiters.delete(flushWriters)
       if (error) log.error('Error flushing Test Optimization data', error)
       if (!isFinalFlush) {
         onDone(error)
@@ -557,6 +560,11 @@ class CiVisibilityExporter extends BufferingExporter {
     }
 
     const flushWriters = () => {
+      if (isFinalFlush && this.#pendingScreenshotUploads.size !== 0) {
+        this.#screenshotFlushWaiters.add(flushWriters)
+        return
+      }
+
       const options = deadline === undefined ? undefined : { deadline }
       if (isFinalFlush) {
         this.#exportDeferredTestSessionTraces(options)
@@ -705,12 +713,53 @@ class CiVisibilityExporter extends BufferingExporter {
    * @param {string} options.traceId - Test trace id used as the screenshot key
    * @param {string} options.idempotencyKey - Stable per-artifact key, reused on retry
    * @param {number} options.capturedAtMs - Capture time in epoch milliseconds
-   * @param {AbortSignal} [options.signal] - Signal used to cancel the upload
+   * @param {AbortSignal} [options.signal] - Additional signal used to cancel the upload
    * @param {Function} callback - Callback function (err)
    */
   uploadTestScreenshot ({ filePath, traceId, idempotencyKey, capturedAtMs, signal }, callback) {
     if (!this._testScreenshotUploadUrl) {
       return callback(new Error('Test screenshot upload URL not configured'))
+    }
+
+    this.#resetFinalFlush()
+    const controller = new AbortController()
+    const deadline = Date.now() + FINAL_FLUSH_TIMEOUT
+    let settled = false
+    const complete = (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      signal?.removeEventListener('abort', onAbort)
+
+      try {
+        callback(error)
+      } finally {
+        this.#pendingScreenshotUploads.delete(controller)
+        if (this.#pendingScreenshotUploads.size === 0) {
+          const waiters = [...this.#screenshotFlushWaiters]
+          this.#screenshotFlushWaiters.clear()
+          for (const waiter of waiters) queueMicrotask(waiter)
+        }
+      }
+    }
+    const onAbort = () => {
+      const error = signal.reason || Object.assign(new Error('Test screenshot upload aborted'), { code: 'ABORT_ERR' })
+      controller.abort(error)
+      complete(error)
+    }
+
+    this.#pendingScreenshotUploads.add(controller)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    const timeoutId = setTimeout(() => {
+      const error = createFinalFlushTimeoutError()
+      controller.abort(error)
+      complete(error)
+    }, FINAL_FLUSH_TIMEOUT)
+    timeoutId.unref?.()
+
+    if (signal?.aborted) {
+      onAbort()
+      return
     }
 
     uploadTestScreenshotRequest({
@@ -721,8 +770,9 @@ class CiVisibilityExporter extends BufferingExporter {
       url: this._testScreenshotUploadUrl,
       isEvpProxy: !!this._isUsingEvpProxy,
       evpProxyPrefix: this.evpProxyPrefix,
-      signal,
-    }, callback)
+      deadline,
+      signal: controller.signal,
+    }, complete)
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -556,7 +556,13 @@ class CiVisibilityExporter extends BufferingExporter {
       finalFlush.error = error
       const callbacks = finalFlush.callbacks
       finalFlush.callbacks = []
-      for (const callback of callbacks) callback(error)
+      for (const callback of callbacks) {
+        try {
+          callback(error)
+        } catch (callbackError) {
+          log.error('Error completing Test Optimization flush callback', callbackError)
+        }
+      }
     }
 
     const flushWriters = () => {

--- a/packages/dd-trace/src/ci-visibility/exporters/request.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/request.js
@@ -9,7 +9,7 @@ const {
   getRetryDelay,
   isRetriableNetworkError,
 } = require('../../exporters/common/retry')
-const { getRateLimitResetDelay } = require('../requests/retry')
+const { getRateLimitResetDelay } = require('../requests/rate-limit')
 
 /**
  * @param {AbortSignal} signal

--- a/packages/dd-trace/src/ci-visibility/exporters/request.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/request.js
@@ -1,0 +1,201 @@
+'use strict'
+
+const { Readable } = require('node:stream')
+
+const commonRequest = require('../../exporters/common/request')
+const {
+  RATE_LIMIT_MAX_WAIT_MS,
+  getMaxAttempts,
+  getRetryDelay,
+  isRetriableNetworkError,
+} = require('../../exporters/common/retry')
+const { getRateLimitResetDelay } = require('../requests/retry')
+
+/**
+ * @param {AbortSignal} signal
+ * @returns {Error}
+ */
+function getAbortError (signal) {
+  return signal.reason || Object.assign(new Error('Request aborted'), { code: 'ABORT_ERR' })
+}
+
+/**
+ * Buffers a stream once so a Test Optimization exporter request can safely retry it.
+ *
+ * @param {Readable} data
+ * @param {AbortSignal} [signal]
+ * @param {(error: Error|null, data?: Buffer) => void} callback
+ * @returns {void}
+ */
+function bufferReadable (data, signal, callback) {
+  const chunks = []
+  let settled = false
+
+  const cleanup = (keepErrorListener = false) => {
+    data.removeListener('data', onData)
+    data.removeListener('end', onEnd)
+    if (!keepErrorListener) data.removeListener('error', onError)
+    signal?.removeEventListener('abort', onAbort)
+  }
+  const onData = chunk => chunks.push(chunk)
+  const onEnd = () => {
+    if (settled) return
+    settled = true
+    cleanup()
+    callback(null, Buffer.concat(chunks))
+  }
+  const onError = error => {
+    if (settled) return
+    settled = true
+    cleanup()
+    callback(error)
+  }
+  const onAbort = () => {
+    if (settled) return
+    settled = true
+    cleanup(true)
+    data.once('close', () => data.removeListener('error', onError))
+    data.destroy()
+    callback(getAbortError(signal))
+  }
+
+  data.on('data', onData)
+  data.once('end', onEnd)
+  data.once('error', onError)
+  signal?.addEventListener('abort', onAbort, { once: true })
+  if (signal?.aborted) onAbort()
+}
+
+/**
+ * Sends Test Optimization exporter data through the common single-attempt transport while
+ * keeping retry and finalization policy scoped to Test Optimization.
+ *
+ * @param {Buffer|string|Readable|Array<Buffer|string>} data
+ * @param {object} options
+ * @param {(error: Error|null, result?: string|null, statusCode?: number,
+ *   headers?: import('node:http').IncomingHttpHeaders) => void} callback
+ * @returns {void}
+ */
+function request (data, options, callback) {
+  const { signal } = options
+  if (signal?.aborted) return callback(getAbortError(signal))
+
+  if (data instanceof Readable) {
+    bufferReadable(data, signal, (error, bufferedData) => {
+      if (error) return callback(error)
+      requestBuffered(bufferedData, options, callback)
+    })
+    return
+  }
+
+  requestBuffered(data, options, callback)
+}
+
+/**
+ * Applies the Test Optimization retry policy to replayable request data.
+ *
+ * @param {Buffer|string|Array<Buffer|string>} data
+ * @param {object} options
+ * @param {(error: Error|null, result?: string|null, statusCode?: number,
+ *   headers?: import('node:http').IncomingHttpHeaders) => void} callback
+ * @returns {void}
+ */
+function requestBuffered (data, options, callback) {
+  const { signal } = options
+  const timeout = options.timeout || 2000
+  let retryTimer
+  let settled = false
+
+  const complete = (error, result, statusCode, headers) => {
+    if (settled) return
+    settled = true
+    clearTimeout(retryTimer)
+    signal?.removeEventListener('abort', onAbort)
+    callback(error, result, statusCode, headers)
+  }
+  const onAbort = () => complete(getAbortError(signal))
+
+  signal?.addEventListener('abort', onAbort, { once: true })
+  if (signal?.aborted) return onAbort()
+
+  /** @param {number} attemptIndex */
+  const attempt = attemptIndex => {
+    if (settled) return
+    if (signal?.aborted) return onAbort()
+
+    const deadline = options.deadline
+    const remaining = deadline === undefined ? Infinity : deadline - Date.now()
+    if (remaining <= 0) {
+      const error = new Error('Test Optimization request reached its finalization deadline')
+      error.code = 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT'
+      complete(error)
+      return
+    }
+
+    if (deadline !== undefined && !commonRequest.writable) {
+      retryTimer = setTimeout(attempt, Math.min(50, remaining), attemptIndex)
+      retryTimer.unref?.()
+      return
+    }
+
+    const attemptOptions = {
+      ...options,
+      headers: options.headers ? { ...options.headers } : undefined,
+      retry: false,
+    }
+    if (deadline !== undefined) attemptOptions.timeout = Math.max(1, Math.min(timeout, remaining))
+
+    commonRequest(data, attemptOptions, (error, result, statusCode, headers) => {
+      if (settled) return
+      if (!error) {
+        complete(null, result, statusCode, headers)
+        return
+      }
+
+      const responseStatus = statusCode ?? error.status
+      const isRetriableHttpError = options.deadline !== undefined &&
+        (responseStatus === 429 || responseStatus >= 500)
+      if (options.retry === false || (attemptIndex >= getMaxAttempts(attemptOptions) &&
+        (isRetriableNetworkError(error) || isRetriableHttpError))) {
+        complete(error, result, statusCode, headers)
+        return
+      }
+
+      if (!isRetriableNetworkError(error) && !isRetriableHttpError) {
+        complete(error, result, statusCode, headers)
+        return
+      }
+
+      let retryDelay
+      if (responseStatus === 429) {
+        const resetDelay = getRateLimitResetDelay(headers)
+        if (Number.isFinite(resetDelay)) {
+          const retryRemaining = options.deadline - Date.now()
+          if (resetDelay > RATE_LIMIT_MAX_WAIT_MS || resetDelay >= retryRemaining) {
+            complete(error, result, statusCode, headers)
+            return
+          }
+          retryDelay = resetDelay
+        }
+      }
+
+      let delay = retryDelay ?? getRetryDelay(attemptOptions, attemptIndex)
+      if (options.deadline !== undefined && retryDelay === undefined) {
+        const retryRemaining = options.deadline - Date.now()
+        if (retryRemaining <= 0) {
+          complete(error, result, statusCode, headers)
+          return
+        }
+        const retryAttemptTimeout = timeout < retryRemaining ? timeout : Math.ceil(retryRemaining / 2)
+        delay = Math.min(delay, Math.max(0, retryRemaining - retryAttemptTimeout))
+      }
+
+      retryTimer = setTimeout(attempt, delay, attemptIndex + 1)
+      retryTimer.unref?.()
+    })
+  }
+
+  attempt(1)
+}
+
+module.exports = request

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/index.js
@@ -127,7 +127,7 @@ class TestWorkerCiVisibilityExporter {
   }
 
   /**
-   * @param {() => void} [onDone]
+   * @param {(error?: Error) => void} [onDone]
    */
   flush (onDone) {
     if (!onDone) {
@@ -141,9 +141,11 @@ class TestWorkerCiVisibilityExporter {
     }
 
     let pendingWriters = this._telemetryWriter ? 4 : 3
-    const onWriterFlushed = () => {
+    let flushError
+    const onWriterFlushed = (error) => {
+      flushError ||= error
       pendingWriters--
-      if (pendingWriters === 0) onDone()
+      if (pendingWriters === 0) onDone(flushError)
     }
 
     this._writer.flush(onWriterFlushed)

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
@@ -21,7 +21,7 @@ class Writer {
   }
 
   /**
-   * @param {() => void} [onDone]
+   * @param {(error?: Error) => void} [onDone]
    */
   flush (onDone) {
     const count = this._encoder.count()
@@ -69,8 +69,9 @@ class Writer {
 
     // child_process workers (jest default, cucumber)
     if (process.send) {
-      process.send(payload, () => {
-        onDone()
+      process.send(payload, (error) => {
+        if (error) log.error('Error sending message to parent process', error)
+        onDone(error)
       })
       return
     }
@@ -82,9 +83,12 @@ class Writer {
         parentPort.postMessage(payload)
       } catch (error) {
         log.error('Error posting message to parent port', error)
-      } finally {
-        onDone()
+        onDone(error)
+        return
       }
+      // postMessage has no acknowledgement callback. Completion means the
+      // message was accepted by the local port, not processed by the parent.
+      onDone()
       return
     }
 

--- a/packages/dd-trace/src/ci-visibility/requests/rate-limit.js
+++ b/packages/dd-trace/src/ci-visibility/requests/rate-limit.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const EPOCH_SECONDS_THRESHOLD = 1_000_000_000
+
+/**
+ * Returns the delay requested by a Test Optimization intake rate-limit response.
+ *
+ * @param {import('node:http').IncomingHttpHeaders} [headers]
+ * @returns {number}
+ */
+function getRateLimitResetDelay (headers) {
+  let retryAfter = headers?.['retry-after']
+  if (Array.isArray(retryAfter)) retryAfter = retryAfter[0]
+  if (typeof retryAfter === 'string' && retryAfter.trim() !== '') {
+    const delaySeconds = Number(retryAfter)
+    if (Number.isFinite(delaySeconds)) {
+      if (delaySeconds >= 0) return delaySeconds * 1000
+    } else {
+      const resetTimestamp = Date.parse(retryAfter)
+      if (Number.isFinite(resetTimestamp)) return Math.max(0, resetTimestamp - Date.now())
+    }
+  }
+
+  let reset = headers?.['x-ratelimit-reset']
+  if (Array.isArray(reset)) reset = reset[0]
+  if (typeof reset !== 'string' || reset.trim() === '') return NaN
+
+  const resetSeconds = Number(reset)
+  if (!Number.isFinite(resetSeconds) || resetSeconds < 0) return NaN
+
+  // Datadog defines this header as delay seconds. Preserve compatibility with
+  // realistic Unix timestamps without confusing ordinary durations with epochs.
+  if (resetSeconds >= EPOCH_SECONDS_THRESHOLD) {
+    return Math.max(0, resetSeconds * 1000 - Date.now())
+  }
+  return resetSeconds * 1000
+}
+
+module.exports = { getRateLimitResetDelay }

--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -13,43 +13,9 @@ const {
   singleJitteredDelay,
 } = require('../../exporters/common/retry')
 const { parseUrl } = require('../../exporters/common/url')
+const { getRateLimitResetDelay } = require('./rate-limit')
 
 const legacyStorage = storage('legacy')
-const EPOCH_SECONDS_THRESHOLD = 1_000_000_000
-
-/**
- * Returns the delay requested by a Test Optimization intake rate-limit response.
- *
- * @param {import('node:http').IncomingHttpHeaders} [headers]
- * @returns {number}
- */
-function getRateLimitResetDelay (headers) {
-  let retryAfter = headers?.['retry-after']
-  if (Array.isArray(retryAfter)) retryAfter = retryAfter[0]
-  if (typeof retryAfter === 'string' && retryAfter.trim() !== '') {
-    const delaySeconds = Number(retryAfter)
-    if (Number.isFinite(delaySeconds)) {
-      if (delaySeconds >= 0) return delaySeconds * 1000
-    } else {
-      const resetTimestamp = Date.parse(retryAfter)
-      if (Number.isFinite(resetTimestamp)) return Math.max(0, resetTimestamp - Date.now())
-    }
-  }
-
-  let reset = headers?.['x-ratelimit-reset']
-  if (Array.isArray(reset)) reset = reset[0]
-  if (typeof reset !== 'string' || reset.trim() === '') return NaN
-
-  const resetSeconds = Number(reset)
-  if (!Number.isFinite(resetSeconds) || resetSeconds < 0) return NaN
-
-  // Datadog defines this header as delay seconds. Preserve compatibility with
-  // realistic Unix timestamps without confusing ordinary durations with epochs.
-  if (resetSeconds >= EPOCH_SECONDS_THRESHOLD) {
-    return Math.max(0, resetSeconds * 1000 - Date.now())
-  }
-  return resetSeconds * 1000
-}
 
 /**
  * Simplified HTTP request for test optimization (library config). Uses common HTTP agents.

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -4,8 +4,8 @@ const { readFileSync } = require('node:fs')
 const { extname } = require('node:path')
 
 const getConfig = require('../../config')
-const request = require('../../exporters/common/request')
 const log = require('../../log')
+const request = require('../exporters/request')
 
 const UPLOAD_TIMEOUT_MS = 30_000
 const TEST_SCREENSHOT_ENDPOINT_PREFIX = '/api/v2/ci/test-runs/'
@@ -74,11 +74,12 @@ function toIdempotencyQueryValue (idempotencyKey) {
  * @param {URL} options.url - The base URL for the screenshot upload
  * @param {boolean} [options.isEvpProxy] - Whether to upload through the Agent's evp_proxy
  * @param {string} [options.evpProxyPrefix] - The evp_proxy path prefix (e.g. '/evp_proxy/v4')
+ * @param {number} [options.deadline] - Absolute finalization deadline in epoch milliseconds
  * @param {AbortSignal} [options.signal] - Signal used to cancel the upload
  * @param {Function} callback - Callback function (err)
  */
 function uploadTestScreenshot (
-  { filePath, traceId, idempotencyKey, capturedAtMs, url, isEvpProxy, evpProxyPrefix, signal },
+  { filePath, traceId, idempotencyKey, capturedAtMs, url, isEvpProxy, evpProxyPrefix, deadline, signal },
   callback
 ) {
   const { DD_API_KEY } = getConfig()
@@ -126,6 +127,7 @@ function uploadTestScreenshot (
     path: `${basePath}?${query}`,
     timeout: UPLOAD_TIMEOUT_MS,
     url,
+    deadline,
     signal,
   }
 

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -74,10 +74,11 @@ function toIdempotencyQueryValue (idempotencyKey) {
  * @param {URL} options.url - The base URL for the screenshot upload
  * @param {boolean} [options.isEvpProxy] - Whether to upload through the Agent's evp_proxy
  * @param {string} [options.evpProxyPrefix] - The evp_proxy path prefix (e.g. '/evp_proxy/v4')
+ * @param {AbortSignal} [options.signal] - Signal used to cancel the upload
  * @param {Function} callback - Callback function (err)
  */
 function uploadTestScreenshot (
-  { filePath, traceId, idempotencyKey, capturedAtMs, url, isEvpProxy, evpProxyPrefix },
+  { filePath, traceId, idempotencyKey, capturedAtMs, url, isEvpProxy, evpProxyPrefix, signal },
   callback
 ) {
   const { DD_API_KEY } = getConfig()
@@ -125,6 +126,7 @@ function uploadTestScreenshot (
     path: `${basePath}?${query}`,
     timeout: UPLOAD_TIMEOUT_MS,
     url,
+    signal,
   }
 
   if (isEvpProxy) {

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -3,7 +3,7 @@
 const { inspect } = require('node:util')
 const { channel } = require('dc-polyfill')
 
-const request = require('../common/request')
+const commonRequest = require('../common/request')
 const { logIntegrations, logAgentError } = require('../../startup-log')
 const runtimeMetrics = require('../../runtime_metrics')
 const log = require('../../log')
@@ -15,12 +15,15 @@ const METRIC_PREFIX = 'datadog.tracer.node.exporter.agent'
 const firstFlushChannel = channel('dd-trace:exporter:first-flush')
 
 class AgentWriter extends BaseWriter {
+  #request = commonRequest
+  #requestTracker
+
   constructor (...args) {
     super({
       ...args[0],
       beforeFirstFlush: () => firstFlushChannel.publish(),
     })
-    const { prioritySampler, lookup, protocolVersion, headers } = args[0]
+    const { prioritySampler, lookup, protocolVersion, headers, isTestOptimization } = args[0]
     const AgentEncoder = getEncoder(protocolVersion)
 
     this._prioritySampler = prioritySampler
@@ -28,13 +31,33 @@ class AgentWriter extends BaseWriter {
     this._protocolVersion = protocolVersion
     this._headers = headers
     this._encoder = new AgentEncoder(this)
+    if (isTestOptimization) {
+      this.#request = require('../../ci-visibility/exporters/request')
+      const TestOptimizationRequestTracker = require('../../ci-visibility/exporters/agentless/request-tracker')
+      this.#requestTracker = new TestOptimizationRequestTracker(this)
+    }
   }
 
-  _sendPayload (data, count, done) {
+  /**
+   * Flushes payloads, including requests already in flight during Test Optimization finalization.
+   *
+   * @param {(error?: Error) => void} [done]
+   * @param {{ deadline?: number }} [options]
+   * @returns {void}
+   */
+  flush (done, options) {
+    if (this.#requestTracker) {
+      this.#requestTracker.flush(done, options)
+      return
+    }
+    super.flush(done, options)
+  }
+
+  _sendPayload (data, count, done, flushOptions) {
     runtimeMetrics.increment(`${METRIC_PREFIX}.requests`, true)
 
     const { _headers, _lookup, _protocolVersion, _url } = this
-    makeRequest(_protocolVersion, data, count, _url, _headers, _lookup, (err, res, status, headers) => {
+    const onResponse = (err, res, status, headers) => {
       if (status) {
         runtimeMetrics.increment(`${METRIC_PREFIX}.responses`, true)
         runtimeMetrics.increment(`${METRIC_PREFIX}.responses.by.status`, `status:${status}`, true)
@@ -49,7 +72,7 @@ class AgentWriter extends BaseWriter {
 
       if (err) {
         log.errorWithoutTelemetry('Error sending payload to the agent (status code: %s)', err.status, err)
-        done()
+        done(flushOptions?.deadline === undefined ? undefined : err)
         return
       }
 
@@ -74,7 +97,19 @@ class AgentWriter extends BaseWriter {
         runtimeMetrics.increment(`${METRIC_PREFIX}.errors.by.name`, `name:${e.name}`, true)
       }
       done()
-    })
+    }
+    makeRequest(
+      _protocolVersion,
+      data,
+      count,
+      _url,
+      _headers,
+      _lookup,
+      flushOptions,
+      this.#request,
+      this.#requestTracker,
+      onResponse
+    )
   }
 }
 
@@ -84,7 +119,7 @@ function getEncoder (protocolVersion) {
     : require('../../encode/0.4').AgentEncoder
 }
 
-function makeRequest (version, data, count, url, headers, lookup, cb) {
+function makeRequest (version, data, count, url, headers, lookup, flushOptions, request, requestTracker, cb) {
   const options = {
     path: `/v${version}/traces`,
     method: 'PUT',
@@ -100,16 +135,21 @@ function makeRequest (version, data, count, url, headers, lookup, cb) {
     lookup,
     url,
   }
+  if (flushOptions?.deadline !== undefined) {
+    options.deadline = flushOptions.deadline
+  }
 
   log.debug('Request to the agent: %j', options)
 
-  request(data, options, (err, res, status, headers) => {
+  const onResponse = (err, res, status, headers) => {
     logIntegrations()
     if (status !== 404 && status !== 200 && err) {
       logAgentError({ status, message: err.message ?? inspect(err) })
     }
     cb(err, res, status, headers)
-  })
+  }
+  if (requestTracker) requestTracker.send(request, data, options, onResponse)
+  else request(data, options, onResponse)
 }
 
 module.exports = AgentWriter

--- a/packages/dd-trace/src/exporters/common/buffering-exporter.js
+++ b/packages/dd-trace/src/exporters/common/buffering-exporter.js
@@ -24,23 +24,25 @@ class BufferingExporter {
     this._export(trace)
   }
 
-  _export (payload, writer = this._writer, timerKey = '_timer') {
+  _export (payload, writer = this._writer, timerKey = '_timer', deferImmediateFlush = false) {
     if (this._config.isCiVisibility) {
       incrementCountMetric(TELEMETRY_EVENTS_ENQUEUED_FOR_SERIALIZATION, {}, payload.length)
     }
-    writer.append(payload)
+    const appended = writer.append(payload)
 
     const { flushInterval } = this._config
 
-    if (flushInterval === 0) {
+    if (flushInterval === 0 && !deferImmediateFlush) {
       writer.flush()
-    } else if (this[timerKey] === undefined) {
+    } else if (flushInterval !== 0 && this[timerKey] === undefined) {
       this[timerKey] = setTimeout(() => {
         writer.flush()
         this[timerKey] = undefined
       }, flushInterval)
       this[timerKey].unref?.()
     }
+
+    return appended
   }
 
   getUncodedTraces () {

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -17,10 +17,10 @@ class Writer {
 
   #isFirstFlush = true
 
-  flush (done = () => {}) {
+  flush (done = () => {}, options) {
     const count = this._encoder.count()
 
-    if (!request.writable) {
+    if (!request.writable && options?.deadline === undefined) {
       this._encoder.reset()
       done()
     } else if (count > 0) {
@@ -44,23 +44,28 @@ class Writer {
         done()
         return
       }
-      this._sendPayload(payload, count, done)
+      if (options === undefined) {
+        this._sendPayload(payload, count, done)
+      } else {
+        this._sendPayload(payload, count, done, options)
+      }
     } else {
       done()
     }
   }
 
-  append (payload) {
-    if (!request.writable) {
+  append (payload, options) {
+    if (!request.writable && options?.deadline === undefined) {
       // eslint-disable-next-line eslint-rules/eslint-log-printf-style
       log.debug(() => `Maximum number of active requests reached. Payload discarded: ${safeJSONStringify(payload)}`)
-      return
+      return false
     }
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Encoding payload: ${safeJSONStringify(payload)}`)
 
     this._encode(payload)
+    return true
   }
 
   _encode (payload) {

--- a/packages/dd-trace/test/agent/info.spec.js
+++ b/packages/dd-trace/test/agent/info.spec.js
@@ -15,6 +15,8 @@ describe('agent/info', () => {
 
   describe('fetchAgentInfo', () => {
     afterEach(() => {
+      nock.abortPendingRequests()
+      nock.cleanAll()
       clearCache()
     })
 
@@ -59,6 +61,41 @@ describe('agent/info', () => {
         assert.strictEqual(scope.isDone(), true)
         done()
       })
+    })
+
+    it('allows the agent info request to be aborted by finalization', (done) => {
+      const controller = new AbortController()
+      nock(url)
+        .get('/info')
+        .delayConnection(1000)
+        .reply(200, JSON.stringify({ endpoints: ['/evp_proxy/v2'] }))
+      let callbackCount = 0
+
+      fetchAgentInfo(new URL(url), (err) => {
+        callbackCount++
+        assert.strictEqual(err.code, 'ABORT_ERR')
+        setImmediate(() => {
+          assert.strictEqual(callbackCount, 1)
+          done()
+        })
+      }, { deadline: Date.now() + 1000, signal: controller.signal })
+      controller.abort()
+    })
+
+    it('uses an injected Test Optimization request implementation', (done) => {
+      const request = sinon.stub().yieldsAsync(null, JSON.stringify({ endpoints: ['/evp_proxy/v4'] }))
+      const options = { deadline: Date.now() + 1000 }
+
+      fetchAgentInfo(new URL(url), (err, response) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(response.endpoints, ['/evp_proxy/v4'])
+        sinon.assert.calledOnceWithMatch(request, '', {
+          ...options,
+          path: '/info',
+          url: new URL(url),
+        })
+        done()
+      }, options, request)
     })
 
     describe('caching', () => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -7,6 +7,7 @@ const { describe, it, beforeEach } = require('mocha')
 const context = describe
 const sinon = require('sinon')
 const nock = require('nock')
+const proxyquire = require('proxyquire')
 
 const { assertObjectContains } = require('../../../../../../integration-tests/helpers')
 require('../../../../../dd-trace/test/setup/core')
@@ -38,6 +39,49 @@ describe('AgentProxyCiVisibilityExporter', () => {
   const queryDelay = 50
   const tags = {}
 
+  function createControlledExporter () {
+    const writers = []
+    let finishAgentInfo
+    let requestOptions
+
+    class Writer {
+      constructor () {
+        this.append = sinon.spy()
+        this.flush = sinon.spy(done => done?.())
+        writers.push(this)
+      }
+    }
+
+    const ControlledExporterBase = proxyquire('../../../../src/ci-visibility/exporters/agent-proxy', {
+      '../../../agent/info': {
+        fetchAgentInfo (agentUrl, callback, options) {
+          finishAgentInfo = callback
+          requestOptions = options
+        },
+      },
+      '../../../exporters/agent/writer': Writer,
+      '../agentless/writer': Writer,
+      '../agentless/coverage-writer': Writer,
+    })
+    class ControlledExporter extends ControlledExporterBase {
+      constructor (config) {
+        super({ testOptimization: {}, ...config })
+      }
+    }
+
+    const exporter = new ControlledExporter({ url, tags })
+    return {
+      exporter,
+      finishAgentInfo (...args) {
+        finishAgentInfo(...args)
+      },
+      getRequestOptions () {
+        return requestOptions
+      },
+      writers,
+    }
+  }
+
   it('should query /info right when it is instantiated', async () => {
     const scope = nock(url)
       .get('/info')
@@ -50,6 +94,121 @@ describe('AgentProxyCiVisibilityExporter', () => {
     assert.notStrictEqual(agentProxyCiVisibilityExporter, null)
     await agentProxyCiVisibilityExporter._canUseCiVisProtocolPromise
     assert.strictEqual(scope.isDone(), true)
+  })
+
+  it('exports buffered data and flushes it when initialization finishes within the final deadline', async () => {
+    const clock = sinon.useFakeTimers()
+    try {
+      const controlled = createControlledExporter()
+      const trace = [{ type: 'test' }]
+      const done = sinon.spy()
+
+      controlled.exporter.export(trace)
+      controlled.exporter.flush(done)
+
+      const requestOptions = controlled.getRequestOptions()
+      assert.strictEqual(requestOptions.signal.aborted, false)
+      assert.strictEqual(requestOptions.deadline, Date.now() + 10_000)
+
+      controlled.finishAgentInfo(null, { endpoints: ['/evp_proxy/v2'] })
+      await Promise.resolve()
+
+      assert.strictEqual(controlled.writers.length, 2)
+      sinon.assert.calledOnceWithExactly(controlled.writers[0].append, trace)
+      for (const writer of controlled.writers) {
+        sinon.assert.calledOnce(writer.flush)
+        assert.strictEqual(writer.flush.firstCall.args[1].deadline, requestOptions.deadline)
+      }
+      sinon.assert.calledOnceWithExactly(done, undefined)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('aborts initialization and uses the fallback writer for later sessions', async () => {
+    const clock = sinon.useFakeTimers()
+    try {
+      const controlled = createControlledExporter()
+      const firstDone = sinon.spy()
+      const firstTrace = [{ type: 'test' }]
+      const firstCoverage = { traceId: '1', spanId: '1', files: [] }
+
+      controlled.exporter.export(firstTrace)
+      controlled.exporter.exportCoverage(firstCoverage)
+      controlled.exporter.flush(firstDone)
+      const { signal } = controlled.getRequestOptions()
+
+      clock.tick(10_000)
+
+      assert.strictEqual(signal.aborted, true)
+      assert.strictEqual(signal.reason.code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+      sinon.assert.calledOnceWithExactly(firstDone, signal.reason)
+
+      controlled.finishAgentInfo(signal.reason)
+      await Promise.resolve()
+      clock.tick(100)
+
+      sinon.assert.calledOnce(firstDone)
+      assert.strictEqual(controlled.writers.length, 1)
+      sinon.assert.notCalled(controlled.writers[0].append)
+      assert.deepStrictEqual(controlled.exporter.getUncodedTraces(), [])
+      assert.deepStrictEqual(controlled.exporter._coverageBuffer, [])
+
+      const secondDone = sinon.spy()
+      const secondTrace = [{ type: 'test' }]
+      controlled.exporter.export(secondTrace)
+      controlled.exporter.flush(secondDone)
+
+      sinon.assert.calledOnceWithExactly(controlled.writers[0].append, secondTrace)
+      sinon.assert.calledOnce(controlled.writers[0].flush)
+      sinon.assert.calledOnceWithExactly(secondDone, undefined)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('keeps overlapping initialization owned by the latest final flush', async () => {
+    const clock = sinon.useFakeTimers()
+    try {
+      const controlled = createControlledExporter()
+      const firstDone = sinon.spy()
+      const firstTrace = [{ type: 'test', name: 'first session' }]
+
+      controlled.exporter.export(firstTrace)
+      controlled.exporter.flush(firstDone)
+      const requestOptions = controlled.getRequestOptions()
+
+      clock.tick(5_000)
+
+      const secondDone = sinon.spy()
+      const secondTrace = [{ type: 'test', name: 'second session' }]
+      controlled.exporter.export(secondTrace)
+      controlled.exporter.flush(secondDone)
+
+      assert.strictEqual(requestOptions.deadline, Date.now() + 10_000)
+
+      clock.tick(5_000)
+
+      assert.strictEqual(requestOptions.signal.aborted, false)
+      sinon.assert.calledOnce(firstDone)
+      assert.strictEqual(firstDone.firstCall.args[0].code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+      sinon.assert.notCalled(secondDone)
+
+      controlled.finishAgentInfo(new Error('agent info unavailable'))
+      await Promise.resolve()
+
+      assert.strictEqual(controlled.writers.length, 1)
+      sinon.assert.calledWithExactly(controlled.writers[0].append.firstCall, firstTrace)
+      sinon.assert.calledWithExactly(controlled.writers[0].append.secondCall, secondTrace)
+      sinon.assert.calledOnce(controlled.writers[0].flush)
+      sinon.assert.calledOnceWithExactly(secondDone, undefined)
+
+      clock.tick(20_000)
+      sinon.assert.calledOnce(firstDone)
+      sinon.assert.calledOnce(secondDone)
+    } finally {
+      clock.restore()
+    }
   })
 
   it('should store traces and coverages as is until the query to /info is resolved', async () => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
@@ -13,6 +13,7 @@ let request
 let encoder
 let url
 let log
+let incrementCountMetric
 
 describe('CI Visibility Coverage Writer', () => {
   beforeEach(() => {
@@ -36,6 +37,7 @@ describe('CI Visibility Coverage Writer', () => {
     log = {
       error: sinon.spy(),
     }
+    incrementCountMetric = sinon.stub()
 
     const CoverageCIVisibilityEncoder = function () {
       return encoder
@@ -44,6 +46,7 @@ describe('CI Visibility Coverage Writer', () => {
     CoverageWriter = proxyquire('../../../../src/ci-visibility/exporters/agentless/coverage-writer.js', {
       '../request': request,
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
+      '../../../ci-visibility/telemetry': { incrementCountMetric },
       '../../../log': log,
     })
     coverageWriter = new CoverageWriter({ url })
@@ -112,6 +115,11 @@ describe('CI Visibility Coverage Writer', () => {
 
       coverageWriter.flush(() => {
         sinon.assert.calledWith(log.error, 'Error sending CI coverage payload', error)
+        sinon.assert.calledWithExactly(
+          incrementCountMetric,
+          'endpoint_payload.dropped',
+          { endpoint: 'code_coverage' }
+        )
         done()
       })
     })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
@@ -42,7 +42,7 @@ describe('CI Visibility Coverage Writer', () => {
     }
 
     CoverageWriter = proxyquire('../../../../src/ci-visibility/exporters/agentless/coverage-writer.js', {
-      '../../../exporters/common/request': request,
+      '../request': request,
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
       '../../../log': log,
     })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/fixtures/final-flush-retry.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/fixtures/final-flush-retry.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+
+let attempts = 0
+const commonRequest = (data, options, callback) => {
+  setImmediate(() => {
+    attempts++
+    if (attempts === 1) {
+      const error = new Error('intake unavailable')
+      error.status = 500
+      callback(error, null, 500, {})
+    } else {
+      callback(null, '', 200, {})
+    }
+  })
+}
+commonRequest.writable = true
+
+const request = proxyquire('../../../../../src/ci-visibility/exporters/request', {
+  '../../exporters/common/request': commonRequest,
+  '../../exporters/common/retry': {
+    ...require('../../../../../src/exporters/common/retry'),
+    getMaxAttempts: () => 2,
+    getRetryDelay: () => 50,
+  },
+})
+const BaseWriter = require('../../../../../src/exporters/common/writer')
+const TestOptimizationRequestTracker = require(
+  '../../../../../src/ci-visibility/exporters/agentless/request-tracker'
+)
+
+const writer = new BaseWriter({ url: 'http://localhost' })
+const requestTracker = new TestOptimizationRequestTracker(writer)
+let hasPayload = true
+writer._encoder = {
+  count: () => hasPayload ? 1 : 0,
+  makePayload: () => {
+    hasPayload = false
+    return Buffer.from('payload')
+  },
+  reset: () => {},
+}
+writer._sendPayload = function (data, count, done, options) {
+  requestTracker.send(request, data, { ...options, method: 'POST', path: '/', headers: {} }, done)
+}
+writer.flush = (done, options) => requestTracker.flush(done, options)
+
+writer.flush()
+writer.flush((error) => {
+  process.stdout.write(error ? error.code : 'flushed')
+}, { deadline: Date.now() + 1000 })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/request-tracker.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/request-tracker.spec.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFile } = require('node:child_process')
+const path = require('node:path')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+require('../../../setup/core')
+
+const BaseWriter = require('../../../../src/exporters/common/writer')
+const TestOptimizationRequestTracker = require('../../../../src/ci-visibility/exporters/agentless/request-tracker')
+
+describe('Test Optimization request tracker', () => {
+  let clock
+  let pendingRequests
+  let request
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+    pendingRequests = []
+    request = (data, options, callback) => {
+      pendingRequests.push({ data, options, callback })
+    }
+    request.writable = true
+  })
+
+  afterEach(() => {
+    clock?.restore()
+  })
+
+  function getWriter () {
+    const writer = new BaseWriter({ url: 'http://localhost' })
+    const requestTracker = new TestOptimizationRequestTracker(writer)
+    writer._encoder = {
+      count: sinon.stub(),
+      makePayload: sinon.stub().returns(Buffer.from('payload')),
+      reset: sinon.stub(),
+    }
+    writer._sendPayload = (data, count, done, options = {}) => {
+      requestTracker.send(request, data, options, done)
+    }
+    writer.flush = (done, options) => requestTracker.flush(done, options)
+    return writer
+  }
+
+  it('waits for a request that was already in flight', () => {
+    const writer = getWriter()
+    writer._encoder.count.onFirstCall().returns(1).returns(0)
+    writer.flush()
+
+    const done = sinon.spy()
+    const deadline = Date.now() + 1000
+    writer.flush(done, { deadline })
+
+    sinon.assert.notCalled(done)
+    assert.strictEqual(pendingRequests[0].options.deadline, deadline)
+    pendingRequests[0].callback(null)
+    sinon.assert.calledOnceWithExactly(done, undefined)
+  })
+
+  it('aborts pending requests and releases the process at the deadline', () => {
+    const writer = getWriter()
+    writer._encoder.count.returns(1)
+    const done = sinon.spy()
+
+    writer.flush(done, { deadline: Date.now() + 1000 })
+    clock.tick(1000)
+
+    assert.strictEqual(pendingRequests[0].options.signal.aborted, true)
+    sinon.assert.calledOnce(done)
+    assert.strictEqual(done.firstCall.args[0].code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+  })
+
+  it('does not wait for a timed-out request on a later final flush', () => {
+    const writer = getWriter()
+    writer._encoder.count.onFirstCall().returns(1).returns(0)
+
+    writer.flush(sinon.spy(), { deadline: Date.now() + 1000 })
+    clock.tick(1000)
+
+    const done = sinon.spy()
+    writer.flush(done, { deadline: Date.now() + 1000 })
+
+    sinon.assert.calledOnceWithExactly(done, undefined)
+  })
+
+  it('does not let an older deadline abort requests owned by a newer final flush', () => {
+    const writer = getWriter()
+    writer._encoder.count.returns(1)
+    const firstDone = sinon.spy()
+    const secondDone = sinon.spy()
+
+    writer.flush(firstDone, { deadline: Date.now() + 1000 })
+    clock.tick(100)
+    const secondDeadline = Date.now() + 2000
+    writer.flush(secondDone, { deadline: secondDeadline })
+
+    clock.tick(900)
+
+    sinon.assert.calledOnce(firstDone)
+    assert.strictEqual(firstDone.firstCall.args[0].code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+    sinon.assert.notCalled(secondDone)
+    assert.strictEqual(pendingRequests[0].options.signal.aborted, false)
+    assert.strictEqual(pendingRequests[1].options.signal.aborted, false)
+    assert.strictEqual(pendingRequests[0].options.deadline, secondDeadline)
+    assert.strictEqual(pendingRequests[1].options.deadline, secondDeadline)
+
+    pendingRequests[0].callback(null)
+    pendingRequests[1].callback(null)
+
+    sinon.assert.calledOnceWithExactly(secondDone, null)
+  })
+
+  it('reports request failures to the final flush callback', () => {
+    const writer = getWriter()
+    writer._encoder.count.returns(1)
+    const done = sinon.spy()
+    const error = new Error('intake unavailable')
+
+    writer.flush(done, { deadline: Date.now() + 1000 })
+    pendingRequests[0].callback(error)
+
+    sinon.assert.calledOnceWithExactly(done, error)
+  })
+
+  it('upgrades an in-flight request and keeps the process alive for its unrefed retry', (done) => {
+    clock.restore()
+    clock = undefined
+    const fixture = path.join(__dirname, 'fixtures', 'final-flush-retry.js')
+
+    execFile(process.execPath, [fixture], { env: { ...process.env, NODE_OPTIONS: '' } }, (error, stdout) => {
+      assert.ifError(error)
+      assert.strictEqual(stdout, 'flushed')
+      done()
+    })
+  })
+})

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -51,7 +51,7 @@ describe('CI Visibility Writer', () => {
     }
 
     Writer = proxyquire('../../../../src/ci-visibility/exporters/agentless/writer', {
-      '../../../exporters/common/request': request,
+      '../request': request,
       '../../../encode/agentless-ci-visibility': { AgentlessCiVisibilityEncoder },
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
       '../../../log': log,

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -14,6 +14,7 @@ let encoder
 let coverageEncoder
 let url
 let log
+let incrementCountMetric
 
 describe('CI Visibility Writer', () => {
   beforeEach(() => {
@@ -35,6 +36,7 @@ describe('CI Visibility Writer', () => {
     log = {
       error: sinon.spy(),
     }
+    incrementCountMetric = sinon.stub()
 
     const AgentlessCiVisibilityEncoder = function () {
       return encoder
@@ -54,6 +56,7 @@ describe('CI Visibility Writer', () => {
       '../request': request,
       '../../../encode/agentless-ci-visibility': { AgentlessCiVisibilityEncoder },
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
+      '../../../ci-visibility/telemetry': { incrementCountMetric },
       '../../../log': log,
     })
     writer = new Writer({ url, tags: { 'runtime-id': 'runtime-id' }, coverageUrl: url })
@@ -115,6 +118,11 @@ describe('CI Visibility Writer', () => {
 
         writer.flush(() => {
           sinon.assert.calledWith(log.error, 'Error sending CI agentless payload', error)
+          sinon.assert.calledWithExactly(
+            incrementCountMetric,
+            'endpoint_payload.dropped',
+            { endpoint: 'test_cycle' }
+          )
           done()
         })
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -865,6 +865,147 @@ describe('CI Visibility Exporter', () => {
         )
         sinon.assert.called(ciVisibilityExporter._writer.append)
       })
+
+      it('defers an immediate session flush until the bounded final flush', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy((done) => done?.()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+
+        ciVisibilityExporter.export([{ type: 'test_session_end' }])
+
+        sinon.assert.notCalled(writer.flush)
+        ciVisibilityExporter.flush(() => {})
+        sinon.assert.calledOnce(writer.flush)
+        assert.strictEqual(typeof writer.flush.firstCall.args[1].deadline, 'number')
+      })
+    })
+  })
+
+  describe('flush', () => {
+    it('completes immediately when initialization is pending without buffered data', () => {
+      const clock = sinon.useFakeTimers()
+      try {
+        const ciVisibilityExporter = new CiVisibilityExporter({ url })
+        const timersBeforeFlush = clock.countTimers()
+        const done = sinon.spy()
+
+        ciVisibilityExporter.flush(done)
+
+        sinon.assert.calledOnceWithExactly(done)
+        assert.strictEqual(clock.countTimers(), timersBeforeFlush)
+      } finally {
+        clock.restore()
+      }
+    })
+
+    for (const [payloadType, writerProperty, exportPayload] of [
+      ['trace', '_writer', exporter => exporter.export([{ type: 'test' }])],
+      ['coverage', '_coverageWriter', exporter => exporter.exportCoverage({})],
+    ]) {
+      it(`waits for exporter initialization with buffered ${payloadType}`, async () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy((done) => done()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url })
+        const done = sinon.spy()
+
+        exportPayload(ciVisibilityExporter)
+        ciVisibilityExporter.flush(done)
+        sinon.assert.notCalled(done)
+
+        ciVisibilityExporter[writerProperty] = writer
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+        await Promise.resolve()
+
+        sinon.assert.calledOnce(writer.flush)
+        sinon.assert.calledOnceWithExactly(done, undefined)
+        assert.strictEqual(typeof writer.flush.firstCall.args[1].deadline, 'number')
+      })
+    }
+
+    it('starts a new final flush after more test data is exported', () => {
+      const writer = {
+        append: sinon.spy(),
+        flush: sinon.spy((done) => done?.()),
+        setUrl: sinon.spy(),
+      }
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+      ciVisibilityExporter._isInitialized = true
+      ciVisibilityExporter._canUseCiVisProtocol = true
+      ciVisibilityExporter._writer = writer
+
+      ciVisibilityExporter.flush(() => {})
+      ciVisibilityExporter.export([{ type: 'test_session_end' }])
+      ciVisibilityExporter.flush(() => {})
+
+      sinon.assert.calledTwice(writer.flush)
+    })
+
+    it('does not coalesce new test data into an active final flush', () => {
+      const flushCallbacks = []
+      const writer = {
+        append: sinon.spy(),
+        flush: sinon.spy(done => flushCallbacks.push(done)),
+        setUrl: sinon.spy(),
+      }
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+      ciVisibilityExporter._isInitialized = true
+      ciVisibilityExporter._canUseCiVisProtocol = true
+      ciVisibilityExporter._writer = writer
+      const firstDone = sinon.spy()
+      const secondDone = sinon.spy()
+
+      ciVisibilityExporter.flush(firstDone)
+      ciVisibilityExporter.export([{ type: 'test_session_end' }])
+      ciVisibilityExporter.flush(secondDone)
+
+      sinon.assert.calledTwice(writer.flush)
+      flushCallbacks[0]()
+      sinon.assert.calledOnceWithExactly(firstDone, undefined)
+      sinon.assert.notCalled(secondDone)
+      flushCallbacks[1]()
+      sinon.assert.calledOnceWithExactly(secondDone, undefined)
+    })
+
+    it('reuses an expired final flush when exporter initialization never completes', () => {
+      const clock = sinon.useFakeTimers()
+      const logError = sinon.stub(ciVisibilityLog, 'error')
+      const beforeExitHandlers = globalThis[Symbol.for('dd-trace')].beforeExitHandlers
+      let beforeExitHandler
+      try {
+        const ciVisibilityExporter = new CiVisibilityExporter({ url })
+        beforeExitHandler = [...beforeExitHandlers].at(-1)
+        const done = sinon.spy()
+
+        ciVisibilityExporter.export([{ type: 'test' }])
+        ciVisibilityExporter.flush(done)
+        clock.tick(10_100)
+
+        sinon.assert.calledOnce(done)
+        const timeoutError = done.firstCall.args[0]
+        assert.strictEqual(timeoutError.code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+
+        const repeatedDone = sinon.spy()
+        ciVisibilityExporter.flush(repeatedDone)
+        sinon.assert.calledOnceWithExactly(repeatedDone, timeoutError)
+
+        const timersBeforeExit = clock.countTimers()
+        beforeExitHandler()
+        assert.strictEqual(clock.countTimers(), timersBeforeExit)
+        sinon.assert.calledOnce(logError)
+      } finally {
+        beforeExitHandlers.delete(beforeExitHandler)
+        clock.restore()
+      }
     })
   })
 

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -22,12 +22,20 @@ const { defaults: { hostname, port } } = require('../../../src/config/defaults')
 const ciVisibilityLog = require('../../../src/log')
 const { uploadCoverageReport: actualUploadCoverageReportRequest } =
   require('../../../src/ci-visibility/requests/upload-coverage-report')
+const { uploadTestScreenshot: actualUploadTestScreenshotRequest } =
+  require('../../../src/ci-visibility/requests/upload-test-screenshot')
 
 let uploadCoverageReportRequest = actualUploadCoverageReportRequest
+let uploadTestScreenshotRequest = actualUploadTestScreenshotRequest
 const CiVisibilityExporterBase = proxyquire('../../../src/ci-visibility/exporters/ci-visibility-exporter', {
   '../requests/upload-coverage-report': {
     uploadCoverageReport (...args) {
       return uploadCoverageReportRequest(...args)
+    },
+  },
+  '../requests/upload-test-screenshot': {
+    uploadTestScreenshot (...args) {
+      return uploadTestScreenshotRequest(...args)
     },
   },
 })
@@ -53,6 +61,7 @@ describe('CI Visibility Exporter', () => {
     config.DD_API_KEY = '1'
     nock.cleanAll()
     uploadCoverageReportRequest = actualUploadCoverageReportRequest
+    uploadTestScreenshotRequest = actualUploadTestScreenshotRequest
   })
 
   afterEach(() => {
@@ -1652,6 +1661,116 @@ describe('CI Visibility Exporter', () => {
       })
       ciVisibilityExporter._testScreenshotUploadUrl = url
       assert.strictEqual(ciVisibilityExporter.canUploadTestScreenshots(), true)
+    })
+  })
+
+  describe('uploadTestScreenshot', () => {
+    const screenshotOptions = {
+      filePath: '/tmp/test-failed-1.png',
+      traceId: '1',
+      idempotencyKey: '1:test-failed-1.png',
+      capturedAtMs: 1,
+    }
+
+    function createScreenshotExporter () {
+      const exporter = new CiVisibilityExporter({
+        url,
+        testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+      })
+      exporter._testScreenshotUploadUrl = url
+      exporter._isInitialized = true
+      exporter._canUseCiVisProtocol = true
+      exporter._writer = { append: sinon.stub(), flush: sinon.stub().yields() }
+      return exporter
+    }
+
+    it('bounds a pending screenshot and lets final flush complete', () => {
+      const clock = sinon.useFakeTimers()
+      try {
+        uploadTestScreenshotRequest = sinon.stub()
+        const exporter = createScreenshotExporter()
+        const screenshotCallback = sinon.spy()
+        const flushCallback = sinon.spy()
+
+        exporter.uploadTestScreenshot(screenshotOptions, screenshotCallback)
+        exporter.flush(flushCallback)
+        const requestOptions = uploadTestScreenshotRequest.firstCall.args[0]
+        assert.strictEqual(requestOptions.deadline, 10_000)
+        assert.strictEqual(requestOptions.signal.aborted, false)
+        sinon.assert.notCalled(exporter._writer.flush)
+        sinon.assert.notCalled(flushCallback)
+
+        clock.tick(9_999)
+        sinon.assert.notCalled(screenshotCallback)
+        sinon.assert.notCalled(flushCallback)
+
+        clock.tick(1)
+        assert.strictEqual(requestOptions.signal.aborted, true)
+        sinon.assert.calledOnce(screenshotCallback)
+        assert.strictEqual(screenshotCallback.firstCall.args[0].code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+        sinon.assert.calledOnce(exporter._writer.flush)
+        sinon.assert.calledOnceWithExactly(flushCallback, undefined)
+
+        uploadTestScreenshotRequest.firstCall.args[1]()
+        sinon.assert.calledOnce(screenshotCallback)
+        sinon.assert.calledOnce(flushCallback)
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('waits for screenshot completion work before flushing writers', async () => {
+      uploadTestScreenshotRequest = sinon.stub()
+      const exporter = createScreenshotExporter()
+      const completed = []
+      const screenshotCallback = () => queueMicrotask(() => completed.push('screenshot'))
+      const flushCallback = sinon.spy()
+
+      exporter.flush(sinon.spy())
+      exporter._writer.flush.resetHistory()
+      exporter.uploadTestScreenshot(screenshotOptions, screenshotCallback)
+      exporter.flush(flushCallback)
+
+      sinon.assert.notCalled(exporter._writer.flush)
+      sinon.assert.notCalled(flushCallback)
+
+      uploadTestScreenshotRequest.firstCall.args[1](null)
+      await new Promise(resolve => queueMicrotask(resolve))
+
+      assert.deepStrictEqual(completed, ['screenshot'])
+      sinon.assert.calledOnce(exporter._writer.flush)
+      sinon.assert.calledOnceWithExactly(flushCallback, undefined)
+    })
+
+    it('forwards caller cancellation and completes once', () => {
+      uploadTestScreenshotRequest = sinon.stub()
+      const exporter = createScreenshotExporter()
+      const controller = new AbortController()
+      const callback = sinon.spy()
+      const error = new Error('framework stopped')
+
+      exporter.uploadTestScreenshot({ ...screenshotOptions, signal: controller.signal }, callback)
+      const requestSignal = uploadTestScreenshotRequest.firstCall.args[0].signal
+      controller.abort(error)
+
+      assert.strictEqual(requestSignal.aborted, true)
+      sinon.assert.calledOnceWithExactly(callback, error)
+      uploadTestScreenshotRequest.firstCall.args[1](error)
+      sinon.assert.calledOnce(callback)
+    })
+
+    it('does not start an upload when the caller signal is already aborted', () => {
+      uploadTestScreenshotRequest = sinon.stub()
+      const exporter = createScreenshotExporter()
+      const controller = new AbortController()
+      const callback = sinon.spy()
+      const error = new Error('framework stopped')
+      controller.abort(error)
+
+      exporter.uploadTestScreenshot({ ...screenshotOptions, signal: controller.signal }, callback)
+
+      sinon.assert.notCalled(uploadTestScreenshotRequest)
+      sinon.assert.calledOnceWithExactly(callback, error)
     })
   })
 })

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -985,6 +985,36 @@ describe('CI Visibility Exporter', () => {
       sinon.assert.calledOnceWithExactly(secondDone, undefined)
     })
 
+    it('completes every coalesced final flush when a callback throws', () => {
+      let flushWriter
+      const callbackError = new Error('framework callback error')
+      const logError = sinon.stub(ciVisibilityLog, 'error')
+      const writer = {
+        append: sinon.spy(),
+        flush: sinon.spy(done => { flushWriter = done }),
+        setUrl: sinon.spy(),
+      }
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+      ciVisibilityExporter._isInitialized = true
+      ciVisibilityExporter._canUseCiVisProtocol = true
+      ciVisibilityExporter._writer = writer
+      const firstDone = sinon.spy(() => { throw callbackError })
+      const secondDone = sinon.spy()
+
+      ciVisibilityExporter.flush(firstDone)
+      ciVisibilityExporter.flush(secondDone)
+
+      sinon.assert.calledOnce(writer.flush)
+      flushWriter()
+      sinon.assert.calledOnceWithExactly(firstDone, undefined)
+      sinon.assert.calledOnceWithExactly(secondDone, undefined)
+      sinon.assert.calledOnceWithExactly(
+        logError,
+        'Error completing Test Optimization flush callback',
+        callbackError
+      )
+    })
+
     it('reuses an expired final flush when exporter initialization never completes', () => {
       const clock = sinon.useFakeTimers()
       const logError = sinon.stub(ciVisibilityLog, 'error')

--- a/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
@@ -1,0 +1,178 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { Readable } = require('node:stream')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../../setup/core')
+
+const commonRetry = require('../../../src/exporters/common/retry')
+
+describe('Test Optimization exporter request', () => {
+  let clock
+  let commonRequest
+  let pendingRequests
+  let request
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers({ now: 10_000 })
+    pendingRequests = []
+    commonRequest = (data, options, callback) => {
+      pendingRequests.push({ data, options, callback })
+    }
+    commonRequest.writable = true
+    request = proxyquire('../../../src/ci-visibility/exporters/request', {
+      '../../exporters/common/request': commonRequest,
+      '../../exporters/common/retry': {
+        ...commonRetry,
+        getMaxAttempts: () => 2,
+        getRetryDelay: () => 6000,
+      },
+    })
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  it('retries a 5xx response within the finalization deadline', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 10_000 }, done)
+
+    const error = Object.assign(new Error('unavailable'), { status: 503 })
+    pendingRequests[0].callback(error, null, 503, {})
+    clock.tick(5999)
+    assert.strictEqual(pendingRequests.length, 1)
+    clock.tick(1)
+    assert.strictEqual(pendingRequests.length, 2)
+
+    pendingRequests[1].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
+  })
+
+  it('uses the remaining finalization budget for a late 5xx retry', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 1000, timeout: 2000 }, done)
+
+    const error = Object.assign(new Error('unavailable'), { status: 503 })
+    pendingRequests[0].callback(error, null, 503, {})
+    clock.tick(499)
+    assert.strictEqual(pendingRequests.length, 1)
+    clock.tick(1)
+
+    assert.strictEqual(pendingRequests.length, 2)
+    assert.strictEqual(pendingRequests[1].options.timeout, 500)
+    pendingRequests[1].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnce(done)
+  })
+
+  it('uses the remaining finalization budget for a late network retry', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 1000, timeout: 2000 }, done)
+
+    const error = Object.assign(new Error('reset'), { code: 'ECONNRESET' })
+    pendingRequests[0].callback(error)
+    clock.tick(500)
+
+    assert.strictEqual(pendingRequests.length, 2)
+    assert.strictEqual(pendingRequests[1].options.timeout, 500)
+    pendingRequests[1].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnce(done)
+  })
+
+  it('waits for a rate-limit reset inside the finalization deadline', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 10_000 }, done)
+
+    const error = Object.assign(new Error('rate limited'), { status: 429 })
+    pendingRequests[0].callback(error, null, 429, { 'x-ratelimit-reset': '5' })
+    clock.tick(4999)
+    assert.strictEqual(pendingRequests.length, 1)
+    clock.tick(1)
+    assert.strictEqual(pendingRequests.length, 2)
+
+    pendingRequests[1].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnce(done)
+  })
+
+  it('does not retry a rate-limit reset at the finalization deadline', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 5000 }, done)
+
+    const error = Object.assign(new Error('rate limited'), { status: 429 })
+    pendingRequests[0].callback(error, null, 429, { 'x-ratelimit-reset': '5' })
+
+    assert.strictEqual(pendingRequests.length, 1)
+    sinon.assert.calledOnceWithExactly(done, error, null, 429, { 'x-ratelimit-reset': '5' })
+  })
+
+  it('preserves ordinary background retry scheduling without a deadline', () => {
+    request('payload', {}, sinon.spy())
+
+    const error = Object.assign(new Error('reset'), { code: 'ECONNRESET' })
+    pendingRequests[0].callback(error)
+    clock.tick(5999)
+    assert.strictEqual(pendingRequests.length, 1)
+    clock.tick(1)
+    assert.strictEqual(pendingRequests.length, 2)
+  })
+
+  it('aborts a scheduled retry and completes once', () => {
+    const controller = new AbortController()
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 10_000, signal: controller.signal }, done)
+
+    const requestError = Object.assign(new Error('reset'), { code: 'ECONNRESET' })
+    pendingRequests[0].callback(requestError)
+    const abortError = Object.assign(new Error('finalization expired'), { code: 'ABORT_ERR' })
+    controller.abort(abortError)
+    clock.tick(10_000)
+
+    assert.strictEqual(pendingRequests.length, 1)
+    sinon.assert.calledOnce(done)
+    assert.strictEqual(done.firstCall.args[0], abortError)
+  })
+
+  it('stops buffering a readable body when finalization aborts', () => {
+    const controller = new AbortController()
+    const readable = new Readable({ read () {} })
+    const done = sinon.spy()
+
+    request(readable, { signal: controller.signal }, done)
+    const abortError = Object.assign(new Error('finalization expired'), { code: 'ABORT_ERR' })
+    controller.abort(abortError)
+
+    sinon.assert.calledOnceWithExactly(done, abortError)
+    assert.strictEqual(pendingRequests.length, 0)
+  })
+
+  it('waits for exporter backpressure to clear inside the deadline', () => {
+    commonRequest.writable = false
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 1000 }, done)
+
+    clock.tick(49)
+    assert.strictEqual(pendingRequests.length, 0)
+    commonRequest.writable = true
+    clock.tick(1)
+    assert.strictEqual(pendingRequests.length, 1)
+
+    pendingRequests[0].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnce(done)
+  })
+
+  it('fails at the deadline while exporter backpressure remains active', () => {
+    commonRequest.writable = false
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 1000 }, done)
+
+    clock.tick(1000)
+
+    sinon.assert.calledOnce(done)
+    assert.strictEqual(done.firstCall.args[0].code, 'ERR_DD_TEST_OPTIMIZATION_FLUSH_TIMEOUT')
+    assert.strictEqual(pendingRequests.length, 0)
+  })
+})

--- a/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
@@ -113,6 +113,18 @@ describe('CI Visibility Test Worker Exporter', () => {
       sinon.assert.calledOnce(onDone)
     })
 
+    it('reports an IPC send error after all writers settle', () => {
+      const error = new Error('IPC channel closed')
+      process.send = sinon.stub().callsFake((payload, callback) => callback(error))
+      const jestWorkerExporter = new TestWorkerCiVisibilityExporter()
+      const onDone = sinon.spy()
+
+      jestWorkerExporter.export([{ type: 'test' }])
+      jestWorkerExporter.flush(onDone)
+
+      sinon.assert.calledOnceWithExactly(onDone, error)
+    })
+
     it('does not break if process.send is undefined', () => {
       delete process.send
       const trace = [{ type: 'test' }]

--- a/packages/dd-trace/test/ci-visibility/requests/rate-limit.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/rate-limit.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+require('../../setup/core')
+
+const { getRateLimitResetDelay } = require('../../../src/ci-visibility/requests/rate-limit')
+
+describe('Test Optimization rate-limit parsing', () => {
+  let clock
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers({ now: 1_700_000_000_000 })
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  it('uses the rate-limit reset duration in seconds', () => {
+    assert.strictEqual(getRateLimitResetDelay({ 'x-ratelimit-reset': '5' }), 5000)
+  })
+
+  it('supports legacy absolute rate-limit reset timestamps', () => {
+    const resetTimestamp = Date.now() / 1000 + 5
+
+    assert.strictEqual(getRateLimitResetDelay({ 'x-ratelimit-reset': `${resetTimestamp}` }), 5000)
+    clock.tick(4999)
+    assert.strictEqual(getRateLimitResetDelay({ 'x-ratelimit-reset': `${resetTimestamp}` }), 1)
+    clock.tick(1)
+    assert.strictEqual(getRateLimitResetDelay({ 'x-ratelimit-reset': `${resetTimestamp}` }), 0)
+  })
+
+  it('prefers Retry-After delay seconds', () => {
+    assert.strictEqual(getRateLimitResetDelay({
+      'retry-after': '3',
+      'x-ratelimit-reset': '5',
+    }), 3000)
+  })
+
+  it('supports Retry-After HTTP dates', () => {
+    const resetDate = new Date(Date.now() + 5000).toUTCString()
+
+    assert.strictEqual(getRateLimitResetDelay({ 'retry-after': resetDate }), 5000)
+  })
+
+  it('falls back to X-RateLimit-Reset when Retry-After is negative', () => {
+    assert.strictEqual(getRateLimitResetDelay({
+      'retry-after': '-1',
+      'x-ratelimit-reset': '5',
+    }), 5000)
+  })
+
+  it('rejects missing, invalid, and negative reset delays', () => {
+    assert.strictEqual(Number.isNaN(getRateLimitResetDelay()), true)
+    assert.strictEqual(Number.isNaN(getRateLimitResetDelay({ 'x-ratelimit-reset': 'invalid' })), true)
+    assert.strictEqual(Number.isNaN(getRateLimitResetDelay({ 'x-ratelimit-reset': '-1' })), true)
+  })
+})

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -38,9 +38,9 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
     )
 
     assert.ok(requestStub.calledOnce)
-    const { path, headers } = requestStub.getCall(0).args[1]
+    const { path, headers, deadline, signal } = requestStub.getCall(0).args[1]
     const query = new URL(path, 'http://localhost:8126').searchParams
-    return { path, headers, query }
+    return { path, headers, query, deadline, signal }
   }
 
   before(() => {
@@ -53,7 +53,7 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       '../../../src/ci-visibility/requests/upload-test-screenshot',
       {
         '../../config': () => ({ DD_API_KEY: 'test-api-key' }),
-        '../../exporters/common/request': requestStub,
+        '../exporters/request': requestStub,
       }
     )
     uploadTestScreenshot = upload
@@ -80,12 +80,14 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       assert.strictEqual(headers['X-Datadog-EVP-Subdomain'], undefined)
     })
 
-    it('forwards the AbortSignal to the media request', () => {
+    it('forwards the deadline and AbortSignal to the media request', () => {
       const abortController = new AbortController()
+      const deadline = Date.now() + 10_000
 
-      uploadForFile('screenshot.png', { signal: abortController.signal })
+      const requestOptions = uploadForFile('screenshot.png', { deadline, signal: abortController.signal })
 
-      assert.strictEqual(requestStub.getCall(0).args[1].signal, abortController.signal)
+      assert.strictEqual(requestOptions.deadline, deadline)
+      assert.strictEqual(requestOptions.signal, abortController.signal)
     })
 
     it('reports an error when the request helper drops the upload', () => {

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -80,6 +80,14 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       assert.strictEqual(headers['X-Datadog-EVP-Subdomain'], undefined)
     })
 
+    it('forwards the AbortSignal to the media request', () => {
+      const abortController = new AbortController()
+
+      uploadForFile('screenshot.png', { signal: abortController.signal })
+
+      assert.strictEqual(requestStub.getCall(0).args[1].signal, abortController.signal)
+    })
+
     it('reports an error when the request helper drops the upload', () => {
       const basename = 'screenshot.png'
       const filePath = join(tmpDir, basename)

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -57,6 +57,7 @@ function describeWriter (protocolVersion) {
 
     Writer = proxyquire('../../../src/exporters/agent/writer', {
       '../common/request': request,
+      '../../ci-visibility/exporters/request': request,
       '../../encode/0.4': { AgentEncoder },
       '../../encode/0.5': { AgentEncoder },
       '../../../../../package.json': { version: 'tracerVersion' },
@@ -172,6 +173,36 @@ function describeWriter (protocolVersion) {
         )
         done()
       })
+    })
+
+    it('should propagate terminal errors during a bounded Test Optimization flush', (done) => {
+      const error = new Error('agent unavailable')
+      const deadline = Date.now() + 10_000
+      request.yieldsAsync(error, null, 503)
+      encoder.count.returns(1)
+      writer = new Writer({ url, prioritySampler, protocolVersion, isTestOptimization: true })
+
+      writer.flush((flushError) => {
+        assert.strictEqual(flushError, error)
+        assert.strictEqual(request.firstCall.args[1].deadline, deadline)
+        done()
+      }, { deadline })
+    })
+
+    it('should wait for Test Optimization requests already in flight during a bounded final flush', () => {
+      request.resetBehavior()
+      writer = new Writer({ url, prioritySampler, protocolVersion, isTestOptimization: true })
+      encoder.count.onFirstCall().returns(1).returns(0)
+      writer.flush()
+
+      const done = sinon.spy()
+      const deadline = Date.now() + 10_000
+      writer.flush(done, { deadline })
+
+      sinon.assert.notCalled(done)
+      assert.strictEqual(request.firstCall.args[1].deadline, deadline)
+      request.firstCall.args[2](null, response, 200)
+      sinon.assert.calledOnceWithExactly(done, undefined)
     })
 
     it('should update sampling rates', (done) => {

--- a/packages/dd-trace/test/exporters/common/writer.spec.js
+++ b/packages/dd-trace/test/exporters/common/writer.spec.js
@@ -19,6 +19,7 @@ describe('common Writer', () => {
   beforeEach(() => {
     encoder = {
       count: sinon.stub().returns(2),
+      encode: sinon.stub(),
       makePayload: sinon.stub().returns(Buffer.from('payload')),
       reset: sinon.stub(),
     }
@@ -72,5 +73,67 @@ describe('common Writer', () => {
 
     sinon.assert.notCalled(encoder.reset)
     sinon.assert.calledOnceWithExactly(writer._sendPayload, payload, 2, done)
+  })
+
+  it('passes final flush options to the payload sender', () => {
+    const done = sinon.stub()
+    const options = { deadline: Date.now() + 1000 }
+
+    writer.flush(done, options)
+
+    sinon.assert.calledOnceWithExactly(
+      writer._sendPayload,
+      Buffer.from('payload'),
+      2,
+      done,
+      options
+    )
+  })
+
+  it('drops a non-final payload when the request buffer is full', () => {
+    request.writable = false
+    const done = sinon.stub()
+
+    writer.flush(done)
+
+    sinon.assert.calledOnce(encoder.reset)
+    sinon.assert.calledOnceWithExactly(done)
+  })
+
+  it('sends a bounded final payload when the request buffer is full', () => {
+    request.writable = false
+    const done = sinon.stub()
+    const options = { deadline: Date.now() + 1000 }
+
+    writer.flush(done, options)
+
+    sinon.assert.notCalled(encoder.reset)
+    sinon.assert.calledOnceWithExactly(
+      writer._sendPayload,
+      Buffer.from('payload'),
+      2,
+      done,
+      options
+    )
+  })
+
+  it('reports whether an appended payload was accepted', () => {
+    const payload = [{ type: 'test_suite_end' }]
+
+    assert.strictEqual(writer.append(payload), true)
+    sinon.assert.calledOnceWithExactly(encoder.encode, payload)
+
+    request.writable = false
+    assert.strictEqual(writer.append(payload), false)
+    sinon.assert.calledOnce(encoder.encode)
+  })
+
+  it('accepts a bounded final append when the request buffer is full', () => {
+    request.writable = false
+    const payload = [{ type: 'test_suite_end' }]
+    const options = { deadline: Date.now() + 1000 }
+
+    assert.strictEqual(writer.append(payload, options), true)
+    sinon.assert.calledOnceWithExactly(encoder.encode, payload)
   })
 })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a bounded Test Optimization final-flush lifecycle that owns queued and active event, coverage, log, screenshot, and agent `/info` requests. Finalization can briefly keep the test process alive, retries only inside its ten-second deadline, aborts remaining work at the boundary, and completes every callback once.

Retry and deadline policy now lives in a Test Optimization exporter request wrapper. It delegates individual HTTP attempts to the unchanged common transport while owning Test Optimization-specific 429/5xx/network retries, stream replay, cancellation, and backpressure waiting. Normal background retries remain unref'd and retain their existing scheduling.

Screenshot uploads use the same Test Optimization request wrapper. Each upload has a ten-second maximum from when it starts, and final flush waits for uploads already in progress before flushing the tagged test events. A stalled upload is aborted at that boundary rather than retaining its previous 30-second transport timeout.

### Motivation
<!-- What inspired you to submit this pull request? -->

Framework shutdown could occur while session, module, or suite data was still buffered, agent discovery was pending, a request was in flight, or a retry was scheduled beyond the useful finalization window. This produced missing session/module/suite events and falsely successful flushes.

This is stack 2 of 3 extracted from #9732:

1. #9788 — Test Optimization rate-limit reset parsing (merged)
2. This PR — bounded Test Optimization final-flush lifecycle
3. #9790 — completed-suite preservation and framework terminal errors

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR is based on `master`, including merged #9788. `exporters/common/request.js`, `exporters/common/retry.js`, and `bootstrap.js` are unchanged; the small shared writer changes only pass final-flush options and report whether a payload was accepted.

The agentless and agent-proxy request clients use the same Test Optimization-only helper to parse rate-limit response headers. Keeping that logic in one place avoids two copies drifting apart while leaving the shared exporter request code unchanged.

Existing Test Optimization telemetry is preserved: `endpoint_payload.dropped` continues to use only its standard `endpoint` tag, and request failures continue to use the existing `error_type` mapping.

Validation:

- 178 combined exporter, writer, request-tracker, worker, and screenshot tests pass.
- 115 request and exporter tests pass with real sockets.
- 80 focused Test Optimization request, screenshot, and exporter tests pass.
- 26 focused rate-limit and request tests pass.
- 9 standalone agent-info tests pass.
- 10 standalone agentless-exporter tests pass.
- 10 webpack integration tests pass across both supported webpack 5 fixtures.
- Full `npm run lint` passes.
