### PR TITLE
test(aws-sdk): wait for EventBridge cold-start traces

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/eventbridge.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/eventbridge.dsm.spec.js
@@ -232,7 +232,7 @@ describe('EventBridge', function () {
         assertObjectContains(putEventsSpanMeta, {
           'pathway.hash': expectedHash,
         })
-      })
+      }, { timeoutMs: 5000 })
     }
 
     function getEventBridgeClient () {


### PR DESCRIPTION
LocalStack can take longer than the test agent's one-second default to process the first EventBridge request. Give both producer-path assertions a five-second service-local timeout so a cold request does not lose its trace expectation.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/32156148610/job/95774028675