### PR TITLE
perf: avoid temporary arrays when building strings

### DIFF
--- a/eslint-rules/eslint-no-unnecessary-array-join.mjs
+++ b/eslint-rules/eslint-no-unnecessary-array-join.mjs
@@ -5,12 +5,25 @@ export default {
       description: 'Prefer building strings directly instead of collecting string fragments in an array',
       recommended: true,
     },
-    schema: [],
+    schema: [{
+      type: 'object',
+      properties: {
+        reportLiteralArrayJoins: {
+          type: 'boolean',
+        },
+        reportMapJoinChains: {
+          type: 'boolean',
+        },
+      },
+      additionalProperties: false,
+    }],
     messages: {
       buildStringDirectly:
         'Build "{{name}}" directly as a string instead of collecting string fragments in an array before joining.',
       buildLiteralStringDirectly:
         'Build this string directly instead of joining an array literal.',
+      buildMappedStringDirectly:
+        'Build this string directly instead of mapping string fragments into an array before joining.',
     },
   },
 
@@ -19,101 +32,211 @@ export default {
    */
   create (context) {
     const { sourceCode } = context
+    const [{ reportLiteralArrayJoins = false, reportMapJoinChains = false } = {}] = context.options
+    const arrayAppenders = new Set()
+    const arrayDeclarators = []
 
     return {
+      /**
+       * @param {import('estree').FunctionDeclaration} node
+       */
+      FunctionDeclaration (node) {
+        const variable = getArrayAppenderVariable(node, sourceCode)
+        if (variable) arrayAppenders.add(variable)
+      },
+
       /**
        * @param {import('estree').VariableDeclarator} node
        */
       VariableDeclarator (node) {
-        if (
-          node.id.type !== 'Identifier' ||
-          node.init?.type !== 'ArrayExpression' ||
-          node.init.elements.length !== 0
-        ) {
-          return
+        arrayDeclarators.push(node)
+      },
+
+      'Program:exit' () {
+        for (const node of arrayDeclarators) {
+          reportUnnecessaryArrayJoin(node, sourceCode, arrayAppenders, context)
         }
-
-        const [variable] = sourceCode.getDeclaredVariables(node)
-        if (variable.defs.length !== 1) return
-
-        const owner = getFunctionOwner(node)
-        let joinCall
-        const pushCalls = []
-
-        for (const reference of variable.references) {
-          const identifier = reference.identifier
-          if (identifier === node.id) continue
-          if (getFunctionOwner(identifier) !== owner) return
-
-          const member = identifier.parent
-          if (
-            member.type !== 'MemberExpression' ||
-            member.object !== identifier ||
-            member.computed ||
-            member.optional ||
-            member.property.type !== 'Identifier'
-          ) {
-            return
-          }
-
-          const call = member.parent
-          if (call.type !== 'CallExpression' || call.callee !== member || call.optional) return
-
-          if (member.property.name === 'push') {
-            if (
-              call.parent.type !== 'ExpressionStatement' ||
-              call.arguments.length === 0 ||
-              call.arguments.some(argument =>
-                argument.type === 'SpreadElement' || isKnownNonStringExpression(argument, sourceCode))
-            ) {
-              return
-            }
-
-            pushCalls.push(call)
-            continue
-          }
-
-          if (member.property.name === 'join') {
-            if (
-              joinCall ||
-              call.arguments.length > 1 ||
-              !isStaticSeparator(call.arguments[0])
-            ) {
-              return
-            }
-
-            joinCall = call
-            continue
-          }
-
-          return
-        }
-
-        if (!joinCall || pushCalls.length === 0) return
-        for (const pushCall of pushCalls) {
-          if (pushCall.range[0] > joinCall.range[0]) return
-        }
-
-        context.report({
-          node: joinCall,
-          messageId: 'buildStringDirectly',
-          data: { name: node.id.name },
-        })
       },
 
       /**
        * @param {import('estree').CallExpression} node
        */
       CallExpression (node) {
-        if (!isLiteralJoin(node)) return
+        if (reportLiteralArrayJoins && isLiteralJoin(node, sourceCode)) {
+          context.report({
+            node,
+            messageId: 'buildLiteralStringDirectly',
+          })
+        }
 
-        context.report({
-          node,
-          messageId: 'buildLiteralStringDirectly',
-        })
+        if (reportMapJoinChains && isMapJoin(node)) {
+          context.report({
+            node,
+            messageId: 'buildMappedStringDirectly',
+          })
+        }
       },
     }
   },
+}
+
+/**
+ * @param {import('estree').VariableDeclarator} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {Set<import('eslint').Scope.Variable>} arrayAppenders
+ * @param {import('eslint').Rule.RuleContext} context
+ */
+function reportUnnecessaryArrayJoin (node, sourceCode, arrayAppenders, context) {
+  if (
+    node.id.type !== 'Identifier' ||
+    node.init?.type !== 'ArrayExpression' ||
+    node.init.elements.length !== 0
+  ) {
+    return
+  }
+
+  const [variable] = sourceCode.getDeclaredVariables(node)
+  if (variable.defs.length !== 1) return
+
+  const owner = getFunctionOwner(node)
+  let joinCall
+  const pushCalls = []
+
+  for (const reference of variable.references) {
+    const identifier = reference.identifier
+    if (identifier === node.id) continue
+    if (getFunctionOwner(identifier) !== owner) return
+
+    const appendCall = getArrayAppenderCall(identifier, sourceCode, arrayAppenders)
+    if (appendCall) {
+      pushCalls.push(appendCall)
+      continue
+    }
+
+    const member = identifier.parent
+    if (
+      member.type !== 'MemberExpression' ||
+      member.object !== identifier ||
+      member.computed ||
+      member.optional ||
+      member.property.type !== 'Identifier'
+    ) {
+      return
+    }
+
+    const call = member.parent
+    if (call.type !== 'CallExpression' || call.callee !== member || call.optional) return
+
+    if (member.property.name === 'push') {
+      if (
+        call.parent.type !== 'ExpressionStatement' ||
+        call.arguments.length === 0 ||
+        call.arguments.some(argument =>
+          argument.type === 'SpreadElement' || isKnownNonStringExpression(argument, sourceCode))
+      ) {
+        return
+      }
+
+      pushCalls.push(call)
+      continue
+    }
+
+    if (member.property.name === 'join') {
+      if (
+        joinCall ||
+        call.arguments.length > 1 ||
+        !isStaticSeparator(call.arguments[0])
+      ) {
+        return
+      }
+
+      joinCall = call
+      continue
+    }
+
+    return
+  }
+
+  if (!joinCall || pushCalls.length === 0) return
+  for (const pushCall of pushCalls) {
+    if (pushCall.range[0] > joinCall.range[0]) return
+  }
+
+  context.report({
+    node: joinCall,
+    messageId: 'buildStringDirectly',
+    data: { name: node.id.name },
+  })
+}
+
+/**
+ * @param {import('estree').FunctionDeclaration} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('eslint').Scope.Variable | undefined}
+ */
+function getArrayAppenderVariable (node, sourceCode) {
+  const [arrayParameter] = node.params
+  if (node.async || node.generator || node.id === null || arrayParameter?.type !== 'Identifier') return
+
+  const variables = sourceCode.getDeclaredVariables(node)
+  const arrayVariable = variables.find(variable => variable.identifiers.includes(arrayParameter))
+  const functionVariable = variables.find(variable => variable.identifiers.includes(node.id))
+  if (!arrayVariable || !functionVariable || arrayVariable.references.length === 0) return
+
+  for (const reference of arrayVariable.references) {
+    const identifier = reference.identifier
+    const member = identifier.parent
+    if (
+      member.type !== 'MemberExpression' ||
+      member.object !== identifier ||
+      member.computed ||
+      member.optional ||
+      member.property.type !== 'Identifier' ||
+      member.property.name !== 'push'
+    ) {
+      return
+    }
+
+    const call = member.parent
+    if (
+      call.type !== 'CallExpression' ||
+      call.callee !== member ||
+      call.optional ||
+      call.parent.type !== 'ExpressionStatement' ||
+      call.arguments.length === 0 ||
+      call.arguments.some(argument =>
+        argument.type === 'SpreadElement' || isKnownNonStringExpression(argument, sourceCode))
+    ) {
+      return
+    }
+  }
+
+  return functionVariable
+}
+
+/**
+ * @param {import('estree').Identifier} identifier
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {Set<import('eslint').Scope.Variable>} arrayAppenders
+ * @returns {import('estree').CallExpression | undefined}
+ */
+function getArrayAppenderCall (identifier, sourceCode, arrayAppenders) {
+  const call = identifier.parent
+  if (
+    call.type !== 'CallExpression' ||
+    call.optional ||
+    call.arguments[0] !== identifier ||
+    call.callee.type !== 'Identifier' ||
+    call.parent.type !== 'ExpressionStatement'
+  ) {
+    return
+  }
+
+  const reference = sourceCode.getScope(call.callee).references
+    .find(candidate => candidate.identifier === call.callee)
+  if (!reference || !arrayAppenders.has(reference.resolved)) return
+
+  return call
 }
 
 /**
@@ -213,9 +336,10 @@ function isKnownNonStringExpression (node, sourceCode, seen = new Set()) {
 
 /**
  * @param {import('estree').CallExpression} node
+ * @param {import('eslint').SourceCode} sourceCode
  * @returns {boolean}
  */
-function isLiteralJoin (node) {
+function isLiteralJoin (node, sourceCode) {
   if (
     node.optional ||
     node.callee.type !== 'MemberExpression' ||
@@ -223,51 +347,88 @@ function isLiteralJoin (node) {
     node.callee.optional ||
     node.callee.property.type !== 'Identifier' ||
     node.callee.property.name !== 'join' ||
-    node.callee.object.type !== 'ArrayExpression' ||
     node.arguments.length > 1 ||
     !isStaticSeparator(node.arguments[0])
   ) {
     return false
   }
 
-  const { elements } = node.callee.object
+  const elements = getLiteralJoinElements(node.callee.object, sourceCode)
+  if (!elements) return false
   if (elements.some(element => element === null || element.type === 'SpreadElement')) return false
 
-  return isNameJoin(elements, node.arguments[0]) || isConditionalTextJoin(node, elements, node.arguments[0])
-}
-
-/**
- * @param {Array<import('estree').Expression>} elements
- * @param {import('estree').Expression | import('estree').SpreadElement | undefined} separator
- * @returns {boolean}
- */
-function isNameJoin (elements, separator) {
-  return (
-    separator?.type === 'Literal' &&
-    separator.value === '.' &&
-    elements.length === 2 &&
-    elements.every(element =>
-      element.type === 'MemberExpression' &&
-      !element.computed &&
-      !element.optional &&
-      element.property.type === 'Identifier' &&
-      element.property.name === 'name'
-    )
-  )
+  return elements.length > 0
 }
 
 /**
  * @param {import('estree').CallExpression} node
- * @param {Array<import('estree').Expression>} elements
- * @param {import('estree').Expression | import('estree').SpreadElement | undefined} separator
  * @returns {boolean}
  */
-function isConditionalTextJoin (node, elements, separator) {
-  return (
-    node.parent.type === 'ConditionalExpression' &&
-    separator?.type === 'Literal' &&
-    separator.value === '\n' &&
-    elements.length > 1 &&
-    elements.every(element => element.type === 'Literal' || element.type === 'TemplateLiteral')
-  )
+function isMapJoin (node) {
+  if (
+    node.optional ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.computed ||
+    node.callee.optional ||
+    node.callee.property.type !== 'Identifier' ||
+    node.callee.property.name !== 'join' ||
+    node.arguments.length > 1 ||
+    !isStaticSeparator(node.arguments[0])
+  ) {
+    return false
+  }
+
+  const mapCall = node.callee.object
+  return mapCall.type === 'CallExpression' &&
+    !mapCall.optional &&
+    mapCall.callee.type === 'MemberExpression' &&
+    !mapCall.callee.computed &&
+    !mapCall.callee.optional &&
+    mapCall.callee.property.type === 'Identifier' &&
+    mapCall.callee.property.name === 'map' &&
+    mapCall.arguments.length === 1 &&
+    mapCall.arguments[0].type !== 'SpreadElement'
+}
+
+/**
+ * @param {import('estree').Expression} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {(import('estree').Expression | import('estree').SpreadElement | null)[] | undefined}
+ */
+function getLiteralJoinElements (node, sourceCode) {
+  if (node.type === 'ArrayExpression') return node.elements
+  if (
+    node.type !== 'CallExpression' ||
+    node.optional ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.computed ||
+    node.callee.optional ||
+    node.callee.property.type !== 'Identifier' ||
+    node.callee.property.name !== 'filter' ||
+    node.callee.object.type !== 'ArrayExpression' ||
+    node.callee.object.elements.length !== 2 ||
+    node.arguments.length !== 1 ||
+    node.arguments[0].type !== 'Identifier' ||
+    node.arguments[0].name !== 'Boolean' ||
+    !isGlobalBoolean(node.arguments[0], sourceCode)
+  ) {
+    return
+  }
+
+  return node.callee.object.elements
+}
+
+/**
+ * @param {import('estree').Identifier} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {boolean}
+ */
+function isGlobalBoolean (node, sourceCode) {
+  let scope = sourceCode.getScope(node)
+  while (scope) {
+    if (scope.set.get('Boolean')?.defs.length) return false
+    scope = scope.upper
+  }
+
+  return true
 }

--- a/eslint-rules/eslint-no-unnecessary-array-join.test.mjs
+++ b/eslint-rules/eslint-no-unnecessary-array-join.test.mjs
@@ -10,7 +10,28 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
   valid: [
     "const parts = ['a']; parts.join('')",
     "const parts = ['a']; parts.join(separator)",
-    "[...parts].join('')",
+    "const text = ['first', 'second'].join('\\n')",
+    {
+      code: "[...parts].join('')",
+      options: [{ reportLiteralArrayJoins: true }],
+    },
+    {
+      code: "['first',, 'second'].join('')",
+      options: [{ reportLiteralArrayJoins: true }],
+    },
+    "messages.map(message => message.text).join('')",
+    {
+      code: "messages.map(message => message.text, receiver).join('')",
+      options: [{ reportMapJoinChains: true }],
+    },
+    {
+      code: "const Boolean = value => value; ['receive', source].filter(Boolean).join(' ')",
+      options: [{ reportLiteralArrayJoins: true }],
+    },
+    {
+      code: "[first, second, third].filter(Boolean).join(' ')",
+      options: [{ reportLiteralArrayJoins: true }],
+    },
     "const parts = []; parts.push('a'); consume(parts); parts.join('')",
     "const parts = []; parts.push('a'); parts.join(separator)",
     "const parts = []; parts.push('a'); parts.join(`$" + '{separator}`)',
@@ -45,6 +66,47 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
     "var parts = []; var parts; parts.push('a'); parts.join('')",
     "const parts = []; parts[0] = 'a'; parts.join('')",
     `
+      function appendNothing (parts) {}
+      const parts = []
+      parts.push('value')
+      appendNothing(parts)
+      parts.join('')
+    `,
+    `
+      function appendNull (parts) {
+        parts.push(null)
+      }
+      const parts = []
+      appendNull(parts)
+      parts.join('')
+    `,
+    `
+      async function appendValue (parts) {
+        parts.push('value')
+      }
+      const parts = []
+      appendValue(parts)
+      parts.join('')
+    `,
+    `
+      function * appendValue (parts) {
+        parts.push('value')
+      }
+      const parts = []
+      appendValue(parts)
+      parts.join('')
+    `,
+    `
+      function appendEmptyTag (parts) {
+        parts.push()
+      }
+      function build () {
+        const parts = []
+        appendEmptyTag(parts)
+        return parts.join('')
+      }
+    `,
+    `
       function build () {
         const parts = []
         function append () {
@@ -54,10 +116,24 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
         return parts.join('')
       }
     `,
+    `
+      function appendValue (parts) {
+        parts.push('a')
+      }
+      function build () {
+        const parts = []
+        function append () {
+          appendValue(parts)
+        }
+        append()
+        return parts.join('')
+      }
+    `,
   ],
   invalid: [
     {
       code: "[this.constructor.name, generateStream.name].join('.')",
+      options: [{ reportLiteralArrayJoins: true }],
       errors: [{ messageId: 'buildLiteralStringDirectly' }],
     },
     {
@@ -80,10 +156,47 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
               '',
             ].join('\\n')
       `,
+      options: [{ reportLiteralArrayJoins: true }],
       errors: [
         { messageId: 'buildLiteralStringDirectly' },
         { messageId: 'buildLiteralStringDirectly' },
       ],
+    },
+    {
+      code: `
+        function appendLogTag (tags, key, value) {
+          if (value !== undefined) tags.push(\`\${key}:\${value}\`)
+        }
+        function getLogTags (logMessage) {
+          const tags = []
+          if (Array.isArray(logMessage.ddtags)) {
+            for (const tag of logMessage.ddtags) tags.push(tag)
+          }
+          appendLogTag(tags, 'env', 'ci')
+          return tags.join(',')
+        }
+      `,
+      errors: [{ messageId: 'buildStringDirectly', data: { name: 'tags' } }],
+    },
+    {
+      code: "new RegExp([NUMERIC_LITERAL, STRING_LITERAL, LINE_COMMENT].join('|'), 'gmi')",
+      options: [{ reportLiteralArrayJoins: true }],
+      errors: [{ messageId: 'buildLiteralStringDirectly' }],
+    },
+    {
+      code: "['receive', source].filter(Boolean).join(' ')",
+      options: [{ reportLiteralArrayJoins: true }],
+      errors: [{ messageId: 'buildLiteralStringDirectly' }],
+    },
+    {
+      code: `
+        const content = messages
+          .filter(message => message.type === 'text')
+          .map(message => message.text)
+          .join('')
+      `,
+      options: [{ reportMapJoinChains: true }],
+      errors: [{ messageId: 'buildMappedStringDirectly' }],
     },
     {
       code: "const parts = []; parts.push('a'); parts.join()",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -705,6 +705,8 @@ export default [
       'unicorn/iteration-fallback-style': 'error',
       'unicorn/no-unsafe-dom-html': 'error',
       'unicorn/no-unused-properties': 'error',
+      'unicorn/prefer-array-find': 'error',
+      'unicorn/prefer-array-some': 'error',
 
       // Overriding recommended unicorn rules.
       // Rules not listed here are left at the `recommended` default. The entries below
@@ -1153,6 +1155,19 @@ export default [
     rules: {
       'import/no-extraneous-dependencies': 'off',
       'n/no-extraneous-require': 'off',
+    },
+  },
+  {
+    name: 'dd-trace/package-source',
+    files: [
+      'packages/*/src/**/*.js',
+      'packages/*/src/**/*.mjs',
+    ],
+    rules: {
+      'eslint-rules/eslint-no-unnecessary-array-join': ['error', {
+        reportLiteralArrayJoins: true,
+        reportMapJoinChains: true,
+      }],
     },
   },
 ]

--- a/integration-tests/ci-visibility/playwright-tests-multiple-suite-errors/multiple-suite-errors-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-multiple-suite-errors/multiple-suite-errors-test.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { test } = require('@playwright/test')
+
+test('first failing test', () => {
+  throw new Error('first failure')
+})
+
+test('second failing test', () => {
+  throw new Error('second failure')
+})

--- a/integration-tests/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const assert = require('assert')
+
+let firstCounter = 0
+let secondCounter = 0
+
+describe('fail', () => {
+  it('first occasionally fails', () => {
+    assert.strictEqual((firstCounter++) % 2, 0)
+  })
+
+  it('second occasionally fails', () => {
+    assert.strictEqual((secondCounter++) % 2, 0)
+  })
+})

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -3028,7 +3028,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
     it('retries flaky tests and sets exit code to 0 as long as one attempt passes', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
-      // Tests from ci-visibility/test/occasionally-failing-test will be considered new
+      // Tests from ci-visibility/test/two-occasionally-failing-tests will be considered new
       receiver.setKnownTests({ jest: {} })
 
       const NUM_RETRIES_EFD = 3
@@ -3054,20 +3054,15 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-          // all but one has been retried
-          assert.strictEqual(tests.length - 1, retriedTests.length)
-          assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD)
-          // Out of NUM_RETRIES_EFD + 1 total runs, half will be passing and half will be failing,
-          // based on the global counter in the test file
-          const passingTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
-          const failingTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
-          assert.strictEqual(passingTests.length, (NUM_RETRIES_EFD + 1) / 2)
-          assert.strictEqual(failingTests.length, (NUM_RETRIES_EFD + 1) / 2)
-          // Test name does not change
-          retriedTests.forEach(test => {
-            assert.strictEqual(test.meta[TEST_NAME], 'fail occasionally fails')
-          })
+          const testNames = ['fail first occasionally fails', 'fail second occasionally fails']
+          assert.deepStrictEqual([...new Set(tests.map(test => test.meta[TEST_NAME]))].sort(), testNames)
+          for (const testName of testNames) {
+            const testRuns = tests.filter(test => test.meta[TEST_NAME] === testName)
+            const statuses = testRuns.map(test => test.meta[TEST_STATUS])
+            assert.ok(testRuns.filter(test => test.meta[TEST_IS_RETRY] === 'true').length >= NUM_RETRIES_EFD)
+            assert.ok(statuses.includes('pass'))
+            assert.ok(statuses.includes('fail'))
+          }
         })
 
       let testOutput = ''
@@ -3077,7 +3072,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           cwd,
           env: {
             ...getCiVisEvpProxyConfig(receiver.port),
-            TESTS_TO_RUN: '**/ci-visibility/test-early-flake-detection/occasionally-failing-test*',
+            TESTS_TO_RUN: '**/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests*',
             SHOULD_CHECK_RESULTS: '1',
           },
         }
@@ -3092,7 +3087,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
       const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
 
-      assert.match(testOutput, /2 failed, 2 passed/)
       // Exit code is 0 because at least one retry of the new flaky test passes
       assert.strictEqual(exitCode, 0)
 
@@ -3100,7 +3094,8 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       assert.match(testOutput, /Datadog Test Optimization/)
       assert.match(testOutput, /\d+ test failure\(s\) were ignored\. Exit code set to 0\./)
       assert.match(testOutput, /Early Flake Detection/)
-      assert.match(testOutput, /occasionally-failing-test.*›.*fail occasionally fails/)
+      assert.match(testOutput, /two-occasionally-failing-tests.*›.*fail first occasionally fails/)
+      assert.match(testOutput, /two-occasionally-failing-tests.*›.*fail second occasionally fails/)
     })
 
     // resetting snapshot state logic only works in latest versions

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -13,6 +13,7 @@ const {
   getCiVisEvpProxyConfig,
   assertObjectContains,
   createParallelIt,
+  withReceiver,
 } = require('../helpers')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -1054,6 +1055,31 @@ versions.forEach((version) => {
       )
       await Promise.all([receiverPromise, once(proc, 'exit')])
     })
+
+    global.it('reports multiple test suite errors', withReceiver(async (receiver, run) => {
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSuiteEvent = events.find(event => event.type === 'test_suite_end').content
+
+          assert.match(
+            testSuiteEvent.meta[ERROR_MESSAGE],
+            /2 errors in this test suite:\n(?:Error: )?first failure\n------\n(?:Error: )?second failure/
+          )
+        })
+      const proc = run(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TEST_DIR: './ci-visibility/playwright-tests-multiple-suite-errors',
+          },
+        }
+      )
+
+      await Promise.all([receiverPromise, once(proc, 'exit')])
+    }))
 
     it('does not crash when maxFailures=1 and there is an error', async (receiver, run) => {
       const receiverPromise = receiver

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -67,7 +67,13 @@ function formatFileSystemError (error, fallbackPath) {
  * @returns {void}
  */
 function warnFileCreationFailures (artifact, failures, consequence, customerVisible = false) {
-  const details = failures.map(({ directory, error }) => formatFileSystemError(error, directory)).join('; ')
+  let details = ''
+  let isFirstFailure = true
+  for (const { directory, error } of failures) {
+    if (!isFirstFailure) details += '; '
+    details += formatFileSystemError(error, directory)
+    isFirstFailure = false
+  }
   const message = 'Datadog could not create %s. Attempts failed: %s. %s'
 
   if (customerVisible) {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -17,7 +17,7 @@ const compiler = {
   parse: (sourceText, options) => {
     try {
       // TODO: Figure out ESBuild `createRequire` issue and remove this hack.
-      const oxc = runtimeRequire(['oxc', 'parser'].join('-'))
+      const oxc = runtimeRequire('oxc-parser')
 
       compiler.parse = (sourceText, { range, isModule } = {}) => {
         const { program, errors } = oxc.parseSync('index.js', sourceText, {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -344,16 +344,17 @@ function getTestStats (testStatuses) {
 function formatIgnoredFailuresSummary (ignoredFailures) {
   if (!ignoredFailures?.efdFailureCount) return ''
 
-  const items = ignoredFailures.efdNames.map(text => ({ text, suffix: 'Early Flake Detection' }))
-
-  if (items.length === 0) return ''
-
-  const shown = items.slice(0, MAX_IGNORED_TEST_NAMES)
-  const more = items.length - shown.length
+  const shown = ignoredFailures.efdNames.slice(0, MAX_IGNORED_TEST_NAMES)
+  const more = ignoredFailures.efdNames.length - shown.length
   const moreSuffix = more > 0 ? `\n  ... and ${more} more` : ''
-  const formattedItems = shown
-    .map(({ text, suffix }) => `  • ${text}${suffix ? ` (${suffix})` : ''}`)
-    .join('\n') + moreSuffix
+  let formattedItems = ''
+  let isFirstItem = true
+  for (const text of shown) {
+    if (!isFirstItem) formattedItems += '\n'
+    formattedItems += `  • ${text} (Early Flake Detection)`
+    isFirstItem = false
+  }
+  formattedItems += moreSuffix
 
   return `${ignoredFailures.efdFailureCount} test failure(s) were ignored. Exit code set to 0.\n\n${formattedItems}`
 }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -614,7 +614,15 @@ function getTestSuiteError (testSuiteAbsolutePath) {
   if (errors.length === 1) {
     return errors[0]
   }
-  return new Error(`${errors.length} errors in this test suite:\n${errors.map(e => e.message).join('\n------\n')}`)
+  let errorMessages = ''
+  let isFirstError = true
+  for (const error of errors) {
+    if (!isFirstError) errorMessages += '\n------\n'
+    errorMessages += error.message
+    isFirstError = false
+  }
+
+  return new Error(`${errors.length} errors in this test suite:\n${errorMessages}`)
 }
 
 function getTestByTestId (dispatcher, testId) {

--- a/packages/datadog-instrumentations/test/cypress-config.spec.js
+++ b/packages/datadog-instrumentations/test/cypress-config.spec.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { mkdtempSync, rmSync, writeFileSync } = require('node:fs')
+const { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } = require('node:fs')
 const { tmpdir } = require('node:os')
 const { join } = require('node:path')
 const { pathToFileURL } = require('node:url')
 
 const { describe, it } = require('mocha')
+const sinon = require('sinon')
 
+const log = require('../../dd-trace/src/log')
 const { wrapCliConfigFileOptions } = require('../src/cypress-config')
 
 describe('Cypress config', () => {
@@ -55,6 +57,31 @@ describe('Cypress config', () => {
       assert.strictEqual(config.e2e.setupNodeEvents.name, 'ddSetupNodeEvents')
     } finally {
       wrapped.cleanup()
+      rmSync(project, { recursive: true, force: true })
+    }
+  })
+
+  it('reports every failed config-wrapper location', () => {
+    const project = mkdtempSync(join(tmpdir(), 'dd-cypress-config-'))
+    const configDirectory = join(project, 'config')
+    const configFile = join(configDirectory, 'cypress.config.cjs')
+    const options = { project, configFile }
+    mkdirSync(configDirectory)
+    writeFileSync(configFile, 'module.exports = {}')
+    const warn = sinon.stub(log, 'warn')
+
+    try {
+      chmodSync(configDirectory, 0o500)
+      chmodSync(project, 0o500)
+
+      const wrapped = wrapCliConfigFileOptions(options)
+
+      assert.strictEqual(wrapped.options, options)
+      assert.match(warn.firstCall.args[2], /; /)
+    } finally {
+      chmodSync(project, 0o700)
+      chmodSync(configDirectory, 0o700)
+      warn.restore()
       rmSync(project, { recursive: true, force: true })
     }
   })

--- a/packages/datadog-plugin-amqp10/src/consumer.js
+++ b/packages/datadog-plugin-amqp10/src/consumer.js
@@ -12,9 +12,11 @@ class Amqp10ConsumerPlugin extends ConsumerPlugin {
 
     const source = getShortName(link)
     const address = getAddress(link)
+    let resource = 'receive'
+    if (source) resource += ` ${source}`
 
     this.startSpan({
-      resource: ['receive', source].filter(Boolean).join(' '),
+      resource,
       type: 'worker',
       meta: {
         'amqp.link.source.address': source,

--- a/packages/datadog-plugin-amqp10/src/producer.js
+++ b/packages/datadog-plugin-amqp10/src/producer.js
@@ -14,9 +14,11 @@ class Amqp10ProducerPlugin extends ProducerPlugin {
 
     const address = getAddress(link)
     const target = getShortName(link)
+    let resource = 'send'
+    if (target) resource += ` ${target}`
 
     this.startSpan({
-      resource: ['send', target].filter(Boolean).join(' '),
+      resource,
       meta: {
         'amqp.link.target.address': target,
         'amqp.link.role': 'sender',

--- a/packages/datadog-plugin-amqp10/src/util.js
+++ b/packages/datadog-plugin-amqp10/src/util.js
@@ -9,7 +9,8 @@ function getAddress (link) {
 function getShortName (link) {
   if (!link || !link.name) return null
 
-  return link.name.split('_').slice(0, -1).join('_')
+  const lastUnderscorePosition = link.name.lastIndexOf('_')
+  return lastUnderscorePosition === -1 ? link.name : link.name.slice(0, lastUnderscorePosition)
 }
 
 module.exports = { getAddress, getShortName }

--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -16,6 +16,7 @@ describe('Plugin', () => {
   let client
   let receiver
   let sender
+  let namedSender
   let callbackPolicy
 
   describe('amqp10', () => {
@@ -29,10 +30,13 @@ describe('Plugin', () => {
       })
 
       afterEach(() => {
-        return Promise.all([
+        const links = [
           receiver && receiver.detach(),
           sender && sender.detach(),
-        ])
+          namedSender && namedSender.detach(),
+        ]
+        namedSender = undefined
+        return Promise.all(links)
       })
 
       afterEach(() => client.disconnect())
@@ -152,6 +156,16 @@ describe('Plugin', () => {
                 `Got: ${inspect(!Object.hasOwn(promise, 'value'))} && ${inspect('value' in promise)}`
               )
             })
+          })
+
+          it('uses a caller-provided link name without an underscore as the resource', async () => {
+            namedSender = await client.createSender('amq.topic', { name: 'custom-link' })
+
+            const traces = agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].resource, 'send custom-link')
+            })
+            namedSender.send({ key: 'value' })
+            await traces
           })
 
           withNamingSchema(

--- a/packages/datadog-plugin-avsc/src/schema_iterator.js
+++ b/packages/datadog-plugin-avsc/src/schema_iterator.js
@@ -50,7 +50,12 @@ class SchemaExtractor {
 
     if (Array.isArray(fieldType)) {
       // Union Type
-      type = 'union[' + fieldType.map(t => SchemaExtractor.getType(t.type || t)).join(',') + ']'
+      type = 'union['
+      for (const typeDefinition of fieldType) {
+        if (type !== 'union[') type += ','
+        type += SchemaExtractor.getType(typeDefinition.type || typeDefinition)
+      }
+      type += ']'
     } else if (fieldType === 'array') {
       // Array Type
       array = true

--- a/packages/datadog-plugin-avsc/test/schema-iterator.spec.js
+++ b/packages/datadog-plugin-avsc/test/schema-iterator.spec.js
@@ -31,5 +31,22 @@ describe('SchemaExtractor', () => {
         type: 'string',
       })
     })
+
+    it('should serialize union fields in the extracted schema', () => {
+      const schema = {
+        name: 'UserWithUnion',
+        fields: [{
+          name: 'email',
+          type: ['null', 'string'],
+        }],
+      }
+
+      const schemaData = SchemaBuilder.getSchemaDefinition(
+        new SchemaBuilder(new SchemaExtractor(schema)).build()
+      )
+      const property = JSON.parse(schemaData.definition).components.schemas.UserWithUnion.properties.email
+
+      assert.deepStrictEqual(property, { type: 'union[null,string]' })
+    })
   })
 })

--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -265,8 +265,11 @@ function extractRequestParams (params, provider) {
         for (const message of requestBody.messages) {
           const textBlocks = message.content?.filter(block => block.text) || []
           if (textBlocks.length > 0) {
+            let content = ''
+            for (const block of textBlocks) content += block.text
+
             messages.push({
-              content: textBlocks.map(block => block.text).join(''),
+              content,
               role: message.role,
             })
           }
@@ -288,9 +291,14 @@ function extractRequestParams (params, provider) {
         for (let idx = requestBody.messages.length - 1; idx >= 0; idx--) {
           const message = requestBody.messages[idx]
           if (message.role === 'user') {
-            prompt = message.content?.filter(block => block.type === 'text')
-              .map(block => block.text)
-              .join('')
+            const content = message.content
+            prompt = undefined
+            if (content) {
+              prompt = ''
+              for (const block of content) {
+                if (block.type === 'text') prompt += block.text
+              }
+            }
             break
           }
         }
@@ -546,7 +554,10 @@ function parseToolInput (inputStr) {
 }
 
 function buildToolResult ({ toolUseId, content }) {
-  const result = (content || []).map(resolveToolResultItem).join('')
+  let result = ''
+  if (content) {
+    for (const item of content) result += resolveToolResultItem(item)
+  }
   return { name: '', result, toolId: toolUseId ?? '', type: 'tool_result' }
 }
 

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
@@ -5,51 +5,117 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 
 const {
+  extractRequestParams,
+  extractMessagesFromConverseContent,
   extractTextAndResponseReasonConverseFromStream,
+  PROVIDER,
 } = require('../src/services/bedrockruntime/utils')
 
-describe('bedrockruntime converse stream extractor', () => {
-  it('returns an empty message when the stream fails before yielding a chunk', () => {
-    const generation = extractTextAndResponseReasonConverseFromStream()
+describe('bedrockruntime utils', () => {
+  it('combines Amazon Nova text blocks from the InvokeModel request body', () => {
+    const requestParams = extractRequestParams({
+      body: JSON.stringify({
+        messages: [{
+          role: 'user',
+          content: [
+            { text: 'Explain' },
+            { image: { format: 'jpeg' } },
+            { text: ' this image.' },
+          ],
+        }],
+      }),
+      modelId: 'amazon.nova-pro-v1:0',
+    }, PROVIDER.AMAZON)
 
-    assert.deepStrictEqual(generation.messages, [{ role: 'assistant', content: '' }])
+    assert.deepStrictEqual(requestParams.prompt, [{
+      content: 'Explain this image.',
+      role: 'user',
+    }])
   })
 
-  it('aggregates streamed text, tool input, metadata, and the stop reason', () => {
-    const generation = extractTextAndResponseReasonConverseFromStream([
-      { messageStart: { role: 'assistant' } },
-      { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'hel' } } },
-      { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'lo' } } },
-      { contentBlockDelta: { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":"Berlin"}' } } } },
-      { metadata: { usage: { inputTokens: 2, outputTokens: 3 } } },
-      { messageStop: { stopReason: 'tool_use' } },
-    ])
+  it('combines Anthropic text blocks from the InvokeModel request body', () => {
+    const requestParams = extractRequestParams({
+      body: JSON.stringify({
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe' },
+            { type: 'image' },
+            { type: 'text', text: ' this image.' },
+          ],
+        }],
+      }),
+      modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+    }, PROVIDER.ANTHROPIC)
 
-    assert.deepStrictEqual(generation.messages, [{
-      role: 'assistant',
-      content: 'hello',
-      toolCalls: [{ name: '', arguments: { city: 'Berlin' }, toolId: '', type: 'toolUse' }],
+    assert.strictEqual(requestParams.prompt, 'Describe this image.')
+  })
+
+  it('combines Converse tool-result blocks', () => {
+    const message = extractMessagesFromConverseContent('user', [{
+      toolResult: {
+        toolUseId: 'tool-1',
+        content: [
+          { text: 'Current weather: ' },
+          { json: { temperature: 24 } },
+        ],
+      },
     }])
-    assert.deepStrictEqual(generation.usage, {
-      inputTokens: 2,
-      outputTokens: 3,
-      cacheReadTokens: undefined,
-      cacheWriteTokens: undefined,
+
+    assert.deepStrictEqual(message, {
+      role: 'user',
+      toolResults: [{
+        name: '',
+        result: 'Current weather: {"temperature":24}',
+        toolId: 'tool-1',
+        type: 'tool_result',
+      }],
     })
-    assert.strictEqual(generation.finishReason, 'tool_use')
   })
 
-  it('emits empty tool-call arguments when the streamed tool-use input is malformed JSON', () => {
-    const generation = extractTextAndResponseReasonConverseFromStream([
-      { messageStart: { role: 'assistant' } },
-      { contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { toolUseId: 't-1', name: 'get_weather' } } } },
-      { contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: 'not valid json{' } } } },
-      { messageStop: { stopReason: 'tool_use' } },
-    ])
+  describe('converse stream extractor', () => {
+    it('returns an empty message when the stream fails before yielding a chunk', () => {
+      const generation = extractTextAndResponseReasonConverseFromStream()
 
-    assert.deepStrictEqual(generation.messages, [{
-      role: 'assistant',
-      toolCalls: [{ name: 'get_weather', arguments: {}, toolId: 't-1', type: 'toolUse' }],
-    }])
+      assert.deepStrictEqual(generation.messages, [{ role: 'assistant', content: '' }])
+    })
+
+    it('aggregates streamed text, tool input, metadata, and the stop reason', () => {
+      const generation = extractTextAndResponseReasonConverseFromStream([
+        { messageStart: { role: 'assistant' } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'hel' } } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'lo' } } },
+        { contentBlockDelta: { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":"Berlin"}' } } } },
+        { metadata: { usage: { inputTokens: 2, outputTokens: 3 } } },
+        { messageStop: { stopReason: 'tool_use' } },
+      ])
+
+      assert.deepStrictEqual(generation.messages, [{
+        role: 'assistant',
+        content: 'hello',
+        toolCalls: [{ name: '', arguments: { city: 'Berlin' }, toolId: '', type: 'toolUse' }],
+      }])
+      assert.deepStrictEqual(generation.usage, {
+        inputTokens: 2,
+        outputTokens: 3,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      })
+      assert.strictEqual(generation.finishReason, 'tool_use')
+    })
+
+    it('emits empty tool-call arguments when the streamed tool-use input is malformed JSON', () => {
+      const generation = extractTextAndResponseReasonConverseFromStream([
+        { messageStart: { role: 'assistant' } },
+        { contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { toolUseId: 't-1', name: 'get_weather' } } } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: 'not valid json{' } } } },
+        { messageStop: { stopReason: 'tool_use' } },
+      ])
+
+      assert.deepStrictEqual(generation.messages, [{
+        role: 'assistant',
+        toolCalls: [{ name: 'get_weather', arguments: {}, toolId: 't-1', type: 'toolUse' }],
+      }])
+    })
   })
 })

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -33,9 +33,14 @@ class CassandraDriverPlugin extends DatabasePlugin {
 }
 
 function combine (queries) {
-  return queries
-    .map(query => (query.query || query).replace(/;?$/, ';'))
-    .join(' ')
+  let combined = ''
+  let isFirstQuery = true
+  for (const query of queries) {
+    if (!isFirstQuery) combined += ' '
+    combined += (query.query || query).replace(/;?$/, ';')
+    isFirstQuery = false
+  }
+  return combined
 }
 
 function trim (str, size) {

--- a/packages/datadog-plugin-google-cloud-pubsub/src/client.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/client.js
@@ -12,9 +12,12 @@ class GoogleCloudPubsubClientPlugin extends ClientPlugin {
 
     if (api === 'publish') return
 
+    let resource = api
+    if (request.name) resource += ` ${request.name}`
+
     const spanOptions = {
       service: this.config.service || this.serviceName(),
-      resource: [api, request.name].filter(Boolean).join(' '),
+      resource,
       kind: this.constructor.kind,
       meta: {
         'pubsub.method': api,

--- a/packages/datadog-plugin-net/src/tcp.js
+++ b/packages/datadog-plugin-net/src/tcp.js
@@ -28,10 +28,12 @@ class NetTCPPlugin extends ClientPlugin {
     const host = ctx.options.host || 'localhost'
     const port = ctx.options.port || 0
     const family = ctx.options.family || 4
+    let resource = host
+    if (port) resource += `:${port}`
 
     this.startSpan('tcp.connect', {
       service: this.config.service,
-      resource: [host, port].filter(Boolean).join(':'),
+      resource,
       kind: 'client',
       meta: {
         'tcp.remote.host': host,

--- a/packages/dd-trace/src/aiguard/messages/anthropic.js
+++ b/packages/dd-trace/src/aiguard/messages/anthropic.js
@@ -208,7 +208,14 @@ function walkContentBlocks (blocks) {
 function partsToContent (parts, hasImages) {
   if (!parts.length) return
   if (hasImages) return parts
-  return parts.map(p => p.text).join('\n')
+  let content = ''
+  let isFirstPart = true
+  for (const part of parts) {
+    if (!isFirstPart) content += '\n'
+    content += part.text
+    isFirstPart = false
+  }
+  return content
 }
 
 /**

--- a/packages/dd-trace/src/aiguard/messages/openai.js
+++ b/packages/dd-trace/src/aiguard/messages/openai.js
@@ -322,7 +322,14 @@ function openAIResponseContentToMessageContent (content) {
 
   if (!parts.length) return
   if (hasImages) return parts
-  return parts.map(part => part.text).join('\n')
+  let textContent = ''
+  let isFirstPart = true
+  for (const part of parts) {
+    if (!isFirstPart) textContent += '\n'
+    textContent += part.text
+    isFirstPart = false
+  }
+  return textContent
 }
 
 /**

--- a/packages/dd-trace/src/aiguard/messages/vercel-ai.js
+++ b/packages/dd-trace/src/aiguard/messages/vercel-ai.js
@@ -62,7 +62,14 @@ function convertVercelPromptToMessages (prompt) {
         if (hasImages) {
           messages.push({ role: 'user', content: contentParts })
         } else {
-          messages.push({ role: 'user', content: contentParts.map(p => p.text).join('\n') })
+          let content = ''
+          let isFirstPart = true
+          for (const part of contentParts) {
+            if (!isFirstPart) content += '\n'
+            content += part.text
+            isFirstPart = false
+          }
+          messages.push({ role: 'user', content })
         }
         break
       }
@@ -161,7 +168,14 @@ function buildTextOutputMessages (inputMessages, text) {
 function buildOutputMessages (inputMessages, content) {
   const toolCalls = content.filter(c => c.type === 'tool-call')
   if (toolCalls.length) return buildToolCallOutputMessages(inputMessages, toolCalls)
-  const text = content.filter(c => c.type === 'text').map(c => c.text).join('\n')
+  let text = ''
+  let isFirstTextPart = true
+  for (const part of content) {
+    if (part.type !== 'text') continue
+    if (!isFirstTextPart) text += '\n'
+    text += part.text
+    isFirstTextPart = false
+  }
   if (text) return buildTextOutputMessages(inputMessages, text)
   return []
 }

--- a/packages/dd-trace/src/appsec/iast/telemetry/span-tags.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/span-tags.js
@@ -46,8 +46,14 @@ function filterTags (tags) {
 }
 
 function processTagValue (tags) {
-  return tags.map(tag => tag.includes(':') ? getSegment(tag, ':', 1) : tag)
-    .join('_').replaceAll('.', '_')
+  let processedTags = ''
+  let isFirstTag = true
+  for (const tag of tags) {
+    if (!isFirstTag) processedTags += '_'
+    processedTags += (tag.includes(':') ? getSegment(tag, ':', 1) : tag) ?? ''
+    isFirstTag = false
+  }
+  return processedTags.replaceAll('.', '_')
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
@@ -13,53 +13,26 @@ const DECIMAL_NUMBER = String.raw`\d*\.\d+`
 const HEX_NUMBER = 'x\'[0-9a-f]+\'|0x[0-9a-f]+'
 const BIN_NUMBER = 'b\'[0-9a-f]+\'|0b[0-9a-f]+'
 const NUMERIC_LITERAL =
-  `[-+]?(?:${
-    [
-      HEX_NUMBER,
-      BIN_NUMBER,
-      DECIMAL_NUMBER + EXPONENT,
-      INTEGER_NUMBER + EXPONENT,
-    ].join('|')
-  })`
+  `[-+]?(?:${HEX_NUMBER}|${BIN_NUMBER}|${DECIMAL_NUMBER + EXPONENT}|${INTEGER_NUMBER + EXPONENT})`
 const ORACLE_ESCAPED_LITERAL = String.raw`q'<.*?>'|q'\(.*?\)'|q'\{.*?\}'|q'\[.*?\]'|q'(?<ESCAPE>.).*?\k<ESCAPE>'`
 
 const patterns = {
   ANSI: new RegExp( // Default
-    [
-      NUMERIC_LITERAL,
-      STRING_LITERAL,
-      LINE_COMMENT,
-      BLOCK_COMMENT,
-    ].join('|'),
+    `${NUMERIC_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),
   MYSQL: new RegExp(
-    [
-      NUMERIC_LITERAL,
-      MYSQL_STRING_LITERAL,
-      LINE_COMMENT,
-      BLOCK_COMMENT,
-    ].join('|'),
+    `${NUMERIC_LITERAL}|${MYSQL_STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),
   POSTGRES: new RegExp(
-    [
-      NUMERIC_LITERAL,
-      POSTGRESQL_ESCAPED_LITERAL,
-      STRING_LITERAL,
-      LINE_COMMENT,
-      BLOCK_COMMENT,
-    ].join('|'),
+    `${NUMERIC_LITERAL}|${POSTGRESQL_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),
-  ORACLE: new RegExp([
-    NUMERIC_LITERAL,
-    ORACLE_ESCAPED_LITERAL,
-    STRING_LITERAL,
-    LINE_COMMENT,
-    BLOCK_COMMENT,
-  ].join('|'),
-  'gmi'),
+  ORACLE: new RegExp(
+    `${NUMERIC_LITERAL}|${ORACLE_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
+    'gmi'
+  ),
 }
 patterns.SQLITE = patterns.MYSQL
 patterns.MARIADB = patterns.MYSQL

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/url-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/url-sensitive-analyzer.js
@@ -8,7 +8,7 @@ const AUTHORITY = '^(?:[^:]+:)?//([^@]+)@'
 // boundaries), so excluding them preserves match semantics for valid URLs while keeping
 // the regex linear on arbitrary input.
 const QUERY_FRAGMENT = '[?#&]([^=&;?#]+)=([^?#&]+)'
-const pattern = new RegExp([AUTHORITY, QUERY_FRAGMENT].join('|'), 'gmi')
+const pattern = new RegExp(`${AUTHORITY}|${QUERY_FRAGMENT}`, 'gmi')
 
 module.exports = function extractSensitiveRanges (evidence) {
   try {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -157,32 +157,34 @@ const GIT_UPLOAD_TIMEOUT = 60_000 // 60 seconds
 const CAN_USE_CI_VIS_PROTOCOL_TIMEOUT = GIT_UPLOAD_TIMEOUT
 const MAX_COVERAGE_REPORT_FLAGS = 32
 
+/**
+ * @param {string} tags
+ * @param {string} key
+ * @param {string | undefined} value
+ */
 function appendLogTag (tags, key, value) {
-  if (value !== undefined) {
-    tags.push(`${key}:${value}`)
-  }
+  if (value === undefined) return tags
+
+  const tag = `${key}:${value}`
+  return tags ? `${tags},${tag}` : tag
 }
 
 function getLogTags (logMessage, { env, version }, gitRepositoryUrl, gitCommitSha) {
-  const tags = []
+  let tags = ''
   if (Array.isArray(logMessage.ddtags)) {
-    for (const tag of logMessage.ddtags) {
-      tags.push(tag)
-    }
+    tags = logMessage.ddtags.join(',')
   } else if (logMessage.ddtags) {
-    for (const tag of logMessage.ddtags.split(',')) {
-      tags.push(tag)
-    }
+    tags = logMessage.ddtags
   }
 
-  appendLogTag(tags, 'env', env)
-  appendLogTag(tags, 'version', version)
-  appendLogTag(tags, 'debugger_version', tracerVersion)
-  appendLogTag(tags, 'host_name', hostname)
-  appendLogTag(tags, GIT_COMMIT_SHA, gitCommitSha)
-  appendLogTag(tags, GIT_REPOSITORY_URL, gitRepositoryUrl)
+  tags = appendLogTag(tags, 'env', env)
+  tags = appendLogTag(tags, 'version', version)
+  tags = appendLogTag(tags, 'debugger_version', tracerVersion)
+  tags = appendLogTag(tags, 'host_name', hostname)
+  tags = appendLogTag(tags, GIT_COMMIT_SHA, gitCommitSha)
+  tags = appendLogTag(tags, GIT_REPOSITORY_URL, gitRepositoryUrl)
 
-  return tags.join(',')
+  return tags
 }
 
 class CiVisibilityExporter extends BufferingExporter {

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -232,7 +232,13 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const lastUserPrompt =
       promptInfo.prompt ??
       promptInfo.messages.reverse().find(message => message.role === 'user')?.content
-    const prompt = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+    let prompt = lastUserPrompt
+    if (Array.isArray(lastUserPrompt)) {
+      prompt = ''
+      for (const part of lastUserPrompt) {
+        if (typeof part.text === 'string') prompt += part.text
+      }
+    }
 
     const output = tags['ai.response.object']
 
@@ -248,7 +254,13 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const lastUserPrompt =
       promptInfo.prompt ??
       promptInfo.messages.reverse().find(message => message.role === 'user')?.content
-    const prompt = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+    let prompt = lastUserPrompt
+    if (Array.isArray(lastUserPrompt)) {
+      prompt = ''
+      for (const part of lastUserPrompt) {
+        if (typeof part.text === 'string') prompt += part.text
+      }
+    }
 
     const output = tags['ai.response.text']
 

--- a/packages/dd-trace/src/llmobs/plugins/ai/vercelTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/vercelTelemetry.js
@@ -38,11 +38,15 @@ function formatLanguageModelInputMessages (instructions, messages) {
   const inputMessages = []
 
   if (instructions) {
-    const systemPrompt = typeof instructions === 'string'
-      ? instructions
-      : Array.isArray(instructions)
-        ? instructions.map(instruction => instruction.content).join('')
-        : instructions.content
+    let systemPrompt = instructions
+    if (typeof instructions !== 'string') {
+      if (Array.isArray(instructions)) {
+        systemPrompt = ''
+        for (const instruction of instructions) systemPrompt += instruction.content
+      } else {
+        systemPrompt = instructions.content
+      }
+    }
 
     inputMessages.push({ role: 'system', content: systemPrompt })
   }
@@ -53,13 +57,13 @@ function formatLanguageModelInputMessages (instructions, messages) {
     if (role === 'system') {
       inputMessages.push({ role, content })
     } else if (role === 'user') {
-      const userMessageContent =
-      typeof content === 'string'
-        ? content
-        : content
-          .filter(part => part.type === 'text')
-          .map(part => part.text)
-          .join('')
+      let userMessageContent = content
+      if (typeof content !== 'string') {
+        userMessageContent = ''
+        for (const part of content) {
+          if (part.type === 'text') userMessageContent += part.text
+        }
+      }
 
       inputMessages.push({ role, content: userMessageContent })
     } else if (role === 'assistant') {
@@ -292,7 +296,13 @@ class VercelAiTelemetryPlugin extends BaseLLMObsPlugin {
     const { event, result } = ctx
 
     const lastUserPrompt = event.messages.findLast(message => message.role === 'user')?.content
-    const input = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+    let input = lastUserPrompt
+    if (Array.isArray(lastUserPrompt)) {
+      input = ''
+      for (const part of lastUserPrompt) {
+        if (part.type === 'text') input += part.text
+      }
+    }
 
     const output =
       ctx.isStream

--- a/packages/dd-trace/src/llmobs/plugins/openai/utils.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/utils.js
@@ -7,7 +7,6 @@ const {
   INPUT_TYPE_FILE,
   IMAGE_FALLBACK,
   FILE_FALLBACK,
-  AUDIO_FALLBACK,
   AUDIO_MIME_TYPES,
 } = require('./constants')
 
@@ -139,22 +138,18 @@ function extractContentParts (parts) {
   const audioParts = []
 
   for (const part of parts) {
-    const partType = part?.type ?? ''
+    const partType = part.type
     let extracted
     if (partType === 'text') {
-      extracted = part.text ?? ''
+      extracted = part.text
     } else if (partType === 'image_url') {
       extracted = IMAGE_FALLBACK
     } else if (partType === 'input_audio') {
-      const inputAudio = part.input_audio ?? {}
-      const data = inputAudio.data
-      if (data) {
-        // Audio is captured as a structured audio part (rendered as a player), so no text marker
-        // is needed. Only fall back to "[audio]" when there's no audio to capture.
-        audioParts.push(formatAudioPart(data, audioMimeTypeFromFormat(inputAudio.format, AUDIO_MIME_TYPES)))
-      } else {
-        extracted = AUDIO_FALLBACK
-      }
+      const inputAudio = part.input_audio
+      audioParts.push(formatAudioPart(
+        inputAudio.data,
+        audioMimeTypeFromFormat(inputAudio.format, AUDIO_MIME_TYPES)
+      ))
     } else {
       extracted = `[${partType}]`
     }

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -29,7 +29,13 @@ const log = {
       const stack = logRecord.stack.split('\n')
       const fn = stack[1].replace(/^\s+at ([^\s]+) .+/, '$1')
       const options = { depth: 2, breakLength: Infinity, compact: true, maxArrayLength: Infinity }
-      const params = args.map(a => inspect(a, options)).join(', ')
+      let params = ''
+      let isFirstParameter = true
+      for (const argument of args) {
+        if (!isFirstParameter) params += ', '
+        params += inspect(argument, options)
+        isFirstParameter = false
+      }
 
       stack[0] = `Trace: ${fn}(${params})`
 

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
@@ -180,10 +180,15 @@ function stableStringify (attributes) {
   // Attributes are sorted by key to ensure consistent serialization regardless of key order.
   // Keys are always strings and values are always strings, numbers, booleans,
   // or arrays of strings, numbers, or booleans.
-  return Object.keys(attributes)
-    .sort()
-    .map(key => `${key}:${JSON.stringify(attributes[key])}`)
-    .join(',')
+  const keys = Object.keys(attributes).sort()
+  let serialized = ''
+  let isFirstKey = true
+  for (const key of keys) {
+    if (!isFirstKey) serialized += ','
+    serialized += `${key}:${JSON.stringify(attributes[key])}`
+    isFirstKey = false
+  }
+  return serialized
 }
 
 module.exports = OtlpTransformerBase

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -2082,12 +2082,17 @@ function formatTestOptimizationList (items) {
   const more = items.length - shown.length
   const moreSuffix = more > 0 ? `\n  ... and ${more} more` : ''
 
-  return shown
-    .map(({ text, suffix }) => `  • ${truncateTestOptimizationNameMiddle(
+  let formattedItems = ''
+  let isFirstItem = true
+  for (const { text, suffix } of shown) {
+    if (!isFirstItem) formattedItems += '\n'
+    formattedItems += `  • ${truncateTestOptimizationNameMiddle(
       sanitizeTestOptimizationName(text),
       MAX_TEST_OPTIMIZATION_NAME_LENGTH
-    )}${suffix ? ` (${suffix})` : ''}`)
-    .join('\n') + moreSuffix
+    )}${suffix ? ` (${suffix})` : ''}`
+    isFirstItem = false
+  }
+  return formattedItems + moreSuffix
 }
 
 /**

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -511,9 +511,10 @@ function addResourceTag (context) {
 
   if (spanContext.getTag(RESOURCE_NAME)) return
 
-  const resource = [req.method, spanContext.getTag(HTTP_ROUTE)]
-    .filter(Boolean)
-    .join(' ')
+  let resource = req.method
+  const route = spanContext.getTag(HTTP_ROUTE)
+
+  if (route) resource += ` ${route}`
 
   span.setTag(RESOURCE_NAME, resource)
 }

--- a/packages/dd-trace/src/profiling/oom.js
+++ b/packages/dd-trace/src/profiling/oom.js
@@ -54,8 +54,13 @@ function strategiesToCallbackMode (strategies, callbackMode) {
  * @returns {string[]}
  */
 function buildExportCommand (exporters, tags) {
-  const tagString = [...Object.entries(tags),
-    ['snapshot', snapshotKinds.ON_OUT_OF_MEMORY]].map(([key, value]) => `${key}:${value}`).join(',')
+  let tagString = ''
+  for (const [key, value] of Object.entries(tags)) {
+    if (tagString) tagString += ','
+    tagString += `${key}:${value}`
+  }
+  if (tagString) tagString += ','
+  tagString += `snapshot:${snapshotKinds.ON_OUT_OF_MEMORY}`
   let urls = ''
   for (const exporter of exporters) {
     const url = exporter.getExportUrl()

--- a/packages/dd-trace/src/profiling/webspan-utils.js
+++ b/packages/dd-trace/src/profiling/webspan-utils.js
@@ -8,10 +8,13 @@ function isWebServerSpan (tags) {
 }
 
 function endpointNameFromTags (tags) {
-  return tags[RESOURCE_NAME] || [
-    tags[HTTP_METHOD],
-    tags[HTTP_ROUTE],
-  ].filter(Boolean).join(' ')
+  const resource = tags[RESOURCE_NAME]
+  if (resource) return resource
+
+  let endpoint = tags[HTTP_METHOD] || ''
+  const route = tags[HTTP_ROUTE]
+  if (route) endpoint += endpoint ? ` ${route}` : route
+  return endpoint
 }
 
 // The endpoint name a web-server span's tag bag yields changes over the span's

--- a/packages/dd-trace/src/service-naming/schemas/util.js
+++ b/packages/dd-trace/src/service-naming/schemas/util.js
@@ -5,7 +5,7 @@ function identityService ({ tracerService }) {
 }
 
 function getFormattedHostString ({ host, port }) {
-  return [host, port].filter(Boolean).join(':')
+  return port ? `${host}:${port}` : host
 }
 
 function httpPluginClientService ({ tracerService, pluginConfig, sessionDetails }) {

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -136,19 +136,8 @@ class SpanAggKey {
   }
 
   toString () {
-    return [
-      this.name,
-      this.service,
-      this.resource,
-      this.type,
-      this.statusCode,
-      this.synthetics,
-      this.method,
-      this.endpoint,
-      this.srvSrc,
-      this.spanKind,
-      this.rpcStatusCode,
-    ].join(',')
+    return `${this.name},${this.service},${this.resource},${this.type},${this.statusCode},${this.synthetics},` +
+      `${this.method},${this.endpoint},${this.srvSrc},${this.spanKind},${this.rpcStatusCode}`
   }
 }
 

--- a/packages/dd-trace/test/appsec/iast/telemetry/span-tags.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/span-tags.spec.js
@@ -67,6 +67,18 @@ describe('Telemetry Span tags', () => {
     assert.deepStrictEqual(rootSpan.addTags.secondCall.args[0], { '_dd.test.executed.source.source_type_2': 2 })
   })
 
+  it('should join multiple tags in a metric name', () => {
+    EXECUTED_SOURCE.inc(context, ['source.type.1', 'origin:parameter'], 42)
+
+    const { metrics } = getNamespaceFromContext(context).toJSON()
+
+    addMetricsToSpan(rootSpan, metrics.series, tagPrefix)
+
+    sinon.assert.calledOnceWithExactly(rootSpan.addTags, {
+      '_dd.test.executed.source.parameter_source_type_1': 42,
+    })
+  })
+
   it('should add span tags with tag name like \'tagPrefix.metricName\' for not tagged metrics', () => {
     REQUEST_TAINTED.inc(context, 42)
 

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1715,6 +1715,33 @@ describe('CI Visibility Exporter', () => {
           },
         }))
       })
+
+      it('preserves string log tags and starts generated tags without a separator', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy(),
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({
+          url,
+          testOptimization: { DD_TEST_FAILED_TEST_REPLAY_ENABLED: true },
+        })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._logsWriter = writer
+        ciVisibilityExporter._canForwardLogs = true
+
+        ciVisibilityExporter.exportDiLogs({}, { message: 'with tags', ddtags: 'custom:value' })
+        ciVisibilityExporter.exportDiLogs({}, { message: 'without tags' })
+
+        assert.strictEqual(
+          writer.append.firstCall.args[0].ddtags,
+          `custom:value,debugger_version:${tracerVersion},host_name:${getHostname()}`
+        )
+        assert.strictEqual(
+          writer.append.secondCall.args[0].ddtags,
+          `debugger_version:${tracerVersion},host_name:${getHostname()}`
+        )
+      })
     })
   })
 

--- a/packages/dd-trace/test/llmobs/openai-utils.spec.js
+++ b/packages/dd-trace/test/llmobs/openai-utils.spec.js
@@ -8,13 +8,12 @@ const { UNKNOWN_MODEL_PROVIDER } = require('../../src/llmobs/constants/tags')
 describe('extractContentParts', () => {
   it('preserves empty text and formats every multimodal fallback', () => {
     assert.deepStrictEqual(extractContentParts([
-      { type: 'text' },
-      { type: 'image_url' },
-      { type: 'input_audio' },
+      { type: 'text', text: '' },
+      { type: 'image_url', image_url: { url: 'https://example.com/image.png' } },
       { type: 'input_audio', input_audio: { data: 'aGVsbG8=', format: 'wav' } },
-      null,
+      { type: 'file', file: { file_id: 'file-1' } },
     ]), {
-      content: '\n[image]\n[audio]\n[]',
+      content: '\n[image]\n[file]',
       audioParts: [{ content: 'aGVsbG8=', mimeType: 'audio/wav' }],
     })
   })

--- a/packages/dd-trace/test/llmobs/plugins/ai/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/index.spec.js
@@ -978,7 +978,14 @@ describe('Plugin', () => {
         messages: [
           { role: 'user', content: 'First user message.' },
           { role: 'assistant', content: 'First response.' },
-          { role: 'user', content: 'Last user message.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Last user ' },
+              { type: 'image', image: new URL('https://example.com/image.png') },
+              { type: 'text', text: 'message.' },
+            ],
+          },
         ],
         experimental_telemetry: { metadata: MOCK_TELEMETRY_METADATA },
       })
@@ -1021,7 +1028,14 @@ describe('Plugin', () => {
         messages: [
           { role: 'user', content: 'First user message.' },
           { role: 'assistant', content: 'First response.' },
-          { role: 'user', content: 'Last user message.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Last user ' },
+              { type: 'image', image: new URL('https://example.com/image.png') },
+              { type: 'text', text: 'message.' },
+            ],
+          },
         ],
         experimental_telemetry: { metadata: MOCK_TELEMETRY_METADATA },
       })

--- a/packages/dd-trace/test/llmobs/plugins/ai/index.v7.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/index.v7.spec.js
@@ -55,7 +55,7 @@ describe('Plugin', () => {
     it('creates spans for generateText', async () => {
       await ai.generateText({
         model: openai('gpt-4o-mini'),
-        instructions: 'You are a helpful assistant',
+        instructions: { role: 'system', content: 'You are a helpful assistant' },
         prompt: 'Hello, OpenAI!',
         maxOutputTokens: 100,
         temperature: 0.5,
@@ -118,6 +118,76 @@ describe('Plugin', () => {
           cache_write_input_tokens: 0,
           cache_read_input_tokens: 0,
           output_tokens: MOCK_NUMBER,
+          reasoning_output_tokens: 0,
+        },
+        tags: { ml_app: 'test', integration: 'ai' },
+      })
+    })
+
+    it('extracts text from structured instructions and user messages', async () => {
+      const OpenAI = require(`../../../../../../versions/@ai-sdk/openai@${openaiVersion}`).get()
+      const mockOpenai = OpenAI.createOpenAI({
+        apiKey: 'test-api-key',
+        fetch: () => new Response(JSON.stringify({
+          id: 'chatcmpl-mock',
+          object: 'chat.completion',
+          created: 1234567890,
+          model: 'gpt-4o-mini',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'Hi!' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+        compatibility: 'strict',
+      })
+
+      await ai.generateText({
+        model: mockOpenai.chat('gpt-4o-mini'),
+        instructions: [
+          { role: 'system', content: 'You are a helpful ' },
+          { role: 'system', content: 'assistant' },
+        ],
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello, ' },
+            { type: 'file', data: new URL('https://example.com/image.png'), mediaType: 'image/png' },
+            { type: 'text', text: 'OpenAI!' },
+          ],
+        }],
+      })
+
+      const { apmSpans, llmobsSpans } = await getEvents(3)
+      const generateTextSpan = llmobsSpans.find(span => span.name === 'generateText')
+      const stepSpan = llmobsSpans.find(span => span.name === 'step')
+      const languageModelCallSpan = llmobsSpans.find(span => span.name === 'languageModelCall')
+
+      assertLlmObsSpanEvent(generateTextSpan, {
+        span: apmSpans.find(span => span.name === 'generateText'),
+        name: 'generateText',
+        spanKind: 'workflow',
+        inputValue: 'Hello, OpenAI!',
+        outputValue: MOCK_STRING,
+        metadata: {},
+        tags: { ml_app: 'test', integration: 'ai' },
+      })
+
+      assertLlmObsSpanEvent(languageModelCallSpan, {
+        span: apmSpans.find(span => span.name === 'languageModelCall'),
+        parentId: stepSpan.span_id,
+        name: 'languageModelCall',
+        spanKind: 'llm',
+        modelName: 'gpt-4o-mini',
+        modelProvider: 'openai',
+        inputMessages: [
+          { content: 'You are a helpful assistant', role: 'system' },
+          { content: 'Hello, OpenAI!', role: 'user' },
+        ],
+        outputMessages: [{ content: 'Hi!', role: 'assistant' }],
+        metadata: {},
+        metrics: {
+          input_tokens: 10,
+          cache_write_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 2,
           reasoning_output_tokens: 0,
         },
         tags: { ml_app: 'test', integration: 'ai' },


### PR DESCRIPTION
Direct concatenation reduced one-block formatting from 22.4–22.6 ns to 5.0 ns and three-block formatting from 46.4–47.6 ns to 12.6–12.9 ns on Node 22.20.0 / V8 12.4 (1M iterations, seven trials, best/worst dropped).