### PR TITLE
fix(http): preserve CORS tracing allow headers

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -334,10 +334,15 @@ const web = {
         headers = typeof statusMessage === 'string' ? headers : statusMessage
         const headersObj = Array.isArray(headers) ? flatHeadersToObject(headers) : headers
         const mergedHeaders = { ...res.getHeaders(), ...headersObj }
+
         if (isOriginAllowed(req, mergedHeaders)) {
           const allowedHeaders = computeAllowedHeaders(req, mergedHeaders)
           if (allowedHeaders) {
-            headers = { ...headersObj, 'access-control-allow-headers': allowedHeaders }
+            // if the original headers is an array preserve it as an array to prevent
+            // overwriting duplicated key.
+            headers = Array.isArray(headers)
+              ? setFlatHeader(headers, 'access-control-allow-headers', allowedHeaders)
+              : { ...headersObj, 'access-control-allow-headers': allowedHeaders }
             headersModified = true
           }
         }
@@ -417,8 +422,26 @@ function splitHeader (str) {
 function flatHeadersToObject (headers) {
   const result = {}
   for (let i = 0; i < headers.length; i += 2) {
-    result[headers[i]] = headers[i + 1]
+    result[headers[i].toLowerCase()] = headers[i + 1]
   }
+  return result
+}
+
+function setFlatHeader (headers, name, value) {
+  const result = headers.slice()
+  let headerFound = false
+
+  for (let i = 0; i < result.length; i += 2) {
+    if (result[i].toLowerCase() === name) {
+      result[i + 1] = value
+      headerFound = true
+    }
+  }
+
+  if (!headerFound) {
+    result.push(name, value)
+  }
+
   return result
 }
 

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -436,7 +436,7 @@ function normalizeHeaderLookup (headers) {
 }
 
 function setFlatHeader (headers, name, value) {
-  const result = headers.slice()
+  const result = [...headers]
   let headerFound = false
 
   for (let i = 0; i < result.length; i += 2) {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -439,7 +439,7 @@ function splitHeader (value) {
 }
 
 function normalizeHeaderLookup (headers) {
-  const result = {}
+  const result = Object.create(null)
 
   if (Array.isArray(headers)) {
     if (Array.isArray(headers[0])) {
@@ -498,7 +498,7 @@ function setTupleHeader (headers, name, value) {
 }
 
 function setObjectHeader (headers, name, value) {
-  const result = {}
+  const result = Object.create(null)
   let headerFound = false
 
   if (headers) {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -329,15 +329,26 @@ const web = {
       // GET / POST / etc. case. Node's http module passes `req.method`
       // through unchanged, so all standard methods are uppercase; the
       // `toLowerCase` fallback covers any non-standard caller.
+      let headersModified = false
       if (req.method === 'OPTIONS' || req.method.toLowerCase() === 'options') {
         headers = typeof statusMessage === 'string' ? headers : statusMessage
-        headers = { ...res.getHeaders(), ...headers }
-
-        if (isOriginAllowed(req, headers)) {
-          addAllowHeaders(req, res, headers)
+        const headersObj = Array.isArray(headers) ? flatHeadersToObject(headers) : headers
+        const mergedHeaders = { ...res.getHeaders(), ...headersObj }
+        if (isOriginAllowed(req, mergedHeaders)) {
+          const allowedHeaders = computeAllowedHeaders(req, mergedHeaders)
+          if (allowedHeaders) {
+            headers = { ...headersObj, 'access-control-allow-headers': allowedHeaders }
+            headersModified = true
+          }
         }
       }
 
+      if (headersModified) {
+        if (typeof statusMessage === 'string') {
+          return writeHead.call(this, statusCode, statusMessage, headers)
+        }
+        return writeHead.call(this, statusCode, headers)
+      }
       return writeHead.apply(this, arguments)
     }
   },
@@ -368,7 +379,7 @@ function normalizeHeadersCarrier (headers) {
   return carrier
 }
 
-function addAllowHeaders (req, res, headers) {
+function computeAllowedHeaders (req, headers) {
   const allowHeaders = splitHeader(headers['access-control-allow-headers'])
   const requestHeaders = splitHeader(req.headers['access-control-request-headers'])
   const contextHeaders = [
@@ -389,9 +400,7 @@ function addAllowHeaders (req, res, headers) {
     }
   }
 
-  if (allowHeaders.length > 0) {
-    res.setHeader('access-control-allow-headers', uniq(allowHeaders).join(','))
-  }
+  return uniq(allowHeaders).join(',')
 }
 
 function isOriginAllowed (req, headers) {
@@ -403,6 +412,14 @@ function isOriginAllowed (req, headers) {
 
 function splitHeader (str) {
   return typeof str === 'string' ? str.split(',').map((header) => header.trim()) : []
+}
+
+function flatHeadersToObject (headers) {
+  const result = {}
+  for (let i = 0; i < headers.length; i += 2) {
+    result[headers[i]] = headers[i + 1]
+  }
+  return result
 }
 
 function addRequestTags (context, spanType) {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -330,19 +330,22 @@ const web = {
       // through unchanged, so all standard methods are uppercase; the
       // `toLowerCase` fallback covers any non-standard caller.
       let headersModified = false
-      const hasStatusMessage = (statusMessage && typeof statusMessage === 'string')
+      const hasStatusMessage = typeof statusMessage === 'string'
       if (req.method === 'OPTIONS' || req.method.toLowerCase() === 'options') {
         headers = hasStatusMessage ? headers : statusMessage
         const headersAreArray = Array.isArray(headers)
+        const headersAreTuples = headersAreArray && Array.isArray(headers[0])
         const headersLookup = normalizeHeaderLookup(headers)
         const mergedHeaders = { ...res.getHeaders(), ...headersLookup }
 
         if (isOriginAllowed(req, mergedHeaders)) {
           const allowedHeaders = computeAllowedHeaders(req, mergedHeaders)
           if (allowedHeaders) {
-            headers = headersAreArray
-              ? setFlatHeader(headers, 'access-control-allow-headers', allowedHeaders)
-              : setObjectHeader(headers, 'access-control-allow-headers', allowedHeaders)
+            headers = headersAreTuples
+              ? setTupleHeader(headers, 'access-control-allow-headers', allowedHeaders)
+              : headersAreArray
+                ? setFlatHeader(headers, 'access-control-allow-headers', allowedHeaders)
+                : setObjectHeader(headers, 'access-control-allow-headers', allowedHeaders)
             headersModified = true
           }
         }
@@ -415,16 +418,38 @@ function isOriginAllowed (req, headers) {
   return origin && (allowOrigin === '*' || allowOrigin === origin)
 }
 
-function splitHeader (str) {
-  return typeof str === 'string' ? str.split(',').map((header) => header.trim()) : []
+function splitHeader (value) {
+  if (typeof value === 'string') {
+    return value.split(',').map((header) => header.trim())
+  }
+
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const result = []
+  for (const item of value) {
+    if (typeof item !== 'string') continue
+
+    for (const header of item.split(',')) {
+      result.push(header.trim())
+    }
+  }
+  return result
 }
 
 function normalizeHeaderLookup (headers) {
   const result = {}
 
   if (Array.isArray(headers)) {
-    for (let i = 0; i < headers.length; i += 2) {
-      result[headers[i].toLowerCase()] = headers[i + 1]
+    if (Array.isArray(headers[0])) {
+      for (const [key, value] of headers) {
+        result[key.toLowerCase()] = value
+      }
+    } else {
+      for (let i = 0; i < headers.length; i += 2) {
+        result[headers[i].toLowerCase()] = headers[i + 1]
+      }
     }
   } else if (headers) {
     for (const key of Object.keys(headers)) {
@@ -448,6 +473,25 @@ function setFlatHeader (headers, name, value) {
 
   if (!headerFound) {
     result.push(name, value)
+  }
+
+  return result
+}
+
+function setTupleHeader (headers, name, value) {
+  const result = [...headers]
+  let headerFound = false
+
+  for (let i = 0; i < result.length; i++) {
+    const [key] = result[i]
+    if (key.toLowerCase() === name) {
+      result[i] = [key, value]
+      headerFound = true
+    }
+  }
+
+  if (!headerFound) {
+    result.push([name, value])
   }
 
   return result

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -330,26 +330,26 @@ const web = {
       // through unchanged, so all standard methods are uppercase; the
       // `toLowerCase` fallback covers any non-standard caller.
       let headersModified = false
+      const hasStatusMessage = (statusMessage && typeof statusMessage === 'string')
       if (req.method === 'OPTIONS' || req.method.toLowerCase() === 'options') {
-        headers = typeof statusMessage === 'string' ? headers : statusMessage
-        const headersObj = Array.isArray(headers) ? flatHeadersToObject(headers) : headers
-        const mergedHeaders = { ...res.getHeaders(), ...headersObj }
+        headers = hasStatusMessage ? headers : statusMessage
+        const headersAreArray = Array.isArray(headers)
+        const headersLookup = normalizeHeaderLookup(headers)
+        const mergedHeaders = { ...res.getHeaders(), ...headersLookup }
 
         if (isOriginAllowed(req, mergedHeaders)) {
           const allowedHeaders = computeAllowedHeaders(req, mergedHeaders)
           if (allowedHeaders) {
-            // if the original headers is an array preserve it as an array to prevent
-            // overwriting duplicated key.
-            headers = Array.isArray(headers)
+            headers = headersAreArray
               ? setFlatHeader(headers, 'access-control-allow-headers', allowedHeaders)
-              : { ...headersObj, 'access-control-allow-headers': allowedHeaders }
+              : setObjectHeader(headers, 'access-control-allow-headers', allowedHeaders)
             headersModified = true
           }
         }
       }
 
       if (headersModified) {
-        if (typeof statusMessage === 'string') {
+        if (hasStatusMessage) {
           return writeHead.call(this, statusCode, statusMessage, headers)
         }
         return writeHead.call(this, statusCode, headers)
@@ -419,11 +419,19 @@ function splitHeader (str) {
   return typeof str === 'string' ? str.split(',').map((header) => header.trim()) : []
 }
 
-function flatHeadersToObject (headers) {
+function normalizeHeaderLookup (headers) {
   const result = {}
-  for (let i = 0; i < headers.length; i += 2) {
-    result[headers[i].toLowerCase()] = headers[i + 1]
+
+  if (Array.isArray(headers)) {
+    for (let i = 0; i < headers.length; i += 2) {
+      result[headers[i].toLowerCase()] = headers[i + 1]
+    }
+  } else if (headers) {
+    for (const key of Object.keys(headers)) {
+      result[key.toLowerCase()] = headers[key]
+    }
   }
+
   return result
 }
 
@@ -440,6 +448,28 @@ function setFlatHeader (headers, name, value) {
 
   if (!headerFound) {
     result.push(name, value)
+  }
+
+  return result
+}
+
+function setObjectHeader (headers, name, value) {
+  const result = {}
+  let headerFound = false
+
+  if (headers) {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === name) {
+        result[key] = value
+        headerFound = true
+      } else {
+        result[key] = headers[key]
+      }
+    }
+  }
+
+  if (!headerFound) {
+    result[name] = value
   }
 
   return result

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -931,7 +931,7 @@ describe('plugins/util/web', () => {
       const forwardedHeaders = res.writeHead.firstCall.args[1]
       assert.strictEqual(Object.getPrototypeOf(forwardedHeaders), null)
       assert.ok(Object.hasOwn(forwardedHeaders, '__proto__'))
-      assert.strictEqual(forwardedHeaders.__proto__, 'preserved')
+      assert.strictEqual(Object.getOwnPropertyDescriptor(forwardedHeaders, '__proto__').value, 'preserved')
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
         [200, nullPrototypeHeaders({

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -901,6 +901,29 @@ describe('plugins/util/web', () => {
       )
     })
 
+    it('merges tracing headers into mixed-case explicit headers', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'baggage'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, {
+        [ALLOW_ORIGIN]: '*',
+        'Access-Control-Allow-Headers': 'content-type',
+      })
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, {
+          [ALLOW_ORIGIN]: '*',
+          'Access-Control-Allow-Headers': 'content-type,baggage',
+        }]
+      )
+    })
+
     it('honours headers passed as the third writeHead argument with a status message', () => {
       req.method = 'OPTIONS'
       req.headers.origin = 'https://example.com'

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -931,7 +931,50 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+        [200, [ALLOW_ORIGIN, '*', ALLOW_HEADERS, 'x-datadog-trace-id']]
+      )
+    })
+
+    it('honours mixed-case headers passed as a flat array in rawHeaders format', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, ['Access-Control-Allow-Origin', '*'])
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, ['Access-Control-Allow-Origin', '*', ALLOW_HEADERS, 'x-datadog-trace-id']]
+      )
+    })
+
+    it('preserves unrelated duplicate headers passed as a flat array', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, [
+        'Set-Cookie', 'first=1',
+        'Access-Control-Allow-Origin', '*',
+        'Set-Cookie', 'second=2',
+      ])
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, [
+          'Set-Cookie', 'first=1',
+          'Access-Control-Allow-Origin', '*',
+          'Set-Cookie', 'second=2',
+          ALLOW_HEADERS, 'x-datadog-trace-id',
+        ]]
       )
     })
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -826,11 +826,13 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
       res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.notCalled)
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(res.writeHead.firstCall.args, [200])
     })
 
     it('skips allow-header tagging on OPTIONS when the origin is not allowed', () => {
@@ -838,11 +840,13 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://evil.example.com'
       req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
       res.getHeaders.returns({ [ALLOW_ORIGIN]: 'https://good.example.com' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.notCalled)
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(res.writeHead.firstCall.args, [200])
     })
 
     it('merges datadog allow-headers on OPTIONS when allow-origin is *', () => {
@@ -851,14 +855,15 @@ describe('plugins/util/web', () => {
       req.headers['access-control-request-headers'] =
         'x-datadog-trace-id, x-datadog-parent-id, x-other'
       res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'x-datadog-parent-id,x-datadog-trace-id']
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_HEADERS]: 'x-datadog-parent-id,x-datadog-trace-id' }]
       )
     })
 
@@ -867,14 +872,15 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'baggage, traceparent, tracestate, x-other'
       res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'baggage,traceparent,tracestate']
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_HEADERS]: 'baggage,traceparent,tracestate' }]
       )
     })
 
@@ -883,14 +889,15 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
       res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200, { [ALLOW_ORIGIN]: 'https://example.com' })
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'x-datadog-trace-id']
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_ORIGIN]: 'https://example.com', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
       )
     })
 
