### PR TITLE
test(plugins): consolidate lifecycle hooks

### DIFF
--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -84,11 +84,10 @@ describe('Plugin', () => {
         let server
         let port
 
-        before(() => agent.load('apollo'))
-        before(() => setupFixtures())
-        before(() => setupApollo(version))
-
-        before(() => {
+        before(async () => {
+          await agent.load('apollo')
+          await setupFixtures()
+          await setupApollo(version)
           ApolloServer = require('../../../versions/@apollo/server/index.js').get().ApolloServer
           startStandaloneServer =
             require('../../../versions/@apollo/server@4.0.0/node_modules/@apollo/server/dist/cjs/standalone/index.js')
@@ -99,11 +98,10 @@ describe('Plugin', () => {
             subscriptions: false, // Disable subscriptions (not supported with Apollo Gateway)
           })
 
-          return startStandaloneServer(server, {
+          const { url } = await startStandaloneServer(server, {
             listen: { port: 0 },
-          }).then(({ url }) => {
-            port = new URL(url).port
           })
+          port = new URL(url).port
         })
 
         after(() => {
@@ -139,9 +137,11 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load('apollo'))
-        before(() => setupFixtures())
-        before(() => setupApollo(version))
+        before(async () => {
+          await agent.load('apollo')
+          await setupFixtures()
+          await setupApollo(version)
+        })
 
         it('should instrument apollo/gateway', done => {
           const operationName = 'MyQuery'
@@ -514,9 +514,11 @@ describe('Plugin', () => {
         )
 
         describe('with configuration', () => {
-          before(() => agent.load('apollo', { service: 'custom', source: true, signature: false }))
-          before(() => setupFixtures())
-          before(() => setupApollo(version))
+          before(async () => {
+            await agent.load('apollo', { service: 'custom', source: true, signature: false })
+            await setupFixtures()
+            await setupApollo(version)
+          })
 
           it('should be configured with the correct values', done => {
             const operationName = 'MyQuery'
@@ -566,9 +568,11 @@ describe('Plugin', () => {
             },
           }
 
-          before(() => agent.load('apollo', config))
-          before(() => setupFixtures())
-          before(() => setupApollo(version))
+          before(async () => {
+            await agent.load('apollo', config)
+            await setupFixtures()
+            await setupApollo(version)
+          })
 
           afterEach(() => Object.keys(config.hooks).forEach(
             key => config.hooks[key].resetHistory()

--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -58,13 +58,18 @@ describe('Plugin', () => {
 
       describe('server', () => {
         describe('without configuration', () => {
-          before(() => agent.load('moleculer', { client: false }))
+          before(async () => {
+            await agent.load('moleculer', { client: false })
+            await startBroker()
+          })
 
-          before(() => startBroker())
-
-          after(() => broker.stop())
-
-          after(() => agent.close())
+          after(async () => {
+            try {
+              await broker.stop()
+            } finally {
+              await agent.close()
+            }
+          })
 
           it('should do automatic instrumentation', done => {
             agent.assertSomeTraces(traces => {
@@ -113,18 +118,23 @@ describe('Plugin', () => {
         })
 
         describe('with configuration', () => {
-          before(() => agent.load('moleculer', {
-            client: false,
-            server: { service: 'custom' },
-            params: true,
-            meta: true,
-          }))
+          before(async () => {
+            await agent.load('moleculer', {
+              client: false,
+              server: { service: 'custom' },
+              params: true,
+              meta: true,
+            })
+            await startBroker()
+          })
 
-          before(() => startBroker())
-
-          after(() => broker.stop())
-
-          after(() => agent.close())
+          after(async () => {
+            try {
+              await broker.stop()
+            } finally {
+              await agent.close()
+            }
+          })
 
           it('should have the configured service name', done => {
             agent.assertSomeTraces(traces => {
@@ -155,18 +165,19 @@ describe('Plugin', () => {
           const hostname = os.hostname()
           let tracer
 
-          beforeEach(() => startBroker())
-
-          afterEach(() => broker.stop())
-
-          beforeEach(done => {
-            agent.load('moleculer', { server: false })
-              .then(() => { tracer = require('../../dd-trace') })
-              .then(done)
-              .catch(done)
+          beforeEach(async () => {
+            await startBroker()
+            await agent.load('moleculer', { server: false })
+            tracer = require('../../dd-trace')
           })
 
-          afterEach(() => agent.close())
+          afterEach(async () => {
+            try {
+              await broker.stop()
+            } finally {
+              await agent.close()
+            }
+          })
 
           withPeerService(
             () => tracer,
@@ -240,18 +251,23 @@ describe('Plugin', () => {
         })
 
         describe('with configuration', () => {
-          before(() => agent.load('moleculer', {
-            client: { service: 'custom' },
-            server: false,
-            params: true,
-            meta: true,
-          }))
+          before(async () => {
+            await agent.load('moleculer', {
+              client: { service: 'custom' },
+              server: false,
+              params: true,
+              meta: true,
+            })
+            await startBroker()
+          })
 
-          before(() => startBroker())
-
-          after(() => broker.stop())
-
-          after(() => agent.close())
+          after(async () => {
+            try {
+              await broker.stop()
+            } finally {
+              await agent.close()
+            }
+          })
 
           it('should have the configured service name', done => {
             agent.assertSomeTraces(traces => {
@@ -278,13 +294,18 @@ describe('Plugin', () => {
       })
 
       describe('client + server (local)', () => {
-        before(() => agent.load('moleculer'))
+        before(async () => {
+          await agent.load('moleculer')
+          await startBroker()
+        })
 
-        before(() => startBroker())
-
-        after(() => broker.stop())
-
-        after(() => agent.close())
+        after(async () => {
+          try {
+            await broker.stop()
+          } finally {
+            await agent.close()
+          }
+        })
 
         it('should propagate context', async () => {
           let spanId
@@ -320,11 +341,9 @@ describe('Plugin', () => {
       describe('client + server (remote)', () => {
         let clientBroker
 
-        before(() => agent.load('moleculer'))
-
-        before(() => startBroker())
-
-        before(function () {
+        before(async function () {
+          await agent.load('moleculer')
+          await startBroker()
           const waitTimeout = 10000
           this.timeout(waitTimeout) // wait for discovery
           const { ServiceBroker } = require(`../../../versions/moleculer@${version}`).get()
@@ -344,15 +363,21 @@ describe('Plugin', () => {
             },
           })
 
-          return clientBroker.start()
-            .then(() => clientBroker.waitForServices('math', waitTimeout))
+          await clientBroker.start()
+          await clientBroker.waitForServices('math', waitTimeout)
         })
 
-        after(() => clientBroker.stop())
-
-        after(() => broker.stop())
-
-        after(() => agent.close())
+        after(async () => {
+          try {
+            await clientBroker.stop()
+          } finally {
+            try {
+              await broker.stop()
+            } finally {
+              await agent.close()
+            }
+          }
+        })
 
         it('should propagate context', async () => {
           let spanId
@@ -385,11 +410,10 @@ describe('Plugin', () => {
         })
       })
       describe('meta propagation', () => {
-        before(() => agent.load('moleculer', {
-          meta: true,
-        }))
-
         before(async () => {
+          await agent.load('moleculer', {
+            meta: true,
+          })
           const { ServiceBroker } = require(`../../../versions/moleculer@${version}`).get()
           broker = new ServiceBroker({
             nodeID: `server-${process.pid}`,
@@ -413,12 +437,16 @@ describe('Plugin', () => {
             },
           })
 
-          return broker.start()
+          await broker.start()
         })
 
-        after(() => broker.stop())
-
-        after(() => agent.close())
+        after(async () => {
+          try {
+            await broker.stop()
+          } finally {
+            await agent.close()
+          }
+        })
 
         it('should propagate meta from child to parent', async () => {
           const result = await broker.call('test.first')


### PR DESCRIPTION
### What does this PR do?

Runs each plugin fixture lifecycle through one ordered setup and teardown hook.

### Motivation

Separate same-phase hooks made fixture startup and cleanup depend on Mocha's registration sequence.