### PR TITLE
chore: ignore Superpowers docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ build
 prebuilds
 prebuilds.*
 docs/test.js
+docs/superpowers/
 dist
 acmeair-nodejs
 !packages/*/test/**/dist


### PR DESCRIPTION
### What does this PR do?

Ignores the generated `docs/superpowers/` directory.

### Motivation

Prevent local Superpowers documentation output from appearing as untracked changes.

### Additional Notes

Generated by Codex.

Tests: `git diff --check`.