### PR TITLE
chore(codeowners): add dd-trace-js team to all rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,514 +1,514 @@
 # TODO: Restructure the project by product and clean up this file.
 
 # Shared repository tooling
-/.agents/ @DataDog/lang-platform-js
-/.claude/ @DataDog/lang-platform-js
-/.github/actions/ @DataDog/lang-platform-js
-/.github/ISSUE_TEMPLATE/ @DataDog/lang-platform-js
-/.gitlab/ @DataDog/lang-platform-js
-/.husky/ @DataDog/lang-platform-js
-/.vscode/ @DataDog/lang-platform-js
-/scripts/ @DataDog/lang-platform-js
-/vendor/ @DataDog/lang-platform-js
+/.agents/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.claude/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/actions/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/ISSUE_TEMPLATE/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.gitlab/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.husky/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.vscode/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/scripts/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/vendor/ @DataDog/dd-trace-js @DataDog/lang-platform-js
 
 # Shared tracer infrastructure; product-specific rules below take precedence.
-/packages/dd-trace/src/agent/ @DataDog/lang-platform-js
-/packages/dd-trace/src/encode/ @DataDog/lang-platform-js
-/packages/dd-trace/src/exporters/agent/ @DataDog/lang-platform-js
-/packages/dd-trace/src/exporters/log/ @DataDog/lang-platform-js
-/packages/dd-trace/src/exporters/span-stats/ @DataDog/lang-platform-js
-/packages/dd-trace/src/external-logger/ @DataDog/lang-platform-js
-/packages/dd-trace/src/flare/ @DataDog/lang-platform-js
-/packages/dd-trace/src/guardrails/ @DataDog/lang-platform-js
-/packages/dd-trace/src/msgpack/ @DataDog/lang-platform-js
-/packages/dd-trace/src/noop/ @DataDog/lang-platform-js
-/packages/dd-trace/test/encode/ @DataDog/lang-platform-js
-/packages/dd-trace/test/fixtures/esm/ @DataDog/lang-platform-js
+/packages/dd-trace/src/agent/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/encode/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/agent/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/log/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/span-stats/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/external-logger/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/flare/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/guardrails/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/msgpack/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/noop/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/encode/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/fixtures/esm/ @DataDog/dd-trace-js @DataDog/lang-platform-js
 
 # AppSec
-/benchmark/sirun/appsec/ @DataDog/asm-js
-/benchmark/sirun/appsec-waf/ @DataDog/asm-js
-/benchmark/sirun/appsec-iast/ @DataDog/asm-js
-/benchmark/sirun/iast/ @DataDog/asm-js
-/integration-tests/appsec/ @DataDog/asm-js
-/integration-tests/graphql/ @DataDog/asm-js
-/integration-tests/standalone-asm/ @DataDog/asm-js
-/packages/dd-trace/src/appsec/ @DataDog/asm-js
-/packages/dd-trace/test/appsec/ @DataDog/asm-js
-/packages/dd-trace/test/fixtures/config/appsec-* @DataDog/asm-js
+/benchmark/sirun/appsec/ @DataDog/dd-trace-js @DataDog/asm-js
+/benchmark/sirun/appsec-waf/ @DataDog/dd-trace-js @DataDog/asm-js
+/benchmark/sirun/appsec-iast/ @DataDog/dd-trace-js @DataDog/asm-js
+/benchmark/sirun/iast/ @DataDog/dd-trace-js @DataDog/asm-js
+/integration-tests/appsec/ @DataDog/dd-trace-js @DataDog/asm-js
+/integration-tests/graphql/ @DataDog/dd-trace-js @DataDog/asm-js
+/integration-tests/standalone-asm/ @DataDog/dd-trace-js @DataDog/asm-js
+/packages/dd-trace/src/appsec/ @DataDog/dd-trace-js @DataDog/asm-js
+/packages/dd-trace/test/appsec/ @DataDog/dd-trace-js @DataDog/asm-js
+/packages/dd-trace/test/fixtures/config/appsec-* @DataDog/dd-trace-js @DataDog/asm-js
 
-/integration-tests/aiguard/ @DataDog/asm-js
-/packages/dd-trace/src/aiguard/ @DataDog/asm-js
-/packages/dd-trace/test/aiguard/ @DataDog/asm-js
-/packages/dd-trace/test/plugins/util/ip_extractor.spec.js @DataDog/asm-js
+/integration-tests/aiguard/ @DataDog/dd-trace-js @DataDog/asm-js
+/packages/dd-trace/src/aiguard/ @DataDog/dd-trace-js @DataDog/asm-js
+/packages/dd-trace/test/aiguard/ @DataDog/dd-trace-js @DataDog/asm-js
+/packages/dd-trace/test/plugins/util/ip_extractor.spec.js @DataDog/dd-trace-js @DataDog/asm-js
 
-/packages/dd-trace/*/standalone @DataDog/asm-js
+/packages/dd-trace/*/standalone @DataDog/dd-trace-js @DataDog/asm-js
 
 # Debugger
-/benchmark/sirun/debugger/ @DataDog/debugger-nodejs
+/benchmark/sirun/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
 
-/integration-tests/code-origin/ @DataDog/debugger-nodejs
-/integration-tests/code-origin-remote-config.spec.js @DataDog/debugger-nodejs
-/integration-tests/code-origin.spec.js @DataDog/debugger-nodejs
-/integration-tests/debugger/ @DataDog/debugger-nodejs
+/integration-tests/code-origin/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/integration-tests/code-origin-remote-config.spec.js @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/integration-tests/code-origin.spec.js @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/integration-tests/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
 
