### PR TITLE
test(debugger): await probe runtime completion

### DIFF
--- a/integration-tests/debugger/input-messages.spec.js
+++ b/integration-tests/debugger/input-messages.spec.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const assert = require('assert')
+const { on, once } = require('node:events')
+const { setTimeout: delay } = require('node:timers/promises')
+
 const { pollInterval, setup, testBasicInput } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
@@ -9,70 +12,58 @@ describe('Dynamic Instrumentation', function () {
   describe('input messages', function () {
     it('should capture and send expected payload when a log line probe is triggered', testBasicInput.bind(null, t))
 
-    // Input messages are multi-shot, so duplicate completion must remain observable to Mocha.
-    it('should respond with updated message if probe message is updated', function (done) {
+    it('should respond with updated message if probe message is updated', async function () {
       const expectedMessages = ['Hello World!', 'Hello Updated World!']
-      const triggers = [
-        async () => {
-          await t.axios.get(t.breakpoint.url)
-          t.rcConfig.config.version++
-          t.rcConfig.config.template = 'Hello Updated World!'
-          t.agent.updateRemoteConfig(t.rcConfig.id, t.rcConfig.config)
-        },
-        async () => {
-          await t.axios.get(t.breakpoint.url)
-        },
-      ]
+      const receivedMessages = []
 
-      t.agent.on('debugger-diagnostics', ({ payload }) => {
-        payload.forEach((event) => {
-          if (event.debugger.diagnostics.status === 'INSTALLED') {
-            const trigger = triggers.shift()
-            assert.ok(trigger, 'expecting a trigger function to be defined')
-            trigger().catch(done)
-          }
-        })
-      })
+      /** @param {{ payload: Array<{ message: string }> }} event */
+      function collectMessages ({ payload }) {
+        for (const { message } of payload) receivedMessages.push(message)
+      }
+      t.agent.on('debugger-input', collectMessages)
 
-      t.agent.on('debugger-input', ({ payload: [payload] }) => {
-        assert.strictEqual(payload.message, expectedMessages.shift())
-        if (expectedMessages.length === 0) done()
-      })
+      try {
+        const firstInput = once(t.agent, 'debugger-input')
+        const firstTrigger = t.triggerBreakpoint()
+        t.agent.addRemoteConfig(t.rcConfig)
+        await Promise.all([firstTrigger, firstInput])
 
-      t.agent.addRemoteConfig(t.rcConfig)
+        t.rcConfig.config.version++
+        t.rcConfig.config.template = 'Hello Updated World!'
+        const secondInput = once(t.agent, 'debugger-input')
+        const secondTrigger = t.triggerBreakpoint()
+        t.agent.updateRemoteConfig(t.rcConfig.id, t.rcConfig.config)
+        await Promise.all([secondTrigger, secondInput])
+        await delay(pollInterval * 2 * 1000)
+      } finally {
+        t.agent.removeListener('debugger-input', collectMessages)
+      }
+
+      assert.deepStrictEqual(receivedMessages, expectedMessages)
     })
 
-    // The absence check has no independent terminal signal and must stay callback-based.
-    it('should not trigger if probe is deleted', function (done) {
-      t.agent.on('debugger-diagnostics', ({ payload }) => {
-        payload.forEach((event) => {
-          if (event.debugger.diagnostics.status === 'INSTALLED') {
-            t.agent.once('remote-config-responded', () => {
-              waitForRemovedProbe()
-            })
+    it('should not trigger if probe is deleted', async function () {
+      const diagnostics = on(t.agent, 'debugger-diagnostics')
+      let inputCount = 0
+      const countInput = () => inputCount++
+      t.agent.on('debugger-input', countInput)
 
-            async function waitForRemovedProbe () {
-              try {
-                await t.axios.get(t.breakpoint.url)
-                // We want to wait enough time to see if the client triggers on the breakpoint so that the test can
-                // fail if it does, but not so long that the test times out.
-                // TODO: Is there some signal we can use instead of a timer?
-                setTimeout(done, pollInterval * 2 * 1000) // wait twice as long as the RC poll interval
-              } catch (error) {
-                done(error)
-              }
-            }
+      try {
+        t.agent.addRemoteConfig(t.rcConfig)
+        for await (const [{ payload }] of diagnostics) {
+          if (payload.some(event => event.debugger.diagnostics.status === 'INSTALLED')) break
+        }
 
-            t.agent.removeRemoteConfig(t.rcConfig.id)
-          }
-        })
-      })
+        const configRemoved = once(t.agent, 'remote-config-responded')
+        t.agent.removeRemoteConfig(t.rcConfig.id)
+        await configRemoved
+        await t.axios.get(t.breakpoint.url)
+        await delay(pollInterval * 2 * 1000)
+      } finally {
+        t.agent.removeListener('debugger-input', countInput)
+      }
 
-      t.agent.on('debugger-input', () => {
-        assert.fail('should not capture anything when the probe is deleted')
-      })
-
-      t.agent.addRemoteConfig(t.rcConfig)
+      assert.strictEqual(inputCount, 0)
     })
   })
 })

--- a/integration-tests/debugger/input-messages.spec.js
+++ b/integration-tests/debugger/input-messages.spec.js
@@ -9,7 +9,8 @@ describe('Dynamic Instrumentation', function () {
   describe('input messages', function () {
     it('should capture and send expected payload when a log line probe is triggered', testBasicInput.bind(null, t))
 
-    it('should respond with updated message if probe message is updated', () => new Promise((resolve, reject) => {
+    // Input messages are multi-shot, so duplicate completion must remain observable to Mocha.
+    it('should respond with updated message if probe message is updated', function (done) {
       const expectedMessages = ['Hello World!', 'Hello Updated World!']
       const triggers = [
         async () => {
@@ -28,20 +29,21 @@ describe('Dynamic Instrumentation', function () {
           if (event.debugger.diagnostics.status === 'INSTALLED') {
             const trigger = triggers.shift()
             assert.ok(trigger, 'expecting a trigger function to be defined')
-            trigger().catch(reject)
+            trigger().catch(done)
           }
         })
       })
 
       t.agent.on('debugger-input', ({ payload: [payload] }) => {
         assert.strictEqual(payload.message, expectedMessages.shift())
-        if (expectedMessages.length === 0) resolve()
+        if (expectedMessages.length === 0) done()
       })
 
       t.agent.addRemoteConfig(t.rcConfig)
-    }))
+    })
 
-    it('should not trigger if probe is deleted', () => new Promise((resolve, reject) => {
+    // The absence check has no independent terminal signal and must stay callback-based.
+    it('should not trigger if probe is deleted', function (done) {
       t.agent.on('debugger-diagnostics', ({ payload }) => {
         payload.forEach((event) => {
           if (event.debugger.diagnostics.status === 'INSTALLED') {
@@ -55,9 +57,9 @@ describe('Dynamic Instrumentation', function () {
                 // We want to wait enough time to see if the client triggers on the breakpoint so that the test can
                 // fail if it does, but not so long that the test times out.
                 // TODO: Is there some signal we can use instead of a timer?
-                setTimeout(resolve, pollInterval * 2 * 1000) // wait twice as long as the RC poll interval
+                setTimeout(done, pollInterval * 2 * 1000) // wait twice as long as the RC poll interval
               } catch (error) {
-                reject(error)
+                done(error)
               }
             }
 
@@ -71,6 +73,6 @@ describe('Dynamic Instrumentation', function () {
       })
 
       t.agent.addRemoteConfig(t.rcConfig)
-    }))
+    })
   })
 })

--- a/integration-tests/debugger/input-messages.spec.js
+++ b/integration-tests/debugger/input-messages.spec.js
@@ -9,7 +9,7 @@ describe('Dynamic Instrumentation', function () {
   describe('input messages', function () {
     it('should capture and send expected payload when a log line probe is triggered', testBasicInput.bind(null, t))
 
-    it('should respond with updated message if probe message is updated', function (done) {
+    it('should respond with updated message if probe message is updated', () => new Promise((resolve, reject) => {
       const expectedMessages = ['Hello World!', 'Hello Updated World!']
       const triggers = [
         async () => {
@@ -28,30 +28,38 @@ describe('Dynamic Instrumentation', function () {
           if (event.debugger.diagnostics.status === 'INSTALLED') {
             const trigger = triggers.shift()
             assert.ok(trigger, 'expecting a trigger function to be defined')
-            trigger().catch(done)
+            trigger().catch(reject)
           }
         })
       })
 
       t.agent.on('debugger-input', ({ payload: [payload] }) => {
         assert.strictEqual(payload.message, expectedMessages.shift())
-        if (expectedMessages.length === 0) done()
+        if (expectedMessages.length === 0) resolve()
       })
 
       t.agent.addRemoteConfig(t.rcConfig)
-    })
+    }))
 
-    it('should not trigger if probe is deleted', function (done) {
+    it('should not trigger if probe is deleted', () => new Promise((resolve, reject) => {
       t.agent.on('debugger-diagnostics', ({ payload }) => {
         payload.forEach((event) => {
           if (event.debugger.diagnostics.status === 'INSTALLED') {
-            t.agent.once('remote-config-responded', async () => {
-              await t.axios.get(t.breakpoint.url)
-              // We want to wait enough time to see if the client triggers on the breakpoint so that the test can fail
-              // if it does, but not so long that the test times out.
-              // TODO: Is there some signal we can use instead of a timer?
-              setTimeout(done, pollInterval * 2 * 1000) // wait twice as long as the RC poll interval
+            t.agent.once('remote-config-responded', () => {
+              waitForRemovedProbe()
             })
+
+            async function waitForRemovedProbe () {
+              try {
+                await t.axios.get(t.breakpoint.url)
+                // We want to wait enough time to see if the client triggers on the breakpoint so that the test can
+                // fail if it does, but not so long that the test times out.
+                // TODO: Is there some signal we can use instead of a timer?
+                setTimeout(resolve, pollInterval * 2 * 1000) // wait twice as long as the RC poll interval
+              } catch (error) {
+                reject(error)
+              }
+            }
 
             t.agent.removeRemoteConfig(t.rcConfig.id)
           }
@@ -63,6 +71,6 @@ describe('Dynamic Instrumentation', function () {
       })
 
       t.agent.addRemoteConfig(t.rcConfig)
-    })
+    }))
   })
 })

--- a/integration-tests/debugger/race-conditions.spec.js
+++ b/integration-tests/debugger/race-conditions.spec.js
@@ -6,7 +6,8 @@ describe('Dynamic Instrumentation', function () {
   const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
   describe('race conditions', function () {
-    it('should remove the last breakpoint completely before trying to add a new one', function (done) {
+    const raceTitle = 'should remove the last breakpoint completely before trying to add a new one'
+    it(raceTitle, () => new Promise((resolve, reject) => {
       const rcConfig2 = t.generateRemoteConfig()
 
       t.agent.on('debugger-diagnostics', ({ payload }) => {
@@ -25,7 +26,7 @@ describe('Dynamic Instrumentation', function () {
             // If the race condition occurred, the debugger will have been detached from the main thread and the new
             // probe will never trigger. If that's the case, the following timer will fire:
             const timer = setTimeout(() => {
-              done(new Error('Race condition occurred!'))
+              reject(new Error('Race condition occurred!'))
             }, 2000)
 
             // If we successfully handled the race condition, the probe will trigger, we'll get a probe result and the
@@ -33,21 +34,21 @@ describe('Dynamic Instrumentation', function () {
             t.agent.once('debugger-input', () => {
               clearTimeout(timer)
               finished = true
-              done()
+              resolve()
             })
 
             // Perform HTTP request to try and trigger the probe
-            t.axios.get(t.breakpoint.url).catch((err) => {
+            t.axios.get(t.breakpoint.url).catch((error) => {
               // If the request hasn't fully completed by the time the tests ends and the target app is destroyed,
               // Axios will complain with a "socket hang up" error. Hence this sanity check before calling
-              // `done(err)`. If we later add more tests below this one, this shouldn't be an issue.
-              if (!finished) done(err)
+              // `reject(error)`. If we later add more tests below this one, this shouldn't be an issue.
+              if (!finished) reject(error)
             })
           }
         })
       })
 
       t.agent.addRemoteConfig(t.rcConfig)
-    })
+    }))
   })
 })

--- a/integration-tests/debugger/race-conditions.spec.js
+++ b/integration-tests/debugger/race-conditions.spec.js
@@ -6,8 +6,8 @@ describe('Dynamic Instrumentation', function () {
   const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
   describe('race conditions', function () {
-    const raceTitle = 'should remove the last breakpoint completely before trying to add a new one'
-    it(raceTitle, () => new Promise((resolve, reject) => {
+    // The timeout and input event are competing terminals; a late second terminal must fail the test.
+    it('should remove the last breakpoint completely before trying to add a new one', function (done) {
       const rcConfig2 = t.generateRemoteConfig()
 
       t.agent.on('debugger-diagnostics', ({ payload }) => {
@@ -26,7 +26,7 @@ describe('Dynamic Instrumentation', function () {
             // If the race condition occurred, the debugger will have been detached from the main thread and the new
             // probe will never trigger. If that's the case, the following timer will fire:
             const timer = setTimeout(() => {
-              reject(new Error('Race condition occurred!'))
+              done(new Error('Race condition occurred!'))
             }, 2000)
 
             // If we successfully handled the race condition, the probe will trigger, we'll get a probe result and the
@@ -34,21 +34,21 @@ describe('Dynamic Instrumentation', function () {
             t.agent.once('debugger-input', () => {
               clearTimeout(timer)
               finished = true
-              resolve()
+              done()
             })
 
             // Perform HTTP request to try and trigger the probe
             t.axios.get(t.breakpoint.url).catch((error) => {
               // If the request hasn't fully completed by the time the tests ends and the target app is destroyed,
               // Axios will complain with a "socket hang up" error. Hence this sanity check before calling
-              // `reject(error)`. If we later add more tests below this one, this shouldn't be an issue.
-              if (!finished) reject(error)
+              // `done(error)`. If we later add more tests below this one, this shouldn't be an issue.
+              if (!finished) done(error)
             })
           }
         })
       })
 
       t.agent.addRemoteConfig(t.rcConfig)
-    }))
+    })
   })
 })

--- a/integration-tests/debugger/race-conditions.spec.js
+++ b/integration-tests/debugger/race-conditions.spec.js
@@ -6,7 +6,6 @@ describe('Dynamic Instrumentation', function () {
   const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
   describe('race conditions', function () {
-    // The timeout and input event are competing terminals; a late second terminal must fail the test.
     it('should remove the last breakpoint completely before trying to add a new one', function (done) {
       const rcConfig2 = t.generateRemoteConfig()
 

--- a/integration-tests/debugger/re-evaluation.spec.js
+++ b/integration-tests/debugger/re-evaluation.spec.js
@@ -2,6 +2,8 @@
 
 const { randomUUID } = require('node:crypto')
 const assert = require('node:assert')
+const { on } = require('node:events')
+const { setTimeout: delay } = require('node:timers/promises')
 
 const Axios = require('axios')
 
@@ -62,11 +64,9 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
           'even if it is not loaded when the probe is received ' +
           `(attempt ${attempt})`
 
-        // Diagnostics are multi-shot; Promise settlement would swallow later assertion failures.
-        it(testName, function (done) {
+        it(testName, async function () {
           this.timeout(5000)
 
-          let doneCalled = false
           const probeId = rcConfig.config.id
           const expectedPayloads = [{
             ddsource: 'dd_debugger',
@@ -81,33 +81,18 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
             service: 're-evaluation-test',
             debugger: { diagnostics: { probeId, probeVersion: 0, status: 'EMITTING' } },
           }]
+          const receivedPayloads = []
 
-          agent.on('debugger-diagnostics', async ({ payload }) => {
-            await Promise.all(payload.map(async (event) => {
-              if (event.debugger.diagnostics.status === 'ERROR') {
-                // shortcut to fail with a more relevant error message in case the target script could not be found,
-                // instead of asserting the entire expected event.
-                assert.fail(event.debugger.diagnostics.exception.message)
-              }
+          /** @param {{ payload: Array<object> }} event */
+          function collectDiagnostics ({ payload }) {
+            receivedPayloads.push(...payload)
+          }
+          agent.on('debugger-diagnostics', collectDiagnostics)
 
-              const expected = expectedPayloads.shift()
-              assertObjectContains(event, expected)
-
-              if (event.debugger.diagnostics.status === 'INSTALLED') {
-                const response = await axios.get('/')
-                assert.strictEqual(response.status, 200)
-              }
-            }))
-
-            if (expectedPayloads.length === 0 && doneCalled === false) {
-              doneCalled = true
-              done()
-            }
-          })
-
+          const diagnostics = on(agent, 'debugger-diagnostics')
           agent.addRemoteConfig(rcConfig)
 
-          spawnProc(sourceFile, {
+          proc = await spawnProc(sourceFile, {
             cwd: sandboxCwd(),
             env: {
               NODE_OPTIONS: '--import dd-trace/initialize.mjs',
@@ -117,13 +102,35 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
               DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
               DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
             },
-          }).then(_proc => {
-            assert(_proc, 'proc must be spawned successfully')
-            proc = _proc
-            // Possible race condition, in case axios.get() is called in the test before it's created here. But we have
-            // to start the test quickly in order to test the re-evaluation of the probe.
-            axios = Axios.create({ baseURL: proc.url })
           })
+          assert(proc, 'proc must be spawned successfully')
+          axios = Axios.create({ baseURL: proc.url })
+
+          try {
+            for await (const [{ payload }] of diagnostics) {
+              for (const event of payload) {
+                if (event.debugger.diagnostics.status === 'ERROR') {
+                  // shortcut to fail with a more relevant error message in case the target script could not be found,
+                  // instead of asserting the entire expected event.
+                  assert.fail(event.debugger.diagnostics.exception.message)
+                }
+
+                const expected = expectedPayloads.shift()
+                assertObjectContains(event, expected)
+
+                if (event.debugger.diagnostics.status === 'INSTALLED') {
+                  const response = await axios.get('/')
+                  assert.strictEqual(response.status, 200)
+                }
+              }
+
+              if (expectedPayloads.length === 0) break
+            }
+            await delay(200)
+          } finally {
+            agent.removeListener('debugger-diagnostics', collectDiagnostics)
+          }
+          assert.strictEqual(receivedPayloads.length, 3)
         })
       }
     }

--- a/integration-tests/debugger/re-evaluation.spec.js
+++ b/integration-tests/debugger/re-evaluation.spec.js
@@ -62,10 +62,9 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
           'even if it is not loaded when the probe is received ' +
           `(attempt ${attempt})`
 
-        it(testName, function (done) {
+        it(testName, async function () {
           this.timeout(5000)
 
-          let doneCalled = false
           const probeId = rcConfig.config.id
           const expectedPayloads = [{
             ddsource: 'dd_debugger',
@@ -81,48 +80,56 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
             debugger: { diagnostics: { probeId, probeVersion: 0, status: 'EMITTING' } },
           }]
 
-          agent.on('debugger-diagnostics', async ({ payload }) => {
-            await Promise.all(payload.map(async (event) => {
-              if (event.debugger.diagnostics.status === 'ERROR') {
+          const diagnosticsPromise = new Promise((resolve, reject) => {
+            agent.on('debugger-diagnostics', ({ payload }) => {
+              handleDiagnostics(payload).catch(reject)
+            })
+
+            async function handleDiagnostics (payload) {
+              await Promise.all(payload.map(async (event) => {
+                if (event.debugger.diagnostics.status === 'ERROR') {
                 // shortcut to fail with a more relevant error message in case the target script could not be found,
                 // instead of asserting the entire expected event.
-                assert.fail(event.debugger.diagnostics.exception.message)
-              }
+                  assert.fail(event.debugger.diagnostics.exception.message)
+                }
 
-              const expected = expectedPayloads.shift()
-              assertObjectContains(event, expected)
+                const expected = expectedPayloads.shift()
+                assertObjectContains(event, expected)
 
-              if (event.debugger.diagnostics.status === 'INSTALLED') {
-                const response = await axios.get('/')
-                assert.strictEqual(response.status, 200)
-              }
-            }))
+                if (event.debugger.diagnostics.status === 'INSTALLED') {
+                  const response = await axios.get('/')
+                  assert.strictEqual(response.status, 200)
+                }
+              }))
 
-            if (expectedPayloads.length === 0 && doneCalled === false) {
-              doneCalled = true
-              done()
+              if (expectedPayloads.length === 0) resolve()
             }
           })
 
           agent.addRemoteConfig(rcConfig)
 
-          spawnProc(sourceFile, {
-            cwd: sandboxCwd(),
-            env: {
-              NODE_OPTIONS: '--import dd-trace/initialize.mjs',
-              DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true',
-              DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS: '0',
-              DD_TRACE_AGENT_PORT: agent.port,
-              DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
-              DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
-            },
-          }).then(_proc => {
-            assert(_proc, 'proc must be spawned successfully')
-            proc = _proc
+          const processPromise = startProcess()
+
+          async function startProcess () {
+            const childProcess = await spawnProc(sourceFile, {
+              cwd: sandboxCwd(),
+              env: {
+                NODE_OPTIONS: '--import dd-trace/initialize.mjs',
+                DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true',
+                DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS: '0',
+                DD_TRACE_AGENT_PORT: agent.port,
+                DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
+                DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
+              },
+            })
+            assert(childProcess, 'proc must be spawned successfully')
+            proc = childProcess
             // Possible race condition, in case axios.get() is called in the test before it's created here. But we have
             // to start the test quickly in order to test the re-evaluation of the probe.
             axios = Axios.create({ baseURL: proc.url })
-          })
+          }
+
+          await Promise.all([processPromise, diagnosticsPromise])
         })
       }
     }

--- a/integration-tests/debugger/re-evaluation.spec.js
+++ b/integration-tests/debugger/re-evaluation.spec.js
@@ -62,9 +62,11 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
           'even if it is not loaded when the probe is received ' +
           `(attempt ${attempt})`
 
-        it(testName, async function () {
+        // Diagnostics are multi-shot; Promise settlement would swallow later assertion failures.
+        it(testName, function (done) {
           this.timeout(5000)
 
+          let doneCalled = false
           const probeId = rcConfig.config.id
           const expectedPayloads = [{
             ddsource: 'dd_debugger',
@@ -80,56 +82,48 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
             debugger: { diagnostics: { probeId, probeVersion: 0, status: 'EMITTING' } },
           }]
 
-          const diagnosticsPromise = new Promise((resolve, reject) => {
-            agent.on('debugger-diagnostics', ({ payload }) => {
-              handleDiagnostics(payload).catch(reject)
-            })
-
-            async function handleDiagnostics (payload) {
-              await Promise.all(payload.map(async (event) => {
-                if (event.debugger.diagnostics.status === 'ERROR') {
+          agent.on('debugger-diagnostics', async ({ payload }) => {
+            await Promise.all(payload.map(async (event) => {
+              if (event.debugger.diagnostics.status === 'ERROR') {
                 // shortcut to fail with a more relevant error message in case the target script could not be found,
                 // instead of asserting the entire expected event.
-                  assert.fail(event.debugger.diagnostics.exception.message)
-                }
+                assert.fail(event.debugger.diagnostics.exception.message)
+              }
 
-                const expected = expectedPayloads.shift()
-                assertObjectContains(event, expected)
+              const expected = expectedPayloads.shift()
+              assertObjectContains(event, expected)
 
-                if (event.debugger.diagnostics.status === 'INSTALLED') {
-                  const response = await axios.get('/')
-                  assert.strictEqual(response.status, 200)
-                }
-              }))
+              if (event.debugger.diagnostics.status === 'INSTALLED') {
+                const response = await axios.get('/')
+                assert.strictEqual(response.status, 200)
+              }
+            }))
 
-              if (expectedPayloads.length === 0) resolve()
+            if (expectedPayloads.length === 0 && doneCalled === false) {
+              doneCalled = true
+              done()
             }
           })
 
           agent.addRemoteConfig(rcConfig)
 
-          const processPromise = startProcess()
-
-          async function startProcess () {
-            const childProcess = await spawnProc(sourceFile, {
-              cwd: sandboxCwd(),
-              env: {
-                NODE_OPTIONS: '--import dd-trace/initialize.mjs',
-                DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true',
-                DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS: '0',
-                DD_TRACE_AGENT_PORT: agent.port,
-                DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
-                DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
-              },
-            })
-            assert(childProcess, 'proc must be spawned successfully')
-            proc = childProcess
+          spawnProc(sourceFile, {
+            cwd: sandboxCwd(),
+            env: {
+              NODE_OPTIONS: '--import dd-trace/initialize.mjs',
+              DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true',
+              DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS: '0',
+              DD_TRACE_AGENT_PORT: agent.port,
+              DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
+              DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
+            },
+          }).then(_proc => {
+            assert(_proc, 'proc must be spawned successfully')
+            proc = _proc
             // Possible race condition, in case axios.get() is called in the test before it's created here. But we have
             // to start the test quickly in order to test the re-evaluation of the probe.
             axios = Axios.create({ baseURL: proc.url })
-          }
-
-          await Promise.all([processPromise, diagnosticsPromise])
+          })
         })
       }
     }

--- a/integration-tests/debugger/sampling.spec.js
+++ b/integration-tests/debugger/sampling.spec.js
@@ -7,12 +7,12 @@ describe('Dynamic Instrumentation', function () {
   const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
   describe('sampling', function () {
-    it('should respect sampling rate for single probe', function (done) {
+    it('should respect sampling rate for single probe', () => new Promise((resolve, reject) => {
       let prev, timer
       const rcConfig = t.generateRemoteConfig({ sampling: { snapshotsPerSecond: 1 } })
 
       function triggerBreakpointContinuously () {
-        t.axios.get(t.breakpoint.url).catch(done)
+        t.axios.get(t.breakpoint.url).catch(reject)
         timer = setTimeout(triggerBreakpointContinuously, 10)
       }
 
@@ -24,31 +24,33 @@ describe('Dynamic Instrumentation', function () {
 
       t.agent.on('debugger-input', ({ payload }) => {
         payload.forEach(({ debugger: { snapshot: { timestamp } } }) => {
-          if (prev !== undefined) {
-            const duration = timestamp - prev
-            clearTimeout(timer)
-
-            // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
-            // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
-            // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
-            // sides of the expected 1000ms gap.
-            assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
-            assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
-
-            // Wait at least a full sampling period, to see if we get any more payloads
-            timer = setTimeout(done, 1250)
+          if (prev === undefined) {
+            prev = timestamp
+            return
           }
-          prev = timestamp
+
+          const duration = timestamp - prev
+          clearTimeout(timer)
+
+          // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
+          // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
+          // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
+          // sides of the expected 1000ms gap.
+          assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
+          assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
+
+          // Wait at least a full sampling period, to see if we get any more payloads
+          timer = setTimeout(resolve, 1250)
         })
       })
 
       t.agent.addRemoteConfig(rcConfig)
-    })
+    }))
 
-    it('should adhere to individual probes sample rate', function (done) {
+    it('should adhere to individual probes sample rate', () => new Promise((resolve, reject) => {
       /** @type {(() => void) & { calledOnce?: boolean }} */
       const doneWhenCalledTwice = () => {
-        if (doneWhenCalledTwice.calledOnce) return done()
+        if (doneWhenCalledTwice.calledOnce) return resolve()
         doneWhenCalledTwice.calledOnce = true
       }
 
@@ -57,13 +59,13 @@ describe('Dynamic Instrumentation', function () {
       const state = {
         [rcConfig1.config.id]: {
           triggerBreakpointContinuously () {
-            t.axios.get(t.breakpoints[0].url).catch(done)
+            t.axios.get(t.breakpoints[0].url).catch(reject)
             this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
           },
         },
         [rcConfig2.config.id]: {
           triggerBreakpointContinuously () {
-            t.axios.get(t.breakpoints[1].url).catch(done)
+            t.axios.get(t.breakpoints[1].url).catch(reject)
             this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
           },
         },
@@ -100,6 +102,6 @@ describe('Dynamic Instrumentation', function () {
 
       t.agent.addRemoteConfig(rcConfig1)
       t.agent.addRemoteConfig(rcConfig2)
-    })
+    }))
   })
 })

--- a/integration-tests/debugger/sampling.spec.js
+++ b/integration-tests/debugger/sampling.spec.js
@@ -7,12 +7,13 @@ describe('Dynamic Instrumentation', function () {
   const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
   describe('sampling', function () {
-    it('should respect sampling rate for single probe', () => new Promise((resolve, reject) => {
+    // Snapshot input is multi-shot; callback completion exposes an unexpected later sample.
+    it('should respect sampling rate for single probe', function (done) {
       let prev, timer
       const rcConfig = t.generateRemoteConfig({ sampling: { snapshotsPerSecond: 1 } })
 
       function triggerBreakpointContinuously () {
-        t.axios.get(t.breakpoint.url).catch(reject)
+        t.axios.get(t.breakpoint.url).catch(done)
         timer = setTimeout(triggerBreakpointContinuously, 10)
       }
 
@@ -24,33 +25,33 @@ describe('Dynamic Instrumentation', function () {
 
       t.agent.on('debugger-input', ({ payload }) => {
         payload.forEach(({ debugger: { snapshot: { timestamp } } }) => {
-          if (prev === undefined) {
-            prev = timestamp
-            return
+          const previousTimestamp = prev
+          prev = timestamp
+          if (previousTimestamp !== undefined) {
+            const duration = timestamp - previousTimestamp
+            clearTimeout(timer)
+
+            // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
+            // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
+            // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
+            // sides of the expected 1000ms gap.
+            assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
+            assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
+
+            // Wait at least a full sampling period, to see if we get any more payloads
+            timer = setTimeout(() => done(), 1250)
           }
-
-          const duration = timestamp - prev
-          clearTimeout(timer)
-
-          // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
-          // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
-          // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
-          // sides of the expected 1000ms gap.
-          assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
-          assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
-
-          // Wait at least a full sampling period, to see if we get any more payloads
-          timer = setTimeout(resolve, 1250)
         })
       })
 
       t.agent.addRemoteConfig(rcConfig)
-    }))
+    })
 
-    it('should adhere to individual probes sample rate', () => new Promise((resolve, reject) => {
+    // Both probe streams must complete, and any later completion must remain visible to Mocha.
+    it('should adhere to individual probes sample rate', function (done) {
       /** @type {(() => void) & { calledOnce?: boolean }} */
       const doneWhenCalledTwice = () => {
-        if (doneWhenCalledTwice.calledOnce) return resolve()
+        if (doneWhenCalledTwice.calledOnce) return done()
         doneWhenCalledTwice.calledOnce = true
       }
 
@@ -59,13 +60,13 @@ describe('Dynamic Instrumentation', function () {
       const state = {
         [rcConfig1.config.id]: {
           triggerBreakpointContinuously () {
-            t.axios.get(t.breakpoints[0].url).catch(reject)
+            t.axios.get(t.breakpoints[0].url).catch(done)
             this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
           },
         },
         [rcConfig2.config.id]: {
           triggerBreakpointContinuously () {
-            t.axios.get(t.breakpoints[1].url).catch(reject)
+            t.axios.get(t.breakpoints[1].url).catch(done)
             this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
           },
         },
@@ -102,6 +103,6 @@ describe('Dynamic Instrumentation', function () {
 
       t.agent.addRemoteConfig(rcConfig1)
       t.agent.addRemoteConfig(rcConfig2)
-    }))
+    })
   })
 })

--- a/integration-tests/debugger/sampling.spec.js
+++ b/integration-tests/debugger/sampling.spec.js
@@ -7,7 +7,6 @@ describe('Dynamic Instrumentation', function () {
   const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
   describe('sampling', function () {
-    // Snapshot input is multi-shot; callback completion exposes an unexpected later sample.
     it('should respect sampling rate for single probe', function (done) {
       let prev, timer
       const rcConfig = t.generateRemoteConfig({ sampling: { snapshotsPerSecond: 1 } })
@@ -31,10 +30,7 @@ describe('Dynamic Instrumentation', function () {
             const duration = timestamp - previousTimestamp
             clearTimeout(timer)
 
-            // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
-            // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
-            // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
-            // sides of the expected 1000ms gap.
+            // Snapshot timestamps use wall-clock time while sampling uses monotonic time, so allow 75ms for drift.
             assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
             assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
 
@@ -47,7 +43,6 @@ describe('Dynamic Instrumentation', function () {
       t.agent.addRemoteConfig(rcConfig)
     })
 
-    // Both probe streams must complete, and any later completion must remain visible to Mocha.
     it('should adhere to individual probes sample rate', function (done) {
       /** @type {(() => void) & { calledOnce?: boolean }} */
       const doneWhenCalledTwice = () => {
@@ -87,10 +82,7 @@ describe('Dynamic Instrumentation', function () {
             const duration = timestamp - _state.prev
             clearTimeout(_state.timer)
 
-            // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
-            // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
-            // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
-            // sides of the expected 1000ms gap.
+            // Snapshot timestamps use wall-clock time while sampling uses monotonic time, so allow 75ms for drift.
             assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
             assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
 

--- a/integration-tests/debugger/snapshot-global-sample-rate.spec.js
+++ b/integration-tests/debugger/snapshot-global-sample-rate.spec.js
@@ -13,7 +13,8 @@ describe('Dynamic Instrumentation', function () {
     describe('with snapshot', function () {
       beforeEach(() => { t.triggerBreakpoint() })
 
-      it('should respect global max snapshot sampling rate', () => new Promise((resolve, reject) => {
+      // The existing guard prevents teardown errors from completing the test after sampling has finished.
+      it('should respect global max snapshot sampling rate', function (_done) {
         const MAX_SNAPSHOTS_PER_SECOND_GLOBALLY = 25
         const snapshotsPerSecond = MAX_SNAPSHOTS_PER_SECOND_GLOBALLY * 2
         const probeConf = { captureSnapshot: true, sampling: { snapshotsPerSecond } }
@@ -29,13 +30,13 @@ describe('Dynamic Instrumentation', function () {
         const state = {
           [rcConfig1.config.id]: {
             triggerBreakpointContinuously () {
-              t.axios.get(t.breakpoints[0].url).catch(finish)
+              t.axios.get(t.breakpoints[0].url).catch(done)
               this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             },
           },
           [rcConfig2.config.id]: {
             triggerBreakpointContinuously () {
-              t.axios.get(t.breakpoints[1].url).catch(finish)
+              t.axios.get(t.breakpoints[1].url).catch(done)
               this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             },
           },
@@ -73,7 +74,7 @@ describe('Dynamic Instrumentation', function () {
               clearTimeout(state[rcConfig1.config.id].timer)
               clearTimeout(state[rcConfig2.config.id].timer)
 
-              finish()
+              done()
             }
           })
         })
@@ -81,16 +82,12 @@ describe('Dynamic Instrumentation', function () {
         t.agent.addRemoteConfig(rcConfig1)
         t.agent.addRemoteConfig(rcConfig2)
 
-        function finish (error) {
+        function done (error) {
           if (isDone) return
           isDone = true
-          if (error) {
-            reject(error)
-          } else {
-            resolve()
-          }
+          _done(error)
         }
-      }))
+      })
     })
   })
 })

--- a/integration-tests/debugger/snapshot-global-sample-rate.spec.js
+++ b/integration-tests/debugger/snapshot-global-sample-rate.spec.js
@@ -13,7 +13,6 @@ describe('Dynamic Instrumentation', function () {
     describe('with snapshot', function () {
       beforeEach(() => { t.triggerBreakpoint() })
 
-      // The existing guard prevents teardown errors from completing the test after sampling has finished.
       it('should respect global max snapshot sampling rate', function (_done) {
         const MAX_SNAPSHOTS_PER_SECOND_GLOBALLY = 25
         const snapshotsPerSecond = MAX_SNAPSHOTS_PER_SECOND_GLOBALLY * 2

--- a/integration-tests/debugger/snapshot-global-sample-rate.spec.js
+++ b/integration-tests/debugger/snapshot-global-sample-rate.spec.js
@@ -13,7 +13,7 @@ describe('Dynamic Instrumentation', function () {
     describe('with snapshot', function () {
       beforeEach(() => { t.triggerBreakpoint() })
 
-      it('should respect global max snapshot sampling rate', function (_done) {
+      it('should respect global max snapshot sampling rate', () => new Promise((resolve, reject) => {
         const MAX_SNAPSHOTS_PER_SECOND_GLOBALLY = 25
         const snapshotsPerSecond = MAX_SNAPSHOTS_PER_SECOND_GLOBALLY * 2
         const probeConf = { captureSnapshot: true, sampling: { snapshotsPerSecond } }
@@ -29,13 +29,13 @@ describe('Dynamic Instrumentation', function () {
         const state = {
           [rcConfig1.config.id]: {
             triggerBreakpointContinuously () {
-              t.axios.get(t.breakpoints[0].url).catch(done)
+              t.axios.get(t.breakpoints[0].url).catch(finish)
               this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             },
           },
           [rcConfig2.config.id]: {
             triggerBreakpointContinuously () {
-              t.axios.get(t.breakpoints[1].url).catch(done)
+              t.axios.get(t.breakpoints[1].url).catch(finish)
               this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             },
           },
@@ -73,7 +73,7 @@ describe('Dynamic Instrumentation', function () {
               clearTimeout(state[rcConfig1.config.id].timer)
               clearTimeout(state[rcConfig2.config.id].timer)
 
-              done()
+              finish()
             }
           })
         })
@@ -81,12 +81,16 @@ describe('Dynamic Instrumentation', function () {
         t.agent.addRemoteConfig(rcConfig1)
         t.agent.addRemoteConfig(rcConfig2)
 
-        function done (err) {
+        function finish (error) {
           if (isDone) return
           isDone = true
-          _done(err)
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
         }
-      })
+      }))
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Returns debugger runtime completion through promises.

### Motivation

Requests, timers, and child startup used callback completion, so failures could escape Mocha's completion path.