### PR TITLE
test(instrumentations): rename anthropic hook callback

### DIFF
--- a/packages/datadog-instrumentations/test/helpers/anthropic-lifecycle.js
+++ b/packages/datadog-instrumentations/test/helpers/anthropic-lifecycle.js
@@ -68,7 +68,7 @@ function createDeferred () {
 }
 
 /**
- * @returns {Array<{ spec: { file: string }, callback: (exports: object) => object }>}
+ * @returns {Array<{ spec: { file: string }, hook: (exports: object) => object }>}
  */
 function loadAnthropicInstrumentation () {
   const instrumentPath = require.resolve('../../src/helpers/instrument')
@@ -81,10 +81,10 @@ function loadAnthropicInstrumentation () {
     ...realInstrument,
     /**
      * @param {{ file: string }} spec
-     * @param {(exports: object) => object} callback
+     * @param {(exports: object) => object} hook
      */
-    addHook (spec, callback) {
-      hookCallbacks.push({ spec, callback })
+    addHook (spec, hook) {
+      hookCallbacks.push({ spec, hook })
     },
   }
 
@@ -99,14 +99,14 @@ function loadAnthropicInstrumentation () {
 }
 
 /**
- * @param {Array<{ spec: { file: string }, callback: (exports: object) => object }>} hookCallbacks
+ * @param {Array<{ spec: { file: string }, hook: (exports: object) => object }>} hookCallbacks
  * @param {string} filePath
  * @param {typeof FakeMessages} Messages
  */
 function applyShim (hookCallbacks, filePath, Messages) {
-  for (const { spec, callback } of hookCallbacks) {
+  for (const { spec, hook } of hookCallbacks) {
     if (spec.file === `${filePath}.js`) {
-      callback({ Messages })
+      hook({ Messages })
       return
     }
   }


### PR DESCRIPTION
eslint-plugin-n 18.3.0 treats the object passed to the Anthropic lifecycle shim as an error-first callback literal because the helper calls its module hook `callback`. Rename it to `hook` so the dependency update passes the full lint check.

Refs: https://github.com/DataDog/dd-trace-js/pull/9824