-/packages/datadog-code-origin/ @DataDog/debugger-nodejs
-/packages/datadog-plugin-*/**/code_origin.* @DataDog/debugger-nodejs
-/packages/dd-trace/src/debugger/ @DataDog/debugger-nodejs
-/packages/dd-trace/test/debugger/ @DataDog/debugger-nodejs
-/packages/dd-trace/test/plugins/util/stacktrace.spec.js @DataDog/debugger-nodejs
+/packages/datadog-code-origin/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/datadog-plugin-*/**/code_origin.* @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/dd-trace/src/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/dd-trace/test/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/dd-trace/test/plugins/util/stacktrace.spec.js @DataDog/dd-trace-js @DataDog/debugger-nodejs
 
 # Serverless
-/packages/dd-trace/src/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
-/packages/dd-trace/src/azure_metadata.js @DataDog/apm-serverless
-/packages/dd-trace/src/serverless.js @DataDog/apm-serverless
-/packages/dd-trace/test/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
-/packages/dd-trace/test/azure_metadata.spec.js @DataDog/apm-serverless
-/packages/dd-trace/test/serverless.spec.js @DataDog/apm-serverless
-/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/src/lambda/ @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/src/azure_metadata.js @DataDog/dd-trace-js @DataDog/apm-serverless
+/packages/dd-trace/src/serverless.js @DataDog/dd-trace-js @DataDog/apm-serverless
+/packages/dd-trace/test/lambda/ @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/test/azure_metadata.spec.js @DataDog/dd-trace-js @DataDog/apm-serverless
+/packages/dd-trace/test/serverless.spec.js @DataDog/dd-trace-js @DataDog/apm-serverless
+/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
 
 # IDM
-/.agents/skills/apm-integrations/ @DataDog/apm-idm-js
-/.claude/skills/apm-integrations @DataDog/apm-idm-js
+/.agents/skills/apm-integrations/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/.claude/skills/apm-integrations @DataDog/dd-trace-js @DataDog/apm-idm-js
 
-/benchmark/sirun/child_process/ @DataDog/apm-idm-js
-/benchmark/sirun/fs/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-aws-sdk/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-cassandra-driver/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-couchbase/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-elasticsearch/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-graphql-long/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-grpc/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-memcached/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-pino/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-redis/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-redis-traced/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-ws/ @DataDog/apm-idm-js
-/benchmark/sirun/url/ @DataDog/apm-idm-js
+/benchmark/sirun/child_process/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/fs/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-aws-sdk/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-cassandra-driver/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-couchbase/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-dns/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-elasticsearch/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-graphql-long/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-grpc/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-http/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-kafkajs/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-memcached/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-mongodb-core/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-net/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-pg/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-pino/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-redis/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-redis-traced/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/plugin-ws/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/url/ @DataDog/dd-trace-js @DataDog/apm-idm-js
 
-/index.electron.js @DataDog/apm-idm-js
-/integration-tests/electron/ @DataDog/apm-idm-js
-/integration-tests/esbuild/ @DataDog/apm-idm-js
-/integration-tests/webpack/ @DataDog/apm-idm-js
-/integration-tests/pino/ @DataDog/apm-idm-js
-/integration-tests/pino.spec.js @DataDog/apm-idm-js
+/index.electron.js @DataDog/dd-trace-js @DataDog/apm-idm-js
+/integration-tests/electron/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/integration-tests/esbuild/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/integration-tests/webpack/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/integration-tests/pino/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/integration-tests/pino.spec.js @DataDog/dd-trace-js @DataDog/apm-idm-js
 
-/packages/datadog-esbuild/ @DataDog/apm-idm-js
-/packages/datadog-webpack/ @DataDog/apm-idm-js
-/packages/datadog-plugin-*/ @DataDog/apm-idm-js
-/packages/datadog-instrumentations/ @DataDog/apm-idm-js
-/packages/dd-trace/index.electron.js @DataDog/apm-idm-js
-/packages/dd-trace/src/exporters/electron/ @DataDog/apm-idm-js
-/packages/dd-trace/src/plugins/ @DataDog/apm-idm-js
-/packages/dd-trace/src/payload-tagging/ @DataDog/apm-idm-js
-/packages/dd-trace/src/process-tags/ @DataDog/apm-idm-js
-/packages/dd-trace/src/propagation-hash/ @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/ @DataDog/apm-idm-js
-/packages/dd-trace/test/process-tags.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/src/service-naming/ @DataDog/apm-idm-js
-/packages/dd-trace/test/service-naming/ @DataDog/apm-idm-js
-/packages/dd-trace/test/payload_tagging.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/payload-tagging/ @DataDog/apm-idm-js
-/packages/dd-trace/test/propagation-hash.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/tracer_metadata.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/src/tracer_metadata.js @DataDog/apm-idm-js
+/packages/datadog-esbuild/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/datadog-webpack/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/datadog-plugin-*/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/datadog-instrumentations/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/index.electron.js @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/exporters/electron/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/plugins/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/payload-tagging/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/process-tags/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/propagation-hash/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/plugins/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/process-tags.spec.js @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/service-naming/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/service-naming/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/payload_tagging.spec.js @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/payload-tagging/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/propagation-hash.spec.js @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/test/tracer_metadata.spec.js @DataDog/dd-trace-js @DataDog/apm-idm-js
+/packages/dd-trace/src/tracer_metadata.js @DataDog/dd-trace-js @DataDog/apm-idm-js
 
 # Test Optimization