@@ -899,14 +906,32 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
       res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200, 'OK', { [ALLOW_ORIGIN]: '*' })
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'x-datadog-trace-id']
+        res.writeHead.firstCall.args,
+        [200, 'OK', { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+      )
+    })
+
+    it('honours headers passed as a flat array in rawHeaders format', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, [ALLOW_ORIGIN, '*'])
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
       )
     })
 
@@ -915,14 +940,15 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
       res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'x-datadog-trace-id']
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
       )
     })
 
@@ -934,14 +960,15 @@ describe('plugins/util/web', () => {
         [ALLOW_ORIGIN]: '*',
         [ALLOW_HEADERS]: 'content-type, x-datadog-trace-id',
       })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'content-type,x-datadog-trace-id']
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_HEADERS]: 'content-type,x-datadog-trace-id' }]
       )
     })
 
@@ -950,11 +977,13 @@ describe('plugins/util/web', () => {
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = 'content-type, x-other'
       res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.notCalled)
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(res.writeHead.firstCall.args, [200])
     })
 
     it('delegates to the original writeHead with the same arguments', () => {
@@ -973,19 +1002,37 @@ describe('plugins/util/web', () => {
       )
     })
 
+    it('passes merged allow-headers to writeHead so it survives writeHead precedence', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'content-type' })
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'content-type,x-datadog-trace-id' }]
+      )
+    })
+
     it('trims whitespace surrounding each requested header entry', () => {
       req.method = 'OPTIONS'
       req.headers.origin = 'https://example.com'
       req.headers['access-control-request-headers'] = '  x-datadog-parent-id  ,x-datadog-trace-id  '
       res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
 
       const wrapped = web.wrapWriteHead(context)
       wrapped.call(res, 200)
 
-      assert.ok(res.setHeader.calledOnce)
+      assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
-        res.setHeader.firstCall.args,
-        [ALLOW_HEADERS, 'x-datadog-parent-id,x-datadog-trace-id']
+        res.writeHead.firstCall.args,
+        [200, { [ALLOW_HEADERS]: 'x-datadog-parent-id,x-datadog-trace-id' }]
       )
     })
   })

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -924,6 +924,29 @@ describe('plugins/util/web', () => {
       )
     })
 
