### PR TITLE
fix(llmobs): prevent duplicate tags in x-datadog-tags on injection

### DIFF
--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -25,7 +25,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution, stripTagsetEntry } = require('./util')
+const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
 const LLMObsEvalMetricsWriter = require('./writers/evaluations')
@@ -161,6 +161,21 @@ function retireWriters (retiredSpanWriter, retiredEvalWriter) {
   for (const writer of retiredWriters) writer.destroy(onWriterDestroyed)
 }
 
+function isReplacedKey (
+  key, parentId, mlApp, sessionId, sampleRate, samplingDecision, propagatedTraceId, parentAgentSpanId
+) {
+  if (parentId && key === PROPAGATED_PARENT_ID_KEY) return true
+  if (mlApp && key === PROPAGATED_ML_APP_KEY) return true
+  if (sessionId && key === PROPAGATED_SESSION_ID_KEY) return true
+  if (sampleRate != null && key === PROPAGATED_SAMPLE_RATE_KEY) return true
+  if (samplingDecision != null && key === PROPAGATED_SAMPLING_DECISION_KEY) return true
+  if (propagatedTraceId != null && key === PROPAGATED_TRACE_ID_KEY) return true
+  if (parentAgentSpanId && (key === PROPAGATED_PARENT_AGENT_ID_KEY || key === PROPAGATED_PARENT_AGENT_NAME_KEY)) {
+    return true
+  }
+  return false
+}
+
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propagate the parent id, mlApp, session id, and sampling rate/decision.
 function handleLLMObsInjection ({ carrier }) {
@@ -204,21 +219,29 @@ function handleLLMObsInjection ({ carrier }) {
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.
   const existing = readDatadogTags(carrier)
-  let tags = existing || ''
+  let tags = ''
+
+  if (existing) {
+    const entries = existing.split(',')
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      const separatorIndex = entry.indexOf('=')
+      const key = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex)
+      if (!isReplacedKey(
+        key, parentId, mlApp, sessionId, sampleRate, samplingDecision, propagatedTraceId, parentAgentSpanId
+      )) {
+        tags += `${tags ? ',' : ''}${entry}`
+      }
+    }
+  }
+
   if (parentId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_ID_KEY}=${parentId}`
   if (mlApp) tags += `${tags ? ',' : ''}${PROPAGATED_ML_APP_KEY}=${mlApp}`
   if (sessionId) tags += `${tags ? ',' : ''}${PROPAGATED_SESSION_ID_KEY}=${sessionId}`
   if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
   if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
   if (propagatedTraceId != null) tags += `${tags ? ',' : ''}${PROPAGATED_TRACE_ID_KEY}=${propagatedTraceId}`
-  // When a local agent attribution is resolved, strip any stale upstream pagent entries that
-  // `_injectTags` may have already written into the carrier (it propagates all `_dd.p.*` from
-  // `_trace.tags`). This ensures the downstream sees a consistent id-only or id+name pair
-  // rather than a mix from different hops. The id is always digit-safe; an unsafe name is wiped.
-  if (parentAgentSpanId) {
-    tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_ID_KEY)
-    tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_NAME_KEY)
-  }
+
   const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
   const tagsWithId = appendOptionalPropagatedTag(
     tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId, null, maxLength

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -294,6 +294,124 @@ describe('module', () => {
       )
     })
 
+    it('does not duplicate _dd.p.llmobs_ml_app when already present in x-datadog-tags', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+
+      const carrier = {
+        'x-datadog-tags': '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test',
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test'
+      )
+    })
+
+    it('preserves non-replaced LLMObs keys from upstream carrier', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+
+      const carrier = {
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_sid=retained-session',
+        ].join(','),
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_sid=retained-session',
+          '_dd.p.llmobs_ml_app=test',
+        ].join(',')
+      )
+    })
+
+    it('updates existing LLMObs tags in x-datadog-tags without duplicating keys', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+      store.span = {
+        context () {
+          return {
+            toSpanId () {
+              return 'new-parent-id'
+            },
+          }
+        },
+      }
+      LLMObsTagger.tagMap.set(store.span, {
+        [SESSION_ID]: 'new-session',
+        [SAMPLE_RATE]: '0.8',
+        [SAMPLING_DECISION]: '1',
+      })
+
+      const carrier = {
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.llmobs_parent_id=old-id',
+          '_dd.p.llmobs_ml_app=old-app',
+          '_dd.p.llmobs_sid=old-session',
+        ].join(','),
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.llmobs_parent_id=new-parent-id',
+          '_dd.p.llmobs_ml_app=test',
+          '_dd.p.llmobs_sid=new-session',
+          '_dd.p.llmobs_sr=0.8',
+          '_dd.p.llmobs_sd=1',
+        ].join(',')
+      )
+    })
+
+    it('prevents duplicate tags through the full extraction -> standard propagation -> injection path (#9714)', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'downstream-app', agentlessEnabled: false } })
+
+      const TextMapPropagator = require('../../src/opentracing/propagation/text_map')
+      const config = getConfigFresh({ llmobs: { mlApp: 'downstream-app', agentlessEnabled: false } })
+      const propagator = new TextMapPropagator(config)
+
+      const inboundCarrier = {
+        'x-datadog-trace-id': '1234567890',
+        'x-datadog-parent-id': '9876543210',
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_ml_app=upstream-app',
+          '_dd.p.llmobs_sid=upstream-session',
+        ].join(','),
+      }
+
+      const spanContext = propagator.extract(inboundCarrier)
+      assert.ok(spanContext)
+      assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_ml_app'], 'upstream-app')
+      assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'upstream-session')
+
+      const outboundCarrier = {}
+      propagator.inject(spanContext, outboundCarrier)
+
+      const tags = outboundCarrier['x-datadog-tags']
+      assert.ok(tags)
+
+      const mlAppEntries = tags.split(',').filter(entry => entry.startsWith('_dd.p.llmobs_ml_app='))
+      assert.strictEqual(mlAppEntries.length, 1, `Expected exactly one _dd.p.llmobs_ml_app entry in: ${tags}`)
+      assert.strictEqual(mlAppEntries[0], '_dd.p.llmobs_ml_app=downstream-app')
+
+      const sidEntries = tags.split(',').filter(entry => entry.startsWith('_dd.p.llmobs_sid='))
+      assert.strictEqual(sidEntries.length, 1, `Expected exactly one _dd.p.llmobs_sid entry in: ${tags}`)
+      assert.strictEqual(sidEntries[0], '_dd.p.llmobs_sid=upstream-session')
+
+      assert.ok(tags.includes('_dd.p.tid=69fe014200000000'))
+      assert.ok(tags.includes('_dd.p.dm=-0'))
+    })
+
     describe('with DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH=0', () => {
       let config
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where LLMObs propagation could duplicate `_dd.p.llmobs_*` entries in `x-datadog-tags` when standard trace propagation had already emitted values inherited from upstream context.

### Motivation

Standard Datadog extraction stores propagated `_dd.p.*` tags on the trace context. During outbound propagation those tags are written into `x-datadog-tags`, after which the LLMObs injection subscriber adds the locally resolved LLMObs values.

Previously, the LLMObs subscriber appended those values without replacing existing entries, producing duplicate keys such as `_dd.p.llmobs_ml_app`.

### Implementation

`handleLLMObsInjection` now:

- provides a zero-allocation fast path when no `x-datadog-tags` header exists;
- scans existing `x-datadog-tags` entries in a single loop using direct key comparisons (`isReplacedKey`), avoiding intermediate `Set` and closure allocations;
- preserves unrelated and non-replaced propagated tags;
- appends the current LLMObs values once;
- preserves existing agent attribution and max-length behavior.

This avoids duplicate keys while also avoiding repeated full scans or intermediate allocation overhead on the tracer injection hot path.

Fixes #9714.

### Tests

- Added focused coverage for replacing existing LLMObs values without duplicates.
- Added an end-to-end regression exercising the real extraction → standard tracer propagation → LLMObs injection path.
- Verified RED/GREEN by disabling the deduplication filtering: the end-to-end regression detects the duplicate `_dd.p.llmobs_ml_app` entry before the fix and passes with the fix restored.
