### PR TITLE
fix(mocha): preserve reporter finalization errors

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -61,6 +61,7 @@ class FakeCiVisIntake extends FakeAgent {
   #waitingTime = 0
   #knownTestsPageIndex = 0
   #testManagementResponse = DEFAULT_TEST_MANAGEMENT_TESTS
+  #testManagementResponses = []
   #testManagementResponseStatusCode = DEFAULT_TEST_MANAGEMENT_TESTS_RESPONSE_STATUS
   #skippableSuitesResponseStatusCode = 200
 
@@ -145,6 +146,16 @@ class FakeCiVisIntake extends FakeAgent {
 
   setTestManagementTests (newTestManagementTests) {
     this.#testManagementResponse = newTestManagementTests
+  }
+
+  /**
+   * Sets Test Management responses to return in order.
+   *
+   * @param {object[]} responses
+   * @returns {void}
+   */
+  setTestManagementTestResponses (responses) {
+    this.#testManagementResponses = responses.slice()
   }
 
   setTestManagementTestsResponseCode (newStatusCode) {
@@ -392,10 +403,13 @@ class FakeCiVisIntake extends FakeAgent {
       '/evp_proxy/:version/api/v2/test/libraries/test-management/tests',
     ], (req, res) => {
       res.setHeader('content-type', 'application/json')
+      const testManagementResponse = this.#testManagementResponses.length
+        ? this.#testManagementResponses.shift()
+        : this.#testManagementResponse
       const data = JSON.stringify({
         data: {
           attributes: {
-            modules: this.#testManagementResponse,
+            modules: testManagementResponse,
           },
         },
       })
@@ -448,6 +462,7 @@ class FakeCiVisIntake extends FakeAgent {
     this.#mediaResponseDelayMs = 0
     this.#testManagementResponseStatusCode = DEFAULT_TEST_MANAGEMENT_TESTS_RESPONSE_STATUS
     this.#testManagementResponse = DEFAULT_TEST_MANAGEMENT_TESTS
+    this.#testManagementResponses = []
     this.#skippableSuitesResponseStatusCode = 200
     this.removeAllListeners()
     if (this.waitingTimeoutId) {

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -46,6 +46,7 @@ const DEFAULT_TEST_MANAGEMENT_TESTS_RESPONSE_STATUS = 200
 
 class FakeCiVisIntake extends FakeAgent {
   #settings = DEFAULT_SETTINGS
+  #settingsResponses = []
   #settingsResponseDelayMs = 0
   #settingsResponseStatusCode = 200
   #settingsResponseStatusCodes = []
@@ -103,6 +104,16 @@ class FakeCiVisIntake extends FakeAgent {
 
   setSettings (newSettings) {
     this.#settings = newSettings
+  }
+
+  /**
+   * Sets library configuration responses to return in order.
+   *
+   * @param {object[]} responses
+   * @returns {void}
+   */
+  setSettingsResponses (responses) {
+    this.#settingsResponses = responses.slice()
   }
 
   /**
@@ -305,11 +316,14 @@ class FakeCiVisIntake extends FakeAgent {
       const respond = () => {
         const settingsResponseStatusCode = this.#settingsResponseStatusCodes.shift() ??
           this.#settingsResponseStatusCode
+        const settings = this.#settingsResponses.length
+          ? this.#settingsResponses.shift()
+          : this.#settings
         res.status(settingsResponseStatusCode)
         if (settingsResponseStatusCode >= 200 && settingsResponseStatusCode < 300) {
           res.send(JSON.stringify({
             data: {
-              attributes: this.#settings,
+              attributes: settings,
             },
           }))
         } else {
@@ -450,6 +464,7 @@ class FakeCiVisIntake extends FakeAgent {
 
   stop () {
     this.#settings = DEFAULT_SETTINGS
+    this.#settingsResponses = []
     this.#settingsResponseDelayMs = 0
     this.#settingsResponseStatusCode = 200
     this.#settingsResponseStatusCodes = []

--- a/integration-tests/ci-visibility/mocha-coverage-reporter.js
+++ b/integration-tests/ci-visibility/mocha-coverage-reporter.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = function CoverageReporter (runner) {
+  runner.on('suite end', suite => {
+    if (suite.root || suite.title !== 'mocha-coverage-reporter') return
+
+    const [coverage] = Object.values(global.__coverage__)
+    // eslint-disable-next-line no-console
+    console.log(`MOCHA REPORTER COVERAGE: ${coverage.s[0]}`)
+    if (process.env.MOCHA_COVERAGE_REPORTER_THROWS) {
+      throw new Error('custom Mocha coverage reporter failed')
+    }
+  })
+}

--- a/integration-tests/ci-visibility/mocha-plugin-tests/failing.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/failing.js
@@ -2,6 +2,11 @@
 
 const assert = require('assert')
 describe('mocha-test-fail', () => {
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER EACH EXECUTED')
+  })
+
   it('can fail', () => {
     assert.strictEqual(true, false)
   })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/failing.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/failing.js
@@ -7,6 +7,11 @@ describe('mocha-test-fail', () => {
     console.log('MOCHA AFTER EACH EXECUTED')
   })
 
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER SECOND EACH EXECUTED')
+  })
+
   it('can fail', () => {
     assert.strictEqual(true, false)
   })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/passing-with-after-each.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/passing-with-after-each.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const assert = require('assert')
+
+describe('mocha-reporter-hook-end', () => {
+  afterEach(() => {})
+
+  it('can pass', () => {
+    assert.strictEqual(true, true)
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/passing-with-after-each.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/passing-with-after-each.js
@@ -9,3 +9,15 @@ describe('mocha-reporter-hook-end', () => {
     assert.strictEqual(true, true)
   })
 })
+
+describe('mocha-reporter-hook-end-outer', () => {
+  afterEach(() => {})
+
+  describe('mocha-reporter-hook-end-inner', () => {
+    afterEach(() => {})
+
+    it('can pass after an inner hook reporter error', () => {
+      assert.strictEqual(true, true)
+    })
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-coverage.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-coverage.js
@@ -1,0 +1,22 @@
+'use strict'
+
+describe('mocha-coverage-reporter', () => {
+  it('keeps coverage visible to suite reporters', () => {
+    global.__coverage__ = {
+      [__filename]: {
+        path: __filename,
+        statementMap: {
+          0: {
+            start: { line: 4, column: 2 },
+            end: { line: 4, column: 3 },
+          },
+        },
+        fnMap: {},
+        branchMap: {},
+        s: { 0: 1 },
+        f: {},
+        b: {},
+      },
+    }
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-hook-end-before-each.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-hook-end-before-each.js
@@ -1,0 +1,18 @@
+'use strict'
+
+describe('mocha-reporter-hook-end-before-each', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA BEFORE EACH EXECUTED')
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER EACH EXECUTED')
+  })
+
+  it('does not execute after the reporter fails', () => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA TEST BODY EXECUTED')
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-reusable-run.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-reusable-run.js
@@ -2,6 +2,8 @@
 
 const tracer = require('dd-trace')
 
+let execution = 0
+
 describe('mocha-reporter-reusable-run', () => {
   beforeEach(() => {
     // eslint-disable-next-line no-console
@@ -14,11 +16,15 @@ describe('mocha-reporter-reusable-run', () => {
   })
 
   it('runs again after reporter recovery', () => {
+    execution++
     if (process.env.MOCHA_REUSABLE_LOG_ACTIVE_TEST) {
       // eslint-disable-next-line no-console
       console.log(`MOCHA REUSABLE ACTIVE TEST: ${tracer.scope().active().context().toSpanId()}`)
     }
     // eslint-disable-next-line no-console
     console.log('MOCHA REUSABLE TEST EXECUTED')
+    if (process.env.MOCHA_REUSABLE_NATIVE_RETRY && execution % 2 === 1) {
+      throw new Error('retry this reusable Mocha test')
+    }
   })
 })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-reusable-run.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-reusable-run.js
@@ -1,0 +1,18 @@
+'use strict'
+
+describe('mocha-reporter-reusable-run', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA REUSABLE FIRST HOOK EXECUTED')
+  })
+
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA REUSABLE SECOND HOOK EXECUTED')
+  })
+
+  it('runs again after reporter recovery', () => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA REUSABLE TEST EXECUTED')
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-reusable-run.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-reusable-run.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const tracer = require('dd-trace')
+
 describe('mocha-reporter-reusable-run', () => {
   beforeEach(() => {
     // eslint-disable-next-line no-console
@@ -12,6 +14,10 @@ describe('mocha-reporter-reusable-run', () => {
   })
 
   it('runs again after reporter recovery', () => {
+    if (process.env.MOCHA_REUSABLE_LOG_ACTIVE_TEST) {
+      // eslint-disable-next-line no-console
+      console.log(`MOCHA REUSABLE ACTIVE TEST: ${tracer.scope().active().context().toSpanId()}`)
+    }
     // eslint-disable-next-line no-console
     console.log('MOCHA REUSABLE TEST EXECUTED')
   })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-run-start.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-run-start.js
@@ -1,0 +1,18 @@
+'use strict'
+
+before(() => {
+  // eslint-disable-next-line no-console
+  console.log('MOCHA BEFORE ALL EXECUTED')
+})
+
+after(() => {
+  // eslint-disable-next-line no-console
+  console.log('MOCHA AFTER ALL EXECUTED')
+})
+
+describe('mocha-reporter-run-start', () => {
+  it('does not execute after the reporter fails', () => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA TEST BODY EXECUTED')
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-suite-start.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-suite-start.js
@@ -1,0 +1,18 @@
+'use strict'
+
+describe('mocha-test-pass', () => {
+  before(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA BEFORE ALL EXECUTED')
+  })
+
+  after(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER ALL EXECUTED')
+  })
+
+  it('does not execute after the reporter fails', () => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA TEST BODY EXECUTED')
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-terminal-event.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-terminal-event.js
@@ -1,0 +1,10 @@
+'use strict'
+
+describe('mocha-test-pass-two', () => {
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER EACH EXECUTED')
+  })
+
+  it('can pass', () => {})
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-terminal-event.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-terminal-event.js
@@ -11,5 +11,10 @@ describe('mocha-test-pass-two', () => {
     console.log('MOCHA AFTER SECOND EACH EXECUTED')
   })
 
+  after(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER ALL EXECUTED')
+  })
+
   it('can pass', () => {})
 })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-terminal-event.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-terminal-event.js
@@ -6,5 +6,10 @@ describe('mocha-test-pass-two', () => {
     console.log('MOCHA AFTER EACH EXECUTED')
   })
 
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER SECOND EACH EXECUTED')
+  })
+
   it('can pass', () => {})
 })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-test-start.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-test-start.js
@@ -6,6 +6,11 @@ describe('mocha-reporter-test-start', () => {
     console.log('MOCHA BEFORE EACH EXECUTED')
   })
 
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA BEFORE SECOND EACH EXECUTED')
+  })
+
   afterEach(() => {
     // eslint-disable-next-line no-console
     console.log('MOCHA AFTER EACH EXECUTED')

--- a/integration-tests/ci-visibility/mocha-plugin-tests/reporter-test-start.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/reporter-test-start.js
@@ -1,0 +1,18 @@
+'use strict'
+
+describe('mocha-reporter-test-start', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA BEFORE EACH EXECUTED')
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER EACH EXECUTED')
+  })
+
+  it('does not execute after the reporter fails', () => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA TEST BODY EXECUTED')
+  })
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/retries.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/retries.js
@@ -6,6 +6,11 @@ let attempt = 0
 describe('mocha-test-retries', function () {
   this.retries(4)
 
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER EACH EXECUTED')
+  })
+
   it('will be retried and pass', () => {
     assert.strictEqual(attempt++, 2)
   })

--- a/integration-tests/ci-visibility/mocha-plugin-tests/skipping-with-after-each.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/skipping-with-after-each.js
@@ -1,0 +1,10 @@
+'use strict'
+
+describe('mocha-reporter-pending-after-each', () => {
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA AFTER EACH EXECUTED')
+  })
+
+  it.skip('can skip', () => {})
+})

--- a/integration-tests/ci-visibility/mocha-reporter-exits-after-suite.js
+++ b/integration-tests/ci-visibility/mocha-reporter-exits-after-suite.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = function ExitingReporter (runner) {
+  runner.on('suite end', (suite) => {
+    if (suite.title !== 'mocha-test-pass-two') return
+
+    const exporter = require('dd-trace')._tracer._exporter
+    exporter.flush(() => process.exit(0))
+  })
+}

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -1,7 +1,13 @@
 'use strict'
 
+const fs = require('node:fs')
+
 module.exports = function ThrowingReporter (runner) {
   const event = process.env.MOCHA_REPORTER_THROW_EVENT || 'end'
+
+  if (process.env.MOCHA_REPORT_RUNNER_EMIT_OWNER) {
+    fs.writeSync(2, `MOCHA RUNNER OWNS EMIT: ${Object.hasOwn(Object.getPrototypeOf(runner), 'emit')}\n`)
+  }
 
   runner.on(event, runnable => {
     if ((event === 'pass' || event === 'test end') && runnable.parent.title !== 'mocha-test-pass-two') return

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -16,6 +16,9 @@ module.exports = function ThrowingReporter (runner) {
       // eslint-disable-next-line no-throw-literal
       throw undefined
     }
+    if (process.env.MOCHA_REPORTER_THROWS_UNCOERCIBLE) {
+      throw Object.create(null)
+    }
     throw new Error('custom Mocha reporter failed')
   })
 }

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -8,6 +8,10 @@ module.exports = function ThrowingReporter (runner) {
     if (event === 'suite' && (runnable.root || runnable.title !== 'mocha-test-pass')) return
     if (event === 'suite end' && runnable.title !== 'mocha-test-pass-two') return
 
+    if (process.env.MOCHA_REPORTER_THROWS_UNDEFINED) {
+      // eslint-disable-next-line no-throw-literal
+      throw undefined
+    }
     throw new Error('custom Mocha reporter failed')
   })
 }

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -5,6 +5,8 @@ module.exports = function ThrowingReporter (runner) {
 
   runner.on(event, runnable => {
     if ((event === 'pass' || event === 'test end') && runnable.parent.title !== 'mocha-test-pass-two') return
+    if (event === 'hook end' && process.env.MOCHA_REPORTER_THROW_INNER_HOOK &&
+      runnable.parent.title !== 'mocha-reporter-hook-end-inner') return
     if (event === 'suite' && (runnable.root || runnable.title !== 'mocha-test-pass')) return
     if (event === 'suite end' && runnable.title !== 'mocha-test-pass-two') return
 

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -5,6 +5,8 @@ module.exports = function ThrowingReporter (runner) {
 
   runner.on(event, runnable => {
     if ((event === 'pass' || event === 'test end') && runnable.parent.title !== 'mocha-test-pass-two') return
+    if (event === 'hook' && process.env.MOCHA_REPORTER_THROW_AFTER_EACH &&
+      !runnable.parent?._afterEach?.includes(runnable)) return
     if (event === 'hook end' && process.env.MOCHA_REPORTER_THROW_INNER_HOOK &&
       runnable.parent.title !== 'mocha-reporter-hook-end-inner') return
     if (event === 'suite' && (runnable.root || runnable.title !== 'mocha-test-pass')) return

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -19,6 +19,8 @@ module.exports = function ThrowingReporter (runner) {
     if ((event === 'pass' || event === 'test end') && runnable.parent.title !== 'mocha-test-pass-two') return
     if (event === 'hook' && process.env.MOCHA_REPORTER_THROW_AFTER_EACH &&
       !runnable.parent?._afterEach?.includes(runnable)) return
+    if (event === 'hook' && process.env.MOCHA_REPORTER_THROW_AFTER_ALL &&
+      !runnable.parent?._afterAll?.includes(runnable)) return
     if (event === 'hook end' && process.env.MOCHA_REPORTER_THROW_INNER_HOOK &&
       runnable.parent.title !== 'mocha-reporter-hook-end-inner') return
     if (event === 'suite' && (runnable.root || runnable.title !== 'mocha-test-pass')) return
@@ -31,6 +33,13 @@ module.exports = function ThrowingReporter (runner) {
     }
     if (process.env.MOCHA_REPORTER_THROWS_UNCOERCIBLE) {
       throw Object.create(null)
+    }
+    if (process.env.MOCHA_REPORTER_THROWS_HOSTILE_ERROR) {
+      const error = new Error('custom Mocha reporter failed')
+      Object.defineProperty(error, 'message', {
+        get () { throw new Error('do not read reporter error message') },
+      })
+      throw error
     }
     throw new Error('custom Mocha reporter failed')
   })

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = function ThrowingReporter (runner) {
+  const event = process.env.MOCHA_REPORTER_THROW_EVENT || 'end'
+
+  runner.on(event, runnable => {
+    if ((event === 'pass' || event === 'test end') && runnable.parent.title !== 'mocha-test-pass-two') return
+    if (event === 'suite' && (runnable.root || runnable.title !== 'mocha-test-pass')) return
+    if (event === 'suite end' && runnable.title !== 'mocha-test-pass-two') return
+
+    throw new Error('custom Mocha reporter failed')
+  })
+}

--- a/integration-tests/ci-visibility/mocha-reporter-throws.js
+++ b/integration-tests/ci-visibility/mocha-reporter-throws.js
@@ -4,9 +4,15 @@ const fs = require('node:fs')
 
 module.exports = function ThrowingReporter (runner) {
   const event = process.env.MOCHA_REPORTER_THROW_EVENT || 'end'
+  let failedTest
 
   if (process.env.MOCHA_REPORT_RUNNER_EMIT_OWNER) {
     fs.writeSync(2, `MOCHA RUNNER OWNS EMIT: ${Object.hasOwn(Object.getPrototypeOf(runner), 'emit')}\n`)
+  }
+  if (process.env.MOCHA_REPORT_PENDING_AT_END) {
+    runner.on('end', () => {
+      fs.writeSync(2, `REPORTER TEST PENDING AT END: ${failedTest?.pending}\n`)
+    })
   }
 
   runner.on(event, runnable => {
@@ -18,6 +24,7 @@ module.exports = function ThrowingReporter (runner) {
     if (event === 'suite' && (runnable.root || runnable.title !== 'mocha-test-pass')) return
     if (event === 'suite end' && runnable.title !== 'mocha-test-pass-two') return
 
+    failedTest = runnable?.type === 'test' ? runnable : runnable?.ctx?.currentTest
     if (process.env.MOCHA_REPORTER_THROWS_UNDEFINED) {
       // eslint-disable-next-line no-throw-literal
       throw undefined

--- a/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
+++ b/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const Mocha = require('mocha')
+
+const reporterEvent = process.env.MOCHA_REUSABLE_REPORTER_EVENT
+let reporterRun = 0
+let firstRunFinished = false
+let firstRunError
+let hasStartedSecondRun = false
+
+class ThrowOnceReporter {
+  constructor (runner) {
+    reporterRun++
+    if (reporterRun !== 1) return
+
+    runner.on(reporterEvent, (runnable) => {
+      if (reporterEvent === 'hook end' && !runnable.title.startsWith('"before each" hook')) return
+
+      throw new Error('custom reusable Mocha reporter failed')
+    })
+  }
+}
+
+const mocha = new Mocha({ reporter: ThrowOnceReporter })
+mocha.cleanReferencesAfterRun?.(false)
+mocha.addFile(require.resolve('./mocha-plugin-tests/reporter-reusable-run.js'))
+
+function runAgainWhenReady () {
+  if (hasStartedSecondRun || !firstRunFinished || !firstRunError) return
+
+  hasStartedSecondRun = true
+  // eslint-disable-next-line no-console
+  console.log(`MOCHA FIRST RUN ERROR: ${firstRunError.message}`)
+  mocha.run((failures) => {
+    // eslint-disable-next-line no-console
+    console.log(`MOCHA SECOND RUN FAILURES: ${failures}`)
+    process.exitCode = failures ? 1 : 0
+  })
+}
+
+process.once('uncaughtException', (error) => {
+  firstRunError = error
+  runAgainWhenReady()
+})
+
+mocha.run(() => {
+  firstRunFinished = true
+  runAgainWhenReady()
+})

--- a/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
+++ b/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
@@ -11,7 +11,7 @@ let hasStartedSecondRun = false
 class ThrowOnceReporter {
   constructor (runner) {
     reporterRun++
-    if (reporterRun !== 1) return
+    if (!reporterEvent || reporterRun !== 1) return
 
     runner.on(reporterEvent, (runnable) => {
       if (reporterEvent === 'hook end' && !runnable.title.startsWith('"before each" hook')) return
@@ -26,11 +26,13 @@ mocha.cleanReferencesAfterRun?.(false)
 mocha.addFile(require.resolve('./mocha-plugin-tests/reporter-reusable-run.js'))
 
 function runAgainWhenReady () {
-  if (hasStartedSecondRun || !firstRunFinished || !firstRunError) return
+  if (hasStartedSecondRun || !firstRunFinished || (reporterEvent && !firstRunError)) return
 
   hasStartedSecondRun = true
-  // eslint-disable-next-line no-console
-  console.log(`MOCHA FIRST RUN ERROR: ${firstRunError.message}`)
+  if (firstRunError) {
+    // eslint-disable-next-line no-console
+    console.log(`MOCHA FIRST RUN ERROR: ${firstRunError.message}`)
+  }
   mocha.run((failures) => {
     // eslint-disable-next-line no-console
     console.log(`MOCHA SECOND RUN FAILURES: ${failures}`)

--- a/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
+++ b/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
@@ -24,6 +24,7 @@ class ThrowOnceReporter {
 
 const mocha = new Mocha({ reporter: ThrowOnceReporter })
 mocha.cleanReferencesAfterRun?.(false)
+if (process.env.MOCHA_REUSABLE_NATIVE_RETRY) mocha.retries(1)
 mocha.addFile(require.resolve('./mocha-plugin-tests/reporter-reusable-run.js'))
 
 function runAgainWhenReady () {

--- a/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
+++ b/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
@@ -3,6 +3,7 @@
 const Mocha = require('mocha')
 
 const reporterEvent = process.env.MOCHA_REUSABLE_REPORTER_EVENT
+const runCallbackThrows = process.env.MOCHA_REUSABLE_RUN_CALLBACK_THROWS
 let reporterRun = 0
 let firstRunFinished = false
 let firstRunError
@@ -41,11 +42,24 @@ function runAgainWhenReady () {
 }
 
 process.once('uncaughtException', (error) => {
+  if (runCallbackThrows) {
+    // eslint-disable-next-line no-console
+    console.log(`MOCHA PROPAGATED ERROR: ${error.message}`)
+    process.exitCode = 1
+    return
+  }
+
   firstRunError = error
   runAgainWhenReady()
 })
 
 mocha.run(() => {
+  if (runCallbackThrows) {
+    // eslint-disable-next-line no-console
+    console.log('MOCHA RUN CALLBACK EXECUTED')
+    throw new Error('custom reusable Mocha run callback failed')
+  }
+
   firstRunFinished = true
   runAgainWhenReady()
 })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -431,6 +431,40 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.notStrictEqual(exitCode, 0)
   })
 
+  it('finalizes a failed session when a reporter Error has a throwing message getter', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/passing.js ' +
+      '--reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'end',
+          MOCHA_REPORTER_THROWS_HOSTILE_ERROR: '1',
+        },
+      }
+    )
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.content.meta[ERROR_MESSAGE], 'Mocha reporter failed')
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.notStrictEqual(exitCode, 0)
+  })
+
   for (const reporterThrows of [false, true]) {
     it(`keeps suite coverage visible to a ${reporterThrows ? 'failing' : 'successful'} reporter`, async function () {
       this.timeout(20_000)
@@ -621,6 +655,52 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       assert.notStrictEqual(exitCode, 0, testOutput)
     })
   }
+
+  it('preserves a completed test when a reporter throws on its afterAll hook', async function () {
+    this.timeout(20_000)
+    const testName = 'mocha-test-pass-two can pass'
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/reporter-terminal-event.js ' +
+      '--reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'hook',
+          MOCHA_REPORTER_THROW_AFTER_ALL: '1',
+          MOCHA_REPORT_PENDING_AT_END: '1',
+        },
+      }
+    )
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.strictEqual(testEvents.length, 1)
+        assert.strictEqual(testEvents[0].content.meta[TEST_STATUS], 'pass')
+        assert.strictEqual(testEvents[0].content.error, 0)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.match(testOutput, /REPORTER TEST PENDING AT END: false/)
+    assert.doesNotMatch(testOutput, /MOCHA AFTER ALL EXECUTED/)
+    assert.notStrictEqual(exitCode, 0, testOutput)
+  })
 
   onlyLatestIt('marks parallel worker suites as failed when the coordinator reporter throws', async function () {
     this.timeout(20_000)
@@ -935,6 +1015,55 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     )
   })
 
+  onlyLatestIt('restores native retries after EFD is disabled for a reusable run', async function () {
+    this.timeout(20_000)
+    const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
+    receiver.setKnownTests({ mocha: {} })
+    receiver.setSettingsResponses([
+      {
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: { '5s': 1 },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
+      },
+      {
+        early_flake_detection: { enabled: false },
+        known_tests_enabled: false,
+      },
+    ])
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: {
+        ...getCiVisAgentlessConfig(receiver.port),
+        MOCHA_REUSABLE_NATIVE_RETRY: '1',
+      },
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.deepStrictEqual(
+          testEvents.map(event => event.content.meta[TEST_STATUS]),
+          ['fail', 'pass', 'fail', 'pass']
+        )
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 4)
+  })
+
   onlyLatestIt('restores a Test Management disabled test before the next run', async function () {
     this.timeout(20_000)
     const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
@@ -1031,6 +1160,58 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
     assert.strictEqual(exitCode, 0, testOutput)
     assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, retryCount + 1)
+  })
+
+  onlyLatestIt('restores native retries after attempt-to-fix is removed for a reusable run', async function () {
+    this.timeout(20_000)
+    const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
+    receiver.setSettings({
+      early_flake_detection: { enabled: false },
+      test_management: { enabled: true, attempt_to_fix_retries: 1 },
+    })
+    receiver.setTestManagementTestResponses([
+      {
+        mocha: {
+          suites: {
+            'ci-visibility/mocha-plugin-tests/reporter-reusable-run.js': {
+              tests: {
+                [testName]: { properties: { attempt_to_fix: true } },
+              },
+            },
+          },
+        },
+      },
+      {},
+    ])
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: {
+        ...getCiVisAgentlessConfig(receiver.port),
+        MOCHA_REUSABLE_NATIVE_RETRY: '1',
+      },
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.deepStrictEqual(
+          testEvents.map(event => event.content.meta[TEST_STATUS]),
+          ['fail', 'pass', 'fail', 'pass']
+        )
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 4)
   })
 
   it('reports a completed suite when the process exits before session finalization', async function () {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -269,6 +269,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           env: {
             ...getCiVisAgentlessConfig(receiver.port),
             MOCHA_REPORTER_THROW_EVENT: reporterEvent,
+            ...(['test', 'hook'].includes(reporterEvent) && { MOCHA_REPORT_PENDING_AT_END: '1' }),
           },
         }
       )
@@ -352,6 +353,9 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       if (reporterEvent === 'start' || reporterEvent === 'suite' || reporterEvent === 'test' ||
         reporterEvent === 'hook') {
         assert.doesNotMatch(testOutput, /MOCHA (?:BEFORE|AFTER|TEST)/)
+      }
+      if (reporterEvent === 'test' || reporterEvent === 'hook') {
+        assert.match(testOutput, /REPORTER TEST PENDING AT END: true/)
       }
       if (['pass', 'fail', 'pending', 'retry', 'test end'].includes(reporterEvent)) {
         assert.doesNotMatch(testOutput, /MOCHA AFTER EACH EXECUTED/)
@@ -473,6 +477,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         env: {
           ...getCiVisAgentlessConfig(receiver.port),
           MOCHA_REPORTER_THROW_EVENT: 'hook end',
+          MOCHA_REPORT_PENDING_AT_END: '1',
         },
       }
     )
@@ -504,6 +509,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     ])
     if (mochaMajor >= 8) assert.match(testOutput, /custom Mocha reporter failed/)
     assert.match(testOutput, /MOCHA BEFORE EACH EXECUTED/)
+    assert.match(testOutput, /REPORTER TEST PENDING AT END: true/)
     assert.doesNotMatch(testOutput, /MOCHA (?:AFTER EACH|TEST BODY) EXECUTED/)
     assert.notStrictEqual(exitCode, 0, testOutput)
   })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -719,6 +719,105 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 2)
   })
 
+  onlyLatestIt('restores EFD test context when the same Mocha instance runs again', async function () {
+    this.timeout(20_000)
+    const retryCount = 2
+    const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
+    receiver.setKnownTests({ mocha: {} })
+    receiver.setSettings({
+      early_flake_detection: {
+        enabled: true,
+        slow_test_retries: { '5s': retryCount },
+        faulty_session_threshold: 100,
+      },
+      known_tests_enabled: true,
+    })
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: {
+        ...getCiVisAgentlessConfig(receiver.port),
+        MOCHA_REUSABLE_LOG_ACTIVE_TEST: '1',
+      },
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.strictEqual(testEvents.length, (retryCount + 1) * 2, testOutput)
+        const activeTestSpanIds = [...testOutput.matchAll(/MOCHA REUSABLE ACTIVE TEST: ([0-9]+)/g)]
+          .map(match => match[1])
+          .sort()
+        assert.deepStrictEqual(
+          activeTestSpanIds,
+          testEvents.map(event => event.content.span_id.toString()).sort()
+        )
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual(
+      (testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length,
+      (retryCount + 1) * 2
+    )
+  })
+
+  onlyLatestIt('restores a Test Management disabled test before the next run', async function () {
+    this.timeout(20_000)
+    const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
+    receiver.setSettings({
+      early_flake_detection: { enabled: false },
+      test_management: { enabled: true },
+    })
+    receiver.setTestManagementTestResponses([
+      {
+        mocha: {
+          suites: {
+            'ci-visibility/mocha-plugin-tests/reporter-reusable-run.js': {
+              tests: {
+                [testName]: { properties: { disabled: true } },
+              },
+            },
+          },
+        },
+      },
+      {},
+    ])
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: getCiVisAgentlessConfig(receiver.port),
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.deepStrictEqual(testEvents.map(event => event.content.meta[TEST_STATUS]), ['skip', 'pass'])
+        assert.strictEqual(testEvents[0].content.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+        assert.ok(!(TEST_MANAGEMENT_IS_DISABLED in testEvents[1].content.meta))
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 1)
+  })
+
   onlyLatestIt('restores attempt-to-fix retries when the same Mocha instance runs again', async function () {
     this.timeout(20_000)
     const retryCount = 2

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -482,6 +482,71 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.notStrictEqual(exitCode, 0)
   })
 
+  for (const { file, name, status } of [
+    {
+      file: 'reporter-terminal-event.js',
+      name: 'mocha-test-pass-two can pass',
+      status: 'pass',
+    },
+    {
+      file: 'failing.js',
+      name: 'mocha-test-fail can fail',
+      status: 'fail',
+    },
+  ]) {
+    it(`preserves a completed ${status} test when a reporter throws on its afterEach hook`, async function () {
+      this.timeout(20_000)
+      childProcess = exec(
+        `node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/${file} ` +
+        '--reporter ./ci-visibility/mocha-reporter-throws.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            MOCHA_REPORTER_THROW_EVENT: 'hook',
+            MOCHA_REPORTER_THROW_AFTER_EACH: '1',
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testEvents = events.filter(event =>
+            event.type === 'test' && event.content.meta[TEST_NAME] === name
+          )
+          assert.strictEqual(testEvents.length, 1, 'expected one completed test event')
+          const [testEvent] = testEvents
+          assert.strictEqual(testEvent.content.meta[TEST_STATUS], status)
+          if (status === 'fail') {
+            assert.strictEqual(testEvent.content.error, 1)
+            assert.match(testEvent.content.meta[ERROR_MESSAGE], /Expected values to be strictly equal/)
+            assert.doesNotMatch(testEvent.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+          } else {
+            assert.strictEqual(testEvent.content.error, 0)
+          }
+          for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+            const event = events.find(event => event.type === eventType)
+            assert.ok(event, `expected ${eventType} event`)
+            assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(event.content.error, 1)
+            assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+          }
+        },
+        { hardTimeout: 20_000 }
+      )
+
+      const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+      if (mochaMajor >= 8) assert.match(testOutput, /custom Mocha reporter failed/)
+      assert.doesNotMatch(testOutput, /MOCHA AFTER EACH EXECUTED/)
+      assert.notStrictEqual(exitCode, 0, testOutput)
+    })
+  }
+
   onlyLatestIt('marks parallel worker suites as failed when the coordinator reporter throws', async function () {
     this.timeout(20_000)
     childProcess = exec(
@@ -621,6 +686,88 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 1)
     })
   }
+
+  onlyLatestIt('reports tests again when the same Mocha instance runs twice successfully', async function () {
+    this.timeout(20_000)
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: getCiVisAgentlessConfig(receiver.port),
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' &&
+          event.content.meta[TEST_NAME] === 'mocha-reporter-reusable-run runs again after reporter recovery'
+        )
+        assert.strictEqual(testEvents.length, 2)
+        assert.deepStrictEqual(testEvents.map(event => event.content.meta[TEST_STATUS]), ['pass', 'pass'])
+        const sessionEvents = events.filter(event => event.type === 'test_session_end')
+        assert.strictEqual(sessionEvents.length, 2)
+        assert.deepStrictEqual(sessionEvents.map(event => event.content.meta[TEST_STATUS]), ['pass', 'pass'])
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 2)
+  })
+
+  onlyLatestIt('restores attempt-to-fix retries when the same Mocha instance runs again', async function () {
+    this.timeout(20_000)
+    const retryCount = 2
+    const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
+    receiver.setSettings({
+      early_flake_detection: { enabled: false },
+      test_management: { enabled: true, attempt_to_fix_retries: retryCount },
+    })
+    receiver.setTestManagementTests({
+      mocha: {
+        suites: {
+          'ci-visibility/mocha-plugin-tests/reporter-reusable-run.js': {
+            tests: {
+              [testName]: { properties: { attempt_to_fix: true } },
+            },
+          },
+        },
+      },
+    })
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: {
+        ...getCiVisAgentlessConfig(receiver.port),
+        MOCHA_REUSABLE_REPORTER_EVENT: 'test',
+      },
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.strictEqual(testEvents.filter(event => event.content.meta[TEST_STATUS] === 'skip').length, 1)
+        const passedEvents = testEvents.filter(event => event.content.meta[TEST_STATUS] === 'pass')
+        assert.strictEqual(passedEvents.length, retryCount + 1)
+        assert.strictEqual(passedEvents.at(-1).content.meta[TEST_FINAL_STATUS], 'pass')
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, retryCount + 1)
+  })
 
   it('reports a completed suite when the process exits before session finalization', async function () {
     this.timeout(20_000)

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -246,7 +246,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       } else if (reporterEvent === 'hook end') {
         reporterTestFile = './ci-visibility/mocha-plugin-tests/passing-with-after-each.js'
       } else if (reporterEvent === 'pending') {
-        reporterTestFile = './ci-visibility/mocha-plugin-tests/skipping.js'
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/skipping-with-after-each.js'
       } else if (reporterEvent === 'retry') {
         reporterTestFile = './ci-visibility/mocha-plugin-tests/retries.js'
       } else if (reporterEvent === 'pass' || reporterEvent === 'test end') {
@@ -302,7 +302,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           if (reporterEvent === 'test end' || reporterEvent === 'hook end' || reporterEvent === 'pending') {
             let expectedTestName = 'mocha-test-pass-two can pass'
             if (reporterEvent === 'hook end') expectedTestName = 'mocha-reporter-hook-end can pass'
-            else if (reporterEvent === 'pending') expectedTestName = 'mocha-test-skip can skip'
+            else if (reporterEvent === 'pending') expectedTestName = 'mocha-reporter-pending-after-each can skip'
             const testEvents = events.filter(event =>
               event.type === 'test' && event.content.meta[TEST_NAME] === expectedTestName
             )
@@ -353,7 +353,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         reporterEvent === 'hook') {
         assert.doesNotMatch(testOutput, /MOCHA (?:BEFORE|AFTER|TEST)/)
       }
-      if (['pass', 'fail', 'retry', 'test end'].includes(reporterEvent)) {
+      if (['pass', 'fail', 'pending', 'retry', 'test end'].includes(reporterEvent)) {
         assert.doesNotMatch(testOutput, /MOCHA AFTER EACH EXECUTED/)
       }
       assert.notStrictEqual(exitCode, 0, testOutput)
@@ -533,6 +533,94 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.match(testOutput, /custom Mocha reporter failed/)
     assert.notStrictEqual(exitCode, 0, testOutput)
   })
+
+  onlyLatestIt('does not schedule parallel workers when the coordinator reporter throws on start', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha --parallel --jobs 2' +
+      ' ./ci-visibility/mocha-plugin-tests/reporter-run-start.js' +
+      ' ./ci-visibility/test/ci-visibility-test-2.js' +
+      ' --reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'start',
+        },
+      }
+    )
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        assert.strictEqual(events.some(event => event.type === 'test'), false)
+        assert.strictEqual(events.some(event => event.type === 'test_suite_end'), false)
+        for (const eventType of ['test_session_end', 'test_module_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.content.error, 1)
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.match(testOutput, /custom Mocha reporter failed/)
+    assert.doesNotMatch(testOutput, /MOCHA (?:BEFORE|AFTER|TEST)/)
+    assert.notStrictEqual(exitCode, 0, testOutput)
+  })
+
+  for (const reporterEvent of ['test', 'hook end']) {
+    onlyLatestIt(`restores reusable Mocha state after a reporter throws on ${reporterEvent}`, async function () {
+      this.timeout(20_000)
+      childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REUSABLE_REPORTER_EVENT: reporterEvent,
+        },
+      })
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testEvents = events.filter(event =>
+            event.type === 'test' &&
+            event.content.meta[TEST_NAME] === 'mocha-reporter-reusable-run runs again after reporter recovery'
+          )
+          assert.deepStrictEqual(
+            testEvents.map(event => event.content.meta[TEST_STATUS]).sort(),
+            ['pass', 'skip'],
+            testOutput
+          )
+          const sessionEvents = events.filter(event => event.type === 'test_session_end')
+          assert.deepStrictEqual(
+            sessionEvents.map(event => event.content.meta[TEST_STATUS]).sort(),
+            ['fail', 'pass'],
+            testOutput
+          )
+        },
+        { hardTimeout: 20_000 }
+      )
+
+      const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+      assert.strictEqual(exitCode, 0, testOutput)
+      assert.match(testOutput, /MOCHA FIRST RUN ERROR: custom reusable Mocha reporter failed/)
+      assert.match(testOutput, /MOCHA SECOND RUN FAILURES: 0/)
+      assert.strictEqual((testOutput.match(/MOCHA REUSABLE SECOND HOOK EXECUTED/g) || []).length, 1)
+      assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 1)
+    })
+  }
 
   it('reports a completed suite when the process exits before session finalization', async function () {
     this.timeout(20_000)

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -393,6 +393,75 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.notStrictEqual(exitCode, 0)
   })
 
+  it('finalizes a failed session when a reporter throws a non-coercible value', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/passing.js ' +
+      '--reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'end',
+          MOCHA_REPORTER_THROWS_UNCOERCIBLE: '1',
+        },
+      }
+    )
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.content.meta[ERROR_MESSAGE], 'Mocha reporter failed')
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.notStrictEqual(exitCode, 0)
+  })
+
+  for (const reporterThrows of [false, true]) {
+    it(`keeps suite coverage visible to a ${reporterThrows ? 'failing' : 'successful'} reporter`, async function () {
+      this.timeout(20_000)
+      childProcess = exec(
+        'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/reporter-coverage.js ' +
+        '--reporter ./ci-visibility/mocha-coverage-reporter.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            ...(reporterThrows && { MOCHA_COVERAGE_REPORTER_THROWS: '1' }),
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const sessionEvent = events.find(event => event.type === 'test_session_end')
+          assert.ok(sessionEvent, 'expected test_session_end event')
+          assert.strictEqual(sessionEvent.content.meta[TEST_STATUS], reporterThrows ? 'fail' : 'pass')
+        },
+        { hardTimeout: 20_000 }
+      )
+
+      const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+      assert.strictEqual(exitCode === 0, !reporterThrows, testOutput)
+      assert.match(testOutput, /MOCHA REPORTER COVERAGE: 1/)
+    })
+  }
+
   it('stops the test body when a custom reporter throws after beforeEach', async function () {
     this.timeout(20_000)
     childProcess = exec(
@@ -751,6 +820,48 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
     assert.strictEqual(exitCode, 0, testOutput)
     assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 2)
+  })
+
+  onlyLatestIt('restores native retry context when the same Mocha instance runs again', async function () {
+    this.timeout(20_000)
+    const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: {
+        ...getCiVisAgentlessConfig(receiver.port),
+        MOCHA_REUSABLE_LOG_ACTIVE_TEST: '1',
+        MOCHA_REUSABLE_NATIVE_RETRY: '1',
+      },
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === testName
+        )
+        assert.deepStrictEqual(
+          testEvents.map(event => event.content.meta[TEST_STATUS]),
+          ['fail', 'pass', 'fail', 'pass']
+        )
+        const activeTestSpanIds = [...testOutput.matchAll(/MOCHA REUSABLE ACTIVE TEST: ([0-9]+)/g)]
+          .map(match => match[1])
+          .sort()
+        assert.deepStrictEqual(
+          activeTestSpanIds,
+          testEvents.map(event => event.content.span_id.toString()).sort()
+        )
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.strictEqual(exitCode, 0, testOutput)
+    assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 4)
   })
 
   onlyLatestIt('restores EFD test context and retry policy when the same Mocha instance runs again', async function () {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -303,9 +303,11 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
             let expectedTestName = 'mocha-test-pass-two can pass'
             if (reporterEvent === 'hook end') expectedTestName = 'mocha-reporter-hook-end can pass'
             else if (reporterEvent === 'pending') expectedTestName = 'mocha-test-skip can skip'
-            const testEvent = events.find(event =>
+            const testEvents = events.filter(event =>
               event.type === 'test' && event.content.meta[TEST_NAME] === expectedTestName
             )
+            assert.strictEqual(testEvents.length, 1, 'expected one completed test event')
+            const [testEvent] = testEvents
             assert.ok(testEvent, 'expected completed test event')
             assert.strictEqual(testEvent.content.meta[TEST_STATUS], reporterEvent === 'pending' ? 'skip' : 'pass')
             assert.strictEqual(testEvent.content.error, 0)
@@ -457,10 +459,12 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       ({ url }) => url.endsWith('/api/v2/citestcycle'),
       (payloads) => {
         const events = payloads.flatMap(({ payload }) => payload.events)
-        const testEvent = events.find(event =>
+        const testEvents = events.filter(event =>
           event.type === 'test' && event.content.meta[TEST_NAME] ===
           'mocha-reporter-hook-end-outer mocha-reporter-hook-end-inner can pass after an inner hook reporter error'
         )
+        assert.strictEqual(testEvents.length, 1, 'expected one completed test event')
+        const [testEvent] = testEvents
         assert.ok(testEvent, 'expected completed test event')
         assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'pass')
         assert.strictEqual(testEvent.content.error, 0)

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -352,6 +352,39 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     })
   }
 
+  it('finalizes a failed session when a custom reporter throws undefined', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/passing.js ' +
+      '--reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'end',
+          MOCHA_REPORTER_THROWS_UNDEFINED: '1',
+        },
+      }
+    )
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.notStrictEqual(exitCode, 0)
+  })
+
   it('stops the test body when a custom reporter throws after beforeEach', async function () {
     this.timeout(20_000)
     childProcess = exec(

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -331,6 +331,12 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
             assert.ok(testEvent, 'expected aborted test event')
             assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'skip')
           }
+          if (reporterEvent === 'hook') {
+            const testEvent = events.find(event => event.type === 'test')
+            assert.ok(testEvent, 'expected aborted test event')
+            assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'skip')
+            assert.strictEqual(testEvent.content.error, 0)
+          }
         },
         { hardTimeout: 20_000 }
       )
@@ -429,6 +435,47 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.match(testOutput, /MOCHA BEFORE EACH EXECUTED/)
     assert.doesNotMatch(testOutput, /MOCHA (?:AFTER EACH|TEST BODY) EXECUTED/)
     assert.notStrictEqual(exitCode, 0, testOutput)
+  })
+
+  it('reports a completed test when a reporter throws on an inner afterEach hook', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/passing-with-after-each.js ' +
+      '--reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'hook end',
+          MOCHA_REPORTER_THROW_INNER_HOOK: '1',
+        },
+      }
+    )
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvent = events.find(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] ===
+          'mocha-reporter-hook-end-outer mocha-reporter-hook-end-inner can pass after an inner hook reporter error'
+        )
+        assert.ok(testEvent, 'expected completed test event')
+        assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'pass')
+        assert.strictEqual(testEvent.content.error, 0)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.notStrictEqual(exitCode, 0)
   })
 
   onlyLatestIt('marks parallel worker suites as failed when the coordinator reporter throws', async function () {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -233,6 +233,271 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     await receiver.stop()
   })
 
+  const reporterEvents = [
+    'end', 'start', 'fail', 'pass', 'pending', 'suite', 'test', 'test end', 'hook', 'hook end', 'suite end',
+  ]
+  if (supportsMochaRetryEvents) reporterEvents.push('retry')
+  for (const reporterEvent of reporterEvents) {
+    it(`finalizes a failed hierarchy when a custom reporter throws during runner ${reporterEvent}`, async function () {
+      this.timeout(20_000)
+      let reporterTestFile = './ci-visibility/mocha-plugin-tests/passing.js'
+      if (reporterEvent === 'fail') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/failing.js'
+      } else if (reporterEvent === 'hook end') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/passing-with-after-each.js'
+      } else if (reporterEvent === 'pending') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/skipping.js'
+      } else if (reporterEvent === 'retry') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/retries.js'
+      } else if (reporterEvent === 'pass' || reporterEvent === 'test end') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/reporter-terminal-event.js'
+      } else if (reporterEvent === 'start') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/reporter-run-start.js'
+      } else if (reporterEvent === 'suite') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/reporter-suite-start.js'
+      } else if (reporterEvent === 'test' || reporterEvent === 'hook') {
+        reporterTestFile = './ci-visibility/mocha-plugin-tests/reporter-test-start.js'
+      }
+      childProcess = exec(
+        [
+          'node node_modules/mocha/bin/mocha',
+          reporterTestFile,
+          '--reporter ./ci-visibility/mocha-reporter-throws.js',
+        ].join(' '),
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            MOCHA_REPORTER_THROW_EVENT: reporterEvent,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+      childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const hierarchyEventTypes = ['test_session_end', 'test_module_end']
+          if (reporterEvent !== 'start') hierarchyEventTypes.push('test_suite_end')
+          for (const eventType of hierarchyEventTypes) {
+            const event = events.find(event => event.type === eventType)
+            assert.ok(event, `expected ${eventType} event`)
+            assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(event.content.error, 1)
+            assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+          }
+          if (reporterEvent === 'fail') {
+            const testEvent = events.find(event =>
+              event.type === 'test' && event.content.meta[TEST_NAME] === 'mocha-test-fail can fail'
+            )
+            assert.ok(testEvent, 'expected failed test event')
+            assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(testEvent.content.error, 1)
+            assert.match(testEvent.content.meta[ERROR_MESSAGE], /Expected values to be strictly equal/)
+            assert.doesNotMatch(testEvent.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+          }
+          if (reporterEvent === 'test end' || reporterEvent === 'hook end' || reporterEvent === 'pending') {
+            let expectedTestName = 'mocha-test-pass-two can pass'
+            if (reporterEvent === 'hook end') expectedTestName = 'mocha-reporter-hook-end can pass'
+            else if (reporterEvent === 'pending') expectedTestName = 'mocha-test-skip can skip'
+            const testEvent = events.find(event =>
+              event.type === 'test' && event.content.meta[TEST_NAME] === expectedTestName
+            )
+            assert.ok(testEvent, 'expected completed test event')
+            assert.strictEqual(testEvent.content.meta[TEST_STATUS], reporterEvent === 'pending' ? 'skip' : 'pass')
+            assert.strictEqual(testEvent.content.error, 0)
+            assert.strictEqual(
+              testEvent.content.meta[TEST_SUITE],
+              reporterTestFile.slice(2)
+            )
+            assert.strictEqual(testEvent.content.meta[TEST_FRAMEWORK], 'mocha')
+            assert.strictEqual(testEvent.content.meta[TEST_TYPE], 'test')
+          }
+          if (reporterEvent === 'retry') {
+            const testEvent = events.find(event =>
+              event.type === 'test' && event.content.meta[TEST_NAME] === 'mocha-test-retries will be retried and pass'
+            )
+            assert.ok(testEvent, 'expected retried test event')
+            assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(testEvent.content.error, 1)
+            assert.match(testEvent.content.meta[ERROR_MESSAGE], /Expected values to be strictly equal/)
+            assert.doesNotMatch(testEvent.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+          }
+          if (reporterEvent === 'test') {
+            const testEvent = events.find(event => event.type === 'test')
+            assert.ok(testEvent, 'expected aborted test event')
+            assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'skip')
+          }
+        },
+        { hardTimeout: 20_000 }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+      // Mocha 5's uncaught-exception listener preserves the exit code but does not print the delayed error.
+      if (mochaMajor >= 8) assert.match(testOutput, /custom Mocha reporter failed/)
+      if (reporterEvent === 'start' || reporterEvent === 'suite' || reporterEvent === 'test' ||
+        reporterEvent === 'hook') {
+        assert.doesNotMatch(testOutput, /MOCHA (?:BEFORE|AFTER|TEST)/)
+      }
+      if (['pass', 'fail', 'retry', 'test end'].includes(reporterEvent)) {
+        assert.doesNotMatch(testOutput, /MOCHA AFTER EACH EXECUTED/)
+      }
+      assert.notStrictEqual(exitCode, 0, testOutput)
+    })
+  }
+
+  it('stops the test body when a custom reporter throws after beforeEach', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha' +
+      ' ./ci-visibility/mocha-plugin-tests/reporter-hook-end-before-each.js' +
+      ' --reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'hook end',
+        },
+      }
+    )
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.content.error, 1)
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+        }
+        const testEvent = events.find(event => event.type === 'test')
+        assert.ok(testEvent, 'expected aborted test event')
+        assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'skip')
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([
+      once(childProcess, 'exit'),
+      eventsPromise,
+    ])
+    if (mochaMajor >= 8) assert.match(testOutput, /custom Mocha reporter failed/)
+    assert.match(testOutput, /MOCHA BEFORE EACH EXECUTED/)
+    assert.doesNotMatch(testOutput, /MOCHA (?:AFTER EACH|TEST BODY) EXECUTED/)
+    assert.notStrictEqual(exitCode, 0, testOutput)
+  })
+
+  onlyLatestIt('marks parallel worker suites as failed when the coordinator reporter throws', async function () {
+    this.timeout(20_000)
+    childProcess = exec(
+      'node node_modules/mocha/bin/mocha --parallel --jobs 2' +
+      ' ./ci-visibility/mocha-plugin-tests/passing.js' +
+      ' ./ci-visibility/test/ci-visibility-test-2.js' +
+      ' --reporter ./ci-visibility/mocha-reporter-throws.js',
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          MOCHA_REPORTER_THROW_EVENT: 'suite end',
+        },
+      }
+    )
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const hierarchyEvents = events.filter(event =>
+          event.type === 'test_session_end' ||
+          event.type === 'test_module_end' ||
+          event.type === 'test_suite_end'
+        )
+        const sessionEvent = hierarchyEvents.find(event => event.type === 'test_session_end')
+        const suiteEvents = hierarchyEvents.filter(event => event.type === 'test_suite_end')
+
+        assert.ok(sessionEvent, 'expected test_session_end event')
+        assert.strictEqual(sessionEvent.content.meta[MOCHA_IS_PARALLEL], 'true')
+        assert.strictEqual(suiteEvents.length, 2)
+        assert.strictEqual(hierarchyEvents.length, 4)
+        for (const event of hierarchyEvents) {
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(event.content.error, 1)
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom Mocha reporter failed/)
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([
+      once(childProcess, 'exit'),
+      eventsPromise,
+    ])
+    assert.match(testOutput, /custom Mocha reporter failed/)
+    assert.notStrictEqual(exitCode, 0, testOutput)
+  })
+
+  it('reports a completed suite when the process exits before session finalization', async function () {
+    this.timeout(20_000)
+    const startedAt = Date.now()
+    childProcess = exec(
+      [
+        'node node_modules/mocha/bin/mocha',
+        './ci-visibility/mocha-plugin-tests/passing.js',
+        '--reporter ./ci-visibility/mocha-reporter-exits-after-suite.js',
+      ].join(' '),
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+        },
+      }
+    )
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const suiteEvents = events.filter(event =>
+          event.type === 'test_suite_end' &&
+          event.content.meta[TEST_SUITE] === 'ci-visibility/mocha-plugin-tests/passing.js'
+        )
+        assert.strictEqual(suiteEvents.length, 1)
+        assert.strictEqual(suiteEvents[0].content.meta[TEST_STATUS], 'pass')
+        assert.strictEqual(suiteEvents[0].content.error, 0)
+
+        const testEvent = events.find(event =>
+          event.type === 'test' && event.content.meta[TEST_NAME] === 'mocha-test-pass-two can pass'
+        )
+        assert.ok(testEvent, 'expected completed test event')
+        assert.strictEqual(testEvent.content.meta[TEST_STATUS], 'pass')
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([
+      once(childProcess, 'exit'),
+      eventsPromise,
+    ])
+
+    assert.strictEqual(exitCode, 0)
+    assert.ok(Date.now() - startedAt < 12_000, 'final writer flush should remain bounded')
+  })
+
   it('can run tests and report tests with the APM protocol (old agents)', (done) => {
     receiver.setInfoResponse({ endpoints: [] })
     receiver.payloadReceived(({ url }) => url === '/v0.4/traces').then(({ payload }) => {
@@ -2033,7 +2298,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       assert.strictEqual(packfileRequest.headers['dd-api-key'], '1')
 
       const eventTypes = eventsRequest.payload.events.map(event => event.type)
-      assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+      assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
       const numSuites = eventTypes.reduce(
         (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
       )
@@ -2148,7 +2413,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.ok(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
         const eventTypes = eventsRequest.payload.events.map(event => event.type)
-        assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
         const numSuites = eventTypes.reduce(
           (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
         )
@@ -2191,7 +2456,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       receiver.assertPayloadReceived(({ headers, payload }) => {
         assert.strictEqual(headers['dd-api-key'], '1')
         const eventTypes = payload.events.map(event => event.type)
-        assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
         const testSession = payload.events.find(event => event.type === 'test_session_end').content
         assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'false')
         assert.strictEqual(testSession.meta[TEST_CODE_COVERAGE_ENABLED], 'false')
@@ -2250,7 +2515,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.strictEqual(skippedSuite.meta[TEST_STATUS], 'skip')
         assert.strictEqual(skippedSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
 
-        assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
         const numSuites = eventTypes.reduce(
           (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
         )
@@ -2535,7 +2800,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.strictEqual(headers['dd-api-key'], '1')
         const eventTypes = payload.events.map(event => event.type)
         // because they are not skipped
-        assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
         const numSuites = eventTypes.reduce(
           (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
         )
@@ -2583,7 +2848,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.strictEqual(headers['dd-api-key'], '1')
         const eventTypes = payload.events.map(event => event.type)
         // because they are not skipped
-        assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
         const numSuites = eventTypes.reduce(
           (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
         )

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -687,6 +687,40 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     })
   }
 
+  onlyLatestIt('propagates a reporter error when the programmatic run callback throws', async function () {
+    this.timeout(20_000)
+    childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
+      cwd,
+      env: {
+        ...getCiVisAgentlessConfig(receiver.port),
+        MOCHA_REUSABLE_REPORTER_EVENT: 'test',
+        MOCHA_REUSABLE_RUN_CALLBACK_THROWS: '1',
+      },
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/citestcycle'),
+      (payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        for (const eventType of ['test_session_end', 'test_module_end', 'test_suite_end']) {
+          const event = events.find(event => event.type === eventType)
+          assert.ok(event, `expected ${eventType} event`)
+          assert.strictEqual(event.content.meta[TEST_STATUS], 'fail')
+          assert.match(event.content.meta[ERROR_MESSAGE], /custom reusable Mocha reporter failed/)
+        }
+      },
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+    assert.notStrictEqual(exitCode, 0, testOutput)
+    assert.match(testOutput, /MOCHA RUN CALLBACK EXECUTED/)
+    assert.match(testOutput, /MOCHA PROPAGATED ERROR: custom reusable Mocha reporter failed/)
+  })
+
   onlyLatestIt('reports tests again when the same Mocha instance runs twice successfully', async function () {
     this.timeout(20_000)
     childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
@@ -719,19 +753,30 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.strictEqual((testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length, 2)
   })
 
-  onlyLatestIt('restores EFD test context when the same Mocha instance runs again', async function () {
+  onlyLatestIt('restores EFD test context and retry policy when the same Mocha instance runs again', async function () {
     this.timeout(20_000)
-    const retryCount = 2
+    const firstRetryCount = 1
+    const secondRetryCount = 2
     const testName = 'mocha-reporter-reusable-run runs again after reporter recovery'
     receiver.setKnownTests({ mocha: {} })
-    receiver.setSettings({
-      early_flake_detection: {
-        enabled: true,
-        slow_test_retries: { '5s': retryCount },
-        faulty_session_threshold: 100,
+    receiver.setSettingsResponses([
+      {
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: { '5s': firstRetryCount },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
       },
-      known_tests_enabled: true,
-    })
+      {
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: { '5s': secondRetryCount },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
+      },
+    ])
     childProcess = exec('node ./ci-visibility/run-mocha-reporter-rerun.js', {
       cwd,
       env: {
@@ -750,7 +795,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         const testEvents = events.filter(event =>
           event.type === 'test' && event.content.meta[TEST_NAME] === testName
         )
-        assert.strictEqual(testEvents.length, (retryCount + 1) * 2, testOutput)
+        const expectedExecutions = firstRetryCount + secondRetryCount + 2
+        assert.strictEqual(testEvents.length, expectedExecutions, testOutput)
         const activeTestSpanIds = [...testOutput.matchAll(/MOCHA REUSABLE ACTIVE TEST: ([0-9]+)/g)]
           .map(match => match[1])
           .sort()
@@ -766,7 +812,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     assert.strictEqual(exitCode, 0, testOutput)
     assert.strictEqual(
       (testOutput.match(/MOCHA REUSABLE TEST EXECUTED/g) || []).length,
-      (retryCount + 1) * 2
+      firstRetryCount + secondRetryCount + 2
     )
   })
 

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -628,6 +628,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         env: {
           ...getCiVisAgentlessConfig(receiver.port),
           MOCHA_REPORTER_THROW_EVENT: 'suite end',
+          MOCHA_REPORT_RUNNER_EMIT_OWNER: '1',
         },
       }
     )
@@ -665,6 +666,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       eventsPromise,
     ])
     assert.match(testOutput, /custom Mocha reporter failed/)
+    assert.match(testOutput, /MOCHA RUNNER OWNS EMIT: false/)
     assert.notStrictEqual(exitCode, 0, testOutput)
   })
 

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -540,7 +540,7 @@ function stopCurrentHook (runner, hook) {
     hook.run = run
     const test = hook.ctx?.currentTest
     if (test) {
-      if (hook.parent?._afterEach?.includes(hook)) {
+      if (hook.parent?._afterEach?.includes(hook) || hook.parent?._afterAll?.includes(hook)) {
         markTestTerminal(runner, test)
         if (!test._ddTestFinishStarted) runnerTestEndHandlers.get(runner)?.(test)
       } else {
@@ -689,6 +689,22 @@ function resetPendingSuiteCoverage (runner) {
 }
 
 /**
+ * Reads a string Error property without invoking user code outside this boundary.
+ *
+ * @param {Error} error
+ * @param {'message' | 'name' | 'stack'} property
+ * @returns {string | undefined}
+ */
+function readErrorString (error, property) {
+  try {
+    const value = error[property]
+    if (typeof value === 'string') return value
+  } catch {
+    // Ignore user-defined accessors.
+  }
+}
+
+/**
  * Creates an Error for Test Optimization tags without coercing a user-thrown value.
  *
  * @param {unknown} frameworkError
@@ -696,13 +712,21 @@ function resetPendingSuiteCoverage (runner) {
  */
 function getFrameworkFinalizationError (frameworkError) {
   if (typeof frameworkError === 'string') return new Error(frameworkError)
+  let isError = false
   try {
-    if (frameworkError instanceof Error) return frameworkError
+    isError = frameworkError instanceof Error
   } catch {
     // User-thrown proxies can fail the instanceof prototype lookup.
   }
+  if (!isError) return new Error('Mocha reporter failed')
 
-  return new Error('Mocha reporter failed')
+  const message = readErrorString(frameworkError, 'message') || 'Mocha reporter failed'
+  const error = new Error(message)
+  const name = readErrorString(frameworkError, 'name')
+  const stack = readErrorString(frameworkError, 'stack')
+  if (name) error.name = name
+  if (stack) error.stack = stack
+  return error
 }
 
 /**

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -629,8 +629,8 @@ function wrapRunnerEmit (Runner) {
         if (hasPropagatedFrameworkError) return
 
         hasPropagatedFrameworkError = true
-        process.removeListener('uncaughtException', this.uncaught)
-        process.removeListener('unhandledRejection', this.unhandled)
+        if (typeof this.uncaught === 'function') process.removeListener('uncaughtException', this.uncaught)
+        if (typeof this.unhandled === 'function') process.removeListener('unhandledRejection', this.unhandled)
         process.nextTick(() => { throw frameworkError })
       }
 

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -53,6 +53,7 @@ const {
   testsQuarantined,
   getTestFullName,
   getRunTestsWrapper,
+  resetRunState,
   newTestsWithDynamicNames,
   attemptToFixExecutions,
   loggedAttemptToFixTests,
@@ -533,7 +534,14 @@ function stopCurrentHook (runner, hook) {
   hook.run = function (onDone) {
     hook.run = run
     const test = hook.ctx?.currentTest
-    if (test) markTestPending(runner, test)
+    if (test) {
+      if (hook.parent?._afterEach?.includes(hook)) {
+        markTestTerminal(runner, test)
+        if (!test._ddTestFinishStarted) runnerTestEndHandlers.get(runner)?.(test)
+      } else {
+        markTestPending(runner, test)
+      }
+    }
     onDone()
   }
 }
@@ -1111,6 +1119,7 @@ addHook({
     }
 
     const { onRunDone, onFlushDone } = getRunCompletionCallbacks(args[0])
+    resetRunState(this.suite)
     runnerFailuresAdjusted.delete(this)
     runnerFrameworkErrors.delete(this)
     runnerStarted.delete(this)

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -63,6 +63,16 @@ require('./common')
 
 const MINIMUM_MOCHA_VERSION = DD_MAJOR >= 6 ? '>=8.0.0' : '>=5.2.0'
 
+/**
+ * @typedef {{ replacement: Function, run: Function }} ReporterReplacement
+ * @typedef {{
+ *   createFileRunner?: ReporterReplacement,
+ *   hookRuns: Map<object, ReporterReplacement>,
+ *   pendingTests: Map<object, { hadPending: boolean, pending: unknown }>,
+ *   tests: Set<object>
+ * }} RunnerRecoveryState
+ */
+
 const patched = new WeakSet()
 const runnerEndHandlers = new WeakMap()
 const runnerHookMethods = new WeakMap()
@@ -70,6 +80,8 @@ const runnerTestEndHandlers = new WeakMap()
 const runnerFailuresAdjusted = new WeakSet()
 const runnerFrameworkErrors = new WeakMap()
 const runnerStarted = new WeakSet()
+const runnerRecoveryStates = new WeakMap()
+const parallelRunners = new WeakSet()
 const wrappedRunnerEmitPrototypes = new WeakSet()
 let hasWarnedDeprecatedMochaVersion = false
 
@@ -390,6 +402,88 @@ function adjustRunnerFailuresOnce (runner) {
 }
 
 /**
+ * Returns the mutations that must be restored after reporter-error recovery.
+ *
+ * @param {object} runner
+ * @returns {RunnerRecoveryState}
+ */
+function getRunnerRecoveryState (runner) {
+  let state = runnerRecoveryStates.get(runner)
+  if (!state) {
+    state = {
+      hookRuns: new Map(),
+      pendingTests: new Map(),
+      tests: new Set(),
+    }
+    runnerRecoveryStates.set(runner, state)
+  }
+  return state
+}
+
+/**
+ * Marks a test pending for the aborted run while retaining its reusable state.
+ *
+ * @param {object} runner
+ * @param {object} test
+ * @returns {void}
+ */
+function markTestPending (runner, test) {
+  const state = getRunnerRecoveryState(runner)
+  if (!state.pendingTests.has(test)) {
+    state.pendingTests.set(test, {
+      hadPending: Object.hasOwn(test, 'pending'),
+      pending: test.pending,
+    })
+  }
+  state.tests.add(test)
+  test.pending = true
+  test._ddReporterStartFailed = true
+}
+
+/**
+ * Marks a completed test for immediate reporter-error finalization.
+ *
+ * @param {object} runner
+ * @param {object} test
+ * @returns {void}
+ */
+function markTestTerminal (runner, test) {
+  getRunnerRecoveryState(runner).tests.add(test)
+  test._ddReporterTerminalFailed = true
+}
+
+/**
+ * Restores test and hook state changed only to abort the current run.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function restoreReporterMutations (runner) {
+  const state = runnerRecoveryStates.get(runner)
+  if (!state) return
+
+  runnerRecoveryStates.delete(runner)
+  for (const [test, { hadPending, pending }] of state.pendingTests) {
+    if (hadPending) test.pending = pending
+    else delete test.pending
+  }
+  for (const test of state.tests) {
+    delete test._ddTestFinishStarted
+    delete test._ddTestFinishPublished
+    delete test._ddIsFinalAttempt
+    delete test._ddHookFailed
+    delete test._ddReporterStartFailed
+    delete test._ddReporterTerminalFailed
+  }
+  for (const [hook, { replacement, run }] of state.hookRuns) {
+    if (hook.run === replacement) hook.run = run
+  }
+  if (state.createFileRunner && runner._createFileRunner === state.createFileRunner.replacement) {
+    runner._createFileRunner = state.createFileRunner.run
+  }
+}
+
+/**
  * Prevents Mocha from entering hooks or the test body after a test-start reporter error.
  *
  * @param {object} runner
@@ -400,8 +494,7 @@ function stopCurrentTest (runner, test) {
   const hookDown = runner.hookDown
   const hookUp = runner.hookUp
 
-  test.pending = true
-  test._ddReporterStartFailed = true
+  markTestPending(runner, test)
   runner.hookDown = function (name, onDone) {
     runner.hookDown = hookDown
     onDone()
@@ -440,10 +533,7 @@ function stopCurrentHook (runner, hook) {
   hook.run = function (onDone) {
     hook.run = run
     const test = hook.ctx?.currentTest
-    if (test) {
-      test.pending = true
-      test._ddReporterStartFailed = true
-    }
+    if (test) markTestPending(runner, test)
     onDone()
   }
 }
@@ -458,7 +548,7 @@ function stopCurrentHook (runner, hook) {
 function stopAfterEachHooks (runner, test) {
   const hookUp = runner.hookUp
 
-  test._ddReporterTerminalFailed = true
+  markTestTerminal(runner, test)
   runner.hookUp = function (name, onDone) {
     runner.hookUp = hookUp
     onDone()
@@ -497,10 +587,11 @@ function restoreFutureHooks (runner) {
 /**
  * Stops hooks remaining in the currently executing hook array.
  *
+ * @param {object} runner
  * @param {object} hook
  * @returns {boolean} whether the completed hook was a before-each hook
  */
-function stopRemainingCurrentHooks (hook) {
+function stopRemainingCurrentHooks (runner, hook) {
   const hookLists = [hook.parent?._beforeAll, hook.parent?._beforeEach, hook.parent?._afterEach, hook.parent?._afterAll]
 
   for (const hooks of hookLists) {
@@ -510,10 +601,12 @@ function stopRemainingCurrentHooks (hook) {
     for (let index = hookIndex + 1; index < hooks.length; index++) {
       const remainingHook = hooks[index]
       const run = remainingHook.run
-      remainingHook.run = function (onDone) {
+      const replacement = function (onDone) {
         remainingHook.run = run
         onDone()
       }
+      getRunnerRecoveryState(runner).hookRuns.set(remainingHook, { replacement, run })
+      remainingHook.run = replacement
     }
     return hooks === hook.parent._beforeEach
   }
@@ -528,10 +621,9 @@ function stopRemainingCurrentHooks (hook) {
  * @returns {void}
  */
 function stopAfterHookEnd (runner, hook) {
-  if (!stopRemainingCurrentHooks(hook) || !runner.test) return
+  if (!stopRemainingCurrentHooks(runner, hook) || !runner.test) return
 
-  runner.test.pending = true
-  runner.test._ddReporterStartFailed = true
+  markTestPending(runner, runner.test)
 }
 
 /**
@@ -547,6 +639,28 @@ function stopRootSuite (runner) {
     runner.runSuite = runSuite
     onDone()
   }
+}
+
+function skipParallelFile () {}
+
+function createSkippedParallelFileRunner () {
+  return skipParallelFile
+}
+
+/**
+ * Prevents a parallel run-start reporter error from scheduling test workers.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function stopParallelWorkers (runner) {
+  const state = getRunnerRecoveryState(runner)
+  if (state.createFileRunner) return
+
+  const run = runner._createFileRunner
+  const replacement = createSkippedParallelFileRunner
+  state.createFileRunner = { replacement, run }
+  runner._createFileRunner = replacement
 }
 
 /**
@@ -578,18 +692,21 @@ function wrapRunnerEmit (Runner) {
           runnerFrameworkErrors.set(this, error)
           this.abort()
           stopFutureHooks(this)
-          if (event === 'start') stopRootSuite(this)
-          else if (event === 'test') stopCurrentTest(this, arguments[1])
+          if (event === 'start') {
+            if (parallelRunners.has(this)) stopParallelWorkers(this)
+            else stopRootSuite(this)
+          } else if (event === 'test') stopCurrentTest(this, arguments[1])
           else if (event === 'hook') stopCurrentHook(this, arguments[1])
           else if (event === 'hook end') {
             const hook = arguments[1]
             stopAfterHookEnd(this, hook)
             const test = hook.ctx?.currentTest
             if (test && hook.parent?._afterEach?.includes(hook)) {
-              test._ddReporterTerminalFailed = true
+              markTestTerminal(this, test)
               if (!test._ddTestFinishStarted) runnerTestEndHandlers.get(this)?.(test)
             }
-          } else if (event === 'pass' || event === 'fail' || event === 'retry' || event === 'test end') {
+          } else if (event === 'pending' || event === 'pass' || event === 'fail' || event === 'retry' ||
+            event === 'test end') {
             const test = arguments[1]
             stopAfterEachHooks(this, test)
             if (event === 'test end' && !test._ddTestFinishStarted) {
@@ -603,6 +720,8 @@ function wrapRunnerEmit (Runner) {
 
     runnerEndHandlers.delete(this)
     restoreFutureHooks(this)
+    restoreReporterMutations(this)
+    parallelRunners.delete(this)
     runnerTestEndHandlers.delete(this)
     runnerStarted.delete(this)
     let result
@@ -1420,6 +1539,7 @@ addHook({
     runnerFailuresAdjusted.delete(this)
     runnerFrameworkErrors.delete(this)
     runnerStarted.delete(this)
+    parallelRunners.add(this)
     arguments[0] = () => {
       adjustRunnerFailuresOnce(this)
       if (!this.failures && runnerFrameworkErrors.has(this)) this.failures = 1

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -417,10 +417,9 @@ function stopCurrentTest (runner, test) {
  *
  * @param {object} runner
  * @param {object} hook
- * @param {Error} error
  * @returns {void}
  */
-function stopCurrentHook (runner, hook, error) {
+function stopCurrentHook (runner, hook) {
   const hookMethod = runner.hook
   const hookDown = runner.hookDown
   const hookUp = runner.hookUp
@@ -440,7 +439,12 @@ function stopCurrentHook (runner, hook, error) {
   }
   hook.run = function (onDone) {
     hook.run = run
-    onDone(error)
+    const test = hook.ctx?.currentTest
+    if (test) {
+      test.pending = true
+      test._ddReporterStartFailed = true
+    }
+    onDone()
   }
 }
 
@@ -576,9 +580,16 @@ function wrapRunnerEmit (Runner) {
           stopFutureHooks(this)
           if (event === 'start') stopRootSuite(this)
           else if (event === 'test') stopCurrentTest(this, arguments[1])
-          else if (event === 'hook') stopCurrentHook(this, arguments[1], error)
-          else if (event === 'hook end') stopAfterHookEnd(this, arguments[1])
-          else if (event === 'pass' || event === 'fail' || event === 'retry' || event === 'test end') {
+          else if (event === 'hook') stopCurrentHook(this, arguments[1])
+          else if (event === 'hook end') {
+            const hook = arguments[1]
+            stopAfterHookEnd(this, hook)
+            const test = hook.ctx?.currentTest
+            if (test && hook.parent?._afterEach?.includes(hook)) {
+              test._ddReporterTerminalFailed = true
+              if (!test._ddTestFinishStarted) runnerTestEndHandlers.get(this)?.(test)
+            }
+          } else if (event === 'pass' || event === 'fail' || event === 'retry' || event === 'test end') {
             const test = arguments[1]
             stopAfterEachHooks(this, test)
             if (event === 'test end' && !test._ddTestFinishStarted) {
@@ -1025,7 +1036,8 @@ addHook({
       if (hasFinishedRun) return
       if (hasEnded && pendingRootFinalizations === 0) {
         hasFinishedRun = true
-        onEnd.call(endRunner, endError, onFrameworkErrorDone)
+        if (onFrameworkErrorDone) onEnd.call(endRunner, endError, onFrameworkErrorDone)
+        else onEnd.call(endRunner)
       }
     }
 

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -376,8 +376,11 @@ function getOnEndHandler (isParallel, onDone) {
       isParallel,
       isFrameworkError: arguments.length > 0,
     }, () => {
-      onDone()
-      onFrameworkErrorDone?.()
+      try {
+        onDone()
+      } finally {
+        onFrameworkErrorDone?.()
+      }
     })
 
     logTestOptimizationSummary({

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -314,7 +314,7 @@ function getOnEndHandler (isParallel, onDone) {
       status = 'fail'
     }
 
-    if (frameworkError) {
+    if (arguments.length > 0) {
       status = 'fail'
     } else if (status === 'fail') {
       error = new Error(`Failed tests: ${this.failures}.`)
@@ -361,7 +361,7 @@ function getOnEndHandler (isParallel, onDone) {
       isEarlyFlakeDetectionFaulty: config.isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled: config.isTestManagementTestsEnabled,
       isParallel,
-      isFrameworkError: !!frameworkError,
+      isFrameworkError: arguments.length > 0,
     }, () => {
       onDone()
       onFrameworkErrorDone?.()
@@ -564,12 +564,13 @@ function wrapRunnerEmit (Runner) {
 
     if (!runnerStarted.has(this)) return emit.apply(this, arguments)
 
+    const hasPendingFrameworkError = runnerFrameworkErrors.has(this)
     const pendingFrameworkError = runnerFrameworkErrors.get(this)
     if (event !== 'end') {
       try {
         return emit.apply(this, arguments)
       } catch (error) {
-        if (!pendingFrameworkError) {
+        if (!hasPendingFrameworkError) {
           runnerFrameworkErrors.set(this, error)
           this.abort()
           stopFutureHooks(this)
@@ -580,7 +581,7 @@ function wrapRunnerEmit (Runner) {
           else if (event === 'pass' || event === 'fail' || event === 'retry' || event === 'test end') {
             const test = arguments[1]
             stopAfterEachHooks(this, test)
-            if (event === 'test end' && !test._ddTestFinishPublished) {
+            if (event === 'test end' && !test._ddTestFinishStarted) {
               runnerTestEndHandlers.get(this)?.(test)
             }
           }
@@ -594,28 +595,36 @@ function wrapRunnerEmit (Runner) {
     runnerTestEndHandlers.delete(this)
     runnerStarted.delete(this)
     let result
+    let hasFrameworkError = hasPendingFrameworkError
     let frameworkError = pendingFrameworkError
     try {
       result = emit.apply(this, arguments)
     } catch (error) {
-      frameworkError ||= error
+      if (!hasFrameworkError) {
+        hasFrameworkError = true
+        frameworkError = error
+        runnerFrameworkErrors.set(this, error)
+      }
     }
-    runnerFrameworkErrors.delete(this)
 
     adjustRunnerFailuresOnce(this)
 
-    if (frameworkError) {
+    if (hasFrameworkError) {
+      const finalizationError = frameworkError instanceof Error
+        ? frameworkError
+        : new Error(String(frameworkError))
       let hasPropagatedFrameworkError = false
       const propagateFrameworkError = () => {
         if (hasPropagatedFrameworkError) return
 
         hasPropagatedFrameworkError = true
         process.removeListener('uncaughtException', this.uncaught)
+        process.removeListener('unhandledRejection', this.unhandled)
         process.nextTick(() => { throw frameworkError })
       }
 
       try {
-        endHandler.call(this, frameworkError, propagateFrameworkError)
+        endHandler.call(this, finalizationError, propagateFrameworkError)
       } catch (finalizerError) {
         log.error('Datadog Mocha finalizer failed after a reporter error', finalizerError)
         propagateFrameworkError()
@@ -979,6 +988,7 @@ addHook({
       adjustRunnerFailuresOnce(this)
       if (!this.failures && runnerFrameworkErrors.has(this)) this.failures = 1
       onRunDone(this.failures)
+      runnerFrameworkErrors.delete(this)
     }
 
     const { suitesByTestFile, numSuitesByTestFile } = getSuitesByTestFile(this.suite)
@@ -1402,6 +1412,7 @@ addHook({
       adjustRunnerFailuresOnce(this)
       if (!this.failures && runnerFrameworkErrors.has(this)) this.failures = 1
       onRunDone(this.failures)
+      runnerFrameworkErrors.delete(this)
     }
 
     this.prependOnceListener('start', getOnStartHandler(frameworkVersion))

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -64,6 +64,13 @@ require('./common')
 const MINIMUM_MOCHA_VERSION = DD_MAJOR >= 6 ? '>=8.0.0' : '>=5.2.0'
 
 const patched = new WeakSet()
+const runnerEndHandlers = new WeakMap()
+const runnerHookMethods = new WeakMap()
+const runnerTestEndHandlers = new WeakMap()
+const runnerFailuresAdjusted = new WeakSet()
+const runnerFrameworkErrors = new WeakMap()
+const runnerStarted = new WeakSet()
+const wrappedRunnerEmitPrototypes = new WeakSet()
 let hasWarnedDeprecatedMochaVersion = false
 
 const unskippableSuites = []
@@ -292,12 +299,12 @@ function getOnStartHandler (frameworkVersion) {
 /**
  * @param {boolean} isParallel
  * @param {() => void} onDone
- * @returns {() => void}
+ * @returns {(frameworkError?: unknown, onFrameworkErrorDone?: () => void) => void}
  */
 function getOnEndHandler (isParallel, onDone) {
-  return function () {
+  return function (frameworkError, onFrameworkErrorDone) {
     let status = 'pass'
-    let error
+    let error = frameworkError
     if (this.stats) {
       status = this.stats.failures === 0 ? 'pass' : 'fail'
       if (this.stats.tests === 0) {
@@ -307,18 +314,9 @@ function getOnEndHandler (isParallel, onDone) {
       status = 'fail'
     }
 
-    adjustRunnerFailuresForTestOptimization(this, config)
-
-    // Recompute status after EFD and quarantine adjustments have reduced failure counts
-    if (status === 'fail') {
-      if (this.stats) {
-        status = this.stats.failures === 0 ? 'pass' : 'fail'
-      } else {
-        status = this.failures === 0 ? 'pass' : 'fail'
-      }
-    }
-
-    if (status === 'fail') {
+    if (frameworkError) {
+      status = 'fail'
+    } else if (status === 'fail') {
       error = new Error(`Failed tests: ${this.failures}.`)
     }
 
@@ -363,7 +361,11 @@ function getOnEndHandler (isParallel, onDone) {
       isEarlyFlakeDetectionFaulty: config.isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled: config.isTestManagementTestsEnabled,
       isParallel,
-    }, onDone)
+      isFrameworkError: !!frameworkError,
+    }, () => {
+      onDone()
+      onFrameworkErrorDone?.()
+    })
 
     logTestOptimizationSummary({
       attemptToFixExecutions,
@@ -372,6 +374,259 @@ function getOnEndHandler (isParallel, onDone) {
     })
     loggedAttemptToFixTests.clear()
   }
+}
+
+/**
+ * Applies Test Optimization failure suppression once per runner execution.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function adjustRunnerFailuresOnce (runner) {
+  if (runnerFailuresAdjusted.has(runner)) return
+
+  runnerFailuresAdjusted.add(runner)
+  adjustRunnerFailuresForTestOptimization(runner, config)
+}
+
+/**
+ * Prevents Mocha from entering hooks or the test body after a test-start reporter error.
+ *
+ * @param {object} runner
+ * @param {object} test
+ * @returns {void}
+ */
+function stopCurrentTest (runner, test) {
+  const hookDown = runner.hookDown
+  const hookUp = runner.hookUp
+
+  test.pending = true
+  test._ddReporterStartFailed = true
+  runner.hookDown = function (name, onDone) {
+    runner.hookDown = hookDown
+    onDone()
+  }
+  runner.hookUp = function (name, onDone) {
+    runner.hookUp = hookUp
+    onDone()
+  }
+}
+
+/**
+ * Prevents Mocha from entering a hook after its hook-start reporter event fails.
+ *
+ * @param {object} runner
+ * @param {object} hook
+ * @param {Error} error
+ * @returns {void}
+ */
+function stopCurrentHook (runner, hook, error) {
+  const hookMethod = runner.hook
+  const hookDown = runner.hookDown
+  const hookUp = runner.hookUp
+  const run = hook.run
+
+  runner.hook = function (name, onDone) {
+    runner.hook = hookMethod
+    onDone()
+  }
+  runner.hookDown = function (name, onDone) {
+    runner.hookDown = hookDown
+    onDone()
+  }
+  runner.hookUp = function (name, onDone) {
+    runner.hookUp = hookUp
+    onDone()
+  }
+  hook.run = function (onDone) {
+    hook.run = run
+    onDone(error)
+  }
+}
+
+/**
+ * Prevents Mocha from running after-each hooks after a terminal test reporter event fails.
+ *
+ * @param {object} runner
+ * @param {object} test
+ * @returns {void}
+ */
+function stopAfterEachHooks (runner, test) {
+  const hookUp = runner.hookUp
+
+  test._ddReporterTerminalFailed = true
+  runner.hookUp = function (name, onDone) {
+    runner.hookUp = hookUp
+    onDone()
+  }
+}
+
+/**
+ * Prevents Mocha from entering any subsequent user hooks after a reporter error.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function stopFutureHooks (runner) {
+  if (runnerHookMethods.has(runner)) return
+
+  runnerHookMethods.set(runner, runner.hook)
+  runner.hook = function (name, onDone) {
+    onDone()
+  }
+}
+
+/**
+ * Restores the runner hook method after reporter-error finalization.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function restoreFutureHooks (runner) {
+  const hook = runnerHookMethods.get(runner)
+  if (!hook) return
+
+  runnerHookMethods.delete(runner)
+  runner.hook = hook
+}
+
+/**
+ * Stops hooks remaining in the currently executing hook array.
+ *
+ * @param {object} hook
+ * @returns {boolean} whether the completed hook was a before-each hook
+ */
+function stopRemainingCurrentHooks (hook) {
+  const hookLists = [hook.parent?._beforeAll, hook.parent?._beforeEach, hook.parent?._afterEach, hook.parent?._afterAll]
+
+  for (const hooks of hookLists) {
+    const hookIndex = hooks?.indexOf(hook) ?? -1
+    if (hookIndex === -1) continue
+
+    for (let index = hookIndex + 1; index < hooks.length; index++) {
+      const remainingHook = hooks[index]
+      const run = remainingHook.run
+      remainingHook.run = function (onDone) {
+        remainingHook.run = run
+        onDone()
+      }
+    }
+    return hooks === hook.parent._beforeEach
+  }
+  return false
+}
+
+/**
+ * Prevents a completed before-each hook from continuing into the test body.
+ *
+ * @param {object} runner
+ * @param {object} hook
+ * @returns {void}
+ */
+function stopAfterHookEnd (runner, hook) {
+  if (!stopRemainingCurrentHooks(hook) || !runner.test) return
+
+  runner.test.pending = true
+  runner.test._ddReporterStartFailed = true
+}
+
+/**
+ * Prevents Mocha from entering the root suite after a run-start reporter error.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function stopRootSuite (runner) {
+  const runSuite = runner.runSuite
+
+  runner.runSuite = function (suite, onDone) {
+    runner.runSuite = runSuite
+    onDone()
+  }
+}
+
+/**
+ * Defers reporter errors until Mocha can emit its remaining lifecycle events, then
+ * runs Datadog's end handler and propagates the original error after finalization.
+ *
+ * @param {Function} Runner
+ * @returns {void}
+ */
+function wrapRunnerEmit (Runner) {
+  if (wrappedRunnerEmitPrototypes.has(Runner.prototype)) return
+
+  wrappedRunnerEmitPrototypes.add(Runner.prototype)
+  shimmer.wrap(Runner.prototype, 'emit', emit => function (event) {
+    const endHandler = runnerEndHandlers.get(this)
+    if (!endHandler) return emit.apply(this, arguments)
+
+    if (event === 'start') runnerStarted.add(this)
+
+    if (!runnerStarted.has(this)) return emit.apply(this, arguments)
+
+    const pendingFrameworkError = runnerFrameworkErrors.get(this)
+    if (event !== 'end') {
+      try {
+        return emit.apply(this, arguments)
+      } catch (error) {
+        if (!pendingFrameworkError) {
+          runnerFrameworkErrors.set(this, error)
+          this.abort()
+          stopFutureHooks(this)
+          if (event === 'start') stopRootSuite(this)
+          else if (event === 'test') stopCurrentTest(this, arguments[1])
+          else if (event === 'hook') stopCurrentHook(this, arguments[1], error)
+          else if (event === 'hook end') stopAfterHookEnd(this, arguments[1])
+          else if (event === 'pass' || event === 'fail' || event === 'retry' || event === 'test end') {
+            const test = arguments[1]
+            stopAfterEachHooks(this, test)
+            if (event === 'test end' && !test._ddTestFinishPublished) {
+              runnerTestEndHandlers.get(this)?.(test)
+            }
+          }
+        }
+        return
+      }
+    }
+
+    runnerEndHandlers.delete(this)
+    restoreFutureHooks(this)
+    runnerTestEndHandlers.delete(this)
+    runnerStarted.delete(this)
+    let result
+    let frameworkError = pendingFrameworkError
+    try {
+      result = emit.apply(this, arguments)
+    } catch (error) {
+      frameworkError ||= error
+    }
+    runnerFrameworkErrors.delete(this)
+
+    adjustRunnerFailuresOnce(this)
+
+    if (frameworkError) {
+      let hasPropagatedFrameworkError = false
+      const propagateFrameworkError = () => {
+        if (hasPropagatedFrameworkError) return
+
+        hasPropagatedFrameworkError = true
+        process.removeListener('uncaughtException', this.uncaught)
+        process.nextTick(() => { throw frameworkError })
+      }
+
+      try {
+        endHandler.call(this, frameworkError, propagateFrameworkError)
+      } catch (finalizerError) {
+        log.error('Datadog Mocha finalizer failed after a reporter error', finalizerError)
+        propagateFrameworkError()
+      }
+
+      return result
+    }
+
+    endHandler.call(this)
+    return result
+  })
 }
 
 function applyKnownTestsResponse ({ err, knownTests }) {
@@ -707,6 +962,7 @@ addHook({
   if (patched.has(Runner)) return Runner
 
   patched.add(Runner)
+  wrapRunnerEmit(Runner)
 
   shimmer.wrap(Runner.prototype, 'runTests', runTests => getRunTestsWrapper(runTests, config))
 
@@ -716,7 +972,14 @@ addHook({
     }
 
     const { onRunDone, onFlushDone } = getRunCompletionCallbacks(args[0])
-    args[0] = onRunDone
+    runnerFailuresAdjusted.delete(this)
+    runnerFrameworkErrors.delete(this)
+    runnerStarted.delete(this)
+    args[0] = () => {
+      adjustRunnerFailuresOnce(this)
+      if (!this.failures && runnerFrameworkErrors.has(this)) this.failures = 1
+      onRunDone(this.failures)
+    }
 
     const { suitesByTestFile, numSuitesByTestFile } = getSuitesByTestFile(this.suite)
     // Root-level tests (direct children of root, no describe wrapper) keyed by file.
@@ -733,6 +996,8 @@ addHook({
     let hasEnded = false
     let hasFinishedRun = false
     let endRunner
+    let endError
+    let onFrameworkErrorDone
 
     function updateRootTestForFinalAttempt (test) {
       if (!test._retriedTest) return
@@ -750,7 +1015,7 @@ addHook({
       if (hasFinishedRun) return
       if (hasEnded && pendingRootFinalizations === 0) {
         hasFinishedRun = true
-        onEnd.call(endRunner)
+        onEnd.call(endRunner, endError, onFrameworkErrorDone)
       }
     }
 
@@ -831,11 +1096,13 @@ addHook({
 
     const onEnd = getOnEndHandler(false, onFlushDone)
 
-    this.once('start', getOnStartHandler(frameworkVersion))
+    this.prependOnceListener('start', getOnStartHandler(frameworkVersion))
 
-    this.once('end', function () {
+    runnerEndHandlers.set(this, function (frameworkError, frameworkErrorDone) {
       hasEnded = true
       endRunner = this
+      endError = frameworkError
+      onFrameworkErrorDone = frameworkErrorDone
       finishRunIfReady()
     })
 
@@ -845,7 +1112,10 @@ addHook({
     // instead of suiteA -> suiteB -> testA -> ... -> testB)
     // when the suite has tests that are in the top level
     // (no describe(...))
-    this.on('test', function (test) {
+    this.prependListener('test', getOnTestHandler(true))
+    // Reporters are registered before Runner#run, so prepend this after the test handler
+    // to start the suite first and preserve the test event if a reporter throws.
+    this.prependListener('test', function (test) {
       const ctx = testFileToSuiteCtx.get(test.file)
       if (ctx?._pendingRootStart) {
         ctx._pendingRootStart = false
@@ -853,45 +1123,46 @@ addHook({
       }
     })
 
-    this.on('test', getOnTestHandler(true))
-
-    this.on('test end', getOnTestEndHandler(config, {
+    // Reporters are registered before this run wrapper. Prepend terminal handlers
+    // so a reporter error cannot strand a test span that Mocha already completed.
+    const onTestEnd = getOnTestEndHandler(config, {
       onStart: incrementPendingRootFinalization,
       onFinish: function (test) {
         finishRootSuiteAfterFinalAttempt(test)
         decrementPendingRootFinalization(test)
       },
-    }))
+    })
+    runnerTestEndHandlers.set(this, onTestEnd)
+    this.prependListener('test end', onTestEnd)
 
-    this.on('retry', getOnTestRetryHandler(config))
+    this.prependListener('retry', getOnTestRetryHandler(config))
 
-    // If the hook passes, 'hook end' will be emitted. Otherwise, 'fail' will be emitted
-    this.on('hook end', getOnHookEndHandler(config, {
-      onStart: incrementPendingRootFinalization,
-      onFinish: function (test) {
-        finishRootSuiteAfterFinalAttempt(test)
-        decrementPendingRootFinalization(test)
-      },
-    }))
-
-    this.on('hook end', function (hook) {
+    this.prependListener('hook end', function (hook) {
       const test = hook.ctx?.currentTest
       if (!test) return
       finishRootSuiteAfterFinalAttempt(test)
     })
 
-    this.on('fail', getOnFailHandler(true, config))
+    // If the hook passes, 'hook end' will be emitted. Otherwise, 'fail' will be emitted.
+    this.prependListener('hook end', getOnHookEndHandler(config, {
+      onStart: incrementPendingRootFinalization,
+      onFinish: function (test) {
+        finishRootSuiteAfterFinalAttempt(test)
+        decrementPendingRootFinalization(test)
+      },
+    }))
 
-    this.on('fail', function (testOrHook) {
+    this.prependListener('fail', function (testOrHook) {
       if (testOrHook.type !== 'hook') return
       const test = testOrHook.ctx?.currentTest
       if (!test) return
       finishRootSuiteAfterFinalAttempt(test)
     })
+    this.prependListener('fail', getOnFailHandler(true, config))
 
-    this.on('pending', getOnPendingHandler())
+    this.prependListener('pending', getOnPendingHandler())
 
-    this.on('suite', function (suite) {
+    this.prependListener('suite', function (suite) {
       if (suite.root || !suite.tests.length) {
         // This branch can be triggered when we have top level it(...) inside test files.
         // In that case, they all (even if they are from different files) are going to be
@@ -940,7 +1211,8 @@ addHook({
       }
     })
 
-    this.on('suite end', function (suite) {
+    // Reporters are registered before Runner#run, so this must run first when one throws.
+    this.prependListener('suite end', function (suite) {
       if (suite.root) {
         // Normal case: pure root-level files are finished by the 'test end' / 'hook end'
         // listeners via finishRootSuiteForFile. Two edge cases remain here:
@@ -1115,16 +1387,25 @@ addHook({
   versions: ['>=8.0.0'],
   file: 'lib/nodejs/parallel-buffered-runner.js',
 }, (ParallelBufferedRunner, frameworkVersion) => {
+  wrapRunnerEmit(ParallelBufferedRunner)
+
   shimmer.wrap(ParallelBufferedRunner.prototype, 'run', run => function (cb, { files, options = {} }) {
     if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
 
     const { onRunDone, onFlushDone } = getRunCompletionCallbacks(cb)
-    arguments[0] = onRunDone
+    runnerFailuresAdjusted.delete(this)
+    runnerFrameworkErrors.delete(this)
+    runnerStarted.delete(this)
+    arguments[0] = () => {
+      adjustRunnerFailuresOnce(this)
+      if (!this.failures && runnerFrameworkErrors.has(this)) this.failures = 1
+      onRunDone(this.failures)
+    }
 
-    this.once('start', getOnStartHandler(frameworkVersion))
-    this.once('end', getOnEndHandler(true, onFlushDone))
+    this.prependOnceListener('start', getOnStartHandler(frameworkVersion))
+    runnerEndHandlers.set(this, getOnEndHandler(true, onFlushDone))
 
     // Populate unskippable suites before config is fetched (matches serial mode at Mocha.prototype.run)
     for (const filePath of files) {

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -523,6 +523,7 @@ function stopCurrentHook (runner, hook) {
   const hookUp = runner.hookUp
   const run = hook.run
 
+  stopRemainingCurrentHooks(runner, hook)
   runner.hook = function (name, onDone) {
     runner.hook = hookMethod
     onDone()
@@ -1570,8 +1571,6 @@ addHook({
   versions: ['>=8.0.0'],
   file: 'lib/nodejs/parallel-buffered-runner.js',
 }, (ParallelBufferedRunner, frameworkVersion) => {
-  wrapRunnerEmit(ParallelBufferedRunner)
-
   shimmer.wrap(ParallelBufferedRunner.prototype, 'run', run => function (cb, { files, options = {} }) {
     if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -764,7 +764,6 @@ function wrapRunnerEmit (Runner) {
 
     runnerEndHandlers.delete(this)
     restoreFutureHooks(this)
-    restoreReporterMutations(this)
     parallelRunners.delete(this)
     runnerTestEndHandlers.delete(this)
     runnerStarted.delete(this)
@@ -779,6 +778,8 @@ function wrapRunnerEmit (Runner) {
         frameworkError = error
         runnerFrameworkErrors.set(this, error)
       }
+    } finally {
+      restoreReporterMutations(this)
     }
 
     adjustRunnerFailuresOnce(this)

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -82,6 +82,7 @@ const runnerFailuresAdjusted = new WeakSet()
 const runnerFrameworkErrors = new WeakMap()
 const runnerStarted = new WeakSet()
 const runnerRecoveryStates = new WeakMap()
+const runnersWithPendingCoverageReset = new WeakSet()
 const parallelRunners = new WeakSet()
 const wrappedRunnerEmitPrototypes = new WeakSet()
 let hasWarnedDeprecatedMochaVersion = false
@@ -675,6 +676,35 @@ function stopParallelWorkers (runner) {
 }
 
 /**
+ * Resets suite coverage after every reporter has observed the completed suite.
+ *
+ * @param {object} runner
+ * @returns {void}
+ */
+function resetPendingSuiteCoverage (runner) {
+  if (!runnersWithPendingCoverageReset.delete(runner) || !global.__coverage__) return
+
+  resetCoverage(global.__coverage__)
+}
+
+/**
+ * Creates an Error for Test Optimization tags without coercing a user-thrown value.
+ *
+ * @param {unknown} frameworkError
+ * @returns {Error}
+ */
+function getFrameworkFinalizationError (frameworkError) {
+  if (typeof frameworkError === 'string') return new Error(frameworkError)
+  try {
+    if (frameworkError instanceof Error) return frameworkError
+  } catch {
+    // User-thrown proxies can fail the instanceof prototype lookup.
+  }
+
+  return new Error('Mocha reporter failed')
+}
+
+/**
  * Defers reporter errors until Mocha can emit its remaining lifecycle events, then
  * runs Datadog's end handler and propagates the original error after finalization.
  *
@@ -726,6 +756,8 @@ function wrapRunnerEmit (Runner) {
           }
         }
         return
+      } finally {
+        if (event === 'suite end') resetPendingSuiteCoverage(this)
       }
     }
 
@@ -751,9 +783,7 @@ function wrapRunnerEmit (Runner) {
     adjustRunnerFailuresOnce(this)
 
     if (hasFrameworkError) {
-      const finalizationError = frameworkError instanceof Error
-        ? frameworkError
-        : new Error(String(frameworkError))
+      const finalizationError = getFrameworkFinalizationError(frameworkError)
       let hasPropagatedFrameworkError = false
       const propagateFrameworkError = () => {
         if (hasPropagatedFrameworkError) return
@@ -1440,7 +1470,7 @@ addHook({
         // We need to reset coverage to get a code coverage per suite
         // Before that, we preserve the original coverage
         mergeCoverage(global.__coverage__, originalCoverageMap)
-        resetCoverage(global.__coverage__)
+        runnersWithPendingCoverageReset.add(this)
       }
 
       const ctx = testFileToSuiteCtx.get(suite.file)

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -36,8 +36,10 @@ const testSuiteErrorCh = channel('ci:mocha:test-suite:error')
 
 const testToContext = new WeakMap()
 const originalFns = new WeakMap()
+const originalPendingByTest = new WeakMap()
 const testToStartLine = new WeakMap()
 const testFileToSuiteCtx = new Map()
+const datadogRetryOriginals = new WeakMap()
 const wrappedFunctions = new WeakSet()
 const newTests = {}
 const efdTests = {}
@@ -272,7 +274,7 @@ function retryTest (test, numRetries, tags, retryPolicy) {
   for (let retryIndex = 0; retryIndex < numRetries; retryIndex++) {
     const clonedTest = test.clone()
     disableMochaRetries(clonedTest)
-    clonedTest._ddIsDatadogRetry = true
+    datadogRetryOriginals.set(clonedTest, test)
     suite.addTest(clonedTest)
     if (isEfdRetry) {
       clonedTest._ddEfdRetryIndex = retryIndex + 1
@@ -297,6 +299,20 @@ function retryTest (test, numRetries, tags, retryPolicy) {
 }
 
 /**
+ * Restores a runnable function wrapped with its Test Optimization context.
+ *
+ * @param {import('mocha').Runnable} runnable
+ * @returns {void}
+ */
+function restoreRunnableFunction (runnable) {
+  const wrappedFunction = runnable.fn
+  if (!wrappedFunctions.has(wrappedFunction)) return
+
+  runnable.fn = originalFns.get(wrappedFunction)
+  wrappedFunctions.delete(wrappedFunction)
+}
+
+/**
  * Clears state that belongs to one Mocha runner execution and removes retry clones from prior executions.
  *
  * @param {import('mocha').Suite} rootSuite
@@ -318,8 +334,17 @@ function resetRunState (rootSuite) {
   while (suites.length) {
     const suite = suites.pop()
     const originalTests = []
-    for (const test of suite.tests) {
-      if (test._ddIsDatadogRetry) continue
+    const retainedTests = new Set()
+    for (const runnable of suite.tests) {
+      const test = datadogRetryOriginals.get(runnable) || runnable
+      if (retainedTests.has(test)) continue
+      retainedTests.add(test)
+
+      restoreRunnableFunction(test)
+      if (originalPendingByTest.has(test)) {
+        test.pending = originalPendingByTest.get(test)
+        originalPendingByTest.delete(test)
+      }
 
       delete test._ddIsAttemptToFix
       delete test._ddIsDisabled
@@ -471,11 +496,7 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
     const test = isTestHook ? this.ctx.currentTest : this
 
     // we restore the original user defined function
-    if (wrappedFunctions.has(this.fn)) {
-      const originalFn = originalFns.get(this.fn)
-      this.fn = originalFn
-      wrappedFunctions.delete(this.fn)
-    }
+    restoreRunnableFunction(this)
 
     if (isDatadogManagedRetryTest(test, libraryConfig)) {
       disableMochaRetries(this)
@@ -518,11 +539,7 @@ function getOnTestHandler (isMain) {
 
     // This may be a retry. If this is the case, `test.fn` is already wrapped,
     // so we need to restore it.
-    if (wrappedFunctions.has(test.fn)) {
-      const originalFn = originalFns.get(test.fn)
-      test.fn = originalFn
-      wrappedFunctions.delete(test.fn)
-    }
+    restoreRunnableFunction(test)
 
     inheritDatadogPropertiesFromRetriedTest(test)
 
@@ -585,6 +602,9 @@ function getOnTestHandler (isMain) {
     }
 
     if (!isAttemptToFix && isDisabled) {
+      if (!originalPendingByTest.has(test)) {
+        originalPendingByTest.set(test, test.pending)
+      }
       test.pending = true
     }
 

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -311,7 +311,6 @@ function restoreRunnableFunction (runnable) {
   if (!wrappedFunctions.has(wrappedFunction)) return
 
   runnable.fn = originalFns.get(wrappedFunction)
-  wrappedFunctions.delete(wrappedFunction)
 }
 
 /**

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -703,7 +703,12 @@ function getOnTestEndHandler (config, finalAttemptHandlers) {
     }
     const ctx = getTestContext(test)
     const status = getTestStatus(test)
-    const shouldFinishTest = ctx && (!getAfterEachHooks(test).length || (test._ddIsDisabled && !test._ddIsAttemptToFix))
+    const shouldFinishTest = ctx && (
+      test._ddReporterStartFailed ||
+      test._ddReporterTerminalFailed ||
+      !getAfterEachHooks(test).length ||
+      (test._ddIsDisabled && !test._ddIsAttemptToFix)
+    )
     let testFinishInfo
     let isFinalAttempt = false
 
@@ -734,6 +739,7 @@ function getOnTestEndHandler (config, finalAttemptHandlers) {
     }
 
     if (shouldFinishTest) {
+      test._ddTestFinishPublished = true
       testFinishCh.publish({
         status,
         hasBeenRetried: isMochaRetry(test),

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -372,6 +372,19 @@ function getTestContext (test) {
 }
 
 /**
+ * Claims publication of a test finish event across Mocha's terminal event paths.
+ *
+ * @param {object} test
+ * @returns {boolean}
+ */
+function startTestFinish (test) {
+  if (test._ddTestFinishStarted || test._ddTestFinishPublished) return false
+
+  test._ddTestFinishStarted = true
+  return true
+}
+
+/**
  * Copies Test Management metadata from Mocha's original runnable to its native retry clone.
  * @param {{
  *   _retriedTest?: {
@@ -702,8 +715,6 @@ function getOnTestEndHandler (config, finalAttemptHandlers) {
       return
     }
     const shouldWaitForHitProbe = test._retriedTest?._ddShouldWaitForHitProbe
-    if (test._ddTestFinishPublished || (shouldWaitForHitProbe && test._ddTestFinishStarted)) return
-    if (shouldWaitForHitProbe) test._ddTestFinishStarted = true
     const ctx = getTestContext(test)
     const status = getTestStatus(test)
     const shouldFinishTest = ctx && (
@@ -712,6 +723,7 @@ function getOnTestEndHandler (config, finalAttemptHandlers) {
       !getAfterEachHooks(test).length ||
       (test._ddIsDisabled && !test._ddIsAttemptToFix)
     )
+    if (shouldFinishTest && !startTestFinish(test)) return
     let testFinishInfo
     let isFinalAttempt = false
 
@@ -769,10 +781,11 @@ function getOnHookEndHandler (config, finalAttemptHandlers) {
         const ctx = getTestContext(test)
         // Disabled tests are already finished in getOnTestEndHandler,
         // skip to avoid double-publishing
-        if (ctx && (!test._ddIsDisabled || test._ddIsAttemptToFix)) {
+        if (ctx && (!test._ddIsDisabled || test._ddIsAttemptToFix) && startTestFinish(test)) {
           const testFinishInfo = getTestFinishInfo(test, status, config, ctx.err || test.err)
           const isFinalAttempt = testFinishInfo.finalStatus !== undefined
           const publishTestFinish = () => {
+            test._ddTestFinishPublished = true
             testFinishCh.publish({
               status,
               hasBeenRetried: isMochaRetry(test),
@@ -896,7 +909,7 @@ function getOnFailHandler (isMain, config) {
       testContext = getTestContext(test)
     }
     if (testContext) {
-      if (isHook) {
+      if (isHook && startTestFinish(test)) {
         const hookError = new Error(`${testOrHook.fullTitle()}: ${err.message}`, { cause: err })
         hookError.name = err.name
         hookError.stack = err.stack
@@ -917,6 +930,7 @@ function getOnFailHandler (isMain, config) {
         // test.state is never set to 'failed' for hook failures (Mocha marks the hook,
         // not the test). Flag it so finishRootSuiteForFile can compute the correct status.
         test._ddHookFailed = true
+        test._ddTestFinishPublished = true
         testFinishCh.publish({
           status: 'fail',
           hasBeenRetried: isMochaRetry(test),

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -272,6 +272,7 @@ function retryTest (test, numRetries, tags, retryPolicy) {
   for (let retryIndex = 0; retryIndex < numRetries; retryIndex++) {
     const clonedTest = test.clone()
     disableMochaRetries(clonedTest)
+    clonedTest._ddIsDatadogRetry = true
     suite.addTest(clonedTest)
     if (isEfdRetry) {
       clonedTest._ddEfdRetryIndex = retryIndex + 1
@@ -292,6 +293,50 @@ function retryTest (test, numRetries, tags, retryPolicy) {
         clonedTest[tag] = true
       }
     }
+  }
+}
+
+/**
+ * Clears state that belongs to one Mocha runner execution and removes retry clones from prior executions.
+ *
+ * @param {import('mocha').Suite} rootSuite
+ * @returns {void}
+ */
+function resetRunState (rootSuite) {
+  for (const key of Object.keys(newTests)) delete newTests[key]
+  for (const key of Object.keys(efdTests)) delete efdTests[key]
+  newTestsWithDynamicNames.clear()
+  testsAttemptToFix.clear()
+  testsQuarantined.clear()
+  testsStatuses.clear()
+  efdRetryCountByTestFullName.clear()
+  efdSlowAbortedTests.clear()
+  attemptToFixExecutions.clear()
+  loggedAttemptToFixTests.clear()
+
+  const suites = [rootSuite]
+  while (suites.length) {
+    const suite = suites.pop()
+    const originalTests = []
+    for (const test of suite.tests) {
+      if (test._ddIsDatadogRetry) continue
+
+      delete test._ddIsAttemptToFix
+      delete test._ddIsDisabled
+      delete test._ddIsQuarantined
+      delete test._ddIsModified
+      delete test._ddIsNew
+      delete test._ddShouldSkipEfdRetry
+      delete test._ddTestFinishStarted
+      delete test._ddTestFinishPublished
+      delete test._ddIsFinalAttempt
+      delete test._ddHookFailed
+      delete test._ddReporterStartFailed
+      delete test._ddReporterTerminalFailed
+      originalTests.push(test)
+    }
+    suite.tests = originalTests
+    suites.push(...suite.suites)
   }
 }
 
@@ -1113,6 +1158,7 @@ module.exports = {
   getOnPendingHandler,
   testFileToSuiteCtx,
   getRunTestsWrapper,
+  resetRunState,
   newTests,
   efdTests,
   newTestsWithDynamicNames,

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -701,6 +701,9 @@ function getOnTestEndHandler (config, finalAttemptHandlers) {
     if (test._ddShouldSkipEfdRetry) {
       return
     }
+    const shouldWaitForHitProbe = test._retriedTest?._ddShouldWaitForHitProbe
+    if (test._ddTestFinishPublished || (shouldWaitForHitProbe && test._ddTestFinishStarted)) return
+    if (shouldWaitForHitProbe) test._ddTestFinishStarted = true
     const ctx = getTestContext(test)
     const status = getTestStatus(test)
     const shouldFinishTest = ctx && (
@@ -734,7 +737,7 @@ function getOnTestEndHandler (config, finalAttemptHandlers) {
       finalAttemptHandlers?.onStart?.(test)
     }
 
-    if (test._retriedTest?._ddShouldWaitForHitProbe) {
+    if (shouldWaitForHitProbe) {
       await waitForHitProbe()
     }
 
@@ -894,10 +897,12 @@ function getOnFailHandler (isMain, config) {
     }
     if (testContext) {
       if (isHook) {
-        err.message = `${testOrHook.fullTitle()}: ${err.message}`
-        testContext.err = err
+        const hookError = new Error(`${testOrHook.fullTitle()}: ${err.message}`, { cause: err })
+        hookError.name = err.name
+        hookError.stack = err.stack
+        testContext.err = hookError
         errorCh.runStores(testContext, () => {})
-        const testFinishInfo = getTestFinishInfo(test, 'fail', config, err)
+        const testFinishInfo = getTestFinishInfo(test, 'fail', config, hookError)
         // ATR never retries hook failures: this.retries(N) is set in runnableWrapper
         // which only runs when the test function executes — hooks bypass that path,
         // so _retries stays at -1 and getIsLastRetry returns false, leaving finalStatus

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -38,6 +38,7 @@ const testToContext = new WeakMap()
 const originalEfdFns = new WeakMap()
 const originalFns = new WeakMap()
 const originalPendingByTest = new WeakMap()
+const originalRetriesByTest = new WeakMap()
 const testToStartLine = new WeakMap()
 const testFileToSuiteCtx = new Map()
 const datadogRetryOriginals = new WeakMap()
@@ -269,6 +270,7 @@ function isEarlyFlakeDetectionTest (test, config) {
 function retryTest (test, numRetries, tags, retryPolicy) {
   const suite = test.parent
   const isEfdRetry = tags.includes('_ddIsEfdRetry')
+  if (!originalRetriesByTest.has(test)) originalRetriesByTest.set(test, test.retries())
   disableMochaRetries(test)
   if (isEfdRetry) {
     wrapOriginalEfdTest(test, retryPolicy)
@@ -360,6 +362,10 @@ function resetRunState (rootSuite) {
       if (originalPendingByTest.has(test)) {
         test.pending = originalPendingByTest.get(test)
         originalPendingByTest.delete(test)
+      }
+      if (originalRetriesByTest.has(test)) {
+        test.retries(originalRetriesByTest.get(test))
+        originalRetriesByTest.delete(test)
       }
 
       delete test._ddIsAttemptToFix

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -35,6 +35,7 @@ const testSuiteErrorCh = channel('ci:mocha:test-suite:error')
 /** @typedef {{ length: number, [index: number]: unknown } & Iterable<unknown>} ArgumentsLike */
 
 const testToContext = new WeakMap()
+const originalEfdFns = new WeakMap()
 const originalFns = new WeakMap()
 const originalPendingByTest = new WeakMap()
 const testToStartLine = new WeakMap()
@@ -171,6 +172,7 @@ function wrapOriginalEfdTest (test, retryPolicy) {
   }
   test._ddEfdDurationWrapped = true
   const originalFn = test.fn
+  originalEfdFns.set(test, originalFn)
   test.fn = shimmer.wrapFunction(originalFn, originalFn => function () {
     const start = performance.now()
     const recordDuration = () => {
@@ -313,6 +315,20 @@ function restoreRunnableFunction (runnable) {
 }
 
 /**
+ * Restores a test function wrapped to measure its EFD duration.
+ *
+ * @param {import('mocha').Test} test
+ * @returns {void}
+ */
+function restoreEfdTestFunction (test) {
+  if (!originalEfdFns.has(test)) return
+
+  test.fn = originalEfdFns.get(test)
+  originalEfdFns.delete(test)
+  delete test._ddEfdDurationWrapped
+}
+
+/**
  * Clears state that belongs to one Mocha runner execution and removes retry clones from prior executions.
  *
  * @param {import('mocha').Suite} rootSuite
@@ -341,6 +357,7 @@ function resetRunState (rootSuite) {
       retainedTests.add(test)
 
       restoreRunnableFunction(test)
+      restoreEfdTestFunction(test)
       if (originalPendingByTest.has(test)) {
         test.pending = originalPendingByTest.get(test)
         originalPendingByTest.delete(test)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -486,11 +486,14 @@ class MochaPlugin extends CiPlugin {
         if (exporter.deferTestSuiteSpan) {
           exporter.deferTestSuiteSpan(testSuiteSpan)
           testSuiteSpan.finish()
-        } else {
+        } else if (exporter.exportDeferredTestSuiteSpans) {
+          const finishTime = this._now()
           this._pendingTestSuiteSpans.push({
             span: testSuiteSpan,
-            finishTime: testSuiteSpan._getTime(),
+            finishTime,
           })
+        } else {
+          testSuiteSpan.finish()
         }
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { performance } = require('node:perf_hooks')
+const dateNow = Date.now
 const { fileURLToPath } = require('node:url')
 
 const { channel } = require('dc-polyfill')
@@ -173,6 +174,15 @@ class MochaPlugin extends CiPlugin {
 
     this._testTitleToParams = {}
     this.sourceRoot = process.cwd()
+    this._pendingTestSuiteSpans = []
+    this._timeOrigin = dateNow()
+    this._perfOrigin = performance.now()
+
+    this.addSub('ci:mocha:session:start', () => {
+      this._pendingTestSuiteSpans = []
+      this._timeOrigin = dateNow()
+      this._perfOrigin = performance.now()
+    })
 
     this.addSub('ci:mocha:worker:configuration', ({
       libraryConfig,
@@ -472,7 +482,16 @@ class MochaPlugin extends CiPlugin {
         if (!testSuiteSpan.context().getTag(TEST_STATUS)) {
           testSuiteSpan.setTag(TEST_STATUS, status)
         }
-        testSuiteSpan.finish()
+        const exporter = this.tracer._exporter
+        if (exporter.deferTestSuiteSpan) {
+          exporter.deferTestSuiteSpan(testSuiteSpan)
+          testSuiteSpan.finish()
+        } else {
+          this._pendingTestSuiteSpans.push({
+            span: testSuiteSpan,
+            finishTime: testSuiteSpan._getTime(),
+          })
+        }
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       }
     })
@@ -522,6 +541,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:worker:finish', ({ onDone } = {}) => {
+      this._finishPendingTestSuiteSpans()
       this.tracer._exporter.flush(onDone)
     })
 
@@ -715,6 +735,7 @@ class MochaPlugin extends CiPlugin {
       isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled,
       isParallel,
+      isFrameworkError,
       onDone,
     }) => {
       this._exportPendingWorkerTraces()
@@ -730,7 +751,16 @@ class MochaPlugin extends CiPlugin {
         if (error) {
           this.testSessionSpan.setTag('error', error)
           this.testModuleSpan.setTag('error', error)
+          if (isFrameworkError) {
+            this.tracer._exporter.setDeferredTestSuiteError?.(error)
+            for (const testSuiteSpan of this._testSuiteSpansByTestSuite.values()) {
+              testSuiteSpan.setTag(TEST_STATUS, 'fail')
+              testSuiteSpan.setTag('error', error)
+            }
+          }
         }
+
+        this._finishPendingTestSuiteSpans()
 
         if (isParallel) {
           this.testSessionSpan.setTag(MOCHA_IS_PARALLEL, 'true')
@@ -769,6 +799,7 @@ class MochaPlugin extends CiPlugin {
           this.testSessionSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'faulty')
         }
 
+        this.tracer._exporter.exportDeferredTestSuiteSpans?.()
         this.testModuleSpan.finish()
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')
         this.testSessionSpan.finish()
@@ -788,6 +819,27 @@ class MochaPlugin extends CiPlugin {
     this.addBind('ci:mocha:global:run', (ctx) => {
       return ctx.currentStore
     })
+  }
+
+  /**
+   * Returns the current time in the coordinate system used by spans.
+   *
+   * @returns {number}
+   */
+  _now () {
+    return this._timeOrigin + performance.now() - this._perfOrigin
+  }
+
+  /**
+   * Finishes suites retained for a later framework finalization event.
+   *
+   * @returns {void}
+   */
+  _finishPendingTestSuiteSpans () {
+    for (const { span, finishTime } of this._pendingTestSuiteSpans) {
+      span.finish(finishTime)
+    }
+    this._pendingTestSuiteSpans = []
   }
 
   /**


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Preserves Mocha Test Optimization events when a custom reporter throws during a runner lifecycle event. Datadog's terminal handlers run before user reporters where required, completed tests are emitted exactly once, and suite/module/session finalization records the original reporter error before Mocha receives it and exits non-zero.

For example:

```js
afterEach(() => {})

it('passes', () => {})

// In a custom reporter:
runner.on('hook end', () => {
  throw new Error('reporter failed')
})
```

Before this change, the thrown listener could stop Mocha from reaching Datadog's remaining listeners. The completed test could be missing or published twice during recovery, and the test session trace could be left without its suite/module/session end events. After this change, the test is reported once as passed, the suite/module/session are reported as failed with `reporter failed`, the final writer flush remains bounded, and Mocha still exits with a non-zero status.

Completed suites also remain available if the process exits before normal session finalization, and suite timestamps use each span's own trace clock so sequential test files do not appear to overlap.

### Motivation
Node.js `EventEmitter` stops dispatching the remaining listeners when one listener throws. A reporter registered before Datadog could therefore interrupt test, hook, suite, or run-end handling and leave an incomplete test session trace. Reporter-error recovery must preserve all completed events without hiding the framework error or changing Mocha's exit behavior.

### Additional Notes
Builds on #9790, which provides deferred test session trace support for applying late status and error tags before the final flush.

Validation:
- Complete Mocha 8 integration suite: 146 passing, 63 version-gated pending
- Complete current-Mocha integration suite: 209 passing
- Reporter failures at runner `start`, `end`, test, hook, retry, suite, and terminal events
- Last and inner `afterEach` regressions assert exactly one completed test event
- Interrupted session-finalization and sequential-suite timing regressions
- ESLint for the modified files