+    it('preserves array values in explicit access-control-allow-headers', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, {
+        [ALLOW_ORIGIN]: '*',
+        [ALLOW_HEADERS]: ['content-type', 'x-custom'],
+      })
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, {
+          [ALLOW_ORIGIN]: '*',
+          [ALLOW_HEADERS]: 'content-type,x-custom,x-datadog-trace-id',
+        }]
+      )
+    })
+
     it('honours headers passed as the third writeHead argument with a status message', () => {
       req.method = 'OPTIONS'
       req.headers.origin = 'https://example.com'
@@ -938,6 +961,23 @@ describe('plugins/util/web', () => {
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
         [200, 'OK', { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+      )
+    })
+
+    it('honours an empty status message and headers passed as the third argument', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, '', { [ALLOW_ORIGIN]: '*', 'x-test': '1' })
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, '', { [ALLOW_ORIGIN]: '*', 'x-test': '1', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
       )
     })
 
@@ -997,6 +1037,55 @@ describe('plugins/util/web', () => {
           'Access-Control-Allow-Origin', '*',
           'Set-Cookie', 'second=2',
           ALLOW_HEADERS, 'x-datadog-trace-id',
+        ]]
+      )
+    })
+
+    it('honours headers passed as an array of tuples', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, [
+        [ALLOW_ORIGIN, '*'],
+        ['Set-Cookie', 'first=1'],
+        ['Set-Cookie', 'second=2'],
+      ])
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, [
+          [ALLOW_ORIGIN, '*'],
+          ['Set-Cookie', 'first=1'],
+          ['Set-Cookie', 'second=2'],
+          [ALLOW_HEADERS, 'x-datadog-trace-id'],
+        ]]
+      )
+    })
+
+    it('replaces mixed-case allow-headers passed as a tuple', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'baggage'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, [
+        [ALLOW_ORIGIN, '*'],
+        ['Access-Control-Allow-Headers', 'content-type'],
+      ])
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, [
+          [ALLOW_ORIGIN, '*'],
+          ['Access-Control-Allow-Headers', 'content-type,baggage'],
         ]]
       )
     })

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -16,6 +16,16 @@ const HTTP_RESPONSE_HEADERS = tagsExt.HTTP_RESPONSE_HEADERS
 const HTTP_ROUTE = tagsExt.HTTP_ROUTE
 const RESOURCE_NAME = tagsExt.RESOURCE_NAME
 
