### PR TITLE
fix(playwright): preserve reporter finalization errors

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -50,6 +50,7 @@ class FakeCiVisIntake extends FakeAgent {
   #settingsResponseStatusCode = 200
   #settingsResponseStatusCodes = []
   #mediaResponseDelayMs = 0
+  #mediaResponsesPending = false
   #mediaResponseStatusCode = 201
   #suitesToSkip = DEFAULT_SUITES_TO_SKIP
   #skippableCoverage = DEFAULT_SKIPPABLE_COVERAGE
@@ -137,6 +138,15 @@ class FakeCiVisIntake extends FakeAgent {
    */
   setMediaResponseDelay (delayMs) {
     this.#mediaResponseDelayMs = delayMs
+  }
+
+  /**
+   * Leaves media requests open until the client cancels them.
+   *
+   * @returns {void}
+   */
+  setMediaResponsesPending () {
+    this.#mediaResponsesPending = true
   }
 
   setWaitingTime (newWaitingTime) {
@@ -280,6 +290,9 @@ class FakeCiVisIntake extends FakeAgent {
         })
       }
 
+      if (this.#mediaResponsesPending) {
+        return
+      }
       if (this.#mediaResponseDelayMs > 0) {
         setTimeout(respond, this.#mediaResponseDelayMs)
       } else {
@@ -446,6 +459,7 @@ class FakeCiVisIntake extends FakeAgent {
     this.#knownTestsPageIndex = 0
     this.#infoResponse = DEFAULT_INFO_RESPONSE
     this.#mediaResponseDelayMs = 0
+    this.#mediaResponsesPending = false
     this.#testManagementResponseStatusCode = DEFAULT_TEST_MANAGEMENT_TESTS_RESPONSE_STATUS
     this.#testManagementResponse = DEFAULT_TEST_MANAGEMENT_TESTS
     this.#skippableSuitesResponseStatusCode = 200

--- a/integration-tests/ci-visibility/playwright-pending-upload-finalization.js
+++ b/integration-tests/ci-visibility/playwright-pending-upload-finalization.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { channel } = require('dc-polyfill')
+
+require('dd-trace/init')
+require('@playwright/test')
+
+channel('dd-trace:instrumentation:load').publish({ name: 'playwright' })
+
+const suitePath = path.join(process.cwd(), 'pending-upload-test.js')
+const screenshotPath = path.join(process.cwd(), 'test-failed-1.png')
+fs.copyFileSync(
+  path.join(process.cwd(), 'ci-visibility/test-early-flake-detection/__image_snapshots__',
+    'jest-image-snapshot-js-snapshot-can-match-1-snap.png'),
+  screenshotPath
+)
+
+channel('ci:playwright:session:start').publish({
+  command: 'playwright test',
+  frameworkVersion: require('@playwright/test/package.json').version,
+  rootDir: process.cwd(),
+  isFailureScreenshotEnabled: true,
+})
+
+const suiteContext = { testSuiteAbsolutePath: suitePath }
+channel('ci:playwright:test-suite:start').runStores(suiteContext, () => {})
+channel('ci:playwright:test-suite:finish').publish({
+  ...suiteContext.currentStore,
+  status: 'fail',
+})
+
+channel('ci:playwright:worker:report').publish({
+  serializedTraces: JSON.stringify([[
+    {
+      trace_id: '0000000000000001',
+      span_id: '0000000000000002',
+      parent_id: '0000000000000000',
+      name: 'playwright.test',
+      resource: 'pending-upload-test.js.pending upload',
+      service: 'node',
+      type: 'test',
+      error: 1,
+      meta: {
+        'test.name': 'pending upload',
+        'test.status': 'fail',
+        test_suite_absolute_path: suitePath,
+        test_source_absolute_path: suitePath,
+      },
+      metrics: {},
+      start: Date.now() * 1e6,
+      duration: 1e6,
+    },
+  ]]),
+  screenshots: [{
+    name: 'screenshot',
+    contentType: 'image/png',
+    path: screenshotPath,
+  }],
+})
+
+setImmediate(() => {
+  const error = new Error('custom Playwright reporter failed')
+  channel('ci:playwright:session:finish').publish({
+    status: 'fail',
+    error,
+    onDone () {
+      process.exitCode = 1
+      // Mirrors Playwright reporting the original reporter error before exiting.
+      // eslint-disable-next-line no-console
+      console.error(error)
+      throw error
+    },
+  })
+})

--- a/integration-tests/ci-visibility/playwright-reporter-frozen.js
+++ b/integration-tests/ci-visibility/playwright-reporter-frozen.js
@@ -1,0 +1,11 @@
+'use strict'
+
+class FrozenReporter {
+  constructor () {
+    Object.freeze(this)
+  }
+
+  onEnd () {}
+}
+
+module.exports = FrozenReporter

--- a/integration-tests/ci-visibility/playwright-reporter-logs-error.js
+++ b/integration-tests/ci-visibility/playwright-reporter-logs-error.js
@@ -1,0 +1,11 @@
+'use strict'
+
+class LoggingReporter {
+  onEnd () {
+    // This is user output, despite matching Playwright's private reporter-error message.
+    // eslint-disable-next-line no-console
+    console.error('Error in reporter', new Error('user reporter diagnostic'))
+  }
+}
+
+module.exports = LoggingReporter

--- a/integration-tests/ci-visibility/playwright-reporter-throws.js
+++ b/integration-tests/ci-visibility/playwright-reporter-throws.js
@@ -12,6 +12,13 @@ class ThrowingReporter {
       // eslint-disable-next-line no-throw-literal
       throw null
     }
+    if (process.env.PLAYWRIGHT_REPORTER_THROWS_HOSTILE_OBJECT) {
+      throw new Proxy({}, {
+        get () {
+          throw new Error('reporter property access failed')
+        },
+      })
+    }
     if (process.env.PLAYWRIGHT_REPORTER_THROWS_UNDEFINED) {
       // eslint-disable-next-line no-throw-literal
       throw undefined

--- a/integration-tests/ci-visibility/playwright-reporter-throws.js
+++ b/integration-tests/ci-visibility/playwright-reporter-throws.js
@@ -1,0 +1,9 @@
+'use strict'
+
+class ThrowingReporter {
+  onEnd () {
+    throw new Error('custom Playwright reporter failed')
+  }
+}
+
+module.exports = ThrowingReporter

--- a/integration-tests/ci-visibility/playwright-reporter-throws.js
+++ b/integration-tests/ci-visibility/playwright-reporter-throws.js
@@ -2,6 +2,10 @@
 
 class ThrowingReporter {
   onEnd () {
+    if (process.env.PLAYWRIGHT_REPORTER_THROWS_UNDEFINED) {
+      // eslint-disable-next-line no-throw-literal
+      throw undefined
+    }
     throw new Error('custom Playwright reporter failed')
   }
 }

--- a/integration-tests/ci-visibility/playwright-reporter-throws.js
+++ b/integration-tests/ci-visibility/playwright-reporter-throws.js
@@ -1,7 +1,21 @@
 'use strict'
 
 class ThrowingReporter {
+  onBegin () {
+    if (!process.env.PLAYWRIGHT_REPORTER_IMMUTABLE_CONSOLE_ERROR) return
+
+    this.consoleErrorDescriptor = Object.getOwnPropertyDescriptor(console, 'error')
+    Object.defineProperty(console, 'error', {
+      ...this.consoleErrorDescriptor,
+      writable: false,
+    })
+  }
+
   onEnd () {
+    if (process.env.PLAYWRIGHT_REPORTER_IMMUTABLE_CONSOLE_ERROR) {
+      Object.defineProperty(console, 'error', this.consoleErrorDescriptor)
+      return
+    }
     if (process.env.PLAYWRIGHT_REPORTER_THROWS_ON_EXIT) return
     if (process.env.PLAYWRIGHT_REPORTER_CUSTOM_STACK) {
       Error.prepareStackTrace = (error, callSites) => error.message === 'Playwright reporter error provenance'

--- a/integration-tests/ci-visibility/playwright-reporter-throws.js
+++ b/integration-tests/ci-visibility/playwright-reporter-throws.js
@@ -2,11 +2,27 @@
 
 class ThrowingReporter {
   onEnd () {
+    if (process.env.PLAYWRIGHT_REPORTER_THROWS_ON_EXIT) return
+    if (process.env.PLAYWRIGHT_REPORTER_CUSTOM_STACK) {
+      Error.prepareStackTrace = (error, callSites) => error.message === 'Playwright reporter error provenance'
+        ? ({ custom: 'stack' })
+        : `${error.name}: ${error.message}\n${callSites.join('\n')}`
+    }
+    if (process.env.PLAYWRIGHT_REPORTER_THROWS_NULL) {
+      // eslint-disable-next-line no-throw-literal
+      throw null
+    }
     if (process.env.PLAYWRIGHT_REPORTER_THROWS_UNDEFINED) {
       // eslint-disable-next-line no-throw-literal
       throw undefined
     }
     throw new Error('custom Playwright reporter failed')
+  }
+
+  onExit () {
+    if (process.env.PLAYWRIGHT_REPORTER_THROWS_ON_EXIT) {
+      throw new Error('custom Playwright reporter onExit failed')
+    }
   }
 }
 

--- a/integration-tests/ci-visibility/playwright-rerun-console.js
+++ b/integration-tests/ci-visibility/playwright-rerun-console.js
@@ -1,0 +1,33 @@
+'use strict'
+
+require('dd-trace/ci/init')
+
+const path = require('node:path')
+
+const playwrightDirectory = path.dirname(require.resolve('playwright/package.json'))
+const { configLoader } = require(path.join(playwrightDirectory, 'lib/common/index'))
+const { testRunner } = require(path.join(playwrightDirectory, 'lib/runner/index'))
+
+async function main () {
+  // eslint-disable-next-line no-console
+  const originalConsoleError = console.error
+  const config = await configLoader.loadConfig({
+    configDir: process.cwd(),
+    resolvedConfigFile: path.join(process.cwd(), 'playwright.config.js'),
+  })
+  const options = { passWithNoTests: true }
+
+  await testRunner.runAllTestsWithConfig(config, options)
+  // eslint-disable-next-line no-console
+  if (console.error !== originalConsoleError) throw new Error('console.error was not restored after the first run')
+
+  await testRunner.runAllTestsWithConfig(config, options)
+  // eslint-disable-next-line no-console
+  if (console.error !== originalConsoleError) throw new Error('console.error was not restored after the second run')
+}
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(error)
+  process.exitCode = 1
+})

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -40,7 +40,11 @@ const config = {
   timeout: Number(process.env.TEST_TIMEOUT) || 30000,
   fullyParallel: process.env.FULLY_PARALLEL === 'true',
   workers: process.env.PLAYWRIGHT_WORKERS ? Number(process.env.PLAYWRIGHT_WORKERS) : undefined,
-  reporter: 'line',
+  reporter: process.env.PLAYWRIGHT_THROWING_REPORTER
+    ? './ci-visibility/playwright-reporter-throws.js'
+    : process.env.PLAYWRIGHT_LOGGING_REPORTER
+      ? './ci-visibility/playwright-reporter-logs-error.js'
+      : 'line',
   /* Configure projects for major browsers */
   projects,
   testMatch: '**/*-test.js',

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -40,11 +40,13 @@ const config = {
   timeout: Number(process.env.TEST_TIMEOUT) || 30000,
   fullyParallel: process.env.FULLY_PARALLEL === 'true',
   workers: process.env.PLAYWRIGHT_WORKERS ? Number(process.env.PLAYWRIGHT_WORKERS) : undefined,
-  reporter: process.env.PLAYWRIGHT_THROWING_REPORTER
-    ? './ci-visibility/playwright-reporter-throws.js'
-    : process.env.PLAYWRIGHT_LOGGING_REPORTER
-      ? './ci-visibility/playwright-reporter-logs-error.js'
-      : 'line',
+  reporter: process.env.PLAYWRIGHT_FROZEN_REPORTER
+    ? './ci-visibility/playwright-reporter-frozen.js'
+    : process.env.PLAYWRIGHT_THROWING_REPORTER
+      ? './ci-visibility/playwright-reporter-throws.js'
+      : process.env.PLAYWRIGHT_LOGGING_REPORTER
+        ? './ci-visibility/playwright-reporter-logs-error.js'
+        : 'line',
   /* Configure projects for major browsers */
   projects,
   testMatch: '**/*-test.js',

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -198,6 +198,95 @@ versions.forEach((version) => {
       assert.notStrictEqual(exitCode, 0)
     })
 
+    it('reports the session when a custom reporter throws null', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_THROWING_REPORTER: '1',
+            PLAYWRIGHT_REPORTER_THROWS_NULL: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const session = events.find(event => event.type === 'test_session_end')
+          assert.ok(session, 'expected test_session_end event')
+          assert.strictEqual(session.content.meta[TEST_STATUS], 'fail')
+          assert.match(session.content.meta[ERROR_MESSAGE], /null/)
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.notStrictEqual(exitCode, 0)
+    })
+
+    it('reports the session when a custom reporter throws during onExit', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_THROWING_REPORTER: '1',
+            PLAYWRIGHT_REPORTER_THROWS_ON_EXIT: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+            const event = events.find(event => event.type === eventType)
+            assert.ok(event, `expected ${eventType} event`)
+            assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+            assert.match(event.content.meta[ERROR_MESSAGE], /custom Playwright reporter onExit failed/)
+          }
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.notStrictEqual(exitCode, 0)
+    })
+
+    it('does not replace reporter errors with a custom stack formatter', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_THROWING_REPORTER: '1',
+            PLAYWRIGHT_REPORTER_CUSTOM_STACK: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const session = events.find(event => event.type === 'test_session_end')
+          assert.ok(session, 'expected test_session_end event')
+          assert.strictEqual(session.content.meta[TEST_STATUS], 'fail')
+          assert.match(session.content.meta[ERROR_MESSAGE], /custom Playwright reporter failed/)
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.notStrictEqual(exitCode, 0)
+    })
+
     contextNewVersions('immutable reporters', () => {
       it('does not abort when a reporter instance is frozen', async (receiver, run) => {
         const proc = run(
@@ -289,6 +378,8 @@ versions.forEach((version) => {
               const event = events.find(event => event.type === eventType)
               assert.match(event.content.meta[ERROR_MESSAGE], /custom Playwright reporter failed/)
             }
+            const test = events.find(event => event.type === 'test')
+            assert.strictEqual(test.content.meta[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], 'true')
           },
           { hardTimeout: 15_000 }
         ).catch((error) => {

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -346,6 +346,35 @@ versions.forEach((version) => {
     })
 
     if (satisfies(version, '>=1.60.0') || version === 'latest') {
+      it('does not abort when console.error is immutable during reporter finalization', async (receiver, run) => {
+        const proc = run(
+          './node_modules/.bin/playwright test -c playwright.config.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              PW_BASE_URL: `http://localhost:${webAppPort}`,
+              PLAYWRIGHT_THROWING_REPORTER: '1',
+              PLAYWRIGHT_REPORTER_IMMUTABLE_CONSOLE_ERROR: '1',
+              TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+            },
+          }
+        )
+        const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+          proc,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            assert.ok(events.find(event => event.type === 'test'))
+            const testSession = events.find(event => event.type === 'test_session_end')
+            assert.ok(testSession, 'expected test_session_end event')
+            assert.strictEqual(testSession.content.meta[TEST_STATUS], 'pass')
+          }
+        )
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+        assert.strictEqual(exitCode, 0)
+      })
+
       context('programmatic reruns', () => {
         it('restores console.error after every run with the same config', async (receiver, run) => {
           let testOutput = ''

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -166,6 +166,67 @@ versions.forEach((version) => {
       assert.notStrictEqual(exitCode, 0)
     })
 
+    it('reports the session when a custom reporter throws undefined', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_THROWING_REPORTER: '1',
+            PLAYWRIGHT_REPORTER_THROWS_UNDEFINED: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+            const event = events.find(event => event.type === eventType)
+            assert.ok(event, `expected ${eventType} event`)
+            assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(event.content.error, 1)
+            assert.match(event.content.meta[ERROR_MESSAGE], /undefined/)
+          }
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.notStrictEqual(exitCode, 0)
+    })
+
+    contextNewVersions('immutable reporters', () => {
+      it('does not abort when a reporter instance is frozen', async (receiver, run) => {
+        const proc = run(
+          './node_modules/.bin/playwright test -c playwright.config.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              PW_BASE_URL: `http://localhost:${webAppPort}`,
+              PLAYWRIGHT_FROZEN_REPORTER: '1',
+              TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+            },
+          }
+        )
+        const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+          proc,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            assert.ok(events.find(event => event.type === 'test'))
+            const testSession = events.find(event => event.type === 'test_session_end')
+            assert.strictEqual(testSession.content.meta[TEST_STATUS], 'pass')
+          }
+        )
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+        assert.strictEqual(exitCode, 0)
+      })
+    })
+
     it('does not treat matching user console output as a reporter failure', async (receiver, run) => {
       const proc = run(
         './node_modules/.bin/playwright test -c playwright.config.js',

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -227,6 +227,35 @@ versions.forEach((version) => {
       assert.notStrictEqual(exitCode, 0)
     })
 
+    it('does not replace a hostile reporter error with a property access error', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_THROWING_REPORTER: '1',
+            PLAYWRIGHT_REPORTER_THROWS_HOSTILE_OBJECT: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const session = events.find(event => event.type === 'test_session_end')
+          assert.ok(session, 'expected test_session_end event')
+          assert.strictEqual(session.content.meta[TEST_STATUS], 'fail')
+          assert.doesNotMatch(session.content.meta[ERROR_MESSAGE], /reporter property access failed/)
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.notStrictEqual(exitCode, 0)
+    })
+
     it('reports the session when a custom reporter throws during onExit', async (receiver, run) => {
       const proc = run(
         './node_modules/.bin/playwright test -c playwright.config.js',
@@ -315,6 +344,30 @@ versions.forEach((version) => {
         assert.strictEqual(exitCode, 0)
       })
     })
+
+    if (satisfies(version, '>=1.60.0') || version === 'latest') {
+      context('programmatic reruns', () => {
+        it('restores console.error after every run with the same config', async (receiver, run) => {
+          let testOutput = ''
+          const proc = run(
+            'node ./ci-visibility/playwright-rerun-console.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                NODE_OPTIONS: '',
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+              },
+            }
+          )
+          proc.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+          proc.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+          const [[exitCode]] = await Promise.all([once(proc, 'exit')])
+          assert.strictEqual(exitCode, 0, testOutput)
+        })
+      })
+    }
 
     it('does not treat matching user console output as a reporter failure', async (receiver, run) => {
       const proc = run(

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -131,6 +131,117 @@ versions.forEach((version) => {
       assert.strictEqual(exitCode, 0)
     }
 
+    it('reports the session when a custom reporter throws', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_THROWING_REPORTER: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          assert.strictEqual(events.filter(event => event.type === 'test_suite_end').length, 1)
+          for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+            const event = events.find(event => event.type === eventType)
+            assert.ok(event, `expected ${eventType} event`)
+            assert.strictEqual(event.content.meta[TEST_STATUS], 'fail', `${eventType} should fail`)
+            assert.strictEqual(event.content.error, 1)
+            assert.match(event.content.meta[ERROR_MESSAGE], /custom Playwright reporter failed/)
+          }
+          const testEvent = events.find(event => event.type === 'test')
+          assert.ok(testEvent, 'expected completed test event')
+          assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'pass')
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.notStrictEqual(exitCode, 0)
+    })
+
+    it('does not treat matching user console output as a reporter failure', async (receiver, run) => {
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PLAYWRIGHT_LOGGING_REPORTER: '1',
+            TEST_DIR: REQUEST_ERROR_TAG_TEST_DIR,
+          },
+        }
+      )
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        proc,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+            const event = events.find(event => event.type === eventType)
+            assert.ok(event, `expected ${eventType} event`)
+            assert.strictEqual(event.content.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(event.content.error, 0)
+          }
+        }
+      )
+      const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+      assert.strictEqual(exitCode, 0)
+    })
+
+    contextNewVersions('failure screenshots', () => {
+      it('bounds reporter error finalization while a screenshot upload is pending', async (receiver, run) => {
+        receiver.setMediaResponsesPending()
+        let testOutput = ''
+        const startedAt = Date.now()
+        const proc = run(
+          'node ./ci-visibility/playwright-pending-upload-finalization.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true',
+            },
+          }
+        )
+        proc.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+        proc.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+        const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+          proc,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end', 'test']) {
+              const event = events.find(event => event.type === eventType)
+              assert.ok(event, `expected ${eventType} event\n${testOutput}`)
+              assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+            }
+            for (const eventType of ['test_session_end', 'test_module_end']) {
+              const event = events.find(event => event.type === eventType)
+              assert.match(event.content.meta[ERROR_MESSAGE], /custom Playwright reporter failed/)
+            }
+          },
+          { hardTimeout: 15_000 }
+        ).catch((error) => {
+          error.message += `\nPlaywright output:\n${testOutput}`
+          throw error
+        })
+
+        const [[exitCode]] = await Promise.all([once(proc, 'exit'), eventsPromise])
+        assert.notStrictEqual(exitCode, 0)
+        assert.match(testOutput, /custom Playwright reporter failed/)
+        assert.ok(Date.now() - startedAt < 15_000, `Playwright finalization exceeded its deadline\n${testOutput}`)
+      })
+    })
+
     const reportMethods = ['agentless', 'evp proxy']
 
     reportMethods.forEach((reportMethod) => {

--- a/packages/datadog-instrumentations/src/playwright-reporter.js
+++ b/packages/datadog-instrumentations/src/playwright-reporter.js
@@ -21,7 +21,7 @@ function isPlaywrightReporterError (message) {
   try {
     Error.prepareStackTrace = (_, callSites) => callSites
     const stack = new Error('Playwright reporter error provenance').stack
-    return PLAYWRIGHT_REPORTER_ERROR_CALLER_RE.test(stack?.[2]?.toString() || '')
+    return PLAYWRIGHT_REPORTER_ERROR_CALLER_RE.test(`at ${stack?.[2]?.toString() || ''}`)
   } finally {
     Error.prepareStackTrace = originalPrepareStackTrace
   }
@@ -36,8 +36,10 @@ class DatadogPlaywrightReporter {
   static restoreConsoleError () {
     // eslint-disable-next-line no-console
     if (console.error === DatadogPlaywrightReporter.consoleError) {
-      // eslint-disable-next-line no-console
-      console.error = DatadogPlaywrightReporter.originalConsoleError
+      try {
+        // eslint-disable-next-line no-console
+        console.error = DatadogPlaywrightReporter.originalConsoleError
+      } catch {}
     }
     DatadogPlaywrightReporter.consoleError = undefined
     DatadogPlaywrightReporter.originalConsoleError = undefined
@@ -53,15 +55,25 @@ class DatadogPlaywrightReporter {
     // Playwright 1.60 and 1.61 only expose reporter errors through this exact console call.
     // eslint-disable-next-line no-console
     const originalConsoleError = console.error
-    DatadogPlaywrightReporter.originalConsoleError = originalConsoleError
     const reporter = this
-    // eslint-disable-next-line no-console
-    DatadogPlaywrightReporter.consoleError = console.error = function (message, error) {
+    const consoleError = function (message, error) {
       if (isPlaywrightReporterError(message)) {
         reporter.onError(error)
       }
       return originalConsoleError.apply(this, arguments)
     }
+    try {
+      // eslint-disable-next-line no-console
+      console.error = consoleError
+    } catch {
+      return
+    }
+    // An accessor may ignore the assignment without throwing.
+    // eslint-disable-next-line no-console
+    if (console.error !== consoleError) return
+
+    DatadogPlaywrightReporter.originalConsoleError = originalConsoleError
+    DatadogPlaywrightReporter.consoleError = consoleError
   }
 
   /**

--- a/packages/datadog-instrumentations/src/playwright-reporter.js
+++ b/packages/datadog-instrumentations/src/playwright-reporter.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const { channel } = require('dc-polyfill')
+
+const reporterErrorCh = channel('ci:playwright:reporter:error')
+const PLAYWRIGHT_REPORTER_ERROR_MESSAGE = 'Error in reporter'
+const PLAYWRIGHT_REPORTER_ERROR_CALLER_RE =
+  /^\s*at wrapAsync .*?[\\/]playwright[\\/]lib[\\/]runner[\\/]index\.js:\d+:\d+\)?$/
+
+/**
+ * Identifies the private Playwright 1.60-1.61 reporter error fallback without
+ * interpreting identical user console output as a framework error.
+ *
+ * @param {unknown} message - First console.error argument
+ * @param {unknown} error - Second console.error argument
+ * @returns {boolean}
+ */
+function isPlaywrightReporterError (message, error) {
+  if (message !== PLAYWRIGHT_REPORTER_ERROR_MESSAGE || error == null) return false
+
+  const stack = new Error('Playwright reporter error provenance').stack
+  const caller = stack?.split('\n', 4)[3]
+  return PLAYWRIGHT_REPORTER_ERROR_CALLER_RE.test(caller || '')
+}
+
+module.exports = class DatadogPlaywrightReporter {
+  /**
+   * Marks the beginning of reporter finalization so later reporter errors can be identified.
+   *
+   * @returns {void}
+   */
+  onEnd () {
+    this.isFinalizing = true
+    // Playwright 1.60 and 1.61 only expose reporter errors through this exact console call.
+    // eslint-disable-next-line no-console
+    const originalConsoleError = console.error
+    this.originalConsoleError = originalConsoleError
+    const reporter = this
+    // eslint-disable-next-line no-console
+    this.consoleError = console.error = function (message, error) {
+      if (isPlaywrightReporterError(message, error)) {
+        reporter.onError(error)
+      }
+      return originalConsoleError.apply(this, arguments)
+    }
+  }
+
+  /**
+   * Reports errors emitted by Playwright while later reporters are finalizing.
+   *
+   * @param {unknown} error
+   * @returns {void}
+   */
+  onError (error) {
+    if (this.isFinalizing) reporterErrorCh.publish(error)
+  }
+
+  /**
+   * Restores console error after all reporters have finalized.
+   *
+   * @returns {void}
+   */
+  onExit () {
+    // eslint-disable-next-line no-console
+    if (console.error === this.consoleError) {
+      // eslint-disable-next-line no-console
+      console.error = this.originalConsoleError
+    }
+  }
+
+  /**
+   * Keeps the internal reporter from affecting Playwright's output reporter selection.
+   *
+   * @returns {boolean}
+   */
+  printsToStdio () {
+    return false
+  }
+}

--- a/packages/datadog-instrumentations/src/playwright-reporter.js
+++ b/packages/datadog-instrumentations/src/playwright-reporter.js
@@ -12,18 +12,37 @@ const PLAYWRIGHT_REPORTER_ERROR_CALLER_RE =
  * interpreting identical user console output as a framework error.
  *
  * @param {unknown} message - First console.error argument
- * @param {unknown} error - Second console.error argument
  * @returns {boolean}
  */
-function isPlaywrightReporterError (message, error) {
-  if (message !== PLAYWRIGHT_REPORTER_ERROR_MESSAGE || error == null) return false
+function isPlaywrightReporterError (message) {
+  if (message !== PLAYWRIGHT_REPORTER_ERROR_MESSAGE) return false
 
-  const stack = new Error('Playwright reporter error provenance').stack
-  const caller = stack?.split('\n', 4)[3]
-  return PLAYWRIGHT_REPORTER_ERROR_CALLER_RE.test(caller || '')
+  const originalPrepareStackTrace = Error.prepareStackTrace
+  try {
+    Error.prepareStackTrace = (_, callSites) => callSites
+    const stack = new Error('Playwright reporter error provenance').stack
+    return PLAYWRIGHT_REPORTER_ERROR_CALLER_RE.test(stack?.[2]?.toString() || '')
+  } finally {
+    Error.prepareStackTrace = originalPrepareStackTrace
+  }
 }
 
-module.exports = class DatadogPlaywrightReporter {
+class DatadogPlaywrightReporter {
+  /**
+   * Restores console error after Playwright completes the reporter lifecycle.
+   *
+   * @returns {void}
+   */
+  static restoreConsoleError () {
+    // eslint-disable-next-line no-console
+    if (console.error === DatadogPlaywrightReporter.consoleError) {
+      // eslint-disable-next-line no-console
+      console.error = DatadogPlaywrightReporter.originalConsoleError
+    }
+    DatadogPlaywrightReporter.consoleError = undefined
+    DatadogPlaywrightReporter.originalConsoleError = undefined
+  }
+
   /**
    * Marks the beginning of reporter finalization so later reporter errors can be identified.
    *
@@ -34,11 +53,11 @@ module.exports = class DatadogPlaywrightReporter {
     // Playwright 1.60 and 1.61 only expose reporter errors through this exact console call.
     // eslint-disable-next-line no-console
     const originalConsoleError = console.error
-    this.originalConsoleError = originalConsoleError
+    DatadogPlaywrightReporter.originalConsoleError = originalConsoleError
     const reporter = this
     // eslint-disable-next-line no-console
-    this.consoleError = console.error = function (message, error) {
-      if (isPlaywrightReporterError(message, error)) {
+    DatadogPlaywrightReporter.consoleError = console.error = function (message, error) {
+      if (isPlaywrightReporterError(message)) {
         reporter.onError(error)
       }
       return originalConsoleError.apply(this, arguments)
@@ -56,19 +75,6 @@ module.exports = class DatadogPlaywrightReporter {
   }
 
   /**
-   * Restores console error after all reporters have finalized.
-   *
-   * @returns {void}
-   */
-  onExit () {
-    // eslint-disable-next-line no-console
-    if (console.error === this.consoleError) {
-      // eslint-disable-next-line no-console
-      console.error = this.originalConsoleError
-    }
-  }
-
-  /**
    * Keeps the internal reporter from affecting Playwright's output reporter selection.
    *
    * @returns {boolean}
@@ -77,3 +83,5 @@ module.exports = class DatadogPlaywrightReporter {
     return false
   }
 }
+
+module.exports = DatadogPlaywrightReporter

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1260,11 +1260,13 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     reporterError = undefined
     hasReporterError = false
     let restoreReporterConsoleError
-    if (satisfies(playwrightVersion, '>=1.60.0') && config?.config && !config.config[kDdPlaywrightReporterConfigured]) {
+    if (satisfies(playwrightVersion, '>=1.60.0') && config?.config) {
       const DatadogPlaywrightReporter = require('./playwright-reporter')
-      Object.defineProperty(config.config, kDdPlaywrightReporterConfigured, { value: true })
-      config.config.reporter.unshift([require.resolve('./playwright-reporter')])
       restoreReporterConsoleError = DatadogPlaywrightReporter.restoreConsoleError
+      if (!config.config[kDdPlaywrightReporterConfigured]) {
+        Object.defineProperty(config.config, kDdPlaywrightReporterConfigured, { value: true })
+        config.config.reporter.unshift([require.resolve('./playwright-reporter')])
+      }
     }
     rootDir = getRootDir(this, config)
     const projects = getProjectsFromRunner(this, config)
@@ -1506,22 +1508,35 @@ function reportersHook (reportersPackage) {
   return shimmer.wrap(reportersPackage, 'createReporters', createReporters => async function () {
     const reporters = await createReporters.apply(this, arguments)
     for (const reporter of reporters) {
-      if (instrumentedPlaywrightReporters.has(reporter) || typeof reporter.onEnd !== 'function') continue
+      if (instrumentedPlaywrightReporters.has(reporter)) continue
 
       const onEnd = reporter.onEnd
+      const onExit = reporter.onExit
       try {
-        reporter.onEnd = async function () {
-          try {
-            return await onEnd.apply(this, arguments)
-          } catch (error) {
-            recordReporterError(error)
-            throw error
+        if (typeof onEnd === 'function') {
+          reporter.onEnd = async function () {
+            try {
+              return await onEnd.apply(this, arguments)
+            } catch (error) {
+              recordReporterError(error)
+              throw error
+            }
+          }
+        }
+        if (typeof onExit === 'function') {
+          reporter.onExit = async function () {
+            try {
+              return await onExit.apply(this, arguments)
+            } catch (error) {
+              recordReporterError(error)
+              throw error
+            }
           }
         }
       } catch {
         continue
       }
-      if (reporter.onEnd !== onEnd) instrumentedPlaywrightReporters.add(reporter)
+      if (reporter.onEnd !== onEnd || reporter.onExit !== onExit) instrumentedPlaywrightReporters.add(reporter)
     }
     return reporters
   }, { replaceGetter: true })
@@ -1657,11 +1672,17 @@ reporterErrorCh.subscribe((error) => {
 function recordReporterError (error) {
   if (hasReporterError) return
 
+  let normalizedError
+  try {
+    const errorObject = error && typeof error === 'object' ? error : undefined
+    normalizedError = new Error(errorObject?.message || errorObject?.value || String(error))
+    normalizedError.name = errorObject?.name || normalizedError.name
+    normalizedError.stack = errorObject?.stack || normalizedError.stack
+  } catch {
+    normalizedError = new Error('Playwright reporter failed')
+  }
+  reporterError = normalizedError
   hasReporterError = true
-  const errorObject = error && typeof error === 'object' ? error : undefined
-  reporterError = new Error(errorObject?.message || errorObject?.value || String(error))
-  reporterError.name = errorObject?.name || reporterError.name
-  reporterError.stack = errorObject?.stack || reporterError.stack
 }
 
 /**

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -45,6 +45,7 @@ const testSkipCh = channel('ci:playwright:test:skip')
 const testSessionStartCh = channel('ci:playwright:session:start')
 const testSessionConfigurationCh = channel('ci:playwright:session:configuration')
 const testSessionFinishCh = channel('ci:playwright:session:finish')
+const reporterErrorCh = channel('ci:playwright:reporter:error')
 
 const libraryConfigurationCh = channel('ci:playwright:library-configuration')
 const knownTestsCh = channel('ci:playwright:known-tests')
@@ -81,6 +82,7 @@ const isFailureScreenshotUploadEnabled =
   getValueFromEnvSources('DD_TEST_FAILURE_SCREENSHOTS_ENABLED') === true
 
 let applyRepeatEachIndex = null
+let reporterError
 
 let startedSuites = []
 
@@ -134,6 +136,8 @@ const DD_PROPERTIES_REQUEST = 'ddPropertiesRequest'
 const DD_PROPERTIES_RESPONSE = 'ddProperties'
 const kDdPlaywrightDisabledTestIds = Symbol('ddPlaywrightDisabledTestIds')
 const kDdPlaywrightFailureScreenshots = Symbol('ddPlaywrightFailureScreenshots')
+const kDdPlaywrightReporterConfigured = Symbol('ddPlaywrightReporterConfigured')
+const kDdPlaywrightReporterInstrumented = Symbol('ddPlaywrightReporterInstrumented')
 const kDdPlaywrightWorkerHostInstrumented = Symbol('ddPlaywrightWorkerHostInstrumented')
 const kDdPlaywrightWorkerInstrumented = Symbol('ddPlaywrightWorkerInstrumented')
 const PLAYWRIGHT_FAILURE_SCREENSHOT_PATH_RE = /(?:^|[\\/])test-failed-\d+\.png$/
@@ -1252,6 +1256,11 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
 function runAllTestsWrapper (runAllTests, playwrightVersion) {
   // Config parameter is only available from >=1.55.0
   return async function (config) {
+    reporterError = undefined
+    if (satisfies(playwrightVersion, '>=1.60.0') && config?.config && !config.config[kDdPlaywrightReporterConfigured]) {
+      Object.defineProperty(config.config, kDdPlaywrightReporterConfigured, { value: true })
+      config.config.reporter.unshift([require.resolve('./playwright-reporter')])
+    }
     rootDir = getRootDir(this, config)
     const projects = getProjectsFromRunner(this, config)
     const isFailureScreenshotEnabled = isFailureScreenshotCaptureEnabled(projects)
@@ -1367,7 +1376,24 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       }
     }
 
-    let runAllTestsReturn = await runAllTests.apply(this, arguments)
+    let runAllTestsReturn
+    try {
+      runAllTestsReturn = await runAllTests.apply(this, arguments)
+    } catch (error) {
+      try {
+        await getChannelPromise(testSessionFinishCh, {
+          status: 'fail',
+          error,
+          isEarlyFlakeDetectionEnabled,
+          isEarlyFlakeDetectionFaulty,
+          isTestManagementTestsEnabled,
+        })
+      } catch (finalizationError) {
+        log.error('Playwright test session finalization error: %s', finalizationError)
+      }
+      reporterError = undefined
+      throw error
+    }
 
     // Tests that have only skipped tests may reach this point
     // Skipped tests may or may not go through `testBegin` or `testEnd`
@@ -1422,12 +1448,21 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     logTestOptimizationSummary({ attemptToFixExecutions, newTestsWithDynamicNames })
     loggedAttemptToFixTests.clear()
 
+    const finalizationError = reporterError
+    const finalStatus = finalizationError
+      ? 'fail'
+      : (preventedToFail ? 'pass' : STATUS_TO_TEST_STATUS[sessionStatus])
     await getChannelPromise(testSessionFinishCh, {
-      status: preventedToFail ? 'pass' : STATUS_TO_TEST_STATUS[sessionStatus],
+      status: finalStatus,
+      error: finalizationError,
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
     })
+    if (finalizationError) {
+      if (typeof runAllTestsReturn === 'string') runAllTestsReturn = 'failed'
+      else runAllTestsReturn.status = 'failed'
+    }
 
     startedSuites = []
     remainingTestsByFile = {}
@@ -1444,11 +1479,57 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     ddPropertiesByTestId.clear()
     ddPropertiesRequestsByTestId.clear()
     disabledTestIds.clear()
+    reporterError = undefined
 
     // TODO: we can trick playwright into thinking the session passed by returning
     // 'passed' here. We might be able to use this for both EFD and Test Management tests.
     return runAllTestsReturn
   }
+}
+
+/**
+ * Records errors thrown or rejected by Playwright reporters before Playwright converts them into run status.
+ *
+ * @param {object} reportersPackage
+ * @returns {object}
+ */
+function reportersHook (reportersPackage) {
+  return shimmer.wrap(reportersPackage, 'createReporters', createReporters => async function () {
+    const reporters = await createReporters.apply(this, arguments)
+    for (const reporter of reporters) {
+      if (reporter[kDdPlaywrightReporterInstrumented] || typeof reporter.onEnd !== 'function') continue
+
+      Object.defineProperty(reporter, kDdPlaywrightReporterInstrumented, { value: true })
+      const onEnd = reporter.onEnd
+      reporter.onEnd = async function () {
+        try {
+          return await onEnd.apply(this, arguments)
+        } catch (error) {
+          reporterError ||= error
+          throw error
+        }
+      }
+    }
+    return reporters
+  }, { replaceGetter: true })
+}
+
+/**
+ * Records errors from the reporter multiplexer used by Playwright before 1.38.
+ *
+ * @param {object} reportersPackage
+ * @returns {object}
+ */
+function reporterMultiplexerHook (reportersPackage) {
+  shimmer.wrap(reportersPackage.Multiplexer.prototype, 'onEnd', onEnd => async function () {
+    try {
+      return await onEnd.apply(this, arguments)
+    } catch (error) {
+      reporterError ||= error
+      throw error
+    }
+  })
+  return reportersPackage
 }
 
 function runnerHook (runnerExport, playwrightVersion) {
@@ -1550,6 +1631,15 @@ pageGotoCh.subscribe({
   },
 })
 
+reporterErrorCh.subscribe((error) => {
+  if (reporterError) return
+
+  const errorObject = error && typeof error === 'object' ? error : undefined
+  reporterError = new Error(errorObject?.message || errorObject?.value || String(error))
+  reporterError.name = errorObject?.name || reporterError.name
+  reporterError.stack = errorObject?.stack || reporterError.stack
+})
+
 /**
  * Records a path created by Playwright's automatic screenshot recorder.
  *
@@ -1597,6 +1687,12 @@ if (DD_MAJOR < 6) { // <1.38.0 is only supported up to version 5
     file: 'lib/runner/runner.js',
     versions: ['>=1.31.0 <1.38.0'],
   }, runnerHook)
+
+  addHook({
+    name: '@playwright/test',
+    file: 'lib/reporters/multiplexer.js',
+    versions: ['>=1.18.0 <1.38.0'],
+  }, reporterMultiplexerHook)
 }
 
 addHook({
@@ -1616,6 +1712,12 @@ addHook({
   file: 'lib/runner/runner.js',
   versions: ['>=1.38.0 <1.60.0'],
 }, runnerHook)
+
+addHook({
+  name: 'playwright',
+  file: 'lib/runner/reporters.js',
+  versions: ['>=1.38.0 <1.60.0'],
+}, reportersHook)
 
 addHook({
   name: 'playwright',

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1390,7 +1390,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       try {
         await getChannelPromise(testSessionFinishCh, {
           status: 'fail',
-          error,
+          error: hasReporterError ? reporterError : error,
           isEarlyFlakeDetectionEnabled,
           isEarlyFlakeDetectionFaulty,
           isTestManagementTestsEnabled,

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1259,9 +1259,12 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
   return async function (config) {
     reporterError = undefined
     hasReporterError = false
+    let restoreReporterConsoleError
     if (satisfies(playwrightVersion, '>=1.60.0') && config?.config && !config.config[kDdPlaywrightReporterConfigured]) {
+      const DatadogPlaywrightReporter = require('./playwright-reporter')
       Object.defineProperty(config.config, kDdPlaywrightReporterConfigured, { value: true })
       config.config.reporter.unshift([require.resolve('./playwright-reporter')])
+      restoreReporterConsoleError = DatadogPlaywrightReporter.restoreConsoleError
     }
     rootDir = getRootDir(this, config)
     const projects = getProjectsFromRunner(this, config)
@@ -1396,6 +1399,8 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       reporterError = undefined
       hasReporterError = false
       throw error
+    } finally {
+      restoreReporterConsoleError?.()
     }
 
     // Tests that have only skipped tests may reach this point

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -83,6 +83,7 @@ const isFailureScreenshotUploadEnabled =
 
 let applyRepeatEachIndex = null
 let reporterError
+let hasReporterError = false
 
 let startedSuites = []
 
@@ -137,9 +138,9 @@ const DD_PROPERTIES_RESPONSE = 'ddProperties'
 const kDdPlaywrightDisabledTestIds = Symbol('ddPlaywrightDisabledTestIds')
 const kDdPlaywrightFailureScreenshots = Symbol('ddPlaywrightFailureScreenshots')
 const kDdPlaywrightReporterConfigured = Symbol('ddPlaywrightReporterConfigured')
-const kDdPlaywrightReporterInstrumented = Symbol('ddPlaywrightReporterInstrumented')
 const kDdPlaywrightWorkerHostInstrumented = Symbol('ddPlaywrightWorkerHostInstrumented')
 const kDdPlaywrightWorkerInstrumented = Symbol('ddPlaywrightWorkerInstrumented')
+const instrumentedPlaywrightReporters = new WeakSet()
 const PLAYWRIGHT_FAILURE_SCREENSHOT_PATH_RE = /(?:^|[\\/])test-failed-\d+\.png$/
 const automaticFailureScreenshotPaths = new Set()
 
@@ -1257,6 +1258,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
   // Config parameter is only available from >=1.55.0
   return async function (config) {
     reporterError = undefined
+    hasReporterError = false
     if (satisfies(playwrightVersion, '>=1.60.0') && config?.config && !config.config[kDdPlaywrightReporterConfigured]) {
       Object.defineProperty(config.config, kDdPlaywrightReporterConfigured, { value: true })
       config.config.reporter.unshift([require.resolve('./playwright-reporter')])
@@ -1392,6 +1394,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
         log.error('Playwright test session finalization error: %s', finalizationError)
       }
       reporterError = undefined
+      hasReporterError = false
       throw error
     }
 
@@ -1449,7 +1452,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     loggedAttemptToFixTests.clear()
 
     const finalizationError = reporterError
-    const finalStatus = finalizationError
+    const finalStatus = hasReporterError
       ? 'fail'
       : (preventedToFail ? 'pass' : STATUS_TO_TEST_STATUS[sessionStatus])
     await getChannelPromise(testSessionFinishCh, {
@@ -1459,7 +1462,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
     })
-    if (finalizationError) {
+    if (hasReporterError) {
       if (typeof runAllTestsReturn === 'string') runAllTestsReturn = 'failed'
       else runAllTestsReturn.status = 'failed'
     }
@@ -1480,6 +1483,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     ddPropertiesRequestsByTestId.clear()
     disabledTestIds.clear()
     reporterError = undefined
+    hasReporterError = false
 
     // TODO: we can trick playwright into thinking the session passed by returning
     // 'passed' here. We might be able to use this for both EFD and Test Management tests.
@@ -1497,18 +1501,22 @@ function reportersHook (reportersPackage) {
   return shimmer.wrap(reportersPackage, 'createReporters', createReporters => async function () {
     const reporters = await createReporters.apply(this, arguments)
     for (const reporter of reporters) {
-      if (reporter[kDdPlaywrightReporterInstrumented] || typeof reporter.onEnd !== 'function') continue
+      if (instrumentedPlaywrightReporters.has(reporter) || typeof reporter.onEnd !== 'function') continue
 
-      Object.defineProperty(reporter, kDdPlaywrightReporterInstrumented, { value: true })
       const onEnd = reporter.onEnd
-      reporter.onEnd = async function () {
-        try {
-          return await onEnd.apply(this, arguments)
-        } catch (error) {
-          reporterError ||= error
-          throw error
+      try {
+        reporter.onEnd = async function () {
+          try {
+            return await onEnd.apply(this, arguments)
+          } catch (error) {
+            recordReporterError(error)
+            throw error
+          }
         }
+      } catch {
+        continue
       }
+      if (reporter.onEnd !== onEnd) instrumentedPlaywrightReporters.add(reporter)
     }
     return reporters
   }, { replaceGetter: true })
@@ -1525,7 +1533,7 @@ function reporterMultiplexerHook (reportersPackage) {
     try {
       return await onEnd.apply(this, arguments)
     } catch (error) {
-      reporterError ||= error
+      recordReporterError(error)
       throw error
     }
   })
@@ -1632,13 +1640,24 @@ pageGotoCh.subscribe({
 })
 
 reporterErrorCh.subscribe((error) => {
-  if (reporterError) return
+  recordReporterError(error)
+})
 
+/**
+ * Records a reporter failure even when the reporter throws a falsy value.
+ *
+ * @param {unknown} error
+ * @returns {void}
+ */
+function recordReporterError (error) {
+  if (hasReporterError) return
+
+  hasReporterError = true
   const errorObject = error && typeof error === 'object' ? error : undefined
   reporterError = new Error(errorObject?.message || errorObject?.value || String(error))
   reporterError.name = errorObject?.name || reporterError.name
   reporterError.stack = errorObject?.stack || reporterError.stack
-})
+}
 
 /**
  * Records a path created by Playwright's automatic screenshot recorder.

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -141,7 +141,7 @@ class PlaywrightPlugin extends CiPlugin {
           testSuiteSpan.setTag('error', error)
         }
         for (const [finishTest, abortController] of this.#pendingTestFinishCallbacks) {
-          finishTest()
+          finishTest(SCREENSHOT_UPLOAD_RESULT_ERROR)
           abortController.abort()
         }
       }

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -79,6 +79,9 @@ function isPlaywrightFailureScreenshot (attachment) {
 class PlaywrightPlugin extends CiPlugin {
   static id = 'playwright'
 
+  #isFinalizingAfterError = false
+  #pendingTestFinishCallbacks = new Map()
+
   constructor (...args) {
     super(...args)
 
@@ -99,6 +102,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:session:start', ({ isFailureScreenshotEnabled }) => {
+      this.#isFinalizingAfterError = false
       if (!getConfig().testOptimization.DD_TEST_FAILURE_SCREENSHOTS_ENABLED) return
 
       if (!isFailureScreenshotEnabled) {
@@ -127,8 +131,21 @@ class PlaywrightPlugin extends CiPlugin {
       isEarlyFlakeDetectionEnabled,
       isEarlyFlakeDetectionFaulty,
       isTestManagementTestsEnabled,
+      error,
       onDone,
     }) => {
+      if (error) {
+        this.#isFinalizingAfterError = true
+        for (const testSuiteSpan of this._testSuiteSpansByTestSuiteAbsolutePath.values()) {
+          testSuiteSpan.setTag(TEST_STATUS, 'fail')
+          testSuiteSpan.setTag('error', error)
+        }
+        for (const [finishTest, abortController] of this.#pendingTestFinishCallbacks) {
+          finishTest()
+          abortController.abort()
+        }
+      }
+
       const finishSession = () => {
         this.testModuleSpan.setTag(TEST_STATUS, status)
         this.testSessionSpan.setTag(TEST_STATUS, status)
@@ -139,20 +156,24 @@ class PlaywrightPlugin extends CiPlugin {
         if (isEarlyFlakeDetectionFaulty) {
           this.testSessionSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'faulty')
         }
-        if (status === 'fail' && this.numFailedSuites > 0) {
+        let sessionError = error
+        if (!sessionError && status === 'fail' && this.numFailedSuites > 0) {
           let errorMessage = `Test suites failed: ${this.numFailedSuites}.`
           if (this.numFailedTests > 0) {
             errorMessage += ` Tests failed: ${this.numFailedTests}`
           }
-          const error = new Error(errorMessage)
-          this.testModuleSpan.setTag('error', error)
-          this.testSessionSpan.setTag('error', error)
+          sessionError = new Error(errorMessage)
+        }
+        if (sessionError) {
+          this.testModuleSpan.setTag('error', sessionError)
+          this.testSessionSpan.setTag('error', sessionError)
         }
 
         if (isTestManagementTestsEnabled) {
           this.testSessionSpan.setTag(TEST_MANAGEMENT_ENABLED, 'true')
         }
 
+        this.tracer._exporter.exportDeferredTestSuiteSpans?.()
         this.testModuleSpan.finish()
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')
         this.testSessionSpan.finish()
@@ -234,6 +255,7 @@ class PlaywrightPlugin extends CiPlugin {
         this.numFailedSuites++
       }
 
+      this.tracer._exporter.deferTestSuiteSpan?.(testSuiteSpan)
       testSuiteSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
     })
@@ -304,16 +326,16 @@ class PlaywrightPlugin extends CiPlugin {
         }
       }
 
-      if (!formattedTestSpan || !screenshots) {
+      if (!formattedTestSpan || !screenshots || this.#isFinalizingAfterError) {
         exportTraces()
         return
       }
 
       this.pendingTestFinishes++
-      const uploadStarted = this.uploadTestScreenshots({
-        screenshots,
-        traceId: formattedTestSpan.trace_id.toString(10),
-      }, (screenshotUploadResult) => {
+      const abortController = new AbortController()
+      const finishTest = (screenshotUploadResult) => {
+        if (!this.#pendingTestFinishCallbacks.delete(finishTest)) return
+
         const screenshotUploadTag = getScreenshotUploadTag(screenshotUploadResult)
         if (screenshotUploadTag) {
           formattedTestSpan.meta[screenshotUploadTag] = 'true'
@@ -323,11 +345,16 @@ class PlaywrightPlugin extends CiPlugin {
         if (this.pendingTestFinishes === 0 && this.finishSession) {
           this.finishSession()
         }
-      })
+      }
+      this.#pendingTestFinishCallbacks.set(finishTest, abortController)
+      const uploadStarted = this.uploadTestScreenshots({
+        screenshots,
+        traceId: formattedTestSpan.trace_id.toString(10),
+        signal: abortController.signal,
+      }, finishTest)
       if (uploadStarted) return
 
-      this.pendingTestFinishes--
-      exportTraces()
+      finishTest()
     })
 
     this.addBind('ci:playwright:test:start', (ctx) => {
@@ -552,10 +579,11 @@ class PlaywrightPlugin extends CiPlugin {
    * @param {object} options - Upload options
    * @param {Array<object>} options.screenshots - Playwright test attachments
    * @param {string} options.traceId - Test trace id used as the screenshot key
+   * @param {AbortSignal} options.signal - Signal used to cancel uploads during error finalization
    * @param {(result: string|undefined) => void} onDone - Completion callback
    * @returns {boolean} Whether at least one upload was started
    */
-  uploadTestScreenshots ({ screenshots, traceId }, onDone) {
+  uploadTestScreenshots ({ screenshots, traceId, signal }, onDone) {
     const exporter = this.tracer?._exporter
     if (!Array.isArray(screenshots) || !screenshots.length ||
       !exporter?.canUploadTestScreenshots?.() ||
@@ -581,6 +609,7 @@ class PlaywrightPlugin extends CiPlugin {
         traceId,
         idempotencyKey: `${traceId}:${basename(filePath)}`,
         capturedAtMs: getScreenshotCapturedAtMs(filePath, filePath),
+        signal,
       }, (error, uploaded = true) => {
         if (uploaded) {
           uploadResults[resultIndex] = error


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Preserves Playwright Test Optimization data when a custom reporter fails during `onEnd` or `onExit`.

The change records the original reporter error before Playwright propagates, swallows, or converts it into a final run status. Test events that completed successfully remain passed, while the suite, module, and session are finalized as failed with the reporter error. The final writer flush remains bounded, including when an automatic failure-screenshot upload is still pending.

Reporter failures are exposed differently across supported Playwright versions:

| Playwright version | How the error is captured |
| --- | --- |
| 1.18–1.37 (dd-trace v5 only) | Wrap the legacy reporter multiplexer and record an `onEnd` failure before rethrowing it. |
| 1.38–1.59 | Wrap each created reporter's `onEnd` and `onExit` callbacks, record the error, and preserve Playwright's original behavior. |
| 1.60+ | Playwright moved the runner into bundled entry points. We inject an internal reporter that observes Playwright's private reporter-error fallback during finalization, records the original error, and restores `console.error` afterward. |

### Motivation

Playwright may handle a reporter exception after all tests have completed. Before this change, Test Optimization could miss that late failure.

For example:

1. A test passes.
2. A custom reporter throws `Error('report upload failed')` in `onEnd` or `onExit`.
3. Playwright exits non-zero.
4. Datadog nevertheless submits the suite, module, and session as passed because finalization did not observe the reporter error.

After this change, the completed test event is still reported as passed, but its suite, module, and session are reported as failed with `report upload failed`. Playwright still exits non-zero.

There was also a data-loss boundary around screenshot uploads. A failed test may finish while its automatic failure screenshot is uploading. If a reporter then fails and that upload never responds, the test event can remain buffered and session finalization can wait indefinitely. The error-finalization path now cancels the pending upload, marks the test with the screenshot-upload error tag, exports the test and parent events, and completes within the existing final-flush deadline.

`integration-tests/ci-visibility/playwright-pending-upload-finalization.js` is a deterministic fixture for that second case. It publishes the same Playwright diagnostic-channel events as a worker, supplies a failed serialized test plus an automatic screenshot, then reports a custom reporter error while the integration test keeps the media endpoint pending. This verifies cancellation, event delivery, failed parent status, original error metadata, non-zero exit behavior, and bounded completion without relying on a timing-sensitive real browser run.

### Additional Notes

Stacked on #9790. PR 3 provides deferred test session trace handling and the bounded final-flush APIs used here.

The internal reporter in `packages/datadog-instrumentations/src/playwright-reporter.js` is only the Playwright 1.60+ compatibility bridge. It does not create Test Optimization events and does not replace the user's configured reporter. It identifies reporter failures during Playwright's final reporter loop and publishes the error back to the main instrumentation, which owns suite/module/session finalization.

Validation:

- Reporter `onEnd` and `onExit` failures across Playwright 1.18 (v5), 1.38, 1.60–1.61, and latest-supported paths
- Primitive and hostile reporter rejection values
- Immutable `console.error`, custom `Error.prepareStackTrace`, and repeated programmatic runs
- Pending screenshot-upload cancellation and bounded finalization
- Completed test event plus failed suite/module/session assertions
- `npm run lint -- --quiet`
