### PR TITLE
feat(aiguard): Sensitive data redaction

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -782,6 +782,7 @@ tracer.init({
       endpoint: 'http://localhost',
       maxMessagesLength: 22,
       maxContentSize: 1024,
+      redactionEnabled: true,
       timeout: 1000
     }
   }
@@ -795,6 +796,14 @@ aiguard.evaluate([
   result.action && result.reason && result.tags
 })
 
+aiguard.evaluate([{
+  role: 'user',
+  content: [
+    { type: 'input_text', text: 'Describe this image' },
+    { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+  ],
+}])
+
 aiguard.evaluate([
   {
     role: 'assistant',
@@ -806,11 +815,18 @@ aiguard.evaluate([
     ],
   }
 ]).then(result => {
-  result.action && result.reason && result.tags && result.tagProbabilities && result.sds
+  result.action && result.reason && result.tags && result.tagProbabilities && result.sds && result.messages
 })
 
 aiguard.evaluate([
   { role: 'tool', tool_call_id: 'call_1', content: '5' },
 ]).then(result => {
   result.action && result.reason && result.tags && result.tagProbabilities && result.sds
+})
+
+aiguard.evaluate([
+  { role: 'user', content: 'My SSN is 123-45-6789' },
+]).then(result => {
+  const replacements: ddTrace.aiguard.RedactionReplacement[] = result.redactionReplacements
+  replacements.map(({ path, replacement }) => `${path}=${replacement}`)
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -789,6 +789,13 @@ declare namespace tracer {
          */
         maxMessagesLength?: number,
         /**
+         * Whether AI Guard applies sensitive data redaction replacements.
+         * @default true
+         * @env DD_AI_GUARD_REDACTION_ENABLED
+         * Programmatic configuration takes precedence over the environment variables listed above.
+         */
+        redactionEnabled?: boolean,
+        /**
          * Max size of the content property set in the meta-struct
          * @env DD_AI_GUARD_MAX_CONTENT_SIZE
          * Programmatic configuration takes precedence over the environment variables listed above.
@@ -1706,6 +1713,25 @@ declare namespace tracer {
     }
 
     /**
+     * A structured content part in an AI Guard message.
+     */
+    export interface ContentPart {
+      type: string;
+      text?: string;
+      image_url?: { url: string };
+    }
+
+    /**
+     * A conversational message whose content is represented by structured parts.
+     */
+    export interface ContentPartsMessage {
+      role: string;
+      content: ContentPart[];
+      tool_call_id?: string;
+      tool_calls?: ToolCall[];
+    }
+
+    /**
      * A standard conversational message exchanged with a Large Language Model (LLM).
      */
     export interface TextMessage {
@@ -1776,9 +1802,24 @@ declare namespace tracer {
 
     export type Message =
       | TextMessage
+      | ContentPartsMessage
       | AssistantTextMessage
       | AssistantToolCallMessage
       | ToolMessage;
+
+    /**
+     * A sensitive data replacement the AI Guard service determined for the evaluated conversation.
+     */
+    export interface RedactionReplacement {
+      /**
+       * Location of the replaced value within the evaluated conversation (e.g. `messages[0].content`).
+       */
+      path: string;
+      /**
+       * The value that replaces the sensitive data found at `path`.
+       */
+      replacement: string;
+    }
 
     /**
      * The result returned by AI Guard after evaluating a conversation.
@@ -1807,6 +1848,16 @@ declare namespace tracer {
        * Sensitive Data Scanner findings from the evaluation.
        */
       sds: Object[];
+      /**
+       * The evaluated conversation, redacted when required by the AI Guard service.
+       * This may contain sensitive data when redaction is disabled or no replacement was applied.
+       */
+      messages: Message[];
+      /**
+       * The replacements the AI Guard service determined for the evaluated conversation, reported whether or not
+       * the tracer applied them. Empty when the service determined no replacement.
+       */
+      redactionReplacements: RedactionReplacement[];
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -789,7 +789,7 @@ declare namespace tracer {
          */
         maxMessagesLength?: number,
         /**
-         * Whether AI Guard applies sensitive data redaction replacements.
+         * Whether AI Guard applies backend-provided sensitive-data redaction replacements.
          * @default true
          * @env DD_AI_GUARD_REDACTION_ENABLED
          * Programmatic configuration takes precedence over the environment variables listed above.

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -859,6 +859,13 @@ declare namespace tracer {
          */
         maxMessagesLength?: number,
         /**
+         * Whether AI Guard applies backend-provided sensitive-data redaction replacements.
+         * @default true
+         * @env DD_AI_GUARD_REDACTION_ENABLED
+         * Programmatic configuration takes precedence over the environment variables listed above.
+         */
+        redactionEnabled?: boolean,
+        /**
          * Max size of the content property set in the meta-struct
          * @env DD_AI_GUARD_MAX_CONTENT_SIZE
          * Programmatic configuration takes precedence over the environment variables listed above.
@@ -1818,6 +1825,25 @@ declare namespace tracer {
     }
 
     /**
+     * A structured content part in an AI Guard message.
+     */
+    export interface ContentPart {
+      type: string;
+      text?: string;
+      image_url?: { url: string };
+    }
+
+    /**
+     * A conversational message whose content is represented by structured parts.
+     */
+    export interface ContentPartsMessage {
+      role: string;
+      content: ContentPart[];
+      tool_call_id?: string;
+      tool_calls?: ToolCall[];
+    }
+
+    /**
      * A standard conversational message exchanged with a Large Language Model (LLM).
      */
     export interface TextMessage {
@@ -1888,9 +1914,24 @@ declare namespace tracer {
 
     export type Message =
       | TextMessage
+      | ContentPartsMessage
       | AssistantTextMessage
       | AssistantToolCallMessage
       | ToolMessage;
+
+    /**
+     * A sensitive data replacement the AI Guard service determined for the evaluated conversation.
+     */
+    export interface RedactionReplacement {
+      /**
+       * Location of the replaced value within the evaluated conversation (e.g. `messages[0].content`).
+       */
+      path: string;
+      /**
+       * The value that replaces the sensitive data found at `path`.
+       */
+      replacement: string;
+    }
 
     /**
      * The result returned by AI Guard after evaluating a conversation.
@@ -1919,6 +1960,16 @@ declare namespace tracer {
        * Sensitive Data Scanner findings from the evaluation.
        */
       sds: Object[];
+      /**
+       * The evaluated conversation, redacted when required by the AI Guard service.
+       * This may contain sensitive data when redaction is disabled or no replacement was applied.
+       */
+      messages: Message[];
+      /**
+       * The replacements the AI Guard service determined for the evaluated conversation, reported whether or not
+       * the tracer applied them. Empty when the service determined no replacement.
+       */
+      redactionReplacements: RedactionReplacement[];
     }
 
     /**

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -150,6 +150,7 @@ class EvaluationReporter {
   #config
   #maxMessagesLength
   #maxContentSize
+  #redactionEnabled
 
   /**
    * @param {import('../config/config-base')} config
@@ -158,6 +159,7 @@ class EvaluationReporter {
     this.#config = config
     this.#maxMessagesLength = config.experimental.aiguard.maxMessagesLength
     this.#maxContentSize = config.experimental.aiguard.maxContentSize
+    this.#redactionEnabled = config.experimental.aiguard.redactionEnabled
   }
 
   /**
@@ -170,12 +172,12 @@ class EvaluationReporter {
    */
   start (span, messages, options) {
     const telemetryTags = { source: options.source, integration: options.integration }
-    const snapshot = clone(messages)
-    const last = snapshot.at(-1)
+    const evaluatedMessages = this.#redactionEnabled ? clone(messages) : messages
+    const last = evaluatedMessages.at(-1)
     const target = this.#isToolCall(last) ? 'tool' : 'prompt'
     span.setTag(TAGS.TARGET_TAG_KEY, target)
     if (target === 'tool') {
-      const name = this.#getToolName(last, snapshot)
+      const name = this.#getToolName(last, evaluatedMessages)
       if (name) {
         span.setTag(TAGS.TOOL_NAME_TAG_KEY, name)
       }
@@ -197,7 +199,7 @@ class EvaluationReporter {
 
     return {
       span,
-      messages: snapshot,
+      messages: evaluatedMessages,
       metaStruct,
       telemetryTags,
     }

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -244,18 +244,18 @@ class EvaluationReporter {
 
     const requestTelemetryTags = redaction.enabled
       ? {
-        action: result.action,
-        error: false,
-        block: shouldBlock,
-        redacted: redaction.applied,
-        ...report.telemetryTags,
-      }
+          action: result.action,
+          error: false,
+          block: shouldBlock,
+          redacted: redaction.applied,
+          ...report.telemetryTags,
+        }
       : {
-        action: result.action,
-        error: false,
-        block: shouldBlock,
-        ...report.telemetryTags,
-      }
+          action: result.action,
+          error: false,
+          block: shouldBlock,
+          ...report.telemetryTags,
+        }
     aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, requestTelemetryTags).inc(1)
 
     report.span.setTag(TAGS.ACTION_TAG_KEY, result.action)

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -13,6 +13,7 @@ const TAGS = require('./tags')
 
 const ALLOW = 'ALLOW'
 
+/** @typedef {import('../../../../index').aiguard.ContentPart} ContentPart */
 /** @typedef {import('../../../../index').aiguard.Message} Message */
 /** @typedef {import('../../../../index').aiguard.RedactionReplacement} RedactionReplacement */
 /** @typedef {import('../opentracing/span')} Span */
@@ -282,16 +283,39 @@ class EvaluationReporter {
     let contentTruncated = false
     for (let i = messages.length - size; i < messages.length; i++) {
       const message = clone(messages[i])
-      if (message.content?.length > this.#maxContentSize) {
-        contentTruncated = true
-        message.content = message.content.slice(0, this.#maxContentSize)
-      }
+      if (this.#truncateMessageContent(message)) contentTruncated = true
       result.push(message)
     }
     if (contentTruncated) {
       aiguardMetrics.count(TAGS.TELEMETRY_TRUNCATED, { type: 'content', ...telemetryTags }).inc(1)
     }
     return result
+  }
+
+  /**
+   * Truncates oversized text fields in a cloned message.
+   *
+   * @param {{ content?: string|ContentPart[] }} message
+   * @returns {boolean}
+   */
+  #truncateMessageContent (message) {
+    if (typeof message.content === 'string') {
+      if (message.content.length <= this.#maxContentSize) return false
+
+      message.content = message.content.slice(0, this.#maxContentSize)
+      return true
+    }
+
+    if (!Array.isArray(message.content)) return false
+
+    let truncated = false
+    for (const part of message.content) {
+      if (typeof part.text === 'string' && part.text.length > this.#maxContentSize) {
+        part.text = part.text.slice(0, this.#maxContentSize)
+        truncated = true
+      }
+    }
+    return truncated
   }
 
   /**

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -8,11 +8,13 @@ const { keepTrace } = require('../priority_sampler')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const { AI_GUARD } = require('../standalone/product')
 const telemetryMetrics = require('../telemetry/metrics')
+const { normalizeRedactionReplacements, redactMessages } = require('./redaction')
 const TAGS = require('./tags')
 
 const ALLOW = 'ALLOW'
 
 /** @typedef {import('../../../../index').aiguard.Message} Message */
+/** @typedef {import('../../../../index').aiguard.RedactionReplacement} RedactionReplacement */
 /** @typedef {import('../opentracing/span')} Span */
 
 /**
@@ -24,19 +26,22 @@ const ALLOW = 'ALLOW'
  * @property {Record<string, unknown>} tagProbabilities
  * @property {boolean} hasTagProbabilities
  * @property {boolean} blockingEnabled
+ * @property {unknown} redactionReplacements
  */
 
 /**
  * @typedef {object} EvaluationOutcome
  * @property {{ action: string, reason: string|undefined, tags: Array<unknown>,
- *   tagProbabilities: Record<string, unknown>, sds: Array<unknown> }} result
+ *   tagProbabilities: Record<string, unknown>, sds: Array<unknown>, messages: Message[],
+ *   redactionReplacements: RedactionReplacement[] }} result
  * @property {boolean} shouldBlock
  * @property {boolean} hasTagProbabilities
+ * @property {{ enabled: boolean, applied: boolean, failures: number }} redaction
  */
 
 /**
  * @typedef {object} EvaluationMetaStruct
- * @property {Message[]} messages
+ * @property {Message[]} [messages]
  * @property {Array<unknown>} [attack_categories]
  * @property {Array<unknown>} [sds]
  * @property {Record<string, unknown>} [tag_probs]
@@ -45,6 +50,7 @@ const ALLOW = 'ALLOW'
 /**
  * @typedef {object} EvaluationReport
  * @property {Span} span
+ * @property {Message[]} messages
  * @property {EvaluationMetaStruct} metaStruct
  * @property {{ source: string, integration: string }} telemetryTags
  */
@@ -79,6 +85,7 @@ function parseEvaluationResponse (body) {
     tagProbabilities: isRecord(attributes.tag_probs) ? attributes.tag_probs : {},
     hasTagProbabilities: isRecord(attributes.tag_probs),
     blockingEnabled: attributes.is_blocking_enabled === true,
+    redactionReplacements: attributes.redaction_replacements,
   }
 }
 
@@ -96,11 +103,16 @@ function shouldBlockEvaluation (block, evaluation) {
 /**
  * Applies local evaluation policy and creates the result returned to the caller.
  *
+ * @param {Message[]} messages
  * @param {EvaluationResponse} evaluation
- * @param {boolean} block
+ * @param {{ block: boolean, redactionEnabled: boolean }} options
  * @returns {EvaluationOutcome}
  */
-function createEvaluationOutcome (evaluation, block) {
+function createEvaluationOutcome (messages, evaluation, options) {
+  const redaction = options.redactionEnabled
+    ? redactMessages(messages, evaluation.redactionReplacements)
+    : { messages, redacted: false, failures: 0 }
+
   return {
     result: {
       action: evaluation.action,
@@ -108,9 +120,16 @@ function createEvaluationOutcome (evaluation, block) {
       tags: evaluation.tags,
       tagProbabilities: evaluation.tagProbabilities,
       sds: evaluation.sdsFindings,
+      messages: redaction.messages,
+      redactionReplacements: normalizeRedactionReplacements(evaluation.redactionReplacements),
     },
-    shouldBlock: shouldBlockEvaluation(block, evaluation),
+    shouldBlock: shouldBlockEvaluation(options.block, evaluation),
     hasTagProbabilities: evaluation.hasTagProbabilities,
+    redaction: {
+      enabled: options.redactionEnabled,
+      applied: redaction.redacted,
+      failures: redaction.failures,
+    },
   }
 }
 
@@ -150,19 +169,18 @@ class EvaluationReporter {
    */
   start (span, messages, options) {
     const telemetryTags = { source: options.source, integration: options.integration }
-    const last = messages.at(-1)
+    const snapshot = clone(messages)
+    const last = snapshot.at(-1)
     const target = this.#isToolCall(last) ? 'tool' : 'prompt'
     span.setTag(TAGS.TARGET_TAG_KEY, target)
     if (target === 'tool') {
-      const name = this.#getToolName(last, messages)
+      const name = this.#getToolName(last, snapshot)
       if (name) {
         span.setTag(TAGS.TOOL_NAME_TAG_KEY, name)
       }
     }
 
-    const metaStruct = {
-      messages: this.#buildMessagesForMetaStruct(messages, telemetryTags),
-    }
+    const metaStruct = {}
     span.meta_struct = {
       [TAGS.META_STRUCT_KEY]: metaStruct,
     }
@@ -178,6 +196,7 @@ class EvaluationReporter {
 
     return {
       span,
+      messages: snapshot,
       metaStruct,
       telemetryTags,
     }
@@ -191,6 +210,7 @@ class EvaluationReporter {
    * @returns {void}
    */
   fail (report, errorType) {
+    report.metaStruct.messages = this.#buildMessagesForMetaStruct(report.messages, report.telemetryTags)
     aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, { error: true, ...report.telemetryTags }).inc(1)
     aiguardMetrics.count(TAGS.TELEMETRY_ERROR, { type: errorType, ...report.telemetryTags }).inc(1)
   }
@@ -203,18 +223,38 @@ class EvaluationReporter {
    * @returns {void}
    */
   finish (report, outcome) {
-    const { result, shouldBlock } = outcome
+    const { result, redaction, shouldBlock } = outcome
 
     if (result.tags.length > 0) report.metaStruct.attack_categories = result.tags
     if (result.sds.length > 0) report.metaStruct.sds = result.sds
     if (outcome.hasTagProbabilities) report.metaStruct.tag_probs = result.tagProbabilities
 
-    const requestTelemetryTags = {
-      action: result.action,
-      error: false,
-      block: shouldBlock,
-      ...report.telemetryTags,
+    if (redaction.enabled) {
+      report.span.setTag(TAGS.REDACTED_TAG_KEY, redaction.applied ? 'true' : 'false')
+      if (redaction.failures > 0) {
+        aiguardMetrics.count(TAGS.TELEMETRY_ERROR, {
+          type: TAGS.ERROR_TYPE_REDACTION,
+          ...report.telemetryTags,
+        }).inc(redaction.failures)
+      }
     }
+
+    report.metaStruct.messages = this.#buildMessagesForMetaStruct(result.messages, report.telemetryTags)
+
+    const requestTelemetryTags = redaction.enabled
+      ? {
+        action: result.action,
+        error: false,
+        block: shouldBlock,
+        redacted: redaction.applied,
+        ...report.telemetryTags,
+      }
+      : {
+        action: result.action,
+        error: false,
+        block: shouldBlock,
+        ...report.telemetryTags,
+      }
     aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, requestTelemetryTags).inc(1)
 
     report.span.setTag(TAGS.ACTION_TAG_KEY, result.action)

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -293,27 +293,32 @@ class EvaluationReporter {
   }
 
   /**
-   * Truncates oversized text fields in a cloned message.
+   * Truncates text in a cloned message to one shared content-size limit.
    *
    * @param {{ content?: string|ContentPart[] }} message
    * @returns {boolean}
    */
   #truncateMessageContent (message) {
-    if (typeof message.content === 'string') {
-      if (message.content.length <= this.#maxContentSize) return false
+    const { content } = message
+    if (typeof content === 'string') {
+      if (content.length <= this.#maxContentSize) return false
 
-      message.content = message.content.slice(0, this.#maxContentSize)
+      message.content = content.slice(0, this.#maxContentSize)
       return true
     }
 
-    if (!Array.isArray(message.content)) return false
+    if (!Array.isArray(content)) return false
 
+    let remainingContentSize = this.#maxContentSize
     let truncated = false
-    for (const part of message.content) {
-      if (typeof part.text === 'string' && part.text.length > this.#maxContentSize) {
-        part.text = part.text.slice(0, this.#maxContentSize)
+    for (const part of content) {
+      if (typeof part.text !== 'string') continue
+
+      if (part.text.length > remainingContentSize) {
+        part.text = part.text.slice(0, remainingContentSize)
         truncated = true
       }
+      remainingContentSize -= part.text.length
     }
     return truncated
   }

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -312,13 +312,16 @@ class EvaluationReporter {
     let remainingContentSize = this.#maxContentSize
     let truncated = false
     for (const part of content) {
-      if (typeof part.text !== 'string') continue
+      const text = part?.text
+      if (typeof text !== 'string') continue
 
-      if (part.text.length > remainingContentSize) {
-        part.text = part.text.slice(0, remainingContentSize)
+      if (text.length > remainingContentSize) {
+        part.text = text.slice(0, remainingContentSize)
         truncated = true
+        remainingContentSize = 0
+      } else {
+        remainingContentSize -= text.length
       }
-      remainingContentSize -= part.text.length
     }
     return truncated
   }

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -244,18 +244,18 @@ class EvaluationReporter {
 
     const requestTelemetryTags = redaction.enabled
       ? {
-          action: result.action,
-          error: false,
-          block: shouldBlock,
-          redacted: redaction.applied,
-          ...report.telemetryTags,
-        }
+        action: result.action,
+        error: false,
+        block: shouldBlock,
+        redacted: redaction.applied,
+        ...report.telemetryTags,
+      }
       : {
-          action: result.action,
-          error: false,
-          block: shouldBlock,
-          ...report.telemetryTags,
-        }
+        action: result.action,
+        error: false,
+        block: shouldBlock,
+        ...report.telemetryTags,
+      }
     aiguardMetrics.count(TAGS.TELEMETRY_REQUESTS, requestTelemetryTags).inc(1)
 
     report.span.setTag(TAGS.ACTION_TAG_KEY, result.action)

--- a/packages/dd-trace/src/aiguard/noop.js
+++ b/packages/dd-trace/src/aiguard/noop.js
@@ -2,7 +2,15 @@
 
 class NoopAIGuard {
   evaluate (messages, opts) {
-    return Promise.resolve({ action: 'ALLOW', reason: 'AI Guard is not enabled', tags: [], sds: [] })
+    return Promise.resolve({
+      action: 'ALLOW',
+      reason: 'AI Guard is not enabled',
+      tags: [],
+      tagProbabilities: {},
+      sds: [],
+      messages,
+      redactionReplacements: [],
+    })
   }
 }
 

--- a/packages/dd-trace/src/aiguard/redaction.js
+++ b/packages/dd-trace/src/aiguard/redaction.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const clone = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
-
 /** @typedef {import('../../../../index').aiguard.RedactionReplacement} RedactionReplacement */
 
 const SEGMENT_PATTERN = /^([A-Za-z0-9_]+)(?:\[([0-9]+)\])?$/
@@ -112,14 +110,14 @@ function resolveWritableString (root, path) {
 
 /**
  * Applies redaction replacements to an AI Guard message list.
- * The input is never mutated.
+ * The caller transfers ownership of a private snapshot. Successful replacements mutate that snapshot in place.
  *
  * @param {Array<object>} messages
  * @param {unknown} replacements
  * @returns {{ messages: Array<object>, redacted: boolean, failures: number }}
  */
 function redactMessages (messages, replacements) {
-  if (!Array.isArray(messages) || !replacements) {
+  if (!Array.isArray(messages) || replacements === undefined || replacements === null) {
     return { messages, redacted: false, failures: 0 }
   }
 
@@ -156,9 +154,8 @@ function redactMessages (messages, replacements) {
 
     if (replacementsByPath.size === 0) return { messages, redacted: false, failures }
 
-    const result = clone(messages)
-    const root = { messages: result }
-    let redacted = false
+    const root = { messages }
+    const targets = []
 
     for (const [path, replacement] of replacementsByPath) {
       const resolved = resolveWritableString(root, path)
@@ -167,11 +164,14 @@ function redactMessages (messages, replacements) {
         continue
       }
 
-      resolved.container[resolved.key] = replacement
-      redacted = true
+      targets.push({ ...resolved, replacement })
     }
 
-    return { messages: redacted ? result : messages, redacted, failures }
+    for (const { container, key, replacement } of targets) {
+      container[key] = replacement
+    }
+
+    return { messages, redacted: targets.length > 0, failures }
   } catch {
     return { messages, redacted: false, failures: 1 }
   }

--- a/packages/dd-trace/src/aiguard/redaction.js
+++ b/packages/dd-trace/src/aiguard/redaction.js
@@ -112,6 +112,7 @@ function resolveWritableString (root, path) {
 
 /**
  * Applies redaction replacements to an AI Guard message list.
+ * The input is never mutated.
  *
  * @param {Array<object>} messages
  * @param {unknown} replacements
@@ -126,6 +127,7 @@ function redactMessages (messages, replacements) {
     if (!Array.isArray(replacements)) {
       return { messages, redacted: false, failures: 1 }
     }
+    if (replacements.length === 0) return { messages, redacted: false, failures: 0 }
 
     const replacementsByPath = new Map()
     const conflictingPaths = new Set()

--- a/packages/dd-trace/src/aiguard/redaction.js
+++ b/packages/dd-trace/src/aiguard/redaction.js
@@ -1,0 +1,181 @@
+'use strict'
+
+const clone = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
+
+/** @typedef {import('../../../../index').aiguard.RedactionReplacement} RedactionReplacement */
+
+const SEGMENT_PATTERN = /^([A-Za-z0-9_]+)(?:\[([0-9]+)\])?$/
+
+/**
+ * Converts the raw backend replacements into the public, typed contract.
+ *
+ * @param {unknown} replacements
+ * @returns {RedactionReplacement[]}
+ */
+function normalizeRedactionReplacements (replacements) {
+  if (!Array.isArray(replacements)) return []
+
+  const result = []
+  for (const entry of replacements) {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) continue
+
+    const { path, replacement } = entry
+    if (typeof path !== 'string' || path.length === 0 || typeof replacement !== 'string') continue
+
+    result.push({ path, replacement })
+  }
+  return result
+}
+
+/**
+ * Parses an AI Guard location path into named segments and optional indexes.
+ *
+ * @param {string} path
+ * @returns {Array<{ name: string, index: number|undefined }>|undefined}
+ */
+function parsePath (path) {
+  const segments = []
+  for (const rawSegment of path.split('.')) {
+    const match = SEGMENT_PATTERN.exec(rawSegment)
+    if (!match) return
+
+    segments.push({
+      name: match[1],
+      index: match[2] === undefined ? undefined : Number(match[2]),
+    })
+  }
+  return segments
+}
+
+/**
+ * Reports whether a parsed path targets an allowed message string.
+ *
+ * @param {Array<{ name: string, index: number|undefined }>} segments
+ * @returns {boolean}
+ */
+function isRedactablePath (segments) {
+  const first = segments[0]
+  if (first?.name !== 'messages' || first.index === undefined) return false
+
+  if (segments.length === 2) {
+    const content = segments[1]
+    return content.name === 'content' && content.index === undefined
+  }
+
+  if (segments.length === 3) {
+    const content = segments[1]
+    const text = segments[2]
+    return content.name === 'content' && content.index !== undefined &&
+      text.name === 'text' && text.index === undefined
+  }
+
+  if (segments.length === 4) {
+    const toolCalls = segments[1]
+    const functionSegment = segments[2]
+    const argumentsSegment = segments[3]
+    return toolCalls.name === 'tool_calls' && toolCalls.index !== undefined &&
+      functionSegment.name === 'function' && functionSegment.index === undefined &&
+      argumentsSegment.name === 'arguments' && argumentsSegment.index === undefined
+  }
+
+  return false
+}
+
+/**
+ * Resolves a location path to a writable string container and key.
+ *
+ * @param {{ messages: Array<object> }} root
+ * @param {string} path
+ * @returns {{ container: object|Array<unknown>, key: string|number }|undefined}
+ */
+function resolveWritableString (root, path) {
+  const segments = parsePath(path)
+  if (!segments || !isRedactablePath(segments)) return
+
+  const terminal = segments.at(-1)
+  let node = root
+  for (let i = 0; i < segments.length - 1; i++) {
+    const { name, index } = segments[i]
+    if (!node || typeof node !== 'object' || !Object.hasOwn(node, name)) return
+
+    node = node[name]
+    if (index !== undefined) {
+      if (!Array.isArray(node) || index >= node.length) return
+      node = node[index]
+    }
+  }
+
+  if (!node || typeof node !== 'object') return
+  if (!Object.hasOwn(node, terminal.name) || typeof node[terminal.name] !== 'string') return
+  return { container: node, key: terminal.name }
+}
+
+/**
+ * Applies redaction replacements to an AI Guard message list.
+ *
+ * @param {Array<object>} messages
+ * @param {unknown} replacements
+ * @returns {{ messages: Array<object>, redacted: boolean, failures: number }}
+ */
+function redactMessages (messages, replacements) {
+  if (!Array.isArray(messages) || !replacements) {
+    return { messages, redacted: false, failures: 0 }
+  }
+
+  try {
+    if (!Array.isArray(replacements)) {
+      return { messages, redacted: false, failures: 1 }
+    }
+
+    const replacementsByPath = new Map()
+    const conflictingPaths = new Set()
+    let failures = 0
+    for (const entry of replacements) {
+      if (!entry || typeof entry !== 'object') {
+        failures++
+        continue
+      }
+
+      const { path, replacement } = entry
+      if (typeof path !== 'string' || path.length === 0 || typeof replacement !== 'string') {
+        failures++
+        continue
+      }
+
+      if (conflictingPaths.has(path)) continue
+      if (replacementsByPath.has(path) && replacementsByPath.get(path) !== replacement) {
+        replacementsByPath.delete(path)
+        conflictingPaths.add(path)
+        failures++
+        continue
+      }
+      replacementsByPath.set(path, replacement)
+    }
+
+    if (replacementsByPath.size === 0) return { messages, redacted: false, failures }
+
+    const result = clone(messages)
+    const root = { messages: result }
+    let redacted = false
+
+    for (const [path, replacement] of replacementsByPath) {
+      const resolved = resolveWritableString(root, path)
+      if (!resolved) {
+        failures++
+        continue
+      }
+
+      resolved.container[resolved.key] = replacement
+      redacted = true
+    }
+
+    return { messages: redacted ? result : messages, redacted, failures }
+  } catch {
+    return { messages, redacted: false, failures: 1 }
+  }
+}
+
+module.exports = {
+  normalizeRedactionReplacements,
+  redactMessages,
+}

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -12,6 +12,7 @@ class AIGuard extends NoopAIGuard {
   #tracer
   #client
   #reporter
+  #redactionEnabled
   #meta
 
   /**
@@ -29,6 +30,7 @@ class AIGuard extends NoopAIGuard {
     this.#tracer = tracer
     this.#client = new AIGuardClient(config)
     this.#reporter = new EvaluationReporter(config)
+    this.#redactionEnabled = config.experimental.aiguard.redactionEnabled
     this.#meta = { service: config.service, env: config.env }
     this.#initialized = true
   }
@@ -45,13 +47,16 @@ class AIGuard extends NoopAIGuard {
       const report = this.#reporter.start(span, messages, { source, integration })
       let evaluation
       try {
-        evaluation = await this.#client.evaluate(messages, this.#meta)
+        evaluation = await this.#client.evaluate(report.messages, this.#meta)
       } catch (error) {
         this.#reporter.fail(report, error.telemetryType ?? TAGS.ERROR_TYPE_CLIENT)
         throw error
       }
 
-      const outcome = createEvaluationOutcome(evaluation, block)
+      const outcome = createEvaluationOutcome(report.messages, evaluation, {
+        block,
+        redactionEnabled: this.#redactionEnabled,
+      })
       this.#reporter.finish(report, outcome)
 
       if (outcome.shouldBlock) {

--- a/packages/dd-trace/src/aiguard/tags.js
+++ b/packages/dd-trace/src/aiguard/tags.js
@@ -7,6 +7,7 @@ module.exports = {
   ACTION_TAG_KEY: 'ai_guard.action',
   REASON_TAG_KEY: 'ai_guard.reason',
   BLOCKED_TAG_KEY: 'ai_guard.blocked',
+  REDACTED_TAG_KEY: 'ai_guard.redacted',
   EVENT_TAG_KEY: 'ai_guard.event',
   META_STRUCT_KEY: 'ai_guard',
 
@@ -27,4 +28,5 @@ module.exports = {
   ERROR_TYPE_CLIENT: 'client_error',
   ERROR_TYPE_STATUS: 'bad_status',
   ERROR_TYPE_RESPONSE: 'bad_response',
+  ERROR_TYPE_REDACTION: 'redaction_error',
 }

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -417,6 +417,7 @@ export interface GeneratedConfig {
       endpoint: string | undefined;
       maxContentSize: number;
       maxMessagesLength: number;
+      redactionEnabled: boolean;
       timeout: number;
     };
     appsec: {
@@ -613,6 +614,7 @@ export interface GeneratedEnvVarConfig {
   DD_AI_GUARD_ENDPOINT: string | undefined;
   DD_AI_GUARD_MAX_CONTENT_SIZE: number;
   DD_AI_GUARD_MAX_MESSAGES_LENGTH: number;
+  DD_AI_GUARD_REDACTION_ENABLED: boolean;
   DD_AI_GUARD_TIMEOUT: number;
   DD_API_KEY: string | undefined;
   DD_API_SECURITY_DOWNSTREAM_BODY_ANALYSIS_SAMPLE_RATE: number;

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -93,6 +93,16 @@
         "default": "16"
       }
     ],
+    "DD_AI_GUARD_REDACTION_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "configurationNames": [
+          "experimental.aiguard.redactionEnabled"
+        ],
+        "default": "true"
+      }
+    ],
     "DD_AI_GUARD_TIMEOUT": [
       {
         "implementation": "A",

--- a/packages/dd-trace/test/aiguard/evaluation.spec.js
+++ b/packages/dd-trace/test/aiguard/evaluation.spec.js
@@ -75,7 +75,7 @@ describe('AI Guard evaluation response', () => {
           action: 'DENY',
           reason: 'Sensitive data detected.',
           tags: ['prompt-injection'],
-          sds_findings: [{ category: 'email_address' }],
+          sds_findings: [{ category: 'email_address', matched_text: 'ops@acme.io' }],
           tag_probs: { 'prompt-injection': 0.9 },
           is_blocking_enabled: true,
           redaction_replacements: [
@@ -94,7 +94,7 @@ describe('AI Guard evaluation response', () => {
         reason: 'Sensitive data detected.',
         tags: ['prompt-injection'],
         tagProbabilities: { 'prompt-injection': 0.9 },
-        sds: [{ category: 'email_address' }],
+        sds: [{ category: 'email_address', matched_text: 'ops@acme.io' }],
         messages: [{ role: 'user', content: 'My SSN is <REDACTED>' }],
         redactionReplacements: [{ path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' }],
       },
@@ -106,6 +106,7 @@ describe('AI Guard evaluation response', () => {
         failures: 0,
       },
     })
+    assert.notStrictEqual(outcome.result.messages, messages)
     assert.strictEqual(messages[0].content, 'My SSN is 123-45-6789')
   })
 

--- a/packages/dd-trace/test/aiguard/evaluation.spec.js
+++ b/packages/dd-trace/test/aiguard/evaluation.spec.js
@@ -13,6 +13,7 @@ const {
 describe('AI Guard evaluation response', () => {
   it('parses the backend response into the internal evaluation contract', () => {
     const sdsFindings = [{ category: 'ssn' }]
+    const redactionReplacements = [{ path: 'messages[0].content', replacement: '<REDACTED>' }]
     const tagProbabilities = { jailbreak: 0.8 }
     const response = {
       data: {
@@ -23,6 +24,7 @@ describe('AI Guard evaluation response', () => {
           sds_findings: sdsFindings,
           tag_probs: tagProbabilities,
           is_blocking_enabled: true,
+          redaction_replacements: redactionReplacements,
         },
       },
     }
@@ -35,6 +37,7 @@ describe('AI Guard evaluation response', () => {
       tagProbabilities,
       hasTagProbabilities: true,
       blockingEnabled: true,
+      redactionReplacements,
     })
   })
 
@@ -47,6 +50,7 @@ describe('AI Guard evaluation response', () => {
       tagProbabilities: {},
       hasTagProbabilities: false,
       blockingEnabled: false,
+      redactionReplacements: undefined,
     })
   })
 
@@ -63,7 +67,8 @@ describe('AI Guard evaluation response', () => {
     })
   }
 
-  it('creates a blocked outcome', () => {
+  it('creates a blocked, redacted outcome', () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
     const evaluation = parseEvaluationResponse({
       data: {
         attributes: {
@@ -73,12 +78,15 @@ describe('AI Guard evaluation response', () => {
           sds_findings: [{ category: 'email_address' }],
           tag_probs: { 'prompt-injection': 0.9 },
           is_blocking_enabled: true,
+          redaction_replacements: [
+            { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+          ],
         },
       },
     })
 
     assert.ok(evaluation)
-    const outcome = createEvaluationOutcome(evaluation, true)
+    const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled: true })
 
     assert.deepStrictEqual(outcome, {
       result: {
@@ -87,10 +95,98 @@ describe('AI Guard evaluation response', () => {
         tags: ['prompt-injection'],
         tagProbabilities: { 'prompt-injection': 0.9 },
         sds: [{ category: 'email_address' }],
+        messages: [{ role: 'user', content: 'My SSN is <REDACTED>' }],
+        redactionReplacements: [{ path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' }],
       },
       shouldBlock: true,
       hasTagProbabilities: true,
+      redaction: {
+        enabled: true,
+        applied: true,
+        failures: 0,
+      },
     })
+    assert.strictEqual(messages[0].content, 'My SSN is 123-45-6789')
+  })
+
+  it('keeps original messages but reports the backend replacements when redaction is disabled', () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const evaluation = parseEvaluationResponse({
+      data: {
+        attributes: {
+          action: 'ALLOW',
+          redaction_replacements: [
+            { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+          ],
+        },
+      },
+    })
+
+    assert.ok(evaluation)
+    const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled: false })
+
+    assert.strictEqual(outcome.result.messages, messages)
+    assert.deepStrictEqual(outcome.result.redactionReplacements, [
+      { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+    ])
+    assert.deepStrictEqual(outcome.redaction, {
+      enabled: false,
+      applied: false,
+      failures: 0,
+    })
+  })
+
+  for (const redactionEnabled of [true, false]) {
+    it(`reports no replacements when the backend sends none and redaction is ${
+      redactionEnabled ? 'enabled' : 'disabled'}`, () => {
+      const messages = [{ role: 'user', content: 'Hello' }]
+      const evaluation = parseEvaluationResponse({ data: { attributes: { action: 'ALLOW' } } })
+
+      assert.ok(evaluation)
+      const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled })
+
+      assert.deepStrictEqual(outcome.result.redactionReplacements, [])
+    })
+  }
+
+  it('reports only well-formed replacements while still counting malformed ones as failures', () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const evaluation = parseEvaluationResponse({
+      data: {
+        attributes: {
+          action: 'ALLOW',
+          redaction_replacements: [
+            { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+            { path: 'messages[8].content', replacement: 'unresolvable but well-formed' },
+            'not an object',
+            { path: 'messages[0].content', replacement: 42 },
+            { path: '', replacement: 'empty path' },
+          ],
+        },
+      },
+    })
+
+    assert.ok(evaluation)
+    const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled: true })
+
+    assert.deepStrictEqual(outcome.result.redactionReplacements, [
+      { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+      { path: 'messages[8].content', replacement: 'unresolvable but well-formed' },
+    ])
+    assert.strictEqual(outcome.redaction.failures, 4)
+  })
+
+  it('reports no replacements when the backend sends a non-array value', () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const evaluation = parseEvaluationResponse({
+      data: { attributes: { action: 'ALLOW', redaction_replacements: 'not an array' } },
+    })
+
+    assert.ok(evaluation)
+    const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled: true })
+
+    assert.deepStrictEqual(outcome.result.redactionReplacements, [])
+    assert.strictEqual(outcome.redaction.failures, 1)
   })
 
   for (const testCase of [

--- a/packages/dd-trace/test/aiguard/evaluation.spec.js
+++ b/packages/dd-trace/test/aiguard/evaluation.spec.js
@@ -67,8 +67,8 @@ describe('AI Guard evaluation response', () => {
     })
   }
 
-  it('creates a blocked, redacted outcome', () => {
-    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+  it('returns the redacted private snapshot in a blocked outcome', () => {
+    const privateSnapshot = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
     const evaluation = parseEvaluationResponse({
       data: {
         attributes: {
@@ -86,7 +86,7 @@ describe('AI Guard evaluation response', () => {
     })
 
     assert.ok(evaluation)
-    const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled: true })
+    const outcome = createEvaluationOutcome(privateSnapshot, evaluation, { block: true, redactionEnabled: true })
 
     assert.deepStrictEqual(outcome, {
       result: {
@@ -106,8 +106,8 @@ describe('AI Guard evaluation response', () => {
         failures: 0,
       },
     })
-    assert.notStrictEqual(outcome.result.messages, messages)
-    assert.strictEqual(messages[0].content, 'My SSN is 123-45-6789')
+    assert.strictEqual(outcome.result.messages, privateSnapshot)
+    assert.strictEqual(privateSnapshot[0].content, 'My SSN is <REDACTED>')
   })
 
   it('keeps original messages but reports the backend replacements when redaction is disabled', () => {
@@ -177,18 +177,26 @@ describe('AI Guard evaluation response', () => {
     assert.strictEqual(outcome.redaction.failures, 4)
   })
 
-  it('reports no replacements when the backend sends a non-array value', () => {
-    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
-    const evaluation = parseEvaluationResponse({
-      data: { attributes: { action: 'ALLOW', redaction_replacements: 'not an array' } },
+  for (const replacements of ['not an array', false]) {
+    it(`reports no replacements when the backend sends non-array ${JSON.stringify(replacements)}`, () => {
+      const privateSnapshot = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+      const evaluation = parseEvaluationResponse({
+        data: { attributes: { action: 'ALLOW', redaction_replacements: replacements } },
+      })
+
+      assert.ok(evaluation)
+      const outcome = createEvaluationOutcome(privateSnapshot, evaluation, { block: true, redactionEnabled: true })
+
+      assert.deepStrictEqual(outcome.result.redactionReplacements, [])
+      assert.strictEqual(outcome.result.messages, privateSnapshot)
+      assert.deepStrictEqual(privateSnapshot, [{ role: 'user', content: 'My SSN is 123-45-6789' }])
+      assert.deepStrictEqual(outcome.redaction, {
+        enabled: true,
+        applied: false,
+        failures: 1,
+      })
     })
-
-    assert.ok(evaluation)
-    const outcome = createEvaluationOutcome(messages, evaluation, { block: true, redactionEnabled: true })
-
-    assert.deepStrictEqual(outcome.result.redactionReplacements, [])
-    assert.strictEqual(outcome.redaction.failures, 1)
-  })
+  }
 
   for (const testCase of [
     { block: false, action: 'DENY', blockingEnabled: true, expected: false },

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -660,7 +660,8 @@ describe('AIGuard SDK', () => {
 
     const result = await disabled.evaluate(messages)
 
-    assert.notStrictEqual(result.messages, messages)
+    assert.strictEqual(result.messages, messages)
+    assert.strictEqual(result.messages[0], messages[0])
     assert.deepStrictEqual(result.messages, messages)
     assert.deepStrictEqual(result.redactionReplacements, redactionReplacements)
     const requestMetricCall = count.getCalls().find(call => call.args[0] === 'requests')

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -26,6 +26,7 @@ const {
   ERROR_TYPE_CLIENT,
   ERROR_TYPE_STATUS,
   ERROR_TYPE_RESPONSE,
+  ERROR_TYPE_REDACTION,
 } = require('../../src/aiguard/tags')
 
 describe('AIGuard SDK', () => {
@@ -42,6 +43,7 @@ describe('AIGuard SDK', () => {
         endpoint: 'https://aiguard.com',
         maxMessagesLength: 16,
         maxContentSize: 512 * 1024,
+        redactionEnabled: true,
         timeout: 10_000,
       },
     },
@@ -113,6 +115,18 @@ describe('AIGuard SDK', () => {
     }
   }
 
+  const mockDeferredFetch = () => {
+    let resolveFetch
+    global.fetch.callsFake(() => new Promise(resolve => {
+      resolveFetch = resolve
+    }))
+
+    return options => resolveFetch({
+      status: options.status ?? 200,
+      json: sinon.stub().resolves(options.body),
+    })
+  }
+
   const assertFetch = (messages, url) => {
     const postData = JSON.stringify(
       { data: { attributes: { messages, meta: { service: config.service, env: config.env } } } }
@@ -150,6 +164,9 @@ describe('AIGuard SDK', () => {
   const sdkTags = { source: SOURCE_SDK, integration: INTEGRATION_NONE }
 
   const assertTelemetry = (metric, tags) => {
+    if (metric === 'requests' && tags.error === false && !Object.hasOwn(tags, 'redacted')) {
+      tags = { ...tags, redacted: false }
+    }
     sinon.assert.calledWith(count, metric, tags)
   }
 
@@ -191,6 +208,8 @@ describe('AIGuard SDK', () => {
           assert.strictEqual(evaluation.tagProbabilities, attributes.tag_probs)
         }
         assert.deepStrictEqual(evaluation.sds, [])
+        assert.notStrictEqual(evaluation.messages, messages)
+        assert.deepStrictEqual(evaluation.messages, messages)
       }
 
       assertTelemetry('requests', { action, error: false, block: shouldBlock, ...sdkTags })
@@ -233,6 +252,8 @@ describe('AIGuard SDK', () => {
       } else {
         const evaluation = await aiguard.evaluate(prompt, opts)
         assert.strictEqual(evaluation.action, 'DENY')
+        assert.notStrictEqual(evaluation.messages, prompt)
+        assert.deepStrictEqual(evaluation.messages, prompt)
       }
 
       assertTelemetry('requests', { error: false, action: 'DENY', block: shouldBlock, ...sdkTags })
@@ -274,6 +295,8 @@ describe('AIGuard SDK', () => {
     const result = await aiguard.evaluate(messages)
 
     assert.deepStrictEqual(result.sds, sdsFindings)
+    assert.notStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.messages, messages)
     await assertAIGuardSpan(
       { 'ai_guard.target': 'prompt', 'ai_guard.action': 'ALLOW' },
       { messages, sds: sdsFindings }
@@ -293,10 +316,242 @@ describe('AIGuard SDK', () => {
     const result = await aiguard.evaluate(messages)
 
     assert.deepStrictEqual(result.sds, [])
+    assert.notStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.redactionReplacements, [])
     await assertAIGuardSpan(
       { 'ai_guard.target': 'prompt', 'ai_guard.action': 'ALLOW' },
       { messages }
     )
+  })
+
+  it('returns redacted messages and reports them in meta-struct without mutating the input', async () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const redactionReplacements = [
+      { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+    ]
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            reason: 'Sensitive data redacted.',
+            redaction_replacements: redactionReplacements,
+            is_blocking_enabled: true,
+          },
+        },
+      },
+    })
+
+    const result = await aiguard.evaluate(messages)
+
+    assert.notStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.messages, [{ role: 'user', content: 'My SSN is <REDACTED>' }])
+    assert.deepStrictEqual(result.redactionReplacements, redactionReplacements)
+    assert.strictEqual(messages[0].content, 'My SSN is 123-45-6789')
+    assertFetch(messages)
+    assertTelemetry('requests', {
+      action: 'ALLOW',
+      error: false,
+      block: false,
+      redacted: true,
+      ...sdkTags,
+    })
+    await assertAIGuardSpan(
+      { 'ai_guard.target': 'prompt', 'ai_guard.action': 'ALLOW', 'ai_guard.redacted': 'true' },
+      { messages: [{ role: 'user', content: 'My SSN is <REDACTED>' }] }
+    )
+  })
+
+  it('uses one message snapshot when the caller mutates messages while evaluation is pending', async () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const originalMessages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const callerMutation = { role: 'system', content: 'Caller mutation' }
+    const resolveFetch = mockDeferredFetch()
+
+    const evaluation = aiguard.evaluate(messages)
+    messages.unshift(callerMutation)
+    resolveFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            redaction_replacements: [
+              { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+            ],
+          },
+        },
+      },
+    })
+
+    const result = await evaluation
+
+    assertFetch(originalMessages)
+    assert.deepStrictEqual(result.messages, [{ role: 'user', content: 'My SSN is <REDACTED>' }])
+    assert.deepStrictEqual(messages, [callerMutation, ...originalMessages])
+    await assertAIGuardSpan(
+      { 'ai_guard.redacted': 'true' },
+      { messages: [{ role: 'user', content: 'My SSN is <REDACTED>' }] }
+    )
+  })
+
+  it('returns complete redacted messages while truncating only the meta-struct copy', async () => {
+    const maxContentSize = 12
+    const limited = new AIGuard(tracer, {
+      ...config,
+      experimental: {
+        ...config.experimental,
+        aiguard: { ...config.experimental.aiguard, maxContentSize },
+      },
+    })
+    const messages = [{
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'My SSN is 123-45-6789' },
+        { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+      ],
+    }]
+    const replacement = 'My SSN is <REDACTED>'
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            redaction_replacements: [{ path: 'messages[0].content[0].text', replacement }],
+          },
+        },
+      },
+    })
+
+    const result = await limited.evaluate(messages)
+
+    assert.deepStrictEqual(result.messages, [{
+      role: 'user',
+      content: [
+        { type: 'input_text', text: replacement },
+        { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+      ],
+    }])
+    assertTelemetry('truncated', { type: 'content', ...sdkTags })
+    await assertAIGuardSpan(
+      { 'ai_guard.redacted': 'true' },
+      {
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'input_text', text: replacement.slice(0, maxContentSize) },
+            { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+          ],
+        }],
+      }
+    )
+  })
+
+  it('redacts blocked payloads in meta-struct without adding messages to the abort error', async () => {
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'DENY',
+            reason: 'Sensitive data blocked.',
+            redaction_replacements: [
+              { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+            ],
+            is_blocking_enabled: true,
+          },
+        },
+      },
+    })
+
+    await rejects(
+      () => aiguard.evaluate(messages),
+      err => err.name === 'AIGuardAbortError' && !Object.hasOwn(err, 'messages')
+    )
+
+    await assertAIGuardSpan(
+      {
+        'ai_guard.action': 'DENY',
+        'ai_guard.blocked': 'true',
+        'ai_guard.redacted': 'true',
+        'error.type': 'AIGuardAbortError',
+      },
+      { messages: [{ role: 'user', content: 'My SSN is <REDACTED>' }] }
+    )
+  })
+
+  it('reports malformed replacements and applies valid siblings', async () => {
+    const messages = [
+      { role: 'system', content: 'ops@acme.io' },
+      { role: 'user', content: '123-45-6789' },
+    ]
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            redaction_replacements: [
+              { path: 'messages[0].content', replacement: '<REDACTED>' },
+              { path: 'messages[8].content', replacement: 'missing' },
+            ],
+          },
+        },
+      },
+    })
+
+    const result = await aiguard.evaluate(messages)
+
+    assert.deepStrictEqual(result.messages, [
+      { role: 'system', content: '<REDACTED>' },
+      { role: 'user', content: '123-45-6789' },
+    ])
+    assertTelemetry('error', { type: ERROR_TYPE_REDACTION, ...sdkTags })
+    sinon.assert.calledWith(inc, 1)
+    await assertAIGuardSpan(
+      { 'ai_guard.redacted': 'true' },
+      {
+        messages: [
+          { role: 'system', content: '<REDACTED>' },
+          { role: 'user', content: '123-45-6789' },
+        ],
+      }
+    )
+  })
+
+  it('keeps originals and omits redaction tags when the kill-switch is off', async () => {
+    const disabled = new AIGuard(tracer, {
+      ...config,
+      experimental: {
+        ...config.experimental,
+        aiguard: { ...config.experimental.aiguard, redactionEnabled: false },
+      },
+    })
+    const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
+    const redactionReplacements = [
+      { path: 'messages[0].content', replacement: 'My SSN is <REDACTED>' },
+    ]
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            redaction_replacements: redactionReplacements,
+          },
+        },
+      },
+    })
+
+    const result = await disabled.evaluate(messages)
+
+    assert.notStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.redactionReplacements, redactionReplacements)
+    const requestMetricCall = count.getCalls().find(call => call.args[0] === 'requests')
+    assert.ok(!Object.hasOwn(requestMetricCall.args[1], 'redacted'))
+    await agent.assertFirstTraceSpan(span => {
+      assert.ok(!Object.hasOwn(span.meta, 'ai_guard.redacted'))
+      assert.deepStrictEqual(msgpack.decode(span.meta_struct.ai_guard), { messages })
+    }, { rejectFirst: true })
   })
 
   it('test evaluate with sds_findings in abort error', async () => {
@@ -350,6 +605,29 @@ describe('AIGuard SDK', () => {
       'ai_guard.target': 'tool',
       'error.type': 'AIGuardClientError',
     })
+  })
+
+  it('reports the message snapshot when a failed request settles after caller mutation', async () => {
+    const messages = [{ role: 'user', content: 'Original message' }]
+    const originalMessages = [{ role: 'user', content: 'Original message' }]
+    const callerMutation = { role: 'system', content: 'Caller mutation' }
+    const resolveFetch = mockDeferredFetch()
+
+    const evaluation = aiguard.evaluate(messages)
+    messages.unshift(callerMutation)
+    resolveFetch({ status: 503, body: { errors: [{ title: 'Unavailable' }] } })
+
+    await rejects(
+      () => evaluation,
+      err => err.name === 'AIGuardClientError' && err.message === 'AI Guard service call failed, status 503'
+    )
+
+    assertFetch(originalMessages)
+    assert.deepStrictEqual(messages, [callerMutation, ...originalMessages])
+    await assertAIGuardSpan(
+      { 'ai_guard.target': 'prompt', 'error.type': 'AIGuardClientError' },
+      { messages: originalMessages }
+    )
   })
 
   it('test evaluate with API exception', async () => {
@@ -409,8 +687,10 @@ describe('AIGuard SDK', () => {
   it('test noop implementation', async () => {
     const noop = new NoopAIGuard()
     const result = await noop.evaluate(prompt)
-    result.action === 'ALLOW'
-    result.reason === 'AI Guard is not enabled'
+    assert.strictEqual(result.action, 'ALLOW')
+    assert.strictEqual(result.reason, 'AI Guard is not enabled')
+    assert.strictEqual(result.messages, prompt)
+    assert.deepStrictEqual(result.redactionReplacements, [])
   })
 
   it('test message length truncation', async () => {

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -604,6 +604,37 @@ describe('AIGuard SDK', () => {
     )
   })
 
+  it('reports a falsy non-array replacement collection as a redaction error', async () => {
+    const messages = [{ role: 'user', content: '123-45-6789' }]
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            redaction_replacements: false,
+          },
+        },
+      },
+    })
+
+    const result = await aiguard.evaluate(messages)
+
+    assert.deepStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.redactionReplacements, [])
+    assertTelemetry('error', { type: ERROR_TYPE_REDACTION, ...sdkTags })
+    assertTelemetry('requests', {
+      action: 'ALLOW',
+      error: false,
+      block: false,
+      redacted: false,
+      ...sdkTags,
+    })
+    await assertAIGuardSpan(
+      { 'ai_guard.redacted': 'false' },
+      { messages }
+    )
+  })
+
   it('keeps originals and omits redaction tags when the kill-switch is off', async () => {
     const disabled = new AIGuard(tracer, {
       ...config,

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 const { rejects } = require('node:assert/strict')
-const { inspect } = require('node:util')
+const { inspect, isDeepStrictEqual } = require('node:util')
 
 const msgpack = require('@msgpack/msgpack')
 const { afterEach, beforeEach, describe, it } = require('mocha')
@@ -50,7 +50,7 @@ describe('AIGuard SDK', () => {
   }
   let tracer
   let aiguard
-  let count, inc
+  let count
 
   const toolCall = [
     { role: 'system', content: 'You are a beautiful AI assistant' },
@@ -88,10 +88,7 @@ describe('AIGuard SDK', () => {
     originalFetch = global.fetch
     global.fetch = sinon.stub()
 
-    inc = sinon.spy()
-    count = sinon.stub(aiguardMetrics, 'count').returns({
-      inc,
-    })
+    count = sinon.stub(aiguardMetrics, 'count').callsFake(() => ({ inc: sinon.spy() }))
     aiguardMetrics.metrics.clear()
 
     aiguard = new AIGuard(tracer, config)
@@ -163,11 +160,19 @@ describe('AIGuard SDK', () => {
 
   const sdkTags = { source: SOURCE_SDK, integration: INTEGRATION_NONE }
 
-  const assertTelemetry = (metric, tags) => {
+  const assertTelemetry = (metric, tags, incAmount = 1) => {
     if (metric === 'requests' && tags.error === false && !Object.hasOwn(tags, 'redacted')) {
       tags = { ...tags, redacted: false }
     }
-    sinon.assert.calledWith(count, metric, tags)
+    const metricCalls = count.getCalls().filter(call =>
+      call.args[0] === metric && isDeepStrictEqual(call.args[1], tags)
+    )
+    assert.strictEqual(
+      metricCalls.length,
+      1,
+      `Expected one telemetry count(${inspect(metric)}, ${inspect(tags)}), got ${metricCalls.length}`
+    )
+    sinon.assert.calledOnceWithExactly(metricCalls[0].returnValue.inc, incAmount)
   }
 
   const testSuite = [
@@ -452,6 +457,38 @@ describe('AIGuard SDK', () => {
     )
   })
 
+  it('skips nullish structured content parts when reporting a successful evaluation', async () => {
+    const messages = [{
+      role: 'user',
+      content: [
+        null,
+        undefined,
+        { type: 'input_text', text: 'Describe this image' },
+        { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+      ],
+    }]
+    mockFetch({
+      body: { data: { attributes: { action: 'ALLOW', reason: 'OK', is_blocking_enabled: false } } },
+    })
+
+    const result = await aiguard.evaluate(messages)
+
+    assert.deepStrictEqual(result.messages, messages)
+    assertFetch(messages)
+    await assertAIGuardSpan(
+      { 'ai_guard.target': 'prompt', 'ai_guard.action': 'ALLOW' },
+      {
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Describe this image' },
+            { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+          ],
+        }],
+      }
+    )
+  })
+
   it('redacts blocked payloads in meta-struct without adding messages to the abort error', async () => {
     const messages = [{ role: 'user', content: 'My SSN is 123-45-6789' }]
     mockFetch({
@@ -498,6 +535,7 @@ describe('AIGuard SDK', () => {
             redaction_replacements: [
               { path: 'messages[0].content', replacement: '<REDACTED>' },
               { path: 'messages[8].content', replacement: 'missing' },
+              { path: 'messages.invalid.content', replacement: 'malformed' },
             ],
           },
         },
@@ -510,8 +548,14 @@ describe('AIGuard SDK', () => {
       { role: 'system', content: '<REDACTED>' },
       { role: 'user', content: '123-45-6789' },
     ])
-    assertTelemetry('error', { type: ERROR_TYPE_REDACTION, ...sdkTags })
-    sinon.assert.calledWith(inc, 1)
+    assertTelemetry('error', { type: ERROR_TYPE_REDACTION, ...sdkTags }, 2)
+    assertTelemetry('requests', {
+      action: 'ALLOW',
+      error: false,
+      block: false,
+      redacted: true,
+      ...sdkTags,
+    })
     await assertAIGuardSpan(
       { 'ai_guard.redacted': 'true' },
       {
@@ -519,6 +563,43 @@ describe('AIGuard SDK', () => {
           { role: 'system', content: '<REDACTED>' },
           { role: 'user', content: '123-45-6789' },
         ],
+      }
+    )
+  })
+
+  it('reports originals when every replacement fails', async () => {
+    const messages = [{ role: 'user', content: '123-45-6789' }]
+    mockFetch({
+      body: {
+        data: {
+          attributes: {
+            action: 'ALLOW',
+            tags: ['pii'],
+            sds_findings: [{ category: 'pii', matched_text: '123-45-6789' }],
+            redaction_replacements: [{ path: 'messages[8].content', replacement: '<REDACTED>' }],
+          },
+        },
+      },
+    })
+
+    const result = await aiguard.evaluate(messages)
+
+    assert.deepStrictEqual(result.messages, messages)
+    assert.deepStrictEqual(result.sds, [{ category: 'pii', matched_text: '123-45-6789' }])
+    assertTelemetry('error', { type: ERROR_TYPE_REDACTION, ...sdkTags })
+    assertTelemetry('requests', {
+      action: 'ALLOW',
+      error: false,
+      block: false,
+      redacted: false,
+      ...sdkTags,
+    })
+    await assertAIGuardSpan(
+      { 'ai_guard.redacted': 'false' },
+      {
+        messages,
+        attack_categories: ['pii'],
+        sds: [{ category: 'pii', matched_text: '123-45-6789' }],
       }
     )
   })
@@ -588,6 +669,14 @@ describe('AIGuard SDK', () => {
       () => aiguard.evaluate(messages, { block: true }),
       err => err.name === 'AIGuardAbortError' && JSON.stringify(err.sds) === JSON.stringify(sdsFindings)
     )
+    await assertAIGuardSpan(
+      { 'ai_guard.blocked': 'true', 'error.type': 'AIGuardAbortError' },
+      {
+        messages,
+        attack_categories: ['pii'],
+        sds: sdsFindings,
+      }
+    )
   })
 
   it('test evaluate with API error', async () => {
@@ -609,7 +698,7 @@ describe('AIGuard SDK', () => {
     await assertAIGuardSpan({
       'ai_guard.target': 'tool',
       'error.type': 'AIGuardClientError',
-    })
+    }, { messages: toolCall })
   })
 
   it('reports the message snapshot when a failed request settles after caller mutation', async () => {
@@ -652,7 +741,25 @@ describe('AIGuard SDK', () => {
     await assertAIGuardSpan({
       'ai_guard.target': 'tool',
       'error.type': 'AIGuardClientError',
-    })
+    }, { messages: toolCall })
+  })
+
+  it('does not mask a client error when structured content contains nullish parts', async () => {
+    const messages = [{ role: 'user', content: [null, { type: 'input_text', text: 'Are you sure?' }] }]
+    mockFetch({ error: new Error('Boom!!!') })
+
+    await rejects(
+      () => aiguard.evaluate(messages),
+      err => err.name === 'AIGuardClientError' && err.message === 'Unexpected error calling AI Guard service: Boom!!!'
+    )
+
+    assertTelemetry('requests', { error: true, ...sdkTags })
+    assertTelemetry('error', { type: ERROR_TYPE_CLIENT, ...sdkTags })
+    assertFetch(messages)
+    await assertAIGuardSpan(
+      { 'ai_guard.target': 'prompt', 'error.type': 'AIGuardClientError' },
+      { messages: [{ role: 'user', content: [{ type: 'input_text', text: 'Are you sure?' }] }] }
+    )
   })
 
   it('test evaluate with invalid JSON', async () => {
@@ -669,7 +776,7 @@ describe('AIGuard SDK', () => {
     await assertAIGuardSpan({
       'ai_guard.target': 'tool',
       'error.type': 'AIGuardClientError',
-    })
+    }, { messages: toolCall })
   })
 
   it('test evaluate with with missing action or response', async () => {
@@ -686,7 +793,7 @@ describe('AIGuard SDK', () => {
     await assertAIGuardSpan({
       'ai_guard.target': 'tool',
       'error.type': 'AIGuardClientError',
-    })
+    }, { messages: toolCall })
   })
 
   it('test noop implementation', async () => {

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -444,7 +444,7 @@ describe('AIGuard SDK', () => {
           role: 'user',
           content: [
             { type: 'input_text', text: replacement.slice(0, maxContentSize) },
-            { type: 'input_text', text: atLimit },
+            { type: 'input_text', text: '' },
             { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
           ],
         }],

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -397,6 +397,7 @@ describe('AIGuard SDK', () => {
 
   it('returns complete redacted messages while truncating only the meta-struct copy', async () => {
     const maxContentSize = 12
+    const atLimit = 'A'.repeat(maxContentSize)
     const limited = new AIGuard(tracer, {
       ...config,
       experimental: {
@@ -408,6 +409,7 @@ describe('AIGuard SDK', () => {
       role: 'user',
       content: [
         { type: 'input_text', text: 'My SSN is 123-45-6789' },
+        { type: 'input_text', text: atLimit },
         { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
       ],
     }]
@@ -429,10 +431,12 @@ describe('AIGuard SDK', () => {
       role: 'user',
       content: [
         { type: 'input_text', text: replacement },
+        { type: 'input_text', text: atLimit },
         { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
       ],
     }])
     assertTelemetry('truncated', { type: 'content', ...sdkTags })
+    assert.strictEqual(count.getCalls().filter(call => call.args[0] === 'truncated').length, 1)
     await assertAIGuardSpan(
       { 'ai_guard.redacted': 'true' },
       {
@@ -440,6 +444,7 @@ describe('AIGuard SDK', () => {
           role: 'user',
           content: [
             { type: 'input_text', text: replacement.slice(0, maxContentSize) },
+            { type: 'input_text', text: atLimit },
             { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
           ],
         }],

--- a/packages/dd-trace/test/aiguard/redaction.spec.js
+++ b/packages/dd-trace/test/aiguard/redaction.spec.js
@@ -87,11 +87,25 @@ describe('AI Guard redaction', () => {
     assert.strictEqual(redacted[0].content, '')
   })
 
-  it('accepts zero-padded indexes in canonical paths', () => {
+  it('accepts zero-padded indexes', () => {
     const messages = [{ role: 'user', content: 'secret' }]
     const result = redactMessages(messages, [{ path: 'messages[00].content', replacement: '<REDACTED>' }])
 
     assert.deepStrictEqual(result.messages, [{ role: 'user', content: '<REDACTED>' }])
+    assert.strictEqual(result.redacted, true)
+    assert.strictEqual(result.failures, 0)
+  })
+
+  it('applies zero-padded aliases as independent raw paths', () => {
+    const messages = [{ role: 'user', content: 'secret' }]
+    const result = redactMessages(messages, [
+      { path: 'messages[0].content', replacement: '<A>' },
+      { path: 'messages[00].content', replacement: '<B>' },
+    ])
+
+    assert.notStrictEqual(result.messages, messages)
+    assert.strictEqual(result.messages[0].content, '<B>')
+    assert.strictEqual(messages[0].content, 'secret')
     assert.strictEqual(result.redacted, true)
     assert.strictEqual(result.failures, 0)
   })
@@ -163,7 +177,17 @@ describe('AI Guard redaction', () => {
     })
   })
 
-  it('fails safe when copying a message throws', () => {
+  it('returns the original messages for an empty replacement array', () => {
+    const messages = [{ role: 'user', content: 'secret' }]
+
+    const result = redactMessages(messages, [])
+
+    assert.strictEqual(result.messages, messages)
+    assert.strictEqual(result.redacted, false)
+    assert.strictEqual(result.failures, 0)
+  })
+
+  it('fails safe when cloning messages throws', () => {
     const message = { role: 'user' }
     Object.defineProperty(message, 'content', {
       enumerable: true,
@@ -176,6 +200,22 @@ describe('AI Guard redaction', () => {
     assert.deepStrictEqual(redactMessages(messages, [
       { path: 'messages[0].content', replacement: '<REDACTED>' },
     ]), { messages, redacted: false, failures: 1 })
+  })
+
+  it('fails safe when replacement preprocessing throws', () => {
+    const messages = [{ role: 'user', content: 'secret' }]
+    const replacements = new Proxy([{}], {
+      get (target, property, receiver) {
+        if (property === Symbol.iterator) throw new Error('unreadable')
+        return Reflect.get(target, property, receiver)
+      },
+    })
+
+    const result = redactMessages(messages, replacements)
+
+    assert.strictEqual(result.messages, messages)
+    assert.strictEqual(result.redacted, false)
+    assert.strictEqual(result.failures, 1)
   })
 
   for (const path of [

--- a/packages/dd-trace/test/aiguard/redaction.spec.js
+++ b/packages/dd-trace/test/aiguard/redaction.spec.js
@@ -1,0 +1,234 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const { redactMessages } = require('../../src/aiguard/redaction')
+
+describe('AI Guard redaction', () => {
+  for (const path of [
+    'messages[-1].content',
+    'messages[0].con-tent',
+    'messages[0].content ',
+    'messages[0].content.',
+  ]) {
+    it(`skips malformed path ${path}`, () => {
+      const messages = [{ role: 'user', content: 'secret' }]
+      const result = redactMessages(messages, [{ path, replacement: '<REDACTED>' }])
+
+      assert.strictEqual(result.messages, messages)
+      assert.strictEqual(result.redacted, false)
+      assert.strictEqual(result.failures, 1)
+    })
+  }
+
+  it('rejects a long malformed segment without excessive backtracking', () => {
+    const path = `messages[0].${'a'.repeat(100_000)}[${'9'.repeat(100_000)}x]`
+    const messages = [{ role: 'user', content: 'secret' }]
+    const result = redactMessages(messages, [{ path, replacement: '<REDACTED>' }])
+
+    assert.strictEqual(result.messages, messages)
+    assert.strictEqual(result.redacted, false)
+    assert.strictEqual(result.failures, 1)
+  })
+
+  it('redacts message content, content-part text, and tool arguments in one copy', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'input_text', text: 'card 4111111111111111' }] },
+      {
+        role: 'assistant',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'pay', arguments: '{"ssn":"123-45-6789"}' },
+        }],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'paid from 000123456789' },
+    ]
+    const replacements = [
+      { path: 'messages[0].content[0].text', replacement: 'card <REDACTED>' },
+      { path: 'messages[1].tool_calls[0].function.arguments', replacement: '{"ssn":"<REDACTED>"}' },
+      { path: 'messages[2].content', replacement: 'paid from <REDACTED>' },
+    ]
+
+    const { messages: redacted } = redactMessages(messages, replacements)
+
+    assert.notStrictEqual(redacted, messages)
+    assert.deepStrictEqual(redacted, [
+      { role: 'user', content: [{ type: 'input_text', text: 'card <REDACTED>' }] },
+      {
+        role: 'assistant',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'pay', arguments: '{"ssn":"<REDACTED>"}' },
+        }],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'paid from <REDACTED>' },
+    ])
+    assert.deepStrictEqual(messages, [
+      { role: 'user', content: [{ type: 'input_text', text: 'card 4111111111111111' }] },
+      {
+        role: 'assistant',
+        tool_calls: [{
+          id: 'call_1',
+          function: { name: 'pay', arguments: '{"ssn":"123-45-6789"}' },
+        }],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'paid from 000123456789' },
+    ])
+  })
+
+  it('accepts an empty string as the remove placeholder', () => {
+    const messages = [{ role: 'user', content: '123-45-6789' }]
+    const { messages: redacted } = redactMessages(messages, [
+      { path: 'messages[0].content', replacement: '' },
+    ])
+
+    assert.strictEqual(redacted[0].content, '')
+  })
+
+  it('accepts zero-padded indexes in canonical paths', () => {
+    const messages = [{ role: 'user', content: 'secret' }]
+    const result = redactMessages(messages, [{ path: 'messages[00].content', replacement: '<REDACTED>' }])
+
+    assert.deepStrictEqual(result.messages, [{ role: 'user', content: '<REDACTED>' }])
+    assert.strictEqual(result.redacted, true)
+    assert.strictEqual(result.failures, 0)
+  })
+
+  it('applies identical duplicate entries once', () => {
+    const messages = [{ role: 'user', content: '123-45-6789' }]
+    const replacement = { path: 'messages[0].content', replacement: '<REDACTED>' }
+    const result = redactMessages(messages, [replacement, replacement])
+
+    assert.strictEqual(result.redacted, true)
+    assert.strictEqual(result.failures, 0)
+    assert.strictEqual(result.messages[0].content, '<REDACTED>')
+  })
+
+  it('keeps a conflicting path skipped after later duplicate values', () => {
+    const messages = [{ role: 'user', content: '123-45-6789' }]
+    const result = redactMessages(messages, [
+      { path: 'messages[0].content', replacement: '<A>' },
+      { path: 'messages[0].content', replacement: '<B>' },
+      { path: 'messages[0].content', replacement: '<A>' },
+    ])
+
+    assert.strictEqual(result.messages, messages)
+    assert.strictEqual(result.redacted, false)
+    assert.strictEqual(result.failures, 1)
+  })
+
+  it('applies valid siblings while counting malformed and unresolvable entries', () => {
+    const messages = [
+      { role: 'system', content: 'ops@acme.io' },
+      { role: 'user', content: '123-45-6789' },
+    ]
+    const result = redactMessages(messages, [
+      { path: 'messages[0].content', replacement: '<REDACTED>' },
+      { path: 'messages[9].content', replacement: 'missing' },
+      { path: 'messages[1].content' },
+    ])
+
+    assert.deepStrictEqual(result.messages, [
+      { role: 'system', content: '<REDACTED>' },
+      { role: 'user', content: '123-45-6789' },
+    ])
+    assert.strictEqual(result.redacted, true)
+    assert.strictEqual(result.failures, 2)
+  })
+
+  it('fails safe for invalid replacement collections and entries', () => {
+    const messages = [{ role: 'user', content: 'secret' }]
+
+    assert.deepStrictEqual(redactMessages(messages, { path: 'messages[0].content' }), {
+      messages,
+      redacted: false,
+      failures: 1,
+    })
+    assert.deepStrictEqual(redactMessages(messages, [undefined]), {
+      messages,
+      redacted: false,
+      failures: 1,
+    })
+    assert.deepStrictEqual(redactMessages(messages, [{ path: 42, replacement: '<REDACTED>' }]), {
+      messages,
+      redacted: false,
+      failures: 1,
+    })
+    assert.deepStrictEqual(redactMessages(messages, []), {
+      messages,
+      redacted: false,
+      failures: 0,
+    })
+  })
+
+  it('fails safe when copying a message throws', () => {
+    const message = { role: 'user' }
+    Object.defineProperty(message, 'content', {
+      enumerable: true,
+      get () {
+        throw new Error('unreadable')
+      },
+    })
+    const messages = [message]
+
+    assert.deepStrictEqual(redactMessages(messages, [
+      { path: 'messages[0].content', replacement: '<REDACTED>' },
+    ]), { messages, redacted: false, failures: 1 })
+  })
+
+  for (const path of [
+    'content',
+    'messages.content',
+    'messages[0].content',
+    'messages[0].content[0]',
+    'messages[0].role',
+    'messages[0].content[0]',
+    'messages[0].content[1].image_url.url',
+    'messages[0].content[1].image_url.url.extra',
+    'messages[1].tool_calls[0].function.name',
+    'messages[1].tool_calls[0].id',
+  ]) {
+    it(`skips non-string, structural, or unsupported target ${path}`, () => {
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'hello' },
+            { type: 'input_image', image_url: { url: 'https://example.com/image.png' } },
+          ],
+        },
+        {
+          role: 'assistant',
+          tool_calls: [{ id: 'call_1', function: { name: 'search', arguments: '{}' } }],
+        },
+      ]
+      const result = redactMessages(messages, [{ path, replacement: '<REDACTED>' }])
+
+      assert.strictEqual(result.messages, messages)
+      assert.strictEqual(result.redacted, false)
+      assert.strictEqual(result.failures, 1)
+    })
+  }
+
+  for (const { path, message } of [
+    { path: 'messages[0].metadata.text', message: { role: 'user', metadata: { text: 'ops@acme.io' } } },
+    {
+      path: 'messages[0].tool_calls[0].arguments',
+      message: { role: 'assistant', tool_calls: [{ id: 'call_1', arguments: '{"ssn":"123-45-6789"}' }] },
+    },
+    { path: 'messages[0].content.text', message: { role: 'user', content: { text: 'ops@acme.io' } } },
+    { path: 'messages[0].function.arguments', message: { role: 'user', function: { arguments: '{}' } } },
+  ]) {
+    it(`skips string target reachable only outside the canonical productions ${path}`, () => {
+      const messages = [message]
+
+      const result = redactMessages(messages, [{ path, replacement: '<REDACTED>' }])
+
+      assert.strictEqual(result.messages, messages)
+      assert.strictEqual(result.redacted, false)
+      assert.strictEqual(result.failures, 1)
+    })
+  }
+})

--- a/packages/dd-trace/test/aiguard/redaction.spec.js
+++ b/packages/dd-trace/test/aiguard/redaction.spec.js
@@ -33,7 +33,7 @@ describe('AI Guard redaction', () => {
     assert.strictEqual(result.failures, 1)
   })
 
-  it('redacts message content, content-part text, and tool arguments in one copy', () => {
+  it('redacts message content, content-part text, and tool arguments in place', () => {
     const messages = [
       { role: 'user', content: [{ type: 'input_text', text: 'card 4111111111111111' }] },
       {
@@ -53,8 +53,8 @@ describe('AI Guard redaction', () => {
 
     const { messages: redacted } = redactMessages(messages, replacements)
 
-    assert.notStrictEqual(redacted, messages)
-    assert.deepStrictEqual(redacted, [
+    assert.strictEqual(redacted, messages)
+    assert.deepStrictEqual(messages, [
       { role: 'user', content: [{ type: 'input_text', text: 'card <REDACTED>' }] },
       {
         role: 'assistant',
@@ -64,17 +64,6 @@ describe('AI Guard redaction', () => {
         }],
       },
       { role: 'tool', tool_call_id: 'call_1', content: 'paid from <REDACTED>' },
-    ])
-    assert.deepStrictEqual(messages, [
-      { role: 'user', content: [{ type: 'input_text', text: 'card 4111111111111111' }] },
-      {
-        role: 'assistant',
-        tool_calls: [{
-          id: 'call_1',
-          function: { name: 'pay', arguments: '{"ssn":"123-45-6789"}' },
-        }],
-      },
-      { role: 'tool', tool_call_id: 'call_1', content: 'paid from 000123456789' },
     ])
   })
 
@@ -103,9 +92,9 @@ describe('AI Guard redaction', () => {
       { path: 'messages[00].content', replacement: '<B>' },
     ])
 
-    assert.notStrictEqual(result.messages, messages)
+    assert.strictEqual(result.messages, messages)
     assert.strictEqual(result.messages[0].content, '<B>')
-    assert.strictEqual(messages[0].content, 'secret')
+    assert.strictEqual(messages[0].content, '<B>')
     assert.strictEqual(result.redacted, true)
     assert.strictEqual(result.failures, 0)
   })
@@ -177,6 +166,32 @@ describe('AI Guard redaction', () => {
     })
   })
 
+  for (const replacements of [false, 0, '']) {
+    it(`treats the falsy non-array replacement collection ${JSON.stringify(replacements)} as malformed`, () => {
+      const messages = [{ role: 'user', content: 'secret' }]
+
+      const result = redactMessages(messages, replacements)
+
+      assert.strictEqual(result.messages, messages)
+      assert.strictEqual(messages[0].content, 'secret')
+      assert.strictEqual(result.redacted, false)
+      assert.strictEqual(result.failures, 1)
+    })
+  }
+
+  for (const replacements of [null, undefined]) {
+    it(`treats ${replacements === null ? 'null' : 'undefined'} replacements as absent`, () => {
+      const messages = [{ role: 'user', content: 'secret' }]
+
+      const result = redactMessages(messages, replacements)
+
+      assert.strictEqual(result.messages, messages)
+      assert.strictEqual(messages[0].content, 'secret')
+      assert.strictEqual(result.redacted, false)
+      assert.strictEqual(result.failures, 0)
+    })
+  }
+
   it('returns the original messages for an empty replacement array', () => {
     const messages = [{ role: 'user', content: 'secret' }]
 
@@ -187,7 +202,7 @@ describe('AI Guard redaction', () => {
     assert.strictEqual(result.failures, 0)
   })
 
-  it('fails safe when cloning messages throws', () => {
+  it('fails safe when reading a replacement target throws', () => {
     const message = { role: 'user' }
     Object.defineProperty(message, 'content', {
       enumerable: true,
@@ -200,6 +215,30 @@ describe('AI Guard redaction', () => {
     assert.deepStrictEqual(redactMessages(messages, [
       { path: 'messages[0].content', replacement: '<REDACTED>' },
     ]), { messages, redacted: false, failures: 1 })
+  })
+
+  it('does not partially redact when a later target property read throws', () => {
+    const unreadableMessage = { role: 'user' }
+    Object.defineProperty(unreadableMessage, 'content', {
+      enumerable: true,
+      get () {
+        throw new Error('unreadable')
+      },
+    })
+    const messages = [
+      { role: 'user', content: 'first secret' },
+      unreadableMessage,
+    ]
+
+    const result = redactMessages(messages, [
+      { path: 'messages[0].content', replacement: '<REDACTED>' },
+      { path: 'messages[1].content', replacement: '<REDACTED>' },
+    ])
+
+    assert.strictEqual(result.messages, messages)
+    assert.strictEqual(messages[0].content, 'first secret')
+    assert.strictEqual(result.redacted, false)
+    assert.strictEqual(result.failures, 1)
   })
 
   it('fails safe when replacement preprocessing throws', () => {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -964,6 +964,7 @@ describe('Config', () => {
           enabled: false,
           endpoint: undefined,
           maxMessagesLength: 16,
+          redactionEnabled: true,
           timeout: 10_000,
           maxContentSize: 512 * 1024,
         },
@@ -1098,6 +1099,7 @@ describe('Config', () => {
       { name: 'DD_AI_GUARD_ENDPOINT', value: null, origin: 'default' },
       { name: 'DD_AI_GUARD_MAX_CONTENT_SIZE', value: 512 * 1024, origin: 'default' },
       { name: 'DD_AI_GUARD_MAX_MESSAGES_LENGTH', value: 16, origin: 'default' },
+      { name: 'DD_AI_GUARD_REDACTION_ENABLED', value: true, origin: 'default' },
       { name: 'DD_AI_GUARD_TIMEOUT', value: 10_000, origin: 'default' },
       { name: 'DD_TRACE_EXPERIMENTAL_GET_RUM_DATA_ENABLED', value: false, origin: 'default' },
       { name: 'DD_TRACE_EXPERIMENTAL_EXPORTER', value: '', origin: 'default' },
@@ -1254,6 +1256,7 @@ describe('Config', () => {
     process.env.DD_AI_GUARD_ENDPOINT = 'https://dd.datad0g.com/api/unstable/ai-guard'
     process.env.DD_AI_GUARD_MAX_CONTENT_SIZE = String(1024 * 1024)
     process.env.DD_AI_GUARD_MAX_MESSAGES_LENGTH = '32'
+    process.env.DD_AI_GUARD_REDACTION_ENABLED = 'false'
     process.env.DD_AI_GUARD_TIMEOUT = '2000'
     process.env.DD_API_SECURITY_ENABLED = 'true'
     process.env.DD_API_SECURITY_SAMPLE_DELAY = '25'
@@ -1445,6 +1448,7 @@ describe('Config', () => {
           endpoint: 'https://dd.datad0g.com/api/unstable/ai-guard',
           maxContentSize: 1024 * 1024,
           maxMessagesLength: 32,
+          redactionEnabled: false,
           timeout: 2000,
         },
         enableGetRumData: true,
@@ -1581,6 +1585,7 @@ describe('Config', () => {
       { name: 'DD_AI_GUARD_ENDPOINT', value: null, origin: 'default' },
       { name: 'DD_AI_GUARD_MAX_CONTENT_SIZE', value: 512 * 1024, origin: 'default' },
       { name: 'DD_AI_GUARD_MAX_MESSAGES_LENGTH', value: 16, origin: 'default' },
+      { name: 'DD_AI_GUARD_REDACTION_ENABLED', value: true, origin: 'default' },
       { name: 'DD_AI_GUARD_TIMEOUT', value: 10_000, origin: 'default' },
       { name: 'DD_AI_GUARD_ENABLED', value: true, origin: 'env_var' },
       { name: 'DD_AI_GUARD_BLOCK', value: true, origin: 'env_var' },
@@ -1588,6 +1593,7 @@ describe('Config', () => {
       { name: 'DD_AI_GUARD_TIMEOUT', value: 2000, origin: 'env_var' },
       { name: 'DD_AI_GUARD_MAX_CONTENT_SIZE', value: 1024 * 1024, origin: 'env_var' },
       { name: 'DD_AI_GUARD_MAX_MESSAGES_LENGTH', value: 32, origin: 'env_var' },
+      { name: 'DD_AI_GUARD_REDACTION_ENABLED', value: false, origin: 'env_var' },
       { name: 'DD_TRACE_EXPERIMENTAL_GET_RUM_DATA_ENABLED', value: true, origin: 'env_var' },
       { name: 'DD_TRACE_EXPERIMENTAL_EXPORTER', value: 'log', origin: 'env_var' },
       { name: 'DD_AGENT_HOST', value: 'agent', origin: 'env_var' },
@@ -1949,6 +1955,7 @@ describe('Config', () => {
           endpoint: 'https://dd.datad0g.com/api/unstable/ai-guard',
           maxContentSize: 1024 * 1024,
           maxMessagesLength: 32,
+          redactionEnabled: true,
           timeout: 2000,
         },
         exporter: 'log',
@@ -2055,6 +2062,7 @@ describe('Config', () => {
           endpoint: 'https://dd.datad0g.com/api/unstable/ai-guard',
           maxContentSize: 1024 * 1024,
           maxMessagesLength: 32,
+          redactionEnabled: true,
           timeout: 2000,
         },
         enableGetRumData: true,
@@ -2200,6 +2208,7 @@ describe('Config', () => {
       { name: 'DD_AI_GUARD_ENDPOINT', value: 'https://dd.datad0g.com/api/unstable/ai-guard', origin: 'code' },
       { name: 'DD_AI_GUARD_MAX_CONTENT_SIZE', value: 1024 * 1024, origin: 'code' },
       { name: 'DD_AI_GUARD_MAX_MESSAGES_LENGTH', value: 32, origin: 'code' },
+      { name: 'DD_AI_GUARD_REDACTION_ENABLED', value: true, origin: 'code' },
       { name: 'DD_AI_GUARD_TIMEOUT', value: 2_000, origin: 'code' },
       { name: 'DD_TRACE_EXPERIMENTAL_GET_RUM_DATA_ENABLED', value: true, origin: 'code' },
       { name: 'DD_TRACE_EXPERIMENTAL_EXPORTER', value: 'log', origin: 'code' },
@@ -2423,6 +2432,7 @@ describe('Config', () => {
     process.env.DD_AI_GUARD_ENDPOINT = 'https://dd.datadog.com/api/unstable/ai-guard'
     process.env.DD_AI_GUARD_MAX_CONTENT_SIZE = String(512 * 1024)
     process.env.DD_AI_GUARD_MAX_MESSAGES_LENGTH = '16'
+    process.env.DD_AI_GUARD_REDACTION_ENABLED = 'false'
     process.env.DD_AI_GUARD_TIMEOUT = '1000'
     process.env.DD_API_KEY = '123'
     process.env.DD_API_SECURITY_ENABLED = 'false'
@@ -2559,6 +2569,7 @@ describe('Config', () => {
           endpoint: 'https://dd.datad0g.com/api/unstable/ai-guard',
           maxContentSize: 1024 * 1024,
           maxMessagesLength: 32,
+          redactionEnabled: true,
           timeout: 2000,
         },
         b3: false,
@@ -2673,6 +2684,7 @@ describe('Config', () => {
           endpoint: 'https://dd.datad0g.com/api/unstable/ai-guard',
           maxContentSize: 1024 * 1024,
           maxMessagesLength: 32,
+          redactionEnabled: true,
           timeout: 2000,
         },
         enableGetRumData: false,


### PR DESCRIPTION
## Summary
Adds sensitive data redaction to AI Guard SDK.

When the AI Guard evaluation endpoint returns `redaction_replacements`, the tracer applies them to a copy of the evaluated messages and returns the redacted conversation from `evaluate()`. Callers can then forward those messages to the LLM without mutating their original input.

Redaction supports only these backend paths:
- `messages[i].content`
- `messages[i].content[j].text`
- `messages[i].tool_calls[j].function.arguments`

Malformed, unsupported, conflicting, or non-string targets are skipped safely. 

`DD_AI_GUARD_REDACTION_ENABLED` disables applying replacements while keeping evaluation enabled.
The redacted conversation is also reported in the AI Guard span meta-struct and redaction state is exposed through the `ai_guard.redacted` span tag and the `redacted` tag on the `ai_guard.requests` telemetry metric.