+/**
+ * Creates the header dictionary expected from object-form OPTIONS responses.
+ *
+ * @param {Record<string, string>} headers
+ * @returns {Record<string, string>}
+ */
+function nullPrototypeHeaders (headers) {
+  return Object.assign(Object.create(null), headers)
+}
+
 describe('plugins/util/web', () => {
   let web
   let tracer
@@ -863,7 +873,7 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_HEADERS]: 'x-datadog-parent-id,x-datadog-trace-id' }]
+        [200, nullPrototypeHeaders({ [ALLOW_HEADERS]: 'x-datadog-parent-id,x-datadog-trace-id' })]
       )
     })
 
@@ -880,7 +890,7 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_HEADERS]: 'baggage,traceparent,tracestate' }]
+        [200, nullPrototypeHeaders({ [ALLOW_HEADERS]: 'baggage,traceparent,tracestate' })]
       )
     })
 
@@ -897,7 +907,38 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_ORIGIN]: 'https://example.com', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+        [200, nullPrototypeHeaders({
+          [ALLOW_ORIGIN]: 'https://example.com',
+          [ALLOW_HEADERS]: 'x-datadog-trace-id',
+        })]
+      )
+    })
+
+    it('preserves explicit headers named __proto__ when adding tracing headers', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, {
+        [ALLOW_ORIGIN]: '*',
+        ['__proto__']: 'preserved',
+      })
+
+      assert.ok(res.writeHead.calledOnce)
+      const forwardedHeaders = res.writeHead.firstCall.args[1]
+      assert.strictEqual(Object.getPrototypeOf(forwardedHeaders), null)
+      assert.ok(Object.hasOwn(forwardedHeaders, '__proto__'))
+      assert.strictEqual(forwardedHeaders.__proto__, 'preserved')
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [200, nullPrototypeHeaders({
+          [ALLOW_ORIGIN]: '*',
+          ['__proto__']: 'preserved',
+          [ALLOW_HEADERS]: 'x-datadog-trace-id',
+        })]
       )
     })
 
