### PR TITLE
fix(core): handle missing async trigger resources

### DIFF
--- a/integration-tests/debugger/probe-file.spec.js
+++ b/integration-tests/debugger/probe-file.spec.js
@@ -1,10 +1,11 @@
 'use strict'
 
+const assert = require('node:assert/strict')
 const { writeFileSync } = require('fs')
 const os = require('os')
 const { join } = require('path')
 
-const { setup, testBasicInputWithoutRC } = require('./utils')
+const { setup, setupAssertionListeners, testBasicInputWithoutRC } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
   describe('probe file', function () {
@@ -18,5 +19,28 @@ describe('Dynamic Instrumentation', function () {
     writeFileSync(probeFile, JSON.stringify([probe]))
 
     it('should install probes from a probe file', testBasicInputWithoutRC.bind(null, t, probe))
+  })
+
+  describe('probe file with OTLP trace export', function () {
+    const probeFile = join(os.tmpdir(), 'otlp-probes.json')
+    const t = setup({
+      testApp: 'target-app/basic.js',
+      env: (agent) => ({
+        DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE: probeFile,
+        OTEL_TRACES_EXPORTER: 'otlp',
+        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: `http://127.0.0.1:${agent.port}/v1/traces`,
+      }),
+      dependencies: ['fastify'],
+    })
+    const probe = t.generateProbeConfig()
+    writeFileSync(probeFile, JSON.stringify([probe]))
+
+    it('should send debugger snapshots while traces use OTLP', function (done) {
+      t.triggerBreakpoint()
+      setupAssertionListeners(t, done, probe, {
+        event: 'otlp-traces',
+        validateSpan: (span) => assert.strictEqual(span.name, 'GET /foo/:name'),
+      })
+    })
   })
 })

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -86,7 +86,8 @@ module.exports = {
  * Setup the integration test harness for live‑debugger scenarios.
  *
  * @param {object} [options] The options for the test environment.
- * @param {object} [options.env] The environment variables to set in the test environment.
+ * @param {object|((agent: import('../helpers').FakeAgent) => object)} [options.env] The environment variables to set
+ *   in the test environment, or a function that derives them from the started fake agent.
  * @param {string} [options.testApp] The path to the test application file.
  * @param {string} [options.testAppSource] The path to the test application source file.
  * @param {string[]} [options.dependencies] The dependencies to install in the test environment.
@@ -214,7 +215,7 @@ function setup ({ env, testApp, testAppSource, dependencies, silent, stdioHandle
         DD_TRACE_AGENT_PORT: t.agent.port,
         DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
         DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: pollInterval,
-        ...env,
+        ...(typeof env === 'function' ? env(t.agent) : env),
       },
       silent: silent ?? false,
     }, stdioHandler, stderrHandler)
@@ -299,24 +300,39 @@ function testBasicInputWithoutRC (t, probe, done) {
  * @param {Function} done - The mocha done callback.
  * @param {import('../../packages/dd-trace/test/debugger/devtools_client/utils').ProbeConfig} [probe] - Optional probe
  *   config to use instead of t.rcConfig.config.
+ * @param {object} [traceOptions] - Options for reading the request span from the fake agent.
+ * @param {'message'|'otlp-traces'} [traceOptions.event] - Fake agent event carrying the request span.
+ * @param {(span: object) => void} [traceOptions.validateSpan] - Additional assertion for the matching request span.
  */
-function setupAssertionListeners (t, done, probe) {
+function setupAssertionListeners (t, done, probe, traceOptions = {}) {
   let traceId, spanId, dd
+  const { event = 'message', validateSpan = () => {} } = traceOptions
 
   const messageListener = ({ payload }) => {
-    const span = payload
-      .flat()
-      .find((span) => span.name === 'fastify.request' && (!dd || span.span_id.toString() === dd.span_id))
+    const spans = event === 'message'
+      ? payload.flat()
+      : payload.resourceSpans.flatMap(({ scopeSpans }) => scopeSpans.flatMap(({ spans }) => spans))
+    const span = spans.find((span) => {
+      if (event === 'message') {
+        return span.name === 'fastify.request' && (!dd || span.span_id.toString() === dd.span_id)
+      }
+
+      const isFastifyRequest = span.attributes?.some(({ key, value }) => (
+        key === 'operation.name' && value.stringValue === 'fastify.request'
+      ))
+      return isFastifyRequest && (!dd || BigInt(`0x${span.spanId}`).toString() === dd.span_id)
+    })
 
     if (!span) return
 
-    traceId = span.trace_id.toString()
-    spanId = span.span_id.toString()
+    validateSpan(span)
+    traceId = event === 'message' ? span.trace_id.toString() : BigInt(`0x${span.traceId.slice(-16)}`).toString()
+    spanId = event === 'message' ? span.span_id.toString() : BigInt(`0x${span.spanId}`).toString()
 
     assertDD()
   }
 
-  t.agent.on('message', messageListener)
+  t.agent.on(event, messageListener)
 
   t.agent.once('debugger-input', ({ payload }) => {
     assertBasicInputPayload(t, payload, probe)
@@ -340,7 +356,7 @@ function setupAssertionListeners (t, done, probe) {
     if (!traceId || !spanId || !dd) return
     assert.strictEqual(dd.trace_id, traceId)
     assert.strictEqual(dd.span_id, spanId)
-    t.agent.removeListener('message', messageListener)
+    t.agent.removeListener(event, messageListener)
     done()
   }
 }

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -20,6 +20,22 @@ const { AsyncLocalStorage } = require('async_hooks')
  */
 class DatadogStorage extends AsyncLocalStorage {
   /**
+   * Node can omit the trigger resource while the inspector is paused. There
+   * is no context to inherit in that case, and the native method would throw.
+   *
+   * @param {object} resource
+   * @param {object | undefined} triggerResource
+   * @param {string} type
+   * @returns {void}
+   */
+  _propagate (resource, triggerResource, type) {
+    if (triggerResource) {
+      // @ts-expect-error Node calls this undocumented AsyncLocalStorage hook.
+      super._propagate(resource, triggerResource, type)
+    }
+  }
+
+  /**
    * Passthrough to the real `getStore()`. A span stashes this handle and feeds
    * it back to `getStore(handle)` later. Identical in both modes: under ACF the
    * handle is the store; without ACF it is the WeakMap key.

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -88,4 +88,8 @@ describe('storage', () => {
 
     assert.strictEqual(testStorage.getStore(), undefined)
   })
+
+  it('should ignore propagation without a trigger resource', () => {
+    testStorage._propagate({}, undefined, 'PROMISE')
+  })
 })


### PR DESCRIPTION
## What does this PR do?

Prevents a debugger snapshot from crashing the process when Node omits an async trigger resource while the inspector is paused. It also verifies snapshots remain correlated with request spans exported over OTLP.

## Testing

- `./node_modules/.bin/mocha packages/datadog-core/test/storage.spec.js`
- `./node_modules/.bin/mocha --timeout 120000 integration-tests/debugger/probe-file.spec.js`
- targeted ESLint and Node 20.1 regression checks
- cherry-picked onto v5.121.0; unit and integration tests pass
