### PR TITLE
fix(profiling): resolve web tags for descendants cached before promotion

### DIFF
--- a/packages/dd-trace/src/otel-thread-ctx.js
+++ b/packages/dd-trace/src/otel-thread-ctx.js
@@ -254,6 +254,12 @@ function onWebTagsResolved (span) {
   cached.webTags = webTags
   const endpoint = finalEndpoint(webTags)
   if (endpoint === undefined) {
+    // A record that already shows the outer request's endpoint goes on showing
+    // it until the nearer one settles: the record buffer is append-only, so
+    // there is no way to take the attribute back, and rebuilding the
+    // ThreadContext would strand every async-context frame holding this one.
+    // The work is still nested in the outer request, which makes that the least
+    // wrong of the values available.
     awaitEndpoint(webTags, cached)
   } else {
     appendEndpoint(cached.context, endpoint)

--- a/packages/dd-trace/src/otel-thread-ctx.js
+++ b/packages/dd-trace/src/otel-thread-ctx.js
@@ -105,6 +105,10 @@ const THREAD_ID = String(threadId)
 //             time onEnter activates the span, and cleared on span finish, which
 //             is how a pendingEndpoints waiter recognizes a record it must no
 //             longer append to.
+//   webTags:  the web-server tag bag the record's endpoint comes from, or is
+//             waiting on; undefined while the span has no web-server ancestry.
+//             Distinguishes a stale announcement from a live one when a nearer
+//             web-server span takes over.
 const CachedSym = Symbol('OtelThreadCtx.cached')
 
 let started = false
@@ -137,6 +141,7 @@ function getOrBuildContext (span) {
     span[CachedSym] = cached
   }
   cached.context = new ThreadContext(traceId, spanId, attrs)
+  cached.webTags = webTags
   if (endpoint === undefined) awaitEndpoint(webTags, cached)
   return cached.context
 }
@@ -227,19 +232,26 @@ function onEndpointResolved (span) {
   if (endpoint === undefined) return
   pendingEndpoints.delete(webTags)
   for (const cached of waiting) {
-    if (cached.context !== undefined) appendEndpoint(cached.context, endpoint)
+    // A record whose span has since been attributed to a nearer web-server span
+    // enlisted again under that bag, and this one is no longer its endpoint.
+    if (cached.context !== undefined && cached.webTags === webTags) appendEndpoint(cached.context, endpoint)
   }
 }
 
-// A span whose record was built before it looked like a web-server span at all
-// has just been recognized as one, so it has no endpoint and never enlisted for
-// this request. Its ancestry can't have changed, only its own tags, so this is
-// only ever about the announced span's own record.
+// webTagsCache has changed which request it attributes this span to: the span
+// itself or an ancestor was recognized as a web-server span, giving a record
+// built without any web-server ancestry its first endpoint, or a nearer
+// web-server span superseded the one this record is showing. Give the record
+// the new request's endpoint if it has settled, or wait for its announcement.
 function onWebTagsResolved (span) {
   if (!started) return
   const cached = span[CachedSym]
   if (cached === undefined || cached.context === undefined) return
   const webTags = webTagsCache.getCachedWebTags(span)
+  if (webTags === cached.webTags) return
+  // Recorded so that an announcement for the bag this record was previously
+  // waiting on no longer applies to it.
+  cached.webTags = webTags
   const endpoint = finalEndpoint(webTags)
   if (endpoint === undefined) {
     awaitEndpoint(webTags, cached)

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -168,8 +168,8 @@ class NativeWallProfiler {
         spanFinishCh.subscribe(this.#boundSpanFinished)
         if (this.#endpointCollectionEnabled) {
           // Web-tags cache publishes once per span at the moment its
-          // walk-result transitions from undefined to a real value —
-          // exactly when we need to refresh the ProfilingContext snapshot.
+          // walk-result changes — exactly when we need to refresh the
+          // ProfilingContext snapshot.
           webTagsCache.resolvedCh.subscribe(this.#boundSpanTagsUpdated)
           // Turn on the cache's own tagsUpdate subscription — it's
           // ref-counted, so this composes with any other active consumer.
@@ -266,8 +266,8 @@ class NativeWallProfiler {
       }
 
       // webTags is snapshotted into the sample context at getProfilingContext
-      // time; if the answer turns out to be undefined and the span later gets
-      // web-server tags, #spanTagsUpdated refreshes this field via the shared
+      // time; if the answer changes later — the span or an ancestor becomes a
+      // web-server span — #spanTagsUpdated refreshes this field via the shared
       // cache (see web-tags-cache.js).
       const webTags = this.#endpointCollectionEnabled ? webTagsCache.getCachedWebTags(span) : undefined
 
@@ -291,9 +291,10 @@ class NativeWallProfiler {
   }
 
   // Invoked (via webTagsCache.resolvedCh) once per span at the moment the
-  // shared cache promotes a previously-undefined webTags answer into a
-  // real value. Refresh the ProfilingContext snapshot so future samples
-  // pick it up.
+  // shared cache changes its webTags answer: an empty one promoted into a real
+  // value, or an outer request's tag bag replaced by a nearer one. Refresh the
+  // ProfilingContext snapshot in place so samples already holding it — including
+  // those of a span that stays active across the promotion — pick it up.
   #spanTagsUpdated (span) {
     if (!this.#started) return
     const profilingContext = span[ProfilingContext]

--- a/packages/dd-trace/src/web-tags-cache.js
+++ b/packages/dd-trace/src/web-tags-cache.js
@@ -73,11 +73,13 @@ function getCachedWebTags (span) {
   if (cached.resolved) return cached.webTags
   const spanContext = span.context()
   const tags = spanContext.getTags()
+  const parentId = spanContext._parentId
   let webTags
   if (isWebServerSpan(tags)) {
     webTags = tags
-  } else {
-    const parentId = spanContext._parentId
+  // A span with no parent has nothing to inherit from, and looking for one
+  // anyway means scanning the entire started-spans list to conclude that.
+  } else if (parentId != null) {
     const startedSpans = getStartedSpans(spanContext)
     for (let i = startedSpans.length; --i >= 0;) {
       const ispan = startedSpans[i]
@@ -111,7 +113,7 @@ function onTagsUpdate (span) {
   if (cached.webTags !== tags && isWebServerSpan(tags)) {
     cached.webTags = tags
     resolvedCh.publish(span)
-    resolveDescendants(spanContext, tags)
+    resolveDescendants(span, spanContext, tags)
   }
   // Endpoint finality is a property of the web-server span itself: for a
   // descendant, cached.webTags is an ancestor's bag rather than these tags, and
@@ -137,20 +139,32 @@ function onTagsUpdate (span) {
 // inherits its parent's unless it is a web-server span itself, in which case its
 // own bag shadows the promotion for its own subtree. Spans outside the subtree
 // are never in `answers`, so they cost one map lookup and nothing else.
-function resolveDescendants (spanContext, webTags) {
+//
+// That same creation order means nothing before the promoted span can be a
+// descendant of it, so the pass starts just past it. Locating it from the end
+// costs one comparison in the common case, where a request span is promoted as
+// it is created and is still the newest entry — leaving nothing to visit and
+// nothing to allocate. A span the list no longer holds (finished, and dropped by
+// a partial flush) ends that scan at -1, which visits the whole list.
+function resolveDescendants (span, spanContext, webTags) {
   const startedSpans = getStartedSpans(spanContext)
+  let index = startedSpans.length - 1
+  while (index >= 0 && startedSpans[index] !== span) index--
+  index++
+  if (index === startedSpans.length) return
   const answers = new Map([[spanContext._spanId, webTags]])
-  for (const span of startedSpans) {
-    const context = span.context()
+  for (; index < startedSpans.length; index++) {
+    const descendant = startedSpans[index]
+    const context = descendant.context()
     const inherited = answers.get(context._parentId)
     if (inherited === undefined) continue
     const tags = context.getTags()
     const answer = isWebServerSpan(tags) ? tags : inherited
     answers.set(context._spanId, answer)
-    const cached = span[CachedSym]
+    const cached = descendant[CachedSym]
     if (cached === undefined || !cached.resolved || cached.webTags === answer) continue
     cached.webTags = answer
-    resolvedCh.publish(span)
+    resolvedCh.publish(descendant)
   }
 }
 

--- a/packages/dd-trace/src/web-tags-cache.js
+++ b/packages/dd-trace/src/web-tags-cache.js
@@ -3,8 +3,9 @@
 // Per-span cache of "which tag bag from the started-spans chain identifies
 // this span (or its nearest web-server ancestor) as a web-server span?"
 // Populated lazily on first `getCachedWebTags(span)`, refreshed
-// automatically when a `dd-trace:span:tags:update` event promotes a
-// previously-empty answer for that span into a real value.
+// automatically when a `dd-trace:span:tags:update` event turns a span into a
+// web-server span after the fact — for that span and for every descendant
+// whose answer the promotion changes.
 //
 // Used by the wall profiler (endpoint-collection label on samples) and by
 // the OTEP-4947 thread-context writer (endpoint attribute in the record);
@@ -13,11 +14,12 @@
 //
 // Consumers that want to react to late web-server-span discovery
 // subscribe to `resolvedCh` — a diagnostics channel we publish on once
-// per span at the moment its cached webTags transitions from undefined
-// to a real value. Doing it via a channel (rather than exposing a
-// stateful "did the transition happen?" query) means each consumer sees
-// every transition exactly once, regardless of subscription order or
-// how many other consumers are attached.
+// per span at the moment its cached webTags changes, i.e. when a promotion
+// gives it an answer it didn't have or replaces the one it had with a
+// nearer one. Doing it via a channel (rather than exposing a stateful "did
+// the transition happen?" query) means each consumer sees every transition
+// exactly once, regardless of subscription order or how many other
+// consumers are attached.
 //
 // `endpointResolvedCh` is the same idea one field over: published once per
 // web-server span at the moment its endpoint name settles (see finalEndpoint in
@@ -63,7 +65,9 @@ function getCache (span) {
 // Returns the web-server tag bag for this span or its nearest web-server
 // ancestor in the started-spans chain, or undefined if none is a
 // web-server span. Lazy: walks the parent chain on the first call, caches
-// the result on the span.
+// the result on the span. Answers only ever change through onTagsUpdate, which
+// rewrites the affected entries in place, so a resolved answer is never
+// revisited here.
 function getCachedWebTags (span) {
   const cached = getCache(span)
   if (cached.resolved) return cached.webTags
@@ -97,11 +101,17 @@ function getCachedWebTags (span) {
 function onTagsUpdate (span) {
   const cached = span[CachedSym]
   if (cached === undefined || !cached.resolved) return
-  const tags = span.context().getTags()
-  if (cached.webTags === undefined) {
-    if (!isWebServerSpan(tags)) return
+  const spanContext = span.context()
+  const tags = spanContext.getTags()
+  // Anything but this span's own bag is an answer that predates it being a
+  // web-server span: either empty, or an outer web-server ancestor's bag that
+  // this span now supersedes for itself and for its descendants. A span whose
+  // cached answer already is its own bag is the overwhelmingly common case here
+  // (every further tag update on a request span), and stops at one comparison.
+  if (cached.webTags !== tags && isWebServerSpan(tags)) {
     cached.webTags = tags
     resolvedCh.publish(span)
+    resolveDescendants(spanContext, tags)
   }
   // Endpoint finality is a property of the web-server span itself: for a
   // descendant, cached.webTags is an ancestor's bag rather than these tags, and
@@ -112,6 +122,36 @@ function onTagsUpdate (span) {
   if (finalEndpoint(tags) === undefined) return
   cached.endpointFinal = true
   endpointResolvedCh.publish(span)
+}
+
+// A span has just become a web-server span; answers cached for its descendants
+// before that moment found a farther ancestor or nothing at all, and are now
+// wrong. Rewrite them here rather than letting each descendant discover it on
+// its next lookup: a descendant that is already active keeps handing samplers
+// its stale answer for as long as it runs without re-entering storage, which is
+// precisely the uninterrupted synchronous stretch profiling cares about.
+//
+// One forward pass over the trace's started-spans list, which is in creation
+// order, so a span's parent always precedes it: `answers` holds the new answer
+// for each span in the promoted span's subtree, keyed by span id, and a span
+// inherits its parent's unless it is a web-server span itself, in which case its
+// own bag shadows the promotion for its own subtree. Spans outside the subtree
+// are never in `answers`, so they cost one map lookup and nothing else.
+function resolveDescendants (spanContext, webTags) {
+  const startedSpans = getStartedSpans(spanContext)
+  const answers = new Map([[spanContext._spanId, webTags]])
+  for (const span of startedSpans) {
+    const context = span.context()
+    const inherited = answers.get(context._parentId)
+    if (inherited === undefined) continue
+    const tags = context.getTags()
+    const answer = isWebServerSpan(tags) ? tags : inherited
+    answers.set(context._spanId, answer)
+    const cached = span[CachedSym]
+    if (cached === undefined || !cached.resolved || cached.webTags === answer) continue
+    cached.webTags = answer
+    resolvedCh.publish(span)
+  }
 }
 
 let activeCount = 0

--- a/packages/dd-trace/test/otel-thread-ctx.spec.js
+++ b/packages/dd-trace/test/otel-thread-ctx.spec.js
@@ -596,6 +596,95 @@ describe('otel-thread-ctx', () => {
       assert.equal(context.appendAttributes.firstCall.args[0][1], 'GET /x')
     })
 
+    it('appends the endpoint to a descendant record built before the ancestry existed', () => {
+      // The record was built while the span had no web-server ancestry at all, so
+      // it never enlisted for a request. webTagsCache announces the descendant
+      // too when the promotion changes its answer, which is what fills the hole —
+      // a span in the middle of synchronous work never re-enters storage.
+      const webTags = { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/x' }
+      activeSpan = makeSpan({ spanId: '2122232425262728', parentId: SPAN_ID_HEX, tags: {} })
+      enterCh.publish()
+      const context = constructedContexts[0]
+      assert.strictEqual(context.attributes[1], undefined)
+
+      cachedWebTags.set(activeSpan, webTags)
+      webTagsResolvedCh.publish(activeSpan)
+      sinon.assert.calledOnce(context.appendAttributes)
+      assert.equal(context.appendAttributes.firstCall.args[0][1], 'GET /x')
+      assert.equal(constructedContexts.length, 1)
+    })
+
+    it('waits for the endpoint when a descendant gains an ancestry before the route', () => {
+      // The announcement finds an ancestor but no settled endpoint yet, so the
+      // record has to join the request's waiting list — the endpoint announcement
+      // then names the ancestor, whose tag bag is the key it is waiting under.
+      const { parent, child, webTags } = makeWebSpanWithChild({ 'span.type': 'web', 'http.method': 'GET' })
+      activeSpan = child
+      enterCh.publish()
+      const context = constructedContexts[0]
+      assert.strictEqual(context.attributes[1], undefined)
+
+      cachedWebTags.set(child, webTags)
+      webTagsResolvedCh.publish(child)
+      sinon.assert.notCalled(context.appendAttributes)
+
+      webTags['http.route'] = '/x'
+      endpointResolvedCh.publish(parent)
+      sinon.assert.calledOnce(context.appendAttributes)
+      assert.equal(context.appendAttributes.firstCall.args[0][1], 'GET /x')
+    })
+
+    it('appends once when the same web-tags resolution is announced twice', () => {
+      const webTags = { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/x' }
+      activeSpan = makeSpan({ tags: {} })
+      enterCh.publish()
+      const context = constructedContexts[0]
+
+      cachedWebTags.set(activeSpan, webTags)
+      webTagsResolvedCh.publish(activeSpan)
+      webTagsResolvedCh.publish(activeSpan)
+      sinon.assert.calledOnce(context.appendAttributes)
+      assert.equal(context.appendAttributes.firstCall.args[0][1], 'GET /x')
+    })
+
+    it('repoints a record at a nearer web-server span', () => {
+      // Nested request handling: the record was attributed to the outer request,
+      // then an intermediate span became a web-server span of its own. The inner
+      // endpoint is the one this span's work belongs to from now on, and the outer
+      // request's own announcement no longer applies to this record.
+      const outerTags = { 'span.type': 'web', 'http.method': 'GET' }
+      const outerSpan = makeSpan({ tags: outerTags })
+      const innerTags = { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/inner' }
+      activeSpan = makeSpan({ spanId: '2122232425262728', parentId: SPAN_ID_HEX, tags: {} })
+      cachedWebTags.set(activeSpan, outerTags)
+      enterCh.publish()
+      const context = constructedContexts[0]
+      assert.strictEqual(context.attributes[1], undefined)
+
+      cachedWebTags.set(activeSpan, innerTags)
+      webTagsResolvedCh.publish(activeSpan)
+      sinon.assert.calledOnce(context.appendAttributes)
+      assert.equal(context.appendAttributes.firstCall.args[0][1], 'GET /inner')
+
+      outerTags['http.route'] = '/outer'
+      endpointResolvedCh.publish(outerSpan)
+      sinon.assert.calledOnce(context.appendAttributes)
+    })
+
+    it('does not query the cache again on re-entry', () => {
+      // Every answer change is announced, so a record that already has its
+      // ancestry never asks again — re-entry is the hottest path there is.
+      const webTags = { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/x' }
+      activeSpan = makeSpan({ tags: {} })
+      enterCh.publish()
+      cachedWebTags.set(activeSpan, webTags)
+      webTagsResolvedCh.publish(activeSpan)
+      const lookups = sinon.spy(webTagsCacheStub, 'getCachedWebTags')
+      enterCh.publish()
+      enterCh.publish()
+      sinon.assert.notCalled(lookups)
+    })
+
     it('endpoint announcements are a no-op for a span that has not been entered', () => {
       const { parent, webTags } = makeWebSpanWithChild(
         { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/x' })

--- a/packages/dd-trace/test/otel-thread-ctx.spec.js
+++ b/packages/dd-trace/test/otel-thread-ctx.spec.js
@@ -107,7 +107,14 @@ describe('otel-thread-ctx', () => {
         constructedContexts.push(this)
       }
 
-      appendAttributes () {}
+      // Applied to `attributes` with the record's last-wins handling of duplicate
+      // keys, so a test can assert the endpoint an out-of-process reader would
+      // read out of the record, not merely the calls the writer made.
+      appendAttributes (appended) {
+        for (const [index, value] of appended.entries()) {
+          if (value !== undefined) this.attributes[index] = value
+        }
+      }
 
       invalidate () {}
 
@@ -663,12 +670,36 @@ describe('otel-thread-ctx', () => {
 
       cachedWebTags.set(activeSpan, innerTags)
       webTagsResolvedCh.publish(activeSpan)
-      sinon.assert.calledOnce(context.appendAttributes)
-      assert.equal(context.appendAttributes.firstCall.args[0][1], 'GET /inner')
+      assert.equal(context.attributes[1], 'GET /inner')
 
       outerTags['http.route'] = '/outer'
       endpointResolvedCh.publish(outerSpan)
       sinon.assert.calledOnce(context.appendAttributes)
+      assert.equal(context.attributes[1], 'GET /inner')
+    })
+
+    it('keeps showing the outer endpoint until a nearer request settles its own', () => {
+      // The unavoidable window: the record already carries the outer request's
+      // settled endpoint, and the nearer web-server span that supersedes it has
+      // no route yet. The record buffer is append-only — there is no way to take
+      // an attribute back — and rebuilding the ThreadContext would strand every
+      // async-context frame already holding this one. So the outer endpoint, the
+      // request this work is still nested in, stands until the inner one settles.
+      const outerTags = { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/outer' }
+      const innerTags = { 'span.type': 'web', 'http.method': 'GET' }
+      activeSpan = makeSpan({ spanId: '2122232425262728', parentId: SPAN_ID_HEX, tags: {} })
+      cachedWebTags.set(activeSpan, outerTags)
+      enterCh.publish()
+      const context = constructedContexts[0]
+      assert.equal(context.attributes[1], 'GET /outer')
+
+      cachedWebTags.set(activeSpan, innerTags)
+      webTagsResolvedCh.publish(activeSpan)
+      assert.equal(context.attributes[1], 'GET /outer')
+
+      innerTags['http.route'] = '/inner'
+      endpointResolvedCh.publish(makeSpan({ tags: innerTags }))
+      assert.equal(context.attributes[1], 'GET /inner')
     })
 
     it('does not query the cache again on re-entry', () => {

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -804,15 +804,19 @@ describe('profilers/native/wall', () => {
     function makeChildSpan (webSpanId, webSpan) {
       const tags = { 'span.type': 'router' }
       const spanId = {}
+      // Shares the parent's _trace, as spans of one trace chunk do: it is the
+      // object holding the started-spans list the parent walk reads, and what the
+      // shared cache scopes its per-trace bookkeeping to.
+      const trace = webSpan.context()._trace
       const ctx = {
         _tags: tags,
         _spanId: spanId,
         _parentId: webSpanId,
-        _trace: { started: [webSpan] },
+        _trace: trace,
         getTags () { return this._tags },
       }
       const span = { context: () => ctx }
-      ctx._trace.started.push(span)
+      trace.started.push(span)
       return { span, tags }
     }
 
@@ -903,6 +907,63 @@ describe('profilers/native/wall', () => {
       profilerState[0] = 2
       enterCh.publish()
       assert.strictEqual(sampleContext.endpoint, 'GET /x')
+
+      profiler.stop()
+    })
+
+    it('should refresh a child snapshot taken before its parent became a web span (ACF path)', () => {
+      // The reverse order of the test below: the child is activated first, so its
+      // snapshot records "no web-server ancestor". It must be refreshed the moment
+      // the parent is promoted, without waiting for the child to be reactivated —
+      // a child running uninterrupted synchronous work is never reactivated, and
+      // that is exactly the stretch samples are taken over.
+      const { span: webSpan, tags: webSpanTags, spanId: webSpanId } = makeWebSpan()
+      const { span: childSpan } = makeChildSpan(webSpanId, webSpan)
+
+      const profiler = makeWall(WallProfiler, {
+        endpointCollectionEnabled: true,
+        codeHotspotsEnabled: true,
+        asyncContextFrameEnabled: true,
+      })
+      profiler.start()
+
+      currentStore = { span: childSpan }
+      enterCh.publish()
+      const childCtx = localPprof.time.setContext.lastCall.args[0]
+      assert.strictEqual(childCtx.webTags, undefined)
+
+      webSpanTags['span.type'] = 'web'
+      tagsUpdateCh.publish(webSpan)
+      assert.strictEqual(childCtx.webTags, webSpanTags)
+
+      profiler.stop()
+    })
+
+    it('should repoint a child snapshot at a nearer web span promoted later (ACF path)', () => {
+      // Nested request handling: the child first resolves to the outer request,
+      // then an intermediate span becomes a web-server span of its own. From then
+      // on the child's samples belong to the inner request's endpoint.
+      const { span: outerSpan, tags: outerTags, spanId: outerSpanId } = makeWebSpan()
+      Object.assign(outerTags, { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/outer' })
+      const { span: innerSpan, tags: innerTags } = makeChildSpan(outerSpanId, outerSpan)
+      const innerSpanId = innerSpan.context()._spanId
+      const { span: childSpan } = makeChildSpan(innerSpanId, innerSpan)
+
+      const profiler = makeWall(WallProfiler, {
+        endpointCollectionEnabled: true,
+        codeHotspotsEnabled: true,
+        asyncContextFrameEnabled: true,
+      })
+      profiler.start()
+
+      currentStore = { span: childSpan }
+      enterCh.publish()
+      const childCtx = localPprof.time.setContext.lastCall.args[0]
+      assert.strictEqual(childCtx.webTags, outerTags)
+
+      Object.assign(innerTags, { 'span.type': 'web', 'http.method': 'GET', 'http.route': '/inner' })
+      tagsUpdateCh.publish(innerSpan)
+      assert.strictEqual(childCtx.webTags, innerTags)
 
       profiler.stop()
     })

--- a/packages/dd-trace/test/web-tags-cache.spec.js
+++ b/packages/dd-trace/test/web-tags-cache.spec.js
@@ -135,6 +135,41 @@ describe('web-tags-cache', () => {
       assert.equal(webTagsCache.getCachedWebTags(child), parent.tags)
     })
 
+    it('does not scan the started-spans list for a parent a span cannot have', () => {
+      const trace = makeTrace()
+      const other = makeSpan(trace, { spanId: 'a', tags: {} })
+      const root = makeSpan(trace, { spanId: 'b' })
+      const context = sinon.spy(other, 'context')
+
+      assert.equal(webTagsCache.getCachedWebTags(root), undefined)
+      assert.equal(context.callCount, 0)
+    })
+
+    it('does not look at spans created before the promoted one', () => {
+      // Creation order rules them out as descendants, so the sweep must not pay
+      // a context() call for each of them. Worth pinning: a long-lived trace can
+      // hold a large prefix, and every web-server span promoted in it would walk
+      // that prefix again.
+      const trace = makeTrace()
+      const older = makeSpan(trace, { spanId: 'a', tags: {} })
+      const promoted = makeSpan(trace, { spanId: 'b', tags: {} })
+      const child = makeSpan(trace, { spanId: 'c', parentId: 'b' })
+      // Created after the promoted span but under the older one: visited by the
+      // sweep, and left alone because the promotion is not in its ancestry.
+      const unrelated = makeSpan(trace, { spanId: 'd', parentId: 'a' })
+      webTagsCache.getCachedWebTags(older)
+      webTagsCache.getCachedWebTags(child)
+      webTagsCache.getCachedWebTags(unrelated)
+
+      const context = sinon.spy(older, 'context')
+      Object.assign(promoted.tags, WEB)
+      tagsUpdateCh.publish(promoted)
+
+      assert.equal(context.callCount, 0)
+      assert.equal(webTagsCache.getCachedWebTags(child), promoted.tags)
+      assert.equal(webTagsCache.getCachedWebTags(unrelated), undefined)
+    })
+
     it('leaves another trace alone when a span is promoted', () => {
       // Promotions are per trace: the walk never leaves its own _trace.started, so
       // another trace's request span cannot be this span's ancestor.

--- a/packages/dd-trace/test/web-tags-cache.spec.js
+++ b/packages/dd-trace/test/web-tags-cache.spec.js
@@ -16,18 +16,16 @@ function makeTrace () {
   return { started: [] }
 }
 
+// One context object per span, as DatadogSpan#context() returns — a spy on its
+// getTags then counts how often the cache actually walks that span.
 function makeSpan (trace, { spanId, parentId, tags = {} } = {}) {
-  const span = {
-    context () {
-      return {
-        _spanId: spanId,
-        _parentId: parentId,
-        _trace: trace,
-        getTags: () => tags,
-      }
-    },
-    tags,
+  const context = {
+    _spanId: spanId,
+    _parentId: parentId,
+    _trace: trace,
+    getTags: () => tags,
   }
+  const span = { context: () => context, tags }
   trace.started.push(span)
   return span
 }
@@ -96,9 +94,159 @@ describe('web-tags-cache', () => {
       const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
       const getTags = sinon.spy(parent.context(), 'getTags')
       assert.equal(webTagsCache.getCachedWebTags(child), tags)
-      const callsAfterFirst = getTags.callCount
+      assert.equal(getTags.callCount, 1)
       assert.equal(webTagsCache.getCachedWebTags(child), tags)
-      assert.equal(getTags.callCount, callsAfterFirst)
+      assert.equal(getTags.callCount, 1)
+    })
+
+    it('does not re-walk an empty answer while nothing has been promoted', () => {
+      const trace = makeTrace()
+      makeSpan(trace, { spanId: 'a' })
+      const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
+      const getTags = sinon.spy(child.context(), 'getTags')
+      assert.equal(webTagsCache.getCachedWebTags(child), undefined)
+      assert.equal(getTags.callCount, 1)
+      assert.equal(webTagsCache.getCachedWebTags(child), undefined)
+      assert.equal(getTags.callCount, 1)
+    })
+
+    it('leaves a span outside the promoted span\'s subtree alone', () => {
+      // A promotion rewrites the answers of the promoted span's descendants and
+      // nothing else: a sibling subtree cannot have it as an ancestor, so it is
+      // neither re-examined nor announced.
+      const trace = makeTrace()
+      const parent = makeSpan(trace, { spanId: 'a', tags: {} })
+      const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
+      assert.equal(webTagsCache.getCachedWebTags(child), undefined)
+      const getTags = sinon.spy(child.context(), 'getTags')
+
+      const sibling = makeSpan(trace, { spanId: 'z', parentId: 'a', tags: {} })
+      webTagsCache.getCachedWebTags(sibling)
+      Object.assign(sibling.tags, WEB)
+      tagsUpdateCh.publish(sibling)
+
+      assert.equal(webTagsCache.getCachedWebTags(child), undefined)
+      assert.equal(getTags.callCount, 0)
+      sinon.assert.neverCalledWith(resolved, child)
+
+      // Its own ancestor being promoted is what resolves it.
+      Object.assign(parent.tags, WEB)
+      tagsUpdateCh.publish(parent)
+      assert.equal(webTagsCache.getCachedWebTags(child), parent.tags)
+    })
+
+    it('leaves another trace alone when a span is promoted', () => {
+      // Promotions are per trace: the walk never leaves its own _trace.started, so
+      // another trace's request span cannot be this span's ancestor.
+      const traceA = makeTrace()
+      makeSpan(traceA, { spanId: 'a' })
+      const child = makeSpan(traceA, { spanId: 'b', parentId: 'a' })
+      assert.equal(webTagsCache.getCachedWebTags(child), undefined)
+      const getTags = sinon.spy(child.context(), 'getTags')
+
+      const traceB = makeTrace()
+      const requestSpan = makeSpan(traceB, { spanId: 'c', tags: {} })
+      webTagsCache.getCachedWebTags(requestSpan)
+      Object.assign(requestSpan.tags, WEB)
+      tagsUpdateCh.publish(requestSpan)
+
+      assert.equal(webTagsCache.getCachedWebTags(child), undefined)
+      assert.equal(getTags.callCount, 0)
+    })
+
+    it('resolves a descendant that cached an empty answer once an ancestor is promoted', () => {
+      // The window this exists for: TracingPlugin.startSpan activates a span
+      // before addRequestTags sets span.type, so a child created in between walks
+      // past an ancestor that is about to become a web-server span.
+      const trace = makeTrace()
+      const parent = makeSpan(trace, { spanId: 'a', tags: {} })
+      const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
+      const grandchild = makeSpan(trace, { spanId: 'c', parentId: 'b' })
+      assert.equal(webTagsCache.getCachedWebTags(grandchild), undefined)
+
+      Object.assign(parent.tags, WEB, { 'http.method': 'GET', 'http.route': '/x' })
+      tagsUpdateCh.publish(parent)
+
+      assert.equal(webTagsCache.getCachedWebTags(child), parent.tags)
+      assert.equal(webTagsCache.getCachedWebTags(grandchild), parent.tags)
+    })
+
+    it('repoints a descendant at a nearer web-server span promoted later', () => {
+      // Nested request handling: the inner request span is created under the
+      // outer one and only becomes a web-server span afterwards, by which time
+      // its descendants are attributed to the outer request.
+      const trace = makeTrace()
+      const outer = makeSpan(trace, { spanId: 'a', tags: { ...WEB } })
+      const inner = makeSpan(trace, { spanId: 'b', parentId: 'a', tags: {} })
+      const child = makeSpan(trace, { spanId: 'c', parentId: 'b' })
+      assert.equal(webTagsCache.getCachedWebTags(child), outer.tags)
+
+      Object.assign(inner.tags, WEB)
+      tagsUpdateCh.publish(inner)
+
+      assert.equal(webTagsCache.getCachedWebTags(inner), inner.tags)
+      assert.equal(webTagsCache.getCachedWebTags(child), inner.tags)
+    })
+
+    it('keeps a nearer web-server span\'s subtree on that span when an outer one is promoted', () => {
+      // The outer promotion stops at the inner request span: everything under it
+      // already has a closer answer, and the outer endpoint is not theirs.
+      const trace = makeTrace()
+      const outer = makeSpan(trace, { spanId: 'a', tags: {} })
+      const inner = makeSpan(trace, { spanId: 'b', parentId: 'a', tags: { ...WEB } })
+      const child = makeSpan(trace, { spanId: 'c', parentId: 'b' })
+      const sibling = makeSpan(trace, { spanId: 'd', parentId: 'a' })
+      assert.equal(webTagsCache.getCachedWebTags(child), inner.tags)
+      assert.equal(webTagsCache.getCachedWebTags(sibling), undefined)
+
+      Object.assign(outer.tags, WEB)
+      tagsUpdateCh.publish(outer)
+
+      assert.equal(webTagsCache.getCachedWebTags(child), inner.tags)
+      assert.equal(webTagsCache.getCachedWebTags(sibling), outer.tags)
+    })
+
+    it('announces a descendant as soon as the ancestor is promoted, not on its next lookup', () => {
+      // A descendant that keeps running without re-entering storage never asks
+      // again, and is precisely the span samples are being attributed to.
+      const trace = makeTrace()
+      const parent = makeSpan(trace, { spanId: 'a', tags: {} })
+      const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
+      webTagsCache.getCachedWebTags(child)
+
+      Object.assign(parent.tags, WEB)
+      tagsUpdateCh.publish(parent)
+
+      sinon.assert.calledWith(resolved, child)
+      sinon.assert.calledTwice(resolved)
+    })
+
+    it('announces a resolved descendant only once', () => {
+      const trace = makeTrace()
+      const parent = makeSpan(trace, { spanId: 'a', tags: {} })
+      const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
+      webTagsCache.getCachedWebTags(child)
+
+      Object.assign(parent.tags, WEB)
+      tagsUpdateCh.publish(parent)
+      resolved.resetHistory()
+
+      tagsUpdateCh.publish(parent)
+      webTagsCache.getCachedWebTags(child)
+      sinon.assert.notCalled(resolved)
+    })
+
+    it('stays silent for a descendant that was never looked up', () => {
+      const trace = makeTrace()
+      const parent = makeSpan(trace, { spanId: 'a', tags: {} })
+      makeSpan(trace, { spanId: 'b', parentId: 'a' })
+      webTagsCache.getCachedWebTags(parent)
+
+      Object.assign(parent.tags, WEB)
+      tagsUpdateCh.publish(parent)
+
+      sinon.assert.calledOnce(resolved)
+      sinon.assert.calledWith(resolved, parent)
     })
   })
 


### PR DESCRIPTION
**What does this PR do?**

Both the wall profiler and the otel thread context writer use a shared web-tags cache to avoid costly recomputation of HTTP endpoint values for spans. As every cache, this one is also hard to get right. By now, it's pretty good except in some corner cases. One such corner case came up in review of #9210 ([discussion](https://github.com/DataDog/dd-trace-js/pull/9210#discussion_r3542837196)).

Essentially, a child span of a web span might store empty endpoint information if the child was created before its web span parent had its web tags set.

This PR fixes it. It makes the cache update the answers of descendant spans once an ancestor becomes a web-server span. In fact, this simplified the implementation quite a bit. 

**Additional Notes**

When a span becomes a web-server span, the cache rewrites the cached answers of its descendants in one forward pass over the trace's started-spans list. That list is in creation order, so a span's parent always precedes it, and a map of new answers for the promoted span's subtree can be built in a single sweep. A span inherits its parent's answer unless it is a web-server span itself, in which case its own tag bag shadows the promotion for its own subtree. This also covers the case of a nested request span promoted under an outer one, where the descendants must switch to the nearer endpoint. `resolvedCh` is published for every span whose answer actually changed, so the consumers refresh what they built from the old one in place.

Jira: [PROF-15353]


[PROF-15353]: https://datadoghq.atlassian.net/browse/PROF-15353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
