### PR TITLE
fix(test-optimization): preserve deferred test session traces

### DIFF
--- a/integration-tests/ci-visibility/cucumber-formatter-throws.js
+++ b/integration-tests/ci-visibility/cucumber-formatter-throws.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const { Formatter } = require('@cucumber/cucumber')
+
+class ThrowingFormatter extends Formatter {
+  constructor (options) {
+    super(options)
+    options.eventBroadcaster.on('envelope', (envelope) => {
+      if (envelope.testRunFinished) {
+        throw new Error('custom Cucumber formatter failed')
+      }
+    })
+  }
+}
+
+module.exports = ThrowingFormatter

--- a/integration-tests/ci-visibility/jest-reporter-throws.js
+++ b/integration-tests/ci-visibility/jest-reporter-throws.js
@@ -1,0 +1,9 @@
+'use strict'
+
+class ThrowingReporter {
+  onRunComplete () {
+    throw new Error('custom reporter failed')
+  }
+}
+
+module.exports = ThrowingReporter

--- a/integration-tests/ci-visibility/vitest-reporter-throws.mjs
+++ b/integration-tests/ci-visibility/vitest-reporter-throws.mjs
@@ -1,0 +1,5 @@
+export default class ThrowingReporter {
+  async onTestRunEnd () {
+    throw new Error('custom Vitest reporter failed')
+  }
+}

--- a/integration-tests/config-jest.js
+++ b/integration-tests/config-jest.js
@@ -27,4 +27,8 @@ if (process.env.CONFIG_TRANSFORM) {
   config.transform = JSON.parse(process.env.CONFIG_TRANSFORM)
 }
 
+if (process.env.JEST_THROWING_REPORTER) {
+  config.reporters = ['<rootDir>/ci-visibility/jest-reporter-throws.js']
+}
+
 module.exports = config

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -103,6 +103,7 @@ const version = process.env.CUCUMBER_VERSION || 'latest'
 const isLatestCucumberSupported = NODE_MAJOR === 22 || NODE_MAJOR === 24 || NODE_MAJOR >= 26
 
 const onlyLatestIt = version === 'latest' ? it : it.skip
+const rejectsFormatterErrorsIt = version === '7.0.0' ? it : it.skip
 
 const runTestsCommand = './node_modules/.bin/cucumber-js ci-visibility/features/*.feature'
 const runTestsWithCoverageCommand = './node_modules/nyc/bin/nyc.js -r=text-summary ' +
@@ -293,6 +294,36 @@ describe(`cucumber@${version} commonJS`, () => {
       once(childProcess, 'exit'),
       telemetryPromise,
     ])
