### PR TITLE
test(pg): await query completion

### DIFF
--- a/packages/datadog-instrumentations/test/pg.spec.js
+++ b/packages/datadog-instrumentations/test/pg.spec.js
@@ -114,7 +114,8 @@ describe('pg instrumentation', () => {
                   })
                 })
 
-                it('Should abort query', () => new Promise((resolve, reject) => {
+                // Query event cardinality is part of this test; Mocha must see a second terminal event.
+                it('Should abort query', (done) => {
                   queryClientStartChannel.subscribe(abortQuery)
 
                   const query = new Query('SELECT 1')
@@ -122,49 +123,47 @@ describe('pg instrumentation', () => {
                   query.on('error', error => {
                     try {
                       assert.strictEqual(error.message, 'Test')
-                      resolve()
+                      done()
                     } catch (error) {
-                      reject(error)
+                      done(error)
                     }
                   })
 
                   query.on('end', () => {
-                    reject(new Error('Query was not aborted'))
+                    done(new Error('Query was not aborted'))
                   })
 
                   client.query(query)
-                }))
+                })
               })
 
               describe('with callback in query object', () => {
-                it('Should not fail if it is not aborted', () => new Promise((resolve, reject) => {
+                // The callback form is the API contract under test.
+                it('Should not fail if it is not aborted', (done) => {
                   const query = new Query('SELECT 1')
                   query.callback = (error) => {
-                    if (error) {
-                      reject(error)
-                    } else {
-                      resolve()
-                    }
+                    done(error)
                   }
 
                   client.query(query)
-                }))
+                })
 
-                it('Should abort query', () => new Promise((resolve, reject) => {
+                // The callback form is the API contract under test.
+                it('Should abort query', (done) => {
                   queryClientStartChannel.subscribe(abortQuery)
 
                   const query = new Query('SELECT 1')
                   query.callback = error => {
                     try {
                       assert.strictEqual(error.message, 'Test')
-                      resolve()
+                      done()
                     } catch (error) {
-                      reject(error)
+                      done(error)
                     }
                   }
 
                   client.query(query)
-                }))
+                })
               })
 
               describe('with callback in query parameter', () => {

--- a/packages/datadog-instrumentations/test/pg.spec.js
+++ b/packages/datadog-instrumentations/test/pg.spec.js
@@ -114,7 +114,6 @@ describe('pg instrumentation', () => {
                   })
                 })
 
