### PR TITLE
fix(cypress): finalize interactive test sessions

### DIFF
--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -2343,6 +2343,46 @@ if (requestedVersion === 'latest' &&
     }
 
     describe('support wrapper', () => {
+      it('does not enable interactive run events when Test Optimization does not register', () => {
+        const projectRoot = createProjectRoot()
+        const { cypressConfig, warnings } = loadCypressConfig()
+        const resolvedConfig = {
+          projectRoot,
+          supportFile: false,
+          isInteractive: true,
+          experimentalInteractiveRunEvents: false,
+        }
+
+        injectSupportFile(cypressConfig, resolvedConfig)
+
+        assert.strictEqual(resolvedConfig.experimentalInteractiveRunEvents, false)
+        assert.deepStrictEqual(warnings, [])
+      })
+
+      it('enables interactive run events after Test Optimization registers', () => {
+        const projectRoot = createProjectRoot()
+        const setupNodeEventsChannel = {
+          hasSubscribers: true,
+          publish (payload) {
+            payload.registered = true
+          },
+        }
+        const { cypressConfig, warnings } = loadCypressConfig(undefined, undefined, setupNodeEventsChannel)
+        const resolvedConfig = {
+          projectRoot,
+          supportFile: false,
+          isInteractive: true,
+          experimentalInteractiveRunEvents: false,
+        }
+
+        injectSupportFile(cypressConfig, resolvedConfig)
+
+        assert.strictEqual(resolvedConfig.experimentalInteractiveRunEvents, true)
+        assert.deepStrictEqual(warnings, [
+          'Datadog enabled Cypress experimentalInteractiveRunEvents so Test Optimization can finish the test session.',
+        ])
+      })
+
       it('falls back to the project root when the support directory is not writable', async () => {
         const projectRoot = createProjectRoot()
         const supportDirectory = path.join(projectRoot, 'cypress', 'support')
@@ -2688,16 +2728,22 @@ if (requestedVersion === 'latest' &&
           },
         }
         const handlers = {}
-        const { cypressConfig } = loadCypressConfig(undefined, undefined, setupNodeEventsChannel)
+        const { cypressConfig, warnings } = loadCypressConfig(undefined, undefined, setupNodeEventsChannel)
         const spec = { relative: 'cypress/e2e/basic-pass.js' }
         const results = { stats: { passes: 1 } }
         const screenshot = { path: 'original.png' }
+        const resolvedConfig = {
+          projectRoot,
+          supportFile: false,
+          isInteractive: true,
+          experimentalInteractiveRunEvents: false,
+        }
         setupNodeEventsChannel.publish.resetHistory()
 
         cypressConfig.wrapConfig(config)
         config.e2e.setupNodeEvents((event, handler) => {
           handlers[event] = handler
-        }, { projectRoot, supportFile: false, isInteractive: false })
+        }, resolvedConfig)
 
         await handlers['before:run']({})
         await handlers['after:spec'](spec, results)
@@ -2709,6 +2755,8 @@ if (requestedVersion === 'latest' &&
         sinon.assert.calledOnceWithExactly(userAfterScreenshotHandler, screenshot)
         sinon.assert.calledOnce(userAfterRunHandler)
         sinon.assert.notCalled(setupNodeEventsChannel.publish)
+        assert.strictEqual(resolvedConfig.experimentalInteractiveRunEvents, false)
+        assert.deepStrictEqual(warnings, [])
       })
 
       for (const event of ['after:run', 'after:spec']) {
@@ -3000,7 +3048,13 @@ if (requestedVersion === 'latest' &&
           },
         }
         const handlers = {}
