### PR TITLE
test: require fake-agent teardown

### DIFF
--- a/eslint-rules/eslint-require-agent-stop.mjs
+++ b/eslint-rules/eslint-require-agent-stop.mjs
@@ -1,22 +1,96 @@
+const FAKE_AGENT_CONSTRUCTORS = new Set(['FakeAgent', 'FakeCiVisIntake'])
+const PROMISE_ADOPTERS = new Set(['resolve'])
+const PROMISE_AGGREGATES = new Set(['all', 'allSettled'])
+const PROMISE_CHAIN_METHODS = new Set(['catch', 'finally', 'then'])
+
+/**
+ * @typedef {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} TeardownCallback
+ */
+
+/**
+ * @typedef {object} ValueReference
+ * @property {import('eslint').Scope.Variable} variable
+ * @property {string} memberPath
+ */
+
+/** @typedef {Map<import('eslint').Scope.Variable, Set<string>>} ValueReferences */
+/** @typedef {Map<TeardownCallback, ValueReferences>} SettledValueReferences */
+
+/**
+ * @param {import('estree').Identifier} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {import('eslint').Scope.Variable | undefined}
+ */
+function getVariable (node, sourceCode) {
+  let scope = sourceCode.getScope(node)
+  while (scope) {
+    const variable = scope.set.get(node.name)
+    if (variable) return variable
+
+    scope = scope.upper
+  }
+}
+
 /**
  * @param {import('estree').Node} node
- * @returns {string | undefined}
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {ValueReference | undefined}
  */