-/ci/ @DataDog/ci-app-libraries
+/ci/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
-/integration-tests/selenium/ @DataDog/ci-app-libraries
+/integration-tests/selenium/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
-/packages/dd-trace/src/ci-visibility/ @DataDog/ci-app-libraries
-/packages/datadog-plugin-jest/ @DataDog/ci-app-libraries
-/packages/datadog-plugin-mocha/ @DataDog/ci-app-libraries
-/packages/datadog-plugin-cucumber/ @DataDog/ci-app-libraries
-/packages/datadog-plugin-cypress/ @DataDog/ci-app-libraries
-/packages/datadog-plugin-playwright/ @DataDog/ci-app-libraries
-/packages/datadog-plugin-vitest/ @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/git.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/ci_plugin.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/ci-visibility/ @DataDog/ci-app-libraries
-/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/encode/agentless-json.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/encode/tags-processors.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/git_metadata.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/git_metadata_tagger.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/fixtures/config/git-folder*/ @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/fixtures/config/git.properties* @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/plugins/util/git.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/ci-env/ @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/fixtures/jest/ @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/jest.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/test.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/test-environment.spec.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/encode/agentless-ci-visibility.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/encode/agentless-json.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/encode/coverage-ci-visibility.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/encode/tags-processors.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/exporters/agentless/ @DataDog/ci-app-libraries
-/packages/dd-trace/src/git_metadata.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/git_metadata_tagger.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/ci.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/env.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/git-cache.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/jest.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/tags.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/test.js @DataDog/ci-app-libraries
-/packages/dd-trace/src/plugins/util/user-provided-git.js @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/__test__/CODEOWNERS @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/fixtures/github_event_payload_malformed.json @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/fixtures/github_event_payload.json @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/fixtures/istanbul-map-fixture.json @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/fixtures/runner/ @DataDog/ci-app-libraries
-/packages/dd-trace/test/plugins/util/fixtures/runner_empty/ @DataDog/ci-app-libraries
+/packages/dd-trace/src/ci-visibility/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-jest/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-mocha/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-cucumber/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-cypress/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-playwright/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-vitest/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/ci_plugin.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/ci-visibility/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/agentless-json.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/tags-processors.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/git_metadata.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/git_metadata_tagger.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/fixtures/config/git-folder*/ @DataDog/dd-trace-js @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/fixtures/config/git.properties* @DataDog/dd-trace-js @DataDog/ci-app-libraries @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/plugins/util/git.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/ci-env/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/jest/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/jest.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/test.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/test-environment.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/agentless-ci-visibility.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/agentless-json.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/coverage-ci-visibility.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/tags-processors.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/exporters/agentless/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/git_metadata.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/git_metadata_tagger.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/ci.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/env.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git-cache.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/jest.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/tags.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/test.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/user-provided-git.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/__test__/CODEOWNERS @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/github_event_payload_malformed.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/github_event_payload.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/istanbul-map-fixture.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/runner/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/runner_empty/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
-/packages/datadog-instrumentations/src/jest.js @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/jest/bail-reporter.js @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/mocha/ @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/cucumber.js @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/cypress.js @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/playwright.js @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/vitest.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/jest.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/jest/bail-reporter.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/mocha/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cucumber.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cypress.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/playwright.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
-/integration-tests/ci-visibility/ @DataDog/ci-app-libraries
-/integration-tests/cucumber/ @DataDog/ci-app-libraries
-/integration-tests/cypress/ @DataDog/ci-app-libraries
-/integration-tests/jest/ @DataDog/ci-app-libraries
-/integration-tests/mocha/ @DataDog/ci-app-libraries
-/integration-tests/playwright/ @DataDog/ci-app-libraries
-/integration-tests/vitest/ @DataDog/ci-app-libraries
-/integration-tests/webdriverio/ @DataDog/ci-app-libraries
-/integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
-/integration-tests/vitest.second-project.config.mjs @DataDog/ci-app-libraries
-/integration-tests/vitest.typecheck.config.mjs @DataDog/ci-app-libraries
-/integration-tests/tsconfig.typecheck.json @DataDog/ci-app-libraries
-/integration-tests/tsconfig.typecheck-overlap.json @DataDog/ci-app-libraries
-/integration-tests/tsconfig.typecheck-fail.json @DataDog/ci-app-libraries
-/integration-tests/tsconfig.typecheck-test-management-fail.json @DataDog/ci-app-libraries
-/integration-tests/tsconfig.typecheck-test-management-file-fail.json @DataDog/ci-app-libraries
-/integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
-/integration-tests/ci-visibility-intake.spec.js @DataDog/ci-app-libraries
-/integration-tests/CODEOWNERS @DataDog/ci-app-libraries
-/integration-tests/config-jest-multiproject.js @DataDog/ci-app-libraries
-/integration-tests/config-jest.js @DataDog/ci-app-libraries
-/integration-tests/cypress-config.json @DataDog/ci-app-libraries
-/integration-tests/cypress-custom-after-hooks.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-custom-after-hooks.config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-auto-esm.config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-component.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-double-run.js @DataDog/ci-app-libraries
-/integration-tests/cypress-double-run.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-esm-config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-legacy-plugin.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-legacy-plugin.config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-plain-object-auto.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-plain-object-auto.config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-plain-object-manual.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-plain-object-manual.config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-return-config.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-return-config.config.mjs @DataDog/ci-app-libraries
-/integration-tests/cypress-support-file-false.config.js @DataDog/ci-app-libraries
-/integration-tests/cypress-typescript.config.ts @DataDog/ci-app-libraries
-/integration-tests/cypress.config.js @DataDog/ci-app-libraries
-/integration-tests/my-nyc.config.js @DataDog/ci-app-libraries
-/integration-tests/playwright.config.js @DataDog/ci-app-libraries
-/integration-tests/playwright.config.ts @DataDog/ci-app-libraries
-/integration-tests/vite.config.mjs @DataDog/ci-app-libraries
+/integration-tests/ci-visibility/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cucumber/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/jest/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/mocha/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/playwright/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/vitest/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/webdriverio/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/vitest.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/vitest.second-project.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/vitest.typecheck.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-overlap.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-fail.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-test-management-fail.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/tsconfig.typecheck-test-management-file-fail.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/ci-visibility-intake.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/ci-visibility-intake.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/CODEOWNERS @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/config-jest-multiproject.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/config-jest.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-config.json @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-custom-after-hooks.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-custom-after-hooks.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-auto-esm.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-component.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-double-run.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-double-run.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-esm-config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-legacy-plugin.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-legacy-plugin.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-auto.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-auto.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-manual.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-manual.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-return-config.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-return-config.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-support-file-false.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-typescript.config.ts @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/my-nyc.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/playwright.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/playwright.config.ts @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/vite.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
-/benchmark/e2e-test-optimization/ @DataDog/ci-app-libraries
+/benchmark/e2e-test-optimization/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
 # LLM Observability
