### PR TITLE
feat(llmobs): add experiments project and evaluator parity

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -694,7 +694,14 @@ llmobs.wrap({ kind: 'llm' }, function myLLM() { })()
 llmobs.wrap({ kind: 'llm', name: 'myLLM', modelName: 'myModel', modelProvider: 'myProvider' }, function myFunction() { })()
 
 // export a span
-llmobs.enable({ mlApp: 'myApp', agentlessEnabled: false })
+llmobs.enable({ mlApp: 'myApp', projectName: 'my-project', agentlessEnabled: false })
+
+class ExampleEvaluator extends llmobs.BaseEvaluator {
+  evaluate (context: llmobs.EvaluatorContext) {
+    return context.outputData
+  }
+}
+
 llmobs.trace({ kind: 'llm', name: 'myLLM' }, (span) => {
   const llmobsSpanCtx = llmobs.exportSpan(span)
   llmobsSpanCtx.traceId;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3604,6 +3604,12 @@ declare namespace tracer {
        * `DD_API_KEY` / `DD_APP_KEY` to be set.
        */
       experiments: Experiments,
+      BaseEvaluator: typeof BaseEvaluator,
+      BaseSummaryEvaluator: typeof BaseSummaryEvaluator,
+      EvaluatorContext: typeof EvaluatorContext,
+      SummaryEvaluatorContext: typeof SummaryEvaluatorContext,
+      EvaluatorResult: typeof EvaluatorResult,
+      MultiEvaluatorResult: typeof MultiEvaluatorResult,
 
       /**
        * Enable LLM Observability tracing.
@@ -3768,37 +3774,109 @@ declare namespace tracer {
     /** JSON-serializable value accepted by LLMObs Experiments. */
     type JSONType = string | number | boolean | null | JSONType[] | { [key: string]: JSONType }
 
-    /**
-     * A task run over each dataset record during an experiment.
-     */
+    /** Context passed to a record-level class evaluator. */
+    class EvaluatorContext {
+      constructor (options: {
+        inputData: JSONType
+        outputData: JSONType
+        expectedOutput?: JSONType
+        metadata?: Record<string, JSONType>
+        spanId?: string
+        traceId?: string
+      })
+      inputData: JSONType
+      outputData: JSONType
+      expectedOutput: JSONType
+      metadata: Record<string, JSONType>
+      spanId?: string
+      traceId?: string
+    }
+
+    /** Context passed to a summary class evaluator. */
+    class SummaryEvaluatorContext {
+      constructor (options: {
+        inputs: JSONType[]
+        outputs: JSONType[]
+        expectedOutputs: JSONType[]
+        evaluationResults: Record<string, JSONType[]>
+        metadata?: Array<Record<string, JSONType>>
+      })
+      inputs: JSONType[]
+      outputs: JSONType[]
+      expectedOutputs: JSONType[]
+      evaluationResults: Record<string, JSONType[]>
+      metadata: Array<Record<string, JSONType>>
+    }
+
+    interface EvaluatorResultOptions {
+      reasoning?: string
+      assessment?: 'pass' | 'fail'
+      metadata?: Record<string, JSONType>
+      tags?: Record<string, JSONType>
+    }
+
+    /** A metric value with optional evaluation details. */
+    class EvaluatorResult {
+      constructor (value: JSONType, options?: EvaluatorResultOptions)
+      constructor (options: EvaluatorResultOptions & { value: JSONType })
+      value: JSONType
+      reasoning?: string
+      assessment?: 'pass' | 'fail'
+      metadata?: Record<string, JSONType>
+      tags?: Record<string, JSONType>
+    }
+
+    /** A result that emits several named metrics from one evaluator invocation. */
+    class MultiEvaluatorResult {
+      constructor (values: Record<string, JSONType | EvaluatorResult>, prefix?: boolean)
+      values: Record<string, JSONType | EvaluatorResult>
+      prefix: boolean
+    }
+
+    /** Base class for reusable record-level evaluators. */
+    class BaseEvaluator {
+      constructor (name?: string)
+      name: string
+      evaluate (context: EvaluatorContext): JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
+    }
+
+    /** Base class for reusable summary evaluators. */
+    class BaseSummaryEvaluator {
+      constructor (name?: string)
+      name: string
+      evaluate (context: SummaryEvaluatorContext): JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
+    }
+
+    /** A task run over each dataset record during an experiment. */
     type ExperimentTask = (
       input: JSONType,
       config: Record<string, JSONType>,
       metadata?: Record<string, JSONType>
     ) => JSONType | Promise<JSONType>
 
-    /**
-     * Scores a single task output. The return type selects the metric:
-     * `boolean` -> boolean, `number` -> score, `string` -> categorical, anything else -> json.
-     */
-    type ExperimentEvaluator = (
+    /** Scores a single task output. */
+    type ExperimentEvaluatorFunction = (
       input: JSONType,
       output: JSONType,
       expectedOutput: JSONType
-    ) => JSONType | Promise<JSONType>
+    ) => JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
 
-    /**
-     * Scores all rows in an experiment run and emits a summary metric.
-     */
-    type ExperimentSummaryEvaluator = (
-      inputs: any[],
-      outputs: any[],
-      expectedOutputs: any[],
-      evaluatorResults: Record<string, any[]>,
-      metadata?: Array<Record<string, any>>
-    ) => any | Promise<any>
+    type ExperimentEvaluator = ExperimentEvaluatorFunction | BaseEvaluator
+
+    /** Scores all rows in an experiment run and emits a summary metric. */
+    type ExperimentSummaryEvaluatorFunction = (
+      inputs: JSONType[],
+      outputs: JSONType[],
+      expectedOutputs: JSONType[],
+      evaluatorResults: Record<string, JSONType[]>,
+      metadata?: Array<Record<string, JSONType>>
+    ) => JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
+
+    type ExperimentSummaryEvaluator = ExperimentSummaryEvaluatorFunction | BaseSummaryEvaluator
 
     interface CreateDatasetOptions {
+      /** Override the configured project for this dataset. */
+      projectName?: string
       description?: string
       records?: Array<{
         id?: string,
@@ -3813,9 +3891,11 @@ declare namespace tracer {
       name: string
       dataset: Dataset
       task: ExperimentTask
-      /** Evaluators keyed by metric label, or named functions. */
+      /** Override the configured project for this experiment. */
+      projectName?: string
+      /** Evaluators keyed by metric label, or named functions or class instances. */
       evaluators?: Record<string, ExperimentEvaluator> | ExperimentEvaluator[]
-      /** Summary evaluators keyed by metric label, or named functions. */
+      /** Summary evaluators keyed by metric label, or named functions or class instances. */
       summaryEvaluators?: Record<string, ExperimentSummaryEvaluator> | ExperimentSummaryEvaluator[]
       description?: string
       config?: Record<string, JSONType>
@@ -3832,6 +3912,8 @@ declare namespace tracer {
     }
 
     interface PullDatasetOptions {
+      /** Override the configured project for this dataset pull. */
+      projectName?: string
       /** Dataset version to pull. Defaults to latest. */
       version?: number
       /** Wait until at least this many records are readable (absorbs write lag). */
@@ -4507,6 +4589,13 @@ declare namespace tracer {
      * Options for enabling LLM Observability tracing.
      */
     interface LLMObsEnableOptions {
+      /**
+       * The name of the project used by LLM Observability Experiments.
+       * @env DD_LLMOBS_PROJECT_NAME
+       * Programmatic configuration takes precedence over the environment variables listed above.
+       */
+      projectName?: string
+
       /**
        * The name of your ML application.
        * @env DD_LLMOBS_ML_APP

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -3810,6 +3810,12 @@ declare namespace tracer {
        * `DD_API_KEY` / `DD_APP_KEY` to be set.
        */
       experiments: Experiments,
+      BaseEvaluator: typeof BaseEvaluator,
+      BaseSummaryEvaluator: typeof BaseSummaryEvaluator,
+      EvaluatorContext: typeof EvaluatorContext,
+      SummaryEvaluatorContext: typeof SummaryEvaluatorContext,
+      EvaluatorResult: typeof EvaluatorResult,
+      MultiEvaluatorResult: typeof MultiEvaluatorResult,
 
       /**
        * Enable LLM Observability tracing.
@@ -3965,37 +3971,109 @@ declare namespace tracer {
     /** JSON-serializable value accepted by LLMObs Experiments. */
     type JSONType = string | number | boolean | null | JSONType[] | { [key: string]: JSONType }
 
-    /**
-     * A task run over each dataset record during an experiment.
-     */
+    /** Context passed to a record-level class evaluator. */
+    class EvaluatorContext {
+      constructor (options: {
+        inputData: JSONType
+        outputData: JSONType
+        expectedOutput?: JSONType
+        metadata?: Record<string, JSONType>
+        spanId?: string
+        traceId?: string
+      })
+      inputData: JSONType
+      outputData: JSONType
+      expectedOutput: JSONType
+      metadata: Record<string, JSONType>
+      spanId?: string
+      traceId?: string
+    }
+
+    /** Context passed to a summary class evaluator. */
+    class SummaryEvaluatorContext {
+      constructor (options: {
+        inputs: JSONType[]
+        outputs: JSONType[]
+        expectedOutputs: JSONType[]
+        evaluationResults: Record<string, JSONType[]>
+        metadata?: Array<Record<string, JSONType>>
+      })
+      inputs: JSONType[]
+      outputs: JSONType[]
+      expectedOutputs: JSONType[]
+      evaluationResults: Record<string, JSONType[]>
+      metadata: Array<Record<string, JSONType>>
+    }
+
+    interface EvaluatorResultOptions {
+      reasoning?: string
+      assessment?: 'pass' | 'fail'
+      metadata?: Record<string, JSONType>
+      tags?: Record<string, JSONType>
+    }
+
+    /** A metric value with optional evaluation details. */
+    class EvaluatorResult {
+      constructor (value: JSONType, options?: EvaluatorResultOptions)
+      constructor (options: EvaluatorResultOptions & { value: JSONType })
+      value: JSONType
+      reasoning?: string
+      assessment?: 'pass' | 'fail'
+      metadata?: Record<string, JSONType>
+      tags?: Record<string, JSONType>
+    }
+
+    /** A result that emits several named metrics from one evaluator invocation. */
+    class MultiEvaluatorResult {
+      constructor (values: Record<string, JSONType | EvaluatorResult>, prefix?: boolean)
+      values: Record<string, JSONType | EvaluatorResult>
+      prefix: boolean
+    }
+
+    /** Base class for reusable record-level evaluators. */
+    class BaseEvaluator {
+      constructor (name?: string)
+      name: string
+      evaluate (context: EvaluatorContext): JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
+    }
+
+    /** Base class for reusable summary evaluators. */
+    class BaseSummaryEvaluator {
+      constructor (name?: string)
+      name: string
+      evaluate (context: SummaryEvaluatorContext): JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
+    }
+
+    /** A task run over each dataset record during an experiment. */
     type ExperimentTask = (
       input: JSONType,
       config: Record<string, JSONType>,
       metadata?: Record<string, JSONType>
     ) => JSONType | Promise<JSONType>
 
-    /**
-     * Scores a single task output. The return type selects the metric:
-     * `boolean` -> boolean, `number` -> score, `string` -> categorical, anything else -> json.
-     */
-    type ExperimentEvaluator = (
+    /** Scores a single task output. */
+    type ExperimentEvaluatorFunction = (
       input: JSONType,
       output: JSONType,
       expectedOutput: JSONType
-    ) => JSONType | Promise<JSONType>
+    ) => JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
 
-    /**
-     * Scores all rows in an experiment run and emits a summary metric.
-     */
-    type ExperimentSummaryEvaluator = (
-      inputs: any[],
-      outputs: any[],
-      expectedOutputs: any[],
-      evaluatorResults: Record<string, any[]>,
-      metadata?: Array<Record<string, any>>
-    ) => any | Promise<any>
+    type ExperimentEvaluator = ExperimentEvaluatorFunction | BaseEvaluator
+
+    /** Scores all rows in an experiment run and emits a summary metric. */
+    type ExperimentSummaryEvaluatorFunction = (
+      inputs: JSONType[],
+      outputs: JSONType[],
+      expectedOutputs: JSONType[],
+      evaluatorResults: Record<string, JSONType[]>,
+      metadata?: Array<Record<string, JSONType>>
+    ) => JSONType | EvaluatorResult | MultiEvaluatorResult | Promise<JSONType | EvaluatorResult | MultiEvaluatorResult>
+
+    type ExperimentSummaryEvaluator = ExperimentSummaryEvaluatorFunction | BaseSummaryEvaluator
 
     interface CreateDatasetOptions {
+      /** Override the configured project for this dataset. */
+      projectName?: string
       description?: string
       records?: Array<{
         id?: string,
@@ -4010,9 +4088,11 @@ declare namespace tracer {
       name: string
       dataset: Dataset
       task: ExperimentTask
-      /** Evaluators keyed by metric label, or named functions. */
+      /** Override the configured project for this experiment. */
+      projectName?: string
+      /** Evaluators keyed by metric label, or named functions or class instances. */
       evaluators?: Record<string, ExperimentEvaluator> | ExperimentEvaluator[]
-      /** Summary evaluators keyed by metric label, or named functions. */
+      /** Summary evaluators keyed by metric label, or named functions or class instances. */
       summaryEvaluators?: Record<string, ExperimentSummaryEvaluator> | ExperimentSummaryEvaluator[]
       description?: string
       config?: Record<string, JSONType>
@@ -4029,6 +4109,8 @@ declare namespace tracer {
     }
 
     interface PullDatasetOptions {
+      /** Override the configured project for this dataset pull. */
+      projectName?: string
       /** Dataset version to pull. Defaults to latest. */
       version?: number
       /** Wait until at least this many records are readable (absorbs write lag). */
@@ -4706,6 +4788,13 @@ declare namespace tracer {
      * Options for enabling LLM Observability tracing.
      */
     interface LLMObsEnableOptions {
+      /**
+       * The name of the project used by LLM Observability Experiments.
+       * @env DD_LLMOBS_PROJECT_NAME
+       * Programmatic configuration takes precedence over the environment variables listed above.
+       */
+      projectName?: string
+
       /**
        * The name of your ML application.
        * @env DD_LLMOBS_ML_APP

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -473,6 +473,7 @@ export interface GeneratedConfig {
     agentlessEnabled: boolean | undefined;
     DD_LLMOBS_ENABLED: boolean;
     mlApp: string | undefined;
+    projectName: string | undefined;
     sampleRate: number;
   };
   logInjection: boolean;
@@ -758,6 +759,7 @@ export interface GeneratedEnvVarConfig {
   DD_LLMOBS_AGENTLESS_ENABLED: boolean | undefined;
   DD_LLMOBS_ENABLED: boolean;
   DD_LLMOBS_ML_APP: string | undefined;
+  DD_LLMOBS_PROJECT_NAME: string | undefined;
   DD_LLMOBS_SAMPLE_RATE: number;
   DD_LOG_LEVEL: "debug" | "info" | "warn" | "error";
   DD_LOGS_INJECTION: boolean;

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -510,7 +510,8 @@ class Config extends ConfigBase {
     if (!this.llmobs.DD_LLMOBS_ENABLED &&
         !trackedConfigOrigins.has('llmobs.DD_LLMOBS_ENABLED') &&
         (trackedConfigOrigins.has('llmobs.agentlessEnabled') ||
-        trackedConfigOrigins.has('llmobs.mlApp'))) {
+        trackedConfigOrigins.has('llmobs.mlApp') ||
+        trackedConfigOrigins.has('llmobs.projectName'))) {
       setAndTrack(this, 'llmobs.DD_LLMOBS_ENABLED', true)
     }
 

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1341,6 +1341,16 @@
         "default": null
       }
     ],
+    "DD_LLMOBS_PROJECT_NAME": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "llmobs.projectName"
+        ],
+        "default": null
+      }
+    ],
     "DD_LLMOBS_SAMPLE_RATE": [
       {
         "implementation": "A",

--- a/packages/dd-trace/src/llmobs/experiments/evaluator.js
+++ b/packages/dd-trace/src/llmobs/experiments/evaluator.js
@@ -1,0 +1,141 @@
+'use strict'
+
+const { validateEvaluatorName } = require('./util')
+
+/**
+ * @param {object} evaluator
+ * @param {string | undefined} name
+ * @returns {string}
+ */
+function resolveEvaluatorName (evaluator, name) {
+  const evaluatorName = name === undefined
+    ? evaluator.constructor.name
+    : typeof name === 'string' ? name.trim() : name
+  validateEvaluatorName(evaluatorName)
+  return evaluatorName
+}
+
+/**
+ * Context passed to a record-level class evaluator.
+ */
+class EvaluatorContext {
+  /**
+   * @param {{inputData: unknown, outputData: unknown, expectedOutput?: unknown, metadata?: object,
+   *   spanId?: string, traceId?: string}} options
+   */
+  constructor ({ inputData, outputData, expectedOutput, metadata = {}, spanId, traceId }) {
+    this.inputData = inputData
+    this.outputData = outputData
+    this.expectedOutput = expectedOutput
+    this.metadata = metadata
+    this.spanId = spanId
+    this.traceId = traceId
+  }
+}
+
+/**
+ * Context passed to a summary class evaluator.
+ */
+class SummaryEvaluatorContext {
+  /**
+   * @param {{inputs: unknown[], outputs: unknown[], expectedOutputs: unknown[], evaluationResults: object,
+   *   metadata?: object[]}} options
+   */
+  constructor ({ inputs, outputs, expectedOutputs, evaluationResults, metadata = [] }) {
+    this.inputs = inputs
+    this.outputs = outputs
+    this.expectedOutputs = expectedOutputs
+    this.evaluationResults = evaluationResults
+    this.metadata = metadata
+  }
+}
+
+/**
+ * A metric value with optional evaluation details.
+ */
+class EvaluatorResult {
+  /**
+   * @param {unknown | {value: unknown, reasoning?: string, assessment?: string, metadata?: object, tags?: object}}
+   *   valueOrOptions
+   * @param {{reasoning?: string, assessment?: string, metadata?: object, tags?: object}} [options]
+   */
+  constructor (valueOrOptions, options = {}) {
+    const resultOptions = valueOrOptions !== null && typeof valueOrOptions === 'object' &&
+      Object.hasOwn(valueOrOptions, 'value') && arguments.length === 1
+      ? valueOrOptions
+      : { value: valueOrOptions, ...options }
+
+    this.value = resultOptions.value
+    this.reasoning = resultOptions.reasoning
+    this.assessment = resultOptions.assessment
+    this.metadata = resultOptions.metadata
+    this.tags = resultOptions.tags
+  }
+}
+
+/**
+ * A result that emits several named metrics from one evaluator invocation.
+ */
+class MultiEvaluatorResult {
+  /**
+   * @param {Record<string, unknown>} values
+   * @param {boolean} [prefix]
+   */
+  constructor (values, prefix = true) {
+    if (values === null || typeof values !== 'object' || Array.isArray(values)) {
+      throw new TypeError('MultiEvaluatorResult.values must be an object')
+    }
+    const keys = Object.keys(values)
+    if (keys.length === 0) throw new Error('MultiEvaluatorResult.values must be a non-empty object')
+    for (const key of keys) validateEvaluatorName(key)
+    this.values = values
+    this.prefix = prefix
+  }
+}
+
+/**
+ * Base class for reusable record-level evaluators.
+ */
+class BaseEvaluator {
+  /**
+   * @param {string} [name] Evaluator name. Defaults to the subclass name.
+   */
+  constructor (name) {
+    this.name = resolveEvaluatorName(this, name)
+  }
+
+  /**
+   * @param {EvaluatorContext} _context
+   */
+  evaluate (_context) {
+    throw new Error('BaseEvaluator subclasses must implement evaluate(context)')
+  }
+}
+
+/**
+ * Base class for reusable summary evaluators.
+ */
+class BaseSummaryEvaluator {
+  /**
+   * @param {string} [name] Evaluator name. Defaults to the subclass name.
+   */
+  constructor (name) {
+    this.name = resolveEvaluatorName(this, name)
+  }
+
+  /**
+   * @param {SummaryEvaluatorContext} _context
+   */
+  evaluate (_context) {
+    throw new Error('BaseSummaryEvaluator subclasses must implement evaluate(context)')
+  }
+}
+
+module.exports = {
+  BaseEvaluator,
+  BaseSummaryEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+  MultiEvaluatorResult,
+  SummaryEvaluatorContext,
+}

--- a/packages/dd-trace/src/llmobs/experiments/experiment.js
+++ b/packages/dd-trace/src/llmobs/experiments/experiment.js
@@ -2,7 +2,16 @@
 
 const id = require('../../id')
 const log = require('../../log')
+const { validateAssessment, validateReasoning } = require('../eval-metric')
 
+const {
+  BaseEvaluator,
+  BaseSummaryEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+  MultiEvaluatorResult,
+  SummaryEvaluatorContext,
+} = require('./evaluator')
 const { Row, ExperimentResult, ExperimentRun } = require('./result')
 const {
   buildSpanMetadata,
@@ -46,6 +55,7 @@ function toSpan (row, metadata, ids, spanName, userTags, recordTags) {
     dataset_record_id: ids.datasetRecordId,
     dataset_name: ids.datasetName,
     experiment_name: ids.experimentName,
+    project_name: ids.projectName,
   })
 
   return {
@@ -64,7 +74,7 @@ function toSpan (row, metadata, ids, spanName, userTags, recordTags) {
 
 // One metric per evaluator per row or summary evaluator.
 function toMetric (
-  label, value, errorMessage, spanId, traceId, timestampMs, experimentId, userTags, source = 'custom'
+  label, value, errorMessage, spanId, traceId, timestampMs, experimentId, userTags, source = 'custom', extras = {}
 ) {
   const metric = {
     metric_source: source,
@@ -72,9 +82,19 @@ function toMetric (
     span_id: spanId,
     trace_id: traceId,
     timestamp_ms: timestampMs,
-    tags: buildTags(userTags, { experiment_id: experimentId }),
+    tags: buildTags({ ...userTags, ...extras.tags }, { experiment_id: experimentId }),
     experiment_id: experimentId,
   }
+
+  if (extras.reasoning !== undefined) {
+    validateReasoning(extras.reasoning)
+    metric.reasoning = extras.reasoning
+  }
+  if (extras.assessment !== undefined) {
+    validateAssessment(extras.assessment)
+    metric.assessment = extras.assessment
+  }
+  if (extras.metadata !== undefined) metric.metadata = extras.metadata
 
   if (errorMessage !== null) {
     metric.metric_type = 'categorical'
@@ -89,6 +109,31 @@ function toMetric (
   else if (type === 'json') metric.json_value = normalizeJsonMetricValue(value)
   else metric.categorical_value = stringify(value)
   return metric
+}
+
+/**
+ * @param {unknown} result
+ * @param {string} label
+ * @returns {Array<{label: string, value: unknown, extras: object}>}
+ */
+function extractEvaluatorResults (result, label) {
+  if (!(result instanceof MultiEvaluatorResult)) {
+    return [{
+      label,
+      value: result instanceof EvaluatorResult ? result.value : result,
+      extras: result instanceof EvaluatorResult ? result : {},
+    }]
+  }
+
+  const results = []
+  for (const [key, value] of Object.entries(result.values)) {
+    results.push({
+      label: result.prefix ? `${label}-${key}` : key,
+      value: value instanceof EvaluatorResult ? value.value : value,
+      extras: value instanceof EvaluatorResult ? value : {},
+    })
+  }
+  return results
 }
 
 function createFallbackSpanContext (startNs) {
@@ -139,6 +184,7 @@ class Experiment {
   #config
   #tags
   #metadata
+  #projectName
   #projectId
   #experimentId
   #runId
@@ -163,7 +209,9 @@ class Experiment {
     this.#config = { ...options.config }
     const filterTags = this.#dataset.filterTags?.() ?? []
     if (filterTags.length > 0) this.#config.filtered_record_tags = filterTags
+    this.#projectName = options.projectName
     this.#tags = { ...options.tags }
+    if (this.#projectName !== undefined) this.#tags.project_name = this.#projectName
     this.#metadata = { ...options.metadata }
     this.#projectId = null
     this.#experimentId = null
@@ -281,6 +329,7 @@ class Experiment {
       projectId: this.#projectId,
       datasetId: this.#dataset.id,
       datasetRecordId: input.datasetRecordId,
+      projectName: this.#projectName,
       runId: input.runId ?? this.#runId,
       runIteration: input.runIteration ?? this.#runIteration,
     }, input.name ?? this.#name, mergeTags(this.#tags, input.tags))
@@ -429,32 +478,59 @@ class Experiment {
         })
 
         const timestampMs = Date.now()
+        const rowEvaluationValues = {}
         for (const [label, evaluator] of this.#evaluators) {
-          if (!evaluatorResults[label]) evaluatorResults[label] = []
           if (row.isError) {
             const msg = 'task error; evaluation skipped'
             row.evaluationErrors[label] = msg
-            evaluatorResults[label].push(null)
+            rowEvaluationValues[label] = null
             metrics.push(toMetric(label, null, msg, row.spanId, row.traceId, timestampMs, experimentId, this.#tags))
             continue
           }
           try {
+            let evaluate
+            if (evaluator instanceof BaseEvaluator) {
+              evaluate = () => evaluator.evaluate(new EvaluatorContext({
+                inputData: record.input,
+                outputData: row.output,
+                expectedOutput: record.expectedOutput,
+                metadata: buildSpanMetadata(record.metadata, this.#config),
+                spanId: row.spanId,
+                traceId: row.traceId,
+              }))
+            } else {
+              evaluate = () => evaluator(record.input, row.output, record.expectedOutput)
+            }
             // eslint-disable-next-line no-await-in-loop
-            const value = await this.#runWithRetries(
-              () => evaluator(record.input, row.output, record.expectedOutput),
-              maxRetries,
-              retryDelay
-            )
-            row.evaluations[label] = value
-            evaluatorResults[label].push(value)
-            metrics.push(toMetric(label, value, null, row.spanId, row.traceId, timestampMs, experimentId, this.#tags))
+            const result = await this.#runWithRetries(evaluate, maxRetries, retryDelay)
+            for (const evaluatorResult of extractEvaluatorResults(result, label)) {
+              row.evaluations[evaluatorResult.label] = evaluatorResult.value
+              rowEvaluationValues[evaluatorResult.label] = evaluatorResult.value
+              metrics.push(toMetric(
+                evaluatorResult.label,
+                evaluatorResult.value,
+                null,
+                row.spanId,
+                row.traceId,
+                timestampMs,
+                experimentId,
+                this.#tags,
+                'custom',
+                evaluatorResult.extras
+              ))
+            }
           } catch (err) {
             if (throwOnErrors) throw err
             const msg = err.message ?? String(err)
             row.evaluationErrors[label] = msg
-            evaluatorResults[label].push(null)
+            rowEvaluationValues[label] = null
             metrics.push(toMetric(label, null, msg, row.spanId, row.traceId, timestampMs, experimentId, this.#tags))
           }
+        }
+
+        for (const [label, value] of Object.entries(rowEvaluationValues)) {
+          if (!evaluatorResults[label]) evaluatorResults[label] = new Array(i).fill(null)
+          evaluatorResults[label].push(value)
         }
 
         rows.push(row)
@@ -467,6 +543,7 @@ class Experiment {
             datasetRecordId,
             datasetName: this.#dataset.name(),
             experimentName: this.#name,
+            projectName: this.#projectName,
             runId,
             runIteration,
           }, this.#task.name || this.#name, this.#tags, record.tags))
@@ -628,27 +705,43 @@ class Experiment {
     const metadata = records.map(record => buildSpanMetadata(record.metadata, this.#config))
     const summaryEvaluations = {}
     const timestampMs = Date.now()
+    const context = new SummaryEvaluatorContext({
+      inputs,
+      outputs,
+      expectedOutputs,
+      evaluationResults: evaluatorResults,
+      metadata,
+    })
 
     for (const [label, evaluator] of this.#summaryEvaluators) {
       try {
+        const evaluate = evaluator instanceof BaseSummaryEvaluator
+          ? () => evaluator.evaluate(context)
+          : evaluator.length === 1
+            ? () => evaluator(context)
+            : () => evaluator(inputs, outputs, expectedOutputs, evaluatorResults, metadata)
         // eslint-disable-next-line no-await-in-loop
-        const value = await this.#runWithRetries(
-          () => evaluator(inputs, outputs, expectedOutputs, evaluatorResults, metadata),
-          options.maxRetries,
-          options.retryDelay
-        )
-        summaryEvaluations[label] = { value, error: null }
-        options.metrics.push(toMetric(
-          label,
-          value,
-          null,
-          '',
-          '',
-          timestampMs,
-          options.experimentId,
-          this.#tags,
-          'summary'
-        ))
+        const result = await this.#runWithRetries(evaluate, options.maxRetries, options.retryDelay)
+        for (const evaluatorResult of extractEvaluatorResults(result, label)) {
+          const summary = { value: evaluatorResult.value, error: null }
+          if (evaluatorResult.extras.reasoning !== undefined) summary.reasoning = evaluatorResult.extras.reasoning
+          if (evaluatorResult.extras.assessment !== undefined) summary.assessment = evaluatorResult.extras.assessment
+          if (evaluatorResult.extras.metadata !== undefined) summary.metadata = evaluatorResult.extras.metadata
+          if (evaluatorResult.extras.tags !== undefined) summary.tags = evaluatorResult.extras.tags
+          summaryEvaluations[evaluatorResult.label] = summary
+          options.metrics.push(toMetric(
+            evaluatorResult.label,
+            evaluatorResult.value,
+            null,
+            '',
+            '',
+            timestampMs,
+            options.experimentId,
+            this.#tags,
+            'summary',
+            evaluatorResult.extras
+          ))
+        }
       } catch (err) {
         if (options.throwOnErrors) throw err
         const msg = err.message ?? String(err)

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -4,6 +4,7 @@ const log = require('../../log')
 const { ExperimentsClient } = require('./client')
 const { Dataset, DatasetRecord } = require('./dataset')
 const { Experiment, ExternalExperiment } = require('./experiment')
+const evaluatorTypes = require('./evaluator')
 const { validateTagsList } = require('./util')
 const NoopExperiments = require('./noop')
 
@@ -34,7 +35,7 @@ class Experiments {
   constructor (config, llmobs) {
     this.#config = config
     this.#llmobs = llmobs
-    this.#projectName = config.llmobs?.mlApp || config.service
+    this.#projectName = config.llmobs?.projectName || config.llmobs?.mlApp || config.service
     this.#client = this.#clientForProject(this.#projectName)
   }
 
@@ -56,7 +57,10 @@ class Experiments {
     const options = typeof descriptionOrOptions === 'string'
       ? { description: descriptionOrOptions }
       : (descriptionOrOptions ?? {})
-    const dataset = new Dataset(this.#client, name, options.description ?? '')
+    const client = options.projectName === undefined || options.projectName === this.#projectName
+      ? this.#client
+      : this.#clientForProject(options.projectName)
+    const dataset = new Dataset(client, name, options.description ?? '')
     const recordIds = new Set()
     if ((options.records) != null) {
       for (const record of options.records) {
@@ -80,9 +84,13 @@ class Experiments {
   // wait until that many records are readable. Pass `tags` to filter records by
   // dataset record tags.
   async pullDataset (name, options = {}) {
-    const { expectedRecordCount, maxWaitMs = 30_000, tags, version } = options
+    const { expectedRecordCount, maxWaitMs = 30_000, projectName, tags, version } = options
     const filterTags = validateTagsList(tags)
-    const projectId = await this.#client.ensureProjectId()
+    const client = projectName === undefined || projectName === this.#projectName
+      ? this.#client
+      : this.#clientForProject(projectName)
+    const resolvedProjectName = projectName ?? this.#projectName
+    const projectId = await client.ensureProjectId()
 
     let pulledDataset = null
     let records = []
@@ -93,7 +101,7 @@ class Experiments {
     const succeeded = await retryWithBackoff(async () => {
       try {
         if (pulledDataset === null) {
-          const datasets = await this.#client.listDatasets(projectId, { name })
+          const datasets = await client.listDatasets(projectId, { name })
           for (const dataset of datasets) {
             if (dataset.name() === name) {
               pulledDataset = dataset
@@ -109,7 +117,7 @@ class Experiments {
         // Follow the meta.after / page[cursor] pagination until the last page.
         for (;;) {
           // eslint-disable-next-line no-await-in-loop
-          const page = await this.#client.listDatasetRecords(projectId, pulledDataset.id(), {
+          const page = await client.listDatasetRecords(projectId, pulledDataset.id(), {
             cursor,
             tags: filterTags,
             version: datasetVersion,
@@ -129,13 +137,13 @@ class Experiments {
     }, { maxTotalMs: maxWaitMs })
 
     if (pulledDataset === null && lastError) {
-      throw new Error(`Failed to list datasets in project '${this.#projectName}': ${lastError}`)
+      throw new Error(`Failed to list datasets in project '${resolvedProjectName}': ${lastError}`)
     }
     if (pulledDataset === null) {
-      throw new Error(`Dataset '${name}' not found in project '${this.#projectName}' (after ${maxWaitMs}ms)`)
+      throw new Error(`Dataset '${name}' not found in project '${resolvedProjectName}' (after ${maxWaitMs}ms)`)
     }
     if (!succeeded && lastError) {
-      throw new Error(`Failed to fetch records for dataset '${name}' in project '${this.#projectName}': ${lastError}`)
+      throw new Error(`Failed to fetch records for dataset '${name}' in project '${resolvedProjectName}': ${lastError}`)
     }
     if (!succeeded && expectedRecordCount != null) {
       throw new Error(
@@ -151,7 +159,7 @@ class Experiments {
     }
 
     return Dataset.fromExisting(
-      this.#client,
+      client,
       name,
       pulledDataset.description(),
       pulledDataset.id(),
@@ -163,9 +171,15 @@ class Experiments {
     )
   }
 
-  // Build an experiment: { name, dataset, task, evaluators, description?, config?, tags? }.
+  // Build an experiment with a dataset, task, evaluators, and optional project/config/tags.
   experiment (options) {
-    return new Experiment(this.#client, options, this.#llmobs)
+    const client = options?.projectName === undefined || options.projectName === this.#projectName
+      ? this.#client
+      : this.#clientForProject(options.projectName)
+    const experimentOptions = options?.projectName === undefined && this.#config.llmobs?.projectName !== undefined
+      ? { ...options, projectName: this.#config.llmobs.projectName }
+      : options
+    return new Experiment(client, experimentOptions, this.#llmobs)
   }
 
   /**
@@ -180,7 +194,10 @@ class Experiments {
     const client = options?.projectName === undefined || options.projectName === this.#projectName
       ? this.#client
       : this.#clientForProject(options.projectName)
-    return new Experiment(client, { ...options, external: true }).start()
+    const experimentOptions = options?.projectName === undefined && this.#config.llmobs?.projectName !== undefined
+      ? { ...options, projectName: this.#config.llmobs.projectName }
+      : options
+    return new Experiment(client, { ...experimentOptions, external: true }).start()
       .then(experiment => new ExternalExperiment(experiment))
   }
 }
@@ -195,10 +212,9 @@ function createExperiments (config, llmobs) {
     log.warn('LLMObs experiments: missing api and/or app keys, set DD_API_KEY and DD_APP_KEY')
     return new NoopExperiments('DD_API_KEY and DD_APP_KEY are required for experiments')
   }
-  if (!config.llmobs?.mlApp && !config.service) {
-    const reason = 'no project name configured; set the DD_LLMOBS_ML_APP environment variable (or llmobs.mlApp in ' +
-      'tracer.init()) to name the LLM Obs project, or DD_SERVICE (or service in tracer.init()) as a fallback, ' +
-      'then retry'
+  if (!config.llmobs?.projectName && !config.llmobs?.mlApp && !config.service) {
+    const reason = 'no project name configured; set DD_LLMOBS_PROJECT_NAME (or llmobs.projectName in tracer.init()), ' +
+      'DD_LLMOBS_ML_APP (or llmobs.mlApp), or DD_SERVICE (or service in tracer.init()), then retry'
     const experiments = new Experiments(config, llmobs)
     return new NoopExperiments(reason, {
       startExperiment: (options) => experiments.startExperiment(options),
@@ -207,4 +223,4 @@ function createExperiments (config, llmobs) {
   return new Experiments(config, llmobs)
 }
 
-module.exports = { Experiments, createExperiments }
+module.exports = { Experiments, createExperiments, ...evaluatorTypes }

--- a/packages/dd-trace/src/llmobs/experiments/util.js
+++ b/packages/dd-trace/src/llmobs/experiments/util.js
@@ -65,9 +65,35 @@ function functionName (fn, fallback) {
 }
 
 /**
+ * @param {unknown} evaluator
+ * @param {string} kind
+ * @returns {boolean}
+ */
+function isClassEvaluator (evaluator, kind) {
+  // Lazy loading avoids a cycle: evaluator.js uses validateEvaluatorName from this module.
+  const { BaseEvaluator, BaseSummaryEvaluator } = require('./evaluator')
+  return kind === 'summary'
+    ? evaluator instanceof BaseSummaryEvaluator
+    : evaluator instanceof BaseEvaluator
+}
+
+/**
+ * @param {unknown} evaluator
+ * @param {string} kind
+ * @param {number} index
+ * @returns {string}
+ */
+function evaluatorName (evaluator, kind, index) {
+  if (isClassEvaluator(evaluator, kind)) return evaluator.name
+  if (typeof evaluator === 'function') return functionName(evaluator, `${kind}_evaluator_${index}`)
+  const baseName = kind === 'summary' ? 'BaseSummaryEvaluator' : 'BaseEvaluator'
+  throw new TypeError(`${kind} evaluator must be a function or a ${baseName} instance`)
+}
+
+/**
  * @param {unknown} evaluators
  * @param {string} kind
- * @returns {Array<[string, (...args: unknown[]) => unknown]>}
+ * @returns {Array<[string, Function | object]>}
  */
 function normalizeEvaluators (evaluators, kind) {
   if (evaluators == null) return []
@@ -77,8 +103,7 @@ function normalizeEvaluators (evaluators, kind) {
     const indexesByName = new Map()
     for (let i = 0; i < evaluators.length; i++) {
       const evaluator = evaluators[i]
-      if (typeof evaluator !== 'function') throw new TypeError(`${kind} evaluator must be a function`)
-      const name = functionName(evaluator, `${kind}_evaluator_${i}`)
+      const name = evaluatorName(evaluator, kind, i)
       validateEvaluatorName(name)
       if (indexesByName.has(name)) {
         log.warn('Duplicate %s evaluator name %s; previous evaluator will be overwritten', kind, name)
@@ -91,13 +116,17 @@ function normalizeEvaluators (evaluators, kind) {
     return normalized
   }
 
-  if (typeof evaluators !== 'object') {
-    throw new TypeError(`${kind} evaluators must be an array of functions or an object keyed by evaluator name`)
+  if (typeof evaluators !== 'object' || evaluators === null) {
+    throw new TypeError(
+      `${kind} evaluators must be an array of functions or class instances, or an object keyed by evaluator name`
+    )
   }
 
   for (const [name, evaluator] of Object.entries(evaluators)) {
     validateEvaluatorName(name)
-    if (typeof evaluator !== 'function') throw new TypeError(`${kind} evaluator '${name}' must be a function`)
+    if (!isClassEvaluator(evaluator, kind) && typeof evaluator !== 'function') {
+      throw new TypeError(`${kind} evaluator '${name}' must be a function or a class instance`)
+    }
     normalized.push([name, evaluator])
   }
   return normalized

--- a/packages/dd-trace/src/llmobs/noop.js
+++ b/packages/dd-trace/src/llmobs/noop.js
@@ -1,6 +1,14 @@
 'use strict'
 
 const NoopExperiments = require('./experiments/noop')
+const {
+  BaseEvaluator,
+  BaseSummaryEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+  MultiEvaluatorResult,
+  SummaryEvaluatorContext,
+} = require('./experiments/evaluator')
 
 class NoopLLMObs {
   constructor (noopTracer) {
@@ -13,6 +21,30 @@ class NoopLLMObs {
 
   get experiments () {
     return new NoopExperiments('LLM Observability is not enabled')
+  }
+
+  get BaseEvaluator () {
+    return BaseEvaluator
+  }
+
+  get BaseSummaryEvaluator () {
+    return BaseSummaryEvaluator
+  }
+
+  get EvaluatorContext () {
+    return EvaluatorContext
+  }
+
+  get SummaryEvaluatorContext () {
+    return SummaryEvaluatorContext
+  }
+
+  get EvaluatorResult () {
+    return EvaluatorResult
+  }
+
+  get MultiEvaluatorResult () {
+    return MultiEvaluatorResult
   }
 
   enable (options) {}

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -98,6 +98,7 @@ class LLMObs extends NoopLLMObs {
     // TODO: These configs should be passed through directly at construction time instead.
     this._config.llmobs.DD_LLMOBS_ENABLED = true
     this._config.llmobs.mlApp = options.mlApp
+    if (options.projectName !== undefined) this._config.llmobs.projectName = options.projectName
     this._config.llmobs.agentlessEnabled = options.agentlessEnabled
 
     // configure writers and channel subscribers

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -3893,6 +3893,23 @@ describe('Config', () => {
       }])
     })
 
+    it('should configure the experiments project name from options and enable llmobs', () => {
+      const config = getConfig({ llmobs: { projectName: 'experiments-project' } })
+      assert.strictEqual(config.llmobs.projectName, 'experiments-project')
+      assert.strictEqual(config.llmobs.DD_LLMOBS_ENABLED, true)
+    })
+
+    it('should configure the experiments project name from DD_LLMOBS_PROJECT_NAME', () => {
+      process.env.DD_LLMOBS_PROJECT_NAME = 'env-project'
+      const config = getConfig()
+      assert.strictEqual(config.llmobs.projectName, 'env-project')
+      assert.strictEqual(config.llmobs.DD_LLMOBS_ENABLED, true)
+
+      assertConfigUpdateContains(updateConfig.getCall(0).args[0], [{
+        name: 'DD_LLMOBS_PROJECT_NAME', value: 'env-project', origin: 'env_var',
+      }])
+    })
+
     it('should have DD_LLMOBS_ENABLED take priority over options', () => {
       process.env.DD_LLMOBS_ENABLED = 'false'
       const config = getConfig({ llmobs: { agentlessEnabled: true } })

--- a/packages/dd-trace/test/llmobs/experiments/example.js
+++ b/packages/dd-trace/test/llmobs/experiments/example.js
@@ -38,6 +38,15 @@ function keywordOverlap (prompt, topics) {
 
 async function runExperiment (experiments) {
   console.log('\n=== Experiment: topic relevance ===')
+  class ExactMatchEvaluator extends tracer.llmobs.BaseEvaluator {
+    constructor () {
+      super('exact_match')
+    }
+
+    evaluate (context) {
+      return context.outputData.response === context.expectedOutput
+    }
+  }
   const dataset = experiments.createDataset('node-tracer-topic-relevance', 'demo dataset')
     .addRecord({ prompt: 'I love hiking in the mountains on weekends.', topics: 'outdoor, travel' }, 'true',
       { source: 'synthetic', difficulty: 'easy' }, ['split:train'])
@@ -54,7 +63,7 @@ async function runExperiment (experiments) {
       return { response: String(overlap), confidence: overlap ? 0.85 : 0.65 }
     },
     evaluators: {
-      exact_match: (_input, output, expected) => output.response === expected, // boolean
+      exact_match: new ExactMatchEvaluator(), // class-based boolean evaluator
       confidence_score: (_input, output) => Number(output.confidence), // score
       verdict_category: (_input, output) => (output.response === 'true' ? 'in-topic' : 'off-topic'), // categorical
     },
@@ -100,7 +109,10 @@ async function main () {
   requireEnv('DD_APP_KEY')
 
   tracer.init({
-    llmobs: { mlApp: 'node-tracer-experiments-demo' },
+    llmobs: {
+      mlApp: 'node-tracer-experiments-demo',
+      projectName: 'node-tracer-experiments-demo',
+    },
   })
 
   const { experiments } = tracer.llmobs

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -6,6 +6,12 @@ const { describe, it } = require('mocha')
 
 const { API_BASE_PATH, ExperimentsClient } = require('../../../src/llmobs/experiments/client')
 const { Dataset, DatasetRecord } = require('../../../src/llmobs/experiments/dataset')
+const {
+  BaseEvaluator,
+  BaseSummaryEvaluator,
+  EvaluatorResult,
+  MultiEvaluatorResult,
+} = require('../../../src/llmobs/experiments/evaluator')
 const { Experiment } = require('../../../src/llmobs/experiments/experiment')
 
 function client () {
@@ -91,6 +97,102 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
     assert.deepEqual(requests.find(request => request.method === 'createExperiment').attributes.config, {
       temperature: 0,
     })
+  })
+
+  it('runs class evaluators with contexts and serializes rich results', async () => {
+    const { client: c, requests } = clientWithMockBackend()
+    const dataset = new Dataset(c, 'demo').addRecord('input', 'expected', { source: 'test' })
+    let recordContext
+    let summaryContext
+
+    class ExactMatchEvaluator extends BaseEvaluator {
+      constructor () {
+        super('exact_match')
+      }
+
+      evaluate (context) {
+        recordContext = context
+        return new EvaluatorResult({
+          value: context.outputData === context.expectedOutput,
+          reasoning: 'The output matches the expected value.',
+          assessment: 'pass',
+          metadata: { source: 'class' },
+          tags: { evaluator: 'exact' },
+        })
+      }
+    }
+
+    class CountEvaluator extends BaseSummaryEvaluator {
+      constructor () {
+        super('match_count')
+      }
+
+      evaluate (context) {
+        summaryContext = context
+        return context.evaluationResults.exact_match.filter(Boolean).length
+      }
+    }
+
+    const result = await new Experiment(c, {
+      name: 'exp-demo',
+      projectName: 'demo-project',
+      dataset,
+      task: input => input,
+      evaluators: [new ExactMatchEvaluator()],
+      summaryEvaluators: [new CountEvaluator()],
+    }).run()
+
+    assert.deepEqual({
+      inputData: recordContext.inputData,
+      outputData: recordContext.outputData,
+      expectedOutput: recordContext.expectedOutput,
+      metadata: recordContext.metadata,
+      spanId: recordContext.spanId,
+      traceId: recordContext.traceId,
+    }, {
+      inputData: 'input',
+      outputData: 'input',
+      expectedOutput: 'expected',
+      metadata: { source: 'test', experiment_config: {} },
+      spanId: result.rows[0].spanId,
+      traceId: result.rows[0].traceId,
+    })
+    assert.deepEqual(summaryContext.evaluationResults, { exact_match: [false] })
+    assert.equal(result.rows[0].evaluations.exact_match, false)
+    assert.equal(result.summaryEvaluations.match_count.value, 0)
+
+    const events = requests.find(request => request.method === 'postExperimentEvents').attributes
+    const metric = events.metrics.find(item => item.label === 'exact_match')
+    assert.equal(metric.assessment, 'pass')
+    assert.equal(metric.reasoning, 'The output matches the expected value.')
+    assert.deepEqual(metric.metadata, { source: 'class' })
+    assert.deepEqual(metric.tags.filter(tag => tag === 'evaluator:exact'), ['evaluator:exact'])
+    assert.equal(metric.tags.includes('project_name:demo-project'), true)
+    assert.equal(events.spans[0].tags.includes('project_name:demo-project'), true)
+  })
+
+  it('supports multiple metrics from a class evaluator', async () => {
+    const { client: c, requests } = clientWithMockBackend()
+    const dataset = new Dataset(c, 'demo').addRecord('input')
+
+    class DetailsEvaluator extends BaseEvaluator {
+      evaluate () {
+        return new MultiEvaluatorResult({
+          length: 5,
+          valid: new EvaluatorResult(true),
+        })
+      }
+    }
+
+    await new Experiment(c, {
+      name: 'exp-demo',
+      dataset,
+      task: input => input,
+      evaluators: [new DetailsEvaluator()],
+    }).run()
+
+    const metrics = requests.find(request => request.method === 'postExperimentEvents').attributes.metrics
+    assert.deepEqual(metrics.map(metric => metric.label), ['DetailsEvaluator-length', 'DetailsEvaluator-valid'])
   })
 
   it('preserves repeated record tags in fallback experiment spans', async () => {

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -140,6 +140,27 @@ describe('LLMObs Experiments facade', () => {
       assert.equal(typeof experiment.run, 'function')
     })
 
+    it('uses the configured project name and supports per-operation overrides', () => {
+      const constructedProjects = []
+      class CapturingExperimentsClient extends ExperimentsClient {
+        constructor (options) {
+          super(options)
+          constructedProjects.push(options.projectName)
+        }
+      }
+      const { createExperiments: createWithProjectCapture } = proxyquire('../../../src/llmobs/experiments', {
+        './client': { ExperimentsClient: CapturingExperimentsClient },
+      })
+
+      const exp = createWithProjectCapture(enabledConfig({
+        llmobs: { DD_LLMOBS_ENABLED: true, projectName: 'configured-project' },
+      }))
+      exp.createDataset('default')
+      exp.createDataset('override', { projectName: 'override-project' })
+
+      assert.deepEqual(constructedProjects, ['configured-project', 'override-project'])
+    })
+
     it('returns a working facade when service is used as the project name fallback', () => {
       const exp = createExperiments(enabledConfig({ service: 'my-service', llmobs: { DD_LLMOBS_ENABLED: true } }))
       const dataset = exp.createDataset('d')

--- a/packages/dd-trace/test/llmobs/experiments/util.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/util.spec.js
@@ -5,6 +5,7 @@ const { afterEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const log = require('../../../src/log')
+const { BaseEvaluator, BaseSummaryEvaluator } = require('../../../src/llmobs/experiments/evaluator')
 
 const {
   buildTags,
@@ -40,6 +41,19 @@ describe('LLMObs Experiments util', () => {
     assert.deepEqual(normalizeEvaluators([namedEvaluator], 'summary'), [['namedEvaluator', namedEvaluator]])
     assert.throws(() => normalizeEvaluators({ 'bad.name': namedEvaluator }, 'row'), /invalid/)
     assert.throws(() => normalizeEvaluators([true], 'summary'), /summary evaluator must be a function/)
+  })
+
+  it('normalizes class evaluator instances by their configured names', () => {
+    class RowEvaluator extends BaseEvaluator {}
+    class SummaryEvaluator extends BaseSummaryEvaluator {}
+
+    const row = new RowEvaluator('row-check')
+    const summary = new SummaryEvaluator()
+
+    assert.deepEqual(normalizeEvaluators([row], 'row'), [['row-check', row]])
+    assert.deepEqual(normalizeEvaluators([summary], 'summary'), [['SummaryEvaluator', summary]])
+    assert.throws(() => normalizeEvaluators([summary], 'row'), /row evaluator must be a function or a BaseEvaluator/)
+    assert.throws(() => normalizeEvaluators([row], 'summary'), /summary evaluator must be a function or a BaseSummaryEvaluator/)
   })
 
   it('warns and keeps the last array evaluator when inferred names collide', () => {

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -95,6 +95,15 @@ describe('sdk', () => {
       assert.strictEqual(typeof llmobs.experiments.createDataset, 'function')
       assert.strictEqual(typeof llmobs.experiments.pullDataset, 'function')
     })
+
+    it('exposes class-based evaluator primitives', () => {
+      assert.strictEqual(typeof llmobs.BaseEvaluator, 'function')
+      assert.strictEqual(typeof llmobs.BaseSummaryEvaluator, 'function')
+      assert.strictEqual(typeof llmobs.EvaluatorContext, 'function')
+      assert.strictEqual(typeof llmobs.SummaryEvaluatorContext, 'function')
+      assert.strictEqual(typeof llmobs.EvaluatorResult, 'function')
+      assert.strictEqual(typeof llmobs.MultiEvaluatorResult, 'function')
+    })
   })
 
   describe('enable', () => {
@@ -110,10 +119,12 @@ describe('sdk', () => {
 
       disabledLLMObs.enable({
         mlApp: 'mlApp',
+        projectName: 'projectName',
       })
 
       assert.strictEqual(disabledLLMObs.enabled, true)
       assert.strictEqual(disabledLLMObs._config.llmobs.mlApp, 'mlApp')
+      assert.strictEqual(disabledLLMObs._config.llmobs.projectName, 'projectName')
       assert.strictEqual(disabledLLMObs._config.llmobs.agentlessEnabled, undefined)
 
       sinon.assert.called(llmobsModule.enable)


### PR DESCRIPTION
### What does this PR do?

Adds dd-trace-js LLM Experiments parity features for project configuration and class-based evaluators:

- Adds `llmobs.projectName` and `DD_LLMOBS_PROJECT_NAME` configuration.
- Supports project overrides for datasets, experiments, and dataset pulls.
- Adds reusable record and summary evaluator classes with evaluator contexts.
- Adds rich evaluator results and multi-metric evaluator results.
- Updates TypeScript declarations, documentation examples, tests, and the experiments example.
- Keeps the existing `mlApp`/`service` fallback behavior.

CSV upload is intentionally out of scope.

### Motivation

Bring the JavaScript Experiments API closer to the dd-trace-py LLM Experiments setup, while providing reusable class-based evaluators for applications that need evaluator state or richer metric output.

### Additional Notes

Targeted lint, configuration validation, declaration checks, evaluator tests, configuration tests, and SDK tests pass.

The VCR-backed facade experiment cases require the local replay service at `127.0.0.1:9126` and were not runnable without that service.
