### PR TITLE
feat(otel): connect durable orchestration spans across worker processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {
+    "@azure/data-tables": "^13.3.0",
     "@datadog/libdatadog": "0.9.4",
     "@datadog/native-appsec": "11.0.1",
     "@datadog/native-iast-taint-tracking": "4.2.0",

--- a/packages/datadog-instrumentations/src/azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/azure-durable-functions.js
@@ -25,6 +25,18 @@ addHook({ name: 'durable-functions', versions: ['>=3'], patchDefault: false }, (
   return df
 })
 
+addHook({
+  name: 'durable-functions',
+  versions: ['>=3'],
+  file: 'lib/src/durableClient/DurableClient.js',
+}, (durableClientModule) => {
+  if (require('./helpers/otel-azure-enabled').isOtelAzureInstrumentationEnabled()) {
+    require('./helpers/otel-orchestration-http-link').patchDurableClient(durableClientModule.DurableClient)
+  }
+
+  return durableClientModule
+})
+
 function entityWrapper (method) {
   return function (entityName, arg) {
     // because this method is overloaded, the second argument can either be an object

--- a/packages/datadog-instrumentations/src/helpers/azure-trace-context.js
+++ b/packages/datadog-instrumentations/src/helpers/azure-trace-context.js
@@ -25,9 +25,11 @@ function extractContext (traceContext) {
 
 function getInstanceId (invocationContext) {
   const attributes = invocationContext?.traceContext?.attributes
-  if (!attributes) return
+  const fromAttributes = attributes &&
+    (attributes['durabletask.task.instance_id'] || attributes.DurableFunctionsInstanceId)
+  if (fromAttributes) return fromAttributes
 
-  return attributes['durabletask.task.instance_id'] || attributes.DurableFunctionsInstanceId
+  return invocationContext?.df?.instanceId
 }
 
 function parentContextFromOrchestrationMeta (meta) {
@@ -45,8 +47,14 @@ function resolveActivityParentContext (invocationContext) {
     return api.trace.setSpan(extractContext(traceContext), orchestrationSpan)
   }
 
-  const { readOrchestrationSpanMetaSync } = require('./otel-orchestration-store')
-  const meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
+  const {
+    readOrchestrationSpanMetaFromSharedStoreSync,
+    readOrchestrationSpanMetaSync,
+  } = require('./otel-orchestration-store')
+  let meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
+  if (!meta) {
+    meta = readOrchestrationSpanMetaFromSharedStoreSync(instanceId, traceContext)
+  }
   if (meta) {
     return parentContextFromOrchestrationMeta(meta)
   }

--- a/packages/datadog-instrumentations/src/helpers/azure-trace-context.js
+++ b/packages/datadog-instrumentations/src/helpers/azure-trace-context.js
@@ -23,6 +23,81 @@ function extractContext (traceContext) {
   return api.propagation.extract(ROOT_CONTEXT, carrier, api.defaultTextMapGetter)
 }
 
+function getInstanceId (invocationContext) {
+  const attributes = invocationContext?.traceContext?.attributes
+  if (!attributes) return
+
+  return attributes['durabletask.task.instance_id'] || attributes.DurableFunctionsInstanceId
+}
+
+function parentContextFromOrchestrationMeta (meta) {
+  const { traceContextFromMeta } = require('./otel-orchestration-meta')
+  return extractContext(traceContextFromMeta(meta))
+}
+
+function resolveActivityParentContext (invocationContext) {
+  const instanceId = getInstanceId(invocationContext)
+  const traceContext = invocationContext?.traceContext
+
+  const { getOrchestrationSpan } = require('./otel-orchestration-registry')
+  const orchestrationSpan = getOrchestrationSpan(instanceId)
+  if (orchestrationSpan) {
+    return api.trace.setSpan(extractContext(traceContext), orchestrationSpan)
+  }
+
+  const { readOrchestrationSpanMetaSync } = require('./otel-orchestration-store')
+  const meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
+  if (meta) {
+    return parentContextFromOrchestrationMeta(meta)
+  }
+
+  return extractContext(traceContext)
+}
+
+async function resolveActivityParentContextAsync (invocationContext) {
+  const instanceId = getInstanceId(invocationContext)
+  const traceContext = invocationContext?.traceContext
+
+  const { getOrchestrationSpan } = require('./otel-orchestration-registry')
+  const orchestrationSpan = getOrchestrationSpan(instanceId)
+  if (orchestrationSpan) {
+    return api.trace.setSpan(extractContext(traceContext), orchestrationSpan)
+  }
+
+  const {
+    readOrchestrationSpanMetaAsync,
+    readOrchestrationSpanMetaSync,
+  } = require('./otel-orchestration-store')
+
+  let meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
+  if (!meta) {
+    meta = await readOrchestrationSpanMetaAsync(instanceId, traceContext)
+  }
+  if (meta) {
+    return parentContextFromOrchestrationMeta(meta)
+  }
+
+  return extractContext(traceContext)
+}
+
+function buildSpanParentContext (args, trigger) {
+  const invocationContext = getInvocationContext(args, trigger)
+  if (trigger === 'durable-activity') {
+    return resolveActivityParentContext(invocationContext)
+  }
+
+  return extractContext(invocationContext?.traceContext)
+}
+
+function buildSpanParentContextAsync (args, trigger) {
+  const invocationContext = getInvocationContext(args, trigger)
+  if (trigger === 'durable-activity') {
+    return resolveActivityParentContextAsync(invocationContext)
+  }
+
+  return Promise.resolve(extractContext(invocationContext?.traceContext))
+}
+
 function runWithTraceContext (traceContext, fn) {
   return api.context.with(extractContext(traceContext), fn)
 }
@@ -52,9 +127,14 @@ function runWithInvocationContext (args, trigger, fn) {
 }
 
 module.exports = {
+  buildSpanParentContext,
+  buildSpanParentContextAsync,
   carrierFromTraceContext,
   extractContext,
+  getInstanceId,
   getInvocationContext,
+  parentContextFromOrchestrationMeta,
+  resolveActivityParentContext,
   runWithInvocationContext,
   runWithTraceContext,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-azure-span.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-azure-span.js
@@ -25,13 +25,26 @@ function spanAttributes (functionName, trigger, operationName) {
   }
 }
 
+function startChildSpan (tracerName, trigger, functionName, operationName, args, parentContext) {
+  return getTracer(tracerName).startSpan(
+    `${trigger} ${functionName}`,
+    { attributes: spanAttributes(functionName, trigger, operationName) },
+    parentContext,
+  )
+}
+
 function wrapSyncWithTraceContext (tracerName, trigger, handler, functionName, operationName) {
   return function (...args) {
-    const { runWithInvocationContext } = require('./azure-trace-context')
+    const { runWithInvocationContext, buildSpanParentContext } = require('./azure-trace-context')
     return runWithInvocationContext(args, trigger, () => {
-      const span = getTracer(tracerName).startSpan(`${trigger} ${functionName}`, {
-        attributes: spanAttributes(functionName, trigger, operationName),
-      })
+      const span = startChildSpan(
+        tracerName,
+        trigger,
+        functionName,
+        operationName,
+        args,
+        buildSpanParentContext(args, trigger),
+      )
       try {
         const result = handler.apply(this, args)
         endSpan(span)
@@ -46,11 +59,17 @@ function wrapSyncWithTraceContext (tracerName, trigger, handler, functionName, o
 
 function wrapAsyncWithTraceContext (tracerName, trigger, handler, functionName) {
   return function (...args) {
-    const { runWithInvocationContext } = require('./azure-trace-context')
-    return runWithInvocationContext(args, trigger, () =>
-      getTracer(tracerName).startActiveSpan(
+    const {
+      runWithInvocationContext,
+      buildSpanParentContextAsync,
+    } = require('./azure-trace-context')
+
+    return runWithInvocationContext(args, trigger, async () => {
+      const parentContext = await buildSpanParentContextAsync(args, trigger)
+      return getTracer(tracerName).startActiveSpan(
         `${trigger} ${functionName}`,
         { attributes: spanAttributes(functionName, trigger) },
+        parentContext,
         async (span) => {
           try {
             const result = await handler.apply(this, args)
@@ -61,7 +80,8 @@ function wrapAsyncWithTraceContext (tracerName, trigger, handler, functionName) 
             throw error
           }
         },
-      ))
+      )
+    })
   }
 }
 

--- a/packages/datadog-instrumentations/src/helpers/otel-azure-span.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-azure-span.js
@@ -65,6 +65,15 @@ function wrapAsyncWithTraceContext (tracerName, trigger, handler, functionName) 
     } = require('./azure-trace-context')
 
     return runWithInvocationContext(args, trigger, async () => {
+      if (trigger === 'durable-activity') {
+        const { getInstanceId, getInvocationContext } = require('./azure-trace-context')
+        const { recordEarliestChildStartTime } = require('./otel-orchestration-store')
+        const instanceId = getInstanceId(getInvocationContext(args, trigger))
+        if (instanceId) {
+          recordEarliestChildStartTime(instanceId, Date.now())
+        }
+      }
+
       const parentContext = await buildSpanParentContextAsync(args, trigger)
       return getTracer(tracerName).startActiveSpan(
         `${trigger} ${functionName}`,

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-export.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-export.js
@@ -60,7 +60,7 @@ function createOrchestrationMeta (instanceId, invocationContext, functionName) {
 // Build orchestration metadata from the HTTP span that called `startNew`. The
 // orchestration runs later, often in another worker process, so its identity has
 // to be decided here while the HTTP span is still known.
-function createOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName) {
+function createOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName, instanceStartTime) {
   if (!httpParent?.traceId || !httpParent.spanId) return
 
   return {
@@ -70,16 +70,23 @@ function createOrchestrationMetaFromHttpParent (instanceId, httpParent, function
     spanId: normalizeSpanId(createId()),
     parentId: normalizeSpanId(httpParent.spanId),
     httpParentSpanId: normalizeSpanId(httpParent.spanId),
-    // Stamped on the first non-replay orchestration turn, not at startNew time.
-    pendingStart: true,
+    // Anchor the backfilled orchestration span to startNew time so it aligns
+    // with the HTTP starter instead of the later orchestrator worker pickup.
+    startTime: instanceStartTime ?? Date.now(),
     status: 'open',
   }
 }
 
-// Backfilled orchestration spans use the first turn start through instance completion.
+// Backfilled orchestration spans use the instance start through completion.
 function resolveOrchestrationSpanBounds (meta, endTime) {
   const resolvedEndTime = endTime ?? Date.now()
   let startTime = meta?.startTime
+
+  if (meta?.earliestChildStartTime != null) {
+    startTime = startTime == null
+      ? meta.earliestChildStartTime
+      : Math.min(startTime, meta.earliestChildStartTime)
+  }
 
   if (startTime == null) {
     startTime = resolvedEndTime

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-export.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-export.js
@@ -70,15 +70,30 @@ function createOrchestrationMetaFromHttpParent (instanceId, httpParent, function
     spanId: normalizeSpanId(createId()),
     parentId: normalizeSpanId(httpParent.spanId),
     httpParentSpanId: normalizeSpanId(httpParent.spanId),
-    startTime: Date.now(),
-    // Replaced with the real start time on the first orchestration turn.
+    // Stamped on the first non-replay orchestration turn, not at startNew time.
     pendingStart: true,
     status: 'open',
   }
 }
 
+// Backfilled orchestration spans use the first turn start through instance completion.
+function resolveOrchestrationSpanBounds (meta, endTime) {
+  const resolvedEndTime = endTime ?? Date.now()
+  let startTime = meta?.startTime
+
+  if (startTime == null) {
+    startTime = resolvedEndTime
+  } else if (startTime > resolvedEndTime) {
+    startTime = resolvedEndTime
+  }
+
+  return { startTime, endTime: resolvedEndTime }
+}
+
 function exportOrchestrationSpanFromMeta (tracerName, meta, { error, endTime } = {}) {
   if (!meta?.traceId || !meta?.spanId) return false
+
+  const { startTime, endTime: resolvedEndTime } = resolveOrchestrationSpanBounds(meta, endTime)
 
   const tracer = getTracer(tracerName)
   const ddContext = new DatadogSpanContext({
@@ -94,14 +109,14 @@ function exportOrchestrationSpanFromMeta (tracerName, meta, { error, endTime } =
     new OtelSpanContext(ddContext),
     api.SpanKind.INTERNAL,
     [],
-    meta.startTime,
+    startTime,
     spanAttributes(meta.functionName || 'orchestration', 'durable-orchestration'),
   )
 
   if (error) {
     endSpan(span, error)
   } else {
-    span.end(endTime ?? Date.now())
+    span.end(resolvedEndTime)
   }
 
   return true
@@ -112,4 +127,5 @@ module.exports = {
   createOrchestrationMetaFromHttpParent,
   exportOrchestrationSpanFromMeta,
   getParentFromTraceContext,
+  resolveOrchestrationSpanBounds,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-export.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-export.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const api = require('@opentelemetry/api')
+const createId = require('../../../dd-trace/src/id')
+const DatadogSpanContext = require('../../../dd-trace/src/opentracing/span_context')
+const OtelSpan = require('../../../dd-trace/src/opentelemetry/span')
+const OtelSpanContext = require('../../../dd-trace/src/opentelemetry/span_context')
+const { extractContext } = require('./azure-trace-context')
+const { getTracer, spanAttributes, endSpan } = require('./otel-azure-span')
+const { normalizeSpanId, normalizeTraceId } = require('./otel-orchestration-meta')
+const { resolveHttpParentForOrchestration } = require('./otel-orchestration-http-link')
+
+function getParentFromTraceContext (traceContext) {
+  const traceParent = traceContext?.traceParent
+  if (!traceParent) return
+
+  const parts = traceParent.split('-')
+  if (parts.length < 4) return
+
+  return {
+    traceId: normalizeTraceId(parts[1]),
+    parentId: normalizeSpanId(parts[2]),
+  }
+}
+
+function createOrchestrationMeta (instanceId, invocationContext, functionName) {
+  const traceContext = invocationContext?.traceContext
+  const httpParent = resolveHttpParentForOrchestration(instanceId, traceContext)
+  const fromHeader = getParentFromTraceContext(traceContext)
+
+  let traceId = httpParent?.traceId ?? fromHeader?.traceId
+  let parentId = httpParent?.spanId ?? fromHeader?.parentId
+
+  if (!traceId) {
+    const parentContext = extractContext(traceContext)
+    const parentSpan = api.trace.getSpan(parentContext)
+    const parentDdContext = parentSpan?.spanContext()?._ddContext
+
+    if (parentDdContext) {
+      traceId = normalizeTraceId(parentDdContext._traceId)
+      parentId ??= normalizeSpanId(parentDdContext._spanId)
+    }
+  }
+
+  if (!traceId) {
+    traceId = normalizeTraceId(createId())
+  }
+
+  return {
+    instanceId,
+    functionName,
+    traceId,
+    spanId: normalizeSpanId(createId()),
+    parentId,
+    startTime: Date.now(),
+    status: 'open',
+  }
+}
+
+// Build orchestration metadata from the HTTP span that called `startNew`. The
+// orchestration runs later, often in another worker process, so its identity has
+// to be decided here while the HTTP span is still known.
+function createOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName) {
+  if (!httpParent?.traceId || !httpParent.spanId) return
+
+  return {
+    instanceId,
+    functionName,
+    traceId: normalizeTraceId(httpParent.traceId),
+    spanId: normalizeSpanId(createId()),
+    parentId: normalizeSpanId(httpParent.spanId),
+    httpParentSpanId: normalizeSpanId(httpParent.spanId),
+    startTime: Date.now(),
+    // Replaced with the real start time on the first orchestration turn.
+    pendingStart: true,
+    status: 'open',
+  }
+}
+
+function exportOrchestrationSpanFromMeta (tracerName, meta, { error, endTime } = {}) {
+  if (!meta?.traceId || !meta?.spanId) return false
+
+  const tracer = getTracer(tracerName)
+  const ddContext = new DatadogSpanContext({
+    traceId: createId(meta.traceId, 16),
+    spanId: createId(meta.spanId, 16),
+    parentId: meta.parentId ? createId(meta.parentId, 16) : null,
+  })
+
+  const span = new OtelSpan(
+    tracer,
+    api.ROOT_CONTEXT,
+    `orchestration ${meta.functionName || 'orchestration'}`,
+    new OtelSpanContext(ddContext),
+    api.SpanKind.INTERNAL,
+    [],
+    meta.startTime,
+    spanAttributes(meta.functionName || 'orchestration', 'durable-orchestration'),
+  )
+
+  if (error) {
+    endSpan(span, error)
+  } else {
+    span.end(endTime ?? Date.now())
+  }
+
+  return true
+}
+
+module.exports = {
+  createOrchestrationMeta,
+  createOrchestrationMetaFromHttpParent,
+  exportOrchestrationSpanFromMeta,
+  getParentFromTraceContext,
+}

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
@@ -72,6 +72,19 @@ function clearHttpInstanceStartTime (instanceId) {
   instanceStartByInstance.delete(String(instanceId))
 }
 
+function clearHttpOrchestrationLinks (instanceId) {
+  if (!instanceId) return
+
+  const key = String(instanceId)
+  const parent = httpParentByInstance.get(key)
+  httpParentByInstance.delete(key)
+  instanceStartByInstance.delete(key)
+
+  if (parent?.traceId) {
+    pendingHttpParentByTraceId.delete(parent.traceId)
+  }
+}
+
 function peekHttpParentForInstance (instanceId) {
   if (!instanceId) return
   return httpParentByInstance.get(String(instanceId))
@@ -141,7 +154,7 @@ function patchDurableClient (DurableClient) {
           // The orchestration usually runs in another worker process, which cannot see
           // the in-process maps above, so persist its identity to the shared store now.
           const { seedOrchestrationMetaFromHttpParent } = require('./otel-orchestration-store')
-          seedOrchestrationMetaFromHttpParent(
+          await seedOrchestrationMetaFromHttpParent(
             instanceId,
             spanMeta,
             typeof args[0] === 'string' ? args[0] : undefined,
@@ -158,6 +171,7 @@ function patchDurableClient (DurableClient) {
 module.exports = {
   applyHttpParentToMeta,
   clearHttpInstanceStartTime,
+  clearHttpOrchestrationLinks,
   patchDurableClient,
   peekHttpInstanceStartTime,
   peekHttpParentForInstance,

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const api = require('@opentelemetry/api')
+const { getSpanMeta, normalizeTraceId } = require('./otel-orchestration-meta')
+
+const httpParentByInstance = new Map()
+const pendingHttpParentByTraceId = new Map()
+
+function traceIdsEquivalent (left, right) {
+  if (!left || !right) return false
+  const a = normalizeTraceId(left)
+  const b = normalizeTraceId(right)
+  if (a === b) return true
+  return a.slice(-16) === b.slice(-16)
+}
+
+function publishHttpParentMeta (instanceId, meta) {
+  if (!instanceId || !meta?.traceId || !meta?.spanId) return
+
+  const key = String(instanceId)
+  const normalized = {
+    traceId: normalizeTraceId(meta.traceId),
+    spanId: meta.spanId,
+  }
+
+  httpParentByInstance.set(key, normalized)
+  pendingHttpParentByTraceId.set(normalized.traceId, normalized)
+
+  const { reconcileOrchestrationHttpParent } = require('./otel-orchestration-store')
+  reconcileOrchestrationHttpParent(key, normalized)
+}
+
+function publishPendingHttpParent (meta) {
+  if (!meta?.traceId || !meta?.spanId) return
+
+  const normalized = {
+    traceId: normalizeTraceId(meta.traceId),
+    spanId: meta.spanId,
+  }
+  pendingHttpParentByTraceId.set(normalized.traceId, normalized)
+}
+
+function peekHttpParentForInstance (instanceId) {
+  if (!instanceId) return
+  return httpParentByInstance.get(String(instanceId))
+}
+
+function peekPendingHttpParent (traceId) {
+  if (!traceId) return
+
+  const normalized = normalizeTraceId(traceId)
+  const direct = pendingHttpParentByTraceId.get(normalized)
+  if (direct) return direct
+
+  for (const [key, meta] of pendingHttpParentByTraceId) {
+    if (traceIdsEquivalent(key, normalized)) {
+      return meta
+    }
+  }
+}
+
+function resolveHttpParentForOrchestration (instanceId, traceContext) {
+  const fromInstance = peekHttpParentForInstance(instanceId)
+  if (fromInstance) return fromInstance
+
+  const traceParent = traceContext?.traceParent
+  if (!traceParent) return
+
+  const traceId = traceParent.split('-')[1]
+  return peekPendingHttpParent(traceId)
+}
+
+function applyHttpParentToMeta (meta, httpParent) {
+  if (!meta || !httpParent?.spanId) return meta
+
+  return {
+    ...meta,
+    traceId: httpParent.traceId ?? meta.traceId,
+    parentId: httpParent.spanId,
+    httpParentSpanId: httpParent.spanId,
+  }
+}
+
+// The class must be handed in by the module hook: requiring `durable-functions`
+// from inside the tracer would resolve against the tracer's own dependencies,
+// not the application's copy, so the patch would target the wrong class.
+function patchDurableClient (DurableClient) {
+  const shimmer = require('../../../datadog-shimmer')
+  if (typeof DurableClient?.prototype?.startNew !== 'function') return
+
+  shimmer.wrap(DurableClient.prototype, 'startNew', startNew => {
+    return async function (...args) {
+      const activeSpan = api.trace.getActiveSpan()
+      const spanMeta = activeSpan ? getSpanMeta(activeSpan) : undefined
+
+      if (spanMeta) {
+        publishPendingHttpParent(spanMeta)
+      }
+
+      const instanceId = await startNew.apply(this, args)
+
+      if (instanceId && spanMeta) {
+        publishHttpParentMeta(instanceId, spanMeta)
+
+        // The orchestration usually runs in another worker process, which cannot see
+        // the in-process maps above, so persist its identity to the shared store now.
+        const { seedOrchestrationMetaFromHttpParent } = require('./otel-orchestration-store')
+        seedOrchestrationMetaFromHttpParent(instanceId, spanMeta, typeof args[0] === 'string' ? args[0] : undefined)
+      }
+
+      return instanceId
+    }
+  })
+}
+
+module.exports = {
+  applyHttpParentToMeta,
+  patchDurableClient,
+  peekHttpParentForInstance,
+  peekPendingHttpParent,
+  publishHttpParentMeta,
+  publishPendingHttpParent,
+  resolveHttpParentForOrchestration,
+  traceIdsEquivalent,
+}

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
@@ -105,7 +105,12 @@ function patchDurableClient (DurableClient) {
         // The orchestration usually runs in another worker process, which cannot see
         // the in-process maps above, so persist its identity to the shared store now.
         const { seedOrchestrationMetaFromHttpParent } = require('./otel-orchestration-store')
-        seedOrchestrationMetaFromHttpParent(instanceId, spanMeta, typeof args[0] === 'string' ? args[0] : undefined)
+        seedOrchestrationMetaFromHttpParent(
+          instanceId,
+          spanMeta,
+          typeof args[0] === 'string' ? args[0] : undefined,
+          Date.now(),
+        )
       }
 
       return instanceId

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-http-link.js
@@ -1,10 +1,15 @@
 'use strict'
 
 const api = require('@opentelemetry/api')
-const { getSpanMeta, normalizeTraceId } = require('./otel-orchestration-meta')
+const {
+  getSpanStartTimeMs,
+  normalizeTraceId,
+  resolveActiveSpanMeta,
+} = require('./otel-orchestration-meta')
 
 const httpParentByInstance = new Map()
 const pendingHttpParentByTraceId = new Map()
+const instanceStartByInstance = new Map()
 
 function traceIdsEquivalent (left, right) {
   if (!left || !right) return false
@@ -14,7 +19,7 @@ function traceIdsEquivalent (left, right) {
   return a.slice(-16) === b.slice(-16)
 }
 
-function publishHttpParentMeta (instanceId, meta) {
+function publishHttpParentMeta (instanceId, meta, instanceStartTime) {
   if (!instanceId || !meta?.traceId || !meta?.spanId) return
 
   const key = String(instanceId)
@@ -25,6 +30,10 @@ function publishHttpParentMeta (instanceId, meta) {
 
   httpParentByInstance.set(key, normalized)
   pendingHttpParentByTraceId.set(normalized.traceId, normalized)
+
+  if (instanceStartTime != null) {
+    recordHttpInstanceStartTime(instanceId, instanceStartTime)
+  }
 
   const { reconcileOrchestrationHttpParent } = require('./otel-orchestration-store')
   reconcileOrchestrationHttpParent(key, normalized)
@@ -38,6 +47,29 @@ function publishPendingHttpParent (meta) {
     spanId: meta.spanId,
   }
   pendingHttpParentByTraceId.set(normalized.traceId, normalized)
+}
+
+function recordHttpInstanceStartTime (instanceId, startTime) {
+  if (!instanceId || startTime == null) return
+
+  const key = String(instanceId)
+  const current = instanceStartByInstance.get(key)
+  if (current != null && current <= startTime) return
+
+  instanceStartByInstance.set(key, startTime)
+
+  const { mergeInstanceStartTime } = require('./otel-orchestration-store')
+  mergeInstanceStartTime(instanceId, startTime)
+}
+
+function peekHttpInstanceStartTime (instanceId) {
+  if (!instanceId) return
+  return instanceStartByInstance.get(String(instanceId))
+}
+
+function clearHttpInstanceStartTime (instanceId) {
+  if (!instanceId) return
+  instanceStartByInstance.delete(String(instanceId))
 }
 
 function peekHttpParentForInstance (instanceId) {
@@ -91,7 +123,8 @@ function patchDurableClient (DurableClient) {
   shimmer.wrap(DurableClient.prototype, 'startNew', startNew => {
     return async function (...args) {
       const activeSpan = api.trace.getActiveSpan()
-      const spanMeta = activeSpan ? getSpanMeta(activeSpan) : undefined
+      const spanMeta = resolveActiveSpanMeta(activeSpan)
+      const instanceStartTime = getSpanStartTimeMs(activeSpan) ?? Date.now()
 
       if (spanMeta) {
         publishPendingHttpParent(spanMeta)
@@ -99,18 +132,22 @@ function patchDurableClient (DurableClient) {
 
       const instanceId = await startNew.apply(this, args)
 
-      if (instanceId && spanMeta) {
-        publishHttpParentMeta(instanceId, spanMeta)
+      if (instanceId) {
+        recordHttpInstanceStartTime(instanceId, instanceStartTime)
 
-        // The orchestration usually runs in another worker process, which cannot see
-        // the in-process maps above, so persist its identity to the shared store now.
-        const { seedOrchestrationMetaFromHttpParent } = require('./otel-orchestration-store')
-        seedOrchestrationMetaFromHttpParent(
-          instanceId,
-          spanMeta,
-          typeof args[0] === 'string' ? args[0] : undefined,
-          Date.now(),
-        )
+        if (spanMeta) {
+          publishHttpParentMeta(instanceId, spanMeta, instanceStartTime)
+
+          // The orchestration usually runs in another worker process, which cannot see
+          // the in-process maps above, so persist its identity to the shared store now.
+          const { seedOrchestrationMetaFromHttpParent } = require('./otel-orchestration-store')
+          seedOrchestrationMetaFromHttpParent(
+            instanceId,
+            spanMeta,
+            typeof args[0] === 'string' ? args[0] : undefined,
+            instanceStartTime,
+          )
+        }
       }
 
       return instanceId
@@ -120,11 +157,14 @@ function patchDurableClient (DurableClient) {
 
 module.exports = {
   applyHttpParentToMeta,
+  clearHttpInstanceStartTime,
   patchDurableClient,
+  peekHttpInstanceStartTime,
   peekHttpParentForInstance,
   peekPendingHttpParent,
   publishHttpParentMeta,
   publishPendingHttpParent,
+  recordHttpInstanceStartTime,
   resolveHttpParentForOrchestration,
   traceIdsEquivalent,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-meta.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-meta.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const TRACE_FLAGS_SAMPLED = '01'
+const TRACESTATE_ORCH_PREFIX = 'dd=o:'
+
+function normalizeTraceId (traceId) {
+  if (!traceId) return
+  if (typeof traceId === 'string' && /^[0-9a-f]+$/i.test(traceId)) {
+    return traceId.padStart(32, '0').slice(-32)
+  }
+  const hex = traceId.toString(16).padStart(32, '0')
+  return hex.length > 32 ? hex.slice(-32) : hex
+}
+
+function normalizeSpanId (spanId) {
+  if (!spanId) return
+  if (typeof spanId === 'string' && /^[0-9a-f]+$/i.test(spanId)) {
+    return spanId.padStart(16, '0').slice(-16)
+  }
+  const hex = spanId.toString(16).padStart(16, '0')
+  return hex.length > 16 ? hex.slice(-16) : hex
+}
+
+function getSpanMeta (span) {
+  if (!span) return
+
+  const ddSpan = span._ddSpan
+  if (ddSpan?.context) {
+    const ctx = ddSpan.context()
+    return {
+      traceId: normalizeTraceId(ctx._traceId),
+      spanId: normalizeSpanId(ctx._spanId),
+    }
+  }
+
+  const spanContext = span.spanContext?.()
+  if (spanContext?.traceId && spanContext.spanId) {
+    return {
+      traceId: normalizeTraceId(spanContext.traceId),
+      spanId: normalizeSpanId(spanContext.spanId),
+    }
+  }
+}
+
+function parseOrchestrationMetaFromTraceContext (traceContext) {
+  const traceState = traceContext?.traceState
+  if (!traceState || typeof traceState !== 'string') return
+
+  const orchEntry = traceState
+    .split(',')
+    .map(entry => entry.trim())
+    .find(entry => entry.startsWith(TRACESTATE_ORCH_PREFIX))
+
+  if (!orchEntry) return
+
+  const spanId = orchEntry.slice(TRACESTATE_ORCH_PREFIX.length)
+  const traceParent = traceContext?.traceParent
+  if (!spanId || !traceParent) return
+
+  const parts = traceParent.split('-')
+  if (parts.length < 4) return
+
+  return {
+    traceId: parts[1],
+    spanId,
+  }
+}
+
+function appendOrchestrationSpanToTraceState (traceState, spanId) {
+  const entry = `${TRACESTATE_ORCH_PREFIX}${spanId}`
+  if (!traceState) return entry
+  if (traceState.includes(TRACESTATE_ORCH_PREFIX)) return traceState
+  return `${traceState},${entry}`
+}
+
+function traceContextFromMeta (meta) {
+  if (!meta?.traceId || !meta?.spanId) return
+
+  return {
+    traceParent: `00-${meta.traceId}-${meta.spanId}-${TRACE_FLAGS_SAMPLED}`,
+  }
+}
+
+module.exports = {
+  appendOrchestrationSpanToTraceState,
+  getSpanMeta,
+  normalizeSpanId,
+  normalizeTraceId,
+  parseOrchestrationMetaFromTraceContext,
+  traceContextFromMeta,
+}

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-meta.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-meta.js
@@ -42,6 +42,23 @@ function getSpanMeta (span) {
   }
 }
 
+function getSpanStartTimeMs (span) {
+  const ddSpan = span?._ddSpan
+  if (ddSpan?._startTime != null) {
+    return ddSpan._startTime
+  }
+
+  const hrStartTime = span?.startTime
+  if (Array.isArray(hrStartTime)) {
+    const { hrTimeToMilliseconds } = require('../../../dd-trace/src/opentelemetry/time')
+    return hrTimeToMilliseconds(hrStartTime)
+  }
+}
+
+function resolveActiveSpanMeta (span) {
+  return getSpanMeta(span)
+}
+
 function parseOrchestrationMetaFromTraceContext (traceContext) {
   const traceState = traceContext?.traceState
   if (!traceState || typeof traceState !== 'string') return
@@ -84,8 +101,10 @@ function traceContextFromMeta (meta) {
 module.exports = {
   appendOrchestrationSpanToTraceState,
   getSpanMeta,
+  getSpanStartTimeMs,
   normalizeSpanId,
   normalizeTraceId,
   parseOrchestrationMetaFromTraceContext,
+  resolveActiveSpanMeta,
   traceContextFromMeta,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-registry.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-registry.js
@@ -1,0 +1,28 @@
+'use strict'
+
+// Maps durable instance IDs to in-flight orchestration OTel spans so activity
+// spans can parent directly to the orchestration span instead of Azure-internal
+// W3C parent IDs that are never exported to Datadog.
+const orchestrationSpansByInstance = new Map()
+
+function registerOrchestrationSpan (instanceId, span) {
+  if (instanceId && span) {
+    orchestrationSpansByInstance.set(instanceId, span)
+  }
+}
+
+function unregisterOrchestrationSpan (instanceId) {
+  if (instanceId) {
+    orchestrationSpansByInstance.delete(instanceId)
+  }
+}
+
+function getOrchestrationSpan (instanceId) {
+  return instanceId ? orchestrationSpansByInstance.get(instanceId) : undefined
+}
+
+module.exports = {
+  getOrchestrationSpan,
+  registerOrchestrationSpan,
+  unregisterOrchestrationSpan,
+}

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
@@ -21,13 +21,30 @@ const {
 } = require('./otel-orchestration-http-link')
 
 const TABLE_NAME = 'DDAzureOrchestrationSpans'
-const TABLE_PARTITION_KEY = 'orch'
+const TABLE_PARTITION_PREFIX = 'orch'
 const META_CACHE = new Map()
 const earliestChildStartByInstance = new Map()
 
 let tableClient
 let tableClientResolved = false
 let tableEnsured = false
+
+function encodeStorageKey (value) {
+  return Buffer.from(String(value), 'utf8').toString('base64url')
+}
+
+function getTaskHubScope () {
+  return getEnvironmentVariable('TASKHUB_NAME') ||
+    getEnvironmentVariable('WEBSITE_SITE_NAME') ||
+    'default'
+}
+
+function getTableKeys (instanceId) {
+  return {
+    partitionKey: `${TABLE_PARTITION_PREFIX}:${encodeStorageKey(getTaskHubScope())}`,
+    rowKey: encodeStorageKey(instanceId),
+  }
+}
 
 function getStoreDirectory () {
   // Internal override for tests and local development only, so it is deliberately
@@ -38,13 +55,17 @@ function getStoreDirectory () {
 }
 
 function getMetaFilePath (instanceId) {
-  return path.join(getStoreDirectory(), `${instanceId}.json`)
+  return path.join(getStoreDirectory(), `${encodeStorageKey(instanceId)}.json`)
 }
 
 function writeMetaFileSync (instanceId, meta) {
-  const directory = getStoreDirectory()
-  fs.mkdirSync(directory, { recursive: true })
-  fs.writeFileSync(getMetaFilePath(instanceId), JSON.stringify(meta))
+  try {
+    const directory = getStoreDirectory()
+    fs.mkdirSync(directory, { recursive: true })
+    fs.writeFileSync(getMetaFilePath(instanceId), JSON.stringify(meta))
+  } catch {
+    // Local cache is best-effort; tracing must not break user handlers.
+  }
 }
 
 function readMetaFileSync (instanceId) {
@@ -78,7 +99,7 @@ function getTableClient () {
   if (!connectionString) return null
 
   try {
-    // Provided by the Azure Functions host, so it is never a tracer dependency.
+    // Bundled via dd-trace optionalDependencies so apps do not need a direct install.
     // eslint-disable-next-line n/no-missing-require
     const { TableClient } = require('@azure/data-tables')
     const resolvedConnectionString = connectionString === 'UseDevelopmentStorage=true'
@@ -111,6 +132,105 @@ function normalizeMeta (meta) {
   return meta
 }
 
+function buildTableEntity (instanceId, normalized) {
+  const keys = getTableKeys(instanceId)
+  return {
+    partitionKey: keys.partitionKey,
+    rowKey: keys.rowKey,
+    instanceId: String(instanceId),
+    traceId: normalized.traceId,
+    spanId: normalized.spanId,
+    parentId: normalized.parentId ?? '',
+    httpParentSpanId: normalized.httpParentSpanId ?? '',
+    functionName: normalized.functionName ?? '',
+    pendingStart: normalized.pendingStart === true,
+    startTime: normalized.startTime,
+    earliestChildStartTime: normalized.earliestChildStartTime,
+    status: normalized.status || 'open',
+  }
+}
+
+function metaFromTableEntity (entity) {
+  return {
+    traceId: entity.traceId,
+    spanId: entity.spanId,
+    parentId: entity.parentId || undefined,
+    httpParentSpanId: entity.httpParentSpanId || undefined,
+    functionName: entity.functionName || undefined,
+    pendingStart: entity.pendingStart === true ? true : undefined,
+    startTime: entity.startTime,
+    earliestChildStartTime: entity.earliestChildStartTime,
+    status: entity.status,
+  }
+}
+
+async function upsertOrchestrationMetaToTable (instanceId, normalized) {
+  const client = getTableClient()
+  if (!client) return
+
+  await ensureTable()
+  await client.upsertEntity(buildTableEntity(instanceId, normalized), 'Replace')
+}
+
+async function deleteOrchestrationMetaFromTable (instanceId) {
+  const client = getTableClient()
+  if (!client || !instanceId) return
+
+  const keys = getTableKeys(instanceId)
+  try {
+    await ensureTable()
+    await client.deleteEntity(keys.partitionKey, keys.rowKey)
+  } catch {}
+}
+
+function awaitPromiseSync (promise, timeoutMs = 500) {
+  const { MessageChannel, receiveMessageOnPort } = require('node:worker_threads')
+  const { port1, port2 } = new MessageChannel()
+  let settled = false
+  let result
+  let error
+
+  promise
+    .then((value) => {
+      result = value
+      settled = true
+      port2.postMessage(true)
+    })
+    .catch((err) => {
+      error = err
+      settled = true
+      port2.postMessage(true)
+    })
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (settled) break
+    receiveMessageOnPort(port1, { timeout: Math.min(50, deadline - Date.now()) })
+  }
+
+  if (error) throw error
+  return result
+}
+
+function readOrchestrationSpanMetaFromSharedStoreSync (instanceId, traceContext, timeoutMs = 500) {
+  const cached = readOrchestrationSpanMetaSync(instanceId, traceContext)
+  if (cached || !getTableClient() || !instanceId) return cached
+
+  return awaitPromiseSync(readOrchestrationSpanMetaAsync(instanceId, traceContext), timeoutMs)
+}
+
+async function publishOrchestrationMetaAsync (instanceId, meta) {
+  const normalized = normalizeMeta(meta)
+  if (!instanceId || !normalized) return
+
+  META_CACHE.set(instanceId, normalized)
+  writeMetaFileSync(instanceId, normalized)
+
+  try {
+    await upsertOrchestrationMetaToTable(instanceId, normalized)
+  } catch {}
+}
+
 function publishOrchestrationMetaSync (instanceId, meta) {
   const normalized = normalizeMeta(meta)
   if (!instanceId || !normalized) return
@@ -118,24 +238,7 @@ function publishOrchestrationMetaSync (instanceId, meta) {
   META_CACHE.set(instanceId, normalized)
   writeMetaFileSync(instanceId, normalized)
 
-  const client = getTableClient()
-  if (!client) return
-
-  ensureTable()
-    .then(table => table.upsertEntity({
-      partitionKey: TABLE_PARTITION_KEY,
-      rowKey: instanceId,
-      traceId: normalized.traceId,
-      spanId: normalized.spanId,
-      parentId: normalized.parentId ?? '',
-      httpParentSpanId: normalized.httpParentSpanId ?? '',
-      functionName: normalized.functionName ?? '',
-      pendingStart: normalized.pendingStart === true,
-      startTime: normalized.startTime,
-      earliestChildStartTime: normalized.earliestChildStartTime,
-      status: normalized.status || 'open',
-    }, 'Replace'))
-    .catch(() => {})
+  upsertOrchestrationMetaToTable(instanceId, normalized).catch(() => {})
 }
 
 function publishOrchestrationSpanMetaSync (instanceId, span) {
@@ -237,13 +340,29 @@ function reconcileOrchestrationHttpParent (instanceId, httpParent) {
   return updated
 }
 
+function finalizeOrchestrationMeta (instanceId, invocationContext, functionName, meta) {
+  let updated = stampOrchestrationStartTime(meta, functionName)
+  let changed = updated.startTime !== meta.startTime || updated.pendingStart !== meta.pendingStart
+
+  const httpParent = resolveHttpParentForOrchestration(instanceId, invocationContext?.traceContext)
+  if (httpParent?.spanId) {
+    const withParent = applyHttpParentToMeta(updated, httpParent)
+    if (withParent.parentId !== updated.parentId || withParent.httpParentSpanId !== updated.httpParentSpanId) {
+      updated = withParent
+      changed = true
+    }
+  }
+
+  return { meta: updated, changed }
+}
+
 // Record the orchestration span identity while the HTTP span that started the
 // instance is still available, so any worker that later runs the orchestration
 // reads the HTTP span as its parent.
-function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName, instanceStartTime) {
+async function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName, instanceStartTime) {
   if (!instanceId || !httpParent?.spanId) return
 
-  const existing = readOrchestrationSpanMetaSync(instanceId)
+  const existing = readOrchestrationSpanMetaFromSharedStoreSync(instanceId)
   if (existing?.traceId && existing.spanId) {
     return reconcileOrchestrationHttpParent(instanceId, httpParent)
   }
@@ -256,7 +375,7 @@ function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionNa
   )
   if (!meta) return
 
-  publishOrchestrationMetaSync(instanceId, meta)
+  await publishOrchestrationMetaAsync(instanceId, meta)
   return meta
 }
 
@@ -265,25 +384,57 @@ function ensureOrchestrationMeta (instanceId, invocationContext, functionName) {
   let meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
 
   if (!meta?.traceId || !meta?.spanId) {
-    meta = stampOrchestrationStartTime(
-      createOrchestrationMeta(instanceId, invocationContext, functionName),
+    meta = readOrchestrationSpanMetaFromSharedStoreSync(instanceId, traceContext)
+  }
+
+  if (!meta?.traceId || !meta?.spanId) {
+    const created = finalizeOrchestrationMeta(
+      instanceId,
+      invocationContext,
       functionName,
+      stampOrchestrationStartTime(
+        createOrchestrationMeta(instanceId, invocationContext, functionName),
+        functionName,
+      ),
     )
+    meta = created.meta
     publishOrchestrationMetaSync(instanceId, meta)
   } else {
-    const stamped = stampOrchestrationStartTime(meta, functionName)
-    if (stamped.startTime !== meta.startTime || stamped.pendingStart !== meta.pendingStart) {
-      meta = stamped
+    const updated = finalizeOrchestrationMeta(instanceId, invocationContext, functionName, meta)
+    if (updated.changed) {
+      meta = updated.meta
       publishOrchestrationMetaSync(instanceId, meta)
     }
   }
 
-  const httpParent = resolveHttpParentForOrchestration(instanceId, traceContext)
-  if (httpParent?.spanId) {
-    const updated = applyHttpParentToMeta(meta, httpParent)
-    if (updated.parentId !== meta.parentId || updated.httpParentSpanId !== meta.httpParentSpanId) {
-      publishOrchestrationMetaSync(instanceId, updated)
-      meta = updated
+  return meta
+}
+
+async function ensureOrchestrationMetaAsync (instanceId, invocationContext, functionName) {
+  const traceContext = invocationContext?.traceContext
+  let meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
+
+  if (!meta?.traceId || !meta?.spanId) {
+    meta = await readOrchestrationSpanMetaAsync(instanceId, traceContext)
+  }
+
+  if (!meta?.traceId || !meta?.spanId) {
+    const created = finalizeOrchestrationMeta(
+      instanceId,
+      invocationContext,
+      functionName,
+      stampOrchestrationStartTime(
+        createOrchestrationMeta(instanceId, invocationContext, functionName),
+        functionName,
+      ),
+    )
+    meta = created.meta
+    await publishOrchestrationMetaAsync(instanceId, meta)
+  } else {
+    const updated = finalizeOrchestrationMeta(instanceId, invocationContext, functionName, meta)
+    if (updated.changed) {
+      meta = updated.meta
+      await publishOrchestrationMetaAsync(instanceId, meta)
     }
   }
 
@@ -319,24 +470,16 @@ async function readOrchestrationSpanMetaAsync (instanceId, traceContext) {
   const client = getTableClient()
   if (!client || !instanceId) return
 
+  const keys = getTableKeys(instanceId)
+
   // Attempts are sequential by nature: each one only runs after the previous
   // read failed, and the backoff grows between them.
   /* eslint-disable no-await-in-loop */
   for (let attempt = 0; attempt < 5; attempt += 1) {
     try {
       await ensureTable()
-      const entity = await client.getEntity(TABLE_PARTITION_KEY, instanceId)
-      const meta = {
-        traceId: entity.traceId,
-        spanId: entity.spanId,
-        parentId: entity.parentId || undefined,
-        httpParentSpanId: entity.httpParentSpanId || undefined,
-        functionName: entity.functionName || undefined,
-        pendingStart: entity.pendingStart === true ? true : undefined,
-        startTime: entity.startTime,
-        earliestChildStartTime: entity.earliestChildStartTime,
-        status: entity.status,
-      }
+      const entity = await client.getEntity(keys.partitionKey, keys.rowKey)
+      const meta = metaFromTableEntity(entity)
       if (meta.traceId && meta.spanId) {
         META_CACHE.set(instanceId, meta)
         writeMetaFileSync(instanceId, meta)
@@ -363,9 +506,10 @@ function clearOrchestrationSpanMeta (instanceId) {
   META_CACHE.delete(instanceId)
   earliestChildStartByInstance.delete(String(instanceId))
   deleteMetaFileSync(instanceId)
+  deleteOrchestrationMetaFromTable(instanceId).catch(() => {})
 
-  const { clearHttpInstanceStartTime } = require('./otel-orchestration-http-link')
-  clearHttpInstanceStartTime(instanceId)
+  const { clearHttpOrchestrationLinks } = require('./otel-orchestration-http-link')
+  clearHttpOrchestrationLinks(instanceId)
 }
 
 function completeOrchestrationSpan (tracerName, instanceId, invocationContext, functionName, error) {
@@ -408,11 +552,14 @@ module.exports = {
   clearOrchestrationSpanMeta,
   completeOrchestrationSpan,
   ensureOrchestrationMeta,
+  ensureOrchestrationMetaAsync,
   injectOrchestrationMetaIntoTraceState,
   mergeInstanceStartTime,
+  publishOrchestrationMetaAsync,
   publishOrchestrationMetaSync,
   publishOrchestrationSpanMetaSync,
   readOrchestrationSpanMetaAsync,
+  readOrchestrationSpanMetaFromSharedStoreSync,
   readOrchestrationSpanMetaSync,
   reconcileOrchestrationHttpParent,
   recordEarliestChildStartTime,

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
@@ -23,6 +23,7 @@ const {
 const TABLE_NAME = 'DDAzureOrchestrationSpans'
 const TABLE_PARTITION_KEY = 'orch'
 const META_CACHE = new Map()
+const earliestChildStartByInstance = new Map()
 
 let tableClient
 let tableClientResolved = false
@@ -168,16 +169,57 @@ function stampOrchestrationStartTime (meta, functionName) {
 function recordEarliestChildStartTime (instanceId, startTime) {
   if (!instanceId || startTime == null) return
 
-  const meta = readOrchestrationSpanMetaSync(instanceId)
-  if (!meta) return
+  const key = String(instanceId)
+  const current = earliestChildStartByInstance.get(key)
+  if (current != null && current <= startTime) {
+    return
+  }
 
-  const earliest = meta.earliestChildStartTime
-  if (earliest != null && earliest <= startTime) return
+  earliestChildStartByInstance.set(key, startTime)
+
+  const meta = readOrchestrationSpanMetaSync(instanceId)
+  if (!meta?.traceId || !meta?.spanId) return
 
   publishOrchestrationMetaSync(instanceId, {
     ...meta,
     earliestChildStartTime: startTime,
   })
+}
+
+function peekEarliestChildStartTime (instanceId) {
+  if (!instanceId) return
+  return earliestChildStartByInstance.get(String(instanceId))
+}
+
+function mergeInstanceStartTime (instanceId, startTime) {
+  if (!instanceId || startTime == null) return
+
+  const meta = readOrchestrationSpanMetaSync(instanceId)
+  if (!meta?.traceId || !meta?.spanId) return
+
+  if (meta.startTime != null && meta.startTime <= startTime) return
+
+  publishOrchestrationMetaSync(instanceId, {
+    ...meta,
+    startTime,
+  })
+}
+
+function resolveExportStartTime (meta, instanceId, endTime) {
+  let startTime = meta?.startTime
+
+  const { peekHttpInstanceStartTime } = require('./otel-orchestration-http-link')
+  const httpStart = peekHttpInstanceStartTime(instanceId)
+  if (httpStart != null) {
+    startTime = startTime == null ? httpStart : Math.min(startTime, httpStart)
+  }
+
+  const childStart = peekEarliestChildStartTime(instanceId) ?? meta?.earliestChildStartTime
+  if (childStart != null) {
+    startTime = startTime == null ? childStart : Math.min(startTime, childStart)
+  }
+
+  return startTime ?? endTime
 }
 
 function reconcileOrchestrationHttpParent (instanceId, httpParent) {
@@ -319,7 +361,11 @@ function markOrchestrationMetaCompleted (instanceId) {
 function clearOrchestrationSpanMeta (instanceId) {
   if (!instanceId) return
   META_CACHE.delete(instanceId)
+  earliestChildStartByInstance.delete(String(instanceId))
   deleteMetaFileSync(instanceId)
+
+  const { clearHttpInstanceStartTime } = require('./otel-orchestration-http-link')
+  clearHttpInstanceStartTime(instanceId)
 }
 
 function completeOrchestrationSpan (tracerName, instanceId, invocationContext, functionName, error) {
@@ -340,7 +386,7 @@ function completeOrchestrationSpan (tracerName, instanceId, invocationContext, f
     {
       ...meta,
       functionName: meta.functionName || functionName,
-      startTime: meta.startTime ?? endTime,
+      startTime: resolveExportStartTime(meta, instanceId, endTime),
     },
     { error, endTime },
   )
@@ -363,12 +409,14 @@ module.exports = {
   completeOrchestrationSpan,
   ensureOrchestrationMeta,
   injectOrchestrationMetaIntoTraceState,
+  mergeInstanceStartTime,
   publishOrchestrationMetaSync,
   publishOrchestrationSpanMetaSync,
   readOrchestrationSpanMetaAsync,
   readOrchestrationSpanMetaSync,
   reconcileOrchestrationHttpParent,
   recordEarliestChildStartTime,
+  resolveExportStartTime,
   seedOrchestrationMetaFromHttpParent,
   stampOrchestrationStartTime,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
@@ -141,9 +141,23 @@ function publishOrchestrationSpanMetaSync (instanceId, span) {
   if (!meta) return
   publishOrchestrationMetaSync(instanceId, {
     ...meta,
-    startTime: Date.now(),
+    startTime: meta.startTime ?? Date.now(),
     status: 'open',
   })
+}
+
+// Record the first non-replay orchestration turn once; never move it on later turns.
+function stampOrchestrationStartTime (meta, functionName) {
+  if (meta.startTime != null && meta.pendingStart !== true) {
+    return meta
+  }
+
+  return {
+    ...meta,
+    functionName: meta.functionName || functionName,
+    startTime: Date.now(),
+    pendingStart: undefined,
+  }
 }
 
 function reconcileOrchestrationHttpParent (instanceId, httpParent) {
@@ -184,17 +198,17 @@ function ensureOrchestrationMeta (instanceId, invocationContext, functionName) {
   let meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
 
   if (!meta?.traceId || !meta?.spanId) {
-    meta = createOrchestrationMeta(instanceId, invocationContext, functionName)
+    meta = stampOrchestrationStartTime(
+      createOrchestrationMeta(instanceId, invocationContext, functionName),
+      functionName,
+    )
     publishOrchestrationMetaSync(instanceId, meta)
-  } else if (meta.pendingStart) {
-    // Seeded at startNew time; the orchestration is only starting now.
-    meta = {
-      ...meta,
-      functionName: meta.functionName || functionName,
-      startTime: Date.now(),
-      pendingStart: undefined,
+  } else {
+    const stamped = stampOrchestrationStartTime(meta, functionName)
+    if (stamped.startTime !== meta.startTime || stamped.pendingStart !== meta.pendingStart) {
+      meta = stamped
+      publishOrchestrationMetaSync(instanceId, meta)
     }
-    publishOrchestrationMetaSync(instanceId, meta)
   }
 
   const httpParent = resolveHttpParentForOrchestration(instanceId, traceContext)
@@ -294,10 +308,15 @@ function completeOrchestrationSpan (tracerName, instanceId, invocationContext, f
 
   if (!markOrchestrationMetaCompleted(instanceId)) return false
 
+  const endTime = Date.now()
   const exported = exportOrchestrationSpanFromMeta(
     tracerName,
-    { ...meta, functionName: meta.functionName || functionName },
-    { error, endTime: Date.now() },
+    {
+      ...meta,
+      functionName: meta.functionName || functionName,
+      startTime: meta.startTime ?? endTime,
+    },
+    { error, endTime },
   )
 
   clearOrchestrationSpanMeta(instanceId)
@@ -324,4 +343,5 @@ module.exports = {
   readOrchestrationSpanMetaSync,
   reconcileOrchestrationHttpParent,
   seedOrchestrationMetaFromHttpParent,
+  stampOrchestrationStartTime,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
@@ -131,6 +131,7 @@ function publishOrchestrationMetaSync (instanceId, meta) {
       functionName: normalized.functionName ?? '',
       pendingStart: normalized.pendingStart === true,
       startTime: normalized.startTime,
+      earliestChildStartTime: normalized.earliestChildStartTime,
       status: normalized.status || 'open',
     }, 'Replace'))
     .catch(() => {})
@@ -146,10 +147,14 @@ function publishOrchestrationSpanMetaSync (instanceId, span) {
   })
 }
 
-// Record the first non-replay orchestration turn once; never move it on later turns.
+// Record the instance start once; never move it on later turns.
 function stampOrchestrationStartTime (meta, functionName) {
-  if (meta.startTime != null && meta.pendingStart !== true) {
-    return meta
+  if (meta.startTime != null) {
+    return {
+      ...meta,
+      functionName: meta.functionName || functionName,
+      pendingStart: undefined,
+    }
   }
 
   return {
@@ -158,6 +163,21 @@ function stampOrchestrationStartTime (meta, functionName) {
     startTime: Date.now(),
     pendingStart: undefined,
   }
+}
+
+function recordEarliestChildStartTime (instanceId, startTime) {
+  if (!instanceId || startTime == null) return
+
+  const meta = readOrchestrationSpanMetaSync(instanceId)
+  if (!meta) return
+
+  const earliest = meta.earliestChildStartTime
+  if (earliest != null && earliest <= startTime) return
+
+  publishOrchestrationMetaSync(instanceId, {
+    ...meta,
+    earliestChildStartTime: startTime,
+  })
 }
 
 function reconcileOrchestrationHttpParent (instanceId, httpParent) {
@@ -178,7 +198,7 @@ function reconcileOrchestrationHttpParent (instanceId, httpParent) {
 // Record the orchestration span identity while the HTTP span that started the
 // instance is still available, so any worker that later runs the orchestration
 // reads the HTTP span as its parent.
-function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName) {
+function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName, instanceStartTime) {
   if (!instanceId || !httpParent?.spanId) return
 
   const existing = readOrchestrationSpanMetaSync(instanceId)
@@ -186,7 +206,12 @@ function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionNa
     return reconcileOrchestrationHttpParent(instanceId, httpParent)
   }
 
-  const meta = createOrchestrationMetaFromHttpParent(instanceId, httpParent, functionName)
+  const meta = createOrchestrationMetaFromHttpParent(
+    instanceId,
+    httpParent,
+    functionName,
+    instanceStartTime,
+  )
   if (!meta) return
 
   publishOrchestrationMetaSync(instanceId, meta)
@@ -267,6 +292,7 @@ async function readOrchestrationSpanMetaAsync (instanceId, traceContext) {
         functionName: entity.functionName || undefined,
         pendingStart: entity.pendingStart === true ? true : undefined,
         startTime: entity.startTime,
+        earliestChildStartTime: entity.earliestChildStartTime,
         status: entity.status,
       }
       if (meta.traceId && meta.spanId) {
@@ -342,6 +368,7 @@ module.exports = {
   readOrchestrationSpanMetaAsync,
   readOrchestrationSpanMetaSync,
   reconcileOrchestrationHttpParent,
+  recordEarliestChildStartTime,
   seedOrchestrationMetaFromHttpParent,
   stampOrchestrationStartTime,
 }

--- a/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
+++ b/packages/datadog-instrumentations/src/helpers/otel-orchestration-store.js
@@ -1,0 +1,327 @@
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { getEnvironmentVariable } = require('../../../dd-trace/src/config/helper')
+const {
+  appendOrchestrationSpanToTraceState,
+  getSpanMeta,
+  parseOrchestrationMetaFromTraceContext,
+} = require('./otel-orchestration-meta')
+const {
+  createOrchestrationMeta,
+  createOrchestrationMetaFromHttpParent,
+  exportOrchestrationSpanFromMeta,
+} = require('./otel-orchestration-export')
+const {
+  applyHttpParentToMeta,
+  resolveHttpParentForOrchestration,
+} = require('./otel-orchestration-http-link')
+
+const TABLE_NAME = 'DDAzureOrchestrationSpans'
+const TABLE_PARTITION_KEY = 'orch'
+const META_CACHE = new Map()
+
+let tableClient
+let tableClientResolved = false
+let tableEnsured = false
+
+function getStoreDirectory () {
+  // Internal override for tests and local development only, so it is deliberately
+  // not a registered configuration.
+  // eslint-disable-next-line eslint-rules/eslint-process-env
+  return process.env.DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR ||
+    path.join(os.tmpdir(), 'dd-orchestration-spans')
+}
+
+function getMetaFilePath (instanceId) {
+  return path.join(getStoreDirectory(), `${instanceId}.json`)
+}
+
+function writeMetaFileSync (instanceId, meta) {
+  const directory = getStoreDirectory()
+  fs.mkdirSync(directory, { recursive: true })
+  fs.writeFileSync(getMetaFilePath(instanceId), JSON.stringify(meta))
+}
+
+function readMetaFileSync (instanceId) {
+  try {
+    const contents = fs.readFileSync(getMetaFilePath(instanceId), 'utf8')
+    return JSON.parse(contents)
+  } catch {}
+}
+
+function deleteMetaFileSync (instanceId) {
+  try {
+    fs.unlinkSync(getMetaFilePath(instanceId))
+  } catch {
+    // ignore missing files
+  }
+}
+
+function getAzuriteConnectionString () {
+  return 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;' +
+    'AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;' +
+    'TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;'
+}
+
+function getTableClient () {
+  if (tableClientResolved) return tableClient
+
+  tableClientResolved = true
+  tableClient = null
+
+  const connectionString = getEnvironmentVariable('AzureWebJobsStorage')
+  if (!connectionString) return null
+
+  try {
+    // Provided by the Azure Functions host, so it is never a tracer dependency.
+    // eslint-disable-next-line n/no-missing-require
+    const { TableClient } = require('@azure/data-tables')
+    const resolvedConnectionString = connectionString === 'UseDevelopmentStorage=true'
+      ? getAzuriteConnectionString()
+      : connectionString
+    tableClient = TableClient.fromConnectionString(resolvedConnectionString, TABLE_NAME)
+  } catch {
+    tableClient = null
+  }
+
+  return tableClient
+}
+
+async function ensureTable () {
+  const client = getTableClient()
+  if (!client || tableEnsured) return client
+
+  try {
+    await client.createTable()
+  } catch (error) {
+    if (error?.statusCode !== 409) throw error
+  }
+
+  tableEnsured = true
+  return client
+}
+
+function normalizeMeta (meta) {
+  if (!meta?.traceId || !meta?.spanId) return
+  return meta
+}
+
+function publishOrchestrationMetaSync (instanceId, meta) {
+  const normalized = normalizeMeta(meta)
+  if (!instanceId || !normalized) return
+
+  META_CACHE.set(instanceId, normalized)
+  writeMetaFileSync(instanceId, normalized)
+
+  const client = getTableClient()
+  if (!client) return
+
+  ensureTable()
+    .then(table => table.upsertEntity({
+      partitionKey: TABLE_PARTITION_KEY,
+      rowKey: instanceId,
+      traceId: normalized.traceId,
+      spanId: normalized.spanId,
+      parentId: normalized.parentId ?? '',
+      httpParentSpanId: normalized.httpParentSpanId ?? '',
+      functionName: normalized.functionName ?? '',
+      pendingStart: normalized.pendingStart === true,
+      startTime: normalized.startTime,
+      status: normalized.status || 'open',
+    }, 'Replace'))
+    .catch(() => {})
+}
+
+function publishOrchestrationSpanMetaSync (instanceId, span) {
+  const meta = getSpanMeta(span)
+  if (!meta) return
+  publishOrchestrationMetaSync(instanceId, {
+    ...meta,
+    startTime: Date.now(),
+    status: 'open',
+  })
+}
+
+function reconcileOrchestrationHttpParent (instanceId, httpParent) {
+  if (!instanceId || !httpParent?.spanId) return
+
+  const existing = readOrchestrationSpanMetaSync(instanceId)
+  if (!existing?.traceId || !existing?.spanId) return
+
+  const updated = applyHttpParentToMeta(existing, httpParent)
+  if (updated.parentId === existing.parentId && updated.httpParentSpanId === existing.httpParentSpanId) {
+    return existing
+  }
+
+  publishOrchestrationMetaSync(instanceId, updated)
+  return updated
+}
+
+// Record the orchestration span identity while the HTTP span that started the
+// instance is still available, so any worker that later runs the orchestration
+// reads the HTTP span as its parent.
+function seedOrchestrationMetaFromHttpParent (instanceId, httpParent, functionName) {
+  if (!instanceId || !httpParent?.spanId) return
+
+  const existing = readOrchestrationSpanMetaSync(instanceId)
+  if (existing?.traceId && existing.spanId) {
+    return reconcileOrchestrationHttpParent(instanceId, httpParent)
+  }
+
+  const meta = createOrchestrationMetaFromHttpParent(instanceId, httpParent, functionName)
+  if (!meta) return
+
+  publishOrchestrationMetaSync(instanceId, meta)
+  return meta
+}
+
+function ensureOrchestrationMeta (instanceId, invocationContext, functionName) {
+  const traceContext = invocationContext?.traceContext
+  let meta = readOrchestrationSpanMetaSync(instanceId, traceContext)
+
+  if (!meta?.traceId || !meta?.spanId) {
+    meta = createOrchestrationMeta(instanceId, invocationContext, functionName)
+    publishOrchestrationMetaSync(instanceId, meta)
+  } else if (meta.pendingStart) {
+    // Seeded at startNew time; the orchestration is only starting now.
+    meta = {
+      ...meta,
+      functionName: meta.functionName || functionName,
+      startTime: Date.now(),
+      pendingStart: undefined,
+    }
+    publishOrchestrationMetaSync(instanceId, meta)
+  }
+
+  const httpParent = resolveHttpParentForOrchestration(instanceId, traceContext)
+  if (httpParent?.spanId) {
+    const updated = applyHttpParentToMeta(meta, httpParent)
+    if (updated.parentId !== meta.parentId || updated.httpParentSpanId !== meta.httpParentSpanId) {
+      publishOrchestrationMetaSync(instanceId, updated)
+      meta = updated
+    }
+  }
+
+  return meta
+}
+
+// The shared store is authoritative: it carries the orchestration parent, which
+// the tracestate marker cannot express. Tracestate is only a fallback for workers
+// that have no store record.
+function readOrchestrationSpanMetaSync (instanceId, traceContext) {
+  if (instanceId) {
+    if (META_CACHE.has(instanceId)) {
+      return META_CACHE.get(instanceId)
+    }
+
+    const fromFile = readMetaFileSync(instanceId)
+    if (fromFile?.traceId && fromFile.spanId) {
+      META_CACHE.set(instanceId, fromFile)
+      return fromFile
+    }
+  }
+
+  const fromTraceState = parseOrchestrationMetaFromTraceContext(traceContext)
+  if (fromTraceState?.traceId && fromTraceState.spanId) {
+    return fromTraceState
+  }
+}
+
+async function readOrchestrationSpanMetaAsync (instanceId, traceContext) {
+  const cached = readOrchestrationSpanMetaSync(instanceId, traceContext)
+  if (cached) return cached
+
+  const client = getTableClient()
+  if (!client || !instanceId) return
+
+  // Attempts are sequential by nature: each one only runs after the previous
+  // read failed, and the backoff grows between them.
+  /* eslint-disable no-await-in-loop */
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      await ensureTable()
+      const entity = await client.getEntity(TABLE_PARTITION_KEY, instanceId)
+      const meta = {
+        traceId: entity.traceId,
+        spanId: entity.spanId,
+        parentId: entity.parentId || undefined,
+        httpParentSpanId: entity.httpParentSpanId || undefined,
+        functionName: entity.functionName || undefined,
+        pendingStart: entity.pendingStart === true ? true : undefined,
+        startTime: entity.startTime,
+        status: entity.status,
+      }
+      if (meta.traceId && meta.spanId) {
+        META_CACHE.set(instanceId, meta)
+        writeMetaFileSync(instanceId, meta)
+        return meta
+      }
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 20 * (attempt + 1)))
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+}
+
+function markOrchestrationMetaCompleted (instanceId) {
+  const meta = readOrchestrationSpanMetaSync(instanceId)
+  if (!meta || meta.status === 'completed') return false
+
+  const completedMeta = { ...meta, status: 'completed' }
+  publishOrchestrationMetaSync(instanceId, completedMeta)
+  return true
+}
+
+function clearOrchestrationSpanMeta (instanceId) {
+  if (!instanceId) return
+  META_CACHE.delete(instanceId)
+  deleteMetaFileSync(instanceId)
+}
+
+function completeOrchestrationSpan (tracerName, instanceId, invocationContext, functionName, error) {
+  let meta = readOrchestrationSpanMetaSync(instanceId, invocationContext?.traceContext)
+  if (!meta || meta.status === 'completed') return false
+
+  const httpParent = resolveHttpParentForOrchestration(instanceId, invocationContext?.traceContext)
+  if (httpParent?.spanId) {
+    meta = applyHttpParentToMeta(meta, httpParent)
+    publishOrchestrationMetaSync(instanceId, meta)
+  }
+
+  if (!markOrchestrationMetaCompleted(instanceId)) return false
+
+  const exported = exportOrchestrationSpanFromMeta(
+    tracerName,
+    { ...meta, functionName: meta.functionName || functionName },
+    { error, endTime: Date.now() },
+  )
+
+  clearOrchestrationSpanMeta(instanceId)
+  return exported
+}
+
+function injectOrchestrationMetaIntoTraceState (traceContext, meta) {
+  if (!traceContext || !meta?.spanId) return traceContext
+
+  return {
+    ...traceContext,
+    traceState: appendOrchestrationSpanToTraceState(traceContext.traceState, meta.spanId),
+  }
+}
+
+module.exports = {
+  clearOrchestrationSpanMeta,
+  completeOrchestrationSpan,
+  ensureOrchestrationMeta,
+  injectOrchestrationMetaIntoTraceState,
+  publishOrchestrationMetaSync,
+  publishOrchestrationSpanMetaSync,
+  readOrchestrationSpanMetaAsync,
+  readOrchestrationSpanMetaSync,
+  reconcileOrchestrationHttpParent,
+  seedOrchestrationMetaFromHttpParent,
+}

--- a/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
@@ -1,11 +1,7 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
-const { extractContext } = require('./helpers/azure-trace-context')
 const {
-  endSpan,
-  getTracer,
-  spanAttributes,
   wrapAsyncWithTraceContext,
   wrapSyncWithTraceContext,
 } = require('./helpers/otel-azure-span')
@@ -67,30 +63,44 @@ function orchestrationWrapper (method) {
 function wrapOrchestrationHandler (handler, functionName) {
   return function * (...args) {
     const invocationContext = args[0]
-    if (invocationContext?.df?.isReplaying) {
-      yield * handler.apply(this, args)
-      return
-    }
+    const { getInstanceId } = require('./helpers/azure-trace-context')
+    const {
+      completeOrchestrationSpan,
+      ensureOrchestrationMeta,
+    } = require('./helpers/otel-orchestration-store')
+    const { unregisterOrchestrationSpan } = require('./helpers/otel-orchestration-registry')
 
-    const parentContext = extractContext(invocationContext?.traceContext)
-    const span = getTracer(TRACER_NAME).startSpan(
-      `orchestration ${functionName}`,
-      { attributes: spanAttributes(functionName, 'durable-orchestration') },
-      parentContext,
-    )
+    const instanceId = getInstanceId(invocationContext)
+
+    if (instanceId && !invocationContext?.df?.isReplaying) {
+      ensureOrchestrationMeta(instanceId, invocationContext, functionName)
+    }
 
     try {
       const gen = handler.apply(this, args)
       let step = gen.next()
       while (!step.done) {
+        if (instanceId) {
+          unregisterOrchestrationSpan(instanceId)
+        }
         const input = yield step.value
         step = gen.next(input)
       }
-      endSpan(span)
+
+      if (instanceId) {
+        completeOrchestrationSpan(TRACER_NAME, instanceId, invocationContext, functionName)
+      }
+
       return step.value
     } catch (error) {
-      endSpan(span, error)
+      if (instanceId) {
+        completeOrchestrationSpan(TRACER_NAME, instanceId, invocationContext, functionName, error)
+      }
       throw error
+    } finally {
+      if (instanceId) {
+        unregisterOrchestrationSpan(instanceId)
+      }
     }
   }
 }

--- a/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
@@ -41,10 +41,13 @@ function entityWrapper (method) {
 
 function activityWrapper (method) {
   return function (activityName, activityOptions) {
-    if (activityOptions && typeof activityOptions.handler === 'function') {
-      // Always wrap activities with the async tracer so parent resolution can read
-      // the shared orchestration store (Azure Table) when the activity runs on a
-      // different worker than the HTTP trigger or orchestrator.
+    if (typeof activityOptions === 'function') {
+      arguments[1] = shimmer.wrapFunction(
+        activityOptions,
+        handler => wrapAsyncWithTraceContext(TRACER_NAME, 'durable-activity', handler, activityName),
+      )
+    } else if (activityOptions && typeof activityOptions.handler === 'function') {
+      // Async wrap so parent resolution can read the shared store cross-worker.
       shimmer.wrap(activityOptions, 'handler', handler =>
         wrapAsyncWithTraceContext(TRACER_NAME, 'durable-activity', handler, activityName),
       )
@@ -71,8 +74,9 @@ function wrapOrchestrationHandler (handler, functionName) {
     const { unregisterOrchestrationSpan } = require('./helpers/otel-orchestration-registry')
 
     const instanceId = getInstanceId(invocationContext)
+    const isReplaying = invocationContext?.df?.isReplaying !== false
 
-    if (instanceId) {
+    if (instanceId && !isReplaying) {
       ensureOrchestrationMeta(instanceId, invocationContext, functionName)
     }
 
@@ -87,13 +91,13 @@ function wrapOrchestrationHandler (handler, functionName) {
         step = gen.next(input)
       }
 
-      if (instanceId) {
+      if (instanceId && !isReplaying) {
         completeOrchestrationSpan(TRACER_NAME, instanceId, invocationContext, functionName)
       }
 
       return step.value
     } catch (error) {
-      if (instanceId) {
+      if (instanceId && !isReplaying) {
         completeOrchestrationSpan(TRACER_NAME, instanceId, invocationContext, functionName, error)
       }
       throw error

--- a/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
@@ -42,12 +42,12 @@ function entityWrapper (method) {
 function activityWrapper (method) {
   return function (activityName, activityOptions) {
     if (activityOptions && typeof activityOptions.handler === 'function') {
-      shimmer.wrap(activityOptions, 'handler', handler => {
-        const isAsync = handler?.constructor?.name === 'AsyncFunction'
-        return isAsync
-          ? wrapAsyncWithTraceContext(TRACER_NAME, 'durable-activity', handler, activityName)
-          : wrapSyncWithTraceContext(TRACER_NAME, 'durable-activity', handler, activityName)
-      })
+      // Always wrap activities with the async tracer so parent resolution can read
+      // the shared orchestration store (Azure Table) when the activity runs on a
+      // different worker than the HTTP trigger or orchestrator.
+      shimmer.wrap(activityOptions, 'handler', handler =>
+        wrapAsyncWithTraceContext(TRACER_NAME, 'durable-activity', handler, activityName),
+      )
     }
     return method.apply(this, arguments)
   }

--- a/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/otel-azure-durable-functions.js
@@ -72,7 +72,7 @@ function wrapOrchestrationHandler (handler, functionName) {
 
     const instanceId = getInstanceId(invocationContext)
 
-    if (instanceId && !invocationContext?.df?.isReplaying) {
+    if (instanceId) {
       ensureOrchestrationMeta(instanceId, invocationContext, functionName)
     }
 

--- a/packages/datadog-instrumentations/src/otel-azure-functions.js
+++ b/packages/datadog-instrumentations/src/otel-azure-functions.js
@@ -50,18 +50,18 @@ function traceGenericOrchestrationHandler (handler, functionName) {
     const { runWithInvocationContext, getInstanceId } = require('./helpers/azure-trace-context')
     const {
       completeOrchestrationSpan,
-      ensureOrchestrationMeta,
+      ensureOrchestrationMetaAsync,
     } = require('./helpers/otel-orchestration-store')
 
     return runWithInvocationContext(args, 'orchestration-generic', () => {
       const invocationContext = args[1]
       const instanceId = getInstanceId(invocationContext)
 
-      if (instanceId) {
-        ensureOrchestrationMeta(instanceId, invocationContext, functionName)
-      }
-
       return (async () => {
+        if (instanceId) {
+          await ensureOrchestrationMetaAsync(instanceId, invocationContext, functionName)
+        }
+
         try {
           const result = await handler.apply(this, args)
           const runtimeStatus = invocationContext?.traceContext?.attributes?.DurableFunctionsRuntimeStatus

--- a/packages/datadog-instrumentations/src/otel-azure-functions.js
+++ b/packages/datadog-instrumentations/src/otel-azure-functions.js
@@ -47,24 +47,39 @@ function traceGenericOrchestrationHandler (handler, functionName) {
       return handler.apply(this, args)
     }
 
-    const { runWithInvocationContext } = require('./helpers/azure-trace-context')
-    const { getTracer, spanAttributes, endSpan } = require('./helpers/otel-azure-span')
+    const { runWithInvocationContext, getInstanceId } = require('./helpers/azure-trace-context')
+    const {
+      completeOrchestrationSpan,
+      ensureOrchestrationMeta,
+    } = require('./helpers/otel-orchestration-store')
 
-    return runWithInvocationContext(args, 'orchestration-generic', () =>
-      getTracer(TRACER_NAME).startActiveSpan(
-        `orchestration ${functionName}`,
-        { attributes: spanAttributes(functionName, 'durable-orchestration') },
-        async (span) => {
-          try {
-            const result = await handler.apply(this, args)
-            span.end()
-            return result
-          } catch (error) {
-            endSpan(span, error)
-            throw error
+    return runWithInvocationContext(args, 'orchestration-generic', () => {
+      const invocationContext = args[1]
+      const instanceId = getInstanceId(invocationContext)
+
+      if (instanceId) {
+        ensureOrchestrationMeta(instanceId, invocationContext, functionName)
+      }
+
+      return (async () => {
+        try {
+          const result = await handler.apply(this, args)
+          const runtimeStatus = invocationContext?.traceContext?.attributes?.DurableFunctionsRuntimeStatus
+          if (
+            instanceId &&
+            (runtimeStatus === 'Completed' || runtimeStatus === 'Failed' || runtimeStatus === 'Terminated')
+          ) {
+            completeOrchestrationSpan(TRACER_NAME, instanceId, invocationContext, functionName)
           }
-        },
-      ))
+          return result
+        } catch (error) {
+          if (instanceId) {
+            completeOrchestrationSpan(TRACER_NAME, instanceId, invocationContext, functionName, error)
+          }
+          throw error
+        }
+      })()
+    })
   }
 }
 

--- a/packages/datadog-instrumentations/test/helpers/otel-orchestration-store.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/otel-orchestration-store.spec.js
@@ -1,0 +1,453 @@
+'use strict'
+
+const Module = require('module')
+const assert = require('node:assert/strict')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+
+const storePath = require.resolve('../../src/helpers/otel-orchestration-store')
+
+const {
+  appendOrchestrationSpanToTraceState,
+  parseOrchestrationMetaFromTraceContext,
+  traceContextFromMeta,
+} = require('../../src/helpers/otel-orchestration-meta')
+const {
+  completeOrchestrationSpan,
+  ensureOrchestrationMeta,
+  injectOrchestrationMetaIntoTraceState,
+  publishOrchestrationMetaSync,
+  publishOrchestrationSpanMetaSync,
+  readOrchestrationSpanMetaSync,
+  reconcileOrchestrationHttpParent,
+  seedOrchestrationMetaFromHttpParent,
+} = require('../../src/helpers/otel-orchestration-store')
+const {
+  createOrchestrationMeta,
+  createOrchestrationMetaFromHttpParent,
+  exportOrchestrationSpanFromMeta,
+  getParentFromTraceContext,
+} = require('../../src/helpers/otel-orchestration-export')
+const { publishHttpParentMeta } = require('../../src/helpers/otel-orchestration-http-link')
+const { buildSpanParentContext } = require('../../src/helpers/azure-trace-context')
+
+describe('otel-orchestration-meta', () => {
+  it('builds traceparent from orchestration metadata', () => {
+    assert.deepEqual(
+      traceContextFromMeta({
+        traceId: '00000000000000000000000000000001',
+        spanId: '0000000000000002',
+      }),
+      {
+        traceParent: '00-00000000000000000000000000000001-0000000000000002-01',
+      },
+    )
+  })
+
+  it('parses orchestration span id from tracestate', () => {
+    assert.deepEqual(
+      parseOrchestrationMetaFromTraceContext({
+        traceParent: '00-00000000000000000000000000000001-0000000000000003-00',
+        traceState: 'dd=s:1,dd=o:0000000000000002',
+      }),
+      {
+        traceId: '00000000000000000000000000000001',
+        spanId: '0000000000000002',
+      },
+    )
+  })
+
+  it('appends orchestration span id to tracestate', () => {
+    assert.equal(
+      appendOrchestrationSpanToTraceState('dd=s:1', '0000000000000002'),
+      'dd=s:1,dd=o:0000000000000002',
+    )
+  })
+})
+
+describe('otel-orchestration-store', () => {
+  let previousStoreDir
+
+  beforeEach(() => {
+    previousStoreDir = process.env.DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR
+    process.env.DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR = path.join(
+      os.tmpdir(),
+      `dd-orch-test-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    )
+  })
+
+  afterEach(() => {
+    if (previousStoreDir === undefined) {
+      delete process.env.DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR
+    } else {
+      process.env.DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR = previousStoreDir
+    }
+  })
+
+  it('writes and reads orchestration metadata from the shared store', () => {
+    publishOrchestrationSpanMetaSync('abc123', {
+      _ddSpan: {
+        context () {
+          return {
+            _traceId: '00000000000000000000000000000001',
+            _spanId: '0000000000000002',
+          }
+        },
+      },
+    })
+
+    assert.deepEqual(
+      readOrchestrationSpanMetaSync('abc123'),
+      {
+        traceId: '00000000000000000000000000000001',
+        spanId: '0000000000000002',
+        startTime: readOrchestrationSpanMetaSync('abc123').startTime,
+        status: 'open',
+      },
+    )
+    assert.ok(fs.existsSync(
+      path.join(
+        process.env.DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR,
+        `${Buffer.from('abc123', 'utf8').toString('base64url')}.json`,
+      ),
+    ))
+  })
+
+  it('creates orchestration metadata once per instance', () => {
+    const invocationContext = {
+      traceContext: {
+        traceParent: '00-00000000000000000000000000000001-0000000000000003-00',
+      },
+    }
+
+    const first = ensureOrchestrationMeta('abc123', invocationContext, 'PizzaOrderOrchestration')
+    const second = ensureOrchestrationMeta('abc123', invocationContext, 'PizzaOrderOrchestration')
+
+    assert.equal(first.spanId, second.spanId)
+    assert.equal(first.traceId, '00000000000000000000000000000001')
+    assert.equal(first.status, 'open')
+  })
+
+  it('parents orchestration metadata to the HTTP span that started the instance', () => {
+    publishHttpParentMeta('abc123', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000004',
+    })
+
+    const meta = createOrchestrationMeta('abc123', {
+      traceContext: {
+        traceParent: '00-00000000000000000000000000000001-0000000000000099-00',
+      },
+    }, 'PizzaOrderOrchestration')
+
+    assert.equal(meta.parentId, '0000000000000004')
+    assert.equal(meta.traceId, '00000000000000000000000000000001')
+  })
+
+  it('reconciles orchestration metadata when the HTTP parent arrives after instance creation', () => {
+    publishOrchestrationMetaSync('abc123', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000002',
+      parentId: '0000000000000099',
+      startTime: Date.now(),
+      status: 'open',
+    })
+
+    const updated = reconcileOrchestrationHttpParent('abc123', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000004',
+    })
+
+    assert.equal(updated.parentId, '0000000000000004')
+    assert.equal(updated.httpParentSpanId, '0000000000000004')
+    assert.equal(readOrchestrationSpanMetaSync('abc123').parentId, '0000000000000004')
+  })
+
+  it('seeds orchestration metadata from the HTTP parent at startNew time', async () => {
+    const meta = await seedOrchestrationMetaFromHttpParent('seed-new', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000004',
+    }, 'PizzaPartyOrchestration')
+
+    assert.equal(meta.traceId, '00000000000000000000000000000001')
+    assert.equal(meta.parentId, '0000000000000004')
+    assert.equal(meta.spanId.length, 16)
+    assert.ok(meta.startTime)
+    assert.equal(meta.pendingStart, undefined)
+    // A worker with no in-process state must still read the HTTP parent.
+    assert.equal(readOrchestrationSpanMetaSync('seed-new').parentId, '0000000000000004')
+  })
+
+  it('keeps the seeded HTTP parent when the orchestration starts on another worker', async () => {
+    await seedOrchestrationMetaFromHttpParent('seed-other-worker', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000004',
+    }, 'PizzaPartyOrchestration')
+
+    const seeded = readOrchestrationSpanMetaSync('seed-other-worker')
+
+    // Azure hands the orchestration its own unrelated trace context.
+    const meta = ensureOrchestrationMeta('seed-other-worker', {
+      traceContext: {
+        traceParent: '00-99999999999999999999999999999999-0000000000000099-01',
+      },
+    }, 'PizzaPartyOrchestration')
+
+    assert.equal(meta.parentId, '0000000000000004')
+    assert.equal(meta.traceId, '00000000000000000000000000000001')
+    assert.equal(meta.spanId, seeded.spanId)
+    assert.strictEqual(meta.startTime, seeded.startTime)
+  })
+
+  it('does not seed twice for the same instance', async () => {
+    const httpParent = {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000004',
+    }
+
+    const first = await seedOrchestrationMetaFromHttpParent('seed-once', httpParent, 'PizzaPartyOrchestration')
+    const second = await seedOrchestrationMetaFromHttpParent('seed-once', httpParent, 'PizzaPartyOrchestration')
+
+    assert.equal(first.spanId, second.spanId)
+  })
+
+  it('prefers the stored HTTP parent over the tracestate marker', () => {
+    publishOrchestrationMetaSync('abc123', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000002',
+      parentId: '0000000000000004',
+      httpParentSpanId: '0000000000000004',
+      startTime: Date.now(),
+      status: 'open',
+      functionName: 'PizzaPartyOrchestration',
+    })
+
+    const merged = readOrchestrationSpanMetaSync('abc123', {
+      traceParent: '00-00000000000000000000000000000001-0000000000000099-00',
+      traceState: 'dd=s:1,dd=o:0000000000000002',
+    })
+
+    assert.equal(merged.parentId, '0000000000000004')
+    assert.equal(merged.httpParentSpanId, '0000000000000004')
+    assert.equal(merged.spanId, '0000000000000002')
+  })
+
+  it('exports one orchestration span on completion', () => {
+    process.env.DD_TRACE_OTEL_ENABLED = 'true'
+    process.env.DD_TRACE_AZURE_DURABLE_FUNCTIONS_ENABLED = 'false'
+
+    const ddtrace = require('../../../dd-trace')
+    ddtrace.init({ plugins: false, sampleRate: 1 })
+    new ddtrace.TracerProvider().register()
+
+    const invocationContext = {
+      traceContext: {
+        traceParent: '00-00000000000000000000000000000001-0000000000000003-00',
+      },
+    }
+
+    const meta = ensureOrchestrationMeta('abc123', invocationContext, 'PizzaOrderOrchestration')
+    const complete = () => completeOrchestrationSpan(
+      '@azure/durable-functions', 'abc123', invocationContext, 'PizzaOrderOrchestration'
+    )
+    assert.equal(complete(), true)
+    assert.equal(complete(), false)
+    assert.equal(readOrchestrationSpanMetaSync('abc123'), undefined)
+    assert.equal(meta.spanId.length, 16)
+  })
+
+  it('parents activity spans to orchestration metadata from the shared store', () => {
+    process.env.DD_TRACE_OTEL_ENABLED = 'true'
+    process.env.DD_TRACE_AZURE_DURABLE_FUNCTIONS_ENABLED = 'false'
+
+    const ddtrace = require('../../../dd-trace')
+    ddtrace.init({ plugins: false, sampleRate: 1 })
+    new ddtrace.TracerProvider().register()
+
+    publishOrchestrationSpanMetaSync('abc123', {
+      _ddSpan: {
+        context () {
+          return {
+            _traceId: '00000000000000000000000000000001',
+            _spanId: '0000000000000002',
+          }
+        },
+      },
+    })
+
+    const activityContext = {
+      traceContext: {
+        traceParent: '00-00000000000000000000000000000001-0000000000000003-00',
+        attributes: {
+          'durabletask.task.instance_id': 'abc123',
+        },
+      },
+    }
+
+    const api = require('@opentelemetry/api')
+    const parentContext = buildSpanParentContext(['input', activityContext], 'durable-activity')
+    const actSpan = api.trace.getTracer('test').startSpan('durable-activity Test', {}, parentContext)
+    assert.equal(actSpan._ddSpan.context()._parentId.toString(16).padStart(16, '0'), '0000000000000002')
+    actSpan.end()
+  })
+
+  it('injects orchestration span ids into tracestate', () => {
+    assert.deepEqual(
+      injectOrchestrationMetaIntoTraceState(
+        { traceState: 'dd=s:1' },
+        { spanId: '0000000000000002' },
+      ),
+      { traceState: 'dd=s:1,dd=o:0000000000000002' },
+    )
+  })
+
+  it('persists orchestration metadata to azure table storage', async () => {
+    const previousStorage = process.env.AzureWebJobsStorage
+    process.env.AzureWebJobsStorage = 'UseDevelopmentStorage=true'
+
+    let upsertCalled = false
+    delete require.cache[storePath]
+    const originalRequire = Module.prototype.require
+    Module.prototype.require = function (id) {
+      if (id === '@azure/data-tables') {
+        return {
+          TableClient: {
+            fromConnectionString (connectionString) {
+              assert.match(connectionString, /127\.0\.0\.1:10002/)
+              return {
+                createTable: async () => {},
+                upsertEntity: async () => { upsertCalled = true },
+              }
+            },
+          },
+        }
+      }
+      return originalRequire.apply(this, arguments)
+    }
+
+    try {
+      const { publishOrchestrationMetaSync } = require('../../src/helpers/otel-orchestration-store')
+      publishOrchestrationMetaSync('table-write', {
+        traceId: '00000000000000000000000000000001',
+        spanId: '0000000000000002',
+        startTime: Date.now(),
+        status: 'open',
+      })
+      await new Promise(resolve => setImmediate(resolve))
+      assert.equal(upsertCalled, true)
+    } finally {
+      Module.prototype.require = originalRequire
+      delete require.cache[storePath]
+      if (previousStorage === undefined) {
+        delete process.env.AzureWebJobsStorage
+      } else {
+        process.env.AzureWebJobsStorage = previousStorage
+      }
+    }
+  })
+
+  it('reads orchestration metadata from azure table storage', async () => {
+    const previousStorage = process.env.AzureWebJobsStorage
+    process.env.AzureWebJobsStorage = 'UseDevelopmentStorage=true'
+
+    delete require.cache[storePath]
+    const originalRequire = Module.prototype.require
+    Module.prototype.require = function (id) {
+      if (id === '@azure/data-tables') {
+        return {
+          TableClient: {
+            fromConnectionString () {
+              return {
+                createTable: async () => {
+                  const error = new Error('exists')
+                  error.statusCode = 409
+                  throw error
+                },
+                getEntity: async () => ({
+                  traceId: '00000000000000000000000000000001',
+                  spanId: '0000000000000005',
+                  parentId: '0000000000000004',
+                  status: 'open',
+                  startTime: Date.now(),
+                }),
+              }
+            },
+          },
+        }
+      }
+      return originalRequire.apply(this, arguments)
+    }
+
+    try {
+      const { readOrchestrationSpanMetaAsync } = require('../../src/helpers/otel-orchestration-store')
+      const meta = await readOrchestrationSpanMetaAsync('table-read')
+      assert.equal(meta.spanId, '0000000000000005')
+      assert.equal(meta.parentId, '0000000000000004')
+    } finally {
+      Module.prototype.require = originalRequire
+      delete require.cache[storePath]
+      if (previousStorage === undefined) {
+        delete process.env.AzureWebJobsStorage
+      } else {
+        process.env.AzureWebJobsStorage = previousStorage
+      }
+    }
+  })
+
+  it('exports orchestration spans with errors', () => {
+    process.env.DD_TRACE_OTEL_ENABLED = 'true'
+    process.env.DD_TRACE_AZURE_DURABLE_FUNCTIONS_ENABLED = 'false'
+
+    const ddtrace = require('../../../dd-trace')
+    ddtrace.init({ plugins: false, sampleRate: 1 })
+    new ddtrace.TracerProvider().register()
+
+    const invocationContext = {
+      traceContext: {
+        traceParent: '00-00000000000000000000000000000001-0000000000000003-00',
+      },
+    }
+
+    ensureOrchestrationMeta('error-inst', invocationContext, 'PizzaOrderOrchestration')
+    assert.equal(
+      completeOrchestrationSpan(
+        '@azure/durable-functions',
+        'error-inst',
+        invocationContext,
+        'PizzaOrderOrchestration',
+        new Error('failed'),
+      ),
+      true,
+    )
+  })
+})
+
+describe('otel-orchestration-export', () => {
+  it('ignores invalid traceparent headers', () => {
+    assert.equal(getParentFromTraceContext({ traceParent: 'invalid' }), undefined)
+  })
+
+  it('ignores HTTP parent metadata without span ids', () => {
+    assert.equal(createOrchestrationMetaFromHttpParent('inst', {}, 'Orch'), undefined)
+  })
+
+  it('exports orchestration spans directly from metadata', () => {
+    process.env.DD_TRACE_OTEL_ENABLED = 'true'
+    process.env.DD_TRACE_AZURE_DURABLE_FUNCTIONS_ENABLED = 'false'
+
+    const ddtrace = require('../../../dd-trace')
+    ddtrace.init({ plugins: false, sampleRate: 1 })
+    new ddtrace.TracerProvider().register()
+
+    assert.equal(exportOrchestrationSpanFromMeta('@azure/durable-functions', {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000002',
+      parentId: '0000000000000004',
+      functionName: 'DirectExport',
+      startTime: Date.now(),
+    }), true)
+  })
+})

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -70,6 +70,9 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'LAMBDA_TASK_ROOT',
   // serverless service-name fallbacks (Config singleton)
   'WEBSITE_SITE_NAME',
+  // azure durable orchestration shared store
+  'AzureWebJobsStorage',
+  'TASKHUB_NAME',
   // azure metadata payload (cached at first build)
   'COMPUTERNAME',
   'FUNCTIONS_WORKER_RUNTIME_VERSION',


### PR DESCRIPTION
## Summary

Stacked on #9683. Fixes **cross-worker trace parenting** for Durable Functions on Azure.

**Problem this solves:** Azure DTF distributed tracing parents each invocation to **extension-internal spans**. Orchestrations also **run later and on different workers** than the HTTP trigger that called `startNew`. Without shared state:

- HTTP → orchestration link is lost when the orchestrator runs on another worker
- Activities parent to Azure's W3C parent (phantom span) instead of the orchestration span
- Orchestration would emit **one span per replay turn** instead of one span per instance

**What this PR does:**

1. **Records one orchestration span identity per `instanceId`** in a shared store (in-process cache → local JSON → Azure Table `DDAzureOrchestrationSpans`)
2. **Seeds orchestration metadata from the active HTTP span at `DurableClient.startNew`** so the orchestration span can parent under HTTP even when the orchestrator runs elsewhere
3. **Exports a single orchestration span at instance completion** with a **full-instance time window** (`startTime` anchored at HTTP `startNew`, `endTime` at completion, clamped to earliest activity start)
4. **Resolves activity parent context from the shared store** so activities on any worker parent under the orchestration span

All activity handlers use **async parent resolution** so sync activities on a different worker than the HTTP trigger can read the Azure Table store (not just local JSON).

### Orchestration span timing (approach 1: backfill at completion)

We intentionally **do not emit a live orchestration span on every replay turn**. Instead, one span is **backfilled when the instance completes**, using metadata timestamps:

- `startTime` — anchored at **`DurableClient.startNew`** (HTTP span start time when available), merged with **`recordEarliestChildStartTime`** at export via `resolveExportStartTime`
- `endTime` — instance completion time

This fixes waterfall ordering where activity spans (live) appeared to start before their orchestration parent. The prior “first non-replay orchestrator turn” stamp was too late because replay turns skipped metadata updates until after the first activity had already exported.

**Drawbacks of this approach (explicit trade-offs):**

- **Not live during execution** — the orchestration span only appears in Datadog after the instance completes; you cannot watch an in-flight orchestration span in Trace Explorer mid-run.
- **Backfilled, not measured per replay turn** — duration covers the whole instance (first turn → completion), not individual orchestrator replays; sub-yield orchestrator work is not separately timed.
- **Activity spans export before the orchestration span** — activities emit live timestamps immediately; the orchestration span is inserted at completion. Parent links are correct, but the orchestration bar is synthesized retroactively (minor waterfall lag vs a live parent span).
- **Clock source mixing** — activities use live OTel timing while the orchestration span uses stored `Date.now()` bounds; extreme clock skew across workers could still produce small visual gaps (clamped on export).
- **Incomplete instances** — if an orchestration fails or is abandoned before completion, no orchestration span is exported (same as before); only activities/orchestrator turns that ran will appear.

A future **live orchestration span** mode (approach 2) could address in-flight visibility but adds complexity across replay, worker scale-out, and agentless flush — out of scope here.

## Required configuration (Function app)

### Everything from #9683, plus:

#### Must be enabled

| Setting | Value | Why |
|--------|-------|-----|
| `AzureWebJobsStorage` | valid connection string (Azurite locally, real storage on Azure) | Backing store for `DDAzureOrchestrationSpans` table used cross-worker |
| `@azure/data-tables` | available at runtime (provided by Functions host / app deps) | Table client for shared orchestration meta |
| HTTP trigger that calls `client.startNew()` | e.g. `PizzaParty` → `startNew('PizzaOrderOrchestration', …)` | `startNew` hook seeds orchestration span identity from the active HTTP span |

#### Optional

| Setting | Value | Why |
|--------|-------|-----|
| `DD_TRACE_AZURE_ORCHESTRATION_STORE_DIR` | custom path | Override local JSON cache dir (tests/dev only; default is `$TMPDIR/dd-orchestration-spans`) |

#### Still must be disabled (same as #9683)

| Setting | Value |
|--------|-------|
| `DD_TRACE_AZURE_DURABLE_FUNCTIONS_ENABLED` | `false` |
| Native dd-trace plugins | `plugins: false` |
| .NET tracer loader | removed |

#### host.json (unchanged from #9683)

```json
"tracing": {
  "distributedTracingEnabled": true,
  "version": "V2"
}
```

### Architecture (brief)

```
HTTP span (worker A)
  └─ startNew → seed orchestration meta → Azure Table + local JSON
       └─ orchestration span (exported once at completion; start=turn 1, end=complete)
            ├─ PreparePizzaActivity (worker A: local file hit)
            └─ BakePizzaActivity (worker B: Azure Table async read)
```

## Changes

- `otel-orchestration-store.js`, `otel-orchestration-meta.js`, `otel-orchestration-export.js`, `otel-orchestration-http-link.js`, `otel-orchestration-registry.js`
- `azure-trace-context.js` — activity parent resolution from store
- `otel-azure-durable-functions.js` / `otel-azure-functions.js` — one span per instance; async activity parent resolution
- `azure-durable-functions.js` — `DurableClient.startNew` hook
- `recordHttpInstanceStartTime` / `recordEarliestChildStartTime` / `resolveExportStartTime` — full-instance orchestration span window

## Test plan

### Verified — local Azurite storage (`durable-node`, not DTS)

Storage: **`AzureWebJobsStorage=UseDevelopmentStorage=true`** (Azurite). Service **`durable-node-azurite-local`**, env **`local`**.

- [x] Unit tests for orchestration span timing bounds (#9793)
- [x] E2E pizza party: `POST http://localhost:7071/api/pizzaparty` (`PizzaOrderOrchestration`: Prepare → Bake)
- [x] Both `PreparePizzaActivity` and `BakePizzaActivity` parent under `orchestration PizzaOrderOrchestration`
- [x] Orchestration span parents under `http PizzaParty`, not phantom root
- [x] Orchestration waterfall bar starts at **HTTP `startNew` time** and covers activity children

**Example trace (2026-08-13):** instance `22d765967b474e87a1c4f54e50020e7d` — https://ddserverless.datadoghq.com/apm/trace/b888f30374a9d9ce987b9b921f204eb4

### Pending — Azure Durable Task Scheduler (`durable-node-fx`)

Storage: **DTS** (`test-scheduler` / `ishara-node-hub`), service **`durable-function-poc-node`**, env **`dev`**.

- [x] E2E pizza party: `POST https://durable-node-fx.azurewebsites.net/api/pizzaparty` — orchestrations complete
- [x] Orchestration timing waterfall on DTS when all spans run on one worker — trace [`17862494001755642471`](https://ddserverless.datadoghq.com/apm/trace/17862494001755642471)
- [ ] **Reliable cross-worker activity parenting on DTS** — see [Known limitation](#known-limitation-multi-worker-activity-parenting) below
- [ ] Multi language-worker regression (`FUNCTIONS_WORKER_PROCESS_COUNT=4` locally or Azure scale-out)

## Known limitation: multi-worker activity parenting

This is **not** an Azurite vs DTS storage issue. The shared store path (local JSON → Azure Table via `AzureWebJobsStorage`) is the same on local Azurite and Azure. What matters is **worker topology**:

| Topology | Parenting | Example |
|----------|-----------|---------|
| **Single worker** (typical local `func start`) | Works — HTTP, orchestration, and activities read the same in-process / local-file meta | Local trace [`b888f303…`](https://ddserverless.datadoghq.com/apm/trace/b888f30374a9d9ce987b9b921f204eb4); DTS trace [`17862494001755642471`](https://ddserverless.datadoghq.com/apm/trace/17862494001755642471) |
| **Multi-worker / scale-out** | **Intermittent** — an activity dispatched to a cold worker can miss orchestration meta in the Azure Table store before the async read window expires and fall back to Azure's internal W3C parent (phantom span) | DTS trace [`5825695498924434065`](https://ddserverless.datadoghq.com/apm/trace/5825695498924434065): `PreparePizzaActivity` parented correctly (same worker as orchestrator); `BakePizzaActivity` orphaned (different worker) |

Locally, `FUNCTIONS_WORKER_PROCESS_COUNT>1` can reproduce the same race; default single-worker dev runs do not exercise it.

**Root cause:** orchestration meta is published to Azure Table asynchronously (errors swallowed); activity handlers async-read with a short retry budget (~300 ms). A second worker that starts before the row is visible gets no meta and parents to the Azure extension span instead.

### Possible follow-ups (not in this PR)

| Approach | Pros | Drawbacks |
|----------|------|-----------|
| **Wire tracestate injection** (`dd=o:{orchestrationSpanId}` at dispatch; helper exists) | No orchestrator stall; propagates with W3C tracecontext | Depends on Azure host preserving custom tracestate keys end-to-end |
| **Await first table publish before orchestrator yield** | Deterministic cross-worker reads | Adds table latency on first turn; must guard replay turns |
| **Extend async retry window** | Smallest change | Still probabilistic; increases activity cold-start delay |
| **Hybrid (recommended)** | Tracestate fast path + first-yield table await + modest retry safety net | Most implementation and test surface |

**Recommended next step:** hybrid — tracestate injection first, then await only the **first** table publish before the orchestrator's first yield.

## Quick reference — full OTel-only stack (#9683 + #9794)

```json
// local.settings.json / Azure app settings
{
  "DD_TRACE_OTEL_ENABLED": "true",
  "DD_TRACE_AZURE_DURABLE_FUNCTIONS_ENABLED": "false",
  "DD_API_KEY": "<key>",
  "DD_TRACE_SAMPLE_RATE": "1",
  "DD_TRACE_FLUSH_INTERVAL": "0",
  "_DD_APM_TRACING_AGENTLESS_ENABLED": "true",
  "languageWorkers__node__arguments": "--require ./src/instrumentation.js",
  "NODE_OPTIONS": "",
  "AzureWebJobsStorage": "<connection-string>"
}
```

```json
// host.json
"extensions": {
  "durableTask": {
    "tracing": {
      "distributedTracingEnabled": true,
      "version": "V2"
    }
  }
}
```