-/.agents/skills/llmobs-integration/ @DataDog/ml-observability
-/.agents/skills/llmobs-testing/ @DataDog/ml-observability
-/.claude/skills/llmobs-integration @DataDog/ml-observability
-/.claude/skills/llmobs-testing @DataDog/ml-observability
-/benchmark/sirun/llmobs/ @DataDog/ml-observability
-/benchmark/sirun/llmobs-evaluations/ @DataDog/ml-observability
-/benchmark/sirun/llmobs-span-processor/ @DataDog/ml-observability
-/packages/datadog-instrumentations/src/ai.js @DataDog/ml-observability
-/packages/datadog-instrumentations/src/anthropic.js @DataDog/ml-observability
-/packages/datadog-instrumentations/src/claude-agent-sdk.js @DataDog/ml-observability
-/packages/datadog-instrumentations/src/google-cloud-vertexai.js @DataDog/ml-observability
-/packages/datadog-instrumentations/src/langchain.js @DataDog/ml-observability
-/packages/datadog-instrumentations/src/openai.js @DataDog/ml-observability
-/packages/datadog-plugin-ai/ @DataDog/ml-observability
-/packages/datadog-plugin-anthropic/ @DataDog/ml-observability
-/packages/datadog-plugin-claude-agent-sdk/ @DataDog/ml-observability
-/benchmark/sirun/plugin-claude-agent-sdk/ @DataDog/ml-observability
-/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/ @DataDog/ml-observability
-/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js @DataDog/ml-observability
-/packages/datadog-plugin-google-cloud-vertexai/ @DataDog/ml-observability
-/packages/datadog-plugin-langchain/ @DataDog/ml-observability
-/packages/datadog-plugin-openai/ @DataDog/ml-observability
-/packages/dd-trace/src/llmobs/ @DataDog/ml-observability
-/packages/dd-trace/test/llmobs/ @DataDog/ml-observability
-/packages/dd-trace/test/plugins/util/llm.spec.js @DataDog/ml-observability
+/.agents/skills/llmobs-integration/ @DataDog/dd-trace-js @DataDog/ml-observability
+/.agents/skills/llmobs-testing/ @DataDog/dd-trace-js @DataDog/ml-observability
+/.claude/skills/llmobs-integration @DataDog/dd-trace-js @DataDog/ml-observability
+/.claude/skills/llmobs-testing @DataDog/dd-trace-js @DataDog/ml-observability
+/benchmark/sirun/llmobs/ @DataDog/dd-trace-js @DataDog/ml-observability
+/benchmark/sirun/llmobs-evaluations/ @DataDog/dd-trace-js @DataDog/ml-observability
+/benchmark/sirun/llmobs-span-processor/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/ai.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/anthropic.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/claude-agent-sdk.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/google-cloud-vertexai.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/langchain.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/openai.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-ai/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-anthropic/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-claude-agent-sdk/ @DataDog/dd-trace-js @DataDog/ml-observability
+/benchmark/sirun/plugin-claude-agent-sdk/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-google-cloud-vertexai/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-langchain/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/datadog-plugin-openai/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/dd-trace/src/llmobs/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/dd-trace/test/llmobs/ @DataDog/dd-trace-js @DataDog/ml-observability
+/packages/dd-trace/test/plugins/util/llm.spec.js @DataDog/dd-trace-js @DataDog/ml-observability
 
 # Data Streams Monitoring
-/benchmark/sirun/datastreams/ @DataDog/data-streams-monitoring
-/packages/dd-trace/src/datastreams/ @DataDog/data-streams-monitoring
-/packages/dd-trace/test/datastreams/ @DataDog/data-streams-monitoring
-/packages/**/dsm.spec.js @DataDog/data-streams-monitoring
-/packages/**/*.dsm.spec.js @DataDog/data-streams-monitoring
+/benchmark/sirun/datastreams/ @DataDog/dd-trace-js @DataDog/data-streams-monitoring
+/packages/dd-trace/src/datastreams/ @DataDog/dd-trace-js @DataDog/data-streams-monitoring
+/packages/dd-trace/test/datastreams/ @DataDog/dd-trace-js @DataDog/data-streams-monitoring
+/packages/**/dsm.spec.js @DataDog/dd-trace-js @DataDog/data-streams-monitoring
+/packages/**/*.dsm.spec.js @DataDog/dd-trace-js @DataDog/data-streams-monitoring
 
 # API SDK Capabilities