-        const { cypressConfig } = loadCypressConfig()
+        const { cypressConfig, warnings } = loadCypressConfig()
+        const resolvedConfig = {
+          projectRoot,
+          supportFile: false,
+          isInteractive: true,
+          experimentalInteractiveRunEvents: false,
+        }
 
         cypressConfig.wrapConfig(config)
         config.e2e.setupNodeEvents(
@@ -3012,8 +3066,13 @@ if (requestedVersion === 'latest' &&
           (event, handler) => {
             handlers[event] = handler
           },
-          { projectRoot, supportFile: false }
+          resolvedConfig
         )
+
+        assert.strictEqual(resolvedConfig.experimentalInteractiveRunEvents, true)
+        assert.deepStrictEqual(warnings, [
+          'Datadog enabled Cypress experimentalInteractiveRunEvents so Test Optimization can finish the test session.',
+        ])
 
         const details = { path: 'original.png' }
         await handlers['after:screenshot'](details)

--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -2593,6 +2593,63 @@ if (requestedVersion === 'latest' &&
     })
 
     describe('manual plugin', () => {
+      it('keeps interactive run events enabled when setupNodeEvents returns a partial config', async () => {
+        const projectRoot = createProjectRoot()
+        const datadogAfterSpecHandler = sinon.stub()
+        datadogAfterSpecHandler[Symbol.for('dd-trace.cypress.after-spec.handler')] = true
+        const datadogAfterRunHandler = sinon.stub()
+        datadogAfterRunHandler[Symbol.for('dd-trace.cypress.after-run.handler')] = true
+        const setupNodeEventsChannel = {
+          hasSubscribers: true,
+          publish: sinon.stub(),
+        }
+        const { cypressConfig, manualPluginOwner, warnings } = loadCypressConfig(
+          undefined,
+          undefined,
+          setupNodeEventsChannel
+        )
+        const taskHandler = {
+          'dd:testSuiteStart': sinon.stub(),
+          'dd:beforeEach': sinon.stub(),
+          'dd:afterEach': sinon.stub(),
+          'dd:addTags': sinon.stub(),
+          [Symbol.for('dd-trace.cypress.task.handler')]: manualPluginOwner,
+        }
+        const config = {
+          e2e: {
+            setupNodeEvents (on) {
+              on('after:spec', datadogAfterSpecHandler)
+              on('after:run', datadogAfterRunHandler)
+              on('task', taskHandler)
+              return { env: { returned: true } }
+            },
+          },
+        }
+        const handlers = {}
+        const initialConfig = {
+          projectRoot,
+          supportFile: false,
+          isInteractive: true,
+          experimentalInteractiveRunEvents: false,
+        }
+        setupNodeEventsChannel.publish.resetHistory()
+
+        cypressConfig.wrapConfig(config)
+        const returnedConfig = config.e2e.setupNodeEvents((event, handler) => {
+          handlers[event] = handler
+        }, initialConfig)
+
+        assert.notStrictEqual(returnedConfig, initialConfig)
+        assert.deepStrictEqual(returnedConfig.env, { returned: true })
+        assert.strictEqual(returnedConfig.experimentalInteractiveRunEvents, true)
+        assert.strictEqual(initialConfig.experimentalInteractiveRunEvents, true)
+        assert.deepStrictEqual(warnings, [
+          'Datadog enabled Cypress experimentalInteractiveRunEvents so Test Optimization can finish the test session.',
+        ])
+        sinon.assert.notCalled(setupNodeEventsChannel.publish)
+        await handlers['after:run']({})
+      })
+
       it('removes a pre-screenshot manual before:run handler when current instrumentation takes ownership', () => {
         const projectRoot = createProjectRoot()
         const legacyBeforeRunHandler = sinon.stub()

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -563,7 +563,12 @@ function registerDdTraceHooks (
       manualPlugin.ownsCurrentPlugin ||
       supportsErrorAwareFinalization(manualPlugin) ||
       !setupNodeEventsCh.hasSubscribers)) {
-    if (manualPlugin.afterRunHandler) enableInteractiveRunEvents(config)
+    if (manualPlugin.afterRunHandler) {
+      enableInteractiveRunEvents(config)
+      if (manualPlugin.initialConfig !== config) {
+        manualPlugin.initialConfig.experimentalInteractiveRunEvents = config.experimentalInteractiveRunEvents
+      }
+    }
     for (const handler of userBeforeRunHandlers) on('before:run', handler)
     registerAfterSpecHandlers(on, userAfterSpecHandlers, manualPlugin.afterSpecHandler, cleanupWrapper)
     registerManualAfterScreenshotHandlers(on, userAfterScreenshotHandlers, manualPlugin.afterScreenshotHandler)
@@ -625,6 +630,7 @@ function wrapSetupNodeEvents (originalSetupNodeEvents) {
     const userAfterScreenshotHandlers = []
     const manualPlugin = {
       detected: false,
+      initialConfig: config,
       beforeRunHandler: undefined,
       afterSpecHandler: undefined,
       afterRunHandler: undefined,

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -485,6 +485,22 @@ function registerAfterSpecHandlers (on, handlers, datadogHandler, cleanup) {
 }
 
 /**
+ * Enables the Cypress lifecycle events needed to finish Test Optimization
+ * sessions in interactive mode.
+ *
+ * @param {object} config Cypress resolved config object
+ * @returns {void}
+ */
+function enableInteractiveRunEvents (config) {
+  if (config.isInteractive && config.experimentalInteractiveRunEvents !== true) {
+    config.experimentalInteractiveRunEvents = true
+    log.warn(
+      'Datadog enabled Cypress experimentalInteractiveRunEvents so Test Optimization can finish the test session.'
+    )
+  }
+}
+
+/**
  * Registers dd-trace's Cypress hooks (before:run, after:spec, after:run, tasks)
  * and injects the support file. Communicates with the plugin layer via
  * the `ci:cypress:setup-node-events` diagnostic channel, avoiding direct
@@ -547,6 +563,7 @@ function registerDdTraceHooks (
       manualPlugin.ownsCurrentPlugin ||
       supportsErrorAwareFinalization(manualPlugin) ||
       !setupNodeEventsCh.hasSubscribers)) {
+    if (manualPlugin.afterRunHandler) enableInteractiveRunEvents(config)
     for (const handler of userBeforeRunHandlers) on('before:run', handler)
     registerAfterSpecHandlers(on, userAfterSpecHandlers, manualPlugin.afterSpecHandler, cleanupWrapper)
     registerManualAfterScreenshotHandlers(on, userAfterScreenshotHandlers, manualPlugin.afterScreenshotHandler)
@@ -592,6 +609,7 @@ function registerDdTraceHooks (
     return config
   }
 
+  enableInteractiveRunEvents(config)
   return payload.configPromise || config
 }
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Enables Cypress's `experimentalInteractiveRunEvents` setting after Test Optimization successfully registers its lifecycle handlers in interactive mode. This allows Cypress to emit `after:run`, which Test Optimization uses to finish and flush the test session and module.

The setting remains unchanged when Test Optimization does not register its handlers or when the detected manual plugin is a no-op. When a user's `setupNodeEvents` returns a new partial config object, the setting is preserved on both the resolved Cypress config and the returned config.

This is split 6 from #9732. The Cypress lifecycle and reusable-run support it builds on was merged in #9797.

### Motivation
<!-- What inspired you to submit this pull request? -->

Cypress open mode does not emit `after:run` unless `experimentalInteractiveRunEvents` is enabled. Without that event, Test Optimization cannot run its normal bounded test-session finalization.

For example, a user can:

1. Start Cypress with `npx cypress open`.
2. Select and run a spec successfully.
3. Close the interactive run.

Before this change, Datadog could report the test and completed suite, but Cypress did not call Datadog's `after:run` handler. The resulting test session trace could therefore be missing its module and session end events.

After this change, once Datadog has registered its `after:run` handler, the instrumentation enables interactive run events. Cypress then calls that handler when the run ends, allowing Test Optimization to finish the module and session and perform its bounded final flush.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- `CYPRESS_VERSION=latest ./node_modules/.bin/mocha --timeout 60000 integration-tests/cypress/cypress-reporting-instrumentation.spec.js --grep "cypress config instrumentation"` (34 passing)
- ESLint passes for both modified files.
- Full repository lint reaches only the existing missing vendored `@datadog/openfeature-node-server` bundle errors.