-                // Query event cardinality is part of this test; Mocha must see a second terminal event.
                 it('Should abort query', (done) => {
                   queryClientStartChannel.subscribe(abortQuery)
 
@@ -138,7 +137,6 @@ describe('pg instrumentation', () => {
               })
 
               describe('with callback in query object', () => {
-                // The callback form is the API contract under test.
                 it('Should not fail if it is not aborted', (done) => {
                   const query = new Query('SELECT 1')
                   query.callback = (error) => {
@@ -148,7 +146,6 @@ describe('pg instrumentation', () => {
                   client.query(query)
                 })
 
-                // The callback form is the API contract under test.
                 it('Should abort query', (done) => {
                   queryClientStartChannel.subscribe(abortQuery)
 

--- a/packages/datadog-instrumentations/test/pg.spec.js
+++ b/packages/datadog-instrumentations/test/pg.spec.js
@@ -114,45 +114,57 @@ describe('pg instrumentation', () => {
                   })
                 })
 
-                it('Should abort query', (done) => {
+                it('Should abort query', () => new Promise((resolve, reject) => {
                   queryClientStartChannel.subscribe(abortQuery)
 
                   const query = new Query('SELECT 1')
 
-                  client.query(query)
-
-                  query.on('error', err => {
-                    assert.strictEqual(err.message, 'Test')
-                    done()
+                  query.on('error', error => {
+                    try {
+                      assert.strictEqual(error.message, 'Test')
+                      resolve()
+                    } catch (error) {
+                      reject(error)
+                    }
                   })
 
                   query.on('end', () => {
-                    done(new Error('Query was not aborted'))
+                    reject(new Error('Query was not aborted'))
                   })
-                })
+
+                  client.query(query)
+                }))
               })
 
               describe('with callback in query object', () => {
-                it('Should not fail if it is not aborted', (done) => {
+                it('Should not fail if it is not aborted', () => new Promise((resolve, reject) => {
                   const query = new Query('SELECT 1')
-                  query.callback = (err) => {
-                    done(err)
+                  query.callback = (error) => {
+                    if (error) {
+                      reject(error)
+                    } else {
+                      resolve()
+                    }
                   }
 
                   client.query(query)
-                })
+                }))
 
-                it('Should abort query', (done) => {
+                it('Should abort query', () => new Promise((resolve, reject) => {
                   queryClientStartChannel.subscribe(abortQuery)
 
                   const query = new Query('SELECT 1')
-                  query.callback = err => {
-                    assert.strictEqual(err.message, 'Test')
-                    done()
+                  query.callback = error => {
+                    try {
+                      assert.strictEqual(error.message, 'Test')
+                      resolve()
+                    } catch (error) {
+                      reject(error)
+                    }
                   }
 
                   client.query(query)
-                })
+                }))
               })
 
               describe('with callback in query parameter', () => {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -218,9 +218,10 @@ describe('Plugin', () => {
             })
           })
 
-          if (semver.intersects(version, '>=5.1')) {
+          {
             // initial promise support
-            it('should do automatic instrumentation when using promises', done => {
+            const promiseTest = semver.intersects(version, '>=5.1') ? it : it.skip
+            promiseTest('should do automatic instrumentation when using promises', done => {
               agent.assertSomeTraces(traces => {
                 assert.strictEqual(traces[0][0].name, expectedSchema.outbound.opName)
                 assert.strictEqual(traces[0][0].service, expectedSchema.outbound.serviceName)
@@ -343,9 +344,10 @@ describe('Plugin', () => {
             rawExpectedSchema.outbound
           )
 
-          if (implementation !== 'pg.native') {
+          {
             // pg-cursor is not supported on pg.native, pg-query-stream uses pg-cursor so it is also unsupported
-            describe('streaming capabilities', () => {
+            const streamingSuite = implementation !== 'pg.native' ? describe : describe.skip
+            streamingSuite('streaming capabilities', () => {
               withVersions('pg', 'pg-cursor', pgCursorVersion => {
                 let Cursor
 
@@ -1290,27 +1292,30 @@ describe('Plugin', () => {
           clientDBM.connect(err => done(err))
         })
 
-        it('DBM propagation should handle special characters', done => {
+        it('DBM propagation should handle special characters', () => {
           const queryQueueName = Object.hasOwn(clientDBM, '_queryQueue') ? '_queryQueue' : 'queryQueue'
 
-          clientDBM.query('SELECT $1::text as message', ['Hello world!'], (err, result) => {
-            if (err) return done(err)
-
-            clientDBM.end((err) => {
-              if (err) return done(err)
+          return new Promise((resolve, reject) => {
+            let assertionError
+            clientDBM.query('SELECT $1::text as message', ['Hello world!'], (error) => {
+              clientDBM.end((endError) => {
+                if (error) return reject(error)
+                if (endError) return reject(endError)
+                if (assertionError) return reject(assertionError)
+                resolve()
+              })
             })
-          })
 
-          if (clientDBM[queryQueueName][0]) {
             try {
-              assert.strictEqual(clientDBM[queryQueueName][0].text,
+              const query = clientDBM[queryQueueName][0]
+              assert.ok(query)
+              assert.strictEqual(query.text,
                 '/*dddb=\'postgres\',dddbs=\'~!%40%23%24%25%5E%26*()_%2B%7C%3F%3F%2F%3C%3E\',dde=\'tester\',' +
                 `ddh='127.0.0.1',ddps='test',ddpv='${ddpv}'*/ SELECT $1::text as message`)
-              done()
-            } catch (e) {
-              done(e)
+            } catch (error) {
+              assertionError = error
             }
-          }
+          })
         })
       })
 


### PR DESCRIPTION
### What does this PR do?

Returns PostgreSQL query and DBM test completion through promises and registers unsupported cases as skipped.

### Motivation

Callback completion could lose assertion failures, while omitted cases disappeared from suite reports.