@@ -917,10 +958,10 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, {
+        [200, nullPrototypeHeaders({
           [ALLOW_ORIGIN]: '*',
           'Access-Control-Allow-Headers': 'content-type,baggage',
-        }]
+        })]
       )
     })
 
@@ -940,10 +981,10 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, {
+        [200, nullPrototypeHeaders({
           [ALLOW_ORIGIN]: '*',
           [ALLOW_HEADERS]: 'content-type,x-custom,x-datadog-trace-id',
-        }]
+        })]
       )
     })
 
@@ -960,7 +1001,10 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, 'OK', { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+        [200, 'OK', nullPrototypeHeaders({
+          [ALLOW_ORIGIN]: '*',
+          [ALLOW_HEADERS]: 'x-datadog-trace-id',
+        })]
       )
     })
 
@@ -977,7 +1021,11 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, '', { [ALLOW_ORIGIN]: '*', 'x-test': '1', [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+        [200, '', nullPrototypeHeaders({
+          [ALLOW_ORIGIN]: '*',
+          'x-test': '1',
+          [ALLOW_HEADERS]: 'x-datadog-trace-id',
+        })]
       )
     })
 
@@ -1103,7 +1151,7 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_HEADERS]: 'x-datadog-trace-id' }]
+        [200, nullPrototypeHeaders({ [ALLOW_HEADERS]: 'x-datadog-trace-id' })]
       )
     })
 
