### PR TITLE
feat(metrics): support agentless intake

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -325,6 +325,8 @@
 /packages/dd-trace/test/custom-metrics-app.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/fixtures/config/span-sampling-rules.json @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/helpers/config.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/agentless-metrics.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/agentless-metrics.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/runtime_metrics/ @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/runtime_metrics.spec.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/startup-log.js @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js

--- a/integration-tests/openfeature/openfeature-exposure-events.spec.js
+++ b/integration-tests/openfeature/openfeature-exposure-events.spec.js
@@ -61,7 +61,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
             DD_TRACE_AGENT_PORT: agent.port,
             DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
             DD_FEATURE_FLAGS_ENABLED: 'true',
-            // Preserve the existing RC exposure path until agentless emission is supported.
+            // Use Remote Config so this Agent-mode test can deliver the fixture.
             DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'remote_config',
           },
         })

--- a/packages/dd-trace/src/agentless-metrics.js
+++ b/packages/dd-trace/src/agentless-metrics.js
@@ -1,0 +1,224 @@
+'use strict'
+
+const os = require('node:os')
+
+const request = require('./exporters/common/request')
+const log = require('./log')
+
+const SERIES_PATH = '/api/v1/series'
+const DISTRIBUTIONS_PATH = '/api/v1/distribution_points'
+const SITE_PATTERN = /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/i
+
+/**
+ * Sends the metrics produced by the existing DogStatsD-compatible API directly
+ * to Datadog without requiring a local Agent.
+ */
+class AgentlessMetricsClient {
+  #apiKey
+  #apiKeyMissingLogged = false
+  #distributions = new Map()
+  #hostname
+  #origin
+  #series = []
+  #tags
+
+  /**
+   * @param {object} options - Agentless metrics options.
+   * @param {string} [options.apiKey] - Datadog API key.
+   * @param {boolean} [options.reportHostname] - Whether to associate the host with metrics.
+   * @param {string} [options.site] - Datadog site.
+   * @param {string[]} [options.tags] - Tags applied to every metric.
+   */
+  constructor ({ apiKey, reportHostname, site = 'datadoghq.com', tags = [] }) {
+    this.#apiKey = apiKey
+    this.#hostname = reportHostname ? os.hostname() : undefined
+    this.#tags = tags
+
+    if (SITE_PATTERN.test(site)) {
+      this.#origin = `https://api.${site}`
+    } else {
+      log.error('Invalid DD_SITE for agentless metrics: %s. Metrics will not be sent.', site)
+    }
+  }
+
+  /**
+   * Records a counter increment.
+   *
+   * @param {string} stat - Metric name.
+   * @param {number} value - Value to add.
+   * @param {string[]} [tags] - Metric tags.
+   * @returns {void}
+   */
+  increment (stat, value, tags) {
+    this.#addSeries(stat, value, 'count', tags)
+  }
+
+  /**
+   * Records a counter decrement.
+   *
+   * @param {string} stat - Metric name.
+   * @param {number} value - Value to subtract.
+   * @param {string[]} [tags] - Metric tags.
+   * @returns {void}
+   */
+  decrement (stat, value, tags) {
+    this.#addSeries(stat, -value, 'count', tags)
+  }
+
+  /**
+   * Records a gauge value.
+   *
+   * @param {string} stat - Metric name.
+   * @param {number} value - Gauge value.
+   * @param {string[]} [tags] - Metric tags.
+   * @returns {void}
+   */
+  gauge (stat, value, tags) {
+    this.#addSeries(stat, value, 'gauge', tags)
+  }
+
+  /**
+   * Records a distribution value.
+   *
+   * @param {string} stat - Metric name.
+   * @param {number} value - Distribution value.
+   * @param {string[]} [tags] - Metric tags.
+   * @returns {void}
+   */
+  distribution (stat, value, tags) {
+    const allTags = this.#getTags(tags)
+    const key = JSON.stringify([stat, allTags])
+    let distribution = this.#distributions.get(key)
+
+    if (distribution === undefined) {
+      distribution = { metric: stat, values: [], tags: allTags }
+      this.#distributions.set(key, distribution)
+    }
+
+    distribution.values.push(value)
+  }
+
+  /**
+   * Records a histogram value as a distribution.
+   *
+   * @param {string} stat - Metric name.
+   * @param {number} value - Histogram value.
+   * @param {string[]} [tags] - Metric tags.
+   * @returns {void}
+   */
+  histogram (stat, value, tags) {
+    this.distribution(stat, value, tags)
+  }
+
+  /**
+   * Flushes all buffered metrics to the direct intake endpoints.
+   *
+   * @returns {void}
+   */
+  flush () {
+    if (this.#series.length === 0 && this.#distributions.size === 0) return
+
+    const series = this.#series
+    const distributions = this.#distributions
+    this.#series = []
+    this.#distributions = new Map()
+
+    if (!this.#apiKey) {
+      if (!this.#apiKeyMissingLogged) {
+        this.#apiKeyMissingLogged = true
+        log.error('DD_API_KEY is required for agentless metrics. Metrics will not be sent.')
+      }
+      return
+    }
+
+    if (!this.#origin) return
+
+    const timestamp = Math.floor(Date.now() / 1000)
+
+    if (series.length > 0) {
+      for (const metric of series) {
+        metric.points = [[timestamp, metric.value]]
+        delete metric.value
+        if (this.#hostname) metric.host = this.#hostname
+      }
+      this.#send(SERIES_PATH, { series }, 'metrics')
+    }
+
+    if (distributions.size > 0) {
+      const distributionSeries = []
+      for (const distribution of distributions.values()) {
+        const metric = {
+          metric: distribution.metric,
+          points: [[timestamp, distribution.values]],
+          tags: distribution.tags,
+          type: 'distribution',
+        }
+        if (this.#hostname) metric.host = this.#hostname
+        distributionSeries.push(metric)
+      }
+      this.#send(DISTRIBUTIONS_PATH, { series: distributionSeries }, 'metric distributions')
+    }
+  }
+
+  /**
+   * Buffers a time-series metric.
+   *
+   * @param {string} stat - Metric name.
+   * @param {number} value - Metric value.
+   * @param {'count'|'gauge'} type - Datadog metric type.
+   * @param {string[]} [tags] - Metric tags.
+   * @returns {void}
+   */
+  #addSeries (stat, value, type, tags) {
+    this.#series.push({
+      metric: stat,
+      value,
+      tags: this.#getTags(tags),
+      type,
+    })
+  }
+
+  /**
+   * Combines global and per-metric tags without modifying either input.
+   *
+   * @param {string[]} [tags] - Per-metric tags.
+   * @returns {string[]} Combined tags.
+   */
+  #getTags (tags) {
+    if (!tags?.length) return this.#tags
+    if (this.#tags.length === 0) return tags
+    return [...this.#tags, ...tags]
+  }
+
+  /**
+   * Sends one JSON payload to a Datadog metrics endpoint.
+   *
+   * @param {string} path - Intake path.
+   * @param {object} payload - Metrics payload.
+   * @param {string} kind - Payload kind used in error messages.
+   * @returns {void}
+   */
+  #send (path, payload, kind) {
+    let body
+    try {
+      body = JSON.stringify(payload)
+    } catch (error) {
+      log.error('Failed to encode agentless %s: %s', kind, error.message)
+      return
+    }
+
+    request(body, {
+      method: 'POST',
+      url: this.#origin,
+      path,
+      headers: {
+        'Content-Type': 'application/json',
+        'DD-API-KEY': this.#apiKey,
+      },
+    }, error => {
+      if (error) log.error('Failed to send agentless %s: %s', kind, error.message)
+    })
+  }
+}
+
+module.exports = AgentlessMetricsClient

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -633,12 +633,6 @@ class Config extends ConfigBase {
       setAndTrack(this, 'dsmEnabled', false)
       setAndTrack(this, 'dynamicInstrumentation.enabled', true)
       setAndTrack(this, 'DD_CRASHTRACKING_ENABLED', false)
-
-      const profilingExporters = this.DD_PROFILING_EXPORTERS.filter(exporter => exporter !== 'agent')
-      setAndTrack(this, 'DD_PROFILING_EXPORTERS', profilingExporters)
-      if (profilingExporters.length === 0) {
-        setAndTrack(this, 'profiling.DD_PROFILING_ENABLED', 'false')
-      }
     }
 
     const agentlessTracingEnabled = this.DD_AGENTLESS_ENABLED ||

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -632,7 +632,6 @@ class Config extends ConfigBase {
       setAndTrack(this, 'runtimeMetrics.enabled', false)
       setAndTrack(this, 'dsmEnabled', false)
       setAndTrack(this, 'dynamicInstrumentation.enabled', true)
-      setAndTrack(this, 'DD_CRASHTRACKING_ENABLED', false)
     }
 
     const agentlessTracingEnabled = this.DD_AGENTLESS_ENABLED ||

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -629,9 +629,20 @@ class Config extends ConfigBase {
       setAndTrack(this, 'featureFlags.DD_FEATURE_FLAGS_CONFIGURATION_SOURCE', 'agentless')
 
       setAndTrack(this, 'remoteConfig.DD_REMOTE_CONFIGURATION_ENABLED', false)
-      setAndTrack(this, 'runtimeMetrics.enabled', false)
+      setAndTrack(this, 'runtimeMetrics.enabled', true)
       setAndTrack(this, 'dsmEnabled', false)
       setAndTrack(this, 'dynamicInstrumentation.enabled', true)
+
+      if (!trackedConfigOrigins.has('OTEL_EXPORTER_OTLP_ENDPOINT') &&
+          !trackedConfigOrigins.has('OTEL_EXPORTER_OTLP_METRICS_ENDPOINT')) {
+        setAndTrack(this, 'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT', `https://otlp.${this.site}/v1/metrics`)
+        if (this.DD_API_KEY) {
+          setAndTrack(this, 'OTEL_EXPORTER_OTLP_METRICS_HEADERS', {
+            ...this.OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+            'dd-api-key': this.DD_API_KEY,
+          })
+        }
+      }
     }
 
     const agentlessTracingEnabled = this.DD_AGENTLESS_ENABLED ||

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -10,6 +10,38 @@ const log = require('../log')
 const pkg = require('../../../../package.json')
 const processTags = require('../process-tags')
 
+const TELEMETRY_INTAKE_SUBDOMAIN = 'instrumentation-telemetry-intake'
+
+/**
+ * Builds the minimal receiver environment libdatadog needs to select its two direct crash
+ * destinations independently: instrumentation telemetry and Errors Tracking intake.
+ *
+ * @param {import('../config/config-base')} config - Tracer configuration
+ * @returns {Array<[string, string]>}
+ */
+function getAgentlessReceiverEnvironment (config) {
+  if (!config.DD_API_KEY) {
+    throw new Error('DD_API_KEY is required for agentless crash tracking')
+  }
+
+  const site = config.site.toLowerCase()
+  const telemetryHostname = `${TELEMETRY_INTAKE_SUBDOMAIN}.${site}`
+  const telemetryUrl = new URL(`https://${telemetryHostname}`)
+  if (telemetryUrl.hostname !== telemetryHostname || telemetryUrl.origin !== `https://${telemetryHostname}`) {
+    throw new Error(`Invalid DD_SITE for agentless crash tracking: ${config.site}`)
+  }
+
+  // libdatadog's telemetry config currently derives its host from DD_TRACE_AGENT_URL even in direct
+  // mode. This override is scoped to the crash receiver; Errors Tracking still derives its own host
+  // from DD_SITE.
+  return [
+    ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
+    ['DD_API_KEY', config.DD_API_KEY],
+    ['DD_SITE', site],
+    ['DD_TRACE_AGENT_URL', telemetryUrl.origin],
+  ]
+}
+
 class Crashtracker {
   #started = false
 
@@ -33,7 +65,7 @@ class Crashtracker {
     try {
       binding.init(
         this.#getConfig(config),
-        this.#getReceiverConfig(),
+        this.#getReceiverConfig(config),
         this.#getMetadata(config)
       )
       this.#started = true
@@ -67,7 +99,21 @@ class Crashtracker {
    * @param {import('../config/config-base')} config - Tracer configuration
    */
   #getConfig (config) {
-    const url = config.url
+    let endpoint = null
+    if (!config.DD_AGENTLESS_ENABLED) {
+      const url = config.url
+      endpoint = {
+        // TODO: Use the string directly when deserialization is fixed.
+        url: {
+          scheme: url.protocol.slice(0, -1),
+          authority: url.protocol === 'unix:'
+            ? Buffer.from(url.pathname).toString('hex')
+            : url.host,
+          path_and_query: '',
+        },
+        timeout_ms: 3000,
+      }
+    }
 
     // Out-of-process symbolication currently works on
     // Linux only, does not work on Mac.
@@ -80,17 +126,7 @@ class Crashtracker {
       collect_all_threads: true,
       create_alt_stack: true,
       use_alt_stack: true,
-      endpoint: {
-        // TODO: Use the string directly when deserialization is fixed.
-        url: {
-          scheme: url.protocol.slice(0, -1),
-          authority: url.protocol === 'unix:'
-            ? Buffer.from(url.pathname).toString('hex')
-            : url.host,
-          path_and_query: '',
-        },
-        timeout_ms: 3000,
-      },
+      endpoint,
       timeout: { secs: 5, nanos: 0 },
       demangle_names: true,
       signals: [],
@@ -124,10 +160,20 @@ class Crashtracker {
     }
   }
 
-  #getReceiverConfig () {
+  /**
+   * @param {import('../config/config-base')} config - Tracer configuration
+   * @returns {{
+   *   args: string[],
+   *   env: Array<[string, string]>,
+   *   path_to_receiver_binary: string,
+   *   stderr_filename: null,
+   *   stdout_filename: null
+   * }}
+   */
+  #getReceiverConfig (config) {
     return {
       args: [],
-      env: [],
+      env: config.DD_AGENTLESS_ENABLED ? getAgentlessReceiverEnvironment(config) : [],
       path_to_receiver_binary: libdatadog.find('crashtracker-receiver', true),
       stderr_filename: null,
       stdout_filename: null,

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -231,6 +231,27 @@ class DogStatsDClient {
   }
 }
 
+/**
+ * Creates the low-level metrics transport for the configured export mode.
+ *
+ * @param {import('./config/config-base')} config - Tracer configuration.
+ * @param {ReturnType<typeof DogStatsDClient.generateClientConfig>} [clientConfig] - Generated transport options.
+ * @returns {DogStatsDClient|import('./agentless-metrics')}
+ */
+function createMetricsTransport (config, clientConfig = DogStatsDClient.generateClientConfig(config)) {
+  if (config.DD_AGENTLESS_ENABLED) {
+    const AgentlessMetricsClient = require('./agentless-metrics')
+    return new AgentlessMetricsClient({
+      apiKey: config.DD_API_KEY,
+      reportHostname: config.reportHostname,
+      site: config.site,
+      tags: clientConfig.tags,
+    })
+  }
+
+  return new DogStatsDClient(clientConfig)
+}
+
 class MetricsAggregationClient {
   constructor (client) {
     this._client = client
@@ -387,8 +408,7 @@ class MetricsAggregationClient {
 class CustomMetrics {
   #client
   constructor (config) {
-    const clientConfig = DogStatsDClient.generateClientConfig(config)
-    this.#client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
+    this.#client = new MetricsAggregationClient(createMetricsTransport(config))
 
     const flush = this.flush.bind(this)
 
@@ -446,4 +466,5 @@ module.exports = {
   DogStatsDClient,
   CustomMetrics,
   MetricsAggregationClient,
+  createMetricsTransport,
 }

--- a/packages/dd-trace/src/openfeature/index.js
+++ b/packages/dd-trace/src/openfeature/index.js
@@ -35,8 +35,6 @@ function _handleFlush () {
  * @returns {void}
  */
 function enable (config) {
-  if (config.DD_AGENTLESS_ENABLED) return
-
   if (exposuresWriter) {
     log.warn('%s already enabled', exposuresWriter.constructor.name)
     return

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -140,7 +140,7 @@ class BaseFFEWriter {
   }
 
   /**
-   * Flushes all buffered events to the agent
+   * Flushes all buffered events to the configured destination
    */
   flush () {
     if (this._buffer.length === 0) {

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -188,7 +188,7 @@ class ExposuresWriter extends BaseFFEWriter {
   }
 
   /**
-   * Flushes buffered exposure events to the agent
+   * Flushes buffered exposure events to the configured destination
    */
   flush () {
     if (!this.#enabled) {

--- a/packages/dd-trace/src/profiling/exporter_cli.js
+++ b/packages/dd-trace/src/profiling/exporter_cli.js
@@ -24,8 +24,13 @@ function exporterFromURL (url) {
   const enabled = profilingEnabled === 'auto'
     ? 'auto'
     : ['true', '1'].includes(profilingEnabled) ? 'true' : 'false'
+  const agentlessHostnamePrefix = 'intake.profile.'
+  const agentless = url.protocol === 'https:' && url.hostname.startsWith(agentlessHostnamePrefix)
   return new AgentExporter({
     url,
+    DD_AGENTLESS_ENABLED: agentless,
+    DD_API_KEY: getValueFromEnvSources('DD_API_KEY', true),
+    site: agentless ? url.hostname.slice(agentlessHostnamePrefix.length) : undefined,
     DD_PROFILING_UPLOAD_TIMEOUT: timeoutMs,
     DD_INJECTION_ENABLED: getValueFromEnvSources('DD_INJECTION_ENABLED'),
     profiling: { DD_PROFILING_ENABLED: enabled },

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -16,6 +16,8 @@ const telemetryMetrics = require('../../telemetry/metrics')
 const { EventSerializer } = require('./event_serializer')
 
 const profilersNamespace = telemetryMetrics.manager.namespace('profilers')
+const AGENT_PATH = '/profiling/v1/input'
+const AGENTLESS_PATH = '/api/v2/profile'
 
 const statusCodeCounters = []
 const requestCounter = profilersNamespace.count('profile_api.requests', [])
@@ -113,13 +115,39 @@ function computeRetries (uploadTimeout) {
 }
 
 class AgentExporter extends EventSerializer {
+  #apiKey
   #backoffTime
   #backoffTries
+  #configurationError
+  #path
 
   /** @param {import('./event_serializer').TracerConfig} config */
   constructor (config) {
     super(config)
-    this._url = config.url
+
+    if (config.DD_AGENTLESS_ENABLED) {
+      this.#apiKey = config.DD_API_KEY
+      this.#path = AGENTLESS_PATH
+
+      const site = config.site
+      try {
+        const expectedHostname = `intake.profile.${site.toLowerCase()}`
+        const url = new URL(`https://${expectedHostname}`)
+        if (url.hostname !== expectedHostname || url.origin !== `https://${expectedHostname}`) {
+          throw new Error('site must be a hostname')
+        }
+        this._url = url
+      } catch (error) {
+        this.#configurationError = new Error(`Invalid DD_SITE for agentless profiling: ${site}`, { cause: error })
+      }
+
+      if (!this.#apiKey) {
+        this.#configurationError = new Error('DD_API_KEY is required for agentless profiling')
+      }
+    } else {
+      this._url = config.url
+      this.#path = AGENT_PATH
+    }
 
     const [backoffTries, backoffTime] = computeRetries(config.DD_PROFILING_UPLOAD_TIMEOUT)
 
@@ -132,6 +160,10 @@ class AgentExporter extends EventSerializer {
   }
 
   export (exportSpec) {
+    if (this.#configurationError) {
+      return Promise.reject(this.#configurationError)
+    }
+
     const { profiles } = exportSpec
     const fields = []
 
@@ -174,13 +206,17 @@ class AgentExporter extends EventSerializer {
 
         const options = {
           method: 'POST',
-          path: '/profiling/v1/input',
+          path: this.#path,
           headers: {
             'DD-EVP-ORIGIN': 'dd-trace-js',
             'DD-EVP-ORIGIN-VERSION': version,
             ...form.getHeaders(),
           },
           timeout: this.#backoffTime * 2 ** attempt,
+        }
+
+        if (this.#apiKey) {
+          options.headers['dd-api-key'] = this.#apiKey
         }
 
         docker.inject(options.headers)
@@ -196,7 +232,10 @@ class AgentExporter extends EventSerializer {
 
         // eslint-disable-next-line eslint-rules/eslint-log-printf-style
         log.debug(() => {
-          return `Submitting profiler agent report attempt #${attempt} to: ${JSON.stringify(options)}`
+          const serializedOptions = JSON.stringify(options, (key, value) => {
+            return key === 'dd-api-key' ? '<redacted>' : value
+          })
+          return `Submitting profiler agent report attempt #${attempt} to: ${serializedOptions}`
         })
 
         sendRequest(options, form, (err, response) => {

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -171,7 +171,7 @@ class Tracer extends NoopProxy {
 
       telemetry.start(config, this._pluginManager)
 
-      if (config.dogstatsd && !config.DD_AGENTLESS_ENABLED && !isOfflineTestOptimizationValidation()) {
+      if (config.dogstatsd && !isOfflineTestOptimizationValidation()) {
         // Custom Metrics
         lazyProxy(this, 'dogstatsd', () => require('./dogstatsd').CustomMetrics, config)
       }

--- a/packages/dd-trace/src/runtime_metrics/client.js
+++ b/packages/dd-trace/src/runtime_metrics/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DogStatsDClient, MetricsAggregationClient } = require('../dogstatsd')
+const { DogStatsDClient, MetricsAggregationClient, createMetricsTransport } = require('../dogstatsd')
 const processTags = require('../process-tags')
 
 /**
@@ -24,7 +24,7 @@ function createMetricsClient (config) {
     }
   }
 
-  return new MetricsAggregationClient(new DogStatsDClient(clientConfig))
+  return new MetricsAggregationClient(createMetricsTransport(config, clientConfig))
 }
 
 module.exports = { createMetricsClient }

--- a/packages/dd-trace/test/agentless-metrics.spec.js
+++ b/packages/dd-trace/test/agentless-metrics.spec.js
@@ -1,0 +1,248 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+describe('AgentlessMetricsClient', () => {
+  let AgentlessMetricsClient
+  let clock
+  let log
+  let requests
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers({ now: 1_700_000_000_000 })
+    log = { error: sinon.stub() }
+    requests = []
+
+    AgentlessMetricsClient = proxyquire('../src/agentless-metrics', {
+      './exporters/common/request': (body, options, callback) => {
+        requests.push({ body: JSON.parse(body), options, callback })
+      },
+      './log': log,
+    })
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  function createClient (options = {}) {
+    return new AgentlessMetricsClient({
+      apiKey: 'test-key',
+      reportHostname: false,
+      site: 'us3.datadoghq.com',
+      tags: ['service:web'],
+      ...options,
+    })
+  }
+
+  it('submits counters and gauges to the direct series endpoint', () => {
+    const client = createClient()
+
+    client.increment('requests', 3, ['route:home'])
+    client.decrement('queue.size', 2)
+    client.gauge('memory', 10)
+    client.flush()
+
+    assert.strictEqual(requests.length, 1)
+    assert.deepStrictEqual(requests[0], {
+      body: {
+        series: [
+          {
+            metric: 'requests',
+            points: [[1_700_000_000, 3]],
+            tags: ['service:web', 'route:home'],
+            type: 'count',
+          },
+          {
+            metric: 'queue.size',
+            points: [[1_700_000_000, -2]],
+            tags: ['service:web'],
+            type: 'count',
+          },
+          {
+            metric: 'memory',
+            points: [[1_700_000_000, 10]],
+            tags: ['service:web'],
+            type: 'gauge',
+          },
+        ],
+      },
+      options: {
+        method: 'POST',
+        url: 'https://api.us3.datadoghq.com',
+        path: '/api/v1/series',
+        headers: {
+          'Content-Type': 'application/json',
+          'DD-API-KEY': 'test-key',
+        },
+      },
+      callback: requests[0].callback,
+    })
+  })
+
+  it('groups distributions by metric and tags', () => {
+    const client = createClient()
+
+    client.distribution('latency', 10, ['route:home'])
+    client.distribution('latency', 20, ['route:home'])
+    client.histogram('latency', 30, ['route:other'])
+    client.flush()
+
+    assert.deepStrictEqual(requests[0].body, {
+      series: [
+        {
+          metric: 'latency',
+          points: [[1_700_000_000, [10, 20]]],
+          tags: ['service:web', 'route:home'],
+          type: 'distribution',
+        },
+        {
+          metric: 'latency',
+          points: [[1_700_000_000, [30]]],
+          tags: ['service:web', 'route:other'],
+          type: 'distribution',
+        },
+      ],
+    })
+    assert.strictEqual(requests[0].options.path, '/api/v1/distribution_points')
+  })
+
+  it('includes the hostname when configured', () => {
+    const client = createClient({ reportHostname: true })
+
+    client.gauge('memory', 10)
+    client.distribution('latency', 20)
+    client.flush()
+
+    assert.strictEqual(requests[0].body.series[0].host, require('node:os').hostname())
+    assert.strictEqual(requests[1].body.series[0].host, require('node:os').hostname())
+  })
+
+  it('does not make an empty request', () => {
+    createClient().flush()
+
+    assert.deepStrictEqual(requests, [])
+  })
+
+  it('drops buffered metrics when the API key is missing', () => {
+    const client = createClient({ apiKey: undefined })
+
+    client.gauge('memory', 10)
+    client.flush()
+    client.gauge('memory', 20)
+    client.flush()
+
+    assert.deepStrictEqual(requests, [])
+    sinon.assert.calledOnceWithExactly(
+      log.error,
+      'DD_API_KEY is required for agentless metrics. Metrics will not be sent.'
+    )
+  })
+
+  it('does not send the API key when the site is invalid', () => {
+    const client = createClient({ site: 'example.com/path' })
+
+    client.gauge('memory', 10)
+    client.flush()
+
+    assert.deepStrictEqual(requests, [])
+    sinon.assert.calledOnceWithExactly(
+      log.error,
+      'Invalid DD_SITE for agentless metrics: %s. Metrics will not be sent.',
+      'example.com/path'
+    )
+  })
+
+  it('logs intake errors', () => {
+    const client = createClient()
+
+    client.gauge('memory', 10)
+    client.flush()
+    requests[0].callback(new Error('unavailable'))
+
+    sinon.assert.calledOnceWithExactly(
+      log.error,
+      'Failed to send agentless %s: %s',
+      'metrics',
+      'unavailable'
+    )
+  })
+
+  it('logs encoding errors instead of throwing', () => {
+    const client = createClient()
+
+    Reflect.apply(client.gauge, client, ['memory', 10n])
+    client.flush()
+
+    assert.deepStrictEqual(requests, [])
+    sinon.assert.calledOnce(log.error)
+    assert.deepStrictEqual(log.error.firstCall.args.slice(0, 2), [
+      'Failed to encode agentless %s: %s',
+      'metrics',
+    ])
+    assert.match(log.error.firstCall.args[2], /BigInt/)
+  })
+})
+
+describe('agentless metrics selection', () => {
+  it('selects the direct transport without creating DogStatsD sockets', () => {
+    const directTransport = {}
+    const AgentlessMetricsClient = sinon.stub().returns(directTransport)
+    const dgram = { createSocket: sinon.stub().throws(new Error('unexpected UDP socket')) }
+    const { createMetricsTransport } = proxyquire('../src/dogstatsd', {
+      dgram,
+      './agentless-metrics': AgentlessMetricsClient,
+    })
+    const config = {
+      DD_AGENTLESS_ENABLED: true,
+      DD_API_KEY: 'test-key',
+      dogstatsd: { hostname: 'localhost', port: 8125 },
+      lookup: sinon.stub(),
+      reportHostname: true,
+      runtimeMetricsRuntimeId: false,
+      site: 'datadoghq.com',
+      tags: { service: 'web' },
+    }
+
+    assert.strictEqual(createMetricsTransport(config), directTransport)
+    sinon.assert.calledOnceWithExactly(AgentlessMetricsClient, {
+      apiKey: 'test-key',
+      reportHostname: true,
+      site: 'datadoghq.com',
+      tags: ['service:web'],
+    })
+    sinon.assert.notCalled(dgram.createSocket)
+  })
+
+  it('preserves runtime process tags on the direct transport', () => {
+    const transport = {}
+    const aggregatedClient = {}
+    const createMetricsTransport = sinon.stub().returns(transport)
+    const MetricsAggregationClient = sinon.stub().returns(aggregatedClient)
+    const DogStatsDClient = {
+      generateClientConfig: sinon.stub().returns({ tags: ['service:web'] }),
+    }
+    const { createMetricsClient } = proxyquire('../src/runtime_metrics/client', {
+      '../dogstatsd': {
+        createMetricsTransport,
+        DogStatsDClient,
+        MetricsAggregationClient,
+      },
+      '../process-tags': { tagsArray: ['entrypoint.name:server.js'] },
+    })
+    const config = {
+      DD_AGENTLESS_ENABLED: true,
+      DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true,
+    }
+
+    assert.strictEqual(createMetricsClient(config), aggregatedClient)
+    sinon.assert.calledOnceWithExactly(createMetricsTransport, config, {
+      tags: ['service:web', 'entrypoint.name:server.js'],
+    })
+    sinon.assert.calledOnceWithExactly(MetricsAggregationClient, transport)
+  })
+})

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -5107,7 +5107,7 @@ rules:
       assert.strictEqual(config.runtimeMetrics.enabled, false)
       assert.strictEqual(config.dsmEnabled, false)
       assert.strictEqual(config.dynamicInstrumentation.enabled, true)
-      assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, false)
+      assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, true)
       assert.deepStrictEqual(config.DD_PROFILING_EXPORTERS, ['agent'])
       assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'true')
     })

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -5108,8 +5108,8 @@ rules:
       assert.strictEqual(config.dsmEnabled, false)
       assert.strictEqual(config.dynamicInstrumentation.enabled, true)
       assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, false)
-      assert.deepStrictEqual(config.DD_PROFILING_EXPORTERS, [])
-      assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'false')
+      assert.deepStrictEqual(config.DD_PROFILING_EXPORTERS, ['agent'])
+      assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'true')
     })
 
     it('should preserve profiling when it does not use the Agent', () => {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -5085,6 +5085,13 @@ rules:
       assert.notStrictEqual(config.experimental.exporter, 'agentless')
     })
 
+    it('should enable runtime metrics when agentless mode is used alone', () => {
+      process.env.DD_AGENTLESS_ENABLED = 'true'
+      const config = getConfig()
+
+      assert.strictEqual(config.runtimeMetrics.enabled, true)
+    })
+
     it('should configure all supported features for agentless mode', () => {
       process.env.DD_AGENTLESS_ENABLED = 'true'
       process.env.DD_FEATURE_FLAGS_CONFIGURATION_SOURCE = 'remote_config'
@@ -5104,12 +5111,35 @@ rules:
       assert.strictEqual(config.llmobs.DD_LLMOBS_ENABLED, false)
       assert.strictEqual(config.featureFlags.DD_FEATURE_FLAGS_CONFIGURATION_SOURCE, 'agentless')
       assert.strictEqual(config.remoteConfig.DD_REMOTE_CONFIGURATION_ENABLED, false)
-      assert.strictEqual(config.runtimeMetrics.enabled, false)
+      assert.strictEqual(config.runtimeMetrics.enabled, true)
       assert.strictEqual(config.dsmEnabled, false)
       assert.strictEqual(config.dynamicInstrumentation.enabled, true)
       assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, true)
       assert.deepStrictEqual(config.DD_PROFILING_EXPORTERS, ['agent'])
       assert.strictEqual(config.profiling.DD_PROFILING_ENABLED, 'true')
+      assert.strictEqual(config.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, 'https://otlp.datadoghq.com/v1/metrics')
+    })
+
+    it('configures authentication for the agentless OTLP metrics endpoint', () => {
+      process.env.DD_AGENTLESS_ENABLED = 'true'
+      process.env.DD_API_KEY = 'test-key'
+      process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS = 'existing=value'
+      const config = getConfig()
+
+      assert.deepStrictEqual(config.OTEL_EXPORTER_OTLP_METRICS_HEADERS, {
+        existing: 'value',
+        'dd-api-key': 'test-key',
+      })
+    })
+
+    it('preserves an explicitly configured OTLP metrics endpoint', () => {
+      process.env.DD_AGENTLESS_ENABLED = 'true'
+      process.env.DD_API_KEY = 'test-key'
+      process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = 'http://localhost:4318/v1/metrics'
+      const config = getConfig()
+
+      assert.strictEqual(config.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, 'http://localhost:4318/v1/metrics')
+      assert.strictEqual(config.OTEL_EXPORTER_OTLP_METRICS_HEADERS, undefined)
     })
 
     it('should preserve profiling when it does not use the Agent', () => {

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -28,6 +28,7 @@ describeNotWindows('crashtracker', () => {
 
     config = {
       url: new URL('http://127.0.0.1:7357'),
+      DD_AGENTLESS_ENABLED: false,
       tags: {
         foo: 'bar',
       },
@@ -107,6 +108,49 @@ describeNotWindows('crashtracker', () => {
 
       sinon.assert.called(binding.init)
       sinon.assert.notCalled(log.error)
+    })
+
+    it('should configure independent direct intakes in agentless mode', () => {
+      config.DD_AGENTLESS_ENABLED = true
+      config.DD_API_KEY = 'test-api-key'
+      config.site = 'US3.DatadogHQ.com'
+
+      crashtracker.start(config)
+
+      sinon.assert.calledOnce(binding.init)
+      assert.strictEqual(binding.init.firstCall.args[0].endpoint, null)
+      assert.deepStrictEqual(binding.init.firstCall.args[1].env, [
+        ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
+        ['DD_API_KEY', 'test-api-key'],
+        ['DD_SITE', 'us3.datadoghq.com'],
+        ['DD_TRACE_AGENT_URL', 'https://instrumentation-telemetry-intake.us3.datadoghq.com'],
+      ])
+      sinon.assert.notCalled(log.error)
+    })
+
+    it('should not initialize agentless crash tracking without an API key', () => {
+      config.DD_AGENTLESS_ENABLED = true
+      config.site = 'datadoghq.com'
+
+      crashtracker.start(config)
+
+      sinon.assert.notCalled(binding.init)
+      sinon.assert.calledOnce(log.error)
+      assert.match(log.error.firstCall.args[1].message, /DD_API_KEY is required/)
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
+    })
+
+    it('should reject an agentless site that could redirect the API key', () => {
+      config.DD_AGENTLESS_ENABLED = true
+      config.DD_API_KEY = 'test-api-key'
+      config.site = 'datadoghq.com@evil.example'
+
+      crashtracker.start(config)
+
+      sinon.assert.notCalled(binding.init)
+      sinon.assert.calledOnce(log.error)
+      assert.match(log.error.firstCall.args[1].message, /Invalid DD_SITE/)
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
     })
   })
 

--- a/packages/dd-trace/test/openfeature/index.spec.js
+++ b/packages/dd-trace/test/openfeature/index.spec.js
@@ -97,12 +97,12 @@ describe('OpenFeature Module', () => {
       sinon.assert.calledOnceWithExactly(replacementWriter.setEnabled, true, currentRoute)
     })
 
-    it('should not setup the Agent-only writer in agentless mode', () => {
+    it('should setup exposure delivery in agentless mode', () => {
       config.DD_AGENTLESS_ENABLED = true
       openfeatureModule.enable(config)
 
-      sinon.assert.notCalled(ExposuresWriterStub)
-      sinon.assert.notCalled(setExposureDeliveryStrategyStub)
+      sinon.assert.calledOnceWithExactly(ExposuresWriterStub, config)
+      sinon.assert.calledOnce(setExposureDeliveryStrategyStub)
     })
 
     it('should handle multiple enable calls gracefully', () => {

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -162,6 +162,17 @@ describe('config', () => {
     )
   })
 
+  it('should route the agent exporter to the profiling intake in agentless mode', () => {
+    process.env.DD_AGENTLESS_ENABLED = 'true'
+    process.env.DD_API_KEY = 'test-api-key'
+    process.env.DD_SITE = 'us3.datadoghq.com'
+
+    const { config } = getProfilerConfig()
+
+    assert.deepStrictEqual(config.exporters.map(exporter => exporter.constructor), [AgentExporter])
+    assert.strictEqual(config.exporters[0].getExportUrl().href, 'https://intake.profile.us3.datadoghq.com/')
+  })
+
   it('should not include host tag when reportHostname is false', () => {
     const { config } = getProfilerConfig({ reportHostname: false })
 

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -5,6 +5,7 @@ const { format } = require('node:util')
 const os = require('node:os')
 const path = require('node:path')
 const { request } = require('node:http')
+const { PassThrough } = require('node:stream')
 
 const { describe, it, before, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
@@ -448,6 +449,96 @@ describe('exporters/agent', function () {
         assert.strictEqual(err.message, 'HTTP Error 400')
       }
       assert.strictEqual(tries, 1)
+    })
+  })
+
+  describe('using the agentless intake', () => {
+    let AgentlessExporter
+    let https
+    let requestOptions
+
+    beforeEach(() => {
+      https = {
+        request: sinon.stub().callsFake((options, callback) => {
+          requestOptions = options
+          const req = new PassThrough()
+
+          process.nextTick(() => {
+            const response = new PassThrough()
+            response.statusCode = 200
+            callback(response)
+            response.end()
+          })
+
+          return req
+        }),
+      }
+      AgentlessExporter = proxyquire('../../../src/profiling/exporters/agent', {
+        '../../exporters/common/docker': docker,
+        https,
+      }).AgentExporter
+    })
+
+    function newAgentlessExporter ({ apiKey = 'test-api-key', site = 'us3.datadoghq.com' } = {}) {
+      return new AgentlessExporter({
+        url: new URL('http://127.0.0.1:8126'),
+        DD_AGENTLESS_ENABLED: true,
+        DD_API_KEY: apiKey,
+        site,
+        DD_PROFILING_UPLOAD_TIMEOUT: 100,
+        env: ENV,
+        service: SERVICE,
+        version: APP_VERSION,
+        hostname: HOST,
+        reportHostname: true,
+      })
+    }
+
+    it('should send profiles directly to the site intake with the API key', async () => {
+      const exporter = newAgentlessExporter()
+
+      await exporter.export({
+        profiles: {},
+        start: new Date(),
+        end: new Date(),
+        tags: { 'runtime-id': RUNTIME_ID },
+      })
+
+      assert.strictEqual(exporter.getExportUrl().href, 'https://intake.profile.us3.datadoghq.com/')
+      assert.strictEqual(https.request.callCount, 1)
+      assertObjectContains(requestOptions, {
+        method: 'POST',
+        path: '/api/v2/profile',
+        protocol: 'https:',
+        hostname: 'intake.profile.us3.datadoghq.com',
+        headers: {
+          'dd-api-key': 'test-api-key',
+          'DD-EVP-ORIGIN': 'dd-trace-js',
+          'DD-EVP-ORIGIN-VERSION': version,
+          test: 'injected',
+        },
+      })
+    })
+
+    it('should not send profiles without an API key', async () => {
+      const exporter = newAgentlessExporter({ apiKey: null })
+
+      await assert.rejects(
+        exporter.export({ profiles: {}, start: new Date(), end: new Date() }),
+        { message: 'DD_API_KEY is required for agentless profiling' }
+      )
+      assert.strictEqual(https.request.callCount, 0)
+    })
+
+    it('should reject a site that could redirect the API key', async () => {
+      const exporter = newAgentlessExporter({ site: 'datadoghq.com@evil.example' })
+
+      assert.strictEqual(exporter.getExportUrl(), undefined)
+      await assert.rejects(
+        exporter.export({ profiles: {}, start: new Date(), end: new Date() }),
+        { message: 'Invalid DD_SITE for agentless profiling: datadoghq.com@evil.example' }
+      )
+      assert.strictEqual(https.request.callCount, 0)
     })
   })
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -849,7 +849,7 @@ describe('TracerProxy', () => {
         proxy.dogstatsd.increment('foo')
       })
 
-      it('should expose noop metrics methods in agentless mode', () => {
+      it('should expose real metrics methods in agentless mode', () => {
         config.DD_AGENTLESS_ENABLED = true
         config.dogstatsd = {
           hostname: 'localhost',
@@ -859,8 +859,9 @@ describe('TracerProxy', () => {
         proxy.init()
         proxy.dogstatsd.increment('foo')
 
-        assert.strictEqual(dogStatsD._config(), undefined)
-        sinon.assert.calledOnceWithExactly(noopDogStatsDClient.increment, 'foo')
+        assert.strictEqual(dogStatsD._config(), config)
+        assert.strictEqual(dogStatsD._increments().length, 1)
+        sinon.assert.notCalled(noopDogStatsDClient.increment)
       })
 
       it('should expose real metrics methods after init when configured', () => {

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -207,7 +207,10 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
         const proxiedObject = {
           // Exercise the real client factory (incl. process tags) but with the spy DogStatsD client.
           './client': proxyquire('../src/runtime_metrics/client', {
-            '../dogstatsd': { DogStatsDClient: Client },
+            '../dogstatsd': {
+              DogStatsDClient: Client,
+              createMetricsTransport: (config, clientConfig) => new Client(clientConfig),
+            },
           }),
         }
         if (!nativeMetrics) {
@@ -552,7 +555,10 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
 
           const localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
             './client': proxyquire('../src/runtime_metrics/client', {
-              '../dogstatsd': { DogStatsDClient: LocalClient },
+              '../dogstatsd': {
+                DogStatsDClient: LocalClient,
+                createMetricsTransport: (config, clientConfig) => new LocalClient(clientConfig),
+              },
             }),
             '@datadog/native-metrics': nativeMetricsModule,
           })
@@ -598,7 +604,10 @@ NATIVE_METRICS_VARIANTS.forEach((nativeMetrics) => {
 
           const localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
             './client': proxyquire('../src/runtime_metrics/client', {
-              '../dogstatsd': { DogStatsDClient: LocalClient },
+              '../dogstatsd': {
+                DogStatsDClient: LocalClient,
+                createMetricsTransport: (config, clientConfig) => new LocalClient(clientConfig),
+              },
             }),
             '../../../../version': { NODE_MAJOR: 24, NODE_MINOR: 19 },
             '@datadog/native-metrics': {
@@ -1008,7 +1017,10 @@ describeSamplePerIteration('runtimeMetrics event loop delay via samplePerIterati
 
     localRuntimeMetrics = proxyquire('../src/runtime_metrics/runtime_metrics', {
       './client': proxyquire('../src/runtime_metrics/client', {
-        '../dogstatsd': { DogStatsDClient: LocalClient },
+        '../dogstatsd': {
+          DogStatsDClient: LocalClient,
+          createMetricsTransport: (config, clientConfig) => new LocalClient(clientConfig),
+        },
       }),
       '@datadog/native-metrics': { start: nativeMetricsStart, stop () {} },
     })


### PR DESCRIPTION
### What does this PR do?

Adds direct runtime and custom metric delivery for global agentless mode.
Counters and gauges are sent to `https://api.<DD_SITE>/api/v1/series`, while
distributions are sent to
`https://api.<DD_SITE>/api/v1/distribution_points`, with API-key authentication
and the existing global, runtime, and process tags.

`DD_AGENTLESS_ENABLED=true` enables runtime metrics and exposes the real
`tracer.dogstatsd` client without creating UDP sockets or falling back to Agent
ports. The optional OpenTelemetry metrics path defaults to
`https://otlp.<DD_SITE>/v1/metrics` with API-key authentication.

### Motivation

Keep runtime metrics and the custom metrics API available without a local
Datadog Agent while preserving DogStatsD-compatible counter, gauge, histogram,
and distribution semantics.

### Additional Notes

- Requires `DD_API_KEY` in agentless mode.
- Explicitly configured OTLP metrics endpoints remain unchanged.
- Direct requests use the shared keep-alive transport and run outside the
  application tracing context.
- Stacked on [#9885](https://github.com/DataDog/dd-trace-js/pull/9885).

*Generated by Codex.*

### Validation

- 74 runtime-metrics tests passed with the required `--expose-gc` runner flag;
  1 runtime-gated test is pending.
- Targeted agentless metrics, DogStatsD, configuration, proxy, crash-tracking,
  profiling, debugger, and OpenFeature tests passed.
- ESLint, carrier-field verification, CODEOWNERS audit, and exercised-test
  verification passed.
- The root license check remains blocked until the unpublished
  `@datadog/libdatadog@^0.19.0` can enter `yarn.lock`.
