### PR TITLE
feat(crashtracking): support agentless intake

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -632,7 +632,6 @@ class Config extends ConfigBase {
       setAndTrack(this, 'runtimeMetrics.enabled', false)
       setAndTrack(this, 'dsmEnabled', false)
       setAndTrack(this, 'dynamicInstrumentation.enabled', true)
-      setAndTrack(this, 'DD_CRASHTRACKING_ENABLED', false)
     }
 
     const agentlessTracingEnabled = this.DD_AGENTLESS_ENABLED ||

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -10,6 +10,38 @@ const log = require('../log')
 const pkg = require('../../../../package.json')
 const processTags = require('../process-tags')
 
+const TELEMETRY_INTAKE_SUBDOMAIN = 'instrumentation-telemetry-intake'
+
+/**
+ * Builds the minimal receiver environment libdatadog needs to select its two direct crash
+ * destinations independently: instrumentation telemetry and Errors Tracking intake.
+ *
+ * @param {import('../config/config-base')} config - Tracer configuration
+ * @returns {Array<[string, string]>}
+ */
+function getAgentlessReceiverEnvironment (config) {
+  if (!config.DD_API_KEY) {
+    throw new Error('DD_API_KEY is required for agentless crash tracking')
+  }
+
+  const site = config.site.toLowerCase()
+  const telemetryHostname = `${TELEMETRY_INTAKE_SUBDOMAIN}.${site}`
+  const telemetryUrl = new URL(`https://${telemetryHostname}`)
+  if (telemetryUrl.hostname !== telemetryHostname || telemetryUrl.origin !== `https://${telemetryHostname}`) {
+    throw new Error(`Invalid DD_SITE for agentless crash tracking: ${config.site}`)
+  }
+
+  // libdatadog's telemetry config currently derives its host from DD_TRACE_AGENT_URL even in direct
+  // mode. This override is scoped to the crash receiver; Errors Tracking still derives its own host
+  // from DD_SITE.
+  return [
+    ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
+    ['DD_API_KEY', config.DD_API_KEY],
+    ['DD_SITE', site],
+    ['DD_TRACE_AGENT_URL', telemetryUrl.origin],
+  ]
+}
+
 class Crashtracker {
   #started = false
 
@@ -33,7 +65,7 @@ class Crashtracker {
     try {
       binding.init(
         this.#getConfig(config),
-        this.#getReceiverConfig(),
+        this.#getReceiverConfig(config),
         this.#getMetadata(config)
       )
       this.#started = true
@@ -67,7 +99,21 @@ class Crashtracker {
    * @param {import('../config/config-base')} config - Tracer configuration
    */
   #getConfig (config) {
-    const url = config.url
+    let endpoint = null
+    if (!config.DD_AGENTLESS_ENABLED) {
+      const url = config.url
+      endpoint = {
+        // TODO: Use the string directly when deserialization is fixed.
+        url: {
+          scheme: url.protocol.slice(0, -1),
+          authority: url.protocol === 'unix:'
+            ? Buffer.from(url.pathname).toString('hex')
+            : url.host,
+          path_and_query: '',
+        },
+        timeout_ms: 3000,
+      }
+    }
 
     // Out-of-process symbolication currently works on
     // Linux only, does not work on Mac.
@@ -80,17 +126,7 @@ class Crashtracker {
       collect_all_threads: true,
       create_alt_stack: true,
       use_alt_stack: true,
-      endpoint: {
-        // TODO: Use the string directly when deserialization is fixed.
-        url: {
-          scheme: url.protocol.slice(0, -1),
-          authority: url.protocol === 'unix:'
-            ? Buffer.from(url.pathname).toString('hex')
-            : url.host,
-          path_and_query: '',
-        },
-        timeout_ms: 3000,
-      },
+      endpoint,
       timeout: { secs: 5, nanos: 0 },
       demangle_names: true,
       signals: [],
@@ -124,10 +160,20 @@ class Crashtracker {
     }
   }
 
-  #getReceiverConfig () {
+  /**
+   * @param {import('../config/config-base')} config - Tracer configuration
+   * @returns {{
+   *   args: string[],
+   *   env: Array<[string, string]>,
+   *   path_to_receiver_binary: string,
+   *   stderr_filename: null,
+   *   stdout_filename: null
+   * }}
+   */
+  #getReceiverConfig (config) {
     return {
       args: [],
-      env: [],
+      env: config.DD_AGENTLESS_ENABLED ? getAgentlessReceiverEnvironment(config) : [],
       path_to_receiver_binary: libdatadog.find('crashtracker-receiver', true),
       stderr_filename: null,
       stdout_filename: null,

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -5107,7 +5107,7 @@ rules:
       assert.strictEqual(config.runtimeMetrics.enabled, false)
       assert.strictEqual(config.dsmEnabled, false)
       assert.strictEqual(config.dynamicInstrumentation.enabled, true)
-      assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, false)
+      assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, true)
       assert.deepStrictEqual(config.DD_PROFILING_EXPORTERS, ['agent'])
       assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'true')
     })

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -28,6 +28,7 @@ describeNotWindows('crashtracker', () => {
 
     config = {
       url: new URL('http://127.0.0.1:7357'),
+      DD_AGENTLESS_ENABLED: false,
       tags: {
         foo: 'bar',
       },
@@ -107,6 +108,49 @@ describeNotWindows('crashtracker', () => {
 
       sinon.assert.called(binding.init)
       sinon.assert.notCalled(log.error)
+    })
+
+    it('should configure independent direct intakes in agentless mode', () => {
+      config.DD_AGENTLESS_ENABLED = true
+      config.DD_API_KEY = 'test-api-key'
+      config.site = 'US3.DatadogHQ.com'
+
+      crashtracker.start(config)
+
+      sinon.assert.calledOnce(binding.init)
+      assert.strictEqual(binding.init.firstCall.args[0].endpoint, null)
+      assert.deepStrictEqual(binding.init.firstCall.args[1].env, [
+        ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
+        ['DD_API_KEY', 'test-api-key'],
+        ['DD_SITE', 'us3.datadoghq.com'],
+        ['DD_TRACE_AGENT_URL', 'https://instrumentation-telemetry-intake.us3.datadoghq.com'],
+      ])
+      sinon.assert.notCalled(log.error)
+    })
+
+    it('should not initialize agentless crash tracking without an API key', () => {
+      config.DD_AGENTLESS_ENABLED = true
+      config.site = 'datadoghq.com'
+
+      crashtracker.start(config)
+
+      sinon.assert.notCalled(binding.init)
+      sinon.assert.calledOnce(log.error)
+      assert.match(log.error.firstCall.args[1].message, /DD_API_KEY is required/)
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
+    })
+
+    it('should reject an agentless site that could redirect the API key', () => {
+      config.DD_AGENTLESS_ENABLED = true
+      config.DD_API_KEY = 'test-api-key'
+      config.site = 'datadoghq.com@evil.example'
+
+      crashtracker.start(config)
+
+      sinon.assert.notCalled(binding.init)
+      sinon.assert.calledOnce(log.error)
+      assert.match(log.error.firstCall.args[1].message, /Invalid DD_SITE/)
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Adds direct crash-tracking uploads to agentless mode through the existing
libdatadog crash-tracker binding. The native receiver sends telemetry and crash
reports to their Datadog intakes using `DD_API_KEY` and `DD_SITE`.

Agent-mode crash tracking remains unchanged.

### Motivation

Keep crash tracking available without a local Datadog Agent by configuring the
native receiver's existing direct-submission support.

### Additional Notes

- Requires `DD_API_KEY` in agentless mode.
- Validates and normalizes `DD_SITE` before constructing the direct telemetry
  destination.
- Stacked on [#9883](https://github.com/DataDog/dd-trace-js/pull/9883).

*Generated by Codex.*

### Validation

- Targeted crash-tracking and configuration tests passed.
- Targeted stack tests and ESLint passed.