-function getValueKey (node) {
+function getValueReference (node, sourceCode) {
   if (node.type === 'ChainExpression') {
-    return getValueKey(node.expression)
+    return getValueReference(node.expression, sourceCode)
   }
 
   if (node.type === 'Identifier') {
-    return node.name
+    const variable = getVariable(node, sourceCode)
+    return variable && { variable, memberPath: '' }
   }
 
   if (node.type !== 'MemberExpression' || node.computed || node.property.type !== 'Identifier') {
     return undefined
   }
 
-  const objectKey = getValueKey(node.object)
-  return objectKey && `${objectKey}.${node.property.name}`
+  const reference = getValueReference(node.object, sourceCode)
+  if (reference) {
+    reference.memberPath += `.${node.property.name}`
+  }
+  return reference
+}
+
+/**
+ * @param {ValueReferences} references
+ * @param {ValueReference} reference
+ */
+function addValueReference (references, reference) {
+  let memberPaths = references.get(reference.variable)
+  if (!memberPaths) {
+    memberPaths = new Set()
+    references.set(reference.variable, memberPaths)
+  }
+  memberPaths.add(reference.memberPath)
+}
+
+/**
+ * @param {ValueReferences} references
+ * @param {ValueReference} reference
+ * @returns {boolean}
+ */
+function hasValueReference (references, reference) {
+  return references.get(reference.variable)?.has(reference.memberPath) === true
+}
+
+/**
+ * @param {SettledValueReferences} references
+ * @param {TeardownCallback} callback
+ * @param {ValueReference} reference
+ */
+function addSettledValueReference (references, callback, reference) {
+  let callbackReferences = references.get(callback)
+  if (!callbackReferences) {
+    callbackReferences = new Map()
+    references.set(callback, callbackReferences)
+  }
+  addValueReference(callbackReferences, reference)
 }
 
 /**
@@ -29,7 +103,7 @@ function isFakeAgent (node) {
   }
 
   if (node.type === 'NewExpression') {
-    return node.callee.type === 'Identifier' && node.callee.name === 'FakeAgent'
+    return node.callee.type === 'Identifier' && FAKE_AGENT_CONSTRUCTORS.has(node.callee.name)
   }
 
   return node.type === 'CallExpression' &&
@@ -70,7 +144,10 @@ function getTeardownCallback (node) {
     currentNode = currentNode.parent
     if (!isFunction(currentNode)) continue
 
-    if (!isTeardownHook(currentNode.parent) || currentNode.parent.arguments[0] !== currentNode) {
+    if (
+      !isTeardownHook(currentNode.parent) ||
+      currentNode.parent.arguments[currentNode.parent.arguments.length - 1] !== currentNode
+    ) {
       return undefined
     }
 
@@ -79,60 +156,132 @@ function getTeardownCallback (node) {
 }
 
 /**
+ * @param {import('estree').CallExpression} node
+ * @param {Set<string>} methodNames
+ * @param {import('estree').Node} argument
+ * @returns {boolean}
+ */
+function isPromiseStaticCall (node, methodNames, argument) {
+  return node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'Promise' &&
+    node.callee.property.type === 'Identifier' &&
+    methodNames.has(node.callee.property.name) &&
+    node.arguments[0] === argument
+}
+
+/**
  * @param {import('estree').Node} node
- * @param {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} callback
+ * @returns {import('estree').Node | undefined}
+ */
+function getResultParent (node) {
+  const parentNode = node.parent
+  if (parentNode.type === 'ChainExpression' && parentNode.expression === node) {
+    return parentNode
+  }
+
+  if (
+    parentNode.type === 'ConditionalExpression' &&
+    (parentNode.consequent === node || parentNode.alternate === node)
+  ) {
+    return parentNode
+  }
+
+  if (parentNode.type === 'LogicalExpression') {
+    if (parentNode.right === node || (parentNode.left === node && parentNode.operator !== '&&')) {
+      return parentNode
+    }
+    return undefined
+  }
+
+  if (
+    parentNode.type === 'SequenceExpression' &&
+    parentNode.expressions[parentNode.expressions.length - 1] === node
+  ) {
+    return parentNode
+  }
+
+  if (parentNode.type === 'AssignmentExpression' && parentNode.right === node) {
+    return parentNode
+  }
+
+  if (parentNode.type === 'ArrayExpression' && parentNode.elements.includes(node)) {
+    const callNode = parentNode.parent
+    if (callNode.type === 'CallExpression' && isPromiseStaticCall(callNode, PROMISE_AGGREGATES, parentNode)) {
+      return callNode
+    }
+    return undefined
+  }
+
+  if (
+    parentNode.type === 'CallExpression' &&
+    isPromiseStaticCall(parentNode, PROMISE_ADOPTERS, node)
+  ) {
+    return parentNode
+  }
+
+  if (
+    parentNode.type === 'MemberExpression' &&
+    parentNode.object === node &&
+    !parentNode.computed &&
+    parentNode.property.type === 'Identifier' &&
+    PROMISE_CHAIN_METHODS.has(parentNode.property.name) &&
+    parentNode.parent.type === 'CallExpression' &&
+    parentNode.parent.callee === parentNode
+  ) {
+    return parentNode.parent
+  }
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @param {TeardownCallback} callback
  * @returns {boolean}
  */
 function isSettled (node, callback) {
   let currentNode = node
-  while (currentNode.parent) {
+  while (currentNode.parent !== callback) {
     const parentNode = currentNode.parent
-    if (parentNode === callback) {
-      return callback.expression
-    }
-
-    if (parentNode.type === 'AwaitExpression' || parentNode.type === 'ReturnStatement') {
+    if (
+      (parentNode.type === 'AwaitExpression' || parentNode.type === 'ReturnStatement') &&
+      parentNode.argument === currentNode
+    ) {
       return true
     }
 
-    if (isFunction(parentNode)) {
-      return false
-    }
+    const resultParent = getResultParent(currentNode)
+    if (!resultParent) return false
 
-    currentNode = parentNode
+    currentNode = resultParent
   }
 
-  return false
+  return callback.expression && callback.body === currentNode
 }
 
 /**
  * @param {import('estree').CallExpression} node
- * @returns {string | undefined}
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {ValueReference | undefined}
  */
-function getAssignedValueKey (node) {
+function getAssignedValueReference (node, sourceCode) {
   let currentNode = node
-  let parentNode = node.parent
-  while (parentNode.type === 'ChainExpression') {
-    currentNode = parentNode
-    parentNode = parentNode.parent
-  }
+  while (currentNode.parent) {
+    const parentNode = currentNode.parent
 
-  if (parentNode.type === 'VariableDeclarator' && parentNode.init === currentNode) {
-    return getValueKey(parentNode.id)
-  }
+    if (parentNode.type === 'VariableDeclarator' && parentNode.init === currentNode) {
+      return getValueReference(parentNode.id, sourceCode)
+    }
 
-  if (parentNode.type === 'AssignmentExpression' && parentNode.right === currentNode) {
-    return getValueKey(parentNode.left)
-  }
-}
+    if (parentNode.type === 'AssignmentExpression' && parentNode.right === currentNode) {
+      return getValueReference(parentNode.left, sourceCode)
+    }
 
-/**
- * @param {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} callback
- * @param {string} valueKey
- * @returns {string}
- */
-function getScopedValueKey (callback, valueKey) {
-  return `${callback.range[0]}:${valueKey}`
+    const resultParent = getResultParent(currentNode)
+    if (!resultParent) return undefined
+
+    currentNode = resultParent
+  }
 }
 
 export default {
@@ -147,36 +296,53 @@ export default {
     },
   },
 
+  /**
+   * @param {import('eslint').Rule.RuleContext} context
+   * @returns {import('eslint').Rule.RuleListener}
+   */
   create (context) {
-    const fakeAgentValues = new Set()
-    const settledValues = new Set()
+    const { sourceCode } = context
+    const fakeAgentValues = new Map()
+    const settledValues = new Map()
     const stopCalls = []
+
+    /**
+     * @param {import('estree').Node} node
+     */
+    function recordSettledValue (node) {
+      const callback = getTeardownCallback(node)
+      if (!callback || !isSettled(node, callback)) return
+
+      const valueReference = getValueReference(node, sourceCode)
+      if (valueReference) {
+        addSettledValueReference(settledValues, callback, valueReference)
+      }
+    }
 
     return {
       VariableDeclarator (node) {
-        const valueKey = getValueKey(node.id)
-        if (valueKey && node.init && isFakeAgent(node.init)) {
-          fakeAgentValues.add(valueKey)
+        const valueReference = getValueReference(node.id, sourceCode)
+        if (valueReference && node.init && isFakeAgent(node.init)) {
+          addValueReference(fakeAgentValues, valueReference)
         }
       },
       AssignmentExpression (node) {
-        const valueKey = getValueKey(node.left)
-        if (valueKey && isFakeAgent(node.right)) {
-          fakeAgentValues.add(valueKey)
+        const valueReference = getValueReference(node.left, sourceCode)
+        if (valueReference && isFakeAgent(node.right)) {
+          addValueReference(fakeAgentValues, valueReference)
         }
       },
       Identifier (node) {
-        const callback = getTeardownCallback(node)
-        if (callback && isSettled(node, callback)) {
-          settledValues.add(getScopedValueKey(callback, node.name))
-        }
+        if (
+          node.parent.type === 'MemberExpression' &&
+          node.parent.property === node &&
+          !node.parent.computed
+        ) return
+
+        recordSettledValue(node)
       },
       MemberExpression (node) {
-        const callback = getTeardownCallback(node)
-        const valueKey = getValueKey(node)
-        if (callback && valueKey && isSettled(node, callback)) {
-          settledValues.add(getScopedValueKey(callback, valueKey))
-        }
+        recordSettledValue(node)
       },
       CallExpression (node) {
         if (
@@ -189,17 +355,22 @@ export default {
         }
 
         const callback = getTeardownCallback(node)
-        const valueKey = getValueKey(node.callee.object)
-        if (callback && valueKey) {
-          stopCalls.push({ callback, node, valueKey })
+        const valueReference = getValueReference(node.callee.object, sourceCode)
+        if (callback && valueReference) {
+          stopCalls.push({ callback, node, valueReference })
         }
       },
       'Program:exit' () {
-        for (const { callback, node, valueKey } of stopCalls) {
-          if (!fakeAgentValues.has(valueKey) || isSettled(node, callback)) continue
+        for (const { callback, node, valueReference } of stopCalls) {
+          if (!hasValueReference(fakeAgentValues, valueReference) || isSettled(node, callback)) continue
 
-          const assignedValueKey = getAssignedValueKey(node)
-          if (assignedValueKey && settledValues.has(getScopedValueKey(callback, assignedValueKey))) continue
+          const assignedValueReference = getAssignedValueReference(node, sourceCode)
+          const callbackReferences = settledValues.get(callback)
+          if (
+            assignedValueReference &&
+            callbackReferences &&
+            hasValueReference(callbackReferences, assignedValueReference)
+          ) continue
 
           context.report({
             node,

--- a/eslint-rules/eslint-require-agent-stop.mjs
+++ b/eslint-rules/eslint-require-agent-stop.mjs
@@ -1,0 +1,212 @@
+/**
+ * @param {import('estree').Node} node
+ * @returns {string | undefined}
+ */
+function getValueKey (node) {
+  if (node.type === 'ChainExpression') {
+    return getValueKey(node.expression)
+  }
+
+  if (node.type === 'Identifier') {
+    return node.name
+  }
+
+  if (node.type !== 'MemberExpression' || node.computed || node.property.type !== 'Identifier') {
+    return undefined
+  }
+
+  const objectKey = getValueKey(node.object)
+  return objectKey && `${objectKey}.${node.property.name}`
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isFakeAgent (node) {
+  if (node.type === 'AwaitExpression' || node.type === 'ChainExpression') {
+    return isFakeAgent(node.argument ?? node.expression)
+  }
+
+  if (node.type === 'NewExpression') {
+    return node.callee.type === 'Identifier' && node.callee.name === 'FakeAgent'
+  }
+
+  return node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'start' &&
+    isFakeAgent(node.callee.object)
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isFunction (node) {
+  return node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression'
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isTeardownHook (node) {
+  return node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    (node.callee.name === 'after' || node.callee.name === 'afterEach')
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression | undefined}
+ */
+function getTeardownCallback (node) {
+  let currentNode = node
+  while (currentNode.parent) {
+    currentNode = currentNode.parent
+    if (!isFunction(currentNode)) continue
+
+    if (!isTeardownHook(currentNode.parent) || currentNode.parent.arguments[0] !== currentNode) {
+      return undefined
+    }
+
+    return /** @type {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} */ (currentNode)
+  }
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @param {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} callback
+ * @returns {boolean}
+ */
+function isSettled (node, callback) {
+  let currentNode = node
+  while (currentNode.parent) {
+    const parentNode = currentNode.parent
+    if (parentNode === callback) {
+      return callback.expression
+    }
+
+    if (parentNode.type === 'AwaitExpression' || parentNode.type === 'ReturnStatement') {
+      return true
+    }
+
+    if (isFunction(parentNode)) {
+      return false
+    }
+
+    currentNode = parentNode
+  }
+
+  return false
+}
+
+/**
+ * @param {import('estree').CallExpression} node
+ * @returns {string | undefined}
+ */
+function getAssignedValueKey (node) {
+  let currentNode = node
+  let parentNode = node.parent
+  while (parentNode.type === 'ChainExpression') {
+    currentNode = parentNode
+    parentNode = parentNode.parent
+  }
+
+  if (parentNode.type === 'VariableDeclarator' && parentNode.init === currentNode) {
+    return getValueKey(parentNode.id)
+  }
+
+  if (parentNode.type === 'AssignmentExpression' && parentNode.right === currentNode) {
+    return getValueKey(parentNode.left)
+  }
+}
+
+/**
+ * @param {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} callback
+ * @param {string} valueKey
+ * @returns {string}
+ */
+function getScopedValueKey (callback, valueKey) {
+  return `${callback.range[0]}:${valueKey}`
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require fake-agent teardown hooks to settle stop promises.',
+    },
+    schema: [],
+    messages: {
+      requireSettledStop: 'FakeAgent.stop() must be awaited or returned from a Mocha teardown hook.',
+    },
+  },
+
+  create (context) {
+    const fakeAgentValues = new Set()
+    const settledValues = new Set()
+    const stopCalls = []
+
+    return {
+      VariableDeclarator (node) {
+        const valueKey = getValueKey(node.id)
+        if (valueKey && node.init && isFakeAgent(node.init)) {
+          fakeAgentValues.add(valueKey)
+        }
+      },
+      AssignmentExpression (node) {
+        const valueKey = getValueKey(node.left)
+        if (valueKey && isFakeAgent(node.right)) {
+          fakeAgentValues.add(valueKey)
+        }
+      },
+      Identifier (node) {
+        const callback = getTeardownCallback(node)
+        if (callback && isSettled(node, callback)) {
+          settledValues.add(getScopedValueKey(callback, node.name))
+        }
+      },
+      MemberExpression (node) {
+        const callback = getTeardownCallback(node)
+        const valueKey = getValueKey(node)
+        if (callback && valueKey && isSettled(node, callback)) {
+          settledValues.add(getScopedValueKey(callback, valueKey))
+        }
+      },
+      CallExpression (node) {
+        if (
+          node.callee.type !== 'MemberExpression' ||
+          node.callee.computed ||
+          node.callee.property.type !== 'Identifier' ||
+          node.callee.property.name !== 'stop'
+        ) {
+          return
+        }
+
+        const callback = getTeardownCallback(node)
+        const valueKey = getValueKey(node.callee.object)
+        if (callback && valueKey) {
+          stopCalls.push({ callback, node, valueKey })
+        }
+      },
+      'Program:exit' () {
+        for (const { callback, node, valueKey } of stopCalls) {
+          if (!fakeAgentValues.has(valueKey) || isSettled(node, callback)) continue
+
+          const assignedValueKey = getAssignedValueKey(node)
+          if (assignedValueKey && settledValues.has(getScopedValueKey(callback, assignedValueKey))) continue
+
+          context.report({
+            node,
+            messageId: 'requireSettledStop',
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-rules/eslint-require-agent-stop.mjs
+++ b/eslint-rules/eslint-require-agent-stop.mjs
@@ -573,7 +573,7 @@ export default {
       'CallExpression:exit' (node) {
         if (isTeardownHook(node)) {
           const callbackNode = node.arguments[node.arguments.length - 1]
-          if (callbackNode?.type !== 'SpreadElement') {
+          if (callbackNode && callbackNode.type !== 'SpreadElement') {
             const callback = resolveCallback(callbackNode, sourceCode)
             if (callback) teardownCallbacks.add(callback)
           }

--- a/eslint-rules/eslint-require-agent-stop.mjs
+++ b/eslint-rules/eslint-require-agent-stop.mjs
@@ -4,7 +4,11 @@ const PROMISE_AGGREGATES = new Set(['all', 'allSettled'])
 const PROMISE_CHAIN_METHODS = new Set(['catch', 'finally', 'then'])
 
 /**
- * @typedef {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} TeardownCallback
+ * @typedef {
+ *   import('estree').FunctionDeclaration |
+ *   import('estree').FunctionExpression |
+ *   import('estree').ArrowFunctionExpression
+ * } TeardownCallback
  */
 
 /**
@@ -14,7 +18,34 @@ const PROMISE_CHAIN_METHODS = new Set(['catch', 'finally', 'then'])
  */
 
 /** @typedef {Map<import('eslint').Scope.Variable, Set<string>>} ValueReferences */
-/** @typedef {Map<TeardownCallback, ValueReferences>} SettledValueReferences */
+
+/**
+ * @typedef {object} AssignedValueReference
+ * @property {ValueReference} valueReference
+ * @property {import('estree').VariableDeclarator | import('estree').AssignmentExpression} assignment
+ */
+
+/**
+ * @typedef {object} FlowEvent
+ * @property {'settle' | 'write'} type
+ * @property {ValueReference} valueReference
+ * @property {import('estree').Node} node
+ * @property {number} position
+ */
+
+/**
+ * @typedef {object} CodePathState
+ * @property {CodePathState | undefined} upper
+ * @property {Set<import('eslint').Rule.CodePathSegment>} currentSegments
+ */
+
+/**
+ * @typedef {object} StopCall
+ * @property {TeardownCallback} callback
+ * @property {import('estree').CallExpression} node
+ * @property {ValueReference} valueReference
+ * @property {Set<import('eslint').Rule.CodePathSegment>} segments
+ */
 
 /**
  * @param {import('estree').Identifier} node
@@ -80,17 +111,24 @@ function hasValueReference (references, reference) {
 }
 
 /**
- * @param {SettledValueReferences} references
- * @param {TeardownCallback} callback
- * @param {ValueReference} reference
+ * @param {ValueReference} left
+ * @param {ValueReference} right
+ * @returns {boolean}
  */
-function addSettledValueReference (references, callback, reference) {
-  let callbackReferences = references.get(callback)
-  if (!callbackReferences) {
-    callbackReferences = new Map()
-    references.set(callback, callbackReferences)
-  }
-  addValueReference(callbackReferences, reference)
+function isSameValueReference (left, right) {
+  return left.variable === right.variable && left.memberPath === right.memberPath
+}
+
+/**
+ * @param {ValueReference} write
+ * @param {ValueReference} value
+ * @returns {boolean}
+ */
+function writesValueReference (write, value) {
+  return write.variable === value.variable &&
+    (write.memberPath === value.memberPath ||
+      write.memberPath === '' ||
+      value.memberPath.startsWith(`${write.memberPath}.`))
 }
 
 /**
@@ -136,22 +174,47 @@ function isTeardownHook (node) {
 
 /**
  * @param {import('estree').Node} node
- * @returns {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression | undefined}
+ * @returns {TeardownCallback | undefined}
  */
-function getTeardownCallback (node) {
+function getEnclosingCallback (node) {
   let currentNode = node
   while (currentNode.parent) {
     currentNode = currentNode.parent
     if (!isFunction(currentNode)) continue
 
-    if (
-      !isTeardownHook(currentNode.parent) ||
-      currentNode.parent.arguments[currentNode.parent.arguments.length - 1] !== currentNode
-    ) {
-      return undefined
-    }
+    return /** @type {TeardownCallback} */ (currentNode)
+  }
+}
 
-    return /** @type {import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} */ (currentNode)
+/**
+ * @param {import('estree').Node} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {Set<import('eslint').Scope.Variable>} [seen]
+ * @returns {TeardownCallback | undefined}
+ */
+function resolveCallback (node, sourceCode, seen = new Set()) {
+  if (isFunction(node)) {
+    return /** @type {TeardownCallback} */ (node)
+  }
+
+  if (node.type !== 'Identifier') return undefined
+
+  const variable = getVariable(node, sourceCode)
+  if (!variable || seen.has(variable)) return undefined
+
+  for (const reference of variable.references) {
+    if (reference.isWrite() && !reference.init) return undefined
+  }
+
+  seen.add(variable)
+  if (variable.defs.length !== 1) return undefined
+
+  const [definition] = variable.defs
+  if (isFunction(definition.node)) {
+    return /** @type {TeardownCallback} */ (definition.node)
+  }
+  if (definition.node.type === 'VariableDeclarator' && definition.node.init) {
+    return resolveCallback(definition.node.init, sourceCode, seen)
   }
 }
 
@@ -262,7 +325,7 @@ function isSettled (node, callback) {
 /**
  * @param {import('estree').CallExpression} node
  * @param {import('eslint').SourceCode} sourceCode
- * @returns {ValueReference | undefined}
+ * @returns {AssignedValueReference | undefined}
  */
 function getAssignedValueReference (node, sourceCode) {
   let currentNode = node
@@ -270,11 +333,13 @@ function getAssignedValueReference (node, sourceCode) {
     const parentNode = currentNode.parent
 
     if (parentNode.type === 'VariableDeclarator' && parentNode.init === currentNode) {
-      return getValueReference(parentNode.id, sourceCode)
+      const valueReference = getValueReference(parentNode.id, sourceCode)
+      return valueReference && { valueReference, assignment: parentNode }
     }
 
     if (parentNode.type === 'AssignmentExpression' && parentNode.right === currentNode) {
-      return getValueReference(parentNode.left, sourceCode)
+      const valueReference = getValueReference(parentNode.left, sourceCode)
+      return valueReference && { valueReference, assignment: parentNode }
     }
 
     const resultParent = getResultParent(currentNode)
@@ -282,6 +347,90 @@ function getAssignedValueReference (node, sourceCode) {
 
     currentNode = resultParent
   }
+}
+
+/**
+ * @param {Map<import('eslint').Rule.CodePathSegment, FlowEvent[]>} events
+ * @param {import('eslint').Rule.CodePathSegment} segment
+ * @returns {FlowEvent[]}
+ */
+function getFlowEvents (events, segment) {
+  return events.get(segment) ?? []
+}
+
+/**
+ * @param {StopCall} stopCall
+ * @param {AssignedValueReference} assignedValue
+ * @param {Map<import('eslint').Rule.CodePathSegment, FlowEvent[]>} events
+ * @returns {boolean}
+ */
+function isAssignedValueSettled (stopCall, assignedValue, events) {
+  const { assignment, valueReference } = assignedValue
+
+  /**
+   * @param {import('eslint').Rule.CodePathSegment} segment
+   * @param {boolean} initial
+   * @param {boolean} skipSourceWrite
+   * @param {Map<import('eslint').Rule.CodePathSegment, number>} visiting
+   * @param {Map<import('eslint').Rule.CodePathSegment, Map<number, boolean>>} memo
+   * @returns {boolean}
+   */
+  function settlesOnEveryPath (segment, initial, skipSourceWrite, visiting, memo) {
+    const state = (initial ? 2 : 0) | (skipSourceWrite ? 1 : 0)
+    const segmentMemo = memo.get(segment)
+    if (segmentMemo?.has(state)) return segmentMemo.get(state)
+
+    const visitingState = visiting.get(segment) ?? 0
+    if ((visitingState & (1 << state)) !== 0) return true
+    visiting.set(segment, visitingState | (1 << state))
+
+    /** @type {boolean | undefined} */
+    let settled
+    for (const event of getFlowEvents(events, segment)) {
+      if (initial && event.position <= stopCall.node.range[1]) continue
+
+      if (event.type === 'settle' && isSameValueReference(event.valueReference, valueReference)) {
+        settled = true
+        break
+      }
+
+      if (event.type === 'write' && writesValueReference(event.valueReference, valueReference)) {
+        if (skipSourceWrite && event.node === assignment) {
+          skipSourceWrite = false
+          continue
+        }
+        settled = false
+        break
+      }
+    }
+
+    if (settled === undefined) {
+      let hasNextSegment = false
+      settled = true
+      for (const nextSegment of segment.nextSegments) {
+        hasNextSegment = true
+        if (!settlesOnEveryPath(nextSegment, false, skipSourceWrite, visiting, memo)) {
+          settled = false
+          break
+        }
+      }
+      if (!hasNextSegment) settled = false
+    }
+
+    visiting.set(segment, visiting.get(segment) & ~(1 << state))
+    let mutableSegmentMemo = segmentMemo
+    if (!mutableSegmentMemo) {
+      mutableSegmentMemo = new Map()
+      memo.set(segment, mutableSegmentMemo)
+    }
+    mutableSegmentMemo.set(state, settled)
+    return settled
+  }
+
+  for (const segment of stopCall.segments) {
+    if (!settlesOnEveryPath(segment, true, true, new Map(), new Map())) return false
+  }
+  return stopCall.segments.size > 0
 }
 
 export default {
@@ -303,35 +452,106 @@ export default {
   create (context) {
     const { sourceCode } = context
     const fakeAgentValues = new Map()
-    const settledValues = new Map()
+    const flowEvents = new Map()
     const stopCalls = []
+    const teardownCallbacks = new Set()
+    /** @type {CodePathState | undefined} */
+    let codePathState
+
+    /**
+     * @param {import('estree').Node} node
+     * @param {'settle' | 'write'} type
+     * @param {ValueReference} valueReference
+     */
+    function recordFlowEvent (node, type, valueReference) {
+      const currentSegments = /** @type {CodePathState} */ (codePathState).currentSegments
+
+      for (const segment of currentSegments) {
+        let events = flowEvents.get(segment)
+        if (!events) {
+          events = []
+          flowEvents.set(segment, events)
+        }
+        events.push({ type, valueReference, node, position: node.range[1] })
+      }
+    }
 
     /**
      * @param {import('estree').Node} node
      */
     function recordSettledValue (node) {
-      const callback = getTeardownCallback(node)
+      const callback = getEnclosingCallback(node)
       if (!callback || !isSettled(node, callback)) return
 
       const valueReference = getValueReference(node, sourceCode)
       if (valueReference) {
-        addSettledValueReference(settledValues, callback, valueReference)
+        recordFlowEvent(node, 'settle', valueReference)
       }
     }
 
     return {
+      onCodePathStart () {
+        codePathState = {
+          upper: codePathState,
+          currentSegments: new Set(),
+        }
+      },
+      onCodePathEnd () {
+        codePathState = codePathState?.upper
+      },
+      /**
+       * @param {import('eslint').Rule.CodePathSegment} segment
+       */
+      onCodePathSegmentStart (segment) {
+        codePathState?.currentSegments.add(segment)
+      },
+      /**
+       * @param {import('eslint').Rule.CodePathSegment} segment
+       */
+      onCodePathSegmentEnd (segment) {
+        codePathState?.currentSegments.delete(segment)
+      },
+      /**
+       * @param {import('estree').VariableDeclarator} node
+       */
       VariableDeclarator (node) {
         const valueReference = getValueReference(node.id, sourceCode)
         if (valueReference && node.init && isFakeAgent(node.init)) {
           addValueReference(fakeAgentValues, valueReference)
         }
       },
+      /**
+       * @param {import('estree').VariableDeclarator} node
+       */
+      'VariableDeclarator:exit' (node) {
+        if (!node.init) return
+
+        const valueReference = getValueReference(node.id, sourceCode)
+        if (valueReference) {
+          recordFlowEvent(node, 'write', valueReference)
+        }
+      },
+      /**
+       * @param {import('estree').AssignmentExpression} node
+       */
       AssignmentExpression (node) {
         const valueReference = getValueReference(node.left, sourceCode)
         if (valueReference && isFakeAgent(node.right)) {
           addValueReference(fakeAgentValues, valueReference)
         }
       },
+      /**
+       * @param {import('estree').AssignmentExpression} node
+       */
+      'AssignmentExpression:exit' (node) {
+        const valueReference = getValueReference(node.left, sourceCode)
+        if (valueReference) {
+          recordFlowEvent(node, 'write', valueReference)
+        }
+      },
+      /**
+       * @param {import('estree').Identifier} node
+       */
       Identifier (node) {
         if (
           node.parent.type === 'MemberExpression' &&
@@ -341,10 +561,24 @@ export default {
 
         recordSettledValue(node)
       },
+      /**
+       * @param {import('estree').MemberExpression} node
+       */
       MemberExpression (node) {
         recordSettledValue(node)
       },
-      CallExpression (node) {
+      /**
+       * @param {import('estree').CallExpression} node
+       */
+      'CallExpression:exit' (node) {
+        if (isTeardownHook(node)) {
+          const callbackNode = node.arguments[node.arguments.length - 1]
+          if (callbackNode?.type !== 'SpreadElement') {
+            const callback = resolveCallback(callbackNode, sourceCode)
+            if (callback) teardownCallbacks.add(callback)
+          }
+        }
+
         if (
           node.callee.type !== 'MemberExpression' ||
           node.callee.computed ||
@@ -354,23 +588,29 @@ export default {
           return
         }
 
-        const callback = getTeardownCallback(node)
+        const callback = getEnclosingCallback(node)
         const valueReference = getValueReference(node.callee.object, sourceCode)
-        if (callback && valueReference) {
-          stopCalls.push({ callback, node, valueReference })
+        if (callback && valueReference && codePathState) {
+          stopCalls.push({
+            callback,
+            node,
+            valueReference,
+            segments: new Set(codePathState.currentSegments),
+          })
         }
       },
       'Program:exit' () {
-        for (const { callback, node, valueReference } of stopCalls) {
+        for (const events of flowEvents.values()) {
+          events.sort((left, right) => left.position - right.position)
+        }
+
+        for (const stopCall of stopCalls) {
+          const { callback, node, valueReference } = stopCall
+          if (!teardownCallbacks.has(callback)) continue
           if (!hasValueReference(fakeAgentValues, valueReference) || isSettled(node, callback)) continue
 
-          const assignedValueReference = getAssignedValueReference(node, sourceCode)
-          const callbackReferences = settledValues.get(callback)
-          if (
-            assignedValueReference &&
-            callbackReferences &&
-            hasValueReference(callbackReferences, assignedValueReference)
-          ) continue
+          const assignedValue = getAssignedValueReference(node, sourceCode)
+          if (assignedValue && isAssignedValueSettled(stopCall, assignedValue, flowEvents)) continue
 
           context.report({
             node,

--- a/eslint-rules/eslint-require-agent-stop.test.mjs
+++ b/eslint-rules/eslint-require-agent-stop.test.mjs
@@ -1,4 +1,5 @@
 import { RuleTester } from 'eslint'
+
 import rule from './eslint-require-agent-stop.mjs'
 
 const ruleTester = new RuleTester({
@@ -14,14 +15,70 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
     beforeEach(async () => { agent = await new FakeAgent().start() })
     afterEach(async () => { await agent.stop() })`,
     `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    afterEach('cleanup', () => agent.stop())`,
+    `let agent
     before(async () => { agent = await new FakeAgent().start() })
     after(async () => {
       const agentStopped = agent?.stop()
       await Promise.all([agentStopped])
     })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      const agentStopped = agent.stop()
+      await Promise.allSettled([agentStopped])
+    })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      const agentStopped = shouldStop ? agent.stop() : undefined
+      await Promise.resolve(agentStopped)
+    })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(() => agent.stop().finally(() => {}))`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => { await (shouldStop && agent.stop()) })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => { await (agent.stop() || Promise.resolve()) })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => { await (cleanup(), agent.stop()) })`,
+    `let agent, agentStopped
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      agentStopped = agent.stop()
+      await agentStopped
+    })`,
     `const state = {}
     before(() => { state.agent = new FakeAgent() })
     after(() => { return state.agent.stop() })`,
+    `describe('fake agent', () => {
+      let agent
+      beforeEach(async () => { agent = await new FakeAgent().start() })
+      afterEach(async () => { await agent.stop() })
+    })
+    describe('other agent', () => {
+      const agent = { stop () {} }
+      afterEach(() => { agent.stop() })
+    })`,
+    `describe('fake agent', () => {
+      const state = {}
+      beforeEach(async () => { state.agent = await new FakeAgent().start() })
+      afterEach(async () => { await state.agent.stop() })
+    })
+    describe('other agent', () => {
+      const state = { agent: { stop () {} } }
+      afterEach(() => { state.agent.stop() })
+    })`,
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    afterEach(() => () => agent.stop())`,
+    `const { agent } = state
+    afterEach(() => { agent.stop() })`,
     'afterEach(() => broker.stop())',
   ],
   invalid: [
@@ -29,6 +86,12 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
       code: `let agent
       beforeEach(async () => { agent = await new FakeAgent().start() })
       afterEach(() => { agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      beforeEach(async () => { agent = await new FakeAgent().start() })
+      afterEach('cleanup', () => { agent.stop() })`,
       errors: [{ messageId: 'requireSettledStop' }],
     },
     {
@@ -41,6 +104,56 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
       code: `let agent
       before(() => { agent = new FakeAgent() })
       after(() => { const stopped = agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => { await [agent.stop()] })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(() => [agent.stop()])`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(() => { return { stopped: agent.stop() } })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        const agentStopped = agent.stop()
+        await [agentStopped]
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => { await (agent.stop() && true) })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let receiver
+      before(() => { receiver = new FakeCiVisIntake() })
+      after(() => { receiver.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `const agent = new FakeAgent()
+      after(() => { agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `const state = {}
+      before(() => { state.agent = new FakeAgent() })
+      after(() => { (state?.agent).stop() })`,
       errors: [{ messageId: 'requireSettledStop' }],
     },
   ],

--- a/eslint-rules/eslint-require-agent-stop.test.mjs
+++ b/eslint-rules/eslint-require-agent-stop.test.mjs
@@ -16,6 +16,42 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
     afterEach(async () => { await agent.stop() })`,
     `let agent
     beforeEach(async () => { agent = await new FakeAgent().start() })
+    async function cleanup () { await agent.stop() }
+    afterEach(cleanup)`,
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    afterEach(cleanup)
+    async function cleanup () { await agent.stop() }`,
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    async function cleanup () { await agent.stop() }
+    const teardown = cleanup
+    afterEach(teardown)`,
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    const cleanup = () => agent.stop()
+    afterEach('cleanup', cleanup)`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    const cleanup = async function () {
+      const agentStopped = agent.stop()
+      await agentStopped
+    }
+    after(cleanup)`,
+    'afterEach(cleanup)',
+    `const cleanup = createCleanup()
+    afterEach(cleanup)`,
+    `const cleanup = cleanup
+    afterEach(cleanup)`,
+    `let agent
+    const cleanup = () => { agent.stop() }
+    cleanup = () => {}
+    afterEach(cleanup)`,
+    `var cleanup = () => {}
+    var cleanup = () => {}
+    afterEach(cleanup)`,
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
     afterEach('cleanup', () => agent.stop())`,
     `let agent
     before(async () => { agent = await new FakeAgent().start() })
@@ -53,6 +89,52 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
       agentStopped = agent.stop()
       await agentStopped
     })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      let agentStopped = agent.stop()
+      await agentStopped
+      agentStopped = stopProc(proc)
+    })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      const agentStopped = agent.stop()
+      if (shouldStop) {
+        await agentStopped
+      } else {
+        await agentStopped
+      }
+    })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      const agentStopped = agent.stop()
+      if (shouldStop) {
+        stopProc(firstProc)
+      } else {
+        stopProc(secondProc)
+      }
+      await agentStopped
+    })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      for (const proc of processes) {
+        const agentStopped = agent.stop()
+        await agentStopped
+        stopProc(proc)
+      }
+    })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      const agentStopped = agent.stop()
+      while (isStopping()) {
+        await stopProc(proc)
+      }
+      await agentStopped
+    })`,
     `const state = {}
     before(() => { state.agent = new FakeAgent() })
     after(() => { return state.agent.stop() })`,
@@ -86,6 +168,34 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
       code: `let agent
       beforeEach(async () => { agent = await new FakeAgent().start() })
       afterEach(() => { agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      beforeEach(async () => { agent = await new FakeAgent().start() })
+      function cleanup () { agent.stop() }
+      afterEach(cleanup)`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      beforeEach(async () => { agent = await new FakeAgent().start() })
+      afterEach(cleanup)
+      function cleanup () { agent.stop() }`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      beforeEach(async () => { agent = await new FakeAgent().start() })
+      const cleanup = () => { agent.stop() }
+      afterEach('cleanup', cleanup)`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(async () => { agent = await new FakeAgent().start() })
+      const cleanup = function () { agent.stop() }
+      after(cleanup)`,
       errors: [{ messageId: 'requireSettledStop' }],
     },
     {
@@ -130,6 +240,80 @@ ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.Rul
       after(async () => {
         const agentStopped = agent.stop()
         await [agentStopped]
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        let agentStopped = agent.stop()
+        agentStopped = stopProc(proc)
+        await agentStopped
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        const state = {}
+        state.agentStopped = agent.stop()
+        state.agentStopped = stopProc(proc)
+        await state.agentStopped
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        let state = {}
+        state.agentStopped = agent.stop()
+        state = {}
+        await state.agentStopped
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        const state = { cleanup: {} }
+        state.cleanup.agentStopped = agent.stop()
+        state.cleanup = {}
+        await state.cleanup.agentStopped
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        const agentStopped = agent.stop()
+        if (shouldStop) await agentStopped
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        let agentStopped
+        while (shouldStop) {
+          agentStopped = agent.stop()
+        }
+        await agentStopped
+      })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(async () => {
+        let agentStopped
+        await agentStopped
+        agentStopped = agent.stop()
       })`,
       errors: [{ messageId: 'requireSettledStop' }],
     },

--- a/eslint-rules/eslint-require-agent-stop.test.mjs
+++ b/eslint-rules/eslint-require-agent-stop.test.mjs
@@ -1,0 +1,47 @@
+import { RuleTester } from 'eslint'
+import rule from './eslint-require-agent-stop.mjs'
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022 },
+})
+
+ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.RuleModule} */ (rule), {
+  valid: [
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    afterEach(() => agent.stop())`,
+    `let agent
+    beforeEach(async () => { agent = await new FakeAgent().start() })
+    afterEach(async () => { await agent.stop() })`,
+    `let agent
+    before(async () => { agent = await new FakeAgent().start() })
+    after(async () => {
+      const agentStopped = agent?.stop()
+      await Promise.all([agentStopped])
+    })`,
+    `const state = {}
+    before(() => { state.agent = new FakeAgent() })
+    after(() => { return state.agent.stop() })`,
+    'afterEach(() => broker.stop())',
+  ],
+  invalid: [
+    {
+      code: `let agent
+      beforeEach(async () => { agent = await new FakeAgent().start() })
+      afterEach(() => { agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `const state = {}
+      before(() => { state.agent = new FakeAgent() })
+      after(() => { state.agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+    {
+      code: `let agent
+      before(() => { agent = new FakeAgent() })
+      after(() => { const stopped = agent.stop() })`,
+      errors: [{ messageId: 'requireSettledStop' }],
+    },
+  ],
+})

--- a/eslint-rules/eslint-require-agent-stop.test.mjs
+++ b/eslint-rules/eslint-require-agent-stop.test.mjs
@@ -8,6 +8,8 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('eslint-require-agent-stop', /** @type {import('eslint').Rule.RuleModule} */ (rule), {
   valid: [
+    'after()',
+    'afterEach()',
     `let agent
     beforeEach(async () => { agent = await new FakeAgent().start() })
     afterEach(() => agent.stop())`,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,7 @@ import eslintNonPrefixEnvNames from './eslint-rules/eslint-non-prefix-env-names.
 import eslintPreferAssertMatch from './eslint-rules/eslint-prefer-assert-match.mjs'
 import eslintPreferSetServiceName from './eslint-rules/eslint-prefer-set-service-name.mjs'
 import eslintProcessEnv from './eslint-rules/eslint-process-env.mjs'
+import eslintRequireAgentStop from './eslint-rules/eslint-require-agent-stop.mjs'
 import eslintRequireBooleanAssertMessage from './eslint-rules/eslint-require-boolean-assert-message.mjs'
 import eslintRequireExportExists from './eslint-rules/eslint-require-export-exists.mjs'
 import eslintSafeTypeOfObject from './eslint-rules/eslint-safe-typeof-object.mjs'
@@ -474,6 +475,7 @@ export default [
           'eslint-safe-typeof-object': eslintSafeTypeOfObject,
           'eslint-log-printf-style': eslintLogPrintfStyle,
           'eslint-no-private-tags-access': eslintNoPrivateTagsAccess,
+          'eslint-require-agent-stop': eslintRequireAgentStop,
           'eslint-require-boolean-assert-message': eslintRequireBooleanAssertMessage,
           'eslint-require-export-exists': eslintRequireExportExists,
           'eslint-timer-unref': eslintTimerUnref,
@@ -987,6 +989,7 @@ export default [
     },
     rules: {
       'eslint-rules/eslint-prefer-assert-match': 'error',
+      'eslint-rules/eslint-require-agent-stop': 'error',
       // TODO: Re-enable this rule once we have a way to fix the false positives or have Node.js report better errors.
       'eslint-rules/eslint-require-boolean-assert-message': 'off',
       'mocha/consistent-spacing-between-blocks': 'off',

--- a/integration-tests/esbuild/esm.integration.spec.js
+++ b/integration-tests/esbuild/esm.integration.spec.js
@@ -6,7 +6,7 @@ const { execSync } = require('node:child_process')
 
 const axios = require('axios')
 
-const { FakeAgent, spawnProc, sandboxCwd, useSandbox } = require('../helpers')
+const { FakeAgent, spawnProc, stopProc, sandboxCwd, useSandbox } = require('../helpers')
 
 const { ESBUILD_VERSION } = process.env
 const esbuildVersions = ESBUILD_VERSION ? [ESBUILD_VERSION] : ['latest', '0.16.12']
@@ -24,7 +24,7 @@ function findWebSpan (payload) {
 
 esbuildVersions.forEach((version) => {
   describe('ESM is built and runs as expected in a sandbox', () => {
-    let agent, cwd
+    let agent, cwd, proc
 
     useSandbox([`esbuild@${version}`, 'hono', '@hono/node-server'], false, [__dirname])
 
@@ -36,8 +36,9 @@ esbuildVersions.forEach((version) => {
       agent = await new FakeAgent().start()
     })
 
-    afterEach(() => {
-      agent.stop()
+    afterEach(async () => {
+      await stopProc(proc)
+      await agent.stop()
     })
 
     it('should build basic esm http server exporting esm and create web traces at runtime', async () => {
@@ -45,7 +46,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'esm-http-test-out.mjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
@@ -68,7 +69,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'esm-http-test-out.cjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
@@ -91,7 +92,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'hono-out.mjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,
@@ -114,7 +115,7 @@ esbuildVersions.forEach((version) => {
       execSync(`node ${builder}`, { cwd })
 
       const appFile = path.join(cwd, 'esbuild', 'hono-out.cjs')
-      const proc = await spawnProc(appFile, {
+      proc = await spawnProc(appFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_URL: `http://localhost:${agent.port}`,

--- a/integration-tests/esbuild/esm.integration.spec.js
+++ b/integration-tests/esbuild/esm.integration.spec.js
@@ -37,8 +37,11 @@ esbuildVersions.forEach((version) => {
     })
 
     afterEach(async () => {
-      await stopProc(proc)
-      await agent.stop()
+      try {
+        await stopProc(proc)
+      } finally {
+        await agent.stop()
+      }
     })
 
     it('should build basic esm http server exporting esm and create web traces at runtime', async () => {

--- a/integration-tests/esbuild/openfeature.spec.js
+++ b/integration-tests/esbuild/openfeature.spec.js
@@ -30,9 +30,7 @@ esbuildVersions.forEach((version) => {
       agent = await new FakeAgent().start()
     })
 
-    afterEach(() => {
-      agent.stop()
-    })
+    afterEach(() => agent.stop())
 
     it('should not crash build after installing with yarn', () => {
       execSync('node esbuild/build.esm-hono-output-esm.mjs', { cwd })


### PR DESCRIPTION
A `FakeAgent.stop()` promise was discarded in two esbuild teardown hooks. In the ESM tests, the spawned application also survived its test case, so its trace could be delivered to the next Hono case.

The lint rule rejects unreturned, unawaited `FakeAgent.stop()` calls from `after` and `afterEach` hooks, while allowing returned calls and awaited aggregates.