-/eslint-rules/ @DataDog/apm-sdk-capabilities-js
-/ext/kinds.* @DataDog/apm-sdk-capabilities-js
-/ext/priority.* @DataDog/apm-sdk-capabilities-js
+/eslint-rules/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/ext/kinds.* @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/ext/priority.* @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 
-/benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
-/benchmark/sirun/sampling/ @DataDog/apm-sdk-capabilities-js
-/benchmark/sirun/span-format/ @DataDog/apm-sdk-capabilities-js
-/benchmark/sirun/spans/ @DataDog/apm-sdk-capabilities-js
-/benchmark/sirun/test-codeowners/ @DataDog/ci-app-libraries
-/benchmark/sirun/test-optimization/ @DataDog/ci-app-libraries
+/benchmark/sirun/propagation/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/sampling/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/span-format/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/spans/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/test-codeowners/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/benchmark/sirun/test-optimization/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
-/integration-tests/log_injection/ @DataDog/apm-sdk-capabilities-js
-/integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
-/integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js
-/integration-tests/opentelemetry-logs.spec.js @DataDog/apm-sdk-capabilities-js
-/integration-tests/opentelemetry-traces.spec.js @DataDog/apm-sdk-capabilities-js
-/integration-tests/opentelemetry.spec.js @DataDog/apm-sdk-capabilities-js
-/integration-tests/remote_config/ @DataDog/apm-sdk-capabilities-js
-/integration-tests/remote_config.spec.js @DataDog/apm-sdk-capabilities-js
-/integration-tests/telemetry-forwarder.sh @DataDog/apm-sdk-capabilities-js
-/integration-tests/telemetry.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/log_injection/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/log_injection.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry-logs.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry-traces.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/remote_config/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/remote_config.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/telemetry-forwarder.sh @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/integration-tests/telemetry.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 
-/packages/dd-trace/src/telemetry/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/telemetry/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/config/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/config/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/log/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/opentelemetry/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/opentelemetry/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/opentracing/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/opentracing/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/remote_config/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/remote_config/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/baggage.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/baggage.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/carrier.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/carrier.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/*sampler.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/*sampler.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/sampling_rule.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/sampling_rule.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/custom-metrics.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/custom-metrics-app.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/fixtures/config/span-sampling-rules.json @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/helpers/config.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/runtime_metrics/ @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/runtime_metrics.spec.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/startup-log.js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/test/startup-log.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/telemetry/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/telemetry/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/config/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/config/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/log/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/opentelemetry/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/opentelemetry/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/opentracing/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/opentracing/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/remote_config/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/remote_config/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/baggage.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/baggage.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/carrier.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/carrier.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/*sampler.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/*sampler.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/sampling_rule.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/sampling_rule.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/custom-metrics.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/custom-metrics-app.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/fixtures/config/span-sampling-rules.json @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/helpers/config.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/runtime_metrics/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/runtime_metrics.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/startup-log.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/startup-log.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 
-/scripts/generate-config-types.js @DataDog/apm-sdk-capabilities-js
-/scripts/generate-supported-integrations.js @DataDog/apm-sdk-capabilities-js
-/scripts/helpers/test-file-index.js @DataDog/apm-sdk-capabilities-js
-/scripts/helpers/test-file-index.spec.js @DataDog/apm-sdk-capabilities-js
-/scripts/verify-exercised-tests.js @DataDog/apm-sdk-capabilities-js
-/scripts/verify-exercised-tests.spec.mjs @DataDog/apm-sdk-capabilities-js
-/supported_versions_output.json @DataDog/apm-sdk-capabilities-js
-/supported_versions_table.csv @DataDog/apm-sdk-capabilities-js
+/scripts/generate-config-types.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/scripts/generate-supported-integrations.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/scripts/helpers/test-file-index.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/scripts/helpers/test-file-index.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/scripts/verify-exercised-tests.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/scripts/verify-exercised-tests.spec.mjs @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/supported_versions_output.json @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/supported_versions_table.csv @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 
 # Feature Flagging
-/integration-tests/esbuild/*openfeature* @DataDog/apm-idm-js @DataDog/feature-flagging-and-experimentation-sdk
-/integration-tests/openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
-/integration-tests/webpack/*openfeature* @DataDog/apm-idm-js @DataDog/feature-flagging-and-experimentation-sdk
-/packages/dd-trace/src/openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
-/packages/dd-trace/test/openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
+/integration-tests/esbuild/*openfeature* @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/feature-flagging-and-experimentation-sdk
+/integration-tests/openfeature/ @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk
+/integration-tests/webpack/*openfeature* @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/feature-flagging-and-experimentation-sdk
+/packages/dd-trace/src/openfeature/ @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk
+/packages/dd-trace/test/openfeature/ @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk
 
 # CI
-/.github/actions/upload-coverage-artifact/ @DataDog/ci-app-libraries
-/.github/actions/upload-junit-artifacts/ @DataDog/ci-app-libraries
-/.github/editorconfig-checker/ @Datadog/lang-platform-js
-/.github/playwright/ @DataDog/ci-app-libraries
-/.github/selenium/ @DataDog/ci-app-libraries
-/.github/chainguard/ @DataDog/sdlc-security
-/.github/codeql_config.yml @DataDog/sdlc-security
-/.github/workflows/codeql-analysis.yml @DataDog/sdlc-security
-/.github/workflows/mirror-image.yml @Datadog/lang-platform-js
-/.github/workflows/all-green.yml @Datadog/lang-platform-js
-/.github/workflows/audit.yml @DataDog/lang-platform-js
-/.github/workflows/custom-node-version-dispatch.yml @Datadog/lang-platform-js
-/.github/workflows/dependabot-automation.yml @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js
-/.github/workflows/flakiness.yml @DataDog/lang-platform-js
-/.github/workflows/platform.yml @DataDog/lang-platform-js
-/.github/workflows/project.yml @Datadog/lang-platform-js
-/.github/workflows/release-proposal.yml @DataDog/lang-platform-js
-/.github/workflows/release-validate.yml @DataDog/lang-platform-js
-/.github/workflows/stale.yml @Datadog/lang-platform-js
-/.github/workflows/update-3rdparty-licenses.yml @DataDog/lang-platform-js
+/.github/actions/upload-coverage-artifact/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/.github/actions/upload-junit-artifacts/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/.github/editorconfig-checker/ @DataDog/dd-trace-js @Datadog/lang-platform-js
+/.github/playwright/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/.github/selenium/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/.github/chainguard/ @DataDog/dd-trace-js @DataDog/sdlc-security
+/.github/codeql_config.yml @DataDog/dd-trace-js @DataDog/sdlc-security
+/.github/workflows/codeql-analysis.yml @DataDog/dd-trace-js @DataDog/sdlc-security
+/.github/workflows/mirror-image.yml @DataDog/dd-trace-js @Datadog/lang-platform-js
+/.github/workflows/all-green.yml @DataDog/dd-trace-js @Datadog/lang-platform-js
+/.github/workflows/audit.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/custom-node-version-dispatch.yml @DataDog/dd-trace-js @Datadog/lang-platform-js
+/.github/workflows/dependabot-automation.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js
+/.github/workflows/flakiness.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/platform.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/project.yml @DataDog/dd-trace-js @Datadog/lang-platform-js
+/.github/workflows/release-proposal.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/release-validate.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/stale.yml @DataDog/dd-trace-js @Datadog/lang-platform-js
+/.github/workflows/update-3rdparty-licenses.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
 
-/.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
-/.github/workflows/eslint-rules.yml @DataDog/apm-sdk-capabilities-js
-/.github/workflows/apm-integrations.yml @DataDog/apm-idm-js
-/.github/workflows/aiguard.yml @DataDog/asm-js
-/.github/workflows/appsec.yml @DataDog/asm-js
-/.github/workflows/debugger.yml @DataDog/debugger-nodejs
-/.github/workflows/instrumentation.yml @DataDog/apm-idm-js
-/.github/workflows/electron.yml @DataDog/apm-idm-js
-/.github/workflows/release.yml @DataDog/lang-platform-js
-/.github/workflows/serverless.yml @DataDog/serverless-aws @DataDog/apm-serverless
-/.github/workflows/llmobs.yml @DataDog/ml-observability
-/.github/workflows/openfeature.yml @DataDog/feature-flagging-and-experimentation-sdk
-/.github/workflows/pr-title.yml @DataDog/lang-platform-js
-/.github/workflows/profiling.yml @DataDog/profiling-js
-/.github/workflows/system-tests.yml @DataDog/asm-js
-/.github/workflows/test-optimization.yml @DataDog/ci-app-libraries
+/.github/workflows/apm-capabilities.yml @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/.github/workflows/eslint-rules.yml @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/.github/workflows/apm-integrations.yml @DataDog/dd-trace-js @DataDog/apm-idm-js
+/.github/workflows/aiguard.yml @DataDog/dd-trace-js @DataDog/asm-js
+/.github/workflows/appsec.yml @DataDog/dd-trace-js @DataDog/asm-js
+/.github/workflows/debugger.yml @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/.github/workflows/instrumentation.yml @DataDog/dd-trace-js @DataDog/apm-idm-js
+/.github/workflows/electron.yml @DataDog/dd-trace-js @DataDog/apm-idm-js
+/.github/workflows/release.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/serverless.yml @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
+/.github/workflows/llmobs.yml @DataDog/dd-trace-js @DataDog/ml-observability
+/.github/workflows/openfeature.yml @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk
+/.github/workflows/pr-title.yml @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/workflows/profiling.yml @DataDog/dd-trace-js @DataDog/profiling-js
+/.github/workflows/system-tests.yml @DataDog/dd-trace-js @DataDog/asm-js
+/.github/workflows/test-optimization.yml @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
 # Profiling
-/benchmark/sirun/profiler/ @DataDog/profiling-js
+/benchmark/sirun/profiler/ @DataDog/dd-trace-js @DataDog/profiling-js
 
-/integration-tests/profiler/ @DataDog/profiling-js
+/integration-tests/profiler/ @DataDog/dd-trace-js @DataDog/profiling-js
 
-/packages/dd-trace/*/profiling/ @DataDog/profiling-js
-/packages/dd-trace/src/otel-thread-ctx.js @DataDog/profiling-js
-/packages/dd-trace/src/profiler.js @DataDog/profiling-js
-/packages/dd-trace/src/storage-channels.js @DataDog/profiling-js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/web-tags-cache.js @DataDog/profiling-js
-/packages/dd-trace/test/exporters/common/form-data.spec.js @DataDog/profiling-js
-/packages/dd-trace/test/otel-thread-ctx.spec.js @DataDog/profiling-js
-/packages/dd-trace/test/web-tags-cache.spec.js @DataDog/profiling-js
+/packages/dd-trace/*/profiling/ @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/src/otel-thread-ctx.js @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/src/profiler.js @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/src/storage-channels.js @DataDog/dd-trace-js @DataDog/profiling-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/web-tags-cache.js @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/test/exporters/common/form-data.spec.js @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/test/otel-thread-ctx.spec.js @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/test/web-tags-cache.spec.js @DataDog/dd-trace-js @DataDog/profiling-js
 
 # Language Platform
-/* @DataDog/lang-platform-js
-/openfeature.d.ts @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
-/openfeature.js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
+/* @DataDog/dd-trace-js @DataDog/lang-platform-js
+/openfeature.d.ts @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
+/openfeature.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
 
-/.github/CODEOWNERS @DataDog/lang-platform-js
-/.github/dependabot.yml @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js
-/.github/pull_request_template.md @DataDog/lang-platform-js
-/.github/vendored-dependencies.csv @DataDog/lang-platform-js
+/.github/CODEOWNERS @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/dependabot.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js
+/.github/pull_request_template.md @DataDog/dd-trace-js @DataDog/lang-platform-js
+/.github/vendored-dependencies.csv @DataDog/dd-trace-js @DataDog/lang-platform-js
 
-/benchmark/* @DataDog/lang-platform-js
-/benchmark/openfeature.js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
-/benchmark/sirun/* @DataDog/lang-platform-js
-/benchmark/stubs/ @DataDog/lang-platform-js
-/benchmark/sirun/async_hooks/ @DataDog/lang-platform-js
-/benchmark/sirun/dogstatsd/ @DataDog/lang-platform-js
-/benchmark/sirun/encoding/ @DataDog/lang-platform-js
-/benchmark/sirun/exporting-pipeline/ @DataDog/lang-platform-js
-/benchmark/sirun/id/ @DataDog/lang-platform-js
-/benchmark/sirun/log/ @DataDog/lang-platform-js
-/benchmark/sirun/runtime-metrics/ @DataDog/lang-platform-js
-/benchmark/sirun/scope/ @DataDog/lang-platform-js
-/benchmark/sirun/shimmer-runtime/ @DataDog/lang-platform-js
-/benchmark/sirun/shimmer-startup/ @DataDog/lang-platform-js
-/benchmark/sirun/startup/ @DataDog/lang-platform-js
-/benchmark/sirun/tracing-channel/ @DataDog/lang-platform-js
+/benchmark/* @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/openfeature.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
+/benchmark/sirun/* @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/stubs/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/async_hooks/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/dogstatsd/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/encoding/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/exporting-pipeline/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/id/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/log/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/runtime-metrics/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/scope/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/shimmer-runtime/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/shimmer-startup/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/startup/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/benchmark/sirun/tracing-channel/ @DataDog/dd-trace-js @DataDog/lang-platform-js
 
-/ext/scopes.* @DataDog/lang-platform-js
+/ext/scopes.* @DataDog/dd-trace-js @DataDog/lang-platform-js
 
-/integration-tests/bun/ @DataDog/lang-platform-js
-/integration-tests/coverage/ @DataDog/lang-platform-js
-/integration-tests/coverage-child-process.spec.js @DataDog/lang-platform-js
-/integration-tests/coverage-merge-lcov.spec.js @DataDog/lang-platform-js
-/integration-tests/coverage-fixtures/ @DataDog/lang-platform-js
-/integration-tests/crashtracking/ @DataDog/lang-platform-js
-/integration-tests/helpers/ @DataDog/lang-platform-js
-/integration-tests/import-variants.spec.js @DataDog/lang-platform-js
-/integration-tests/init/ @DataDog/lang-platform-js
-/integration-tests/init.spec.js @DataDog/lang-platform-js
-/integration-tests/helpers/fake-agent.js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
-/integration-tests/memory-leak/ @DataDog/lang-platform-js
-/integration-tests/mocha-parallel-files-fixtures/ @DataDog/lang-platform-js
-/integration-tests/mocha-parallel-files.spec.js @DataDog/lang-platform-js
-/integration-tests/package-guardrails/ @DataDog/lang-platform-js
-/integration-tests/package-guardrails.spec.js @DataDog/lang-platform-js
-/integration-tests/startup/ @DataDog/lang-platform-js
-/integration-tests/startup.spec.js @DataDog/lang-platform-js
-/integration-tests/tsconfig.json @DataDog/lang-platform-js
+/integration-tests/bun/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/coverage/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/coverage-child-process.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/coverage-merge-lcov.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/coverage-fixtures/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/crashtracking/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/helpers/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/import-variants.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/init/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/init.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/helpers/fake-agent.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
+/integration-tests/memory-leak/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/mocha-parallel-files-fixtures/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/mocha-parallel-files.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/package-guardrails/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/package-guardrails.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/startup/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/startup.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/integration-tests/tsconfig.json @DataDog/dd-trace-js @DataDog/lang-platform-js
 
-/packages/datadog-core/ @DataDog/lang-platform-js
-/packages/datadog-shimmer/ @DataDog/lang-platform-js
-/packages/dd-trace/*/crashtracking/ @DataDog/lang-platform-js
-/packages/dd-trace/index.js @DataDog/lang-platform-js
-/packages/dd-trace/src/bootstrap.js @DataDog/lang-platform-js
-/packages/dd-trace/src/constants.js @DataDog/lang-platform-js
-/packages/dd-trace/src/dogstatsd.js @DataDog/lang-platform-js
-/packages/dd-trace/src/exporter.js @DataDog/lang-platform-js
-/packages/dd-trace/src/feature-registry.js @DataDog/lang-platform-js
-/packages/dd-trace/src/exporters/common/ @DataDog/lang-platform-js
-/packages/dd-trace/src/exporters/common/client-library-headers.js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
-/packages/dd-trace/src/evp_proxy/ @DataDog/lang-platform-js
-/packages/dd-trace/src/heap_snapshots.js @DataDog/lang-platform-js
-/packages/dd-trace/src/histogram.js @DataDog/lang-platform-js
-/packages/dd-trace/src/id.js @DataDog/lang-platform-js
-/packages/dd-trace/src/iitm.js @DataDog/lang-platform-js
-/packages/dd-trace/src/index.js @DataDog/lang-platform-js
-/packages/dd-trace/src/pkg.js @DataDog/lang-platform-js
-/packages/dd-trace/src/proxy.js @DataDog/lang-platform-js
-/packages/dd-trace/src/rate_limiter.js @DataDog/lang-platform-js
-/packages/dd-trace/src/require-package-json.js @DataDog/lang-platform-js
-/packages/dd-trace/src/ritm.js @DataDog/lang-platform-js
-/packages/dd-trace/src/scope.js @DataDog/lang-platform-js
-/packages/dd-trace/src/span_format.js @DataDog/lang-platform-js
-/packages/dd-trace/src/span_processor.js @DataDog/lang-platform-js
-/packages/dd-trace/src/span_stats.js @DataDog/lang-platform-js
-/packages/dd-trace/src/spanleak.js @DataDog/lang-platform-js
-/packages/dd-trace/src/tagger.js @DataDog/lang-platform-js
-/packages/dd-trace/src/tracer.js @DataDog/lang-platform-js
-/packages/dd-trace/src/util.js @DataDog/lang-platform-js
-/packages/dd-trace/test/agent/ @DataDog/lang-platform-js
-/packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/evp_proxy/ @DataDog/lang-platform-js
-/packages/dd-trace/test/esm-named-exports.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/exporter.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/exporters/ @DataDog/lang-platform-js
-/packages/dd-trace/test/external-logger/ @DataDog/lang-platform-js
-/packages/dd-trace/test/flare.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/guardrails/ @DataDog/lang-platform-js
-/packages/dd-trace/test/heap_snapshots.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/histogram.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/id.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/iitm.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/loader-hook.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/log.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/msgpack/ @DataDog/lang-platform-js
-/packages/dd-trace/test/mocha-hooks.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/node_modules/ @DataDog/lang-platform-js
-/packages/dd-trace/test/noop.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/pkg.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/plugin_manager.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/plugins/plugin.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/plugins/util/env.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/pkg-loader.js @DataDog/lang-platform-js
-/packages/dd-trace/test/profile.js @DataDog/lang-platform-js
-/packages/dd-trace/test/proxy.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/proxyquire.js @DataDog/lang-platform-js
-/packages/dd-trace/test/rate_limiter.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/register.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/require-package-json.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/ritm-tests/ @DataDog/lang-platform-js
-/packages/dd-trace/test/ritm.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/scope.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/setup/ @DataDog/lang-platform-js
-/packages/dd-trace/test/span_format.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/span_processor.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/span_stats.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/tagger.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/tracer.spec.js @DataDog/lang-platform-js
-/packages/dd-trace/test/util.spec.js @DataDog/lang-platform-js
+/packages/datadog-core/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/datadog-shimmer/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/*/crashtracking/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/index.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/bootstrap.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/constants.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/dogstatsd.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporter.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/feature-registry.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/common/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/common/client-library-headers.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
+/packages/dd-trace/src/evp_proxy/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/heap_snapshots.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/histogram.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/id.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/iitm.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/index.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/pkg.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/proxy.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/rate_limiter.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/require-package-json.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/ritm.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/scope.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/span_format.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/span_processor.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/span_stats.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/spanleak.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/tagger.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/tracer.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/src/util.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/agent/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/dd-trace.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/dogstatsd.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/evp_proxy/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/esm-named-exports.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/exporter.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/exporters/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/external-logger/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/flare.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/guardrails/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/heap_snapshots.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/histogram.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/id.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/iitm.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/loader-hook.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/log.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/msgpack/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/mocha-hooks.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/node_modules/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/noop.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/pkg.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/plugin_manager.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/plugins/plugin.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/plugins/util/env.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/pkg-loader.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/profile.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/proxy.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/proxyquire.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/rate_limiter.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/register.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/require-package-json.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/ritm-tests/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/ritm.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/scope.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/setup/ @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/span_format.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/span_processor.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/span_stats.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/tagger.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/tracer.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
+/packages/dd-trace/test/util.spec.js @DataDog/dd-trace-js @DataDog/lang-platform-js
 
 # Multiple teams
-/devdocs/ @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
-/docs/ @DataDog/apm-idm-js @DataDog/lang-platform-js
-/docs/API.md @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
-/docs/test.ts @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
-/.gitlab/benchmarks/ @DataDog/lang-platform-js @DataDog/ecosystems-performance
-/eslint-rules/* @DataDog/apm-sdk-capabilities-js @DataDog/lang-platform-js
-/ext/exporters.* @DataDog/apm-idm-js @DataDog/ci-app-libraries @DataDog/lang-platform-js
-/ext/formats.* @DataDog/apm-sdk-capabilities-js @DataDog/data-streams-monitoring
-/ext/index.* @DataDog/apm-idm-js @DataDog/apm-sdk-capabilities-js @DataDog/apm-serverless @DataDog/ci-app-libraries @DataDog/data-streams-monitoring @DataDog/lang-platform-js
-/ext/tags.* @DataDog/apm-idm-js @DataDog/apm-sdk-capabilities-js @DataDog/data-streams-monitoring
-/ext/types.* @DataDog/apm-idm-js @DataDog/apm-serverless
-/packages/dd-trace/src/plugin_manager.js @DataDog/lang-platform-js @DataDog/apm-idm-js
+/devdocs/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
+/docs/ @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/lang-platform-js
+/docs/API.md @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
+/docs/test.ts @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @DataDog/apm-idm-js
+/.gitlab/benchmarks/ @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/ecosystems-performance
+/eslint-rules/* @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @DataDog/lang-platform-js
+/ext/exporters.* @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/ci-app-libraries @DataDog/lang-platform-js
+/ext/formats.* @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @DataDog/data-streams-monitoring
+/ext/index.* @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/apm-sdk-capabilities-js @DataDog/apm-serverless @DataDog/ci-app-libraries @DataDog/data-streams-monitoring @DataDog/lang-platform-js
+/ext/tags.* @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/apm-sdk-capabilities-js @DataDog/data-streams-monitoring
+/ext/types.* @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/apm-serverless
+/packages/dd-trace/src/plugin_manager.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/apm-idm-js


### PR DESCRIPTION
## Summary

Add @DataDog/dd-trace-js as the first owner on every CODEOWNERS rule.

This enables enforcing code owner review without disrupting the current workflow: existing specialist teams remain owners on their rules, while the dd-trace-js team is consistently included for review coverage.

## Testing

- Verified every non-comment CODEOWNERS rule lists @DataDog/dd-trace-js first.
- Ran git diff --check.

## Authorship

Authored by Codex.