@@ -1123,7 +1171,7 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_HEADERS]: 'content-type,x-datadog-trace-id' }]
+        [200, nullPrototypeHeaders({ [ALLOW_HEADERS]: 'content-type,x-datadog-trace-id' })]
       )
     })
 
@@ -1170,7 +1218,10 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_ORIGIN]: '*', [ALLOW_HEADERS]: 'content-type,x-datadog-trace-id' }]
+        [200, nullPrototypeHeaders({
+          [ALLOW_ORIGIN]: '*',
+          [ALLOW_HEADERS]: 'content-type,x-datadog-trace-id',
+        })]
       )
     })
 
@@ -1187,7 +1238,7 @@ describe('plugins/util/web', () => {
       assert.ok(res.writeHead.calledOnce)
       assert.deepStrictEqual(
         res.writeHead.firstCall.args,
-        [200, { [ALLOW_HEADERS]: 'x-datadog-parent-id,x-datadog-trace-id' }]
+        [200, nullPrototypeHeaders({ [ALLOW_HEADERS]: 'x-datadog-parent-id,x-datadog-trace-id' })]
       )
     })
   })


### PR DESCRIPTION
### What does this PR do?

Updates CORS preflight handling so tracing headers merged into `access-control-allow-headers` are also written back to explicit headers passed through the second or third `ServerResponse.writeHead()` argument.

The explicit header collection is handled case-insensitively and retains Node.js object or flat-array form. Calls that do not need an allow-list update continue to receive their original arguments unchanged.

### Motivation

Node.js gives headers passed directly to `writeHead()` precedence over values previously set with `res.setHeader()`. As a result, an application-provided value such as `content-type` could overwrite the computed `content-type,baggage` allow-list and cause the browser preflight to fail.

### Additional Notes

Validation:

- `./node_modules/.bin/mocha packages/dd-trace/test/plugins/util/web.spec.js` — 81 passing
- `./node_modules/.bin/mocha packages/datadog-plugin-http/test/server.spec.js` — 56 passing
- Focused NYC coverage for `web.js` — 91.86% lines
- `git diff --check` and syntax checks pass