### PR TITLE
test(esbuild): stop bundled servers between cases

### DIFF
--- a/integration-tests/esbuild/esm.integration.spec.js
+++ b/integration-tests/esbuild/esm.integration.spec.js
@@ -6,7 +6,7 @@ const { execSync } = require('node:child_process')
 
 const axios = require('axios')
 
-const { FakeAgent, spawnProc, sandboxCwd, useSandbox } = require('../helpers')
+const { FakeAgent, spawnProc, stopProc, sandboxCwd, useSandbox } = require('../helpers')
 
 const { ESBUILD_VERSION } = process.env
 const esbuildVersions = ESBUILD_VERSION ? [ESBUILD_VERSION] : ['latest', '0.16.12']
@@ -24,7 +24,7 @@ function findWebSpan (payload) {
 
 esbuildVersions.forEach((version) => {
   describe('ESM is built and runs as expected in a sandbox', () => {
-    let agent, cwd
+    let agent, cwd, proc
 
     useSandbox([`esbuild@${version}`, 'hono', '@hono/node-server'], false, [__dirname])
 
@@ -36,8 +36,9 @@ esbuildVersions.forEach((version) => {
       agent = await new FakeAgent().start()
     })
 
-    afterEach(() => {
-      agent.stop()
+    afterEach(async () => {
+      await stopProc(proc)
+      await agent.stop()
     })
 
     it('should build basic esm http server exporting esm and create web traces at runtime', async () => {
@@ -45,7 +46,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'esm-http-test-out.mjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
@@ -68,7 +69,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'esm-http-test-out.cjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
@@ -91,7 +92,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'hono-out.mjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
@@ -114,7 +115,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'hono-out.cjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,


### PR DESCRIPTION
A spawned server can outlive the fake agent that receives its traces, letting a later case observe a generic HTTP trace instead of its Hono result.