+  })
+
+  rejectsFormatterErrorsIt('marks completed suites failed when a custom formatter throws', async () => {
+    childProcess = exec(
+      './node_modules/.bin/cucumber-js ci-visibility/features/greetings.feature ' +
+      '--format ./ci-visibility/cucumber-formatter-throws.js',
+      {
+        cwd,
+        env: getCiVisAgentlessConfig(receiver.port),
+      }
+    )
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        assert.strictEqual(events.filter(event => event.type === 'test_suite_end').length, 1)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.content.error, 1, `${eventType} should contain the formatter error`)
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom Cucumber formatter failed/)
+        }
+      }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.notStrictEqual(exitCode, 0)
   })
 
   it('forwards telemetry from parallel workers', async () => {
@@ -886,7 +917,7 @@ describe(`cucumber@${version} commonJS`, () => {
             }
 
             const eventTypes = eventsRequest.payload.events.map(event => event.type)
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+            assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
             const numSuites = eventTypes.reduce(
               (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
             )
@@ -960,7 +991,7 @@ describe(`cucumber@${version} commonJS`, () => {
             assert.ok(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
             const eventTypes = eventsRequest.payload.events.map(event => event.type)
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+            assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
             const numSuites = eventTypes.reduce(
               (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
             )
@@ -1001,7 +1032,7 @@ describe(`cucumber@${version} commonJS`, () => {
 
           receiver.assertPayloadReceived(({ payload }) => {
             const eventTypes = payload.events.map(event => event.type)
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+            assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
             const testSession = payload.events.find(event => event.type === 'test_session_end').content
             assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'false')
             assert.strictEqual(testSession.meta[TEST_CODE_COVERAGE_ENABLED], 'false')
@@ -1066,7 +1097,7 @@ describe(`cucumber@${version} commonJS`, () => {
               assert.strictEqual(skippedSuite.meta[TEST_STATUS], 'skip')
               assert.strictEqual(skippedSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
 
-              assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+              assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
               const numSuites = eventTypes.reduce(
                 (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
               )
@@ -1159,7 +1190,7 @@ describe(`cucumber@${version} commonJS`, () => {
           receiver.assertPayloadReceived(({ payload }) => {
             const eventTypes = payload.events.map(event => event.type)
             // because they are not skipped
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+            assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
             const numSuites = eventTypes.reduce(
               (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
             )
@@ -1206,7 +1237,7 @@ describe(`cucumber@${version} commonJS`, () => {
           receiver.assertPayloadReceived(({ payload }) => {
             const eventTypes = payload.events.map(event => event.type)
             // because they are not skipped
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+            assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
             const numSuites = eventTypes.reduce(
               (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
             )

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -1909,7 +1909,8 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     assert.strictEqual(childProcess.exitCode, 1)
   })
 
-  it('does not hang if server is not available and logs an error', (done) => {
+  it('bounds the final flush if the server is not available and logs an error', async function () {
+    this.timeout(20_000)
     // Very slow intake
     receiver.setWaitingTime(30000)
     // Needs to run with the CLI if we want --forceExit to work
@@ -1924,17 +1925,71 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         },
       }
     )
-    childProcess.on('exit', () => {
-      assert.match(testOutput, /Jest's '--forceExit' flag has been passed/)
-      assert.match(testOutput, /Timeout waiting for the tracer to flush/)
-      done()
-    })
     childProcess.stdout?.on('data', (chunk) => {
       testOutput += chunk.toString()
     })
     childProcess.stderr?.on('data', (chunk) => {
       testOutput += chunk.toString()
     })
+
+    await Promise.all([
+      once(childProcess, 'exit'),
+      once(childProcess.stdout, 'end'),
+      once(childProcess.stderr, 'end'),
+    ])
+
+    assert.match(testOutput, /Jest's '--forceExit' flag has been passed/)
+    assert.match(testOutput, /Error flushing Test Optimization data/)
+  })
+
+  it('reports the session when a custom reporter rejects runCLI', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node ./node_modules/jest/bin/jest --config config-jest.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          CONFIG_TEST_MATCH: '**/ci-visibility/test/ci-visibility-test.js',
+          JEST_THROWING_REPORTER: '1',
+        },
+      }
+    )
+
+    const receiverPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testSession = events.find(event => event.type === 'test_session_end')?.content
+        const testModule = events.find(event => event.type === 'test_module_end')?.content
+        const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+        const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+        assert.ok(testSession)
+        assert.ok(testModule)
+        assert.strictEqual(testSuites.length, 1)
+        assert.strictEqual(tests.length, 1)
+
+        const [testSuite] = testSuites
+        for (const event of [testSession, testModule, testSuite]) {
+          assert.strictEqual(event.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.error, 1)
+          assert.match(event.meta[ERROR_MESSAGE], /custom reporter failed/)
+        }
+        assert.strictEqual(testSuite.test_session_id.toString(), testSession.test_session_id.toString())
+        assert.strictEqual(testSuite.test_module_id.toString(), testModule.test_module_id.toString())
+        assert.strictEqual(tests[0].test_suite_id.toString(), testSuite.test_suite_id.toString())
+        assert.strictEqual(tests[0].meta[TEST_STATUS], 'pass')
+      }
+    )
+
+    const [[exitCode]] = await Promise.all([
+      once(childProcess, 'exit'),
+      receiverPromise,
+    ])
+
+    assert.notStrictEqual(exitCode, 0)
   })
 
   it('grabs the jest displayName config and sets tag in tests and suites', (done) => {

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -26,6 +26,10 @@ const config = {
   },
 }
 
+if (process.env.VITEST_THROWING_REPORTER) {
+  config.test.reporters.push('./ci-visibility/vitest-reporter-throws.mjs')
+}
+
 if (process.env.VITEST_PRESERVE_SYMLINKS) {
   config.resolve = {
     preserveSymlinks: true,

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -191,6 +191,46 @@ versions.forEach((version) => {
       assert.notStrictEqual(exitCode, 0)
     })
 
+    typecheckIt('reports a failed typecheck suite when a custom reporter rejects onTestRunEnd', async function () {
+      this.timeout(20_000)
+      childProcess = exec(
+        './node_modules/.bin/vitest run --config=./vitest.typecheck.config.mjs ' +
+          'ci-visibility/vitest-tests/typecheck.test-d.ts --reporter=verbose ' +
+          '--reporter=./ci-visibility/vitest-reporter-throws.mjs',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+          },
+        }
+      )
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const { testSession, testModule, testSuite } = assertCompleteTestSessionTrace(events, testOutput)
+
+          assert.strictEqual(events.filter(event => event.type === 'test_suite_end').length, 1)
+          for (const event of [testSession, testModule, testSuite]) {
+            assert.strictEqual(event.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(event.error, 1)
+            assert.match(event.meta[ERROR_MESSAGE], /custom Vitest reporter failed/)
+          }
+        },
+        { hardTimeout: 20_000 }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.notStrictEqual(exitCode, 0)
+    })
+
     poolConfig.forEach((poolConfig) => {
       it(`can run and report tests with pool=${poolConfig}`, async () => {
         childProcess = exec(

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -75,7 +75,7 @@ const FLAKY_UNNECESSARY_RETRY_RESOURCE =
   'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 
-function assertCompleteEventHierarchy (events, testOutput) {
+function assertCompleteTestSessionTrace (events, testOutput) {
   const testSessionEvent = events.find(event => event.type === 'test_session_end')
   const testModuleEvent = events.find(event => event.type === 'test_module_end')
   const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
@@ -146,6 +146,50 @@ versions.forEach((version) => {
     })
 
     const poolConfig = ['forks', 'threads']
+
+    newerVitestIt('reports a failed session when a custom reporter rejects onTestRunEnd', async function () {
+      this.timeout(20_000)
+      childProcess = exec(
+        './node_modules/.bin/vitest run',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            TEST_DIR: 'ci-visibility/vitest-tests/test-visibility-passed-suite.mjs',
+            VITEST_THROWING_REPORTER: '1',
+          },
+        }
+      )
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const { testSession, testModule, testSuite, tests } = assertCompleteTestSessionTrace(events, testOutput)
+
+          assert.strictEqual(events.filter(event => event.type === 'test_suite_end').length, 1)
+          for (const event of [testSession, testModule, testSuite]) {
+            assert.strictEqual(event.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(event.error, 1)
+            assert.match(event.meta[ERROR_MESSAGE], /custom Vitest reporter failed/)
+          }
+          assert.deepStrictEqual(
+            [...new Set(tests.map(test => test.meta[TEST_STATUS]))].sort(),
+            ['pass', 'skip']
+          )
+        },
+        { hardTimeout: 20_000 }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.notStrictEqual(exitCode, 0)
+    })
 
     poolConfig.forEach((poolConfig) => {
       it(`can run and report tests with pool=${poolConfig}`, async () => {
@@ -418,7 +462,7 @@ versions.forEach((version) => {
             testModule,
             testSuite,
             tests,
-          } = assertCompleteEventHierarchy(events, testOutput)
+          } = assertCompleteTestSessionTrace(events, testOutput)
           const passedTest = tests.find(test =>
             test.meta[TEST_NAME] === 'typecheck can report type assertion'
           )
@@ -1052,7 +1096,7 @@ versions.forEach((version) => {
             testModule,
             testSuite,
             tests,
-          } = assertCompleteEventHierarchy(events, testOutput)
+          } = assertCompleteTestSessionTrace(events, testOutput)
           const test = tests.find(test =>
             test.meta[TEST_NAME] === 'typecheck can report failing assertion'
           )

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -1222,7 +1222,28 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
       itrSkippedSuitesCh.publish({ skippedSuites, frameworkVersion })
     }
 
-    const result = await start.apply(this, arguments)
+    let result
+    try {
+      result = await start.apply(this, arguments)
+    } catch (error) {
+      try {
+        await getChannelPromise(sessionFinishCh, {
+          status: 'fail',
+          error,
+          isSuitesSkipped,
+          numSkippedSuites: skippedSuites.length,
+          hasUnskippableSuites: isUnskippable,
+          hasForcedToRunSuites: isForcedToRun,
+          isEarlyFlakeDetectionEnabled,
+          isEarlyFlakeDetectionFaulty,
+          isTestManagementTestsEnabled,
+          isParallel,
+        })
+      } catch (finalizationError) {
+        log.error('Cucumber test session finalization error: %s', finalizationError)
+      }
+      throw error
+    }
     const success = satisfies(frameworkVersion, '>=13.1.0') ? result.success : result
 
     let untestedCoverage

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -97,7 +97,9 @@ const itrSkippedSuitesCh = channel('ci:jest:itr:skipped-suites')
 const CHILD_MESSAGE_CALL = 1
 
 // Maximum time we'll wait for the tracer to flush
-const FLUSH_TIMEOUT = 10_000
+// The exporter has a 10-second bounded final-flush deadline. Leave enough time
+// for its completion callback before Jest's --forceExit fallback takes over.
+const FLUSH_TIMEOUT = 12_000
 const JEST_SESSION_STATE = Symbol.for('dd-trace:jest:session')
 const JEST_BAIL_REPORTER_PATH = require.resolve('./jest/bail-reporter')
 const DD_JEST_HANDLE_TEST_EVENT_WRAPPED = Symbol('dd-trace:jest:handle-test-event-wrapped')
@@ -3066,7 +3068,19 @@ function getCliWrapper (isNewJestVersion) {
         frameworkVersion: jestVersion,
       })
 
-      const result = await runCLI.apply(this, arguments)
+      let result
+      try {
+        result = await runCLI.apply(this, arguments)
+      } catch (error) {
+        try {
+          await waitForTestSessionFinish(getTestSessionFinishPayload('fail', error, {
+            isTestSessionFinalizationError: true,
+          }))
+        } catch (finalizationError) {
+          log.error('Jest test session finalization error: %s', finalizationError)
+        }
+        throw error
+      }
 
       const {
         results: {

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -1684,6 +1684,7 @@ async function reportTypecheckFile (file, sessionConfiguration, frameworkVersion
   }
 
   await getChannelPromise(testSuiteFinishCh, {
+    deferFlush: true,
     frameworkVersion,
     status: getTypecheckTaskStatus(file),
     ...testSuiteCtx.currentStore,

--- a/packages/datadog-instrumentations/src/vitest-main.js
+++ b/packages/datadog-instrumentations/src/vitest-main.js
@@ -67,6 +67,7 @@ const coverageWrappedProviders = new WeakSet()
 const finishWrappedContexts = new WeakSet()
 const runFilesWrappedPrototypes = new WeakSet()
 const activeRunFilesContexts = new WeakSet()
+const runErrorsByContext = new WeakMap()
 let isFlakyTestRetriesEnabled = false
 let flakyTestRetriesCount = 0
 let isEarlyFlakeDetectionEnabled = false
@@ -1195,15 +1196,18 @@ function getFinishWrapper (exitOrClose) {
     }
 
     const failedSuites = this.state.getFailedFilepaths()
-    let error
-    if (failedSuites.length) {
+    const runError = runErrorsByContext.get(this)
+    runErrorsByContext.delete(this)
+    let error = runError
+    if (!error && failedSuites.length) {
       error = new Error(`Test suites failed: ${failedSuites.length}.`)
     }
 
     const flushPromise = getChannelPromise(testSessionFinishCh, {
-      status: areAllSuitesSkipped ? 'skip' : getSessionStatus(this.state),
+      status: runError ? 'fail' : (areAllSuitesSkipped ? 'skip' : getSessionStatus(this.state)),
       testCodeCoverageLinesTotal,
       error,
+      isTestSessionFinalizationError: Boolean(runError),
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
@@ -1376,6 +1380,9 @@ function wrapVitestRunFiles (Vitest, frameworkVersion) {
     activeRunFilesContexts.add(this)
     try {
       return await runFiles.apply(this, arguments)
+    } catch (error) {
+      runErrorsByContext.set(this, error)
+      throw error
     } finally {
       activeRunFilesContexts.delete(this)
     }

--- a/packages/datadog-instrumentations/test/vitest-main.spec.js
+++ b/packages/datadog-instrumentations/test/vitest-main.spec.js
@@ -123,6 +123,7 @@ describe('vitest main instrumentation', () => {
     const knownTestsCh = {}
     const noWorkerInitStates = []
     const providedContexts = []
+    const testSuiteFinishPayloads = []
     let reserveEarlyFlakeDetectionSuite
     let shouldUseNoWorkerInit = false
     const testSuiteFinishCh = {
@@ -166,6 +167,9 @@ describe('vitest main instrumentation', () => {
           }
           if (currentChannel === knownTestsCh) {
             return Promise.resolve({ knownTests: { vitest: {} } })
+          }
+          if (currentChannel === testSuiteFinishCh) {
+            testSuiteFinishPayloads.push(data)
           }
           return Promise.resolve()
         },
@@ -245,7 +249,9 @@ describe('vitest main instrumentation', () => {
 
     class Typechecker {
       async prepareResults () {
-        return { files: [] }
+        return {
+          files: [{ filepath: '/repo/typecheck.ts', result: { state: 'pass' }, tasks: [] }],
+        }
       }
     }
     const typecheckerHook = hooks.find(({ target }) => target.versions[0] === '>=4.0.0').hook
@@ -254,6 +260,8 @@ describe('vitest main instrumentation', () => {
     const typechecker = new Typechecker()
     typechecker.ctx = ctx
     await typechecker.prepareResults()
+    assert.strictEqual(testSuiteFinishPayloads.length, 1)
+    assert.strictEqual(testSuiteFinishPayloads[0].deferFlush, true)
 
     const customPoolTypechecker = new Typechecker()
     customPoolTypechecker.ctx = {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -72,6 +72,7 @@ class CucumberPlugin extends CiPlugin {
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
       isParallel,
+      error,
       onDone,
     }) => {
       this._exportPendingWorkerTraces()
@@ -115,6 +116,15 @@ class CucumberPlugin extends CiPlugin {
 
       this.testSessionSpan.setTag(TEST_STATUS, status)
       this.testModuleSpan.setTag(TEST_STATUS, status)
+      if (error) {
+        for (const testSuiteSpan of this._testSuiteSpansByTestSuite.values()) {
+          testSuiteSpan.setTag(TEST_STATUS, 'fail')
+          testSuiteSpan.setTag('error', error)
+        }
+        this.testSessionSpan.setTag('error', error)
+        this.testModuleSpan.setTag('error', error)
+      }
+      this.tracer._exporter.exportDeferredTestSuiteSpans?.()
       this.testModuleSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')
       this.testSessionSpan.finish()
@@ -192,6 +202,7 @@ class CucumberPlugin extends CiPlugin {
     this.addSub('ci:cucumber:test-suite:finish', ({ status, testSuitePath }) => {
       const testSuiteSpan = this._testSuiteSpansByTestSuite.get(testSuitePath)
       testSuiteSpan.setTag(TEST_STATUS, status)
+      this.tracer._exporter.deferTestSuiteSpan?.(testSuiteSpan)
       testSuiteSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
     })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -113,6 +113,7 @@ class JestPlugin extends CiPlugin {
       hasUnskippableSuites,
       hasForcedToRunSuites,
       error,
+      isTestSessionFinalizationError,
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
@@ -123,6 +124,9 @@ class JestPlugin extends CiPlugin {
         this.testModuleSpan.setTag(TEST_STATUS, status)
 
         if (error) {
+          if (isTestSessionFinalizationError) {
+            this.tracer._exporter.setDeferredTestSuiteError?.(error)
+          }
           this.testSessionSpan.setTag('error', error)
           this.testModuleSpan.setTag('error', error)
         }
@@ -159,6 +163,7 @@ class JestPlugin extends CiPlugin {
           this.testSessionSpan.setTag(TEST_MANAGEMENT_ENABLED, 'true')
         }
 
+        this.tracer._exporter.exportDeferredTestSuiteSpans?.()
         this.testModuleSpan.finish()
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')
         this.testSessionSpan.finish()
@@ -329,6 +334,7 @@ class JestPlugin extends CiPlugin {
       this.pendingTestSuiteFinishes.add(pendingFinish)
 
       const finish = () => {
+        this.tracer._exporter.deferTestSuiteSpan?.(testSuiteSpan)
         testSuiteSpan.finish()
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
         // Suites potentially run in a different process than the session,

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -523,6 +523,7 @@ class VitestPlugin extends CiPlugin {
           this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: coverageLibrary })
           this.telemetry.distribution(TELEMETRY_CODE_COVERAGE_NUM_FILES, {}, relativeFiles.length)
         }
+        this.tracer._exporter.deferTestSuiteSpan?.(testSuiteSpan)
         testSuiteSpan.finish()
         finishAllTraceSpans(testSuiteSpan)
       }
@@ -566,6 +567,7 @@ class VitestPlugin extends CiPlugin {
     this.addSub('ci:vitest:session:finish', ({
       status,
       error,
+      isTestSessionFinalizationError,
       testCodeCoverageLinesTotal,
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
@@ -588,6 +590,9 @@ class VitestPlugin extends CiPlugin {
       this.testSessionSpan.setTag(TEST_STATUS, status)
       this.testModuleSpan.setTag(TEST_STATUS, status)
       if (error) {
+        if (isTestSessionFinalizationError) {
+          this.tracer._exporter.setDeferredTestSuiteError?.(error)
+        }
         this.testModuleSpan.setTag('error', error)
         this.testSessionSpan.setTag('error', error)
       }
@@ -617,6 +622,7 @@ class VitestPlugin extends CiPlugin {
       if (vitestPool) {
         this.testSessionSpan.setTag(VITEST_POOL, vitestPool)
       }
+      this.tracer._exporter.exportDeferredTestSuiteSpans?.()
       this.testModuleSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')
       this.testSessionSpan.finish()

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -112,7 +112,8 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
         this.resetDeferredTestSuiteSpans()
         return
       }
-      if (!isEvpCompatible) this.resetDeferredTestSuiteSpans()
+      if (isEvpCompatible) this.exportDeferredTestSuiteSpans()
+      else this.resetDeferredTestSuiteSpans()
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
     }, initializationOptions, request)

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -52,6 +52,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
     }
 
     fetchAgentInfo(this._url, (err, agentInfo) => {
+      const initializationFinalFlush = this._initializationRequest?.finalFlush
       this._initializationRequest = undefined
       const initializationAborted = initializationController.signal.aborted
       const agentInfoError = err || (initializationAborted ? initializationController.signal.reason : undefined)
@@ -112,8 +113,11 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
         this.resetDeferredTestSuiteSpans()
         return
       }
-      if (isEvpCompatible) this.exportDeferredTestSuiteSpans()
-      else this.resetDeferredTestSuiteSpans()
+      if (isEvpCompatible) {
+        if (initializationFinalFlush) this.exportDeferredTestSuiteSpans()
+      } else {
+        this.resetDeferredTestSuiteSpans()
+      }
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
     }, initializationOptions, request)

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -109,8 +109,10 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       this._resolveCanUseCiVisProtocol(isEvpCompatible)
       if (initializationAborted) {
         this.resetUncodedTraces()
+        this.resetDeferredTestSuiteSpans()
         return
       }
+      if (!isEvpCompatible) this.resetDeferredTestSuiteSpans()
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
     }, initializationOptions, request)

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -12,6 +12,7 @@ const { getTestManagementTests: getTestManagementTestsRequest } =
   require('../test-management/get-test-management-tests')
 const { writeSettingsToCache } = require('../test-optimization-cache')
 const { CACHE_MISS, TestOptimizationHttpCache } = require('../test-optimization-http-cache')
+const { incrementCountMetric, TELEMETRY_EVENTS_ENQUEUED_FOR_SERIALIZATION } = require('../telemetry')
 const { uploadCoverageReport: uploadCoverageReportRequest } = require('../requests/upload-coverage-report')
 const { uploadTestScreenshot: uploadTestScreenshotRequest } = require('../requests/upload-test-screenshot')
 const { parsers } = require('../../config/parsers')
@@ -520,9 +521,14 @@ class CiVisibilityExporter extends BufferingExporter {
    * @returns {boolean|undefined}
    */
   #appendDeferredTestSuiteSpan (formattedSpan, options) {
-    if (options === undefined) return this._writer.append([formattedSpan])
+    const appended = options === undefined
+      ? this._writer.append([formattedSpan])
+      : this._writer.append([formattedSpan], options)
 
-    return this._writer.append([formattedSpan], options)
+    if (appended !== false && this._config.isCiVisibility) {
+      incrementCountMetric(TELEMETRY_EVENTS_ENQUEUED_FOR_SERIALIZATION)
+    }
+    return appended
   }
 
   /**

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -16,9 +16,11 @@ const { uploadCoverageReport: uploadCoverageReportRequest } = require('../reques
 const { uploadTestScreenshot: uploadTestScreenshotRequest } = require('../requests/upload-test-screenshot')
 const { parsers } = require('../../config/parsers')
 const log = require('../../log')
+const spanFormat = require('../../span_format')
 const { getSegment } = require('../../util')
 const BufferingExporter = require('../../exporters/common/buffering-exporter')
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../../plugins/util/tags')
+const { TEST_STATUS } = require('../../plugins/util/test')
 const { sendGitMetadata: sendGitMetadataRequest } = require('./git/git_metadata')
 
 const hostname = getHostname()
@@ -102,6 +104,7 @@ class CiVisibilityExporter extends BufferingExporter {
   #deferredTestSessionTraces = []
   #pendingScreenshotUploads = new Set()
   #screenshotFlushWaiters = new Set()
+  #deferredTestSuiteSpans = new Map()
 
   constructor (config, options = {}) {
     super(config)
@@ -405,7 +408,34 @@ class CiVisibilityExporter extends BufferingExporter {
 
   export (trace) {
     this.#resetFinalFlush()
-    this.#exportTrace(trace)
+
+    if (this.#deferredTestSuiteSpans.size === 0) {
+      this.#exportTrace(trace)
+      return
+    }
+
+    let hasDeferredTestSuiteSpan = false
+    let immediateTrace
+    for (let index = 0; index < trace.length; index++) {
+      const formattedSpan = trace[index]
+      const spanId = formattedSpan.span_id?.toString()
+      const deferredTestSuiteSpan = this.#deferredTestSuiteSpans.get(spanId)
+      if (deferredTestSuiteSpan) {
+        if (!hasDeferredTestSuiteSpan && index > 0) immediateTrace = trace.slice(0, index)
+        hasDeferredTestSuiteSpan = true
+        if (deferredTestSuiteSpan.emitted || (this._isInitialized && !this.canReportSessionTraces())) {
+          this.#deferredTestSuiteSpans.delete(spanId)
+        } else {
+          deferredTestSuiteSpan.formattedSpan = formattedSpan
+        }
+      } else if (hasDeferredTestSuiteSpan) {
+        immediateTrace ??= []
+        immediateTrace.push(formattedSpan)
+      }
+    }
+
+    if (!hasDeferredTestSuiteSpan) this.#exportTrace(trace)
+    else if (immediateTrace) this.#exportTrace(immediateTrace)
   }
 
   /**
@@ -427,6 +457,110 @@ class CiVisibilityExporter extends BufferingExporter {
     if (this._export(trace, undefined, undefined, isTestSessionTrace) === false && isTestSessionTrace) {
       this.#deferredTestSessionTraces.push(trace)
     }
+  }
+
+  /**
+   * Retains a completed suite until finalization so a later framework error can still update it.
+   *
+   * @param {import('../../opentracing/span')} testSuiteSpan
+   * @returns {void}
+   */
+  deferTestSuiteSpan (testSuiteSpan) {
+    this.#resetFinalFlush()
+    this.#deferredTestSuiteSpans.set(testSuiteSpan.context()._spanId.toString(), {
+      span: testSuiteSpan,
+      formattedSpan: undefined,
+      emitted: false,
+    })
+  }
+
+  /**
+   * Retains formatted test suite events received from test framework workers until finalization.
+   *
+   * @param {Array<object>} trace
+   * @returns {void}
+   */
+  exportTraceWithDeferredTestSuite (trace) {
+    for (const formattedSpan of trace) {
+      if (formattedSpan.type !== 'test_suite_end') continue
+
+      this.#deferredTestSuiteSpans.set(formattedSpan.span_id.toString(), {
+        span: undefined,
+        formattedSpan,
+        emitted: false,
+      })
+    }
+    this.export(trace)
+  }
+
+  /**
+   * Applies a late framework error to every completed suite retained by the current finalization boundary.
+   *
+   * @param {Error} error
+   * @returns {void}
+   */
+  setDeferredTestSuiteError (error) {
+    for (const { span, formattedSpan, emitted } of this.#deferredTestSuiteSpans.values()) {
+      if (emitted) continue
+      if (span) {
+        span.setTag(TEST_STATUS, 'fail')
+        span.setTag('error', error)
+      } else if (formattedSpan) {
+        formattedSpan.meta[TEST_STATUS] = 'fail'
+        spanFormat.addError(formattedSpan, error)
+      }
+    }
+  }
+
+  /**
+   * Appends a completed suite while preserving the ordinary writer call shape outside finalization.
+   *
+   * @param {object} formattedSpan
+   * @param {{ deadline?: number }} [options]
+   * @returns {boolean|undefined}
+   */
+  #appendDeferredTestSuiteSpan (formattedSpan, options) {
+    if (options === undefined) return this._writer.append([formattedSpan])
+
+    return this._writer.append([formattedSpan], options)
+  }
+
+  /**
+   * Appends completed suites before their module and session parents are exported.
+   *
+   * @param {{ deadline?: number }} [options]
+   * @returns {void}
+   */
+  exportDeferredTestSuiteSpans (options) {
+    if (!this._writer || !this.canReportSessionTraces()) return
+
+    for (const [spanId, deferredTestSuiteSpan] of this.#deferredTestSuiteSpans) {
+      const { span, formattedSpan, emitted } = deferredTestSuiteSpan
+      if (emitted) continue
+      const updatedSpan = span && spanFormat(span)
+      if (span && formattedSpan) {
+        formattedSpan.error = updatedSpan.error
+        Object.assign(formattedSpan.meta, updatedSpan.meta)
+        Object.assign(formattedSpan.metrics, updatedSpan.metrics)
+        if (this.#appendDeferredTestSuiteSpan(formattedSpan, options) === false) continue
+        this.#deferredTestSuiteSpans.delete(spanId)
+      } else if (formattedSpan) {
+        if (this.#appendDeferredTestSuiteSpan(formattedSpan, options) === false) continue
+        this.#deferredTestSuiteSpans.delete(spanId)
+      } else {
+        if (this.#appendDeferredTestSuiteSpan(updatedSpan, options) === false) continue
+        deferredTestSuiteSpan.emitted = true
+      }
+    }
+  }
+
+  /**
+   * Discards completed suites that the selected transport cannot deliver.
+   *
+   * @returns {void}
+   */
+  resetDeferredTestSuiteSpans () {
+    this.#deferredTestSuiteSpans.clear()
   }
 
   /**
@@ -516,7 +650,8 @@ class CiVisibilityExporter extends BufferingExporter {
 
     if (isFinalFlush && !this._isInitialized &&
       this._traceBuffer.length === 0 && this._coverageBuffer.length === 0 &&
-      this.#deferredTestSessionTraces.length === 0 && this.#pendingScreenshotUploads.size === 0) {
+      this.#deferredTestSuiteSpans.size === 0 && this.#deferredTestSessionTraces.length === 0 &&
+      this.#pendingScreenshotUploads.size === 0) {
       onDone()
       return
     }
@@ -573,6 +708,7 @@ class CiVisibilityExporter extends BufferingExporter {
 
       const options = deadline === undefined ? undefined : { deadline }
       if (isFinalFlush) {
+        this.exportDeferredTestSuiteSpans(options)
         this.#exportDeferredTestSessionTraces(options)
       }
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -728,7 +728,12 @@ module.exports = class CiPlugin extends Plugin {
       this._bufferWorkerTrace(missingTestSuite, trace)
       return
     }
-    this.tracer._exporter.export(trace)
+    const exporter = this.tracer._exporter
+    if (exporter.exportTraceWithDeferredTestSuite) {
+      exporter.exportTraceWithDeferredTestSuite(trace)
+    } else {
+      exporter.export(trace)
+    }
   }
 
   /**

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -851,7 +851,7 @@ function getTestTypeFromFramework (testFramework) {
  */
 function finishAllTraceSpans (span) {
   for (const traceSpan of span.context()._trace.started) {
-    if (traceSpan !== span) {
+    if (traceSpan !== span && !traceSpan._finished) {
       traceSpan.finish()
     }
   }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -851,7 +851,7 @@ function getTestTypeFromFramework (testFramework) {
  */
 function finishAllTraceSpans (span) {
   for (const traceSpan of span.context()._trace.started) {
-    if (traceSpan !== span && !traceSpan._finished) {
+    if (traceSpan !== span && traceSpan._duration === undefined) {
       traceSpan.finish()
     }
   }

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -450,3 +450,4 @@ function isUrl (obj) {
 }
 
 module.exports = format
+module.exports.addError = extractError

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -340,6 +340,30 @@ describe('CiPlugin', () => {
     sinon.assert.calledWith(distributionMetric, 'code_coverage.files', {}, 3)
   })
 
+  it('defers worker suite events when the exporter supports late test suite updates', () => {
+    const plugin = createPlugin('vitest_worker')
+    const exportTraceWithDeferredTestSuite = sinon.spy()
+    const exportTrace = sinon.spy()
+    const trace = [{ type: 'test_suite_end', meta: {} }]
+    plugin.tracer._exporter = { export: exportTrace, exportTraceWithDeferredTestSuite }
+
+    plugin._exportWorkerTraceOrBuffer(trace)
+
+    sinon.assert.calledOnceWithExactly(exportTraceWithDeferredTestSuite, trace)
+    sinon.assert.notCalled(exportTrace)
+  })
+
+  it('exports worker traces normally when late test suite updates are unsupported', () => {
+    const plugin = createPlugin('vitest_worker')
+    const exportTrace = sinon.spy()
+    const trace = [{ type: 'test', meta: {} }]
+    plugin.tracer._exporter = { export: exportTrace }
+
+    plugin._exportWorkerTraceOrBuffer(trace)
+
+    sinon.assert.calledOnceWithExactly(exportTrace, trace)
+  })
+
   it('uploads regular coverage reports from canonical paths', () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-coverage-reports-'))
     const coverageDir = path.join(rootDir, 'coverage')

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -125,6 +125,27 @@ describe('AgentProxyCiVisibilityExporter', () => {
     }
   })
 
+  it('exports deferred suite events before buffered module and session events after initialization', async () => {
+    const controlled = createControlledExporter()
+    const suiteEvent = { type: 'test_suite_end', span_id: '1' }
+    const moduleAndSessionEvents = [
+      { type: 'test_module_end' },
+      { type: 'test_session_end' },
+    ]
+    const done = sinon.spy()
+
+    controlled.exporter.exportTraceWithDeferredTestSuite([suiteEvent])
+    controlled.exporter.export(moduleAndSessionEvents)
+    controlled.exporter.flush(done)
+
+    controlled.finishAgentInfo(null, { endpoints: ['/evp_proxy/v2'] })
+    await Promise.resolve()
+
+    sinon.assert.calledWithExactly(controlled.writers[0].append.firstCall, [suiteEvent])
+    sinon.assert.calledWithExactly(controlled.writers[0].append.secondCall, moduleAndSessionEvents)
+    sinon.assert.calledOnceWithExactly(done, undefined)
+  })
+
   it('aborts initialization and uses the fallback writer for later sessions', async () => {
     const clock = sinon.useFakeTimers()
     try {

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -146,6 +146,38 @@ describe('AgentProxyCiVisibilityExporter', () => {
     sinon.assert.calledOnceWithExactly(done, undefined)
   })
 
+  it('retains deferred suites for reporter errors when initialization finishes before finalization', async () => {
+    const controlled = createControlledExporter()
+    const suiteEvent = {
+      type: 'test_suite_end',
+      span_id: '1',
+      error: 0,
+      meta: { 'test.status': 'pass' },
+      metrics: {},
+    }
+    const reporterError = new Error('custom reporter failed')
+    const moduleAndSessionEvents = [
+      { type: 'test_module_end' },
+      { type: 'test_session_end' },
+    ]
+
+    controlled.exporter.exportTraceWithDeferredTestSuite([suiteEvent])
+    controlled.finishAgentInfo(null, { endpoints: ['/evp_proxy/v2'] })
+    await Promise.resolve()
+
+    sinon.assert.notCalled(controlled.writers[0].append)
+
+    controlled.exporter.setDeferredTestSuiteError(reporterError)
+    controlled.exporter.exportDeferredTestSuiteSpans()
+    controlled.exporter.export(moduleAndSessionEvents)
+
+    sinon.assert.calledWithExactly(controlled.writers[0].append.firstCall, [suiteEvent])
+    assert.strictEqual(suiteEvent.meta['test.status'], 'fail')
+    assert.strictEqual(suiteEvent.error, 1)
+    assert.strictEqual(suiteEvent.meta['error.message'], reporterError.message)
+    sinon.assert.calledWithExactly(controlled.writers[0].append.secondCall, moduleAndSessionEvents)
+  })
+
   it('aborts initialization and uses the fallback writer for later sessions', async () => {
     const clock = sinon.useFakeTimers()
     try {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -29,6 +29,7 @@ const { uploadTestScreenshot: actualUploadTestScreenshotRequest } =
 let uploadCoverageReportRequest = actualUploadCoverageReportRequest
 let uploadTestScreenshotRequest = actualUploadTestScreenshotRequest
 let formatSpan = actualSpanFormat
+let incrementCountMetric
 const formatSpanStub = (...args) => formatSpan(...args)
 formatSpanStub.addError = actualSpanFormat.addError
 const CiVisibilityExporterBase = proxyquire('../../../src/ci-visibility/exporters/ci-visibility-exporter', {
@@ -41,6 +42,12 @@ const CiVisibilityExporterBase = proxyquire('../../../src/ci-visibility/exporter
     uploadTestScreenshot (...args) {
       return uploadTestScreenshotRequest(...args)
     },
+  },
+  '../telemetry': {
+    incrementCountMetric (...args) {
+      return incrementCountMetric?.(...args)
+    },
+    TELEMETRY_EVENTS_ENQUEUED_FOR_SERIALIZATION: 'events_enqueued_for_serialization',
   },
   '../../span_format': formatSpanStub,
 })
@@ -68,6 +75,7 @@ describe('CI Visibility Exporter', () => {
     uploadCoverageReportRequest = actualUploadCoverageReportRequest
     uploadTestScreenshotRequest = actualUploadTestScreenshotRequest
     formatSpan = actualSpanFormat
+    incrementCountMetric = sinon.stub()
   })
 
   afterEach(() => {
@@ -998,7 +1006,7 @@ describe('CI Visibility Exporter', () => {
           flush: sinon.spy(done => done?.()),
           setUrl: sinon.spy(),
         }
-        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0, isCiVisibility: true })
         ciVisibilityExporter._isInitialized = true
         ciVisibilityExporter._writer = writer
         ciVisibilityExporter._canUseCiVisProtocol = true
@@ -1029,6 +1037,10 @@ describe('CI Visibility Exporter', () => {
           [suiteEvent],
           sinon.match({ deadline: sinon.match.number })
         )
+        sinon.assert.calledOnceWithExactly(
+          incrementCountMetric,
+          'events_enqueued_for_serialization'
+        )
         sinon.assert.calledOnceWithExactly(formatSpan, testSuiteSpan)
         sinon.assert.calledOnceWithExactly(firstDone, undefined)
 
@@ -1048,7 +1060,7 @@ describe('CI Visibility Exporter', () => {
           flush: sinon.spy(done => done?.()),
           setUrl: sinon.spy(),
         }
-        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0, isCiVisibility: true })
         ciVisibilityExporter._isInitialized = true
         ciVisibilityExporter._writer = writer
         ciVisibilityExporter._canUseCiVisProtocol = true
@@ -1070,12 +1082,17 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter.exportDeferredTestSuiteSpans()
 
         sinon.assert.calledOnceWithExactly(writer.append, [suiteEvent])
+        sinon.assert.notCalled(incrementCountMetric)
         const done = sinon.spy()
         ciVisibilityExporter.flush(done)
 
         sinon.assert.calledTwice(writer.append)
         assert.strictEqual(writer.append.secondCall.args[0][0], suiteEvent)
         assert.strictEqual(typeof writer.append.secondCall.args[1].deadline, 'number')
+        sinon.assert.calledOnceWithExactly(
+          incrementCountMetric,
+          'events_enqueued_for_serialization'
+        )
         sinon.assert.calledOnceWithExactly(done, undefined)
 
         ciVisibilityExporter.exportDeferredTestSuiteSpans()

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -20,6 +20,7 @@ const { createEfdRetryPolicy } = require('../../../src/ci-visibility/efd-retry-p
 const getConfig = require('../../../src/config')
 const { defaults: { hostname, port } } = require('../../../src/config/defaults')
 const ciVisibilityLog = require('../../../src/log')
+const actualSpanFormat = require('../../../src/span_format')
 const { uploadCoverageReport: actualUploadCoverageReportRequest } =
   require('../../../src/ci-visibility/requests/upload-coverage-report')
 const { uploadTestScreenshot: actualUploadTestScreenshotRequest } =
@@ -27,6 +28,9 @@ const { uploadTestScreenshot: actualUploadTestScreenshotRequest } =
 
 let uploadCoverageReportRequest = actualUploadCoverageReportRequest
 let uploadTestScreenshotRequest = actualUploadTestScreenshotRequest
+let formatSpan = actualSpanFormat
+const formatSpanStub = (...args) => formatSpan(...args)
+formatSpanStub.addError = actualSpanFormat.addError
 const CiVisibilityExporterBase = proxyquire('../../../src/ci-visibility/exporters/ci-visibility-exporter', {
   '../requests/upload-coverage-report': {
     uploadCoverageReport (...args) {
@@ -38,6 +42,7 @@ const CiVisibilityExporterBase = proxyquire('../../../src/ci-visibility/exporter
       return uploadTestScreenshotRequest(...args)
     },
   },
+  '../../span_format': formatSpanStub,
 })
 
 // The real tracer Config always carries a `testOptimization` namespace object.
@@ -62,6 +67,7 @@ describe('CI Visibility Exporter', () => {
     nock.cleanAll()
     uploadCoverageReportRequest = actualUploadCoverageReportRequest
     uploadTestScreenshotRequest = actualUploadTestScreenshotRequest
+    formatSpan = actualSpanFormat
   })
 
   afterEach(() => {
@@ -893,6 +899,240 @@ describe('CI Visibility Exporter', () => {
         sinon.assert.calledOnce(writer.flush)
         assert.strictEqual(typeof writer.flush.firstCall.args[1].deadline, 'number')
       })
+
+      it('retains a completed suite until final flush and applies later span tags', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(done => done?.()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+        const spanId = { toString: () => 'suite-span-id' }
+        const testSuiteSpan = {
+          context: () => ({ _spanId: spanId }),
+        }
+        const testEvent = { type: 'test' }
+        const suiteEvent = {
+          type: 'test_suite_end',
+          span_id: spanId,
+          error: 0,
+          meta: { 'test.status': 'pass' },
+          metrics: {},
+        }
+        formatSpan = sinon.stub().returns({
+          error: 1,
+          meta: {
+            'error.message': 'late reporter error',
+            'test.status': 'fail',
+          },
+          metrics: {},
+        })
+
+        ciVisibilityExporter.deferTestSuiteSpan(testSuiteSpan)
+        ciVisibilityExporter.export([testEvent, suiteEvent])
+
+        sinon.assert.calledOnceWithExactly(writer.append, [testEvent])
+        ciVisibilityExporter.flush()
+        sinon.assert.calledOnce(writer.append)
+
+        const done = sinon.spy()
+        ciVisibilityExporter.flush(done)
+
+        sinon.assert.calledTwice(writer.append)
+        assert.deepStrictEqual(writer.append.secondCall.args[0], [{
+          ...suiteEvent,
+          error: 1,
+          meta: {
+            'error.message': 'late reporter error',
+            'test.status': 'fail',
+          },
+        }])
+        sinon.assert.calledOnceWithExactly(formatSpan, testSuiteSpan)
+        sinon.assert.calledOnceWithExactly(done, undefined)
+      })
+
+      it('retains a formatted worker suite and applies a later reporter error', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(done => done?.()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+        const spanId = { toString: () => 'suite-span-id' }
+        const testEvent = { type: 'test' }
+        const suiteEvent = {
+          type: 'test_suite_end',
+          span_id: spanId,
+          error: 0,
+          meta: { 'test.status': 'pass' },
+          metrics: {},
+        }
+        const error = new Error('late reporter error')
+
+        ciVisibilityExporter.exportTraceWithDeferredTestSuite([testEvent, suiteEvent])
+        ciVisibilityExporter.setDeferredTestSuiteError(error)
+
+        sinon.assert.calledOnceWithExactly(writer.append, [testEvent])
+        const done = sinon.spy()
+        ciVisibilityExporter.flush(done)
+
+        sinon.assert.calledTwice(writer.append)
+        assert.strictEqual(writer.append.secondCall.args[0][0], suiteEvent)
+        assert.strictEqual(suiteEvent.error, 1)
+        assert.strictEqual(suiteEvent.meta['test.status'], 'fail')
+        assert.strictEqual(suiteEvent.meta['error.message'], error.message)
+        assert.strictEqual(suiteEvent.meta['error.type'], error.name)
+        assert.strictEqual(suiteEvent.meta['error.stack'], error.stack)
+        sinon.assert.calledOnceWithExactly(done, undefined)
+      })
+
+      it('serializes a completed suite at final flush before SpanProcessor exports it', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(done => done?.()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+        const spanId = { toString: () => 'suite-span-id' }
+        const testSuiteSpan = {
+          context: () => ({ _spanId: spanId }),
+        }
+        const suiteEvent = {
+          type: 'test_suite_end',
+          span_id: spanId,
+          error: 1,
+          meta: {
+            'error.message': 'late reporter error',
+            'test.status': 'fail',
+          },
+          metrics: {},
+        }
+        const moduleEvent = { type: 'test_module_end' }
+        const sessionEvent = { type: 'test_session_end' }
+        formatSpan = sinon.stub().returns(suiteEvent)
+        const firstDone = sinon.spy()
+
+        ciVisibilityExporter.deferTestSuiteSpan(testSuiteSpan)
+        ciVisibilityExporter.flush(firstDone)
+
+        sinon.assert.calledOnceWithExactly(
+          writer.append,
+          [suiteEvent],
+          sinon.match({ deadline: sinon.match.number })
+        )
+        sinon.assert.calledOnceWithExactly(formatSpan, testSuiteSpan)
+        sinon.assert.calledOnceWithExactly(firstDone, undefined)
+
+        ciVisibilityExporter.export([suiteEvent, moduleEvent, sessionEvent])
+        const secondDone = sinon.spy()
+        ciVisibilityExporter.flush(secondDone)
+
+        sinon.assert.calledTwice(writer.append)
+        sinon.assert.calledWithExactly(writer.append.secondCall, [moduleEvent, sessionEvent])
+        sinon.assert.calledOnceWithExactly(formatSpan, testSuiteSpan)
+        sinon.assert.calledOnceWithExactly(secondDone, undefined)
+      })
+
+      it('retains a deferred suite until a bounded final append is accepted', () => {
+        const writer = {
+          append: sinon.stub().onFirstCall().returns(false).onSecondCall().returns(true),
+          flush: sinon.spy(done => done?.()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+        const spanId = { toString: () => 'suite-span-id' }
+        const testSuiteSpan = {
+          context: () => ({ _spanId: spanId }),
+        }
+        const suiteEvent = {
+          type: 'test_suite_end',
+          span_id: spanId,
+          error: 0,
+          meta: { 'test.status': 'pass' },
+          metrics: {},
+        }
+        formatSpan = sinon.stub().returns(suiteEvent)
+
+        ciVisibilityExporter.deferTestSuiteSpan(testSuiteSpan)
+        ciVisibilityExporter.export([suiteEvent])
+        ciVisibilityExporter.exportDeferredTestSuiteSpans()
+
+        sinon.assert.calledOnceWithExactly(writer.append, [suiteEvent])
+        const done = sinon.spy()
+        ciVisibilityExporter.flush(done)
+
+        sinon.assert.calledTwice(writer.append)
+        assert.strictEqual(writer.append.secondCall.args[0][0], suiteEvent)
+        assert.strictEqual(typeof writer.append.secondCall.args[1].deadline, 'number')
+        sinon.assert.calledOnceWithExactly(done, undefined)
+
+        ciVisibilityExporter.exportDeferredTestSuiteSpans()
+        sinon.assert.calledTwice(writer.append)
+      })
+
+      it('retains module and session events until bounded final appends are accepted', () => {
+        const writer = {
+          append: sinon.stub()
+            .onFirstCall().returns(false)
+            .onSecondCall().returns(true)
+            .onThirdCall().returns(true),
+          flush: sinon.spy(done => done?.()),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+        const spanId = { toString: () => 'suite-span-id' }
+        const testSuiteSpan = {
+          context: () => ({ _spanId: spanId }),
+        }
+        const suiteEvent = {
+          type: 'test_suite_end',
+          span_id: spanId,
+          error: 0,
+          meta: { 'test.status': 'pass' },
+          metrics: {},
+        }
+        const moduleEvent = { type: 'test_module_end' }
+        const sessionEvent = { type: 'test_session_end' }
+        const moduleAndSessionEvents = [moduleEvent, sessionEvent]
+        formatSpan = sinon.stub().returns(suiteEvent)
+
+        ciVisibilityExporter.deferTestSuiteSpan(testSuiteSpan)
+        ciVisibilityExporter.export([suiteEvent, ...moduleAndSessionEvents])
+
+        sinon.assert.calledOnceWithExactly(writer.append, moduleAndSessionEvents)
+
+        const done = sinon.spy()
+        ciVisibilityExporter.flush(done)
+
+        sinon.assert.calledThrice(writer.append)
+        sinon.assert.calledWithExactly(
+          writer.append.secondCall,
+          [suiteEvent],
+          sinon.match({ deadline: sinon.match.number })
+        )
+        sinon.assert.calledWithExactly(
+          writer.append.thirdCall,
+          moduleAndSessionEvents,
+          writer.append.secondCall.args[1]
+        )
+        sinon.assert.calledOnceWithExactly(writer.flush, sinon.match.func, writer.append.secondCall.args[1])
+        sinon.assert.calledOnceWithExactly(done, undefined)
+      })
     })
   })
 
@@ -911,6 +1151,46 @@ describe('CI Visibility Exporter', () => {
       } finally {
         clock.restore()
       }
+    })
+
+    it('waits for initialization when a completed suite is deferred', async () => {
+      const writer = {
+        append: sinon.spy(),
+        flush: sinon.spy(done => done()),
+        setUrl: sinon.spy(),
+      }
+      const ciVisibilityExporter = new CiVisibilityExporter({ url })
+      const spanId = { toString: () => 'suite-span-id' }
+      const testSuiteSpan = {
+        context: () => ({ _spanId: spanId }),
+      }
+      const suiteEvent = {
+        type: 'test_suite_end',
+        span_id: spanId,
+        error: 0,
+        meta: {},
+        metrics: {},
+      }
+      formatSpan = sinon.stub().returns(suiteEvent)
+      const done = sinon.spy()
+
+      ciVisibilityExporter.deferTestSuiteSpan(testSuiteSpan)
+      ciVisibilityExporter.export([suiteEvent])
+      ciVisibilityExporter.flush(done)
+      sinon.assert.notCalled(done)
+
+      ciVisibilityExporter._writer = writer
+      ciVisibilityExporter._isInitialized = true
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      await Promise.resolve()
+
+      sinon.assert.calledOnceWithExactly(
+        writer.append,
+        [suiteEvent],
+        sinon.match({ deadline: sinon.match.number })
+      )
+      sinon.assert.calledOnce(writer.flush)
+      sinon.assert.calledOnceWithExactly(done, undefined)
     })
 
     for (const [payloadType, writerProperty, exportPayload] of [
@@ -957,6 +1237,39 @@ describe('CI Visibility Exporter', () => {
       ciVisibilityExporter.flush(() => {})
 
       sinon.assert.calledTwice(writer.flush)
+    })
+
+    it('starts a new final flush after a suite is deferred', () => {
+      const writer = {
+        append: sinon.spy(),
+        flush: sinon.spy(done => done?.()),
+        setUrl: sinon.spy(),
+      }
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, flushInterval: 0 })
+      ciVisibilityExporter._isInitialized = true
+      ciVisibilityExporter._canUseCiVisProtocol = true
+      ciVisibilityExporter._writer = writer
+      const testSuiteSpan = {
+        context: () => ({ _spanId: { toString: () => 'suite-span-id' } }),
+      }
+      const suiteEvent = {
+        type: 'test_suite_end',
+        error: 0,
+        meta: { 'test.status': 'pass' },
+        metrics: {},
+      }
+      formatSpan = sinon.stub().returns(suiteEvent)
+
+      const firstDone = sinon.spy()
+      ciVisibilityExporter.flush(firstDone)
+      ciVisibilityExporter.deferTestSuiteSpan(testSuiteSpan)
+      const secondDone = sinon.spy()
+      ciVisibilityExporter.flush(secondDone)
+
+      sinon.assert.calledTwice(writer.flush)
+      sinon.assert.calledOnceWithExactly(writer.append, [suiteEvent], sinon.match({ deadline: sinon.match.number }))
+      sinon.assert.calledOnceWithExactly(firstDone, undefined)
+      sinon.assert.calledOnceWithExactly(secondDone, undefined)
     })
 
     it('does not coalesce new test data into an active final flush', () => {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -70,15 +70,22 @@ const {
 
 describe('finishAllTraceSpans', () => {
   it('does not finish completed spans twice', () => {
-    const completedSpan = { _finished: true, finish: sinon.spy() }
-    const activeSpan = { _finished: false, finish: sinon.spy() }
-    const rootSpan = {
-      context: () => ({
-        _trace: {
-          started: [rootSpan, completedSpan, activeSpan],
-        },
-      }),
-    }
+    const tracer = { _config: getConfig() }
+    const processor = { process () {} }
+    const prioritySampler = { sample () {} }
+    const rootSpan = new Span(tracer, processor, prioritySampler, { operationName: 'root' })
+    const completedSpan = new Span(tracer, processor, prioritySampler, {
+      operationName: 'completed',
+      parent: rootSpan.context(),
+    })
+    const activeSpan = new Span(tracer, processor, prioritySampler, {
+      operationName: 'active',
+      parent: rootSpan.context(),
+    })
+    sinon.spy(completedSpan, 'finish')
+    sinon.spy(activeSpan, 'finish')
+    completedSpan.finish()
+    completedSpan.finish.resetHistory()
 
     finishAllTraceSpans(rootSpan)
 

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -46,6 +46,7 @@ const {
   logTestOptimizationSummary,
   getTestOptimizationRequestResults,
   getLibraryCapabilitiesTags,
+  finishAllTraceSpans,
   getTestParentSpan,
   setRumTestCorrelation,
   setRumTestTags,
@@ -66,6 +67,25 @@ const {
   TELEMETRY_GIT_COMMIT_SHA_DISCREPANCY,
   TELEMETRY_GIT_SHA_MATCH,
 } = require('../../../src/ci-visibility/telemetry')
+
+describe('finishAllTraceSpans', () => {
+  it('does not finish completed spans twice', () => {
+    const completedSpan = { _finished: true, finish: sinon.spy() }
+    const activeSpan = { _finished: false, finish: sinon.spy() }
+    const rootSpan = {
+      context: () => ({
+        _trace: {
+          started: [rootSpan, completedSpan, activeSpan],
+        },
+      }),
+    }
+
+    finishAllTraceSpans(rootSpan)
+
+    sinon.assert.notCalled(completedSpan.finish)
+    sinon.assert.calledOnceWithExactly(activeSpan.finish)
+  })
+})
 
 describe('library capabilities', () => {
   it('advertises TIA for Vitest unless the execution mode does not support it', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Preserves completed Test Optimization suites until the test session trace can be serialized and exported, including when completed suite events remain buffered because their module and session spans are still open and the partial-flush threshold has not been reached. It also records and propagates terminal reporter or formatter failures from Jest, Vitest, and Cucumber so the submitted test session trace is marked failed without losing completed test events.

### Motivation
<!-- What inspired you to submit this pull request? -->

Completed suite events can remain buffered while their module and session spans are unfinished. If finalization is interrupted, or a framework reporter throws before the normal end event completes, the test session trace can otherwise be incomplete or report passing session, module, and suite statuses.

This is stack 3 of 3 extracted from #9732:

1. #9788 — Test Optimization rate-limit reset parsing (merged)
2. #9789 — bounded Test Optimization final-flush lifecycle (merged)
3. This PR — deferred test session traces and Jest/Vitest/Cucumber terminal errors
