### PR TITLE
refactor(tracing): centralize span state writes

### DIFF
--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -2012,6 +2012,7 @@ function createJasminePlugin (libraryConfig) {
       finish: () => {
         context._isFinished = true
       },
+      finishOpenChildren () {},
       setTag: (name, value) => {
         tags[name] = value
       },

--- a/packages/datadog-plugin-avsc/src/schema_iterator.js
+++ b/packages/datadog-plugin-avsc/src/schema_iterator.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const AVRO = 'avro'
+const schemaSpans = new WeakSet()
 const {
   SCHEMA_DEFINITION,
   SCHEMA_ID,
@@ -140,11 +141,12 @@ class SchemaExtractor {
       return
     }
 
-    if (span.context().getTag(SCHEMA_TYPE) && operation === 'serialization') {
+    if (schemaSpans.has(span) && operation === 'serialization') {
       // we have already added a schema to this span, this call is an encode of nested schema types
       return
     }
 
+    schemaSpans.add(span)
     span.setTag(SCHEMA_TYPE, AVRO)
     span.setTag(SCHEMA_NAME, descriptor.name)
     span.setTag(SCHEMA_OPERATION, operation)

--- a/packages/datadog-plugin-aws-durable-execution-sdk-js/src/checkpoint.js
+++ b/packages/datadog-plugin-aws-durable-execution-sdk-js/src/checkpoint.js
@@ -12,10 +12,9 @@ class AwsDurableExecutionSdkJsCheckpointPlugin extends TracingPlugin {
     if (data?.Action !== 'RETRY' || !data.Error) return
 
     const span = this.activeSpan
-    if (!span || span.context().getTag('error')) return
+    if (!span?.setTagIfAbsent('error', 1)) return
 
     const { ErrorMessage, ErrorType, StackTrace } = data.Error
-    span.setTag('error', 1)
     if (ErrorMessage) span.setTag('error.message', ErrorMessage)
     if (ErrorType) span.setTag('error.type', ErrorType)
     if (Array.isArray(StackTrace)) span.setTag('error.stack', StackTrace.join('\n'))

--- a/packages/datadog-plugin-aws-durable-execution-sdk-js/src/context.js
+++ b/packages/datadog-plugin-aws-durable-execution-sdk-js/src/context.js
@@ -33,7 +33,7 @@ class BaseContextPlugin extends TracingPlugin {
 
   bindStart (ctx) {
     const spanName = this.constructor.spanName
-    const parentName = this.activeSpan?.context()._name
+    const parentName = storage('legacy').getStore()?.awsDurableSpanName
     const operationName = this.getOperationName(ctx)
     const resource = HIGH_CARDINALITY_PARENT_SPAN_NAMES.has(parentName) ? undefined : operationName
 
@@ -55,6 +55,7 @@ class BaseContextPlugin extends TracingPlugin {
       meta,
       metrics,
     }, ctx)
+    ctx.currentStore.awsDurableSpanName = spanName
 
     return ctx.currentStore
   }

--- a/packages/datadog-plugin-aws-durable-execution-sdk-js/src/handler.js
+++ b/packages/datadog-plugin-aws-durable-execution-sdk-js/src/handler.js
@@ -86,16 +86,7 @@ class AwsDurableExecutionSdkJsHandlerPlugin extends TracingPlugin {
 }
 
 function finishOpenChildSpans (executeSpan) {
-  const trace = executeSpan?._spanContext?._trace
-  if (!trace?.started) return
-
-  for (const span of trace.started) {
-    if (span === executeSpan) continue
-    if (span._integrationName !== AwsDurableExecutionSdkJsHandlerPlugin.id) continue
-    if (span._duration === undefined) {
-      span.finish()
-    }
-  }
+  executeSpan?.finishOpenChildren(AwsDurableExecutionSdkJsHandlerPlugin.id)
 }
 
 // Save state is kept on the shared `ctx` so repeated terminate() calls within one execution

--- a/packages/datadog-plugin-azure-event-hubs/src/producer.js
+++ b/packages/datadog-plugin-azure-event-hubs/src/producer.js
@@ -30,7 +30,7 @@ class AzureEventHubsProducerPlugin extends ProducerPlugin {
     }, ctx)
 
     if (ctx.functionName === 'tryAdd') {
-      span._spanContext._name = 'azure.eventhubs.create'
+      span.setOperationName('azure.eventhubs.create')
       span.setTag('messaging.operation', 'create')
 
       if (ctx.eventData.messageID !== undefined) {

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -53,8 +53,8 @@ class AzureFunctionsPlugin extends TracingPlugin {
         ctx
       )
 
-      span._integrationName = 'azure-functions'
-      span.context().setTag('component', 'azure-functions')
+      span.setIntegrationName('azure-functions')
+      span.setTag('component', 'azure-functions')
       span.addTags(meta)
       webContext.span = span
       webContext.azureFunctionCtx = ctx

--- a/packages/datadog-plugin-azure-service-bus/src/producer.js
+++ b/packages/datadog-plugin-azure-service-bus/src/producer.js
@@ -29,7 +29,7 @@ class AzureServiceBusProducerPlugin extends ProducerPlugin {
     }, ctx)
 
     if (ctx.functionName === 'tryAddMessage') {
-      span._spanContext._name = 'azure.servicebus.create'
+      span.setOperationName('azure.servicebus.create')
       span.setTag('messaging.operation', 'create')
 
       if (ctx.msg.messageID !== undefined) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -586,6 +586,7 @@ class CypressPlugin {
     this.lastFinishedTest = null
     this.pendingScreenshotUploads = []
     this.activeTestSpan = null
+    this.testSpanState = new WeakMap()
     this.testSuiteSpan = null
     this.finishedTestSuiteSpans = []
     this.testModuleSpan = null
@@ -1039,7 +1040,7 @@ class CypressPlugin {
 
     this.ciVisEvent(TELEMETRY_EVENT_CREATED, 'test', { hasCodeOwners: !!codeOwners })
 
-    return this.tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test`, {
+    const span = this.tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test`, {
       childOf,
       tags: {
         [COMPONENT]: TEST_FRAMEWORK_NAME,
@@ -1050,6 +1051,12 @@ class CypressPlugin {
       },
       integrationName: TEST_FRAMEWORK_NAME,
     })
+    this.testSpanState.set(span, {
+      hasCodeOwners: Boolean(codeOwners),
+      isDisabled: Boolean(isDisabled),
+      isQuarantined: Boolean(isQuarantined),
+    })
+    return span
   }
 
   /**
@@ -1538,22 +1545,24 @@ class CypressPlugin {
 
         // Update test status - but NOT for non-ATF quarantined tests where we intentionally
         // report 'fail' to Datadog even though Cypress sees it as 'pass'
-        const isQuarantinedTest = finishedTest.testSpan?.context()?.getTag(TEST_MANAGEMENT_IS_QUARANTINED) === 'true'
+        const spanState = finishedTest.spanState
+        const isQuarantinedTest = spanState.isQuarantined
         if (cypressTestStatus !== finishedTest.testStatus && (!isQuarantinedTest || finishedTest.isAttemptToFix)) {
           finishedTest.testSpan.setTag(TEST_STATUS, cypressTestStatus)
+          spanState.status = cypressTestStatus
           finishedTest.testSpan.setTag('error', latestError)
           if (finishedTest.isAttemptToFix && cypressTestStatus === 'fail') {
             finishedTest.testSpan.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
+            spanState.hasPassedAllAtfRetries = false
           }
         }
-        const testManagementTags = finishedTest.testSpan.context().getTags()
         recordTestManagementExecution({
           testSuite: spec.relative,
           testName,
-          status: testManagementTags[TEST_STATUS] || cypressTestStatus,
+          status: spanState.status || cypressTestStatus,
           isAttemptToFix: finishedTest.isAttemptToFix,
-          isDisabled: testManagementTags[TEST_MANAGEMENT_IS_DISABLED] === 'true',
-          isQuarantined: testManagementTags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true',
+          isDisabled: spanState.isDisabled,
+          isQuarantined: spanState.isQuarantined,
         })
         if (this.itrCorrelationId) {
           finishedTest.testSpan.setTag(ITR_CORRELATION_ID, this.itrCorrelationId)
@@ -1571,29 +1580,23 @@ class CypressPlugin {
 
         if (codeOwners) {
           finishedTest.testSpan.setTag(TEST_CODE_OWNERS, codeOwners)
+          spanState.hasCodeOwners = true
         }
 
         if (isLastAttempt) {
-          const testSpanTags = finishedTest.testSpan.context().getTags()
           const retryKind = getFinalStatusRetryKind({
             finishedTest,
             finishedTestAttempts,
             flakyTestRetriesCount: this.flakyTestRetriesCount,
           })
 
-          const hasFailedAllRetries = testSpanTags[TEST_HAS_FAILED_ALL_RETRIES] === 'true'
-          const hasPassedAllAtfRetries =
-            testSpanTags[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'true'
-          const isQuarantined = testSpanTags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true'
-          const isDisabled = testSpanTags[TEST_MANAGEMENT_IS_DISABLED] === 'true'
-
           const finalStatus = getFinalStatus({
             status: cypressTestStatus,
             retryKind,
-            hasFailedAllRetries,
-            hasPassedAllAtfRetries,
-            isQuarantined,
-            isDisabled,
+            hasFailedAllRetries: spanState.hasFailedAllRetries,
+            hasPassedAllAtfRetries: spanState.hasPassedAllAtfRetries,
+            isQuarantined: spanState.isQuarantined,
+            isDisabled: spanState.isDisabled,
           })
 
           if (finalStatus) {
@@ -1854,6 +1857,8 @@ class CypressPlugin {
           testStatus = 'pass'
         }
         this.activeTestSpan.setTag(TEST_STATUS, testStatus)
+        const spanState = this.testSpanState.get(this.activeTestSpan)
+        spanState.status = testStatus
 
         const testIdentifier = `${testSuite}\0${testName}`
         let testStatuses = this.testStatuses[testIdentifier]
@@ -1862,8 +1867,6 @@ class CypressPlugin {
         } else {
           testStatuses = this.testStatuses[testIdentifier] = [testStatus]
         }
-        const activeSpanTags = this.activeTestSpan.context().getTags()
-
         if (error) {
           this.activeTestSpan.setTag('error', error)
         }
@@ -1918,6 +1921,7 @@ class CypressPlugin {
           const isLastEfdAttempt = testStatuses.length === efdRetryCount + 1
           if (efdRetryCount > 0 && isLastEfdAttempt && testStatuses.every(status => status === 'fail')) {
             this.activeTestSpan.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
+            spanState.hasFailedAllRetries = true
           }
         }
         if (isAttemptToFix) {
@@ -1930,19 +1934,22 @@ class CypressPlugin {
           if (isLastAttempt) {
             if (testStatuses.includes('fail')) {
               this.activeTestSpan.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
+              spanState.hasPassedAllAtfRetries = false
             }
             if (testStatuses.every(status => status === 'fail')) {
               this.activeTestSpan.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
+              spanState.hasFailedAllRetries = true
             } else if (testStatuses.every(status => status === 'pass')) {
               this.activeTestSpan.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
+              spanState.hasPassedAllAtfRetries = true
             }
           }
           recordAttemptToFixExecution(this.attemptToFixExecutions, {
             testSuite,
             testName,
             status: testStatus,
-            isDisabled: activeSpanTags[TEST_MANAGEMENT_IS_DISABLED] === 'true',
-            isQuarantined: activeSpanTags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true',
+            isDisabled: spanState.isDisabled,
+            isQuarantined: spanState.isQuarantined,
           })
         }
         // ATR: set TEST_HAS_FAILED_ALL_RETRIES when all auto test retries were exhausted and every attempt failed
@@ -1950,15 +1957,18 @@ class CypressPlugin {
           this.flakyTestRetriesCount > 0 && testStatuses.length === this.flakyTestRetriesCount + 1 &&
           testStatuses.every(status => status === 'fail')) {
           this.activeTestSpan.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
+          spanState.hasFailedAllRetries = true
         }
 
         // Ensure quarantined tests reported from support.js are tagged
         // (This catches cases where the test ran but failed, but Cypress saw it as passed)
         if (isQuarantinedFromSupport) {
           this.activeTestSpan.setTag(TEST_MANAGEMENT_IS_QUARANTINED, 'true')
+          spanState.isQuarantined = true
         }
         if (isDisabledFromSupport) {
           this.activeTestSpan.setTag(TEST_MANAGEMENT_IS_DISABLED, 'true')
+          spanState.isDisabled = true
         }
 
         if (Array.isArray(commands) && commands.length > 0) {
@@ -1994,6 +2004,7 @@ class CypressPlugin {
           isEfdRetry,
           isEfdManagedTest,
           isAttemptToFix,
+          spanState,
         }
         if (this.finishedTestsByFile[testSuite]) {
           this.finishedTestsByFile[testSuite].push(finishedTest)
@@ -2003,13 +2014,13 @@ class CypressPlugin {
         this.lastFinishedTest = finishedTest
         // test spans are finished at after:spec
         this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'test', {
-          hasCodeOwners: !!activeSpanTags[TEST_CODE_OWNERS],
+          hasCodeOwners: spanState.hasCodeOwners,
           isNew,
           isRum: isRUMActive,
           browserDriver: 'cypress',
-          isQuarantined: activeSpanTags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true',
+          isQuarantined: spanState.isQuarantined,
           isModified,
-          isDisabled: activeSpanTags[TEST_MANAGEMENT_IS_DISABLED] === 'true',
+          isDisabled: spanState.isDisabled,
         })
         this.activeTestSpan = null
 
@@ -2018,6 +2029,19 @@ class CypressPlugin {
       'dd:addTags': (tags) => {
         if (this.activeTestSpan) {
           this.activeTestSpan.addTags(tags)
+          const spanState = this.testSpanState.get(this.activeTestSpan)
+          if (tags[TEST_STATUS]) spanState.status = tags[TEST_STATUS]
+          if (tags[TEST_CODE_OWNERS]) spanState.hasCodeOwners = true
+          if (tags[TEST_HAS_FAILED_ALL_RETRIES] === 'true') spanState.hasFailedAllRetries = true
+          if (tags[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] !== undefined) {
+            spanState.hasPassedAllAtfRetries = tags[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'true'
+          }
+          if (tags[TEST_MANAGEMENT_IS_DISABLED] !== undefined) {
+            spanState.isDisabled = tags[TEST_MANAGEMENT_IS_DISABLED] === 'true'
+          }
+          if (tags[TEST_MANAGEMENT_IS_QUARANTINED] !== undefined) {
+            spanState.isQuarantined = tags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true'
+          }
         }
         return null
       },

--- a/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
@@ -38,8 +38,9 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
     // Inject current span's trace context into message attributes
     this.tracer.inject(activeSpan, 'text_map', attributes)
 
-    const traceIdUpperBits = activeSpan.context()._trace.tags['_dd.p.tid']
-    if (traceIdUpperBits) attributes['_dd.p.tid'] = traceIdUpperBits
+    const fullTraceId = activeSpan.context().toTraceId(true)
+    const traceIdUpperBits = fullTraceId.slice(0, 16)
+    if (traceIdUpperBits !== '0000000000000000') attributes['_dd.p.tid'] = traceIdUpperBits
 
     if (pubsub) attributes['gcloud.project_id'] = pubsub.projectId
     if (topicName) attributes['pubsub.topic'] = topicName
@@ -104,8 +105,10 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
 
     const lastSlash = topic.lastIndexOf('/')
     const topicName = lastSlash === -1 ? topic : topic.slice(lastSlash + 1)
+    const batchStartTime = Date.now()
     const batchSpan = this.startSpan({
       childOf: parentData ? this.#extractParentContext(parentData) : undefined,
+      startTime: batchStartTime,
       resource: `${api} to Topic ${topicName}`,
       meta: {
         'gcloud.project_id': projectId,
@@ -129,7 +132,8 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
     const batchSpanIdHex = spanCtx.toSpanId(true)
     // Extract lower 64 bits (last 16 hex chars) for trace ID
     const batchTraceIdHex = fullTraceIdHex.slice(-16)
-    const batchTraceIdUpper = spanCtx._trace.tags['_dd.p.tid']
+    const traceIdUpper = fullTraceIdHex.slice(0, 16)
+    const batchTraceIdUpper = traceIdUpper === '0000000000000000' ? undefined : traceIdUpper
 
     if (spanLinkData.length) {
       batchSpan.setTag('_dd.span_links', JSON.stringify(
@@ -142,7 +146,7 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
     }
 
     const messageCountStr = String(messageCount)
-    const startTimeStr = String(Math.floor(batchSpan._startTime))
+    const startTimeStr = String(batchStartTime)
 
     for (let i = 0; i < messageCount; i++) {
       const msg = messages[i]
@@ -173,7 +177,7 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
   }
 
   bindFinish (ctx) {
-    if (ctx.batchSpan && !ctx.batchSpan._duration) ctx.batchSpan.finish()
+    ctx.batchSpan?.finish()
     return super.bindFinish(ctx)
   }
 

--- a/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription.js
@@ -36,7 +36,7 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
 
   #finishPushReceiveSpan (req) {
     const pushReceiveSpan = pushReceiveSpans.get(req)
-    if (pushReceiveSpan && !pushReceiveSpan._duration) {
+    if (pushReceiveSpan) {
       pushReceiveSpan.finish()
       pushReceiveSpans.delete(req)
     }
@@ -90,7 +90,7 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
       return
     }
 
-    this.enter(pushReceiveSpan, { req, res })
+    this.enter(pushReceiveSpan, { req, res, pubsubPushReceiveSpan: pushReceiveSpan })
     pushReceiveSpans.set(req, pushReceiveSpan)
   }
 
@@ -170,7 +170,7 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
       return null
     }
 
-    span._integrationName = 'google-cloud-pubsub'
+    span.setIntegrationName('google-cloud-pubsub')
     // Calculate delivery latency (queue time from publish to delivery)
     if (publishStartTime) {
       const deliveryDuration = Date.now() - Number(publishStartTime)
@@ -180,12 +180,7 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
     this.#addBatchMetadata(span, attrs)
 
     if (linkContext) {
-      if (span.addLink) {
-        span.addLink({ context: linkContext, attributes: {} })
-      } else {
-        span._links ??= []
-        span._links.push({ context: linkContext, attributes: {} })
-      }
+      span.addLink({ context: linkContext, attributes: {} })
     }
 
     return span

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { performance } = require('node:perf_hooks')
+
 const dc = require('dc-polyfill')
 
 const { storage } = require('../../datadog-core')
@@ -505,11 +507,11 @@ function wrapResolve (resolve) {
     }
 
     const executeSpan = rootCtx.executeSpan
-    const startTime = executeSpan._getTime()
+    const startTime = performance.timeOrigin + performance.now()
     const span = rootCtx.plugin.startResolveSpan(field, rootCtx, executeSpan, startTime)
 
     return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, field.currentStore, (err, res) => {
-      const endTime = executeSpan._getTime()
+      const endTime = performance.timeOrigin + performance.now()
       rootCtx.plugin.finishResolveSpan(span, field, err, res, endTime || startTime)
       if (updateFieldCh.hasSubscribers) {
         updateFieldCh.publish({ rootCtx, field, error: err, pathString: field.pathString })

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { performance } = require('node:perf_hooks')
-
 const dc = require('dc-polyfill')
 
 const { storage } = require('../../datadog-core')
@@ -296,7 +294,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
   // Public — called from wrapResolve (free function, crosses class boundary).
   // Resolve-span creation is inline at first-encounter; deferring to a batch
   // produces a bursty encoder stall when many spans finish together.
-  startResolveSpan (field, rootCtx, executeSpan, startTime) {
+  startResolveSpan (field, rootCtx, executeSpan) {
     const { fieldNode, fieldName, returnType, baseTypeName, variableValues, collapsedKey } = field
 
     const parent = getParentField(rootCtx, field)
@@ -314,7 +312,6 @@ class GraphQLExecutePlugin extends TracingPlugin {
       resource: `${fieldName}:${returnType}`,
       childOf,
       type: 'graphql',
-      startTime,
       meta: {
         'graphql.field.coordinates': `${field.parentTypeName}.${fieldName}`,
         'graphql.field.name': fieldName,
@@ -360,9 +357,9 @@ class GraphQLExecutePlugin extends TracingPlugin {
     return filtered
   }
 
-  // Public — called from wrapResolve. endTime reflects when the resolver
-  // actually completed, not when the field record was created.
-  finishResolveSpan (span, field, error, result, endTime) {
+  // Public — called from wrapResolve. Span owns the trace clock used for both
+  // resolver start and finish, so child spans remain inside their parent.
+  finishResolveSpan (span, field, error, result) {
     if (error) span.setTag('error', error)
 
     if (this.config.hooks.resolve) {
@@ -376,7 +373,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
       })
     }
 
-    span.finish(endTime)
+    span.finish()
   }
 }
 
@@ -507,12 +504,10 @@ function wrapResolve (resolve) {
     }
 
     const executeSpan = rootCtx.executeSpan
-    const startTime = performance.timeOrigin + performance.now()
-    const span = rootCtx.plugin.startResolveSpan(field, rootCtx, executeSpan, startTime)
+    const span = rootCtx.plugin.startResolveSpan(field, rootCtx, executeSpan)
 
     return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, field.currentStore, (err, res) => {
-      const endTime = performance.timeOrigin + performance.now()
-      rootCtx.plugin.finishResolveSpan(span, field, err, res, endTime || startTime)
+      rootCtx.plugin.finishResolveSpan(span, field, err, res)
       if (updateFieldCh.hasSubscribers) {
         updateFieldCh.publish({ rootCtx, field, error: err, pathString: field.pathString })
       }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -62,7 +62,7 @@ class HttpClientPlugin extends ClientPlugin {
 
     // TODO: Figure out a better way to do this for any span.
     if (!allowed) {
-      span._spanContext._trace.record = false
+      span.setRecording(false)
     }
 
     if (this.shouldInjectTraceHeaders(options, uri)) {

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -50,7 +50,7 @@ class HttpServerPlugin extends ServerPlugin {
       span.setTag(SVC_SRC_KEY, this.#serviceSource)
     }
     span.setTag(COMPONENT, this.constructor.id)
-    span._integrationName = this.constructor.id
+    span.setIntegrationName(this.constructor.id)
 
     const context = web.getContext(req)
     context.parentStore = store

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -61,7 +61,7 @@ class Http2ClientPlugin extends ClientPlugin {
 
     // TODO: Figure out a better way to do this for any span.
     if (!allowed) {
-      span._spanContext._trace.record = false
+      span.setRecording(false)
     }
 
     addHeaderTags(span, headers, HTTP_REQUEST_HEADERS, this.config)

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -39,7 +39,7 @@ class Http2ServerPlugin extends ServerPlugin {
     }
 
     span.setTag(COMPONENT, this.constructor.id)
-    span._integrationName = this.constructor.id
+    span.setIntegrationName(this.constructor.id)
 
     ctx.currentStore.req = req
     ctx.currentStore.res = res

--- a/packages/datadog-plugin-langchain/src/tracing.js
+++ b/packages/datadog-plugin-langchain/src/tracing.js
@@ -53,6 +53,8 @@ class BaseLangChainTracingPlugin extends TracingPlugin {
     const instance = ctx.instance
     const provider = handler.extractProvider(instance)
     const model = handler.extractModel(instance)
+    ctx.modelProvider = provider
+    ctx.modelName = model
 
     const span = this.startSpan('langchain.request', {
       service: this.config.service,

--- a/packages/datadog-plugin-langgraph/src/stream.js
+++ b/packages/datadog-plugin-langgraph/src/stream.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { spanHasError } = require('../../dd-trace/src/llmobs/util')
+const { hasError } = require('../../dd-trace/src/opentracing/span-projections')
 
 // We are only tracing Pregel.stream because Pregel.invoke calls stream internally resulting in
 // a graph with spans that look redundant.
@@ -29,7 +29,7 @@ class NextStreamPlugin extends TracingPlugin {
   asyncEnd (ctx) {
     const span = ctx.currentStore?.span
     if (!span) return
-    if (ctx.result.done === true || spanHasError(span)) {
+    if (ctx.result.done === true || hasError(span)) {
       span.finish()
     }
   }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -175,6 +175,7 @@ class MochaPlugin extends CiPlugin {
     this._testTitleToParams = {}
     this.sourceRoot = process.cwd()
     this._pendingTestSuiteSpans = []
+    this._failedTestSuiteSpans = new WeakSet()
     this._timeOrigin = dateNow()
     this._perfOrigin = performance.now()
 
@@ -479,7 +480,7 @@ class MochaPlugin extends CiPlugin {
     this.addSub('ci:mocha:test-suite:finish', ({ testSuiteSpan, status }) => {
       if (testSuiteSpan) {
         // the test status of the suite may have been set in ci:mocha:test-suite:error already
-        if (!testSuiteSpan.context().getTag(TEST_STATUS)) {
+        if (!this._failedTestSuiteSpans.has(testSuiteSpan)) {
           testSuiteSpan.setTag(TEST_STATUS, status)
         }
         const exporter = this.tracer._exporter
@@ -506,6 +507,7 @@ class MochaPlugin extends CiPlugin {
       if (testSuiteSpan) {
         testSuiteSpan.setTag('error', error)
         testSuiteSpan.setTag(TEST_STATUS, 'fail')
+        this._failedTestSuiteSpans.add(testSuiteSpan)
 
         ctx.parentStore = ctx.currentStore
         ctx.currentStore = { ...ctx.currentStore, testSuiteSpan }

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -10,6 +10,7 @@ const { HTTP_ROUTE, RESOURCE_NAME } = require('../../../ext/tags')
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
 const reusedNextRequestStores = new WeakSet()
 const nextParentRoutes = new WeakMap()
+const nextSpanState = new WeakMap()
 
 class NextPlugin extends ServerPlugin {
   static id = 'next'
@@ -22,8 +23,8 @@ class NextPlugin extends ServerPlugin {
   bindStart ({ req, res }) {
     const store = storage('legacy').getStore()
     const parentSpan = store?.span
-    if (parentSpan?._integrationName === this.constructor.id) {
-      const reusedStore = { ...store, span: parentSpan, req }
+    if (parentSpan && store.nextRequestSpan) {
+      const reusedStore = { ...store, span: parentSpan, req, nextRequestSpan: true }
       reusedNextRequestStores.add(reusedStore)
       return reusedStore
     }
@@ -52,10 +53,10 @@ class NextPlugin extends ServerPlugin {
 
     analyticsSampler.sample(span, this.config.measured, true)
 
-    const isHttpParent = parentSpan?._integrationName === 'http'
-    const httpParentSpan = isHttpParent ? parentSpan : undefined
-    const httpParentReq = isHttpParent ? web.getRequest(parentSpan) : undefined
-    return { ...store, span, req, httpParentSpan, httpParentReq }
+    const httpParentReq = parentSpan && web.getRequest(parentSpan)
+    const httpParentSpan = httpParentReq ? parentSpan : undefined
+    nextSpanState.set(span, {})
+    return { ...store, span, req, httpParentSpan, httpParentReq, nextRequestSpan: true }
   }
 
   error ({ span, error }) {
@@ -67,6 +68,8 @@ class NextPlugin extends ServerPlugin {
     }
 
     this.addError(error, span)
+    const state = nextSpanState.get(span)
+    if (state) state.error = error
   }
 
   finish ({ req, res, nextRequest = {} }) {
@@ -76,7 +79,7 @@ class NextPlugin extends ServerPlugin {
     if (reusedNextRequestStores.has(store)) return
 
     const span = store.span
-    const error = span.context().getTag('error')
+    const error = nextSpanState.get(span)?.error
     const requestError = req.error || nextRequest.error
 
     if (requestError) {
@@ -113,7 +116,8 @@ class NextPlugin extends ServerPlugin {
     if (!req) return
 
     // Only use error page names if there's not already a name
-    const current = span.context().getTag('next.page')
+    const state = nextSpanState.get(span)
+    const current = state?.page
     const isErrorPage = errorPages.has(page)
 
     if (current && isErrorPage) {
@@ -138,6 +142,7 @@ class NextPlugin extends ServerPlugin {
       'resource.name': `${req.method} ${page}`.trim(),
       'next.page': page,
     })
+    if (state) state.page = page
     const routeRequest = httpParentReq || req
     web.setRouteOrEndpointTag(routeRequest)
     setHttpParentRoute(httpParentSpan, req.method, page, isStatic)
@@ -169,13 +174,11 @@ function normalizeAppPath (page) {
 
 function setHttpParentRoute (span, method, page, isStatic) {
   if (!span) return
-  const currentRoute = span.context().getTag(HTTP_ROUTE)
-
-  // Only refine a route that Next itself set; static resources are fallbacks.
-  if (currentRoute && (nextParentRoutes.get(span) !== currentRoute || isStatic)) return
-
-  span.setTag(HTTP_ROUTE, page)
-  span.setTag(RESOURCE_NAME, `${method} ${page}`.trim())
-  nextParentRoutes.set(span, page)
+  const expectedRoute = isStatic ? undefined : nextParentRoutes.get(span)
+  const written = span.setTagsIfTagMatches(HTTP_ROUTE, expectedRoute, {
+    [HTTP_ROUTE]: page,
+    [RESOURCE_NAME]: `${method} ${page}`.trim(),
+  })
+  if (written) nextParentRoutes.set(span, page)
 }
 module.exports = NextPlugin

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -2,8 +2,9 @@
 
 const path = require('path')
 
-const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 const { storage } = require('../../datadog-core')
+const { getSpanDuration } = require('../../dd-trace/src/opentracing/span-lifecycle')
+const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 const Sampler = require('../../dd-trace/src/sampler')
 const { MEASURED } = require('../../../ext/tags')
 
@@ -81,6 +82,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
     const { methodName, args } = ctx
     const payload = normalizeRequestPayload(methodName, args)
     const normalizedMethodName = normalizeMethodName(methodName)
+    const resource = DD_MAJOR >= 6 ? normalizedMethodName : methodName
 
     const store = storage('legacy').getStore() || {}
 
@@ -89,10 +91,11 @@ class OpenAiTracingPlugin extends TracingPlugin {
     // the normalized method name corresponds to the resource name (e.g. createChatCompletion, createCompletion)
     store.originalMethodName = methodName
     store.normalizedMethodName = normalizedMethodName
+    store.openaiResource = resource
 
     const span = this.startSpan('openai.request', {
       service: this.config.service,
-      resource: DD_MAJOR >= 6 ? normalizedMethodName : methodName,
+      resource,
       type: 'openai',
       kind: 'client',
       meta: {
@@ -158,7 +161,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
     const span = store?.span
     if (!span) return
 
-    const error = !!span.context().getTag('error')
+    const error = Boolean(store.openaiError)
 
     let headers, body, method, path
     if (!error) {
@@ -172,7 +175,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
       headers = Object.fromEntries(headers)
     }
 
-    const resource = span.context().getTag('resource.name')
+    const resource = store.openaiResource
     const normalizedMethodName = store.normalizedMethodName
 
     body = coerceResponseBody(body, normalizedMethodName)
@@ -207,13 +210,14 @@ class OpenAiTracingPlugin extends TracingPlugin {
 
     span.finish()
     this.sendLog(resource, span, tags, openaiStore, error)
-    this.sendMetrics(headers, body, endpoint, span._duration, error, tags)
+    this.sendMetrics(headers, body, endpoint, getSpanDuration(span), error, tags)
   }
 
   error (ctx) {
     const span = ctx.currentStore?.span
     if (!span) return
 
+    ctx.currentStore.openaiError = true
     super.error(ctx) // add normal error tag
 
     const errorType = ctx.error?.type

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -29,7 +29,6 @@ const {
   TEST_IS_MODIFIED,
   TEST_IS_NEW,
   TEST_IS_RETRY,
-  TEST_IS_RUM_ACTIVE,
   TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
   TEST_MANAGEMENT_ENABLED,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
@@ -86,6 +85,7 @@ class PlaywrightPlugin extends CiPlugin {
     super(...args)
 
     this._testSuiteSpansByTestSuiteAbsolutePath = new Map()
+    this._testSpanState = new WeakMap()
     this.numFailedTests = 0
     this.numFailedSuites = 0
     this.pendingTestFinishes = 0
@@ -262,8 +262,12 @@ class PlaywrightPlugin extends CiPlugin {
 
     this.addSub('ci:playwright:test:page-goto', (ctx) => {
       const activeSpan = storage('legacy').getStore()?.span
-      if (!setRumTestCorrelation(ctx, activeSpan)) {
+      const testSpan = setRumTestCorrelation(ctx, activeSpan)
+      if (!testSpan) {
         log.error('ci:playwright:test:page-goto: test span not found')
+      } else if (ctx.isRumActive) {
+        const spanState = this._testSpanState.get(testSpan)
+        if (spanState) spanState.isRumActive = true
       }
     })
 
@@ -420,7 +424,7 @@ class PlaywrightPlugin extends CiPlugin {
         return
       }
 
-      const isRUMActive = span.context().getTag(TEST_IS_RUM_ACTIVE)
+      const spanState = this._testSpanState.get(span) || {}
 
       span.setTag(TEST_STATUS, testStatus)
 
@@ -510,9 +514,9 @@ class PlaywrightPlugin extends CiPlugin {
         TELEMETRY_EVENT_FINISHED,
         'test',
         {
-          hasCodeOwners: !!span.context().getTag(TEST_CODE_OWNERS),
+          hasCodeOwners: spanState.hasCodeOwners,
           isNew,
-          isRum: isRUMActive === 'true' || undefined,
+          isRum: spanState.isRumActive || undefined,
           browserDriver: 'playwright',
           isQuarantined,
           isDisabled,
@@ -654,7 +658,15 @@ class PlaywrightPlugin extends CiPlugin {
       extraTags.test_source_absolute_path = testSourceFileAbsolutePath
     }
 
-    return super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)
+    const span = super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)
+    this._testSpanState.set(span, {
+      hasCodeOwners: Boolean(this.getCodeOwners({
+        ...extraTags,
+        [TEST_SUITE]: testSuite,
+      })),
+      isRumActive: false,
+    })
+    return span
   }
 }
 

--- a/packages/datadog-plugin-prisma/src/datadog-tracing-helper.js
+++ b/packages/datadog-plugin-prisma/src/datadog-tracing-helper.js
@@ -36,17 +36,12 @@ class DatadogTracingHelper {
   getTraceParent (context) {
     const store = storage('legacy').getStore()
     const span = store?.span
-    if (span?._spanContext) {
-      const context = span._spanContext
-
-      const traceId = context.toTraceId(true)
-      const spanId = context.toSpanId(true)
-      const version = (context._traceparent && context._traceparent.version) || '00'
-
+    if (span) {
+      const traceparent = span.context().toTraceparent()
       // always sampled a sampled traceparent due to the following reasons:
       // 1. Datadog spans are sampled on span.finish
       // 2. Prisma engine spans only generate spans when the trace is sampled
-      return `${version}-${traceId}-${spanId}-01`
+      return `${traceparent.slice(0, -2)}01`
     }
 
     // No active span - return sampled
@@ -82,7 +77,7 @@ class DatadogTracingHelper {
 
   getActiveContext () {
     const store = storage('legacy').getStore()
-    return store?.span?._spanContext
+    return store?.span?.context()
   }
 
   /**

--- a/packages/datadog-plugin-prisma/src/index.js
+++ b/packages/datadog-plugin-prisma/src/index.js
@@ -47,6 +47,7 @@ class PrismaPlugin extends DatabasePlugin {
       childOf,
       resource: spanName,
       service,
+      startTime: hrTimeToUnixTimeMs(engineSpan.startTime),
       kind: engineSpan.kind,
       meta: {
         prisma: {
@@ -72,7 +73,6 @@ class PrismaPlugin extends DatabasePlugin {
     }
 
     const activeSpan = this.startSpan(this.operationName({ operation: 'engine' }), options)
-    activeSpan._startTime = hrTimeToUnixTimeMs(engineSpan.startTime)
     const children = childrenByParent.get(engineSpan.id)
     if (children) {
       for (const span of children) {

--- a/packages/datadog-plugin-prisma/test/index.spec.js
+++ b/packages/datadog-plugin-prisma/test/index.spec.js
@@ -153,12 +153,9 @@ describe('Plugin', () => {
       const helper = new DatadogTracingHelper(undefined, {})
 
       const span = {
-        _spanContext: {
-          _sampling: { priority: 0 },
-          _traceparent: { version: 'ff' },
-          toTraceId: () => '00000000000000000000000000000001',
-          toSpanId: () => '0000000000000001',
-        },
+        context: () => ({
+          toTraceparent: () => 'ff-00000000000000000000000000000001-0000000000000001-00',
+        }),
       }
 
       storage('legacy').enterWith({ span })
@@ -168,8 +165,6 @@ describe('Plugin', () => {
         traceparentWithExplicitNotSampledPriority,
         'ff-00000000000000000000000000000001-0000000000000001-01'
       )
-
-      span._spanContext._sampling.priority = undefined
 
       const traceparentWithUndefinedPriority = helper.getTraceParent()
       assert.strictEqual(
@@ -183,7 +178,7 @@ describe('Plugin', () => {
       const helper = new DatadogTracingHelper(undefined, {})
 
       const spanContext = { hello: 'world' }
-      storage('legacy').enterWith({ span: { _spanContext: spanContext } })
+      storage('legacy').enterWith({ span: { context: () => spanContext } })
 
       assert.strictEqual(helper.getActiveContext(), spanContext)
     })

--- a/packages/datadog-plugin-protobufjs/src/schema_iterator.js
+++ b/packages/datadog-plugin-protobufjs/src/schema_iterator.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const PROTOBUF = 'protobuf'
+const schemaSpans = new WeakSet()
 const {
   SCHEMA_DEFINITION,
   SCHEMA_ID,
@@ -135,11 +136,12 @@ class SchemaExtractor {
       return
     }
 
-    if (span.context().getTag(SCHEMA_TYPE) && operation === 'serialization') {
+    if (schemaSpans.has(span) && operation === 'serialization') {
       // we have already added a schema to this span, this call is an encode of nested schema types
       return
     }
 
+    schemaSpans.add(span)
     span.setTag(SCHEMA_TYPE, PROTOBUF)
     span.setTag(SCHEMA_NAME, removeLeadingPeriod(descriptor.fullName))
     span.setTag(SCHEMA_OPERATION, operation)

--- a/packages/datadog-plugin-rhea/src/producer.js
+++ b/packages/datadog-plugin-rhea/src/producer.js
@@ -3,6 +3,7 @@
 const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 const { getAmqpMessageSize, DsmPathwayCodec } = require('../../dd-trace/src/datastreams')
+const { storage } = require('../../datadog-core')
 
 class RheaProducerPlugin extends ProducerPlugin {
   static id = 'rhea'
@@ -26,23 +27,24 @@ class RheaProducerPlugin extends ProducerPlugin {
         [CLIENT_PORT_KEY]: port,
       },
     }, ctx)
+    ctx.currentStore.rheaTargetName = name
 
     return ctx.currentStore
   }
 
   encode (msg) {
-    addDeliveryAnnotations(msg, this.tracer, this.activeSpan)
+    const store = storage('legacy').getStore()
+    addDeliveryAnnotations(msg, this.tracer, store?.span, store?.rheaTargetName)
   }
 }
 
-function addDeliveryAnnotations (msg, tracer, span) {
+function addDeliveryAnnotations (msg, tracer, span, targetName) {
   if (msg) {
     msg.delivery_annotations ||= {}
 
     tracer.inject(span, 'text_map', msg.delivery_annotations)
 
     if (tracer._config.dsmEnabled) {
-      const targetName = span.context().getTag('amqp.link.target.address')
       const payloadSize = getAmqpMessageSize({ content: msg.body, headers: msg.delivery_annotations })
       const dataStreamsContext = tracer
         .setCheckpoint(['direction:out', `exchange:${targetName}`, 'type:rabbitmq'], span, payloadSize)

--- a/packages/datadog-plugin-undici/src/index.js
+++ b/packages/datadog-plugin-undici/src/index.js
@@ -88,7 +88,7 @@ class UndiciPlugin extends HttpClientPlugin {
 
     // Disable recording if not allowed
     if (!allowed) {
-      span._spanContext._trace.record = false
+      span.setRecording(false)
     }
 
     // Capture request headers if configured

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { performance } = require('node:perf_hooks')
+
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
 const { writeDatadogParentId, writeDatadogTraceId } = require('../../dd-trace/src/carrier')
@@ -94,6 +96,7 @@ class VitestPlugin extends CiPlugin {
     super(...args)
 
     this.taskToFinishTime = new WeakMap()
+    this.spanToStartTime = new WeakMap()
 
     this.addSub('ci:vitest:session:configuration', ({ onDone }) => {
       const testSessionSpanContext = this.testSessionSpan?.context()
@@ -186,14 +189,16 @@ class VitestPlugin extends CiPlugin {
         isBrowserMode,
       }, true)
 
+      const spanStartTime = startTime ?? performance.timeOrigin + performance.now()
       const span = this.startTestSpan(
         testName,
         testSuite,
         testSuiteSpan,
         extraTags,
         testExecutionId,
-        startTime
+        spanStartTime
       )
+      this.spanToStartTime.set(span, spanStartTime)
 
       ctx.parentStore = store
       ctx.currentStore = { ...store, span }
@@ -226,7 +231,10 @@ class VitestPlugin extends CiPlugin {
           span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
         }
 
-        const finishTime = typeof duration === 'number' ? span._startTime + duration : span._getTime()
+        const spanStartTime = this.spanToStartTime.get(span)
+        const finishTime = typeof duration === 'number'
+          ? spanStartTime + duration
+          : performance.timeOrigin + performance.now()
         this.taskToFinishTime.set(task, finishTime)
 
         ctx.parentStore = ctx.currentStore
@@ -309,8 +317,9 @@ class VitestPlugin extends CiPlugin {
       }
       const finish = () => {
         if (Number.isFinite(duration) && duration >= 0) {
+          const spanStartTime = this.spanToStartTime.get(span)
           span.finish(
-            span._startTime + Math.max(duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION, 0)
+            spanStartTime + Math.max(duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION, 0)
           ) // milliseconds
         } else {
           span.finish() // `duration` is empty for retries, so we'll use clock time

--- a/packages/datadog-plugin-ws/src/close.js
+++ b/packages/datadog-plugin-ws/src/close.js
@@ -88,8 +88,8 @@ class WSClosePlugin extends TracingPlugin {
           const counter = incrementWebSocketCounter(ctx.socket, counterType)
 
           const ptrHash = buildWebSocketSpanPointerHash(
-            handshakeContext._traceId,
-            handshakeContext._spanId,
+            handshakeContext.toTraceId(true),
+            handshakeContext.toSpanId(true),
             counter,
             true, // isServer
             isIncoming

--- a/packages/datadog-plugin-ws/src/producer.js
+++ b/packages/datadog-plugin-ws/src/producer.js
@@ -72,8 +72,8 @@ class WSProducerPlugin extends TracingPlugin {
           const counter = incrementWebSocketCounter(ctx.socket, 'sendCounter')
 
           const ptrHash = buildWebSocketSpanPointerHash(
-            handshakeContext._traceId,
-            handshakeContext._spanId,
+            handshakeContext.toTraceId(true),
+            handshakeContext.toSpanId(true),
             counter,
             true, // isServer
             false // isIncoming (this is outgoing)

--- a/packages/datadog-plugin-ws/src/receiver.js
+++ b/packages/datadog-plugin-ws/src/receiver.js
@@ -82,8 +82,8 @@ class WSReceiverPlugin extends TracingPlugin {
           const counter = incrementWebSocketCounter(ctx.socket, 'receiveCounter')
 
           const ptrHash = buildWebSocketSpanPointerHash(
-            handshakeContext._traceId,
-            handshakeContext._spanId,
+            handshakeContext.toTraceId(true),
+            handshakeContext.toSpanId(true),
             counter,
             true, // isServer
             true // isIncoming

--- a/packages/datadog-plugin-ws/src/server.js
+++ b/packages/datadog-plugin-ws/src/server.js
@@ -67,7 +67,7 @@ class WSServerPlugin extends TracingPlugin {
       'resource.name': resourceName,
       'service.name': service,
     }
-    ctx.socket.spanContext = createWebSocketSpanContext(ctx.span._spanContext)
+    ctx.socket.spanContext = createWebSocketSpanContext(ctx.span.context())
     ctx.socket.hasTraceHeaders = hasTraceHeaders(req.headers)
 
     // Initialize message counters for span pointers

--- a/packages/datadog-plugin-ws/src/util.js
+++ b/packages/datadog-plugin-ws/src/util.js
@@ -1,7 +1,10 @@
 'use strict'
 
 const { readDatadogTraceId, readTraceparent } = require('../../dd-trace/src/carrier')
+const id = require('../../dd-trace/src/id')
 const DatadogSpanContext = require('../../dd-trace/src/opentracing/span_context')
+const TraceState = require('../../dd-trace/src/opentracing/propagation/tracestate')
+const { AUTO_KEEP, AUTO_REJECT } = require('../../../ext/priority')
 
 const TRACE_ID_UPPER_TAG = '_dd.p.tid'
 
@@ -16,19 +19,20 @@ const socketCounters = new WeakMap()
 function createWebSocketSpanContext (spanContext) {
   if (!spanContext) return
 
-  const traceIdUpper = spanContext._trace?.tags?.[TRACE_ID_UPPER_TAG]
-  const trace = traceIdUpper
+  const [version, traceId, spanId, flags] = spanContext.toTraceparent().split('-')
+  const traceIdUpper = traceId.slice(0, 16)
+  const trace = traceIdUpper &&
+    traceIdUpper !== '0000000000000000'
     ? { started: [], finished: [], tags: { [TRACE_ID_UPPER_TAG]: traceIdUpper } }
     : undefined
 
   return new DatadogSpanContext({
-    traceId: spanContext._traceId,
-    spanId: spanContext._spanId,
-    parentId: spanContext._parentId,
-    sampling: spanContext._sampling,
-    traceparent: spanContext._traceparent,
-    tracestate: spanContext._tracestate,
-    isRemote: spanContext._isRemote,
+    traceId: id(traceId.slice(-16), 16),
+    spanId: id(spanId, 16),
+    sampling: { priority: (Number.parseInt(flags, 16) & 1) === 1 ? AUTO_KEEP : AUTO_REJECT },
+    traceparent: { version },
+    tracestate: TraceState.fromString(spanContext.toTracestate()),
+    isRemote: false,
     trace,
   })
 }
@@ -76,8 +80,8 @@ function incrementWebSocketCounter (socket, counterType) {
  * Format: <prefix><128 bit hex trace id><64 bit hex span id><32 bit hex counter>
  * Prefix: 'S' for server outgoing or client incoming, 'C' for server incoming or client outgoing
  *
- * @param {bigint} handshakeTraceId - The trace ID from the handshake span (as a BigInt)
- * @param {bigint} handshakeSpanId - The span ID from the handshake span (as a BigInt)
+ * @param {string|bigint} handshakeTraceId - The trace ID from the handshake span
+ * @param {string|bigint} handshakeSpanId - The span ID from the handshake span
  * @param {number} counter - The message counter
  * @param {boolean} isServer - Whether this is a server (true) or client (false)
  * @param {boolean} isIncoming - Whether this is an incoming message (true) or outgoing (false)
@@ -90,10 +94,14 @@ function buildWebSocketSpanPointerHash (handshakeTraceId, handshakeSpanId, count
   const prefix = (isServer && !isIncoming) || (!isServer && isIncoming) ? 'S' : 'C'
 
   // Pad trace ID to 32 hex chars (128 bits)
-  const traceIdHex = handshakeTraceId.toString(16).padStart(32, '0')
+  const traceIdHex = typeof handshakeTraceId === 'string'
+    ? handshakeTraceId.padStart(32, '0')
+    : handshakeTraceId.toString(16).padStart(32, '0')
 
   // Pad span ID to 16 hex chars (64 bits)
-  const spanIdHex = handshakeSpanId.toString(16).padStart(16, '0')
+  const spanIdHex = typeof handshakeSpanId === 'string'
+    ? handshakeSpanId.padStart(16, '0')
+    : handshakeSpanId.toString(16).padStart(16, '0')
 
   // Pad counter to 8 hex chars (32 bits)
   const counterHex = counter.toString(16).padStart(8, '0')
@@ -113,21 +121,7 @@ function buildWebSocketSpanPointerHash (handshakeTraceId, handshakeSpanId, count
  * @returns {boolean} True if the span has distributed tracing context
  */
 function hasDistributedTracingContext (spanContext, socket) {
-  if (!spanContext) return false
-
-  // Check if this span has a parent. If the parent was extracted from remote headers,
-  // then this span is part of a distributed trace.
-  // We check if the span has a parent by looking at _parentId.
-  // In the JavaScript tracer, when a context is extracted from headers and a child span
-  // is created, the child will have _parentId set to the extracted parent's span ID.
-  //
-  // For testing purposes, we also check if Datadog trace headers are present in the socket's
-  // upgrade request, which indicates distributed tracing context was sent by the client.
-  if (spanContext._parentId !== null) {
-    return true
-  }
-
-  return !!socket?.hasTraceHeaders
+  return Boolean(spanContext && socket?.hasTraceHeaders)
 }
 
 module.exports = {

--- a/packages/datadog-plugin-ws/test/util.spec.js
+++ b/packages/datadog-plugin-ws/test/util.spec.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const id = require('../../dd-trace/src/id')
+const SpanContext = require('../../dd-trace/src/opentracing/span_context')
+const TraceState = require('../../dd-trace/src/opentracing/propagation/tracestate')
+const { createWebSocketSpanContext, hasDistributedTracingContext } = require('../src/util')
+
+describe('WebSocket context utilities', () => {
+  it('detaches link context through its public propagation projection', () => {
+    const context = new SpanContext({
+      traceId: id('0123456789abcdef', 16),
+      spanId: id('fedcba9876543210', 16),
+      sampling: { priority: 1 },
+      traceparent: { version: '00' },
+      tracestate: TraceState.fromString('dd=s:1;o:synthetics;t.dm:-4'),
+      trace: {
+        started: [],
+        finished: [],
+        tags: { '_dd.p.tid': '1234567890abcdef' },
+      },
+    })
+
+    const detachedContext = createWebSocketSpanContext(context)
+
+    assert.notStrictEqual(detachedContext, context)
+    assert.strictEqual(detachedContext.toTraceId(true), context.toTraceId(true))
+    assert.strictEqual(detachedContext.toSpanId(true), context.toSpanId(true))
+    assert.strictEqual(detachedContext.toTraceparent(), context.toTraceparent())
+    assert.strictEqual(detachedContext.toTracestate(), context.toTracestate())
+  })
+
+  it('uses socket-owned header state for distributed tracing eligibility', () => {
+    const context = {}
+
+    assert.strictEqual(hasDistributedTracingContext(context, { hasTraceHeaders: true }), true)
+    assert.strictEqual(hasDistributedTracingContext(context, { hasTraceHeaders: false }), false)
+    assert.strictEqual(hasDistributedTracingContext(undefined, { hasTraceHeaders: true }), false)
+  })
+})

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -4,6 +4,8 @@ const { HTTP_CLIENT_IP, HTTP_USERAGENT, NETWORK_CLIENT_IP } = require('../../../
 const clone = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
 const { USER_ID, USER_SESSION_ID } = require('../appsec/addresses')
 const { getActiveRequest } = require('../appsec/store')
+const eventWriter = require('../opentracing/event-writer')
+const { getLocalRootSpan } = require('../opentracing/span-projections')
 const { keepTrace } = require('../priority_sampler')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const { AI_GUARD } = require('../standalone/product')
@@ -163,11 +165,9 @@ class EvaluationReporter {
     const metaStruct = {
       messages: this.#buildMessagesForMetaStruct(messages, telemetryTags),
     }
-    span.meta_struct = {
-      [TAGS.META_STRUCT_KEY]: metaStruct,
-    }
+    span.setStructuredTag(TAGS.META_STRUCT_KEY, metaStruct)
 
-    const rootSpan = span.context()?._trace?.started?.[0]
+    const rootSpan = getLocalRootSpan(span)
     if (rootSpan) {
       this.#setRootSpanClientIpTags(rootSpan)
       this.#copyServiceEntryTagsToGuardSpan(span, rootSpan)
@@ -298,36 +298,17 @@ class EvaluationReporter {
    * @returns {void}
    */
   #setRootSpanClientIpTags (rootSpan) {
-    const currentTags = rootSpan.context().getTags()
-    const needsHttpClientIp = !Object.hasOwn(currentTags, HTTP_CLIENT_IP)
-    const needsNetworkClientIp = !Object.hasOwn(currentTags, NETWORK_CLIENT_IP)
-
-    if (!needsHttpClientIp && !needsNetworkClientIp) return
-
     const request = getActiveRequest()
     if (!request) return
 
-    const newTags = {}
-    let hasNewTags = false
-
-    if (needsHttpClientIp) {
-      const clientIp = extractIp(this.#config, request)
-      if (clientIp) {
-        newTags[HTTP_CLIENT_IP] = clientIp
-        hasNewTags = true
-      }
+    const clientIp = extractIp(this.#config, request)
+    if (clientIp) {
+      eventWriter.setTagIfAbsent(rootSpan, HTTP_CLIENT_IP, clientIp)
     }
 
-    if (needsNetworkClientIp) {
-      const networkClientIp = request.socket?.remoteAddress
-      if (networkClientIp) {
-        newTags[NETWORK_CLIENT_IP] = networkClientIp
-        hasNewTags = true
-      }
-    }
-
-    if (hasNewTags) {
-      rootSpan.addTags(newTags)
+    const networkClientIp = request.socket?.remoteAddress
+    if (networkClientIp) {
+      eventWriter.setTagIfAbsent(rootSpan, NETWORK_CLIENT_IP, networkClientIp)
     }
   }
 
@@ -339,13 +320,7 @@ class EvaluationReporter {
    * @returns {void}
    */
   #copyServiceEntryTagsToGuardSpan (guardSpan, rootSpan) {
-    const rootTags = rootSpan.context().getTags()
-    for (const [sourceTag, destinationTag] of SERVICE_ENTRY_TAG_MAPPINGS) {
-      const value = rootTags[sourceTag]
-      if (value !== undefined && value !== null) {
-        guardSpan.setTag(destinationTag, value)
-      }
-    }
+    eventWriter.copyTags(rootSpan, guardSpan, SERVICE_ENTRY_TAG_MAPPINGS)
   }
 }
 

--- a/packages/dd-trace/src/appsec/api_security/index.js
+++ b/packages/dd-trace/src/appsec/api_security/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { getApiSecurityFramework } = require('../../opentracing/span-projections')
 const web = require('../../plugins/util/web')
 const { isSchemaAttribute } = require('../reporter')
 const appsecTelemetry = require('../telemetry')
@@ -35,7 +36,7 @@ function reportRequest (req, samplingDecision, wafResult) {
 }
 
 function getFramework (req) {
-  return web.root(req)?.context()?.getTag?.('component')
+  return getApiSecurityFramework(web.root(req))
 }
 
 function hasSchemaAttributes (attributes) {

--- a/packages/dd-trace/src/appsec/api_security/normalized-route.js
+++ b/packages/dd-trace/src/appsec/api_security/normalized-route.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { HTTP_ROUTE } = require('../../../../../ext/tags')
-const web = require('../../plugins/util/web')
 const { getParse, getMatch } = require('../../../../datadog-instrumentations/src/path-to-regexp')
+const { getApiSecurityFramework, getApiSecurityHttpRoute } = require('../../opentracing/span-projections')
+const web = require('../../plugins/util/web')
 
 /**
  * Normalize an HTTP route to the RFC-1103 _dd.appsec.normalized_route format.
@@ -423,8 +423,8 @@ function normalizeRouteExpress (route, params, urlPath, parse, makeMatcher) {
  * @returns {string|null}
  */
 function normalizeRoute (req) {
-  const spanContext = web.root(req)?.context()
-  const component = spanContext?.getTag?.('component')
+  const span = web.root(req)
+  const component = getApiSecurityFramework(span)
 
   // eslint-disable-next-line sonarjs/no-small-switch
   switch (component) {
@@ -438,7 +438,7 @@ function normalizeRoute (req) {
       const makeMatcher = getMatch()
       if (parse === undefined || makeMatcher === undefined) return null
       // Reuse the http.route tag set by web.setRouteOrEndpointTag just before this hook.
-      const route = spanContext.getTag(HTTP_ROUTE)
+      const route = getApiSecurityHttpRoute(span)
       return normalizeRouteExpress(route, req.params, req.originalUrl || req.url, parse, makeMatcher)
     }
     default:

--- a/packages/dd-trace/src/appsec/api_security/sampler.js
+++ b/packages/dd-trace/src/appsec/api_security/sampler.js
@@ -3,7 +3,8 @@
 const { TTLCache } = require('../../../../../vendor/dist/@isaacs/ttlcache')
 const web = require('../../plugins/util/web')
 const log = require('../../log')
-const { AUTO_REJECT, USER_REJECT } = require('../../../../../ext/priority')
+const eventWriter = require('../../opentracing/event-writer')
+const { getHttpEndpoint } = require('../../opentracing/span-projections')
 const { keepTrace } = require('../../priority_sampler')
 const { ASM } = require('../../standalone/product')
 const { isBlocked } = require('../blocking')
@@ -55,17 +56,7 @@ function sampleRequest (req, res, record = false) {
   const rootSpan = web.root(req)
   if (!rootSpan) return SamplingDecision.SKIP
 
-  if (!asmStandaloneEnabled) {
-    let priority = getSpanPriority(rootSpan)
-    if (!priority) {
-      rootSpan._prioritySampler?.sample(rootSpan)
-      priority = getSpanPriority(rootSpan)
-    }
-
-    if (priority === AUTO_REJECT || priority === USER_REJECT) {
-      return SamplingDecision.SKIP
-    }
-  }
+  if (!asmStandaloneEnabled && !eventWriter.sampleForApiSecurity(rootSpan)) return SamplingDecision.SKIP
 
   const resolved = resolveSamplingKey(req, res)
   if (!resolved) return SamplingDecision.SKIP
@@ -127,15 +118,10 @@ function getRouteOrEndpoint (context, statusCode) {
 
   if (statusCode === 404) return null
 
-  const endpoint = context?.span?.context()?.getTag?.('http.endpoint')
+  const endpoint = getHttpEndpoint(context?.span)
   if (endpoint) return endpoint
 
   return null
-}
-
-function getSpanPriority (span) {
-  const spanContext = span.context?.()
-  return spanContext._sampling?.priority
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/handlers/auth.js
+++ b/packages/dd-trace/src/appsec/handlers/auth.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const log = require('../../log')
+const { hasUserSessionId } = require('../../opentracing/span-projections')
 const web = require('../../plugins/util/web')
 const addresses = require('../addresses')
 const { handleResults } = require('../blocking')
@@ -43,8 +44,7 @@ function onExpressSession ({ req, res, sessionId, abortController }) {
     return
   }
 
-  const isSdkCalled = rootSpan.context().getTag('usr.session_id')
-  if (isSdkCalled) return
+  if (hasUserSessionId(rootSpan)) return
 
   const results = waf.run({
     persistent: {

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -2,7 +2,7 @@
 
 const { LRUCache } = require('../../../../../vendor/dist/lru-cache')
 const { keepTrace } = require('../../priority_sampler')
-const { reportStackTrace, getCallsiteFrames, canReportStackTrace, STACK_TRACE_NAMESPACES } = require('../stack_trace')
+const { reportStackTrace, getCallsiteFrames, STACK_TRACE_NAMESPACES } = require('../stack_trace')
 const { ASM } = require('../../standalone/product')
 const vulnerabilitiesFormatter = require('./vulnerabilities-formatter')
 const { IAST_ENABLED_TAG_KEY, IAST_JSON_TAG_KEY } = require('./tags')
@@ -52,14 +52,15 @@ function addVulnerability (iastContext, vulnerability, callSiteFrames) {
 
   keepTrace(span, ASM)
 
-  if (stackTraceEnabled && canReportStackTrace(span, maxStackTraces, STACK_TRACE_NAMESPACES.IAST)) {
+  if (stackTraceEnabled) {
     const originalCallSiteList = callSiteFrames.map(callsite => replaceCallSiteFromSourceMap(callsite))
 
     reportStackTrace(
       span,
       vulnerability.location.stackId,
       originalCallSiteList,
-      STACK_TRACE_NAMESPACES.IAST
+      STACK_TRACE_NAMESPACES.IAST,
+      maxStackTraces
     )
   }
 

--- a/packages/dd-trace/src/appsec/rasp/utils.js
+++ b/packages/dd-trace/src/appsec/rasp/utils.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const web = require('../../plugins/util/web')
-const { getCallsiteFrames, reportStackTrace, canReportStackTrace } = require('../stack_trace')
+const {
+  getCallsiteFrames,
+  reportStackTrace,
+  STACK_TRACE_NAMESPACES,
+} = require('../stack_trace')
 const { getBlockingAction } = require('../blocking')
 const log = require('../../log')
 const { updateRaspRuleMatchMetricTags } = require('../telemetry')
@@ -51,13 +55,15 @@ function handleResult (result, req, res, abortController, config, raspRule) {
 
   const ruleTriggered = !!result?.events?.length
 
-  if (generateStackTraceAction && enabled && canReportStackTrace(rootSpan, maxStackTraces)) {
+  if (generateStackTraceAction && enabled && rootSpan) {
     const frames = getCallsiteFrames(maxDepth, handleResult)
 
     reportStackTrace(
       rootSpan,
       generateStackTraceAction.stack_id,
-      frames
+      frames,
+      STACK_TRACE_NAMESPACES.RASP,
+      maxStackTraces
     )
   }
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -3,8 +3,9 @@
 const zlib = require('zlib')
 const dc = require('dc-polyfill')
 
-const { NETWORK_CLIENT_IP } = require('../../../../ext/tags')
 const web = require('../plugins/util/web')
+const eventWriter = require('../opentracing/event-writer')
+const { shouldCollectAppSecEventHeaders } = require('../opentracing/span-projections')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const { keepTrace } = require('../priority_sampler')
 const { ASM } = require('../standalone/product')
@@ -382,36 +383,13 @@ function reportAttack ({ events: attackData, actions }, req, rootSpan) {
 
   if (!req || !rootSpan) return
 
-  const spanContext = rootSpan.context()
-
-  const newTags = {
-    'appsec.event': 'true',
-  }
-
-  // TODO: maybe add this to format.js later (to take decision as late as possible)
-  if (!spanContext.getTag('_dd.origin')) {
-    newTags['_dd.origin'] = 'appsec'
-  }
-
-  const currentJson = spanContext.getTag('_dd.appsec.json')
-
-  // merge JSON arrays without parsing them
-  const attackDataStr = JSON.stringify(attackData)
-  newTags['_dd.appsec.json'] = currentJson
-    ? currentJson.slice(0, -2) + ',' + attackDataStr.slice(1) + '}'
-    : '{"triggers":' + attackDataStr + '}'
-
-  if (req.socket) {
-    newTags[NETWORK_CLIENT_IP] = req.socket.remoteAddress
-  }
-
-  rootSpan.addTags(newTags)
+  const appSecJson = eventWriter.addAppSecEvent(rootSpan, attackData, req.socket?.remoteAddress)
 
   // Add _dd.appsec.json tag to inferred proxy span
   if (config.inferredProxyServicesEnabled) {
     const context = web.getContext(req)
     if (context?.inferredProxySpan) {
-      context.inferredProxySpan.setTag('_dd.appsec.json', newTags['_dd.appsec.json'])
+      context.inferredProxySpan.setTag('_dd.appsec.json', appSecJson)
     }
   }
 
@@ -484,26 +462,20 @@ function truncateRequestBody (target, depth = 0) {
 function reportRequestBody (rootSpan, requestBody, comesFromRaspAction = false) {
   if (!requestBody || isEmpty(requestBody)) return
 
-  if (!rootSpan.meta_struct) {
-    rootSpan.meta_struct = {}
-  }
+  const { truncated, value } = truncateRequestBody(requestBody)
+  const reported = rootSpan.setStructuredTagIfAbsent('http.request.body', value)
 
-  if (rootSpan.meta_struct['http.request.body']) {
+  if (!reported) {
     // If the rasp.exceed metric exists, set also the same for the new tag
-    const sizeExceedTagValue = rootSpan.context().getTag('_dd.appsec.rasp.request_body_size.exceeded')
-
-    if (sizeExceedTagValue) {
-      rootSpan.setTag('_dd.appsec.request_body_size.exceeded', sizeExceedTagValue)
-    }
-  } else {
-    const { truncated, value } = truncateRequestBody(requestBody)
-    rootSpan.meta_struct['http.request.body'] = value
-    if (truncated) {
-      const sizeExceedTagKey = comesFromRaspAction
-        ? '_dd.appsec.rasp.request_body_size.exceeded' // TODO old metric to delete in a major
-        : '_dd.appsec.request_body_size.exceeded'
-      rootSpan.setTag(sizeExceedTagKey, 'true')
-    }
+    eventWriter.copyTags(rootSpan, rootSpan, [[
+      '_dd.appsec.rasp.request_body_size.exceeded',
+      '_dd.appsec.request_body_size.exceeded',
+    ]])
+  } else if (truncated) {
+    const sizeExceedTagKey = comesFromRaspAction
+      ? '_dd.appsec.rasp.request_body_size.exceeded' // TODO old metric to delete in a major
+      : '_dd.appsec.request_body_size.exceeded'
+    rootSpan.setTag(sizeExceedTagKey, 'true')
   }
 }
 
@@ -610,11 +582,9 @@ function finishRequest (req, res, storedResponseHeaders, requestBody, rootSpan) 
 
   incrementWafRequestsMetric(req)
 
-  const tags = rootSpan.context().getTags()
-
   const extendedDataCollection = extendedDataCollectionRequest.get(req)
   const newTags = getCollectedHeaders(
-    req, res, shouldCollectEventHeaders(tags), storedResponseHeaders, extendedDataCollection
+    req, res, shouldCollectAppSecEventHeaders(rootSpan), storedResponseHeaders, extendedDataCollection
   )
 
   if (extendedDataCollection) {
@@ -622,20 +592,6 @@ function finishRequest (req, res, storedResponseHeaders, requestBody, rootSpan) 
   }
 
   rootSpan.addTags(newTags)
-}
-
-function shouldCollectEventHeaders (tags = {}) {
-  if (tags['appsec.event'] === 'true') {
-    return true
-  }
-
-  for (const tagName of Object.keys(tags)) {
-    if (tagName.startsWith('appsec.events.')) {
-      return true
-    }
-  }
-
-  return false
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -4,6 +4,7 @@ const { USER_ID } = require('../addresses')
 const waf = require('../waf')
 const { block, getBlockingAction } = require('../blocking')
 const log = require('../../log')
+const { hasUserId } = require('../../opentracing/span-projections')
 const web = require('../../plugins/util/web')
 const { getActiveRequest } = require('../store')
 const { setUserTags } = require('./set_user')
@@ -22,7 +23,7 @@ function checkUserAndSetUser (tracer, user) {
 
   const rootSpan = getRootSpan()
   if (rootSpan) {
-    if (!rootSpan.context().getTag('usr.id')) {
+    if (!hasUserId(rootSpan)) {
       setUserTags(user, rootSpan)
     }
   } else {

--- a/packages/dd-trace/src/appsec/sdk/utils.js
+++ b/packages/dd-trace/src/appsec/sdk/utils.js
@@ -1,29 +1,12 @@
 'use strict'
 
 const { storage } = require('../../../../datadog-core')
+const { getAppSecRootSpan } = require('../../opentracing/span-projections')
 
 function getRootSpan () {
-  let span = storage('legacy').getStore()?.span
+  const span = storage('legacy').getStore()?.span
   if (!span) return
-
-  const context = span.context()
-  const started = context._trace.started
-
-  let parentId = context._parentId
-  while (parentId) {
-    const parent = started.find(s => s.context()._spanId === parentId)
-    const pContext = parent?.context()
-
-    if (!pContext) break
-
-    parentId = pContext._parentId
-
-    if (!pContext.getTag('_inferred_span')) {
-      span = parent
-    }
-  }
-
-  return span
+  return getAppSecRootSpan(span)
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -80,38 +80,19 @@ function getCallsiteFrames (maxDepth = 32, constructorOpt = getCallsiteFrames, c
   return indexedFrames
 }
 
-function reportStackTrace (rootSpan, stackId, frames, namespace = STACK_TRACE_NAMESPACES.RASP) {
+function reportStackTrace (rootSpan, stackId, frames, namespace = STACK_TRACE_NAMESPACES.RASP, maxStackTraces = 0) {
   if (!rootSpan) return
   if (!Array.isArray(frames)) return
 
-  if (!rootSpan.meta_struct) {
-    rootSpan.meta_struct = {}
-  }
-
-  if (!rootSpan.meta_struct['_dd.stack']) {
-    rootSpan.meta_struct['_dd.stack'] = {}
-  }
-
-  if (!rootSpan.meta_struct['_dd.stack'][namespace]) {
-    rootSpan.meta_struct['_dd.stack'][namespace] = []
-  }
-
-  rootSpan.meta_struct['_dd.stack'][namespace].push({
+  return rootSpan.appendStackTrace(namespace, {
     id: stackId,
     language: 'nodejs',
     frames,
-  })
-}
-
-function canReportStackTrace (rootSpan, maxStackTraces, namespace = STACK_TRACE_NAMESPACES.RASP) {
-  if (!rootSpan) return false
-
-  return maxStackTraces < 1 || (rootSpan.meta_struct?.['_dd.stack']?.[namespace]?.length ?? 0) < maxStackTraces
+  }, maxStackTraces)
 }
 
 module.exports = {
   getCallsiteFrames,
   reportStackTrace,
-  canReportStackTrace,
   STACK_TRACE_NAMESPACES,
 }

--- a/packages/dd-trace/src/appsec/user_tracking.js
+++ b/packages/dd-trace/src/appsec/user_tracking.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto')
 const log = require('../log')
+const eventWriter = require('../opentracing/event-writer')
 const { keepTrace } = require('../priority_sampler')
 const { ASM } = require('../standalone/product')
 const telemetry = require('./telemetry')
@@ -10,6 +11,14 @@ const waf = require('./waf')
 
 // the RFC doesn't include '_id', but it's common in MongoDB
 const USER_ID_FIELDS = ['id', '_id', 'email', 'username', 'login', 'user']
+const LOGIN_SUCCESS_SDK_OWNED_TAGS = new Set([
+  'appsec.events.users.login.success.usr.login',
+  'usr.id',
+])
+const LOGIN_FAILURE_SDK_OWNED_TAGS = new Set([
+  'appsec.events.users.login.failure.usr.login',
+  'appsec.events.users.login.failure.usr.id',
+])
 
 let collectionMode
 
@@ -91,53 +100,35 @@ function trackLogin (framework, login, user, success, rootSpan) {
     [addresses.USER_LOGIN]: login,
   }
 
-  const spanContext = rootSpan.context()
   const sdkTag = `_dd.appsec.events.users.login.${success ? 'success' : 'failure'}.sdk`
-  const isSdkCalled = spanContext.getTag(sdkTag) === 'true'
-
-  // used to not overwrite tags set by SDK
-  function shouldSetTag (tag) {
-    return !(isSdkCalled && spanContext.getTag(tag))
-  }
+  let sdkOwnedTags
 
   if (success) {
     newTags = {
       'appsec.events.users.login.success.track': 'true',
+      'appsec.events.users.login.success.usr.login': login,
       '_dd.appsec.events.users.login.success.auto.mode': collectionMode,
       '_dd.appsec.usr.login': login,
     }
 
-    if (shouldSetTag('appsec.events.users.login.success.usr.login')) {
-      newTags['appsec.events.users.login.success.usr.login'] = login
-    }
-
     if (userId) {
       newTags['_dd.appsec.usr.id'] = userId
-
-      if (shouldSetTag('usr.id')) {
-        newTags['usr.id'] = userId
-        persistent[addresses.USER_ID] = userId
-      }
+      newTags['usr.id'] = userId
     }
 
+    sdkOwnedTags = LOGIN_SUCCESS_SDK_OWNED_TAGS
     persistent[addresses.LOGIN_SUCCESS] = null
   } else {
     newTags = {
       'appsec.events.users.login.failure.track': 'true',
+      'appsec.events.users.login.failure.usr.login': login,
       '_dd.appsec.events.users.login.failure.auto.mode': collectionMode,
       '_dd.appsec.usr.login': login,
     }
 
-    if (shouldSetTag('appsec.events.users.login.failure.usr.login')) {
-      newTags['appsec.events.users.login.failure.usr.login'] = login
-    }
-
     if (userId) {
       newTags['_dd.appsec.usr.id'] = userId
-
-      if (shouldSetTag('appsec.events.users.login.failure.usr.id')) {
-        newTags['appsec.events.users.login.failure.usr.id'] = userId
-      }
+      newTags['appsec.events.users.login.failure.usr.id'] = userId
     }
 
     /* TODO: if one day we have this info
@@ -146,12 +137,20 @@ function trackLogin (framework, login, user, success, rootSpan) {
     }
     */
 
+    sdkOwnedTags = LOGIN_FAILURE_SDK_OWNED_TAGS
     persistent[addresses.LOGIN_FAILURE] = null
   }
 
   keepTrace(rootSpan, ASM)
 
-  rootSpan.addTags(newTags)
+  const userIdWritten = eventWriter.setAppSecAutoLoginTags(
+    rootSpan,
+    sdkTag,
+    newTags,
+    sdkOwnedTags,
+    'usr.id'
+  )
+  if (success && userId && userIdWritten) persistent[addresses.USER_ID] = userId
 
   return waf.run({ persistent })
 }
@@ -166,16 +165,7 @@ function trackUser (user, rootSpan) {
     return
   }
 
-  rootSpan.setTag('_dd.appsec.usr.id', userId)
-
-  const isSdkCalled = rootSpan.context().getTag('_dd.appsec.user.collection_mode') === 'sdk'
-  // do not override SDK
-  if (!isSdkCalled) {
-    rootSpan.addTags({
-      'usr.id': userId,
-      '_dd.appsec.user.collection_mode': collectionMode,
-    })
-
+  if (eventWriter.setAppSecAutoUser(rootSpan, userId, collectionMode)) {
     return waf.run({
       persistent: {
         [addresses.USER_ID]: userId,

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -7,6 +7,7 @@ const {
   getTestSuitePath,
 } = require('../../plugins/util/test')
 const { storage } = require('../../../../datadog-core')
+const { getSpanStore } = require('../../opentracing/span-store')
 
 const legacyStorage = storage('legacy')
 
@@ -28,9 +29,10 @@ class TestApiManualPlugin extends CiPlugin {
       const store = legacyStorage.getStore()
       const testSpan = store && store.span
       if (testSpan) {
-        const previousStore = testSpan._store === undefined
+        const spanStore = getSpanStore(testSpan)
+        const previousStore = spanStore === undefined
           ? undefined
-          : legacyStorage.getStore(testSpan._store)
+          : legacyStorage.getStore(spanStore)
         testSpan.setTag(TEST_STATUS, status)
         if (error) {
           testSpan.setTag('error', error)

--- a/packages/dd-trace/src/git_metadata_tagger.js
+++ b/packages/dd-trace/src/git_metadata_tagger.js
@@ -2,6 +2,7 @@
 
 const { SCI_COMMIT_SHA, SCI_REPOSITORY_URL } = require('./constants')
 const getGitMetadata = require('./git_metadata')
+const eventWriter = require('./opentracing/event-writer')
 
 class GitMetadataTagger {
   #commitSHA
@@ -17,9 +18,8 @@ class GitMetadataTagger {
 
   tagGitMetadata (spanContext) {
     if (this.#enabled) {
-      const tags = spanContext._trace.tags
-      tags[SCI_COMMIT_SHA] = this.#commitSHA
-      tags[SCI_REPOSITORY_URL] = this.#repositoryUrl
+      eventWriter.setTraceTag(spanContext, SCI_COMMIT_SHA, this.#commitSHA)
+      eventWriter.setTraceTag(spanContext, SCI_REPOSITORY_URL, this.#repositoryUrl)
     }
   }
 }

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -23,6 +23,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
+const { disable: disableSpanState, enable: enableSpanState, getTraceTags } = require('./span-state')
 const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution, stripTagsetEntry } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
@@ -65,6 +66,7 @@ let globalTracerConfig
  */
 function enable (config) {
   globalTracerConfig = config
+  enableSpanState()
 
   const startTime = performance.now()
   // create writers and eval writer append and flush channels
@@ -112,6 +114,7 @@ function disable () {
   spanWriter?.destroy()
   evalWriter?.destroy()
   spanProcessor?.setWriter(null)
+  disableSpanState()
 
   spanWriter = null
   evalWriter = null
@@ -129,24 +132,24 @@ function handleLLMObsInjection ({ carrier }) {
   const parent = storage.getStore()?.span
   const mlObsSpanTags = LLMObsTagger.tagMap.get(parent)
 
-  const parentContext = parent?.context()
-  const parentId = parentContext?.toSpanId()
+  const parentId = parent?.context().toSpanId()
+  const traceTags = getTraceTags(parent) || {}
   const mlApp =
     mlObsSpanTags?.[ML_APP] ||
-    parentContext?._trace?.tags?.[PROPAGATED_ML_APP_KEY] ||
+    traceTags[PROPAGATED_ML_APP_KEY] ||
     globalTracerConfig.llmobs.mlApp
 
   const sampleRate =
-    mlObsSpanTags?.[SAMPLE_RATE] ?? parentContext?._trace?.tags?.[PROPAGATED_SAMPLE_RATE_KEY]
+    mlObsSpanTags?.[SAMPLE_RATE] ?? traceTags[PROPAGATED_SAMPLE_RATE_KEY]
   const samplingDecision =
-    mlObsSpanTags?.[SAMPLING_DECISION] ?? parentContext?._trace?.tags?.[PROPAGATED_SAMPLING_DECISION_KEY]
+    mlObsSpanTags?.[SAMPLING_DECISION] ?? traceTags[PROPAGATED_SAMPLING_DECISION_KEY]
   const sessionId =
     mlObsSpanTags?.[SESSION_ID] ??
-    parentContext?._trace?.tags?.[SESSION_ID_TRACE_DEFAULT_KEY] ??
-    parentContext?._trace?.tags?.[PROPAGATED_SESSION_ID_KEY]
+    traceTags[SESSION_ID_TRACE_DEFAULT_KEY] ??
+    traceTags[PROPAGATED_SESSION_ID_KEY]
   const llmobsTraceId = mlObsSpanTags?.[TRACE_ID]
   const propagatedTraceId = llmobsTraceId === undefined
-    ? parentContext?._trace?.tags?.[PROPAGATED_TRACE_ID_KEY]
+    ? traceTags[PROPAGATED_TRACE_ID_KEY]
     : llmObsTraceIdToWire(llmobsTraceId)
 
   if (!parentId && !mlApp && samplingDecision == null && !sessionId && !propagatedTraceId) return

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -132,8 +132,7 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
    * @override
    */
   getLLMObsSpanRegisterOptions (ctx) {
-    const span = ctx.currentStore?.span
-    const operation = getOperation(span)
+    const operation = getOperation(ctx.name)
     const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
     if (!kind) return
 
@@ -147,7 +146,7 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const span = ctx.currentStore?.span
     if (!span) return
 
-    const operation = getOperation(span)
+    const operation = getOperation(ctx.name)
     const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
     if (!kind) return
 

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -136,7 +136,11 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
     if (!kind) return
 
-    return { kind, name: getLlmObsSpanName(operation, ctx.attributes['ai.telemetry.functionId']) }
+    return {
+      kind,
+      name: getLlmObsSpanName(operation, ctx.attributes['ai.telemetry.functionId']),
+      parent: kind === 'tool' ? ctx.parentStore?.span : undefined,
+    }
   }
 
   /**

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -136,11 +136,7 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
     if (!kind) return
 
-    return {
-      kind,
-      name: getLlmObsSpanName(operation, ctx.attributes['ai.telemetry.functionId']),
-      parent: kind === 'tool' ? ctx.parentStore?.span : undefined,
-    }
+    return { kind, name: getLlmObsSpanName(operation, ctx.attributes['ai.telemetry.functionId']) }
   }
 
   /**

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const { channel } = require('dc-polyfill')
-const BaseLLMObsPlugin = require('../base')
 const { getModelProvider } = require('../../../../../datadog-plugin-ai/src/utils')
+const LLMObsTagger = require('../../tagger')
+const BaseLLMObsPlugin = require('../base')
 
 const toolCreationCh = channel('tracing:orchestrion:ai:tool:start')
 const setAttributesCh = channel('dd-trace:vercel-ai:span:setAttributes')
@@ -131,12 +132,18 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
   /**
    * @override
    */
-  getLLMObsSpanRegisterOptions (ctx) {
+  getLLMObsSpanRegisterOptions (ctx, parent) {
     const operation = getOperation(ctx.name)
     const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
     if (!kind) return
 
-    return { kind, name: getLlmObsSpanName(operation, ctx.attributes['ai.telemetry.functionId']) }
+    const name = getLlmObsSpanName(operation, ctx.attributes['ai.telemetry.functionId'])
+    if (kind === 'tool' && LLMObsTagger.getSpanKind(parent) === 'llm') {
+      const semanticParent = LLMObsTagger.getParent(parent)
+      if (semanticParent) return { kind, name, parent: semanticParent }
+    }
+
+    return { kind, name }
   }
 
   /**

--- a/packages/dd-trace/src/llmobs/plugins/ai/util.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/util.js
@@ -65,26 +65,22 @@ const UNSUPPORTED_TOOL_RESULT = '[Unsupported Tool Result]'
  * @returns {SpanTags}
  */
 function getSpanTags (ctx) {
-  const span = ctx.currentStore?.span
-  return /** @type {SpanTags} */ (ctx.attributes ?? span?.context().getTags() ?? {})
+  return /** @type {SpanTags} */ (ctx.attributes ?? {})
 }
 
 /**
- * Get the operation name from the span name
+ * Get the operation name from the instrumentation-owned span name.
  *
  * @example
- * span._name = 'ai.generateText'
- * getOperation(span) // 'generateText'
+ * getOperation('ai.generateText') // 'generateText'
  *
  * @example
- * span._name = 'ai.generateText.doGenerate'
- * getOperation(span) // 'doGenerate'
+ * getOperation('ai.generateText.doGenerate') // 'doGenerate'
  *
- * @param {import('../../../opentracing/span')} span
+ * @param {string} name
  * @returns {string | undefined}
  */
-function getOperation (span) {
-  const name = span._name
+function getOperation (name) {
   if (!name) return
 
   return name.split('.').pop()

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -18,7 +18,7 @@ class LLMObsPlugin extends TracingPlugin {
     throw new Error('setLLMObsTags must be implemented by the subclass')
   }
 
-  getLLMObsSpanRegisterOptions (ctx) {
+  getLLMObsSpanRegisterOptions (ctx, parent) {
     throw new Error('getLLMObsSPanRegisterOptions must be implemented by the subclass')
   }
 
@@ -29,10 +29,11 @@ class LLMObsPlugin extends TracingPlugin {
     if (!enabled) return
 
     const parentStore = llmobsStorage.getStore()
+    const parent = parentStore?.span
     const apmStore = ctx.currentStore
     const span = apmStore?.span
 
-    const registerOptions = this.getLLMObsSpanRegisterOptions(ctx)
+    const registerOptions = this.getLLMObsSpanRegisterOptions(ctx, parent)
 
     // register options may not be set for operations we do not trace with llmobs
     // ie OpenAI fine tuning jobs, file jobs, etc.
@@ -44,7 +45,7 @@ class LLMObsPlugin extends TracingPlugin {
       ctx.llmobs.parent = parentStore
 
       this._tagger.registerLLMObsSpan(span, {
-        parent: parentStore?.span,
+        parent,
         integration: this.constructor.integration,
         ...registerOptions,
       })

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -81,6 +81,7 @@ class LLMObsPlugin extends TracingPlugin {
     }
 
     this.setLLMObsTags(ctx)
+    if (ctx.llmobs) llmobsStorage.enterWith(ctx.llmobs.parent)
   }
 
   configure (config) {

--- a/packages/dd-trace/src/llmobs/plugins/genai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/genai/index.js
@@ -56,7 +56,7 @@ class GenAiLLMObsPlugin extends LLMObsPlugin {
 
     const inputs = args[0]
     const response = ctx.result
-    const error = !!span.context().getTag('error')
+    const error = Boolean(ctx.error)
 
     const operation = getOperation(methodName)
 

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/chain.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/chain.js
@@ -1,23 +1,22 @@
 'use strict'
 
-const { spanHasError } = require('../../../util')
 const { formatIO } = require('../messages')
 const LangChainLLMObsHandler = require('.')
 
 class LangChainLLMObsChainHandler extends LangChainLLMObsHandler {
-  setMetaTags ({ span, inputs, results }) {
+  setMetaTags ({ span, inputs, results, error }) {
     let input
     if (inputs) {
       input = formatIO(inputs)
     }
 
-    const output = !results || spanHasError(span) ? '' : formatIO(results)
+    const output = !results || error ? '' : formatIO(results)
 
     // chain spans will always be workflows
     this._tagger.tagTextIO(span, input, output)
   }
 
-  getName ({ span, instance }) {
+  getName ({ instance, resource }) {
     const firstCallable = instance?.first
 
     if (firstCallable?.constructor?.name === 'ChannelWrite') return
@@ -25,7 +24,7 @@ class LangChainLLMObsChainHandler extends LangChainLLMObsHandler {
     const firstCallableIsLangGraph = firstCallable?.lc_namespace?.includes('langgraph')
     const firstCallableName = firstCallable?.name
 
-    return firstCallableIsLangGraph ? firstCallableName : super.getName({ span })
+    return firstCallableIsLangGraph ? firstCallableName : super.getName({ resource })
   }
 }
 

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/chat_model.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/chat_model.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const LLMObsTagger = require('../../../tagger')
-const { spanHasError } = require('../../../util')
 const { getRole } = require('../messages')
 const LangChainLLMObsHandler = require('.')
 
 const LLM = 'llm'
 
 class LangChainLLMObsChatModelHandler extends LangChainLLMObsHandler {
-  setMetaTags ({ span, inputs, results, options, integrationName }) {
+  setMetaTags ({ span, inputs, results, options, integrationName, error }) {
     if (integrationName === 'openai' && options?.response_format) {
       // langchain-openai will call a beta client if "response_format" is passed in on the options object
       // we do not trace these calls, so this should be an llm span
@@ -28,7 +27,7 @@ class LangChainLLMObsChatModelHandler extends LangChainLLMObsHandler {
       }
     }
 
-    if (spanHasError(span)) {
+    if (error) {
       if (isWorkflow) {
         this._tagger.tagTextIO(span, inputMessages, [{ content: '' }])
       } else {

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/embedding.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/embedding.js
@@ -1,12 +1,11 @@
 'use strict'
 
 const LLMObsTagger = require('../../../tagger')
-const { spanHasError } = require('../../../util')
 const { formatIO } = require('../messages')
 const LangChainLLMObsHandler = require('.')
 
 class LangChainLLMObsEmbeddingHandler extends LangChainLLMObsHandler {
-  setMetaTags ({ span, inputs, results }) {
+  setMetaTags ({ span, inputs, results, error }) {
     const isWorkflow = LLMObsTagger.getSpanKind(span) === 'workflow'
     let embeddingInput, embeddingOutput
 
@@ -17,7 +16,7 @@ class LangChainLLMObsEmbeddingHandler extends LangChainLLMObsHandler {
       embeddingInput = input.map(doc => ({ text: doc }))
     }
 
-    if (spanHasError(span) || !results) {
+    if (error || !results) {
       embeddingOutput = ''
     } else {
       let embeddingDimensions, embeddingsCount

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/index.js
@@ -6,8 +6,8 @@ class LangChainLLMObsHandler {
     this._tagger = tagger
   }
 
-  getName ({ span }) {
-    return span?.context()?.getTag('resource.name')
+  getName ({ resource }) {
+    return resource
   }
 
   setMetaTags () {}

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/llm.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/llm.js
@@ -1,16 +1,15 @@
 'use strict'
 
 const LLMObsTagger = require('../../../tagger')
-const { spanHasError } = require('../../../util')
 const LangChainLLMObsHandler = require('.')
 
 class LangChainLLMObsLlmHandler extends LangChainLLMObsHandler {
-  setMetaTags ({ span, inputs, results }) {
+  setMetaTags ({ span, inputs, results, error }) {
     const isWorkflow = LLMObsTagger.getSpanKind(span) === 'workflow'
     const prompts = Array.isArray(inputs) ? inputs : [inputs]
 
     let outputs
-    if (spanHasError(span)) {
+    if (error) {
       outputs = [{ content: '' }]
     } else {
       outputs = results.generations.map(completion => ({ content: completion[0].text }))

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/vectorstore.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/vectorstore.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const { spanHasError } = require('../../../util')
 const { formatIO } = require('../messages')
 const LangChainLLMObsHandler = require('.')
 
 class LangChainLLMObsVectorStoreHandler extends LangChainLLMObsHandler {
-  setMetaTags ({ span, inputs, results }) {
+  setMetaTags ({ span, inputs, results, error }) {
     const input = formatIO(inputs)
-    if (spanHasError(span)) {
+    if (error) {
       this._tagger.tagRetrievalIO(span, input)
       return
     }

--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -79,7 +79,7 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
 
     const provider = ctx.modelProvider
     const integrationName = this.getIntegrationName(type, provider)
-    this.setMetadata(span, ctx.instance)
+    this.setMetadata(span, ctx.instance, provider)
 
     const inputs = ctx.args?.[0]
     const options = ctx.args?.[1]
@@ -95,7 +95,9 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
     })
   }
 
-  setMetadata (span, instance) {
+  setMetadata (span, instance, provider) {
+    if (!provider) return
+
     const metadata = {}
 
     // these fields won't be set for non model-based operations

--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -47,17 +47,13 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
   }
 
   getLLMObsSpanRegisterOptions (ctx) {
-    const span = ctx.currentStore?.span
-    const spanContext = span?.context()
-    const tags = spanContext?.getTags() || {}
-
-    const modelProvider = tags['langchain.request.provider'] // could be undefined
-    const modelName = tags['langchain.request.model'] // could be undefined
+    const modelProvider = ctx.modelProvider
+    const modelName = ctx.modelName
     const kind = this.getKind(ctx.type, modelProvider)
 
     const instance = ctx.instance || ctx.self
     const handler = this._handlers[ctx.type]
-    const name = handler?.getName({ span, instance })
+    const name = handler?.getName({ instance, resource: ctx.resource })
 
     if (name == null) return
 
@@ -81,32 +77,39 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
       return
     }
 
-    const provider = span?.context()?.getTag('langchain.request.provider')
+    const provider = ctx.modelProvider
     const integrationName = this.getIntegrationName(type, provider)
-    this.setMetadata(span, provider)
+    this.setMetadata(span, ctx.instance)
 
     const inputs = ctx.args?.[0]
     const options = ctx.args?.[1]
     const results = ctx.result
 
-    this._handlers[type].setMetaTags({ span, inputs, results, options, integrationName })
+    this._handlers[type].setMetaTags({
+      span,
+      inputs,
+      results,
+      options,
+      integrationName,
+      error: Boolean(ctx.error),
+    })
   }
 
-  setMetadata (span, provider) {
-    if (!provider) return
-
+  setMetadata (span, instance) {
     const metadata = {}
 
     // these fields won't be set for non model-based operations
-    const spanContext = span?.context()
     const temperature =
-      spanContext?.getTag(`langchain.request.${provider}.parameters.temperature`) ||
-      spanContext?.getTag(`langchain.request.${provider}.parameters.model_kwargs.temperature`)
+      instance?.temperature ??
+      instance?.modelKwargs?.temperature ??
+      instance?.model_kwargs?.temperature
 
     const maxTokens =
-      spanContext?.getTag(`langchain.request.${provider}.parameters.max_tokens`) ||
-      spanContext?.getTag(`langchain.request.${provider}.parameters.maxTokens`) ||
-      spanContext?.getTag(`langchain.request.${provider}.parameters.model_kwargs.max_tokens`)
+      instance?.maxTokens ??
+      instance?.max_tokens ??
+      instance?.modelKwargs?.maxTokens ??
+      instance?.modelKwargs?.max_tokens ??
+      instance?.model_kwargs?.max_tokens
 
     if (temperature) {
       metadata.temperature = Number.parseFloat(temperature)

--- a/packages/dd-trace/src/llmobs/plugins/langgraph/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langgraph/index.js
@@ -2,7 +2,6 @@
 
 const LLMObsPlugin = require('../base')
 const { formatIO } = require('../langchain/messages')
-const { spanHasError } = require('../../util')
 
 const streamDataMap = new WeakMap()
 
@@ -63,7 +62,7 @@ class NextStreamLLMObsPlugin extends LLMObsPlugin {
 
     // Tag on last chunk
     if (ctx.result?.done) {
-      const hasError = ctx.error || spanHasError(span)
+      const hasError = Boolean(ctx.error)
       this.#tagAndCleanup(span, hasError)
     }
   }

--- a/packages/dd-trace/src/llmobs/plugins/openai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/index.js
@@ -81,7 +81,7 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
 
     const inputs = ctx.args[0] // completion, chat completion, and embeddings take one argument
     const response = ctx.result?.data // no result if error
-    const error = !!span.context().getTag('error')
+    const error = Boolean(ctx.error)
 
     const operation = getOperation(methodName)
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -6,6 +6,7 @@ const { isError } = require('../util')
 const logger = require('../log')
 const { getValueFromEnvSources } = require('../config/helper')
 const Span = require('../opentracing/span')
+const { isSpanFinished } = require('../opentracing/span-lifecycle')
 const {
   SPAN_KIND,
   OUTPUT_VALUE,
@@ -271,7 +272,7 @@ class LLMObs extends NoopLLMObs {
         err = 'invalid_span_type'
         throw new Error('Span must be an LLMObs-generated span')
       }
-      if (span._duration !== undefined) {
+      if (isSpanFinished(span)) {
         err = 'invalid_finished_span'
         throw new Error('Cannot annotate a finished span')
       }

--- a/packages/dd-trace/src/llmobs/span-state.js
+++ b/packages/dd-trace/src/llmobs/span-state.js
@@ -1,0 +1,187 @@
+'use strict'
+
+const { channel } = require('dc-polyfill')
+const {
+  PROPAGATED_ML_APP_KEY,
+  PROPAGATED_PARENT_AGENT_ID_KEY,
+  PROPAGATED_PARENT_AGENT_NAME_KEY,
+  PROPAGATED_PARENT_ID_KEY,
+  PROPAGATED_SAMPLE_RATE_KEY,
+  PROPAGATED_SAMPLING_DECISION_KEY,
+  PROPAGATED_SESSION_ID_KEY,
+  PROPAGATED_TRACE_ID_KEY,
+  SESSION_ID_TRACE_DEFAULT_KEY,
+} = require('./constants/tags')
+
+const contextInitializedCh = channel('dd-trace:span:event-writer:context-initialized')
+const spanStartedCh = channel('dd-trace:span:event-writer:span-started')
+const tagsClearedCh = channel('dd-trace:span:event-writer:tags-cleared')
+const tagDeletedCh = channel('dd-trace:span:event-writer:tag-deleted')
+const tagSetCh = channel('dd-trace:span:event-writer:tag-set')
+const tagsSetCh = channel('dd-trace:span:event-writer:tags-set')
+const traceTagSetCh = channel('dd-trace:span:event-writer:trace-tag-set')
+const traceTagsSetCh = channel('dd-trace:span:event-writer:trace-tags-set')
+
+const propagatedKeys = new Set([
+  PROPAGATED_ML_APP_KEY,
+  PROPAGATED_PARENT_AGENT_ID_KEY,
+  PROPAGATED_PARENT_AGENT_NAME_KEY,
+  PROPAGATED_PARENT_ID_KEY,
+  PROPAGATED_SAMPLE_RATE_KEY,
+  PROPAGATED_SAMPLING_DECISION_KEY,
+  PROPAGATED_SESSION_ID_KEY,
+  PROPAGATED_TRACE_ID_KEY,
+  SESSION_ID_TRACE_DEFAULT_KEY,
+])
+
+const contexts = new WeakMap()
+const spans = new WeakMap()
+const traces = new WeakMap()
+let enabled = false
+
+function createTraceState () {
+  return { tags: Object.create(null) }
+}
+
+function getContextState (context) {
+  let state = contexts.get(context)
+  if (state === undefined) {
+    state = { trace: createTraceState() }
+    contexts.set(context, state)
+  }
+  return state
+}
+
+function onContextInitialized ({ context, traceIdentity }) {
+  let trace = traces.get(traceIdentity)
+  if (trace === undefined) {
+    trace = createTraceState()
+    traces.set(traceIdentity, trace)
+  }
+  contexts.set(context, { trace })
+}
+
+function onSpanStarted ({ span, context, parentContext, operationName, startTime }) {
+  const contextState = getContextState(context)
+  const parentSpan = contexts.get(parentContext)?.span
+  spans.set(span, {
+    context,
+    errorKeys: new Set(),
+    genAIKeys: new Set(),
+    name: operationName,
+    parent: spans.get(parentSpan),
+    startTime,
+    trace: contextState.trace,
+  })
+  contextState.span = span
+}
+
+function onTagSet ({ context, key, value }) {
+  const span = contexts.get(context)?.span
+  const state = spans.get(span)
+  if (state === undefined) return
+
+  if (key === 'error' || key === 'error.type') {
+    if (value) state.errorKeys.add(key)
+    else state.errorKeys.delete(key)
+  }
+  if (key.startsWith('gen_ai.')) {
+    if (value === undefined) state.genAIKeys.delete(key)
+    else state.genAIKeys.add(key)
+  }
+}
+
+function onTagsSet ({ context, tags }) {
+  for (const key of Object.keys(tags)) {
+    onTagSet({ context, key, value: tags[key] })
+  }
+}
+
+function onTagDeleted ({ context, key }) {
+  const state = spans.get(contexts.get(context)?.span)
+  if (state === undefined) return
+  if (key === 'error' || key === 'error.type') state.errorKeys.delete(key)
+  if (key.startsWith('gen_ai.')) state.genAIKeys.delete(key)
+}
+
+function onTagsCleared ({ context }) {
+  const state = spans.get(contexts.get(context)?.span)
+  if (state === undefined) return
+  state.errorKeys.clear()
+  state.genAIKeys.clear()
+}
+
+function onTraceTagSet ({ context, key, value }) {
+  if (!propagatedKeys.has(key)) return
+  getContextState(context).trace.tags[key] = value
+}
+
+function onTraceTagsSet ({ context, tags }) {
+  for (const key of Object.keys(tags)) {
+    if (propagatedKeys.has(key)) getContextState(context).trace.tags[key] = tags[key]
+  }
+}
+
+function enable () {
+  if (enabled) return
+  enabled = true
+  contextInitializedCh.subscribe(onContextInitialized)
+  spanStartedCh.subscribe(onSpanStarted)
+  tagsClearedCh.subscribe(onTagsCleared)
+  tagDeletedCh.subscribe(onTagDeleted)
+  tagSetCh.subscribe(onTagSet)
+  tagsSetCh.subscribe(onTagsSet)
+  traceTagSetCh.subscribe(onTraceTagSet)
+  traceTagsSetCh.subscribe(onTraceTagsSet)
+}
+
+function disable () {
+  if (!enabled) return
+  enabled = false
+  contextInitializedCh.unsubscribe(onContextInitialized)
+  spanStartedCh.unsubscribe(onSpanStarted)
+  tagsClearedCh.unsubscribe(onTagsCleared)
+  tagDeletedCh.unsubscribe(onTagDeleted)
+  tagSetCh.unsubscribe(onTagSet)
+  tagsSetCh.unsubscribe(onTagsSet)
+  traceTagSetCh.unsubscribe(onTraceTagSet)
+  traceTagsSetCh.unsubscribe(onTraceTagsSet)
+}
+
+function getOperationName (span) {
+  return spans.get(span)?.name
+}
+
+function getStartTime (span) {
+  return spans.get(span)?.startTime
+}
+
+function getTraceTags (target) {
+  const state = typeof target?.context === 'function'
+    ? spans.get(target) ?? contexts.get(target.context())
+    : contexts.get(target)
+  return state?.trace.tags
+}
+
+function hasError (span) {
+  return (spans.get(span)?.errorKeys.size ?? 0) > 0
+}
+
+function findGenAIAncestorSpanId (span) {
+  let parent = spans.get(span)?.parent
+  while (parent !== undefined) {
+    if (parent.genAIKeys.size > 0) return parent.context.toSpanId()
+    parent = parent.parent
+  }
+  return null
+}
+
+module.exports = {
+  disable,
+  enable,
+  findGenAIAncestorSpanId,
+  getOperationName,
+  getStartTime,
+  getTraceTags,
+  hasError,
+}

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -74,6 +74,7 @@ const {
 // global registry of LLMObs spans
 // maps LLMObs spans to their annotations
 const registry = new WeakMap()
+const parents = new WeakMap()
 
 class LLMObsTagger {
   /** @type {import('../config/config-base')} */
@@ -113,6 +114,16 @@ class LLMObsTagger {
     return registry.get(span)?.[SPAN_KIND]
   }
 
+  /**
+   * Return the semantic LLMObs parent captured when a span was registered.
+   *
+   * @param {import('../opentracing/span') | undefined} span
+   * @returns {import('../opentracing/span') | undefined}
+   */
+  static getParent (span) {
+    return parents.get(span)
+  }
+
   registerLLMObsSpan (span, {
     modelName,
     modelProvider,
@@ -142,6 +153,7 @@ class LLMObsTagger {
     }
 
     this._register(span)
+    parents.set(span, parent)
 
     const traceTags = getTraceTags(span) || {}
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const log = require('../log')
+const eventWriter = require('../opentracing/event-writer')
 const Sampler = require('../sampler')
 const { formatKnuthRate } = require('../util')
 const {
@@ -59,6 +60,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
+const { enable: enableSpanState, getOperationName, getStartTime, getTraceTags } = require('./span-state')
 const {
   findGenAIAncestorSpanId,
   resolveAgentAttribution,
@@ -84,6 +86,7 @@ class LLMObsTagger {
     this.#config = config
 
     this.softFail = softFail
+    if (config.llmobs.DD_LLMOBS_ENABLED) enableSpanState()
   }
 
   /**
@@ -127,7 +130,7 @@ class LLMObsTagger {
     const spanMlApp =
       mlApp ||
       registry.get(parent)?.[ML_APP] ||
-      span.context()._trace.tags[PROPAGATED_ML_APP_KEY] ||
+      getTraceTags(span)?.[PROPAGATED_ML_APP_KEY] ||
       this.#config.llmobs.mlApp ||
       this.#config.service // this should always have a default
 
@@ -140,12 +143,12 @@ class LLMObsTagger {
 
     this._register(span)
 
-    const traceTags = span.context()._trace.tags
+    const traceTags = getTraceTags(span) || {}
 
     const llmobsTraceId =
       registry.get(parent)?.[TRACE_ID] ??
       normalizeLlmObsTraceId(traceTags[PROPAGATED_TRACE_ID_KEY]) ??
-      generateLlmObsTraceId(span._startTime)
+      generateLlmObsTraceId(getStartTime(span) ?? Date.now())
     this._setTag(span, TRACE_ID, llmobsTraceId)
 
     // When the registering span sits below an OTel `gen_ai.*` ancestor, use
@@ -172,7 +175,7 @@ class LLMObsTagger {
 
     const parentId =
       parent?.context().toSpanId() ??
-      span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY] ??
+      traceTags[PROPAGATED_PARENT_ID_KEY] ??
       genAIAncestorSpanId ??
       ROOT_PARENT_ID
     this._setTag(span, PARENT_ID_KEY, parentId)
@@ -210,7 +213,7 @@ class LLMObsTagger {
   }
 
   #tagSamplingDecision (span, parent) {
-    const traceTags = span.context()._trace.tags
+    const traceTags = getTraceTags(span) || {}
     const parentTags = registry.get(parent)
 
     let sampleRate, samplingDecision
@@ -250,11 +253,11 @@ class LLMObsTagger {
     if (registry.has(parent)) {
       // Local LLMObs parent: attribute to it if it is an agent, else inherit its resolution.
       ({ name, spanId } = resolveAgentAttribution(registry.get(parent), parent))
-    } else if (span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY]) {
+    } else if (getTraceTags(span)?.[PROPAGATED_PARENT_ID_KEY]) {
       // Distributed LLMObs parent: inherit the nearest agent propagated from upstream. The
       // name may be absent when the upstream hop ran an older SDK or its name was not
       // wire-safe; the id-only case is expected and the backend resolves the name by span id.
-      const traceTags = span.context()._trace.tags
+      const traceTags = getTraceTags(span) || {}
       name = traceTags[PROPAGATED_PARENT_AGENT_NAME_KEY]
       spanId = traceTags[PROPAGATED_PARENT_AGENT_ID_KEY]
     }
@@ -925,7 +928,7 @@ class LLMObsTagger {
   _register (span) {
     if (!this.#config.llmobs.DD_LLMOBS_ENABLED) return
     if (registry.has(span)) {
-      this.#handleFailure(`LLMObs Span "${span._name}" already registered.`)
+      this.#handleFailure(`LLMObs Span "${getOperationName(span) ?? 'unknown'}" already registered.`)
       return
     }
 
@@ -935,7 +938,7 @@ class LLMObsTagger {
   _setTag (span, key, value) {
     if (!this.#config.llmobs.DD_LLMOBS_ENABLED) return
     if (!registry.has(span)) {
-      this.#handleFailure(`Span "${span._name}" must be an LLMObs generated span.`)
+      this.#handleFailure(`Span "${getOperationName(span) ?? 'unknown'}" must be an LLMObs generated span.`)
       return
     }
 
@@ -948,10 +951,7 @@ class LLMObsTagger {
     // integrations after span start also seed it. First-writer wins, so an explicit session still
     // overrides locally. Cross-service injection is handled centrally in `handleLLMObsInjection`.
     if (key === SESSION_ID && value) {
-      const traceTags = span.context()._trace.tags
-      if (traceTags[SESSION_ID_TRACE_DEFAULT_KEY] === undefined) {
-        traceTags[SESSION_ID_TRACE_DEFAULT_KEY] = value
-      }
+      eventWriter.setTraceTagIfAbsent(span, SESSION_ID_TRACE_DEFAULT_KEY, value)
     }
   }
 }

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const ERROR_TYPE = require('../constants')
-
 const telemetryMetrics = require('../telemetry/metrics')
 const { getSegment } = require('../util')
 const {
@@ -16,6 +14,7 @@ const {
 } = require('./constants/tags')
 
 const LLMObsTagger = require('./tagger')
+const { hasError } = require('./span-state')
 
 const llmobsMetrics = telemetryMetrics.manager.namespace('mlobs')
 
@@ -46,7 +45,6 @@ function incrementLLMObsSpanStartCount (tags, value = 1) {
 
 function incrementLLMObsSpanFinishedCount (span, value = 1) {
   const mlObsTags = LLMObsTagger.tagMap.get(span)
-  const spanTags = span.context().getTags()
 
   const isRootSpan = mlObsTags[PARENT_ID_KEY] === ROOT_PARENT_ID
   const hasSessionId = mlObsTags[SESSION_ID] != null
@@ -55,7 +53,7 @@ function incrementLLMObsSpanFinishedCount (span, value = 1) {
   const decorator = !!mlObsTags[DECORATOR]
   const spanKind = mlObsTags[SPAN_KIND]
   const modelProvider = mlObsTags[MODEL_PROVIDER]
-  const error = spanTags.error || spanTags[ERROR_TYPE]
+  const error = hasError(span)
 
   const tags = {
     autoinstrumented: Number(autoInstrumented),

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -2,6 +2,7 @@
 
 const id = require('../id')
 const log = require('../log')
+const eventWriter = require('../opentracing/event-writer')
 const {
   LLMOBS_PARENT_ID_BRIDGE_KEY,
   LLMOBS_TRACE_ID_BRIDGE_KEY,
@@ -11,6 +12,7 @@ const {
   PARENT_AGENT_NAME,
   PARENT_AGENT_SPAN_ID,
 } = require('./constants/tags')
+const spanState = require('./span-state')
 
 const DECIMAL_TRACE_ID_REGEX = /^\d+$/
 const HEX_TRACE_ID_REGEX = /^[0-9a-f]{32}$/i
@@ -332,7 +334,7 @@ function agentNameWireSafe (name) {
 function resolveAgentAttribution (tags, span) {
   if (!tags) return { name: undefined, spanId: undefined }
   if (tags[SPAN_KIND] === 'agent') {
-    return { name: tags[NAME] || span._name, spanId: span.context().toSpanId() }
+    return { name: tags[NAME] || spanState.getOperationName(span), spanId: span.context().toSpanId() }
   }
   return { name: tags[PARENT_AGENT_NAME], spanId: tags[PARENT_AGENT_SPAN_ID] }
 }
@@ -368,11 +370,6 @@ function appendOptionalPropagatedTag (tags, key, value, safeguard, maxTagSetLeng
   return `${tags}${entry}`
 }
 
-function spanHasError (span) {
-  const spanContext = span.context()
-  return !!(spanContext.getTag('error') || spanContext.getTag('error.type'))
-}
-
 // LLM SDKs stream tool-call argument JSON across SSE chunks; a malformed
 // accumulation would otherwise throw straight into the chunk subscriber.
 function safeJsonParse (value, fallback) {
@@ -394,11 +391,16 @@ function safeJsonParse (value, fallback) {
  * @param {{ includeParentId?: boolean, llmobsTraceId?: string }} [opts]
  */
 function writeBridgeTags (span, { includeParentId = true, llmobsTraceId } = {}) {
-  const traceTags = span?.context?.()._trace?.tags
-  if (!traceTags || traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) return
-  traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY] = llmobsTraceId ?? span.context().toTraceId(true)
+  const context = span?.context?.()
+  if (!context?.toTraceId || !context?.toSpanId) return
+  const written = eventWriter.setTraceTagIfAbsent(
+    span,
+    LLMOBS_TRACE_ID_BRIDGE_KEY,
+    llmobsTraceId ?? context.toTraceId(true)
+  )
+  if (!written) return
   if (includeParentId) {
-    traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
+    eventWriter.setTraceTag(span, LLMOBS_PARENT_ID_BRIDGE_KEY, context.toSpanId())
   }
 }
 
@@ -411,34 +413,7 @@ function writeBridgeTags (span, { includeParentId = true, llmobsTraceId } = {}) 
  * @returns {string | null}
  */
 function findGenAIAncestorSpanId (span) {
-  const ctx = span?.context?.()
-  let parentId = ctx?._parentId?.toString(10)
-  if (!parentId || parentId === '0') return null
-
-  const started = ctx._trace?.started
-  if (!started || started.length === 0) return null
-
-  // Linear scan per hop — parent chains are short, avoids a per-call Map.
-  while (parentId && parentId !== '0') {
-    let parent = null
-    for (const s of started) {
-      if (s.context()._spanId.toString(10) === parentId) {
-        parent = s
-        break
-      }
-    }
-    if (!parent) return null
-
-    const tags = parent.context().getTags()
-    if (tags) {
-      for (const key of Object.keys(tags)) {
-        if (key.startsWith('gen_ai.')) return parentId
-      }
-    }
-
-    parentId = parent.context()._parentId?.toString(10)
-  }
-  return null
+  return spanState.findGenAIAncestorSpanId(span)
 }
 
 /**
@@ -532,7 +507,6 @@ module.exports = {
   validateKind,
   getFunctionArguments,
   safeJsonParse,
-  spanHasError,
   writeBridgeTags,
   validateToolDefinitions,
 }

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -2,13 +2,14 @@
 
 const id = require('../id')
 const { storage } = require('../../../datadog-core') // TODO: noop storage?
+const { setSpanStore } = require('../opentracing/span-store')
 const NoopSpanContext = require('./span_context')
 
 const legacyStorage = storage('legacy')
 
 class NoopSpan {
   constructor (tracer, parent) {
-    this._store = legacyStorage.getHandle()
+    setSpanStore(this, legacyStorage.getHandle())
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }
@@ -16,13 +17,51 @@ class NoopSpan {
   context () { return this._noopContext }
   tracer () { return this._noopTracer }
   setOperationName (name) { return this }
+
+  /**
+   * Preserve the DatadogSpan semantic mutation surface on non-recording spans.
+   *
+   * @param {string} name
+   * @returns {NoopSpan}
+   */
+  setIntegrationName (name) { return this }
+
+  /**
+   * Preserve the DatadogSpan recording mutation surface on non-recording spans.
+   *
+   * @param {boolean} enabled
+   * @returns {NoopSpan}
+   */
+  setRecording (enabled) { return this }
+
   setBaggageItem (key, value) { return this }
   getBaggageItem (key) {}
   getAllBaggageItems () {}
   removeBaggageItem (key) { return this }
   removeAllBaggageItems () { return this }
   setTag (key, value) { return this }
+
+  /**
+   * Report that a non-recording span did not retain the conditional tag.
+   *
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setTagIfAbsent (key, value) { return false }
+
   addTags (keyValueMap) { return this }
+
+  /**
+   * Report that a non-recording span did not retain conditional tags.
+   *
+   * @param {string} expectedKey
+   * @param {unknown} expectedValue
+   * @param {Record<string, unknown>} tags
+   * @returns {boolean}
+   */
+  setTagsIfTagMatches (expectedKey, expectedValue, tags) { return false }
+
   addLink (link) { return this }
   addLinks (links) { return this }
   addSpanPointer (ptrKind, ptrDir, ptrHash) { return this }

--- a/packages/dd-trace/src/noop/span_context.js
+++ b/packages/dd-trace/src/noop/span_context.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const DatadogSpanContext = require('../opentracing/span_context')
+const eventWriter = require('../opentracing/event-writer')
 const priority = require('../../../../ext/priority')
 
 const USER_REJECT = priority.USER_REJECT
@@ -9,7 +10,7 @@ class NoopSpanContext extends DatadogSpanContext {
   constructor (props) {
     super(props)
 
-    this._sampling.priority = USER_REJECT
+    eventWriter.setSamplingPriority(this, USER_REJECT)
   }
 }
 

--- a/packages/dd-trace/src/opentelemetry/active-span-proxy.js
+++ b/packages/dd-trace/src/opentelemetry/active-span-proxy.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const BridgeSpanBase = require('./bridge-span-base')
-const { setOtelResource } = require('./span-helpers')
 
 /**
  * OTel `Span`-compatible proxy around an already-active Datadog span.
@@ -32,7 +31,7 @@ class ActiveSpanProxy extends BridgeSpanBase {
    * @param {string} name
    */
   updateName (name) {
-    setOtelResource(this._ddSpan, name)
+    this._updateDatadogName(name, false)
     return this
   }
 

--- a/packages/dd-trace/src/opentelemetry/bridge-span-base.js
+++ b/packages/dd-trace/src/opentelemetry/bridge-span-base.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { isSpanFinished } = require('../opentracing/span-lifecycle')
 const {
   addOtelEvent,
   addOtelLink,
@@ -8,7 +9,10 @@ const {
   recordException,
   setOtelAttribute,
   setOtelAttributes,
+  setOtelOperationName,
+  setOtelResource,
 } = require('./span-helpers')
+const { registerDatadogSpan } = require('./span-registry')
 
 /**
  * Shared base for the OTel-bridge span classes (`Span` and `ActiveSpanProxy`). Subclasses
@@ -16,12 +20,11 @@ const {
  * and `updateName()`. The writable-span gate lives in the helpers in `span-helpers.js`,
  * so neither bridge can drift from it.
  *
- * `_ddSpan` is left as a `_underscore` field rather than `#private` so the bridge does not
- * expand its published API to expose the underlying DD span. External callers that need
- * the reference (`ContextManager` proxy-cache check, OTLP serialization, tests) reach in
- * via `_ddSpan`, matching the existing convention for "internal, may break".
+ * The wrapped span is private. Cross-module adapter identity is maintained by
+ * `span-registry.js` rather than by exposing a mutable backing field.
  */
 class BridgeSpanBase {
+  #datadogSpan
   // OTel SpanStatusCode: 0 = UNSET, 1 = OK, 2 = ERROR. Tracked for OK-is-final precedence.
   #statusCode = 0
 
@@ -29,12 +32,13 @@ class BridgeSpanBase {
    * @param {import('../opentracing/span')} ddSpan
    */
   constructor (ddSpan) {
-    this._ddSpan = ddSpan
+    this.#datadogSpan = ddSpan
+    registerDatadogSpan(this, ddSpan)
     this._otelTraceSemanticsEnabled = false
   }
 
   get ended () {
-    return this._ddSpan._duration !== undefined
+    return isSpanFinished(this.#datadogSpan)
   }
 
   isRecording () {
@@ -46,7 +50,7 @@ class BridgeSpanBase {
    * @param {import('@opentelemetry/api').AttributeValue} value
    */
   setAttribute (key, value) {
-    setOtelAttribute(this._ddSpan, key, value, this._otelTraceSemanticsEnabled)
+    setOtelAttribute(this.#datadogSpan, key, value, this._otelTraceSemanticsEnabled)
     return this
   }
 
@@ -54,7 +58,7 @@ class BridgeSpanBase {
    * @param {import('@opentelemetry/api').Attributes} attributes
    */
   setAttributes (attributes) {
-    setOtelAttributes(this._ddSpan, attributes, this._otelTraceSemanticsEnabled)
+    setOtelAttributes(this.#datadogSpan, attributes, this._otelTraceSemanticsEnabled)
     return this
   }
 
@@ -64,7 +68,7 @@ class BridgeSpanBase {
    * @param {import('@opentelemetry/api').TimeInput} [startTime]
    */
   addEvent (name, attributesOrStartTime, startTime) {
-    addOtelEvent(this._ddSpan, name, attributesOrStartTime, startTime)
+    addOtelEvent(this.#datadogSpan, name, attributesOrStartTime, startTime)
     return this
   }
 
@@ -75,7 +79,7 @@ class BridgeSpanBase {
    * @param {import('@opentelemetry/api').Attributes} [attrs]
    */
   addLink (link, attrs) {
-    addOtelLink(this._ddSpan, link, attrs)
+    addOtelLink(this.#datadogSpan, link, attrs)
     return this
   }
 
@@ -83,7 +87,7 @@ class BridgeSpanBase {
    * @param {import('@opentelemetry/api').Link[]} links
    */
   addLinks (links) {
-    addOtelLinks(this._ddSpan, links)
+    addOtelLinks(this.#datadogSpan, links)
     return this
   }
 
@@ -92,15 +96,52 @@ class BridgeSpanBase {
    * @param {import('@opentelemetry/api').TimeInput} [timeInput]
    */
   recordException (exception, timeInput) {
-    recordException(this._ddSpan, exception, timeInput, this._otelTraceSemanticsEnabled)
+    recordException(this.#datadogSpan, exception, timeInput, this._otelTraceSemanticsEnabled)
   }
 
   /**
    * @param {import('@opentelemetry/api').SpanStatus} status
    */
   setStatus (status) {
-    this.#statusCode = applyOtelStatus(this._ddSpan, this.#statusCode, status, this._otelTraceSemanticsEnabled)
+    this.#statusCode = applyOtelStatus(
+      this.#datadogSpan,
+      this.#statusCode,
+      status,
+      this._otelTraceSemanticsEnabled
+    )
     return this
+  }
+
+  /**
+   * Apply an OTel name update to the wrapped Datadog span.
+   *
+   * @param {string} name
+   * @param {boolean} operationName
+   */
+  _updateDatadogName (name, operationName) {
+    if (operationName) {
+      setOtelOperationName(this.#datadogSpan, name)
+    } else {
+      setOtelResource(this.#datadogSpan, name)
+    }
+  }
+
+  /**
+   * Finish the wrapped Datadog span.
+   *
+   * @param {number} endTime
+   */
+  _finishDatadogSpan (endTime) {
+    this.#datadogSpan.finish(endTime)
+  }
+
+  /**
+   * Invoke a callback with the wrapped Datadog span without exposing it.
+   *
+   * @param {(span: import('../opentracing/span')) => void} callback
+   */
+  _withDatadogSpan (callback) {
+    callback(this.#datadogSpan)
   }
 }
 

--- a/packages/dd-trace/src/opentelemetry/bridge-span-base.js
+++ b/packages/dd-trace/src/opentelemetry/bridge-span-base.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { isSpanFinished } = require('../opentracing/span-lifecycle')
+const id = require('../id')
 const {
   addOtelEvent,
   addOtelLink,
@@ -14,6 +15,29 @@ const {
 } = require('./span-helpers')
 const { registerDatadogSpan } = require('./span-registry')
 
+class LegacyDatadogSpanFacade {
+  #context
+
+  /**
+   * @param {import('./span_context')} spanContext
+   */
+  constructor (spanContext) {
+    this.#context = Object.freeze({
+      _traceId: id(spanContext.traceId),
+      _spanId: id(spanContext.spanId),
+    })
+  }
+
+  /**
+   * Return the immutable identifier envelope used by legacy system tests.
+   *
+   * @returns {{ _traceId: import('../id'), _spanId: import('../id') }}
+   */
+  context () {
+    return this.#context
+  }
+}
+
 /**
  * Shared base for the OTel-bridge span classes (`Span` and `ActiveSpanProxy`). Subclasses
  * pass the underlying Datadog span to `super(ddSpan)` and provide `spanContext()`, `end()`,
@@ -25,6 +49,7 @@ const { registerDatadogSpan } = require('./span-registry')
  */
 class BridgeSpanBase {
   #datadogSpan
+  #legacyDatadogSpan
   // OTel SpanStatusCode: 0 = UNSET, 1 = OK, 2 = ERROR. Tracked for OK-is-final precedence.
   #statusCode = 0
 
@@ -43,6 +68,18 @@ class BridgeSpanBase {
 
   isRecording () {
     return !this.ended
+  }
+
+  /**
+   * Compatibility facade for callers that only used `_ddSpan.context()` to
+   * obtain identifiers. The mutable Datadog span remains private.
+   *
+   * @returns {LegacyDatadogSpanFacade}
+   * @deprecated Use spanContext().
+   */
+  get _ddSpan () {
+    this.#legacyDatadogSpan ??= new LegacyDatadogSpanFacade(this.spanContext())
+    return this.#legacyDatadogSpan
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -3,9 +3,14 @@
 const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const { storage } = require('../../../datadog-core')
 const { getAllBaggageItems, setAllBaggageItems, removeAllBaggageItems } = require('../baggage')
+const { getSpanStore } = require('../opentracing/span-store')
 
 const ActiveSpanProxy = require('./active-span-proxy')
 const SpanContext = require('./span_context')
+const { getDatadogSpan } = require('./span-registry')
+
+const activeSpans = new WeakMap()
+const spanContexts = new WeakMap()
 
 class ContextManager {
   constructor () {
@@ -33,7 +38,7 @@ class ContextManager {
     }
 
     // If stored span wraps the active DD span, prefer the stored context
-    if (storedSpan && storedSpan._ddSpan === activeSpan) {
+    if (storedSpan && getDatadogSpan(storedSpan) === activeSpan) {
       if (otelBaggages) return propagation.setBaggage(store, otelBaggages)
       return store
     }
@@ -44,24 +49,28 @@ class ContextManager {
     }
 
     const ddContext = activeSpan.context()
+    let spanContext = spanContexts.get(ddContext)
 
-    if (!ddContext._otelSpanContext) {
-      ddContext._otelSpanContext = new SpanContext(ddContext)
+    if (spanContext === undefined) {
+      spanContext = new SpanContext(ddContext)
+      spanContexts.set(ddContext, spanContext)
     }
 
     // Cache the active-span proxy next to the bridge span context. This lets
     // `trace.getActiveSpan()` forward attribute/status/link/exception writes
     // onto the active Datadog span rather than returning a NonRecordingSpan
     // whose mutation methods are silent no-ops.
-    if (!ddContext._otelActiveSpan) {
-      ddContext._otelActiveSpan = new ActiveSpanProxy(activeSpan, ddContext._otelSpanContext)
+    let otelActiveSpan = activeSpans.get(ddContext)
+    if (otelActiveSpan === undefined) {
+      otelActiveSpan = new ActiveSpanProxy(activeSpan, spanContext)
+      activeSpans.set(ddContext, otelActiveSpan)
     }
 
-    if (store && trace.getSpan(store) === ddContext._otelActiveSpan) {
+    if (store && trace.getSpan(store) === otelActiveSpan) {
       return otelBaggages ? propagation.setBaggage(store, otelBaggages) : store
     }
 
-    const wrappedContext = trace.setSpan(baseContext, ddContext._otelActiveSpan)
+    const wrappedContext = trace.setSpan(baseContext, otelActiveSpan)
     return otelBaggages ? propagation.setBaggage(wrappedContext, otelBaggages) : wrappedContext
   }
 
@@ -84,9 +93,9 @@ class ContextManager {
     } else {
       removeAllBaggageItems()
     }
-    if (span && span._ddSpan) {
-      const ddSpan = span._ddSpan
-      const parentStore = storage('legacy').getStore(ddSpan._store) ?? storage('legacy').getStore()
+    const ddSpan = span && getDatadogSpan(span)
+    if (ddSpan) {
+      const parentStore = storage('legacy').getStore(getSpanStore(ddSpan)) ?? storage('legacy').getStore()
       return storage('legacy').run({ ...parentStore, span: ddSpan }, run)
     }
     return run()

--- a/packages/dd-trace/src/opentelemetry/span-helpers.js
+++ b/packages/dd-trace/src/opentelemetry/span-helpers.js
@@ -5,9 +5,11 @@ const { performance } = require('node:perf_hooks')
 const { timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/core')
 
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE, IGNORE_OTEL_ERROR } = require('../constants')
+const { getDatadogContext } = require('../opentracing/context-registry')
 const DatadogSpanContext = require('../opentracing/span_context')
 const TraceState = require('../opentracing/propagation/tracestate')
 const { DD_MAJOR } = require('../../../../version')
+const { isSpanFinished } = require('../opentracing/span-lifecycle')
 
 const id = require('../id')
 
@@ -15,7 +17,6 @@ const { timeOrigin } = performance
 
 /**
  * @typedef {{
- *   _ddContext?: import('../opentracing/span_context'),
  *   toTraceId?: (get128?: boolean) => string,
  *   toSpanId?: (get128?: boolean) => string,
  *   traceId?: string,
@@ -38,7 +39,7 @@ const { timeOrigin } = performance
  * @param {import('../opentracing/span')} ddSpan
  */
 function isWritable (ddSpan) {
-  return ddSpan._duration === undefined
+  return !isSpanFinished(ddSpan)
 }
 
 /**
@@ -101,7 +102,7 @@ function normalizeOtelEvent (attributesOrStartTime, startTime) {
 
 /**
  * Accepts the native `DatadogSpanContext` (`toTraceId`/`toSpanId`), the bridge wrapper
- * (`_ddContext`), or a standard OTel `SpanContext` (`traceId`/`spanId` strings); returns
+ * (registered out of band), or a standard OTel `SpanContext` (`traceId`/`spanId` strings); returns
  * a `DatadogSpanContext` or `undefined` when nothing usable is present.
  *
  * @param {LinkContextLike | undefined | null} context
@@ -109,7 +110,8 @@ function normalizeOtelEvent (attributesOrStartTime, startTime) {
 function normalizeLinkContext (context) {
   if (!context) return
 
-  if (context._ddContext) return context._ddContext
+  const datadogContext = getDatadogContext(context)
+  if (datadogContext) return datadogContext
 
   if (isDatadogSpanContext(context)) return context
 

--- a/packages/dd-trace/src/opentelemetry/span-registry.js
+++ b/packages/dd-trace/src/opentelemetry/span-registry.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const spans = new WeakMap()
+
+/**
+ * Register the Datadog span wrapped by an OTel bridge object.
+ *
+ * @param {object} bridgeSpan
+ * @param {import('../opentracing/span')} datadogSpan
+ */
+function registerDatadogSpan (bridgeSpan, datadogSpan) {
+  spans.set(bridgeSpan, datadogSpan)
+}
+
+/**
+ * Return the Datadog span wrapped by an OTel bridge object.
+ *
+ * @param {object} bridgeSpan
+ * @returns {import('../opentracing/span')|undefined}
+ */
+function getDatadogSpan (bridgeSpan) {
+  return spans.get(bridgeSpan)
+}
+
+module.exports = { getDatadogSpan, registerDatadogSpan }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -8,15 +8,17 @@ const { timeOrigin } = performance
 const { timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/core')
 
 const tracer = require('../../')
+const { getSpanDuration } = require('../opentracing/span-lifecycle')
 const DatadogSpan = require('../opentracing/span')
 const { SERVICE_NAME, RESOURCE_NAME, SPAN_KIND } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
 
 const id = require('../id')
+const { getDatadogContext } = require('../opentracing/context-registry')
 const BridgeSpanBase = require('./bridge-span-base')
 const SpanContext = require('./span_context')
+const { getDatadogSpan } = require('./span-registry')
 const spanEndingHook = require('./span-ending-hook')
-const { setOtelOperationName, setOtelResource } = require('./span-helpers')
 
 const spanKindNames = {
   [api.SpanKind.INTERNAL]: kinds.INTERNAL,
@@ -152,7 +154,7 @@ class Span extends BridgeSpanBase {
 
     const ddSpan = new DatadogSpan(_tracer, _tracer._processor, _tracer._prioritySampler, {
       operationName: spanNameMapper(spanName, kind, attributes),
-      context: spanContext._ddContext,
+      context: getDatadogContext(spanContext),
       startTime,
       hostname: _tracer._hostname,
       integrationName: parentTracer?._isOtelLibrary ? 'otel.library' : 'otel',
@@ -179,7 +181,7 @@ class Span extends BridgeSpanBase {
 
     this._parentTracer = parentTracer
     this._context = context
-    this.#otelName = spanName || this._ddSpan.context()._name
+    this.#otelName = spanName || getDatadogSpan(this).context()._name
 
     // NOTE: Need to grab the value before setting it on the span because the
     // math for computing opentracing timestamps is apparently lossy...
@@ -189,7 +191,7 @@ class Span extends BridgeSpanBase {
   }
 
   get parentSpanId () {
-    const { _parentId } = this._ddSpan.context()
+    const { _parentId } = getDatadogSpan(this).context()
     return _parentId && _parentId.toString(16)
   }
 
@@ -211,7 +213,7 @@ class Span extends BridgeSpanBase {
   }
 
   spanContext () {
-    return new SpanContext(this._ddSpan.context())
+    return new SpanContext(getDatadogSpan(this).context())
   }
 
   /**
@@ -241,9 +243,9 @@ class Span extends BridgeSpanBase {
     if (this.ended) return this
     this.#otelName = name
     if (this._otelTraceSemanticsEnabled) {
-      setOtelResource(this._ddSpan, name)
+      this._updateDatadogName(name, false)
     } else {
-      setOtelOperationName(this._ddSpan, name)
+      this._updateDatadogName(name, true)
     }
     return this
   }
@@ -262,14 +264,14 @@ class Span extends BridgeSpanBase {
 
     // Must run before `finish()`, while the DD span is still unfinished. See span-ending-hook.js.
     if (spanEndingHook.hook !== undefined) {
-      spanEndingHook.hook(this._ddSpan)
+      this._withDatadogSpan(spanEndingHook.hook)
     }
-    this._ddSpan.finish(endTime)
+    this._finishDatadogSpan(endTime)
     this._spanProcessor.onEnd(this)
   }
 
   get duration () {
-    return this._ddSpan._duration
+    return getSpanDuration(getDatadogSpan(this))
   }
 }
 

--- a/packages/dd-trace/src/opentelemetry/span_context.js
+++ b/packages/dd-trace/src/opentelemetry/span_context.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const api = require('@opentelemetry/api')
-const { AUTO_KEEP } = require('../../../../ext/priority')
+const { registerDatadogContext } = require('../opentracing/context-registry')
 const DatadogSpanContext = require('../opentracing/span_context')
 const id = require('../id')
 
@@ -14,31 +14,32 @@ function newContext () {
 }
 
 class SpanContext {
+  #datadogContext
+
   constructor (context) {
     if (!(context instanceof DatadogSpanContext)) {
       context = context
         ? new DatadogSpanContext(context)
         : newContext()
     }
-    this._ddContext = context
+    this.#datadogContext = context
+    registerDatadogContext(this, context)
   }
 
   get traceId () {
-    return this._ddContext.toTraceId(true)
+    return this.#datadogContext.toTraceId(true)
   }
 
   get spanId () {
-    return this._ddContext.toSpanId(true)
+    return this.#datadogContext.toSpanId(true)
   }
 
   get traceFlags () {
-    this._ddContext._ensureSamplingPriority()
-    return this._ddContext._sampling.priority >= AUTO_KEEP ? 1 : 0
+    return this.#datadogContext.toTraceFlags()
   }
 
   get traceState () {
-    const ts = this._ddContext._tracestate
-    return api.createTraceState(ts ? ts.toString() : '')
+    return api.createTraceState(this.#datadogContext.toTracestate())
   }
 }
 

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -7,6 +7,8 @@ const tracer = require('../../')
 
 const id = require('../id')
 const log = require('../log')
+const { getDatadogContext } = require('../opentracing/context-registry')
+const eventWriter = require('../opentracing/event-writer')
 const TextMapPropagator = require('../opentracing/propagation/text_map')
 const TraceState = require('../opentracing/propagation/tracestate')
 const SpanContext = require('./span_context')
@@ -86,8 +88,9 @@ class Tracer {
       traceId: id(traceId, 16), spanId: id(), tags: meta, parentId: id(spanId, 16),
     })
 
-    spanContext._ddContext._sampling = { priority: samplingPriority }
-    spanContext._ddContext._trace = { ...spanContext._ddContext._trace, origin }
+    const datadogContext = getDatadogContext(spanContext)
+    eventWriter.setSamplingPriority(datadogContext, samplingPriority)
+    eventWriter.setOrigin(datadogContext, origin)
     return spanContext
   }
 
@@ -100,8 +103,9 @@ class Tracer {
     const parentSpanContext = parentSpan?.spanContext()
     let spanContext
     if (parentSpanContext && api.trace.isSpanContextValid(parentSpanContext)) {
-      spanContext = parentSpanContext._ddContext
-        ? this._createSpanContextFromParent(parentSpanContext._ddContext)
+      const datadogContext = getDatadogContext(parentSpanContext)
+      spanContext = datadogContext
+        ? this._createSpanContextFromParent(datadogContext)
         : this._createSpanContextForNewSpan(parentSpanContext)
     } else {
       spanContext = new SpanContext()

--- a/packages/dd-trace/src/opentracing/context-registry.js
+++ b/packages/dd-trace/src/opentracing/context-registry.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const contexts = new WeakMap()
+
+/**
+ * Associate a public context wrapper with its Datadog propagation context.
+ *
+ * @param {object} wrapper
+ * @param {import('./span_context')} context
+ */
+function registerDatadogContext (wrapper, context) {
+  contexts.set(wrapper, context)
+}
+
+/**
+ * Resolve the Datadog propagation context behind a public context wrapper.
+ *
+ * @param {object} wrapper
+ * @returns {import('./span_context') | undefined}
+ */
+function getDatadogContext (wrapper) {
+  return contexts.get(wrapper)
+}
+
+module.exports = { getDatadogContext, registerDatadogContext }

--- a/packages/dd-trace/src/opentracing/event-writer.js
+++ b/packages/dd-trace/src/opentracing/event-writer.js
@@ -1,0 +1,705 @@
+'use strict'
+
+/* eslint-disable eslint-rules/eslint-no-private-tags-access */
+
+const { channel } = require('dc-polyfill')
+const { AUTO_REJECT, USER_KEEP, USER_REJECT } = require('../../../../ext/priority')
+const { isSpanFinished, markSpanFinished, markSpanStarted } = require('./span-lifecycle')
+
+const contextInitializedCh = channel('dd-trace:span:event-writer:context-initialized')
+const spanStartedCh = channel('dd-trace:span:event-writer:span-started')
+const tagsClearedCh = channel('dd-trace:span:event-writer:tags-cleared')
+const tagDeletedCh = channel('dd-trace:span:event-writer:tag-deleted')
+const tagSetCh = channel('dd-trace:span:event-writer:tag-set')
+const tagsSetCh = channel('dd-trace:span:event-writer:tags-set')
+const traceTagSetCh = channel('dd-trace:span:event-writer:trace-tag-set')
+const traceTagsSetCh = channel('dd-trace:span:event-writer:trace-tags-set')
+
+/**
+ * Compatibility EventWriter backed by the current JavaScript span objects.
+ *
+ * The public methods are the write boundary that a native implementation will
+ * replace. Production callers must not mutate the backing fields directly.
+ */
+class EventWriter {
+  /**
+   * @param {import('./span_context')} context
+   * @param {object} [props]
+   */
+  initializeContext (context, props = {}) {
+    context._traceId = props.traceId
+    context._spanId = props.spanId
+    context._isRemote = props.isRemote ?? true
+    context._parentId = props.parentId || null
+    context._name = props.name
+    context._isFinished = props.isFinished || false
+    context._tags = props.tags || {}
+    context._sampling = props.sampling || {}
+    context._spanSampling = undefined
+    context._links = props.links || []
+    context._baggageItems = props.baggageItems || {}
+    context._traceparent = props.traceparent
+    context._tracestate = props.tracestate
+    context._noop = props.noop || null
+    context._trace = props.trace || {
+      started: [],
+      finished: [],
+      tags: {},
+    }
+    if (contextInitializedCh.hasSubscribers) {
+      contextInitializedCh.publish({ context, traceIdentity: context._trace })
+    }
+    if (props.trace?.tags && traceTagsSetCh.hasSubscribers) {
+      traceTagsSetCh.publish({ context, tags: props.trace.tags })
+    }
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {object} fields
+   * @param {import('./span_context')} fields.context
+   * @param {object} fields.processor
+   * @param {object} fields.prioritySampler
+   * @param {unknown} fields.debug
+   * @param {string} fields.operationName
+   * @param {string} fields.integrationName
+   * @param {number} fields.startTime
+   * @param {Array<object>} fields.links
+   * @param {string} [fields.hostname]
+   * @param {import('./span_context')} [fields.parentContext]
+   */
+  startSpan (span, fields) {
+    const {
+      context,
+      processor,
+      prioritySampler,
+      debug,
+      operationName,
+      integrationName,
+      startTime,
+      links,
+      hostname,
+    } = fields
+
+    span._debug = debug
+    span._processor = processor
+    span._prioritySampler = prioritySampler
+    span._duration = undefined
+    span._events = []
+    span._name = operationName
+    span._integrationName = integrationName
+    span._spanContext = context
+    span._startTime = startTime
+    span._links = links
+
+    context._name = operationName
+    context._hostname = hostname
+    context._trace.started.push(span)
+    markSpanStarted(span)
+    if (spanStartedCh.hasSubscribers) {
+      spanStartedCh.publish({
+        span,
+        context,
+        parentContext: fields.parentContext,
+        traceIdentity: context._trace,
+        spanId: context._spanId,
+        parentId: context._parentId,
+        operationName,
+        startTime,
+      })
+    }
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} name
+   */
+  setOperationName (span, name) {
+    span._spanContext._name = name
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} name
+   */
+  setIntegrationName (span, name) {
+    span._integrationName = name
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {boolean} enabled
+   */
+  setRecording (span, enabled) {
+    span._spanContext._trace.record = enabled
+    span._spanContext._trace.isRecording = enabled
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string} key
+   * @param {unknown} value
+   */
+  setTag (target, key, value) {
+    const context = getContext(target)
+    context._tags[key] = value
+    if (tagSetCh.hasSubscribers) tagSetCh.publish({ context, key, value })
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   * @param {Record<string, unknown>} tags
+   */
+  setTags (target, tags) {
+    const context = getContext(target)
+    Object.assign(context._tags, tags)
+    if (tagsSetCh.hasSubscribers) tagsSetCh.publish({ context, tags })
+  }
+
+  /**
+   * Set multiple tags when an ownership tag is absent or still has the expected value.
+   *
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string} expectedKey
+   * @param {unknown} expectedValue
+   * @param {Record<string, unknown>} tags
+   * @returns {boolean}
+   */
+  setTagsIfTagMatches (target, expectedKey, expectedValue, tags) {
+    const context = getContext(target)
+    const currentValue = context._tags[expectedKey]
+    if (currentValue !== undefined && currentValue !== expectedValue) return false
+    Object.assign(context._tags, tags)
+    if (tagsSetCh.hasSubscribers) tagsSetCh.publish({ context, tags })
+    return true
+  }
+
+  /**
+   * Copy selected tags without exposing the source span's tag state.
+   *
+   * @param {import('./span')} source
+   * @param {import('./span')} destination
+   * @param {Array<[string, string]>} mappings
+   */
+  copyTags (source, destination, mappings) {
+    const tags = source._spanContext._tags
+    for (const [sourceTag, destinationTag] of mappings) {
+      const value = tags[sourceTag]
+      if (value !== undefined && value !== null) {
+        this.setTag(destination, destinationTag, value)
+      }
+    }
+  }
+
+  /**
+   * Atomically write automatic login tags without replacing SDK-owned values.
+   *
+   * @param {import('./span')} span
+   * @param {string} sdkTag
+   * @param {Record<string, unknown>} tags
+   * @param {Set<string>} sdkOwnedTags
+   * @param {string} trackedTag
+   * @returns {boolean}
+   */
+  setAppSecAutoLoginTags (span, sdkTag, tags, sdkOwnedTags, trackedTag) {
+    const context = span._spanContext
+    const sdkCalled = context._tags[sdkTag] === 'true'
+    let trackedTagWritten = false
+
+    for (const key of Object.keys(tags)) {
+      if (sdkCalled && sdkOwnedTags.has(key) && context._tags[key]) continue
+      this.setTag(span, key, tags[key])
+      if (key === trackedTag) trackedTagWritten = true
+    }
+
+    return trackedTagWritten
+  }
+
+  /**
+   * Atomically write automatic user tags unless the SDK owns user collection.
+   * The internal AppSec user identifier is recorded in either case.
+   *
+   * @param {import('./span')} span
+   * @param {string} userId
+   * @param {string} collectionMode
+   * @returns {boolean}
+   */
+  setAppSecAutoUser (span, userId, collectionMode) {
+    this.setTag(span, '_dd.appsec.usr.id', userId)
+
+    if (span._spanContext._tags['_dd.appsec.user.collection_mode'] === 'sdk') return false
+
+    this.setTags(span, {
+      'usr.id': userId,
+      '_dd.appsec.user.collection_mode': collectionMode,
+    })
+    return true
+  }
+
+  /**
+   * Atomically merge an AppSec attack into the span's event tags.
+   *
+   * @param {import('./span')} span
+   * @param {Array<unknown>} attackData
+   * @param {string|undefined} remoteAddress
+   * @returns {string}
+   */
+  addAppSecEvent (span, attackData, remoteAddress) {
+    const tags = span._spanContext._tags
+    const currentJson = tags['_dd.appsec.json']
+    const attackDataString = JSON.stringify(attackData)
+    const appSecJson = currentJson
+      ? currentJson.slice(0, -2) + ',' + attackDataString.slice(1) + '}'
+      : '{"triggers":' + attackDataString + '}'
+
+    this.setTag(span, 'appsec.event', 'true')
+    this.setTagIfAbsent(span, '_dd.origin', 'appsec')
+    this.setTag(span, '_dd.appsec.json', appSecJson)
+    if (remoteAddress !== undefined) this.setTag(span, 'network.client.ip', remoteAddress)
+    return appSecJson
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setTagIfAbsent (target, key, value) {
+    const context = getContext(target)
+    const tags = context._tags
+    if (Object.hasOwn(tags, key)) return false
+    tags[key] = value
+    if (tagSetCh.hasSubscribers) tagSetCh.publish({ context, key, value })
+    return true
+  }
+
+  /**
+   * Atomically add the initial web request tags once, using `http.url` as the
+   * ownership marker.
+   *
+   * @param {import('./span')} span
+   * @param {Record<string, unknown>} tags
+   * @returns {boolean}
+   */
+  setWebRequestTagsIfAbsent (span, tags) {
+    const context = getContext(span)
+    if (Object.hasOwn(context._tags, 'http.url')) return false
+    this.setTags(context, tags)
+    return true
+  }
+
+  /**
+   * Set the web error tag unless an error or error message already owns the
+   * span's error state.
+   *
+   * @param {import('./span')} span
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setWebErrorIfAbsent (span, value) {
+    const tags = getContext(span)._tags
+    if (tags.error || tags['error.message']) return false
+    this.setTag(span, 'error', value)
+    return true
+  }
+
+  /**
+   * Derive the endpoint from the stored request URL without exposing that URL
+   * to the caller.
+   *
+   * @param {import('./span')} span
+   * @param {(url: string) => string} calculateEndpoint
+   * @returns {boolean}
+   */
+  setHttpEndpointIfAbsent (span, calculateEndpoint) {
+    const tags = getContext(span)._tags
+    if (Object.hasOwn(tags, 'http.route') || Object.hasOwn(tags, 'http.endpoint')) return false
+    const url = tags['http.url']
+    this.setTag(span, 'http.endpoint', url ? calculateEndpoint(String(url)) : '/')
+    return true
+  }
+
+  /**
+   * Derive the web resource from the request method and stored route without
+   * returning either tag to the caller.
+   *
+   * @param {import('./span')} span
+   * @param {string|undefined} method
+   * @returns {boolean}
+   */
+  setWebResourceNameIfAbsent (span, method) {
+    const tags = getContext(span)._tags
+    if (tags['resource.name']) return false
+    const route = tags['http.route']
+    const resource = method && route ? `${method} ${route}` : method || route || ''
+    this.setTag(span, 'resource.name', resource)
+    return true
+  }
+
+  /**
+   * Resolve the final service-source tag atomically at span finish.
+   *
+   * @param {import('./span')} span
+   * @param {string|undefined} tracerService
+   * @param {string|undefined} integrationService
+   * @param {string} sourceKey
+   * @param {string} manualSource
+   */
+  resolveServiceSource (span, tracerService, integrationService, sourceKey, manualSource) {
+    const tags = getContext(span)._tags
+    const currentService = tags['service.name']
+    const existingSource = tags[sourceKey]
+
+    if (currentService === tracerService) {
+      if (existingSource !== undefined) this.setTag(span, sourceKey, undefined)
+      return
+    }
+
+    if (integrationService !== currentService) this.setTag(span, sourceKey, manualSource)
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string} key
+   */
+  deleteTag (target, key) {
+    const context = getContext(target)
+    delete context._tags[key]
+    if (tagDeletedCh.hasSubscribers) tagDeletedCh.publish({ context, key })
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   */
+  clearTags (target) {
+    const context = getContext(target)
+    context._tags = Object.create(null)
+    if (tagsClearedCh.hasSubscribers) tagsClearedCh.publish({ context })
+  }
+
+  /**
+   * Ensure priority sampling has run and atomically decide whether API Security
+   * may retain the request.
+   *
+   * @param {import('./span')} span
+   * @returns {boolean}
+   */
+  sampleForApiSecurity (span) {
+    const context = span._spanContext
+    if (context._sampling.priority === undefined) {
+      span._prioritySampler?.sample(span)
+    }
+    const priority = context._sampling.priority
+    return priority !== AUTO_REJECT && priority !== USER_REJECT
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string} key
+   * @param {unknown} value
+   */
+  setTraceTag (target, key, value) {
+    const context = getContext(target)
+    context._trace.tags[key] = value
+    if (traceTagSetCh.hasSubscribers) traceTagSetCh.publish({ context, key, value })
+  }
+
+  /**
+   * Set a trace-level propagation tag only when it has no defined value.
+   *
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setTraceTagIfAbsent (target, key, value) {
+    const context = getContext(target)
+    const tags = context._trace.tags
+    if (tags[key] !== undefined) return false
+    tags[key] = value
+    if (traceTagSetCh.hasSubscribers) traceTagSetCh.publish({ context, key, value })
+    return true
+  }
+
+  /**
+   * Set multiple trace-level propagation tags.
+   *
+   * @param {import('./span')|import('./span_context')} target
+   * @param {Record<string, unknown>} tags
+   */
+  setTraceTags (target, tags) {
+    const context = getContext(target)
+    Object.assign(context._trace.tags, tags)
+    if (traceTagsSetCh.hasSubscribers) traceTagsSetCh.publish({ context, tags })
+  }
+
+  /**
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string|undefined} origin
+   */
+  setOrigin (target, origin) {
+    getContext(target)._trace.origin = origin
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {number|undefined} priority
+   * @param {number} [mechanism]
+   */
+  setSamplingPriority (context, priority, mechanism) {
+    context._sampling.priority = priority
+    if (mechanism !== undefined) context._sampling.mechanism = mechanism
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {number} mechanism
+   */
+  setSamplingMechanism (context, mechanism) {
+    context._sampling.mechanism = mechanism
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {{ sampleRate: number, maxPerSecond: number }} decision
+   */
+  setSpanSamplingDecision (context, decision) {
+    context._spanSampling = decision
+  }
+
+  /**
+   * Keep a trace using the span's configured priority sampler.
+   *
+   * @param {import('./span')} span
+   * @param {{ id: number, mechanism?: number }} [product]
+   */
+  keepTrace (span, product) {
+    span._prioritySampler?.setPriority(span, USER_KEEP, product)
+  }
+
+  /**
+   * Record an internal trace-level sampling decision input.
+   *
+   * @param {import('./span')|import('./span_context')} target
+   * @param {string|symbol} key
+   * @param {unknown} value
+   */
+  setTraceDecision (target, key, value) {
+    getContext(target)._trace[key] = value
+  }
+
+  /**
+   * Replace the span identifier in a propagation context.
+   *
+   * @param {import('./span_context')} context
+   * @param {object} spanId
+   */
+  setSpanId (context, spanId) {
+    context._spanId = spanId
+  }
+
+  /**
+   * Update the W3C traceparent metadata associated with a context.
+   *
+   * @param {import('./span_context')} context
+   * @param {object|undefined} traceparent
+   */
+  setTraceparent (context, traceparent) {
+    context._traceparent = traceparent
+  }
+
+  /**
+   * Update the W3C tracestate associated with a context.
+   *
+   * @param {import('./span_context')} context
+   * @param {object|undefined} tracestate
+   */
+  setTracestate (context, tracestate) {
+    context._tracestate = tracestate
+  }
+
+  /**
+   * Append a pending propagation link to an extracted context.
+   *
+   * @param {import('./span_context')} context
+   * @param {object} link
+   */
+  addContextLink (context, link) {
+    context._links.push(link)
+  }
+
+  /**
+   * Replace the pending propagation links on an extracted context.
+   *
+   * @param {import('./span_context')} context
+   * @param {Array<object>} links
+   */
+  replaceContextLinks (context, links) {
+    context._links = links
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} key
+   * @param {string} value
+   */
+  setBaggageItem (span, key, value) {
+    getContext(span)._baggageItems[key] = value
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} key
+   */
+  removeBaggageItem (span, key) {
+    delete span._spanContext._baggageItems[key]
+  }
+
+  /**
+   * @param {import('./span')} span
+   */
+  removeAllBaggageItems (span) {
+    span._spanContext._baggageItems = {}
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {object} link
+   */
+  addLink (span, link) {
+    span._links.push(link)
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {object} event
+   */
+  addEvent (span, event) {
+    span._events.push(event)
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} key
+   * @param {unknown} value
+   */
+  setStructuredTag (span, key, value) {
+    span.meta_struct ||= {}
+    span.meta_struct[key] = value
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setStructuredTagIfAbsent (span, key, value) {
+    span.meta_struct ||= {}
+    if (Object.hasOwn(span.meta_struct, key)) return false
+    span.meta_struct[key] = value
+    return true
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {string} namespace
+   * @param {object} value
+   * @param {number} maxItems
+   * @returns {boolean}
+   */
+  appendStackTrace (span, namespace, value, maxItems) {
+    span.meta_struct ||= {}
+    const stacks = span.meta_struct['_dd.stack'] ||= {}
+    const traces = stacks[namespace] ||= []
+    if (maxItems >= 1 && traces.length >= maxItems) return false
+    traces.push(value)
+    return true
+  }
+
+  /**
+   * @param {import('./span')} span
+   * @param {number} finishTime
+   * @returns {boolean} Whether the span transitioned to finished.
+   */
+  finishSpan (span, finishTime) {
+    if (isSpanFinished(span)) return false
+    const duration = finishTime - span._startTime
+    span._duration = duration
+    span._spanContext._trace.finished.push(span)
+    span._spanContext._isFinished = true
+    markSpanFinished(span, duration)
+    return true
+  }
+
+  /**
+   * Finish open spans in the same trace, optionally restricted to an integration.
+   *
+   * @param {import('./span')} span
+   * @param {string} [integrationName]
+   */
+  finishOpenChildren (span, integrationName) {
+    for (const child of span._spanContext._trace.started) {
+      if (child === span || isSpanFinished(child)) continue
+      if (integrationName !== undefined && child._integrationName !== integrationName) continue
+      child.finish()
+    }
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {number} startTime
+   */
+  setTraceStartTime (context, startTime) {
+    context._trace.startTime = startTime
+  }
+
+  /**
+   * Copy the trace clock used to align manually constructed child contexts.
+   *
+   * @param {import('./span_context')} target
+   * @param {import('./span_context')} source
+   */
+  copyTraceTiming (target, source) {
+    target._trace.startTime = source._trace.startTime
+    target._trace.ticks = source._trace.ticks
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {() => number} getTicks
+   */
+  setTraceTicksIfAbsent (context, getTicks) {
+    context._trace.ticks ||= getTicks()
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {boolean} isRemote
+   */
+  setRemote (context, isRemote) {
+    context._isRemote = isRemote
+  }
+
+  /**
+   * @param {import('./span_context')} context
+   * @param {Record<string, string>} baggageItems
+   */
+  replaceBaggageItems (context, baggageItems) {
+    context._baggageItems = baggageItems
+  }
+}
+
+/**
+ * @param {import('./span')|import('./span_context')} target
+ * @returns {import('./span_context')}
+ */
+function getContext (target) {
+  return typeof target.context === 'function' ? target.context() : target
+}
+
+const eventWriter = new EventWriter()
+
+module.exports = eventWriter
+module.exports.EventWriter = EventWriter

--- a/packages/dd-trace/src/opentracing/event-writer.js
+++ b/packages/dd-trace/src/opentracing/event-writer.js
@@ -12,6 +12,7 @@ const tagsClearedCh = channel('dd-trace:span:event-writer:tags-cleared')
 const tagDeletedCh = channel('dd-trace:span:event-writer:tag-deleted')
 const tagSetCh = channel('dd-trace:span:event-writer:tag-set')
 const tagsSetCh = channel('dd-trace:span:event-writer:tags-set')
+const traceSpansReplacedCh = channel('dd-trace:span:event-writer:trace-spans-replaced')
 const traceTagSetCh = channel('dd-trace:span:event-writer:trace-tag-set')
 const traceTagsSetCh = channel('dd-trace:span:event-writer:trace-tags-set')
 
@@ -143,7 +144,9 @@ class EventWriter {
   setTag (target, key, value) {
     const context = getContext(target)
     context._tags[key] = value
-    if (tagSetCh.hasSubscribers) tagSetCh.publish({ context, key, value })
+    if (typeof key === 'string' && tagSetCh.hasSubscribers) {
+      tagSetCh.publish({ context, key, value })
+    }
   }
 
   /**
@@ -270,7 +273,9 @@ class EventWriter {
     const tags = context._tags
     if (Object.hasOwn(tags, key)) return false
     tags[key] = value
-    if (tagSetCh.hasSubscribers) tagSetCh.publish({ context, key, value })
+    if (typeof key === 'string' && tagSetCh.hasSubscribers) {
+      tagSetCh.publish({ context, key, value })
+    }
     return true
   }
 
@@ -366,7 +371,9 @@ class EventWriter {
   deleteTag (target, key) {
     const context = getContext(target)
     delete context._tags[key]
-    if (tagDeletedCh.hasSubscribers) tagDeletedCh.publish({ context, key })
+    if (typeof key === 'string' && tagDeletedCh.hasSubscribers) {
+      tagDeletedCh.publish({ context, key })
+    }
   }
 
   /**
@@ -631,6 +638,18 @@ class EventWriter {
     span._spanContext._isFinished = true
     markSpanFinished(span, duration)
     return true
+  }
+
+  /**
+   * Replace the spans retained by a processed trace chunk.
+   *
+   * @param {object} traceIdentity
+   * @param {Array<import('./span')>} activeSpans
+   */
+  replaceTraceSpans (traceIdentity, activeSpans) {
+    if (traceSpansReplacedCh.hasSubscribers) {
+      traceSpansReplacedCh.publish({ traceIdentity, activeSpans })
+    }
   }
 
   /**

--- a/packages/dd-trace/src/opentracing/propagation/log.js
+++ b/packages/dd-trace/src/opentracing/propagation/log.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const id = require('../../id')
+const eventWriter = require('../event-writer')
 const DatadogSpanContext = require('../span_context')
 
 class LogPropagator {
@@ -60,7 +61,7 @@ class LogPropagator {
         spanId: id(carrier.dd.span_id, 10),
       })
 
-      spanContext._trace.tags['_dd.p.tid'] = hi
+      eventWriter.setTraceTag(spanContext, '_dd.p.tid', hi)
 
       return spanContext
     }

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -35,6 +35,7 @@ const {
   writeTracestate,
 } = require('../../carrier')
 const id = require('../../id')
+const eventWriter = require('../event-writer')
 const DatadogSpanContext = require('../span_context')
 const log = require('../../log')
 const tags = require('../../../../../ext/tags')
@@ -454,7 +455,7 @@ class TextMapPropagator {
   _updateParentIdFromDdHeaders (carrier, firstSpanContext) {
     const ddCtx = this._extractDatadogContext(carrier)
     if (ddCtx !== undefined) {
-      firstSpanContext._trace.tags[tags.DD_PARENT_ID] = ddCtx._spanId.toString().padStart(16, '0')
+      eventWriter.setTraceTag(firstSpanContext, tags.DD_PARENT_ID, ddCtx._spanId.toString().padStart(16, '0'))
     }
   }
 
@@ -464,13 +465,13 @@ class TextMapPropagator {
     }
     if (this._hasParentIdInTags(w3cSpanContext)) {
       // tracecontext headers contain a p value, ensure this value is sent to backend
-      firstSpanContext._trace.tags[tags.DD_PARENT_ID] = w3cSpanContext._trace.tags[tags.DD_PARENT_ID]
+      eventWriter.setTraceTag(firstSpanContext, tags.DD_PARENT_ID, w3cSpanContext._trace.tags[tags.DD_PARENT_ID])
     } else {
       // if p value is not present in tracestate, use the parent id from the datadog headers
       this._updateParentIdFromDdHeaders(carrier, firstSpanContext)
     }
     // the span_id in tracecontext takes precedence over the first extracted propagation style
-    firstSpanContext._spanId = w3cSpanContext._spanId
+    eventWriter.setSpanId(firstSpanContext, w3cSpanContext._spanId)
     return firstSpanContext
   }
 
@@ -506,23 +507,22 @@ class TextMapPropagator {
             context: extractedContext,
             attributes: { reason: 'terminated_context', context_headers: extractor },
           }
-          context._links.push(link)
+          eventWriter.addContextLink(context, link)
         }
       }
     }
 
     if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'ignore') {
-      if (context !== undefined) context._links = []
+      if (context !== undefined) eventWriter.replaceContextLinks(context, [])
     } else {
       if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'restart' && context) {
-        context._links = []
-        context._links.push({
+        eventWriter.replaceContextLinks(context, [{
           context,
           attributes:
           {
             reason: 'propagation_behavior_extract', context_headers: style,
           },
-        })
+        }])
       }
       this._extractBaggageItems(carrier, context)
     }
@@ -550,8 +550,8 @@ class TextMapPropagator {
     const tc = this._extractTraceparentContext(carrier)
 
     if (tc && spanContext._traceId.equals(tc._traceId)) {
-      spanContext._traceparent = tc._traceparent
-      spanContext._tracestate = tc._tracestate
+      eventWriter.setTraceparent(spanContext, tc._traceparent)
+      eventWriter.setTracestate(spanContext, tc._tracestate)
     }
 
     return spanContext
@@ -586,7 +586,7 @@ class TextMapPropagator {
         })
       }
 
-      spanContext._sampling.priority = priority
+      eventWriter.setSamplingPriority(spanContext, priority)
     }
 
     this._extract128BitTraceId(b3.traceId, spanContext)
@@ -639,7 +639,7 @@ class TextMapPropagator {
         for (const [key, value] of state.entries()) {
           switch (key) {
             case 'p': {
-              spanContext._trace.tags[tags.DD_PARENT_ID] = value
+              eventWriter.setTraceTag(spanContext, tags.DD_PARENT_ID, value)
               break
             }
             case 's': {
@@ -649,18 +649,18 @@ class TextMapPropagator {
                 (spanContext._sampling.priority === 1 && priority > 0) ||
                 (spanContext._sampling.priority === 0 && priority < 0)
               ) {
-                spanContext._sampling.priority = priority
+                eventWriter.setSamplingPriority(spanContext, priority)
               }
               break
             }
             case 'o':
-              spanContext._trace.origin = value.replaceAll('~', '=')
+              eventWriter.setOrigin(spanContext, value.replaceAll('~', '='))
               break
             case 't.dm': {
               const mechanism = Math.abs(Number.parseInt(value, 10))
               if (Number.isInteger(mechanism)) {
-                spanContext._sampling.mechanism = mechanism
-                spanContext._trace.tags['_dd.p.dm'] = `-${mechanism}`
+                eventWriter.setSamplingMechanism(spanContext, mechanism)
+                eventWriter.setTraceTag(spanContext, '_dd.p.dm', `-${mechanism}`)
               }
               break
             }
@@ -676,7 +676,7 @@ class TextMapPropagator {
                 }
                 continue
               }
-              spanContext._trace.tags[`_dd.p.${subKey}`] = transformedValue
+              eventWriter.setTraceTag(spanContext, `_dd.p.${subKey}`, transformedValue)
             }
           }
         }
@@ -772,13 +772,17 @@ class TextMapPropagator {
     const origin = readDatadogOrigin(carrier)
 
     if (typeof origin === 'string') {
-      spanContext._trace.origin = origin
+      eventWriter.setOrigin(spanContext, origin)
     }
   }
 
   _extractLegacyBaggageItems (carrier, spanContext) {
     if (!this._config.legacyBaggageEnabled) return
-    readLegacyBaggage(carrier, spanContext._baggageItems)
+    const items = {}
+    readLegacyBaggage(carrier, items)
+    for (const [key, value] of Object.entries(items)) {
+      eventWriter.setBaggageItem(spanContext, key, value)
+    }
   }
 
   _extractBaggageItems (carrier, spanContext) {
@@ -845,7 +849,7 @@ class TextMapPropagator {
       itemCount++
 
       if (spanContext && (tagAllKeys || baggageTagKeys.has(key))) {
-        spanContext._trace.tags['baggage.' + key] = value
+        eventWriter.setTraceTag(spanContext, 'baggage.' + key, value)
       }
     }
 
@@ -861,15 +865,13 @@ class TextMapPropagator {
     const priority = Number.parseInt(header, 10)
 
     if (Number.isInteger(priority)) {
-      spanContext._sampling.priority = priority
+      eventWriter.setSamplingPriority(spanContext, priority)
     }
   }
 
   _extractTags (carrier, spanContext) {
     const header = readDatadogTags(carrier)
     if (!header) return
-
-    const trace = spanContext._trace
 
     if (this._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH === 0) {
       log.debug('Trace tag propagation is disabled, skipping extraction.')
@@ -895,7 +897,7 @@ class TextMapPropagator {
         tags[key] = value
       }
 
-      Object.assign(trace.tags, tags)
+      eventWriter.setTraceTags(spanContext, tags)
     }
   }
 
@@ -910,7 +912,7 @@ class TextMapPropagator {
 
     if (tid === zeroTraceId) return
 
-    spanContext._trace.tags['_dd.p.tid'] = tid
+    eventWriter.setTraceTag(spanContext, '_dd.p.tid', tid)
   }
 
   _validateTagKey (key) {

--- a/packages/dd-trace/src/opentracing/span-lifecycle.js
+++ b/packages/dd-trace/src/opentracing/span-lifecycle.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const durations = new WeakMap()
+
+/**
+ * Mark a span as started in the compatibility lifecycle projection.
+ *
+ * @param {object} span
+ */
+function markSpanStarted (span) {
+  durations.delete(span)
+}
+
+/**
+ * Mark a span as finished in the compatibility lifecycle projection.
+ *
+ * @param {object} span
+ * @param {number} duration
+ */
+function markSpanFinished (span, duration) {
+  durations.set(span, duration)
+}
+
+/**
+ * Check the write-time lifecycle projection without reading native span state.
+ *
+ * @param {object} span
+ * @returns {boolean}
+ */
+function isSpanFinished (span) {
+  return durations.has(span)
+}
+
+/**
+ * Read the duration projected by the finish event.
+ *
+ * @param {object} span
+ * @returns {number|undefined}
+ */
+function getSpanDuration (span) {
+  return durations.get(span)
+}
+
+module.exports = { getSpanDuration, isSpanFinished, markSpanFinished, markSpanStarted }

--- a/packages/dd-trace/src/opentracing/span-projections.js
+++ b/packages/dd-trace/src/opentracing/span-projections.js
@@ -1,0 +1,306 @@
+'use strict'
+
+const { channel } = require('dc-polyfill')
+
+const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../../ext/tags')
+const { WEB } = require('../../../../ext/types')
+
+const HTTP_ENDPOINT = 'http.endpoint'
+const INFERRED_SPAN = '_inferred_span'
+const COMPONENT = 'component'
+const USER_ID = 'usr.id'
+const USER_SESSION_ID = 'usr.session_id'
+
+const spans = new WeakMap()
+const contexts = new WeakMap()
+const traces = new WeakMap()
+
+const spanStartedCh = channel('dd-trace:span:event-writer:span-started')
+const tagsClearedCh = channel('dd-trace:span:event-writer:tags-cleared')
+const tagDeletedCh = channel('dd-trace:span:event-writer:tag-deleted')
+const tagSetCh = channel('dd-trace:span:event-writer:tag-set')
+const tagsSetCh = channel('dd-trace:span:event-writer:tags-set')
+
+function getTraceProjection (trace) {
+  let projection = traces.get(trace)
+  if (projection === undefined) {
+    projection = new Map()
+    traces.set(trace, projection)
+  }
+  return projection
+}
+
+/**
+ * Capture the immutable topology and identifiers needed by downstream consumers.
+ * This is called only from the EventWriter span-start path.
+ *
+ * @param {import('./span')} span
+ * @param {import('./span_context')} context
+ * @param {object} [fields]
+ */
+function startSpan (span, context, fields = {}) {
+  const trace = getTraceProjection(fields.traceIdentity ?? context._trace)
+  const parent = trace.get(fields.parentId ?? context._parentId)
+  const projection = {
+    span,
+    parent,
+    localRoot: parent?.localRoot ?? span,
+    spanId: fields.spanId ?? context._spanId,
+    tags: Object.create(null),
+  }
+  spans.set(span, projection)
+  contexts.set(context, projection)
+  trace.set(projection.spanId, projection)
+}
+
+function getProjection (target) {
+  return typeof target?.context === 'function' ? spans.get(target) : contexts.get(target)
+}
+
+/**
+ * Update the selected tag projection needed by AppSec and profiling consumers.
+ *
+ * @param {import('./span')|import('./span_context')} target
+ * @param {string} key
+ * @param {unknown} value
+ */
+function setTag (target, key, value) {
+  const projection = getProjection(target)
+  if (projection === undefined) return
+
+  if (key === 'appsec.event') {
+    if (value === 'true') {
+      projection.appSecEventTags ??= new Set()
+      projection.appSecEventTags.add(key)
+    } else {
+      projection.appSecEventTags?.delete(key)
+    }
+  } else if (key.startsWith('appsec.events.')) {
+    projection.appSecEventTags ??= new Set()
+    projection.appSecEventTags.add(key)
+  }
+
+  switch (key) {
+    case HTTP_METHOD:
+    case HTTP_ROUTE:
+    case RESOURCE_NAME:
+    case SPAN_TYPE:
+    case HTTP_ENDPOINT:
+    case COMPONENT:
+    case USER_ID:
+    case USER_SESSION_ID:
+      projection.tags[key] = value
+      break
+    case INFERRED_SPAN:
+      projection.inferred = value !== undefined && value !== false
+      break
+  }
+}
+
+/**
+ * @param {import('./span')|import('./span_context')} target
+ * @param {Record<string, unknown>} tags
+ */
+function setTags (target, tags) {
+  for (const key of Object.keys(tags)) {
+    setTag(target, key, tags[key])
+  }
+}
+
+/**
+ * @param {import('./span')|import('./span_context')} target
+ * @param {string} key
+ */
+function deleteTag (target, key) {
+  const projection = getProjection(target)
+  if (projection === undefined) return
+  projection.appSecEventTags?.delete(key)
+  if (key === INFERRED_SPAN) {
+    projection.inferred = false
+  } else {
+    delete projection.tags[key]
+  }
+}
+
+/**
+ * @param {import('./span')|import('./span_context')} target
+ */
+function clearTags (target) {
+  const projection = getProjection(target)
+  if (projection === undefined) return
+  projection.tags = Object.create(null)
+  projection.inferred = false
+  projection.appSecEventTags?.clear()
+}
+
+function onSpanStarted ({ span, context, traceIdentity, spanId, parentId }) {
+  startSpan(span, context, { traceIdentity, spanId, parentId })
+}
+
+function onTagSet ({ context, key, value }) {
+  setTag(context, key, value)
+}
+
+function onTagsSet ({ context, tags }) {
+  setTags(context, tags)
+}
+
+function onTagDeleted ({ context, key }) {
+  deleteTag(context, key)
+}
+
+function onTagsCleared ({ context }) {
+  clearTags(context)
+}
+
+/**
+ * Return the local root span while excluding inferred-proxy ancestors.
+ *
+ * @param {import('./span')} span
+ * @returns {import('./span')|undefined}
+ */
+function getAppSecRootSpan (span) {
+  const active = spans.get(span)
+  if (active === undefined) return
+
+  let root = active
+  let current = active.parent
+  while (current !== undefined) {
+    if (!current.inferred) root = current
+    current = current.parent
+  }
+  return root.span
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {import('./span')|undefined}
+ */
+function getLocalRootSpan (span) {
+  return spans.get(span)?.localRoot
+}
+
+/**
+ * Return the selected web tag projection for the span itself.
+ *
+ * @param {import('./span')} span
+ * @returns {Record<string, unknown>|undefined}
+ */
+function getOwnWebTags (span) {
+  const projection = spans.get(span)
+  return projection?.tags
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {import('./span')|undefined}
+ */
+function getParentSpan (span) {
+  return spans.get(span)?.parent?.span
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {{ spanId: unknown, localRootSpanId: unknown }|undefined}
+ */
+function getCodeHotspotIds (span) {
+  const projection = spans.get(span)
+  if (projection === undefined) return
+  return {
+    spanId: projection.spanId,
+    localRootSpanId: spans.get(projection.localRoot)?.spanId,
+  }
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {string|undefined}
+ */
+function getHttpEndpoint (span) {
+  const value = spans.get(span)?.tags[HTTP_ENDPOINT]
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {string|undefined}
+ */
+function getApiSecurityFramework (span) {
+  const value = spans.get(span)?.tags[COMPONENT]
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {string|undefined}
+ */
+function getApiSecurityHttpRoute (span) {
+  const value = spans.get(span)?.tags[HTTP_ROUTE]
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {boolean}
+ */
+function hasUserId (span) {
+  return Boolean(spans.get(span)?.tags[USER_ID])
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {boolean}
+ */
+function hasUserSessionId (span) {
+  return Boolean(spans.get(span)?.tags[USER_SESSION_ID])
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {boolean}
+ */
+function isOutermostWebSpan (span) {
+  let projection = spans.get(span)
+  if (projection?.tags[SPAN_TYPE] !== WEB) return false
+
+  projection = projection.parent
+  while (projection !== undefined) {
+    if (projection.tags[SPAN_TYPE] === WEB) return false
+    projection = projection.parent
+  }
+  return true
+}
+
+/**
+ * @param {import('./span')} span
+ * @returns {boolean}
+ */
+function shouldCollectAppSecEventHeaders (span) {
+  return (spans.get(span)?.appSecEventTags?.size ?? 0) > 0
+}
+
+spanStartedCh.subscribe(onSpanStarted)
+tagsClearedCh.subscribe(onTagsCleared)
+tagDeletedCh.subscribe(onTagDeleted)
+tagSetCh.subscribe(onTagSet)
+tagsSetCh.subscribe(onTagsSet)
+
+module.exports = {
+  clearTags,
+  deleteTag,
+  getApiSecurityFramework,
+  getApiSecurityHttpRoute,
+  getAppSecRootSpan,
+  getCodeHotspotIds,
+  getHttpEndpoint,
+  getLocalRootSpan,
+  getOwnWebTags,
+  getParentSpan,
+  hasUserId,
+  hasUserSessionId,
+  isOutermostWebSpan,
+  setTag,
+  setTags,
+  shouldCollectAppSecEventHeaders,
+  startSpan,
+}

--- a/packages/dd-trace/src/opentracing/span-projections.js
+++ b/packages/dd-trace/src/opentracing/span-projections.js
@@ -20,6 +20,7 @@ const tagsClearedCh = channel('dd-trace:span:event-writer:tags-cleared')
 const tagDeletedCh = channel('dd-trace:span:event-writer:tag-deleted')
 const tagSetCh = channel('dd-trace:span:event-writer:tag-set')
 const tagsSetCh = channel('dd-trace:span:event-writer:tags-set')
+const traceSpansReplacedCh = channel('dd-trace:span:event-writer:trace-spans-replaced')
 
 function getTraceProjection (trace) {
   let projection = traces.get(trace)
@@ -42,8 +43,10 @@ function startSpan (span, context, fields = {}) {
   const trace = getTraceProjection(fields.traceIdentity ?? context._trace)
   const parent = trace.get(fields.parentId ?? context._parentId)
   const projection = {
+    errorState: 0,
     span,
     parent,
+    parentId: fields.parentId ?? context._parentId,
     localRoot: parent?.localRoot ?? span,
     spanId: fields.spanId ?? context._spanId,
     tags: Object.create(null),
@@ -66,7 +69,7 @@ function getProjection (target) {
  */
 function setTag (target, key, value) {
   const projection = getProjection(target)
-  if (projection === undefined) return
+  if (projection === undefined || typeof key !== 'string') return
 
   if (key === 'appsec.event') {
     if (value === 'true') {
@@ -78,6 +81,12 @@ function setTag (target, key, value) {
   } else if (key.startsWith('appsec.events.')) {
     projection.appSecEventTags ??= new Set()
     projection.appSecEventTags.add(key)
+  }
+
+  if (key === 'error') {
+    projection.errorState = value ? projection.errorState | 1 : projection.errorState & ~1
+  } else if (key === 'error.type') {
+    projection.errorState = value ? projection.errorState | 2 : projection.errorState & ~2
   }
 
   switch (key) {
@@ -115,6 +124,11 @@ function deleteTag (target, key) {
   const projection = getProjection(target)
   if (projection === undefined) return
   projection.appSecEventTags?.delete(key)
+  if (key === 'error') {
+    projection.errorState &= ~1
+  } else if (key === 'error.type') {
+    projection.errorState &= ~2
+  }
   if (key === INFERRED_SPAN) {
     projection.inferred = false
   } else {
@@ -129,6 +143,7 @@ function clearTags (target) {
   const projection = getProjection(target)
   if (projection === undefined) return
   projection.tags = Object.create(null)
+  projection.errorState = 0
   projection.inferred = false
   projection.appSecEventTags?.clear()
 }
@@ -151,6 +166,21 @@ function onTagDeleted ({ context, key }) {
 
 function onTagsCleared ({ context }) {
   clearTags(context)
+}
+
+function onTraceSpansReplaced ({ traceIdentity, activeSpans }) {
+  const active = new Map()
+
+  for (const span of activeSpans) {
+    const projection = spans.get(span)
+    if (projection === undefined) continue
+
+    projection.parent = active.get(projection.parentId)
+    projection.localRoot = projection.parent?.localRoot ?? span
+    active.set(projection.spanId, projection)
+  }
+
+  traces.set(traceIdentity, active)
 }
 
 /**
@@ -256,6 +286,16 @@ function hasUserSessionId (span) {
 }
 
 /**
+ * Return whether the span has an error without exposing its tag state.
+ *
+ * @param {import('./span')} span
+ * @returns {boolean}
+ */
+function hasError (span) {
+  return (spans.get(span)?.errorState ?? 0) !== 0
+}
+
+/**
  * @param {import('./span')} span
  * @returns {boolean}
  */
@@ -284,6 +324,7 @@ tagsClearedCh.subscribe(onTagsCleared)
 tagDeletedCh.subscribe(onTagDeleted)
 tagSetCh.subscribe(onTagSet)
 tagsSetCh.subscribe(onTagsSet)
+traceSpansReplacedCh.subscribe(onTraceSpansReplaced)
 
 module.exports = {
   clearTags,
@@ -296,6 +337,7 @@ module.exports = {
   getLocalRootSpan,
   getOwnWebTags,
   getParentSpan,
+  hasError,
   hasUserId,
   hasUserSessionId,
   isOutermostWebSpan,

--- a/packages/dd-trace/src/opentracing/span-store.js
+++ b/packages/dd-trace/src/opentracing/span-store.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const stores = new WeakMap()
+
+/**
+ * Associate a span with the async-context store active at creation time.
+ *
+ * @param {object} span
+ * @param {unknown} store
+ */
+function setSpanStore (span, store) {
+  stores.set(span, store)
+}
+
+/**
+ * Return the async-context store associated with a span.
+ *
+ * @param {object} span
+ * @returns {unknown}
+ */
+function getSpanStore (span) {
+  return stores.get(span)
+}
+
+module.exports = { getSpanStore, setSpanStore }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -14,7 +14,11 @@ const { resolveServiceSource } = require('../service-naming/source-resolver')
 const telemetryMetrics = require('../telemetry/metrics')
 const { MANUAL_DROP, MANUAL_KEEP, SAMPLING_PRIORITY } = require('../../../../ext/tags')
 const { DD_MAJOR } = require('../../../../version')
+const { getDatadogContext } = require('./context-registry')
+const eventWriter = require('./event-writer')
+const { isSpanFinished } = require('./span-lifecycle')
 const SpanContext = require('./span_context')
+const { setSpanStore } = require('./span-store')
 
 const dateNow = Date.now
 
@@ -86,37 +90,32 @@ class DatadogSpan {
     const operationName = fields.operationName
     const parent = fields.parent || null
     const hostname = fields.hostname
+    const integrationName = fields.integrationName || 'opentracing'
 
     this.#parentTracer = tracer
-    this._debug = debug
-    this._processor = processor
-    this._prioritySampler = prioritySampler
-    this._store = storage('legacy').getHandle()
-    this._duration = undefined
-
-    this._events = []
-
-    // For internal use only. You probably want `context()._name`.
-    // This name property is not updated when the span name changes.
-    // This is necessary for span count metrics.
-    this._name = operationName
-    this._integrationName = fields.integrationName || 'opentracing'
-
-    getIntegrationCounter('spans_created', this._integrationName).inc()
-
-    this._spanContext = this._createContext(parent, fields)
-    this._spanContext._name = operationName
-    if (fields.tags) Object.assign(this._spanContext.getTags(), fields.tags)
-    this._spanContext._hostname = hostname
-
-    this._spanContext._trace.started.push(this)
-
-    this._startTime = fields.startTime || this._getTime()
-
-    this._links = fields.links?.map(link => ({
-      context: link.context._ddContext ?? link.context,
+    const spanContext = this._createContext(parent, fields)
+    const startTime = fields.startTime || getTime(spanContext)
+    const links = fields.links?.map(link => ({
+      context: getDatadogContext(link.context) ?? link.context,
       attributes: this._sanitizeAttributes(link.attributes),
     })) ?? []
+
+    eventWriter.startSpan(this, {
+      context: spanContext,
+      processor,
+      prioritySampler,
+      debug,
+      operationName,
+      integrationName,
+      startTime,
+      links,
+      hostname,
+      parentContext: parent,
+    })
+    setSpanStore(this, storage('legacy').getHandle())
+    if (fields.tags) eventWriter.setTags(this, fields.tags)
+
+    getIntegrationCounter('spans_created', integrationName).inc()
 
     if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.increment('runtime.node.spans.unfinished')
@@ -176,12 +175,34 @@ class DatadogSpan {
   }
 
   setOperationName (name) {
-    this._spanContext._name = name
+    eventWriter.setOperationName(this, name)
+    return this
+  }
+
+  /**
+   * Set the integration that owns this span.
+   *
+   * @param {string} name
+   * @returns {DatadogSpan}
+   */
+  setIntegrationName (name) {
+    eventWriter.setIntegrationName(this, name)
+    return this
+  }
+
+  /**
+   * Enable or disable recording for this span's trace.
+   *
+   * @param {boolean} enabled
+   * @returns {DatadogSpan}
+   */
+  setRecording (enabled) {
+    eventWriter.setRecording(this, enabled)
     return this
   }
 
   setBaggageItem (key, value) {
-    this._spanContext._baggageItems[key] = value
+    eventWriter.setBaggageItem(this, key, value)
     return this
   }
 
@@ -194,17 +215,17 @@ class DatadogSpan {
   }
 
   removeBaggageItem (key) {
-    delete this._spanContext._baggageItems[key]
+    eventWriter.removeBaggageItem(this, key)
   }
 
   removeAllBaggageItems () {
-    this._spanContext._baggageItems = {}
+    eventWriter.removeAllBaggageItems(this)
   }
 
   setTag (key, value) {
     this._spanContext.setTag(key, value)
 
-    if (isSamplingPriorityTag(key) && this._spanContext._sampling.priority === undefined) {
+    if (isSamplingPriorityTag(key)) {
       this._prioritySampler.sample(this, false)
     }
 
@@ -213,6 +234,19 @@ class DatadogSpan {
     }
 
     return this
+  }
+
+  /**
+   * Set a tag only when it is absent, without exposing the current tag value.
+   *
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setTagIfAbsent (key, value) {
+    const written = eventWriter.setTagIfAbsent(this, key, value)
+    if (written && tagsUpdateCh.hasSubscribers) tagsUpdateCh.publish(this)
+    return written
   }
 
   addTags (keyValueMap) {
@@ -221,11 +255,10 @@ class DatadogSpan {
     // surface, and no internal v6 caller passes one (see MIGRATING.md).
     // v5 still accepts both via `tagger.add` for `config.tags` /
     // `options.tags` callers that pass `'key:val,key:val'` strings.
-    const tags = this._spanContext.getTags()
     let mayChangeSamplingPriority
 
     if (keyValueMap !== null && typeof keyValueMap === 'object' && !Array.isArray(keyValueMap)) {
-      Object.assign(tags, keyValueMap)
+      eventWriter.setTags(this, keyValueMap)
       mayChangeSamplingPriority =
         MANUAL_KEEP in keyValueMap ||
         MANUAL_DROP in keyValueMap ||
@@ -233,14 +266,16 @@ class DatadogSpan {
     } else {
       /* istanbul ignore if: v5 fallback, master ships 6.0.0-pre */
       if (DD_MAJOR < 6 && (typeof keyValueMap === 'string' || Array.isArray(keyValueMap))) {
+        const tags = {}
         tagger.add(tags, keyValueMap)
+        eventWriter.setTags(this, tags)
         mayChangeSamplingPriority = true
       } else {
         return this
       }
     }
 
-    if (mayChangeSamplingPriority && this._spanContext._sampling.priority === undefined) {
+    if (mayChangeSamplingPriority) {
       this._prioritySampler.sample(this, false)
     }
 
@@ -249,6 +284,20 @@ class DatadogSpan {
     }
 
     return this
+  }
+
+  /**
+   * Set tags only while a caller-owned tag value still matches the span.
+   *
+   * @param {string} expectedKey
+   * @param {unknown} expectedValue
+   * @param {Record<string, unknown>} tags
+   * @returns {boolean}
+   */
+  setTagsIfTagMatches (expectedKey, expectedValue, tags) {
+    const written = eventWriter.setTagsIfTagMatches(this, expectedKey, expectedValue, tags)
+    if (written && tagsUpdateCh.hasSubscribers) tagsUpdateCh.publish(this)
+    return written
   }
 
   log () {
@@ -266,8 +315,8 @@ class DatadogSpan {
 
     const { context, attributes } = link
 
-    this._links.push({
-      context: context._ddContext ?? context,
+    eventWriter.addLink(this, {
+      context: getDatadogContext(context) ?? context,
       attributes: this._sanitizeAttributes(attributes),
     })
   }
@@ -303,13 +352,57 @@ class DatadogSpan {
       }
     }
     event.startTime = startTime || this._getTime()
-    this._events.push(event)
+    eventWriter.addEvent(this, event)
+  }
+
+  /**
+   * Set structured span metadata.
+   *
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {DatadogSpan}
+   */
+  setStructuredTag (key, value) {
+    eventWriter.setStructuredTag(this, key, value)
+    return this
+  }
+
+  /**
+   * Set structured span metadata only when the key is absent.
+   *
+   * @param {string} key
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  setStructuredTagIfAbsent (key, value) {
+    return eventWriter.setStructuredTagIfAbsent(this, key, value)
+  }
+
+  /**
+   * Append a stack trace while atomically enforcing its configured cap.
+   *
+   * @param {string} namespace
+   * @param {object} value
+   * @param {number} maxItems
+   * @returns {boolean}
+   */
+  appendStackTrace (namespace, value, maxItems) {
+    return eventWriter.appendStackTrace(this, namespace, value, maxItems)
+  }
+
+  /**
+   * Finish all open child spans, optionally restricted to an integration.
+   *
+   * @param {string} [integrationName]
+   * @returns {DatadogSpan}
+   */
+  finishOpenChildren (integrationName) {
+    eventWriter.finishOpenChildren(this, integrationName)
+    return this
   }
 
   finish (finishTime) {
-    if (this._duration !== undefined) {
-      return
-    }
+    if (isSpanFinished(this)) return
 
     if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_STATE_TRACKING && !this._spanContext.getTag('service.name')) {
       log.error('Finishing invalid span: %s', this)
@@ -339,9 +432,7 @@ class DatadogSpan {
       ? this._getTime()
       : (Number.parseFloat(finishTime) || this._getTime())
 
-    this._duration = finishTime - this._startTime
-    this._spanContext._trace.finished.push(this)
-    this._spanContext._isFinished = true
+    if (!eventWriter.finishSpan(this, finishTime)) return
     finishCh.publish(this)
     this._processor.process(this)
   }
@@ -427,34 +518,41 @@ class DatadogSpan {
         traceId: spanId,
         spanId,
       })
-      spanContext._trace.startTime = startTime
+      eventWriter.setTraceStartTime(spanContext, startTime)
 
       if (fields.traceId128BitGenerationEnabled) {
-        spanContext._trace.tags['_dd.p.tid'] = Math.floor(startTime / 1000).toString(16)
+        eventWriter.setTraceTag(spanContext, '_dd.p.tid', Math.floor(startTime / 1000).toString(16)
           .padStart(8, '0')
-          .padEnd(16, '0')
+          .padEnd(16, '0'))
       }
 
       if (propagationBehavior === 'restart') {
-        spanContext._baggageItems = baggage ?? {}
+        eventWriter.replaceBaggageItems(spanContext, baggage ?? {})
       }
     }
 
-    spanContext._trace.ticks ||= now()
+    eventWriter.setTraceTicksIfAbsent(spanContext, now)
     if (startTime) {
-      spanContext._trace.startTime = startTime
+      eventWriter.setTraceStartTime(spanContext, startTime)
     }
     // SpanContext was NOT propagated from a remote parent
-    spanContext._isRemote = false
+    eventWriter.setRemote(spanContext, false)
 
     return spanContext
   }
 
   _getTime () {
-    const { startTime, ticks } = this._spanContext._trace
-
-    return startTime + now() - ticks
+    return getTime(this._spanContext)
   }
+}
+
+/**
+ * @param {import('./span_context')} context
+ * @returns {number}
+ */
+function getTime (context) {
+  const { startTime, ticks } = context._trace
+  return startTime + now() - ticks
 }
 
 function createRegistry (type) {

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -2,35 +2,14 @@
 
 const util = require('util')
 const { AUTO_KEEP } = require('../../../../ext/priority')
+const eventWriter = require('./event-writer')
 
 // the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present
 const TRACE_ID_128 = '_dd.p.tid'
 
 class DatadogSpanContext {
   constructor (props) {
-    props ||= {}
-
-    this._traceId = props.traceId
-    this._spanId = props.spanId
-    this._isRemote = props.isRemote ?? true
-    this._parentId = props.parentId || null
-    this._name = props.name
-    this._isFinished = props.isFinished || false
-    this._tags = props.tags || {}
-    this._sampling = props.sampling || {}
-    this._spanSampling = undefined
-    this._links = props.links || []
-    this._baggageItems = props.baggageItems || {}
-    this._traceparent = props.traceparent
-    this._tracestate = props.tracestate
-    this._noop = props.noop || null
-    this._trace = props.trace || {
-      started: [],
-      finished: [],
-      tags: {},
-    }
-    this._otelSpanContext = undefined
-    this._otelActiveSpan = undefined
+    eventWriter.initializeContext(this, props)
   }
 
   [util.inspect.custom] () {
@@ -62,9 +41,36 @@ class DatadogSpanContext {
     return this._spanId.toBigInt()
   }
 
-  toTraceparent () {
+  /**
+   * Return the trace identifier used by deterministic samplers.
+   *
+   * @returns {bigint}
+   */
+  toBigIntTraceId () {
+    return this._traceId.toBigInt()
+  }
+
+  /**
+   * Return W3C trace flags after materializing lazy priority sampling.
+   *
+   * @returns {number}
+   */
+  toTraceFlags () {
     this._ensureSamplingPriority()
-    const flags = this._sampling.priority >= AUTO_KEEP ? '01' : '00'
+    return this._sampling.priority >= AUTO_KEEP ? 1 : 0
+  }
+
+  /**
+   * Serialize W3C tracestate from the propagation envelope.
+   *
+   * @returns {string}
+   */
+  toTracestate () {
+    return this._tracestate?.toString() || ''
+  }
+
+  toTraceparent () {
+    const flags = this.toTraceFlags() ? '01' : '00'
     const traceId = this.toTraceId(true)
     const spanId = this.toSpanId(true)
     const version = (this._traceparent && this._traceparent.version) || '00'
@@ -93,7 +99,7 @@ class DatadogSpanContext {
    * @param {unknown} value - Tag value
    */
   setTag (key, value) {
-    this._tags[key] = value
+    eventWriter.setTag(this, key, value)
   }
 
   /**
@@ -116,7 +122,7 @@ class DatadogSpanContext {
    * Delete a tag.
    * @param {string} key - Tag key
    */
-  deleteTag (key) { delete this._tags[key] }
+  deleteTag (key) { eventWriter.deleteTag(this, key) }
 
   /**
    * Get the live internal tags map. The returned reference is mutable;
@@ -134,7 +140,7 @@ class DatadogSpanContext {
   /**
    * Clear all tags.
    */
-  clearTags () { this._tags = Object.create(null) }
+  clearTags () { eventWriter.clearTags(this) }
 }
 
 module.exports = DatadogSpanContext

--- a/packages/dd-trace/src/otel-thread-ctx.js
+++ b/packages/dd-trace/src/otel-thread-ctx.js
@@ -35,8 +35,8 @@ const {
 } = require('./storage-channels')
 const {
   finalEndpoint,
-  getStartedSpans,
 } = require('./profiling/webspan-utils')
+const { getCodeHotspotIds } = require('./opentracing/span-projections')
 const webTagsCache = require('./web-tags-cache')
 
 // OTEP-4947 duplicates are last-wins, so appending a later endpoint value would
@@ -94,7 +94,7 @@ const ATTRIBUTE_KEYS = [
 const THREAD_NAME = (isMainThread ? 'Main' : `Worker #${threadId}`) + ' Event Loop'
 const THREAD_ID = String(threadId)
 
-// Cache slot on span objects. One ThreadContext is built per span on first
+// One ThreadContext is built per span on first
 // activation and re-installed across every async-context frame that
 // re-enters the span — V8's AsyncContextFrame inherits the JS
 // reference verbatim, and the context's record buffer is mutated in
@@ -105,7 +105,7 @@ const THREAD_ID = String(threadId)
 //             time onEnter activates the span, and cleared on span finish, which
 //             is how a pendingEndpoints waiter recognizes a record it must no
 //             longer append to.
-const CachedSym = Symbol('OtelThreadCtx.cached')
+const contexts = new WeakMap()
 
 let started = false
 let ThreadContext
@@ -113,28 +113,24 @@ let getContext
 let clearContext
 
 function getOrBuildContext (span) {
-  let cached = span[CachedSym]
+  let cached = contexts.get(span)
   if (cached !== undefined && cached.context !== undefined) return cached.context
   const spanContext = span.context()
   const traceId = Uint8Array.from(Buffer.from(spanContext.toTraceId(true), 'hex'))
   const spanId = Uint8Array.from(Buffer.from(spanContext.toSpanId(true), 'hex'))
-  // Local root span: the first entry in the trace's started-spans list, or
-  // this span itself when it IS the root. Encoded as 16-char lowercase hex
-  // per the libdatadog convention.
-  const startedSpans = getStartedSpans(spanContext)
-  const rootContext = startedSpans.length ? startedSpans[0].context() : spanContext
+  const localRootSpanId = getCodeHotspotIds(span)?.localRootSpanId
   // Only write the endpoint when its value has settled; otherwise leave a hole
   // and wait for webTagsCache to announce that it has.
   const webTags = webTagsCache.getCachedWebTags(span)
   const endpoint = finalEndpoint(webTags)
   const attrs = []
-  attrs[LOCAL_ROOT_SPAN_ID_IDX] = rootContext.toSpanId(true)
+  attrs[LOCAL_ROOT_SPAN_ID_IDX] = localRootSpanId?.toString(16) ?? spanContext.toSpanId(true)
   if (endpoint !== undefined) attrs[ENDPOINT_IDX] = endpoint
   attrs[THREAD_NAME_IDX] = THREAD_NAME
   attrs[THREAD_ID_IDX] = THREAD_ID
   if (cached === undefined) {
     cached = {}
-    span[CachedSym] = cached
+    contexts.set(span, cached)
   }
   cached.context = new ThreadContext(traceId, spanId, attrs)
   if (endpoint === undefined) awaitEndpoint(webTags, cached)
@@ -181,9 +177,9 @@ function onEnter () {
 
 function onSpanFinished (span) {
   if (!started) return
-  const cached = span[CachedSym]
+  const cached = contexts.get(span)
   if (cached === undefined) return
-  span[CachedSym] = undefined
+  contexts.delete(span)
   const context = cached.context
   if (context === undefined) return
   // The span is over, so its record must stop presenting itself as an active
@@ -219,7 +215,7 @@ function onSpanFinished (span) {
 // descendants enlisted under.
 function onEndpointResolved (span) {
   if (!started) return
-  const webTags = span.context().getTags()
+  const webTags = webTagsCache.getCachedWebTags(span)
   const waiting = pendingEndpoints.get(webTags)
   if (waiting === undefined) return
   const endpoint = finalEndpoint(webTags)
@@ -237,7 +233,7 @@ function onEndpointResolved (span) {
 // only ever about the announced span's own record.
 function onWebTagsResolved (span) {
   if (!started) return
-  const cached = span[CachedSym]
+  const cached = contexts.get(span)
   if (cached === undefined || cached.context === undefined) return
   const webTags = webTagsCache.getCachedWebTags(span)
   const endpoint = finalEndpoint(webTags)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -20,6 +20,7 @@ const getDiClient = require('../ci-visibility/dynamic-instrumentation')
 const { DD_MAJOR } = require('../../../../version')
 const { version: tracerVersion } = require('../../../../package.json')
 const id = require('../id')
+const eventWriter = require('../opentracing/event-writer')
 const { OS_VERSION, OS_PLATFORM, OS_ARCHITECTURE, RUNTIME_NAME, RUNTIME_VERSION } = require('./util/env')
 const {
   CI_PROVIDER_NAME,
@@ -888,8 +889,7 @@ module.exports = class CiPlugin extends Plugin {
     if (testSuiteSpan) {
       // This is a hack to get good time resolution on test events, while keeping
       // the test event as the root span of its trace.
-      childOf._trace.startTime = testSuiteSpan.context()._trace.startTime
-      childOf._trace.ticks = testSuiteSpan.context()._trace.ticks
+      eventWriter.copyTraceTiming(childOf, testSuiteSpan.context())
 
       const suiteTags = {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
@@ -923,7 +923,7 @@ module.exports = class CiPlugin extends Plugin {
         integrationName: this.constructor.id,
       })
 
-    testSpan.context()._trace.origin = CI_APP_ORIGIN
+    eventWriter.setOrigin(testSpan, CI_APP_ORIGIN)
 
     return testSpan
   }

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -113,7 +113,7 @@ class DatabasePlugin extends StoragePlugin {
     } else if (mode === 'full') {
       span.setTag('_dd.dbm_trace_injected', 'true')
       span._processor.sample(span)
-      const traceparent = span._spanContext.toTraceparent()
+      const traceparent = span.context().toTraceparent()
       return `${dbmComment},traceparent='${traceparent}'`
     }
   }

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -3,7 +3,8 @@
 const { storage } = require('../../../datadog-core')
 const analyticsSampler = require('../analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../constants')
-const { INTEGRATION_SERVICE } = require('../service-naming/source-resolver')
+const eventWriter = require('../opentracing/event-writer')
+const { setIntegrationService } = require('../service-naming/source-resolver')
 const Plugin = require('./plugin')
 
 const legacyStorage = storage('legacy')
@@ -143,7 +144,7 @@ class TracingPlugin extends Plugin {
    */
   stampIntegrationService (span, name) {
     if (name === undefined) return
-    span[INTEGRATION_SERVICE] = name
+    setIntegrationService(span, name)
   }
 
   /**
@@ -159,8 +160,7 @@ class TracingPlugin extends Plugin {
    * @param {string} name Service name the integration is claiming.
    */
   setServiceName (span, name) {
-    // eslint-disable-next-line eslint-rules/eslint-prefer-set-service-name -- this is the implementation
-    span._spanContext.setTag('service.name', name)
+    eventWriter.setTag(span, 'service.name', name)
     this.stampIntegrationService(span, name)
   }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -850,11 +850,7 @@ function getTestTypeFromFramework (testFramework) {
  * @param {import('../../opentracing/span')} span
  */
 function finishAllTraceSpans (span) {
-  for (const traceSpan of span.context()._trace.started) {
-    if (traceSpan !== span && traceSpan._duration === undefined) {
-      traceSpan.finish()
-    }
-  }
+  span.finishOpenChildren()
 }
 
 /**

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -4,10 +4,10 @@ const uniq = require('../../../../datadog-core/src/utils/src/uniq')
 const analyticsSampler = require('../../analytics_sampler')
 const FORMAT_HTTP_HEADERS = 'http_headers'
 const log = require('../../log')
+const eventWriter = require('../../opentracing/event-writer')
 const tags = require('../../../../../ext/tags')
 const types = require('../../../../../ext/types')
 const kinds = require('../../../../../ext/kinds')
-const { ERROR_MESSAGE } = require('../../constants')
 const TracingPlugin = require('../tracing')
 const { storage } = require('../../../../datadog-core')
 const legacyStorage = storage('legacy')
@@ -18,15 +18,12 @@ const { NETWORK_PEER_ADDRESS } = require('./http-otel-semantics')
 
 const WEB = types.WEB
 const SERVER = kinds.SERVER
-const RESOURCE_NAME = tags.RESOURCE_NAME
 const SPAN_TYPE = tags.SPAN_TYPE
 const SPAN_KIND = tags.SPAN_KIND
-const ERROR = tags.ERROR
 const HTTP_METHOD = tags.HTTP_METHOD
 const HTTP_URL = tags.HTTP_URL
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_ROUTE = tags.HTTP_ROUTE
-const HTTP_ENDPOINT = tags.HTTP_ENDPOINT
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 const HTTP_USERAGENT = tags.HTTP_USERAGENT
@@ -93,9 +90,9 @@ const web = {
 
     if (!span) return
 
-    span.context()._name = `${name}.request`
-    span.context().setTag('component', name)
-    span._integrationName = name
+    span.setOperationName(`${name}.request`)
+    span.setTag('component', name)
+    span.setIntegrationName(name)
 
     web.setConfig(req, config)
   },
@@ -108,7 +105,7 @@ const web = {
 
     if (!config.filter(req.url)) {
       span.setTag(MANUAL_DROP, true)
-      span.context()._trace.isRecording = false
+      span.setRecording(false)
     }
 
     if (config.service) {
@@ -124,7 +121,7 @@ const web = {
     let span
 
     if (context.span) {
-      context.span.context()._name = name
+      context.span.setOperationName(name)
       span = context.span
     } else {
       span = web.startServerlessSpanWithInferredProxy(tracer, config, name, req, traceCtx)
@@ -224,7 +221,7 @@ const web = {
     const headers = req.headers
     const reqCtx = contexts.get(req)
     const store = legacyStorage.getStore()
-    const pubsubSpan = store?.span?._name === 'pubsub.push.receive' ? store.span : null
+    const pubsubSpan = store?.pubsubPushReceiveSpan
 
     let childOf = pubsubSpan || this.extractIncomingServerContext(tracer, headers)
 
@@ -248,21 +245,11 @@ const web = {
     const context = contexts.get(req)
     const { span, inferredProxySpan, error } = context
 
-    const spanContext = span.context()
-    const spanHasExistingError = spanContext.getTag('error') || spanContext.getTag(ERROR_MESSAGE)
-    const inferredSpanContext = inferredProxySpan?.context()
-    const inferredSpanHasExistingError = inferredSpanContext?.getTag('error') ||
-      inferredSpanContext?.getTag(ERROR_MESSAGE)
-
     const isValidStatusCode = context.config.validateStatus(statusCode)
 
-    if (!spanHasExistingError && !isValidStatusCode) {
-      span.setTag(ERROR, error || true)
-    }
-
-    if (inferredProxySpan && !inferredSpanHasExistingError && !isValidStatusCode) {
-      inferredProxySpan.setTag(ERROR, error || true)
-    }
+    if (isValidStatusCode) return
+    eventWriter.setWebErrorIfAbsent(span, error || true)
+    if (inferredProxySpan) eventWriter.setWebErrorIfAbsent(inferredProxySpan, error || true)
   },
 
   // Add an error to the request
@@ -411,26 +398,20 @@ function splitHeader (str) {
 
 function addRequestTags (context, spanType) {
   const { req, span, inferredProxySpan, config } = context
-  const spanContext = span.context()
-
-  // Idempotency guard. `addRequestTags` runs in `web.startSpan` for the
-  // normal HTTP path and again in `web.finishSpan`; without this guard the
-  // second call would re-extract the URL, re-obfuscate the query string,
-  // and re-publish five `tagsUpdateCh` events with the same values. The
-  // serverless path skips `startSpan` and lands here first, in which case
-  // HTTP_URL is unset and the work runs normally.
-  if (spanContext.hasTag(HTTP_URL)) return
+  if (context.requestTagsAdded) return
 
   const url = extractURL(req)
   const type = spanType ?? WEB
 
-  span.addTags({
+  const requestTagsAdded = eventWriter.setWebRequestTagsIfAbsent(span, {
     [HTTP_URL]: obfuscateQs(config, url),
     [HTTP_METHOD]: req.method,
     [SPAN_KIND]: SERVER,
     [SPAN_TYPE]: type,
     [HTTP_USERAGENT]: req.headers['user-agent'],
   })
+  context.requestTagsAdded = true
+  if (!requestTagsAdded) return
 
   // OTel `network.peer.address` is the immediate socket peer. It has no Datadog
   // equivalent and the socket isn't available at serialization, so (unlike the
@@ -442,11 +423,10 @@ function addRequestTags (context, spanType) {
   }
 
   // if client ip has already been set by appsec, no need to run it again
-  if (config.extractIp && !spanContext.hasTag(HTTP_CLIENT_IP)) {
+  if (config.extractIp) {
     const clientIp = config.extractIp(config, req)
 
-    if (clientIp) {
-      span.setTag(HTTP_CLIENT_IP, clientIp)
+    if (clientIp && span.setTagIfAbsent(HTTP_CLIENT_IP, clientIp)) {
       inferredProxySpan?.setTag(HTTP_CLIENT_IP, clientIp)
     }
   }
@@ -483,11 +463,6 @@ function addResponseTags (context) {
 function applyRouteOrEndpointTag (context) {
   const { paths, span, config } = context
   if (!span) return
-  const spanContext = span.context()
-
-  // AppSec runs this from a pre-finish hook and the finish path runs it
-  // again. http.route is terminal once set; nothing supersedes it.
-  if (spanContext.hasTag(HTTP_ROUTE)) return
 
   // Skip the `Array.prototype.join` builtin in the empty / single-segment
   // cases; `paths[0]` covers both (`undefined` is falsy for the empty case).
@@ -497,29 +472,19 @@ function applyRouteOrEndpointTag (context) {
     // A framework route supersedes any http.endpoint fallback a pre-finish
     // call stamped before the route resolved; it must not be gated on
     // HTTP_ENDPOINT.
-    span.setTag(HTTP_ROUTE, route)
+    span.setTagIfAbsent(HTTP_ROUTE, route)
     return
   }
 
   // Route unavailable. Compute the http.endpoint fallback once across both calls.
-  if (!config.resourceRenamingEnabled || spanContext.hasTag(HTTP_ENDPOINT)) return
-
-  const url = spanContext.getTag(HTTP_URL)
-  const endpoint = url ? calculateHttpEndpoint(url) : '/'
-  span.setTag(HTTP_ENDPOINT, endpoint)
+  if (config.resourceRenamingEnabled) {
+    eventWriter.setHttpEndpointIfAbsent(span, calculateHttpEndpoint)
+  }
 }
 
 function addResourceTag (context) {
   const { req, span } = context
-  const spanContext = span.context()
-
-  if (spanContext.getTag(RESOURCE_NAME)) return
-
-  const resource = [req.method, spanContext.getTag(HTTP_ROUTE)]
-    .filter(Boolean)
-    .join(' ')
-
-  span.setTag(RESOURCE_NAME, resource)
+  eventWriter.setWebResourceNameIfAbsent(span, req.method)
 }
 
 function addRequestHeaders (context) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -15,6 +15,7 @@ const {
   },
 } = require('../../../ext')
 const log = require('./log')
+const eventWriter = require('./opentracing/event-writer')
 const RateLimiter = require('./rate_limiter')
 const Sampler = require('./sampler')
 const { setSamplingRules } = require('./startup-log')
@@ -116,10 +117,9 @@ class PrioritySampler {
     const tag = this._getPriorityFromTags(context.getTags(), context)
 
     if (this.validate(tag)) {
-      context._sampling.priority = tag
-      context._sampling.mechanism = SAMPLING_MECHANISM_MANUAL
+      eventWriter.setSamplingPriority(context, tag, SAMPLING_MECHANISM_MANUAL)
     } else if (auto) {
-      context._sampling.priority = this._getPriorityFromAuto(root)
+      eventWriter.setSamplingPriority(context, this._getPriorityFromAuto(root))
     } else {
       return
     }
@@ -183,10 +183,8 @@ class PrioritySampler {
       return // noop span
     }
 
-    context._sampling.priority = samplingPriority
-
     const mechanism = product?.mechanism ?? SAMPLING_MECHANISM_MANUAL
-    context._sampling.mechanism = mechanism
+    eventWriter.setSamplingPriority(context, samplingPriority, mechanism)
 
     log.trace(span, samplingPriority, mechanism)
 
@@ -254,13 +252,13 @@ class PrioritySampler {
    * @returns {SamplingPriority}
    */
   #getPriorityByRule (context, rule) {
-    context._trace[SAMPLING_RULE_DECISION] = rule.sampleRate
-    context._trace.tags[SAMPLING_KNUTH_RATE] = formatKnuthRate(rule.sampleRate)
-    context._sampling.mechanism = SAMPLING_MECHANISM_RULE
+    eventWriter.setTraceDecision(context, SAMPLING_RULE_DECISION, rule.sampleRate)
+    eventWriter.setTraceTag(context, SAMPLING_KNUTH_RATE, formatKnuthRate(rule.sampleRate))
+    eventWriter.setSamplingMechanism(context, SAMPLING_MECHANISM_RULE)
     if (rule.provenance === 'customer') {
-      context._sampling.mechanism = SAMPLING_MECHANISM_REMOTE_USER
+      eventWriter.setSamplingMechanism(context, SAMPLING_MECHANISM_REMOTE_USER)
     } else if (rule.provenance === 'dynamic') {
-      context._sampling.mechanism = SAMPLING_MECHANISM_REMOTE_DYNAMIC
+      eventWriter.setSamplingMechanism(context, SAMPLING_MECHANISM_REMOTE_DYNAMIC)
     }
 
     return rule.sample(context) && this._isSampledByRateLimit(context)
@@ -279,7 +277,7 @@ class PrioritySampler {
     // TODO: Change underscored properties to private ones.
     const allowed = this._limiter.isAllowed()
 
-    context._trace[SAMPLING_LIMIT_DECISION] = this._limiter.effectiveRate()
+    eventWriter.setTraceDecision(context, SAMPLING_LIMIT_DECISION, this._limiter.effectiveRate())
 
     return allowed
   }
@@ -296,13 +294,13 @@ class PrioritySampler {
     const sampler = this._samplers[key] || this._samplers[DEFAULT_KEY]
 
     const rate = sampler.rate()
-    context._trace[SAMPLING_AGENT_DECISION] = rate
+    eventWriter.setTraceDecision(context, SAMPLING_AGENT_DECISION, rate)
 
     if (sampler === defaultSampler) {
-      context._sampling.mechanism = SAMPLING_MECHANISM_DEFAULT
+      eventWriter.setSamplingMechanism(context, SAMPLING_MECHANISM_DEFAULT)
     } else {
-      context._trace.tags[SAMPLING_KNUTH_RATE] = formatKnuthRate(rate)
-      context._sampling.mechanism = SAMPLING_MECHANISM_AGENT
+      eventWriter.setTraceTag(context, SAMPLING_KNUTH_RATE, formatKnuthRate(rate))
+      eventWriter.setSamplingMechanism(context, SAMPLING_MECHANISM_AGENT)
     }
 
     return sampler.isSampled(context) ? AUTO_KEEP : AUTO_REJECT
@@ -322,14 +320,14 @@ class PrioritySampler {
 
     if (priority >= AUTO_KEEP) {
       if (!trace.tags[DECISION_MAKER_KEY]) {
-        trace.tags[DECISION_MAKER_KEY] = `-${mechanism}`
+        eventWriter.setTraceTag(context, DECISION_MAKER_KEY, `-${mechanism}`)
       }
     } else if (trace.tags[DECISION_MAKER_KEY] !== undefined) {
       // Clear by assigning undefined rather than deleting: `delete` drops
       // trace.tags into V8 dictionary (slow) mode for the per-trace extract
       // and propagation scans that follow. Both skip undefined values, so the
       // emitted meta and injected headers are unchanged.
-      trace.tags[DECISION_MAKER_KEY] = undefined
+      eventWriter.setTraceTag(context, DECISION_MAKER_KEY, undefined)
     }
   }
 
@@ -382,7 +380,7 @@ class PrioritySampler {
    * @param {Product} [product]
    */
   static keepTrace (span, product) {
-    span?._prioritySampler?.setPriority(span, USER_KEEP, product)
+    if (span) eventWriter.keepTrace(span, product)
   }
 }
 

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -4,27 +4,14 @@ const { EventEmitter } = require('events')
 const dc = require('dc-polyfill')
 const crashtracker = require('../crashtracking')
 const log = require('../log')
+const { getOwnWebTags, isOutermostWebSpan } = require('../opentracing/span-projections')
 const { buildProfilingRuntime } = require('./config')
 const { snapshotKinds } = require('./constants')
 const { threadNamePrefix } = require('./profilers/shared')
-const { isWebServerSpan, endpointNameFromTags, getStartedSpans } = require('./webspan-utils')
+const { endpointNameFromTags } = require('./webspan-utils')
 
 const profileSubmittedChannel = dc.channel('datadog:profiling:profile-submitted')
 const spanFinishedChannel = dc.channel('dd-trace:span:finish')
-
-function findWebSpan (startedSpans, spanId) {
-  for (let i = startedSpans.length; --i >= 0;) {
-    const ispan = startedSpans[i]
-    const context = ispan.context()
-    if (context._spanId === spanId) {
-      if (isWebServerSpan(context.getTags())) {
-        return true
-      }
-      spanId = context._parentId
-    }
-  }
-  return false
-}
 
 const MISSING_SOURCE_MAPS_TOKEN = 'dd:has-missing-map-files'
 
@@ -288,15 +275,11 @@ class Profiler extends EventEmitter {
   }
 
   #onSpanFinish (span) {
-    const context = span.context()
-    const tags = context.getTags()
-    if (!isWebServerSpan(tags)) return
+    if (!isOutermostWebSpan(span)) return
 
+    const tags = getOwnWebTags(span)
     const endpointName = endpointNameFromTags(tags)
     if (!endpointName) return
-
-    // Make sure this is the outermost web span, just in case so we don't overcount
-    if (findWebSpan(getStartedSpans(context), context._parentId)) return
 
     let counter = this.#endpointCounts.get(endpointName)
     if (counter === undefined) {

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { performance } = require('perf_hooks')
+const { performance } = require('node:perf_hooks')
+const { getCodeHotspotIds } = require('../../../opentracing/span-projections')
 const TracingPlugin = require('../../../plugins/tracing')
 
 // We are leveraging the TracingPlugin class for its functionality to bind
@@ -51,9 +52,10 @@ class EventPlugin extends TracingPlugin {
       return
     }
 
-    const context = (ctx.currentStore?.span || this.activeSpan)?.context()
-    event._ddSpanId = context?.toBigIntSpanId()
-    event._ddRootSpanId = context?._trace.started[0]?.context().toBigIntSpanId() || event._ddSpanId
+    const span = ctx.currentStore?.span || this.activeSpan
+    const ids = span && getCodeHotspotIds(span)
+    event._ddSpanId = ids?.spanId?.toBigInt()
+    event._ddRootSpanId = ids?.localRootSpanId?.toBigInt() ?? event._ddSpanId
 
     this.#eventHandler(this.extendEvent(event, ctx))
   }

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -3,7 +3,8 @@
 const log = require('../../log')
 const runtimeMetrics = require('../../runtime_metrics')
 const telemetryMetrics = require('../../telemetry/metrics')
-const { endpointNameFromTags, finalEndpoint, getStartedSpans } = require('../webspan-utils')
+const { getCodeHotspotIds } = require('../../opentracing/span-projections')
+const { endpointNameFromTags, finalEndpoint } = require('../webspan-utils')
 const { SAMPLING_INTERVAL } = require('../constants')
 const {
   enterCh,
@@ -28,7 +29,7 @@ const TRACE_ENDPOINT_LABEL = 'trace endpoint'
 
 const profilerTelemetryMetrics = telemetryMetrics.manager.namespace('profilers')
 
-const ProfilingContext = Symbol('NativeWallProfiler.ProfilingContext')
+const profilingContexts = new WeakMap()
 
 let kSampleCount
 
@@ -233,7 +234,7 @@ class NativeWallProfiler {
       // (a node::ObjectWrap with its own v8::Global<v8::Value>) in the native
       // profiler. Skip the call if the CPED already holds this sampleContext,
       // which is the common case when the same span is repeatedly activated:
-      // #getProfilingContext caches profilingContext on span[ProfilingContext],
+      // #getProfilingContext caches profilingContext for each span,
       // so identity comparison short-circuits.
       } else if (current !== sampleContext) {
         this.#pprof.time.setContext(sampleContext)
@@ -253,16 +254,14 @@ class NativeWallProfiler {
   }
 
   #getProfilingContext (span) {
-    let profilingContext = span[ProfilingContext]
+    let profilingContext = profilingContexts.get(span)
     if (profilingContext === undefined) {
-      const context = span.context()
-
       let spanId
       let rootSpanId
       if (this.#codeHotspotsEnabled) {
-        const startedSpans = getStartedSpans(context)
-        spanId = context._spanId
-        rootSpanId = startedSpans.length ? startedSpans[0].context()._spanId : context._spanId
+        const ids = getCodeHotspotIds(span)
+        spanId = ids?.spanId
+        rootSpanId = ids?.localRootSpanId
       }
 
       // webTags is snapshotted into the sample context at getProfilingContext
@@ -272,7 +271,7 @@ class NativeWallProfiler {
       const webTags = this.#endpointCollectionEnabled ? webTagsCache.getCachedWebTags(span) : undefined
 
       profilingContext = { spanId, rootSpanId, webTags }
-      span[ProfilingContext] = profilingContext
+      profilingContexts.set(span, profilingContext)
     }
     return profilingContext
   }
@@ -285,9 +284,7 @@ class NativeWallProfiler {
   }
 
   #spanFinished (span) {
-    if (span[ProfilingContext] !== undefined) {
-      span[ProfilingContext] = undefined
-    }
+    profilingContexts.delete(span)
   }
 
   // Invoked (via webTagsCache.resolvedCh) once per span at the moment the
@@ -296,7 +293,7 @@ class NativeWallProfiler {
   // pick it up.
   #spanTagsUpdated (span) {
     if (!this.#started) return
-    const profilingContext = span[ProfilingContext]
+    const profilingContext = profilingContexts.get(span)
     if (profilingContext === undefined) return
     profilingContext.webTags = webTagsCache.getCachedWebTags(span)
   }

--- a/packages/dd-trace/src/profiling/webspan-utils.js
+++ b/packages/dd-trace/src/profiling/webspan-utils.js
@@ -45,26 +45,8 @@ function finalEndpoint (tags) {
   return endpoint
 }
 
-// The trace's started-spans list, whose first entry is the local root span by
-// repo-wide convention — priority_sampler, span_format, the wall profiler's
-// local-root-span-id label, the event plugins and the OTEP-4947 writer all read
-// it that way, and web-tags-cache walks it to find a span's parent.
-//
-// Partial flush weakens that convention for every one of them alike:
-// span_processor's _erase() replaces the list with the still-active spans only,
-// so once a trace crosses DD_TRACE_PARTIAL_FLUSH_MIN_SPANS a local root that has
-// already finished drops out, and the first entry becomes merely the oldest span
-// still running — while a finished web-server ancestor stops being reachable for
-// the parent-chain walk. Correcting it needs a local-root reference the tracer
-// core keeps across flushes; until there is one, consumers share the same skew
-// on large traces rather than each compensating differently.
-function getStartedSpans (context) {
-  return context._trace.started
-}
-
 module.exports = {
   isWebServerSpan,
   endpointNameFromTags,
   finalEndpoint,
-  getStartedSpans,
 }

--- a/packages/dd-trace/src/sampler.js
+++ b/packages/dd-trace/src/sampler.js
@@ -56,7 +56,7 @@ class Sampler {
 
     span = typeof span.context === 'function' ? span.context() : span
 
-    return (span._traceId.toBigInt() * SAMPLING_KNUTH_FACTOR) % UINT64_MODULO <= this.#threshold
+    return (span.toBigIntTraceId() * SAMPLING_KNUTH_FACTOR) % UINT64_MODULO <= this.#threshold
   }
 }
 

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { storage } = require('../../datadog-core')
+const { getSpanStore } = require('./opentracing/span-store')
 
 const legacyStorage = storage('legacy')
 
@@ -16,7 +17,7 @@ class Scope {
     if (typeof callback !== 'function') return callback
 
     const oldStore = legacyStorage.getStore()
-    const newStore = span ? legacyStorage.getStore(span._store) : oldStore
+    const newStore = span ? legacyStorage.getStore(getSpanStore(span)) : oldStore
 
     legacyStorage.enterWith({ ...newStore, span })
 

--- a/packages/dd-trace/src/service-naming/source-resolver.js
+++ b/packages/dd-trace/src/service-naming/source-resolver.js
@@ -1,9 +1,20 @@
 'use strict'
 
 const { SVC_SRC_KEY } = require('../constants')
+const eventWriter = require('../opentracing/event-writer')
 
-const INTEGRATION_SERVICE = Symbol('dd.integrationService')
+const integrationServices = new WeakMap()
 const MANUAL = 'm'
+
+/**
+ * Record the service name claimed by an integration without attaching state to the span.
+ *
+ * @param {object} span
+ * @param {string} service
+ */
+function setIntegrationService (span, service) {
+  integrationServices.set(span, service)
+}
 
 /**
  * Reconcile `_dd.svc_src` against the span's final `service.name`. Called from
@@ -20,31 +31,12 @@ const MANUAL = 'm'
  * @param {string|undefined} tracerService The tracer's configured default service.
  */
 function resolveServiceSource (span, tracerService) {
-  const spanContext = span._spanContext
-  const currentService = spanContext.getTag('service.name')
-  const existingSource = spanContext.getTag(SVC_SRC_KEY)
-
-  if (currentService === tracerService) {
-    if (existingSource === undefined) return
-    // Clear by assigning undefined rather than deleting: `delete` on the plain
-    // `_tags` object drops it into dictionary (slow) mode, so the per-span
-    // extractTags scan that follows pays the slow path. The encode loop skips
-    // undefined values, so the emitted meta is unchanged.
-    spanContext.setTag(SVC_SRC_KEY, undefined)
-    return
-  }
-
-  const marker = span[INTEGRATION_SERVICE]
-
-  if (marker === currentService) {
-    return
-  }
-
-  spanContext.setTag(SVC_SRC_KEY, MANUAL)
+  const marker = integrationServices.get(span)
+  eventWriter.resolveServiceSource(span, tracerService, marker, SVC_SRC_KEY, MANUAL)
 }
 
 module.exports = {
-  INTEGRATION_SERVICE,
   MANUAL,
   resolveServiceSource,
+  setIntegrationService,
 }

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -7,6 +7,7 @@ const GitMetadataTagger = require('./git_metadata_tagger')
 const processTags = require('./process-tags')
 const { applyHttpOtelSemantics } = require('./plugins/util/http-otel-semantics')
 const { APM_TRACING_ENABLED_KEY } = require('./constants')
+const eventWriter = require('./opentracing/event-writer')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
@@ -170,6 +171,7 @@ class SpanProcessor {
 
     trace.started = active
     trace.finished = []
+    eventWriter.replaceTraceSpans(trace, active)
   }
 }
 

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -97,7 +97,7 @@ class SpanProcessor {
     this._killAll = true
   }
 
-  _erase (trace, active) {
+  _erase (trace, active = []) {
     if (this._config.DD_TRACE_EXPERIMENTAL_STATE_TRACKING) {
       const started = new Set()
       const startedIds = new Set()

--- a/packages/dd-trace/src/span_sampler.js
+++ b/packages/dd-trace/src/span_sampler.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { USER_KEEP, AUTO_KEEP } = require('../../../ext').priority
+const eventWriter = require('./opentracing/event-writer')
 const SamplingRule = require('./sampling_rule')
 
 /**
@@ -46,10 +47,10 @@ class SpanSampler {
     for (const span of started) {
       const rule = this.findRule(span)
       if (rule && rule.sample(spanContext)) {
-        span.context()._spanSampling = {
+        eventWriter.setSpanSamplingDecision(span.context(), {
           sampleRate: rule.sampleRate,
           maxPerSecond: rule.maxPerSecond,
-        }
+        })
       }
     }
   }

--- a/packages/dd-trace/src/spanleak.js
+++ b/packages/dd-trace/src/spanleak.js
@@ -2,7 +2,9 @@
 
 /* eslint-disable no-console */
 
+const { channel } = require('dc-polyfill')
 const SortedSet = require('../../../vendor/dist/tlhunter-sorted-set')
+const eventWriter = require('./opentracing/event-writer')
 
 const INTERVAL = 1000 // look for expired spans every 1s
 const LIFETIME = 60 * 1000 // all spans have a max lifetime of 1m
@@ -18,6 +20,8 @@ const MODES = {
 module.exports.MODES = MODES
 
 const spans = new SortedSet()
+const spanNames = new WeakMap()
+const spanStartedCh = channel('dd-trace:span:event-writer:span-started')
 
 // TODO: should these also be delivered as runtime metrics?
 
@@ -27,17 +31,24 @@ const spans = new SortedSet()
 
 let interval
 let mode = MODES.DISABLED
+let subscribed = false
 
 module.exports.disable = function () {
   mode = MODES.DISABLED
+  if (subscribed) {
+    spanStartedCh.unsubscribe(onSpanStarted)
+    subscribed = false
+  }
 }
 
 module.exports.enableLogging = function () {
   mode = MODES.LOG
+  subscribeToSpanStarts()
 }
 
 module.exports.enableGarbageCollection = function () {
   mode = MODES.GC_AND_LOG
+  subscribeToSpanStarts()
 }
 
 module.exports.startScrubber = function () {
@@ -60,13 +71,14 @@ module.exports.startScrubber = function () {
       if (!span) continue // span has already been garbage collected
 
       // TODO: Should we also do things like record the route to help users debug leaks?
-      if (!expirationsByType[span._name]) expirationsByType[span._name] = 0
-      expirationsByType[span._name]++
+      const name = spanNames.get(span) || 'unknown'
+      if (!expirationsByType[name]) expirationsByType[name] = 0
+      expirationsByType[name]++
 
       if (!gc) continue // everything after this point is related to manual GC
 
       // TODO: what else can we do to alleviate memory usage
-      span.context().clearTags()
+      eventWriter.clearTags(span)
     }
 
     console.log('expired spans:' +
@@ -93,4 +105,14 @@ function isEnabled () {
 
 function isGarbageCollecting () {
   return mode >= MODES.GC_AND_LOG
+}
+
+function subscribeToSpanStarts () {
+  if (subscribed) return
+  spanStartedCh.subscribe(onSpanStarted)
+  subscribed = true
+}
+
+function onSpanStarted ({ span, operationName }) {
+  spanNames.set(span, operationName)
 }

--- a/packages/dd-trace/src/standalone/index.js
+++ b/packages/dd-trace/src/standalone/index.js
@@ -2,6 +2,7 @@
 
 const { channel } = require('dc-polyfill')
 const { USER_KEEP } = require('../../../../ext/priority')
+const eventWriter = require('../opentracing/event-writer')
 const TraceSourcePrioritySampler = require('./tracesource_priority_sampler')
 const { hasTraceSourcePropagationTag } = require('./tracesource')
 
@@ -25,9 +26,9 @@ function onSpanExtract ({ spanContext = {} }) {
 
   // reset upstream priority if _dd.p.ts is not found
   if (!hasTraceSourcePropagationTag(spanContext._trace.tags)) {
-    spanContext._sampling.priority = undefined
+    eventWriter.setSamplingPriority(spanContext, undefined)
   } else if (spanContext._sampling.priority !== USER_KEEP) {
-    spanContext._sampling.priority = USER_KEEP
+    eventWriter.setSamplingPriority(spanContext, USER_KEEP)
   }
 }
 

--- a/packages/dd-trace/src/standalone/tracesource_priority_sampler.js
+++ b/packages/dd-trace/src/standalone/tracesource_priority_sampler.js
@@ -3,7 +3,8 @@
 const PrioritySampler = require('../priority_sampler')
 const { MANUAL_KEEP } = require('../../../../ext/tags')
 const { USER_KEEP, AUTO_KEEP, AUTO_REJECT } = require('../../../../ext/priority')
-const { SAMPLING_MECHANISM_DEFAULT } = require('../constants')
+const { SAMPLING_MECHANISM_DEFAULT, TRACE_SOURCE_PROPAGATION_KEY } = require('../constants')
+const eventWriter = require('../opentracing/event-writer')
 const { addTraceSourceTag, hasTraceSourcePropagationTag } = require('./tracesource')
 const { getProductRateLimiter } = require('./product')
 
@@ -36,7 +37,7 @@ class TraceSourcePrioritySampler extends PrioritySampler {
   _getPriorityFromAuto (span) {
     const context = this._getContext(span)
 
-    context._sampling.mechanism = SAMPLING_MECHANISM_DEFAULT
+    eventWriter.setSamplingMechanism(context, SAMPLING_MECHANISM_DEFAULT)
 
     if (hasTraceSourcePropagationTag(context._trace.tags)) {
       return USER_KEEP
@@ -52,7 +53,12 @@ class TraceSourcePrioritySampler extends PrioritySampler {
     super.setPriority(span, samplingPriority, product)
 
     const context = this._getContext(span)
-    addTraceSourceTag(context?._trace?.tags, product)
+    const tags = context?._trace?.tags
+    if (!tags || !product) return
+
+    const traceSourceTags = { [TRACE_SOURCE_PROPAGATION_KEY]: tags[TRACE_SOURCE_PROPAGATION_KEY] }
+    addTraceSourceTag(traceSourceTags, product)
+    eventWriter.setTraceTag(context, TRACE_SOURCE_PROPAGATION_KEY, traceSourceTags[TRACE_SOURCE_PROPAGATION_KEY])
   }
 }
 

--- a/packages/dd-trace/src/web-tags-cache.js
+++ b/packages/dd-trace/src/web-tags-cache.js
@@ -37,7 +37,8 @@
 // deactivate() when they stop caring.
 
 const dc = require('dc-polyfill')
-const { finalEndpoint, isWebServerSpan, getStartedSpans } = require('./profiling/webspan-utils')
+const { getOwnWebTags, getParentSpan } = require('./opentracing/span-projections')
+const { finalEndpoint, isWebServerSpan } = require('./profiling/webspan-utils')
 
 // Fields on the cache entry:
 //   resolved:      true once the parent-chain walk has run.
@@ -45,17 +46,17 @@ const { finalEndpoint, isWebServerSpan, getStartedSpans } = require('./profiling
 //                  empty (no web-server span found in the started-spans chain).
 //   endpointFinal: true once this span is a web-server span whose endpoint name
 //                  has settled and endpointResolvedCh has been published for it.
-const CachedSym = Symbol('WebTagsCache')
+const cache = new WeakMap()
 
 const tagsUpdateCh = dc.channel('dd-trace:span:tags:update')
 const resolvedCh = dc.channel('dd-trace:web-tags:resolved')
 const endpointResolvedCh = dc.channel('dd-trace:web-tags:endpoint-resolved')
 
 function getCache (span) {
-  let cached = span[CachedSym]
+  let cached = cache.get(span)
   if (cached === undefined) {
     cached = {}
-    span[CachedSym] = cached
+    cache.set(span, cached)
   }
   return cached
 }
@@ -67,21 +68,13 @@ function getCache (span) {
 function getCachedWebTags (span) {
   const cached = getCache(span)
   if (cached.resolved) return cached.webTags
-  const spanContext = span.context()
-  const tags = spanContext.getTags()
+  const tags = getOwnWebTags(span)
   let webTags
   if (isWebServerSpan(tags)) {
     webTags = tags
   } else {
-    const parentId = spanContext._parentId
-    const startedSpans = getStartedSpans(spanContext)
-    for (let i = startedSpans.length; --i >= 0;) {
-      const ispan = startedSpans[i]
-      if (ispan.context()._spanId === parentId) {
-        webTags = getCachedWebTags(ispan)
-        break
-      }
-    }
+    const parent = getParentSpan(span)
+    if (parent !== undefined) webTags = getCachedWebTags(parent)
   }
   cached.webTags = webTags
   cached.resolved = true
@@ -95,9 +88,9 @@ function getCachedWebTags (span) {
 // `DatadogSpan#setTag` / `addTags` never enter the publish path on our
 // behalf.
 function onTagsUpdate (span) {
-  const cached = span[CachedSym]
+  const cached = cache.get(span)
   if (cached === undefined || !cached.resolved) return
-  const tags = span.context().getTags()
+  const tags = getOwnWebTags(span)
   if (cached.webTags === undefined) {
     if (!isWebServerSpan(tags)) return
     cached.webTags = tags

--- a/packages/dd-trace/test/appsec/api_security/index.spec.js
+++ b/packages/dd-trace/test/appsec/api_security/index.spec.js
@@ -38,6 +38,9 @@ describe('API Security domain', () => {
 
       apiSecurity = proxyquire('../../../src/appsec/api_security', {
         './sampler': sampler,
+        '../../opentracing/span-projections': {
+          getApiSecurityFramework: span => span.context().getTag('component'),
+        },
         '../../plugins/util/web': web,
         '../reporter': reporter,
         '../telemetry': telemetry,

--- a/packages/dd-trace/test/appsec/api_security/normalized-route.spec.js
+++ b/packages/dd-trace/test/appsec/api_security/normalized-route.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 // path-to-regexp is a transitive (vendored) dependency; require it directly to exercise the
 // normalizer against the real Express 5 parser/matcher (path-to-regexp 8).
@@ -10,7 +11,12 @@ const { parse: rawParse, match: rawMatch } = require('path-to-regexp')
 const {
   normalizeRouteExpress,
   normalizeRoute,
-} = require('../../../src/appsec/api_security/normalized-route')
+} = proxyquire('../../../src/appsec/api_security/normalized-route', {
+  '../../opentracing/span-projections': {
+    getApiSecurityFramework: span => span?.framework,
+    getApiSecurityHttpRoute: span => span?.route,
+  },
+})
 
 // Mirror the getParse instrumentation adapter: TokenData ({ tokens }) or undefined.
 function parse (pattern) {
@@ -270,7 +276,7 @@ describe('normalizeRouteExpress', () => {
     // A process can serve both Express majors while the parser adapters are process-wide, so the
     // major is decided per request off the serving app.
     it('returns null for an Express 4 request even when a parser is available', () => {
-      const span = { context: () => ({ getTag: tag => (tag === 'component' ? 'express' : '/users/:id') }) }
+      const span = { framework: 'express', route: '/users/:id' }
       const req = { originalUrl: '/users/1', params: { id: '1' }, app: { del () {} } }
       const web = require('../../../src/plugins/util/web')
       const root = sinon.stub(web, 'root').returns(span)
@@ -283,7 +289,7 @@ describe('normalizeRouteExpress', () => {
 
     // The host never loaded path-to-regexp 8 here, so there is no parser to read the route with.
     it('returns null when no path-to-regexp 8 adapter is available', () => {
-      const span = { context: () => ({ getTag: tag => (tag === 'component' ? 'express' : '/users/:id') }) }
+      const span = { framework: 'express', route: '/users/:id' }
       const req = { originalUrl: '/users/1', params: { id: '1' } }
       const web = require('../../../src/plugins/util/web')
       const root = sinon.stub(web, 'root').returns(span)

--- a/packages/dd-trace/test/appsec/api_security/sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security/sampler.spec.js
@@ -6,12 +6,12 @@ const { performance } = require('node:perf_hooks')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const { USER_KEEP, AUTO_KEEP, AUTO_REJECT, USER_REJECT } = require('../../../../../ext/priority')
 
 describe('API Security Sampler', () => {
   const req = { route: { path: '/test' }, method: 'GET' }
   const res = { statusCode: 200 }
-  let apiSecuritySampler, SamplingDecision, webStub, blockingStub, span, clock, performanceNowStub
+  let apiSecuritySampler, SamplingDecision, webStub, blockingStub, eventWriterStub, projectionsStub
+  let span, clock, performanceNowStub
 
   beforeEach(() => {
     clock = sinon.useFakeTimers({
@@ -32,17 +32,23 @@ describe('API Security Sampler', () => {
       isBlocked: sinon.stub().returns(false),
     }
 
+    eventWriterStub = {
+      sampleForApiSecurity: sinon.stub().returns(true),
+    }
+
+    projectionsStub = {
+      getHttpEndpoint: sinon.stub().callsFake(span => span?.httpEndpoint),
+    }
+
     apiSecuritySampler = proxyquire('../../../src/appsec/api_security/sampler', {
       '../../plugins/util/web': webStub,
+      '../../opentracing/event-writer': eventWriterStub,
+      '../../opentracing/span-projections': projectionsStub,
       '../blocking': blockingStub,
     })
     SamplingDecision = apiSecuritySampler.SamplingDecision
 
-    span = {
-      context: sinon.stub().returns({
-        _sampling: { priority: AUTO_KEEP },
-      }),
-    }
+    span = {}
 
     webStub.root.returns(span)
     webStub.getContext.returns({ paths: ['path'] })
@@ -65,12 +71,12 @@ describe('API Security Sampler', () => {
   })
 
   it('should return SKIP for AUTO_REJECT priority', () => {
-    span.context.returns({ _sampling: { priority: AUTO_REJECT } })
+    eventWriterStub.sampleForApiSecurity.returns(false)
     assert.strictEqual(apiSecuritySampler.sampleRequest(req, res), SamplingDecision.SKIP)
   })
 
   it('should return SKIP for USER_REJECT priority', () => {
-    span.context.returns({ _sampling: { priority: USER_REJECT } })
+    eventWriterStub.sampleForApiSecurity.returns(false)
     assert.strictEqual(apiSecuritySampler.sampleRequest(req, res), SamplingDecision.SKIP)
   })
 
@@ -144,14 +150,9 @@ describe('API Security Sampler', () => {
       assert.strictEqual(apiSecuritySampler.wasSampled(req, res404), true)
     })
 
-    it('should sample for AUTO_KEEP priority without checking prioritySampler', () => {
-      span.context.returns({ _sampling: { priority: AUTO_KEEP } })
+    it('should sample when the atomic sampling decision allows it', () => {
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res), SamplingDecision.SAMPLE)
-    })
-
-    it('should sample for USER_KEEP priority without checking prioritySampler', () => {
-      span.context.returns({ _sampling: { priority: USER_KEEP } })
-      assert.strictEqual(apiSecuritySampler.sampleRequest(req, res), SamplingDecision.SAMPLE)
+      sinon.assert.calledOnceWithExactly(eventWriterStub.sampleForApiSecurity, span)
     })
   })
 
@@ -207,33 +208,33 @@ describe('API Security Sampler', () => {
     })
 
     it('returns MISSING_ROUTE when there is no route and status is not 404 and response is not blocked', () => {
-      webStub.getContext.returns({ paths: [], span: { context: () => ({ _tags: {} }) } })
+      webStub.getContext.returns({ paths: [], span: {} })
 
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.MISSING_ROUTE)
     })
 
     it('returns SKIP (not MISSING_ROUTE) on 404 routeless responses', () => {
-      webStub.getContext.returns({ paths: [], span: { context: () => ({ _tags: {} }) } })
+      webStub.getContext.returns({ paths: [], span: {} })
 
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, { statusCode: 404 }, true), SamplingDecision.SKIP)
     })
 
     it('returns SKIP (not MISSING_ROUTE) on blocked routeless responses', () => {
-      webStub.getContext.returns({ paths: [], span: { context: () => ({ _tags: {} }) } })
+      webStub.getContext.returns({ paths: [], span: {} })
       blockingStub.isBlocked.returns(true)
 
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.SKIP)
     })
 
     it('returns SKIP (not MISSING_ROUTE) when priority is rejected', () => {
-      span.context.returns({ _sampling: { priority: AUTO_REJECT } })
-      webStub.getContext.returns({ paths: [], span: { context: () => ({ _tags: {} }) } })
+      eventWriterStub.sampleForApiSecurity.returns(false)
+      webStub.getContext.returns({ paths: [], span: {} })
 
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.SKIP)
     })
 
     it('does not record routeless requests in the TTL cache (missing_route ignores TTL)', () => {
-      webStub.getContext.returns({ paths: [], span: { context: () => ({ _tags: {} }) } })
+      webStub.getContext.returns({ paths: [], span: {} })
 
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.MISSING_ROUTE)
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.MISSING_ROUTE)
@@ -247,6 +248,8 @@ describe('API Security Sampler', () => {
       keepTraceStub = sinon.stub()
       apiSecuritySampler = proxyquire('../../../src/appsec/api_security/sampler', {
         '../../plugins/util/web': webStub,
+        '../../opentracing/event-writer': eventWriterStub,
+        '../../opentracing/span-projections': projectionsStub,
         '../blocking': blockingStub,
         '../../priority_sampler': {
           keepTrace: keepTraceStub,
@@ -272,10 +275,10 @@ describe('API Security Sampler', () => {
     })
 
     it('should not check priority sampling in standalone mode', () => {
-      span.context.returns({ _sampling: { priority: AUTO_REJECT } })
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.SAMPLE)
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.SKIP)
       assert.strictEqual(keepTraceStub.calledWith(span, 'asm'), true)
+      sinon.assert.notCalled(eventWriterStub.sampleForApiSecurity)
     })
   })
 
@@ -286,14 +289,7 @@ describe('API Security Sampler', () => {
 
     function makeSpan (tags) {
       return {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: tags,
-          getTag: (key) => tags[key],
-          getTags: () => tags,
-          setTag: (key, value) => { tags[key] = value },
-          hasTag: (key) => key in tags,
-        }),
+        httpEndpoint: tags['http.endpoint'],
       }
     }
 
@@ -327,12 +323,7 @@ describe('API Security Sampler', () => {
       assert.strictEqual(apiSecuritySampler.sampleRequest(req, res, true), SamplingDecision.SAMPLE)
 
       // Same http.route but different http.endpoint; should share the TTL slot
-      const spanWithDifferentEndpoint = {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: { 'http.endpoint': '/api/other' },
-        }),
-      }
+      const spanWithDifferentEndpoint = makeSpan({ 'http.endpoint': '/api/other' })
       webStub.root.returns(spanWithDifferentEndpoint)
       webStub.getContext.returns({ paths: ['/users/:id'], span: spanWithDifferentEndpoint })
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -10,6 +10,12 @@ const VulnerabilityAnalyzer = require('../../../../dd-trace/src/appsec/iast/anal
 const { USER_KEEP } = require('../../../../../ext/priority')
 const { ASM } = require('../../../src/standalone/product')
 
+function createRootSpan (appendResult = true) {
+  return {
+    appendStackTrace: sinon.stub().returns(appendResult),
+  }
+}
+
 describe('vulnerability-reporter', () => {
   let vulnerabilityAnalyzer
 
@@ -33,12 +39,12 @@ describe('vulnerability-reporter', () => {
 
     describe('with rootSpan', () => {
       let iastContext = {
-        rootSpan: {},
+        rootSpan: createRootSpan(),
       }
 
       afterEach(() => {
         iastContext = {
-          rootSpan: {},
+          rootSpan: createRootSpan(),
         }
       })
 
@@ -101,6 +107,7 @@ describe('vulnerability-reporter', () => {
           _prioritySampler: prioritySampler,
           finish: sinon.spy(),
           addTags: sinon.spy(),
+          appendStackTrace: sinon.stub().returns(true),
           context () {
             return {
               toSpanId () {
@@ -166,11 +173,7 @@ describe('vulnerability-reporter', () => {
 
     beforeEach(() => {
       iastContext = {
-        rootSpan: {
-          meta_struct: {
-            '_dd.stack': {},
-          },
-        },
+        rootSpan: createRootSpan(),
       }
       vulnerability = vulnerabilityAnalyzer._createVulnerability(
         'INSECURE_HASHING',
@@ -206,7 +209,12 @@ describe('vulnerability-reporter', () => {
       })
       addVulnerability(iastContext, vulnerability, callSiteFrames)
 
-      assert.strictEqual(iastContext.rootSpan.meta_struct['_dd.stack'].vulnerability.length, 1)
+      sinon.assert.calledOnceWithExactly(
+        iastContext.rootSpan.appendStackTrace,
+        'vulnerability',
+        sinon.match({ id: vulnerability.location.stackId, language: 'nodejs' }),
+        2
+      )
     })
 
     it('should not report stack trace when at maxStackTraces limit', () => {
@@ -225,12 +233,16 @@ describe('vulnerability-reporter', () => {
           },
         },
       })
-      iastContext.rootSpan.meta_struct['_dd.stack'].vulnerability = ['existing_stack']
+      iastContext.rootSpan.appendStackTrace.returns(false)
 
       addVulnerability(iastContext, vulnerability, callSiteFrames)
 
-      assert.strictEqual(iastContext.rootSpan.meta_struct['_dd.stack'].vulnerability.length, 1)
-      assert.strictEqual(iastContext.rootSpan.meta_struct['_dd.stack'].vulnerability[0], 'existing_stack')
+      sinon.assert.calledOnceWithExactly(
+        iastContext.rootSpan.appendStackTrace,
+        'vulnerability',
+        sinon.match({ id: vulnerability.location.stackId, language: 'nodejs' }),
+        1
+      )
     })
 
     it('should always report stack trace when maxStackTraces is 0', () => {
@@ -249,11 +261,14 @@ describe('vulnerability-reporter', () => {
           },
         },
       })
-      iastContext.rootSpan.meta_struct['_dd.stack'].vulnerability = ['stack1', 'stack2']
-
       addVulnerability(iastContext, vulnerability, callSiteFrames)
 
-      assert.strictEqual(iastContext.rootSpan.meta_struct['_dd.stack'].vulnerability.length, 3)
+      sinon.assert.calledOnceWithExactly(
+        iastContext.rootSpan.appendStackTrace,
+        'vulnerability',
+        sinon.match({ id: vulnerability.location.stackId, language: 'nodejs' }),
+        0
+      )
     })
   })
 
@@ -270,6 +285,7 @@ describe('vulnerability-reporter', () => {
       span = {
         _prioritySampler: prioritySampler,
         addTags: sinon.stub(),
+        appendStackTrace: sinon.stub().returns(true),
         context: sinon.stub().returns(context),
       }
       start({
@@ -551,6 +567,7 @@ describe('vulnerability-reporter', () => {
       global.clearInterval = sinon.spy(global.clearInterval)
       span = {
         addTags: sinon.stub(),
+        appendStackTrace: sinon.stub().returns(true),
         keep: sinon.stub(),
       }
     })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -136,6 +136,9 @@ describe('AppSec Index', function () {
     }
 
     const apiSecuritySampler = proxyquire('../../src/appsec/api_security/sampler', {
+      '../../opentracing/event-writer': {
+        sampleForApiSecurity: () => web._prioritySampler.isSampled(),
+      },
       '../../plugins/util/web': web,
     })
     apiSecurity = proxyquire('../../src/appsec/api_security', {
@@ -170,6 +173,9 @@ describe('AppSec Index', function () {
     const authHandlers = proxyquire('../../src/appsec/handlers/auth', {
       '../../plugins/util/web': web,
       '../../log': log,
+      '../../opentracing/span-projections': {
+        hasUserSessionId: span => Boolean(span._tags['usr.session_id']),
+      },
       '../user_tracking': UserTracking,
     })
 

--- a/packages/dd-trace/test/appsec/lambda.spec.js
+++ b/packages/dd-trace/test/appsec/lambda.spec.js
@@ -17,9 +17,11 @@ describe('AppSec Lambda handler', () => {
   const fakeSpan = () => {
     const tags = {}
     const spanContext = {
+      _tags: tags,
       getTag (key) { return tags[key] },
     }
     return {
+      _spanContext: spanContext,
       addTags: sinon.stub().callsFake((obj) => Object.assign(tags, obj)),
       setTag: sinon.stub().callsFake((k, v) => { tags[k] = v }),
       context: sinon.stub().returns(spanContext),
@@ -355,12 +357,14 @@ describe('WAF path safety with non-HTTP req', () => {
   const fakeSpan = () => {
     const tags = {}
     const spanContext = {
+      _tags: tags,
       getTags () { return tags },
       getTag (key) { return tags[key] },
       setTag (key, value) { tags[key] = value },
       hasTag (key) { return key in tags },
     }
     return {
+      _spanContext: spanContext,
       addTags: sinon.stub().callsFake((obj) => Object.assign(tags, obj)),
       setTag: sinon.stub().callsFake((k, v) => { tags[k] = v }),
       context: sinon.stub().returns(spanContext),

--- a/packages/dd-trace/test/appsec/rasp/utils.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/utils.spec.js
@@ -20,7 +20,7 @@ describe('RASP - utils.js', () => {
     stackTrace = {
       reportStackTrace: sinon.stub(),
       getCallsiteFrames: sinon.stub().returns([]),
-      canReportStackTrace: sinon.stub().returns(false),
+      STACK_TRACE_NAMESPACES: { RASP: 'exploit' },
     }
 
     telemetry = {
@@ -86,20 +86,20 @@ describe('RASP - utils.js', () => {
       }
 
       web.root.returns(rootSpan)
-      stackTrace.canReportStackTrace.returns(true)
 
       utils.handleResult(result, req, undefined, undefined, config, raspRule)
-      sinon.assert.calledOnceWithExactly(stackTrace.reportStackTrace, rootSpan, stackId, sinon.match.array)
+      sinon.assert.calledOnceWithExactly(
+        stackTrace.reportStackTrace,
+        rootSpan,
+        stackId,
+        sinon.match.array,
+        'exploit',
+        2
+      )
     })
 
-    it('should not report stack trace when max stack traces limit is reached', () => {
-      const rootSpan = {
-        meta_struct: {
-          '_dd.stack': {
-            exploit: ['stack1', 'stack2'],
-          },
-        },
-      }
+    it('should let the span writer enforce the max stack traces limit', () => {
+      const rootSpan = {}
       const result = {
         actions: {
           generate_stack: {
@@ -111,7 +111,14 @@ describe('RASP - utils.js', () => {
       web.root.returns(rootSpan)
 
       utils.handleResult(result, req, undefined, undefined, config, raspRule)
-      sinon.assert.notCalled(stackTrace.reportStackTrace)
+      sinon.assert.calledOnceWithExactly(
+        stackTrace.reportStackTrace,
+        rootSpan,
+        'stackId',
+        sinon.match.array,
+        'exploit',
+        2
+      )
     })
 
     it('should not report stack trace when rootSpan is null', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -24,6 +24,8 @@ describe('reporter', () => {
   let web
   let telemetry
   let prioritySampler
+  let spanProjections
+  let eventWriter
 
   const defaultReporterConfig = {
     rateLimit: 100,
@@ -43,6 +45,7 @@ describe('reporter', () => {
     }
 
     const spanTags = {}
+    const structuredTagKeys = new Set()
     const spanContext = {
       _tags: spanTags,
       getTags () { return this._tags },
@@ -55,7 +58,38 @@ describe('reporter', () => {
       context: sinon.stub().returns(spanContext),
       addTags: sinon.stub(),
       setTag: sinon.stub(),
+      setStructuredTagIfAbsent: sinon.stub().callsFake(key => {
+        if (structuredTagKeys.has(key)) return false
+
+        structuredTagKeys.add(key)
+        return true
+      }),
       keep: sinon.stub(),
+    }
+
+    eventWriter = {
+      addAppSecEvent: sinon.stub().callsFake((rootSpan, attackData, remoteAddress) => {
+        const currentJson = spanTags['_dd.appsec.json']
+        const attackDataString = JSON.stringify(attackData)
+        const appSecJson = currentJson
+          ? currentJson.slice(0, -2) + ',' + attackDataString.slice(1) + '}'
+          : '{"triggers":' + attackDataString + '}'
+        const tags = {
+          'appsec.event': 'true',
+          '_dd.appsec.json': appSecJson,
+        }
+        if (spanTags['_dd.origin'] === undefined) tags['_dd.origin'] = 'appsec'
+        if (remoteAddress !== undefined) tags['network.client.ip'] = remoteAddress
+        Object.assign(spanTags, tags)
+        rootSpan.addTags(tags)
+        return appSecJson
+      }),
+      copyTags: sinon.stub().callsFake((source, destination, mappings) => {
+        for (const [sourceTag, destinationTag] of mappings) {
+          const value = spanTags[sourceTag]
+          if (value !== undefined && value !== null) destination.setTag(destinationTag, value)
+        }
+      }),
     }
 
     web = {
@@ -75,8 +109,14 @@ describe('reporter', () => {
       getRequestMetrics: sinon.stub(),
     }
 
+    spanProjections = {
+      shouldCollectAppSecEventHeaders: sinon.stub().returns(false),
+    }
+
     Reporter = proxyquire('../../src/appsec/reporter', {
       '../plugins/util/web': web,
+      '../opentracing/event-writer': eventWriter,
+      '../opentracing/span-projections': spanProjections,
       './telemetry': telemetry,
     })
   })
@@ -433,7 +473,7 @@ describe('reporter', () => {
     })
 
     it('should not overwrite origin tag', () => {
-      span.context()._tags = { '_dd.origin': 'tracer' }
+      span.context().setTag('_dd.origin', 'tracer')
 
       Reporter.reportAttack({ events: [] })
 
@@ -446,7 +486,7 @@ describe('reporter', () => {
     })
 
     it('should merge attacks json', () => {
-      span.context()._tags = { '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}' }
+      span.context().setTag('_dd.appsec.json', '{"triggers":[{"rule":{},"rule_matches":[{}]}]}')
 
       Reporter.reportAttack({
         events: [
@@ -470,7 +510,7 @@ describe('reporter', () => {
     })
 
     it('should call standalone sample', () => {
-      span.context()._tags = { '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}' }
+      span.context().setTag('_dd.appsec.json', '{"triggers":[{"rule":{},"rule_matches":[{}]}]}')
 
       Reporter.reportAttack({
         events: [
@@ -604,7 +644,11 @@ describe('reporter', () => {
           ],
         })
 
-        assert.deepStrictEqual(span.meta_struct['http.request.body'], expectedBody)
+        sinon.assert.calledOnceWithExactly(
+          span.setStructuredTagIfAbsent,
+          'http.request.body',
+          expectedBody
+        )
       })
 
       it('should not report request body in meta struct on rasp event when disabled', () => {
@@ -634,7 +678,7 @@ describe('reporter', () => {
           ],
         })
 
-        assert.strictEqual(span.meta_struct?.['http.request.body'], undefined)
+        sinon.assert.notCalled(span.setStructuredTagIfAbsent)
       })
 
       describe('Request body truncation', () => {
@@ -758,7 +802,7 @@ describe('reporter', () => {
           })
 
           sinon.assert.calledWithExactly(span.setTag, '_dd.appsec.rasp.request_body_size.exceeded', 'true')
-          span.context()._tags = { '_dd.appsec.rasp.request_body_size.exceeded': 'true' }
+          span.context().setTag('_dd.appsec.rasp.request_body_size.exceeded', 'true')
 
           const res = {}
           Reporter.finishRequest(req, res, {}, req.body)
@@ -873,8 +917,6 @@ describe('reporter', () => {
     })
 
     it('should do nothing when passed incomplete objects', () => {
-      span.context()._tags['appsec.event'] = 'true'
-
       web.root.withArgs(null).returns(null)
       web.root.withArgs({}).returns(span)
 
@@ -995,7 +1037,7 @@ describe('reporter', () => {
         },
       }
 
-      span.context()._tags['appsec.event'] = 'true'
+      spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
       Reporter.finishRequest(req, res)
       sinon.assert.calledOnceWithExactly(web.root, req)
@@ -1019,7 +1061,7 @@ describe('reporter', () => {
           return {}
         },
       }
-      span.context()._tags['appsec.event'] = 'true'
+      spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
       Reporter.finishRequest(req, res)
 
@@ -1044,8 +1086,7 @@ describe('reporter', () => {
         },
       }
 
-      span.context()
-        ._tags['appsec.events.users.login.success.track'] = 'true'
+      spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
       Reporter.finishRequest(req, res)
 
@@ -1070,8 +1111,7 @@ describe('reporter', () => {
         },
       }
 
-      span.context()
-        ._tags['appsec.events.users.login.failure.track'] = 'true'
+      spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
       Reporter.finishRequest(req, res)
 
@@ -1096,8 +1136,7 @@ describe('reporter', () => {
         },
       }
 
-      span.context()
-        ._tags['appsec.events.custon.event.track'] = 'true'
+      spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
       Reporter.finishRequest(req, res)
 
@@ -1217,7 +1256,7 @@ describe('reporter', () => {
             return extendedResponseHeadersAndValues
           },
         }
-        span.context()._tags['appsec.event'] = 'true'
+        spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
         const config = getAppSecConfig({
           rateLimit: 100,
@@ -1256,7 +1295,7 @@ describe('reporter', () => {
             return extendedResponseHeadersAndValues
           },
         }
-        span.context()._tags['appsec.event'] = 'true'
+        spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
         const maxHeaders = 20
         const reportedExtReqHeadersCount = maxHeaders - (requestHeadersToTrackOnEvent.length + 1)
@@ -1307,7 +1346,7 @@ describe('reporter', () => {
             return extendedResponseHeadersAndValues
           },
         }
-        span.context()._tags['appsec.event'] = 'true'
+        spanProjections.shouldCollectAppSecEventHeaders.returns(true)
 
         const config = getAppSecConfig({
           rateLimit: 100,

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -63,6 +63,9 @@ describe('user_blocking - Internal API', () => {
       './utils': { getRootSpan },
       '../blocking': { block },
       '../../log': log,
+      '../../opentracing/span-projections': {
+        hasUserId: span => Boolean(span.context().getTag('usr.id')),
+      },
     })
   })
 

--- a/packages/dd-trace/test/appsec/sdk/utils.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/utils.spec.js
@@ -4,7 +4,6 @@ const assert = require('node:assert/strict')
 const { getRootSpan } = require('../../../src/appsec/sdk/utils')
 const DatadogTracer = require('../../../src/tracer')
 const { getConfigFresh } = require('../../helpers/config')
-const id = require('../../../src/id')
 
 describe('Appsec SDK utils', () => {
   let tracer
@@ -26,17 +25,6 @@ describe('Appsec SDK utils', () => {
 
     it('should return root span of single child', () => {
       const childOf = tracer.startSpan('parent')
-
-      tracer.trace('child1', { childOf }, child1 => {
-        const root = getRootSpan()
-
-        assert.strictEqual(root, childOf)
-      })
-    })
-
-    it('should return root span of single child from unknown parent', () => {
-      const childOf = tracer.startSpan('parent')
-      childOf.context()._parentId = id()
 
       tracer.trace('child1', { childOf }, child1 => {
         const root = getRootSpan()

--- a/packages/dd-trace/test/appsec/stack_trace.spec.js
+++ b/packages/dd-trace/test/appsec/stack_trace.spec.js
@@ -2,7 +2,6 @@
 
 const assert = require('node:assert/strict')
 const path = require('path')
-const { inspect } = require('node:util')
 
 const { reportStackTrace, getCallsiteFrames } = require('../../src/appsec/stack_trace')
 
@@ -64,14 +63,10 @@ describe('Stack trace reporter', () => {
           },
         ])
 
-      const rootSpan = {}
-      const stackId = 'test_stack_id'
       const maxDepth = 32
       const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
 
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+      assert.deepStrictEqual(frames, expectedFrames)
     })
   })
 
@@ -97,35 +92,12 @@ describe('Stack trace reporter', () => {
       }
     })
 
-    it('should add stack trace to rootSpan when meta_struct is not present', () => {
-      const rootSpan = {}
-      const stackId = 'test_stack_id'
-      const maxDepth = 32
-      const expectedFrames = Array(20).fill().map((_, i) => (
-        {
-          id: i,
-          file: `file${i}`,
-          line: i,
-          column: i,
-          function: `function${i}`,
-          class_name: `type${i}`,
-          isNative: false,
-        }
-      ))
-
-      const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
-
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].id, stackId)
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].language, 'nodejs')
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-    })
-
-    it('should add stack trace to rootSpan when meta_struct is already present', () => {
+    it('should append a stack trace through the span API', () => {
+      const calls = []
       const rootSpan = {
-        meta_struct: {
-          another_tag: [],
+        appendStackTrace (...args) {
+          calls.push(args)
+          return true
         },
       }
       const stackId = 'test_stack_id'
@@ -144,112 +116,52 @@ describe('Stack trace reporter', () => {
 
       const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
 
-      reportStackTrace(rootSpan, stackId, frames)
+      const appended = reportStackTrace(rootSpan, stackId, frames)
 
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].id, stackId)
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].language, 'nodejs')
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-      assert.ok(
-        Object.hasOwn(rootSpan.meta_struct, 'another_tag'),
-        `Available keys: ${inspect(Object.keys(rootSpan.meta_struct))}`
-      )
-    })
-
-    it('should add stack trace to rootSpan when meta_struct is already present and contains another stack', () => {
-      const rootSpan = {
-        meta_struct: {
-          another_tag: [],
-          '_dd.stack': {
-            exploit: [callSiteList],
-          },
-        },
-      }
-      const stackId = 'test_stack_id'
-      const maxDepth = 32
-      const expectedFrames = Array(20).fill().map((_, i) => (
+      assert.strictEqual(appended, true)
+      assert.deepStrictEqual(calls, [[
+        'exploit',
         {
-          id: i,
-          file: `file${i}`,
-          line: i,
-          column: i,
-          function: `function${i}`,
-          class_name: `type${i}`,
-          isNative: false,
-        }
-      ))
-
-      const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
-
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].id, stackId)
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].language, 'nodejs')
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].frames, expectedFrames)
-      assert.ok(
-        Object.hasOwn(rootSpan.meta_struct, 'another_tag'),
-        `Available keys: ${inspect(Object.keys(rootSpan.meta_struct))}`
-      )
+          id: stackId,
+          language: 'nodejs',
+          frames: expectedFrames,
+        },
+        0,
+      ]])
     })
 
-    it('should add stack trace when the max stack trace is 0', () => {
+    it('should pass the namespace and cap to the span API', () => {
+      const calls = []
       const rootSpan = {
-        meta_struct: {
-          '_dd.stack': {
-            exploit: [callSiteList, callSiteList],
-          },
-          another_tag: [],
+        appendStackTrace (...args) {
+          calls.push(args)
+          return false
         },
       }
       const stackId = 'test_stack_id'
-      const maxDepth = 32
+      const frames = [{ file: 'test.js' }]
 
-      const frames = getCallsiteFrames(maxDepth, () => callSiteList)
+      const appended = reportStackTrace(rootSpan, stackId, frames, 'vulnerability', 2)
 
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit.length, 3)
-      assert.ok(
-        Object.hasOwn(rootSpan.meta_struct, 'another_tag'),
-        `Available keys: ${inspect(Object.keys(rootSpan.meta_struct))}`
-      )
-    })
-
-    it('should add stack trace when the max stack trace is negative', () => {
-      const rootSpan = {
-        meta_struct: {
-          '_dd.stack': {
-            exploit: [callSiteList, callSiteList],
-          },
-          another_tag: [],
+      assert.strictEqual(appended, false)
+      assert.deepStrictEqual(calls, [[
+        'vulnerability',
+        {
+          id: stackId,
+          language: 'nodejs',
+          frames,
         },
-      }
-      const stackId = 'test_stack_id'
-      const maxDepth = 32
-
-      const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
-
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit.length, 3)
-      assert.ok(
-        Object.hasOwn(rootSpan.meta_struct, 'another_tag'),
-        `Available keys: ${inspect(Object.keys(rootSpan.meta_struct))}`
-      )
+        2,
+      ]])
     })
 
     it('should not report stackTraces if callSiteList is undefined', () => {
       const rootSpan = {
-        meta_struct: {
-          another_tag: [],
-        },
+        appendStackTrace: () => assert.fail(),
       }
       const stackId = 'test_stack_id'
-      reportStackTrace(rootSpan, stackId, undefined)
-      assert.ok(
-        Object.hasOwn(rootSpan.meta_struct, 'another_tag'),
-        `Available keys: ${inspect(Object.keys(rootSpan.meta_struct))}`
-      )
-      assert.ok(!('_dd.stack' in rootSpan.meta_struct))
+
+      assert.strictEqual(reportStackTrace(rootSpan, stackId, undefined), undefined)
     })
   })
 
@@ -266,8 +178,6 @@ describe('Stack trace reporter', () => {
     ))
 
     it('limit frames to max depth', () => {
-      const rootSpan = {}
-      const stackId = 'test_stack_id'
       const maxDepth = 5
       const expectedFrames = [0, 1, 2, 118, 119].map(i => (
         {
@@ -283,14 +193,10 @@ describe('Stack trace reporter', () => {
 
       const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
 
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+      assert.deepStrictEqual(frames, expectedFrames)
     })
 
     it('limit frames to max depth with filtered frames', () => {
-      const rootSpan = {}
-      const stackId = 'test_stack_id'
       const maxDepth = 5
       const callSiteListWithLibraryFrames = [
         {
@@ -334,14 +240,10 @@ describe('Stack trace reporter', () => {
 
       const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteListWithLibraryFrames)
 
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+      assert.deepStrictEqual(frames, expectedFrames)
     })
 
     it('no limit if maxDepth is 0', () => {
-      const rootSpan = {}
-      const stackId = 'test_stack_id'
       const maxDepth = 0
       const expectedFrames = Array(120).fill().map((_, i) => (
         {
@@ -357,14 +259,10 @@ describe('Stack trace reporter', () => {
 
       const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
 
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+      assert.deepStrictEqual(frames, expectedFrames)
     })
 
     it('no limit if maxDepth is negative', () => {
-      const rootSpan = {}
-      const stackId = 'test_stack_id'
       const maxDepth = -1
       const expectedFrames = Array(120).fill().map((_, i) => (
         {
@@ -380,9 +278,7 @@ describe('Stack trace reporter', () => {
 
       const frames = getCallsiteFrames(maxDepth, getCallsiteFrames, () => callSiteList)
 
-      reportStackTrace(rootSpan, stackId, frames)
-
-      assert.deepStrictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+      assert.deepStrictEqual(frames, expectedFrames)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/user_tracking.spec.js
+++ b/packages/dd-trace/test/appsec/user_tracking.spec.js
@@ -14,6 +14,7 @@ describe('User Tracking', () => {
   let log
   let waf
   let keepTrace
+  let eventWriter
 
   let setCollectionMode
   let trackLogin
@@ -46,8 +47,31 @@ describe('User Tracking', () => {
 
     keepTrace = sinon.stub()
 
+    eventWriter = {
+      setAppSecAutoLoginTags: sinon.stub().callsFake((span, sdkTag, tags, sdkOwnedTags, trackedTag) => {
+        const writtenTags = {}
+        const sdkCalled = currentTags[sdkTag] === 'true'
+        for (const key of Object.keys(tags)) {
+          if (sdkCalled && sdkOwnedTags.has(key) && currentTags[key]) continue
+          writtenTags[key] = tags[key]
+        }
+        span.addTags(writtenTags)
+        return Object.hasOwn(writtenTags, trackedTag)
+      }),
+      setAppSecAutoUser: sinon.stub().callsFake((span, userId, mode) => {
+        span.setTag('_dd.appsec.usr.id', userId)
+        if (currentTags['_dd.appsec.user.collection_mode'] === 'sdk') return false
+        span.addTags({
+          'usr.id': userId,
+          '_dd.appsec.user.collection_mode': mode,
+        })
+        return true
+      }),
+    }
+
     const UserTracking = proxyquire('../../src/appsec/user_tracking', {
       '../log': log,
+      '../opentracing/event-writer': eventWriter,
       '../priority_sampler': { keepTrace },
       './waf': waf,
     })

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -10,11 +10,13 @@ const sinon = require('sinon')
 const { DD_MAJOR } = require('../../../../version')
 const { INCOMPATIBLE_INITIALIZATION } = require('../../src/llmobs/constants/text')
 const LLMObsTagger = require('../../src/llmobs/tagger')
+const eventWriter = require('../../src/opentracing/event-writer')
 const {
   PROPAGATED_TRACE_ID_KEY,
   SAMPLE_RATE,
   SAMPLING_DECISION,
   SESSION_ID,
+  SESSION_ID_TRACE_DEFAULT_KEY,
   TRACE_ID,
 } = require('../../src/llmobs/constants/tags')
 const { getConfigFresh } = require('../helpers/config')
@@ -24,6 +26,18 @@ const spanFinishCh = channel('dd-trace:span:finish')
 const evalMetricAppendCh = channel('llmobs:eval-metric:append')
 const flushCh = channel('llmobs:writers:flush')
 const injectCh = channel('dd-trace:span:inject')
+
+function makeProjectedSpan (traceTags) {
+  const context = {
+    toSpanId () {
+      return 'parent-id'
+    },
+  }
+  const span = { context: () => context }
+  eventWriter.initializeContext(context)
+  if (traceTags) eventWriter.setTraceTags(span, traceTags)
+  return span
+}
 
 describe('module', () => {
   let llmobsModule
@@ -173,16 +187,8 @@ describe('module', () => {
 
     it('injects the session_id from the trace-level default when the active span carries none', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
-      store.span = {
-        context () {
-          return {
-            toSpanId () {
-              return 'parent-id'
-            },
-            _trace: { tags: { '_ml_obs.trace_session_id': 'trace-session' } },
-          }
-        },
-      }
+      store.span = makeProjectedSpan()
+      eventWriter.setTraceTag(store.span, SESSION_ID_TRACE_DEFAULT_KEY, 'trace-session')
 
       const carrier = {
         'x-datadog-tags': '',
@@ -197,14 +203,7 @@ describe('module', () => {
 
     it('converts the local LLMObs trace id to decimal for propagation', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
-      store.span = {
-        context () {
-          return {
-            _trace: { tags: {} },
-            toSpanId () { return 'parent-id' },
-          }
-        },
-      }
+      store.span = makeProjectedSpan()
       LLMObsTagger.tagMap.set(store.span, {
         [TRACE_ID]: '6a5f76e7000000001973227978d8110b',
       })
@@ -222,14 +221,7 @@ describe('module', () => {
     it('forwards an extracted LLMObs trace id without reinterpreting it', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
       const wireTraceId = '12345678901234567890123456789012'
-      store.span = {
-        context () {
-          return {
-            _trace: { tags: { [PROPAGATED_TRACE_ID_KEY]: wireTraceId } },
-            toSpanId () { return 'parent-id' },
-          }
-        },
-      }
+      store.span = makeProjectedSpan({ [PROPAGATED_TRACE_ID_KEY]: wireTraceId })
 
       const carrier = { 'x-datadog-tags': '' }
       injectCh.publish({ carrier })

--- a/packages/dd-trace/test/llmobs/plugin-base.spec.js
+++ b/packages/dd-trace/test/llmobs/plugin-base.spec.js
@@ -12,14 +12,22 @@ class TracingPlugin {
   }
 }
 
-class LLMObsTagger {}
+class LLMObsTagger {
+  registerLLMObsSpan () {}
+}
 
 const BaseLLMObsPlugin = proxyquire('../../src/llmobs/plugins/base', {
   '../../plugins/tracing': TracingPlugin,
   '../tagger': LLMObsTagger,
+  '../telemetry': { incrementLLMObsSpanStartCount () {} },
 })
 
 class TestLLMObsPlugin extends BaseLLMObsPlugin {
+  getLLMObsSpanRegisterOptions (ctx, parent) {
+    this.registerOptionsParent = parent
+    return { kind: 'tool' }
+  }
+
   setLLMObsTags () {
     this.storeDuringTagging = llmobsStorage.getStore()
   }
@@ -36,6 +44,17 @@ describe('BaseLLMObsPlugin', () => {
 
   afterEach(() => {
     llmobsStorage.enterWith(undefined)
+  })
+
+  it('passes the ambient LLMObs parent to register option resolution', () => {
+    const parent = {}
+    const ctx = { currentStore: { span: {} } }
+
+    llmobsStorage.enterWith({ span: parent })
+
+    plugin.start(ctx)
+
+    assert.strictEqual(plugin.registerOptionsParent, parent)
   })
 
   it('restores the parent LLMObs store after async tagging', () => {

--- a/packages/dd-trace/test/llmobs/plugin-base.spec.js
+++ b/packages/dd-trace/test/llmobs/plugin-base.spec.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const proxyquire = require('proxyquire')
+
+const { storage: llmobsStorage } = require('../../src/llmobs/storage')
+
+class TracingPlugin {
+  constructor (tracer, tracerConfig) {
+    this._tracerConfig = tracerConfig
+  }
+}
+
+class LLMObsTagger {}
+
+const BaseLLMObsPlugin = proxyquire('../../src/llmobs/plugins/base', {
+  '../../plugins/tracing': TracingPlugin,
+  '../tagger': LLMObsTagger,
+})
+
+class TestLLMObsPlugin extends BaseLLMObsPlugin {
+  setLLMObsTags () {
+    this.storeDuringTagging = llmobsStorage.getStore()
+  }
+}
+
+describe('BaseLLMObsPlugin', () => {
+  let plugin
+
+  beforeEach(() => {
+    plugin = new TestLLMObsPlugin(undefined, {
+      llmobs: { DD_LLMOBS_ENABLED: true },
+    })
+  })
+
+  afterEach(() => {
+    llmobsStorage.enterWith(undefined)
+  })
+
+  it('restores the parent LLMObs store after async tagging', () => {
+    const parentStore = { span: {} }
+    const streamedStore = { span: {} }
+    const ctx = {
+      currentStore: { span: {} },
+      llmobs: { parent: parentStore },
+    }
+
+    llmobsStorage.enterWith(streamedStore)
+
+    plugin.asyncEnd(ctx)
+
+    assert.strictEqual(plugin.storeDuringTagging, streamedStore)
+    assert.strictEqual(llmobsStorage.getStore(), parentStore)
+  })
+
+  it('clears the LLMObs store after tagging a root span', () => {
+    const streamedStore = { span: {} }
+    const ctx = {
+      currentStore: { span: {} },
+      llmobs: { parent: undefined },
+    }
+
+    llmobsStorage.enterWith(streamedStore)
+
+    plugin.asyncEnd(ctx)
+
+    assert.strictEqual(plugin.storeDuringTagging, streamedStore)
+    assert.strictEqual(llmobsStorage.getStore(), undefined)
+  })
+
+  it('preserves the current store for an unregistered operation', () => {
+    const currentStore = { span: {} }
+    const ctx = { currentStore: { span: {} } }
+
+    llmobsStorage.enterWith(currentStore)
+
+    plugin.asyncEnd(ctx)
+
+    assert.strictEqual(plugin.storeDuringTagging, currentStore)
+    assert.strictEqual(llmobsStorage.getStore(), currentStore)
+  })
+})

--- a/packages/dd-trace/test/llmobs/plugins/ai/dd-telemetry.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/dd-telemetry.spec.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const proxyquire = require('proxyquire')
+
+const parents = new WeakMap()
+const spanKinds = new WeakMap()
+const LLMObsTagger = {
+  getParent (span) {
+    return parents.get(span)
+  },
+  getSpanKind (span) {
+    return spanKinds.get(span)
+  },
+}
+
+class BaseLLMObsPlugin {}
+
+const DdTelemetryPlugin = proxyquire('../../../../src/llmobs/plugins/ai/ddTelemetry', {
+  '../../tagger': LLMObsTagger,
+  '../base': BaseLLMObsPlugin,
+})
+
+describe('AI SDK DD telemetry register options', () => {
+  const plugin = new DdTelemetryPlugin()
+
+  function getToolOptions (parent) {
+    return plugin.getLLMObsSpanRegisterOptions({
+      attributes: {},
+      name: 'ai.streamText.toolCall',
+    }, parent)
+  }
+
+  it('uses the semantic parent of an ambient LLM span for a tool', () => {
+    const semanticParent = {}
+    const parent = {}
+    parents.set(parent, semanticParent)
+    spanKinds.set(parent, 'llm')
+
+    assert.strictEqual(getToolOptions(parent).parent, semanticParent)
+  })
+
+  it('does not override a non-LLM ambient parent', () => {
+    const parent = {}
+    spanKinds.set(parent, 'workflow')
+
+    assert.strictEqual(Object.hasOwn(getToolOptions(parent), 'parent'), false)
+  })
+
+  it('does not override an LLM parent without a resolved semantic parent', () => {
+    const parent = {}
+    spanKinds.set(parent, 'llm')
+
+    assert.strictEqual(Object.hasOwn(getToolOptions(parent), 'parent'), false)
+  })
+})

--- a/packages/dd-trace/test/llmobs/span-state.spec.js
+++ b/packages/dd-trace/test/llmobs/span-state.spec.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { after, before, describe, it } = require('mocha')
+const eventWriter = require('../../src/opentracing/event-writer')
+const spanState = require('../../src/llmobs/span-state')
+
+function makeSpan (parent, tags) {
+  const context = {}
+  eventWriter.initializeContext(context, {
+    parentId: parent ? 'parent-id' : undefined,
+    spanId: parent ? 'child-id' : 'parent-id',
+    trace: parent?.context()._trace,
+  })
+  context.toSpanId = () => parent ? 'child' : 'parent'
+  const span = {
+    context () { return context },
+  }
+  eventWriter.startSpan(span, {
+    context,
+    processor: {},
+    prioritySampler: {},
+    debug: false,
+    integrationName: 'llmobs',
+    links: [],
+    startTime: 10,
+    parentContext: parent?.context(),
+    operationName: parent ? 'child-operation' : 'parent-operation',
+  })
+  if (tags) eventWriter.setTags(span, tags)
+  return span
+}
+
+describe('LLMObs span state projection', () => {
+  before(() => spanState.enable())
+  after(() => spanState.disable())
+
+  it('retains the start operation name', () => {
+    const span = makeSpan()
+    assert.strictEqual(spanState.getOperationName(span), 'parent-operation')
+
+    eventWriter.setOperationName(span, 'updated-operation')
+
+    assert.strictEqual(spanState.getOperationName(span), 'parent-operation')
+  })
+
+  it('tracks error tag deletion and clearing', () => {
+    const span = makeSpan()
+    eventWriter.setTag(span, 'error', true)
+    eventWriter.setTag(span, 'error.type', 'Error')
+    assert.strictEqual(spanState.hasError(span), true)
+
+    eventWriter.deleteTag(span, 'error')
+    assert.strictEqual(spanState.hasError(span), true)
+
+    eventWriter.clearTags(span)
+    assert.strictEqual(spanState.hasError(span), false)
+  })
+
+  it('captures initial tags written immediately after the start event', () => {
+    const span = makeSpan(undefined, { error: true })
+
+    assert.strictEqual(spanState.hasError(span), true)
+  })
+
+  it('tracks gen_ai ancestry as tags are written and removed', () => {
+    const parent = makeSpan()
+    const child = makeSpan(parent)
+    eventWriter.setTag(parent, 'gen_ai.operation.name', 'invoke_agent')
+    assert.strictEqual(spanState.findGenAIAncestorSpanId(child), 'parent')
+
+    eventWriter.deleteTag(parent, 'gen_ai.operation.name')
+    assert.strictEqual(spanState.findGenAIAncestorSpanId(child), null)
+  })
+
+  it('shares propagated trace tag overwrites across contexts', () => {
+    const parent = makeSpan()
+    const child = makeSpan(parent)
+    eventWriter.setTraceTag(parent, '_dd.p.llmobs_sid', 'one')
+    assert.strictEqual(spanState.getTraceTags(child)['_dd.p.llmobs_sid'], 'one')
+
+    eventWriter.setTraceTag(child, '_dd.p.llmobs_sid', 'two')
+    assert.strictEqual(spanState.getTraceTags(parent)['_dd.p.llmobs_sid'], 'two')
+  })
+
+  it('replays propagation tags from a pre-populated trace', () => {
+    const context = {}
+    const trace = {
+      started: [],
+      finished: [],
+      tags: { '_dd.p.llmobs_ml_app': 'upstream-app' },
+    }
+
+    eventWriter.initializeContext(context, { trace })
+
+    assert.strictEqual(spanState.getTraceTags(context)['_dd.p.llmobs_ml_app'], 'upstream-app')
+  })
+})

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -200,6 +200,7 @@ describe('tagger', () => {
           '_ml_obs.session_id': 'my-session',
           '_ml_obs.llmobs_parent_id': '5678',
         })
+        assert.strictEqual(Tagger.getParent(span), parentSpan)
       })
 
       it('uses the propagated trace id if provided', () => {

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -2,9 +2,11 @@
 
 const assert = require('node:assert/strict')
 
+const { channel } = require('dc-polyfill')
 const { beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
+const eventWriter = require('../../src/opentracing/event-writer')
 const { INPUT_PROMPT } = require('../../src/llmobs/constants/tags')
 const { writeBridgeTags, findGenAIAncestorSpanId, normalizeLlmObsTraceId } = require('../../src/llmobs/util')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
@@ -28,6 +30,7 @@ describe('tagger', () => {
       _tags: {},
       _trace: { tags: {} },
       _traceId: { toBigInt () { return 0x1111111111111111n } },
+      toBigIntTraceId () { return 0x1111111111111111n },
       toTraceId () { return '00000000000000001111111111111111' },
       toSpanId () { return '2222222222222222' },
     }
@@ -114,7 +117,7 @@ describe('tagger', () => {
       })
 
       it('inherits the trace-level default session when the span sets none', () => {
-        spanContext._trace.tags['_ml_obs.trace_session_id'] = 'trace-session'
+        eventWriter.setTraceTag(spanContext, '_ml_obs.trace_session_id', 'trace-session')
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -122,7 +125,7 @@ describe('tagger', () => {
       })
 
       it('inherits the session propagated from an upstream service', () => {
-        spanContext._trace.tags['_dd.p.llmobs_sid'] = 'propagated-session'
+        eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_sid', 'propagated-session')
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -130,7 +133,7 @@ describe('tagger', () => {
       })
 
       it('lets an explicit session override without changing the established trace default', () => {
-        spanContext._trace.tags['_ml_obs.trace_session_id'] = 'trace-session'
+        eventWriter.setTraceTag(spanContext, '_ml_obs.trace_session_id', 'trace-session')
 
         tagger.registerLLMObsSpan(span, { kind: 'llm', sessionId: 'other-session' })
 
@@ -200,7 +203,7 @@ describe('tagger', () => {
       })
 
       it('uses the propagated trace id if provided', () => {
-        spanContext._trace.tags['_dd.p.llmobs_trace_id'] = '141393847380800662846519802803680448779'
+        eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_trace_id', '141393847380800662846519802803680448779')
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -211,7 +214,7 @@ describe('tagger', () => {
       })
 
       it('uses the propagated parent id if provided', () => {
-        spanContext._trace.tags['_dd.p.llmobs_parent_id'] = '-567'
+        eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_parent_id', '-567')
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -288,9 +291,9 @@ describe('tagger', () => {
         })
 
         it('inherits the rate and decision propagated from an upstream service', () => {
-          spanContext._trace.tags['_dd.p.llmobs_parent_id'] = '5678'
-          spanContext._trace.tags['_dd.p.llmobs_sr'] = '0.25'
-          spanContext._trace.tags['_dd.p.llmobs_sd'] = '0'
+          eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_parent_id', '5678')
+          eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_sr', '0.25')
+          eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_sd', '0')
 
           tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -322,7 +325,7 @@ describe('tagger', () => {
           // Distributed trace from a service that predates sampling propagation:
           // there is an LLMObs parent context but no rate/decision. We must not
           // start a fresh (divergent) decision mid-trace — mirrors dd-trace-py.
-          spanContext._trace.tags['_dd.p.llmobs_parent_id'] = '5678'
+          eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_parent_id', '5678')
 
           tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -333,7 +336,7 @@ describe('tagger', () => {
       })
 
       it('uses the propagated mlApp over the global mlApp if both are provided', () => {
-        spanContext._trace.tags['_dd.p.llmobs_ml_app'] = 'my-propagated-ml-app'
+        eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_ml_app', 'my-propagated-ml-app')
 
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -347,7 +350,7 @@ describe('tagger', () => {
         })
 
         it('uses the mlApp from the propagated mlApp if no mlApp is provided', () => {
-          spanContext._trace.tags['_dd.p.llmobs_ml_app'] = 'my-propagated-ml-app'
+          eventWriter.setTraceTag(spanContext, '_dd.p.llmobs_ml_app', 'my-propagated-ml-app')
 
           tagger.registerLLMObsSpan(span, { kind: 'llm' })
 
@@ -471,22 +474,30 @@ describe('tagger', () => {
             const genAISpanId = '333333333333333'
             const leafSpanId = '444444444444444'
             const traceTags = {}
-            const traceStarted = []
+            const traceIdentity = { tags: traceTags }
 
             const genAISpanCtx = {
-              _spanId: { toString: () => genAISpanId },
-              _parentId: null,
-              getTags () { return { 'gen_ai.operation.name': 'invoke_agent' } },
-              _trace: { tags: traceTags, started: traceStarted },
+              _tags: {},
+              _trace: traceIdentity,
+              toSpanId () { return genAISpanId },
             }
             const genAISpan = { context: () => genAISpanCtx }
+            channel('dd-trace:span:event-writer:context-initialized').publish({
+              context: genAISpanCtx,
+              traceIdentity,
+            })
+            channel('dd-trace:span:event-writer:span-started').publish({
+              span: genAISpan,
+              context: genAISpanCtx,
+              operationName: 'gen_ai',
+              startTime: 0,
+            })
+            eventWriter.setTag(genAISpan, 'gen_ai.operation.name', 'invoke_agent')
 
             const leafTags = {}
             const leafSpanCtx = {
-              _spanId: { toString: () => leafSpanId },
-              _parentId: { toString: () => genAISpanId },
-              getTags () { return leafTags },
-              _trace: { tags: traceTags, started: traceStarted },
+              _tags: leafTags,
+              _trace: traceIdentity,
               toTraceId () { return '00000000000000009999999999999999' },
               toSpanId () { return leafSpanId },
             }
@@ -495,7 +506,17 @@ describe('tagger', () => {
               setTag (k, v) { leafTags[k] = v },
             }
 
-            traceStarted.push(genAISpan, leafSpan)
+            channel('dd-trace:span:event-writer:context-initialized').publish({
+              context: leafSpanCtx,
+              traceIdentity,
+            })
+            channel('dd-trace:span:event-writer:span-started').publish({
+              span: leafSpan,
+              context: leafSpanCtx,
+              parentContext: genAISpanCtx,
+              operationName: 'leaf',
+              startTime: 0,
+            })
 
             realTagger.registerLLMObsSpan(leafSpan, { kind: 'llm' })
 

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -2,9 +2,10 @@
 
 const assert = require('node:assert/strict')
 
+const { channel } = require('dc-polyfill')
 const { before, describe, it } = require('mocha')
-
-const getConfig = require('../../src/config')
+const eventWriter = require('../../src/opentracing/event-writer')
+const spanState = require('../../src/llmobs/span-state')
 const {
   agentNameWireSafe,
   appendOptionalPropagatedTag,
@@ -20,7 +21,6 @@ const {
   validateCostTags,
   safeJsonParse,
   validateKind,
-  spanHasError,
   writeBridgeTags,
 } = require('../../src/llmobs/util')
 
@@ -336,42 +336,6 @@ describe('util', () => {
     })
   })
 
-  describe('spanHasError', () => {
-    let Span
-    let tracer
-    let ps
-
-    before(() => {
-      Span = require('../../src/opentracing/span')
-      tracer = { _config: getConfig() }
-      ps = {
-        sample () {},
-      }
-    })
-
-    it('returns false when there is no error', () => {
-      const span = new Span(tracer, null, ps, {})
-      assert.strictEqual(spanHasError(span), false)
-    })
-
-    it('returns true if the span has an "error" tag', () => {
-      const span = new Span(tracer, null, ps, {})
-      span.setTag('error', true)
-      assert.strictEqual(spanHasError(span), true)
-    })
-
-    it('returns true if the span has the error properties as tags', () => {
-      const err = new Error('boom')
-      const span = new Span(tracer, null, ps, {})
-
-      span.setTag('error.type', err.name)
-      span.setTag('error.msg', err.message)
-      span.setTag('error.stack', err.stack)
-
-      assert.strictEqual(spanHasError(span), true)
-    })
-  })
-
   describe('writeBridgeTags', () => {
     function makeSpan (traceTags = {}) {
       return {
@@ -417,24 +381,32 @@ describe('util', () => {
   })
 
   describe('findGenAIAncestorSpanId', () => {
-    // Build a minimal Datadog-shaped span fixture: each span has `_spanId`,
-    // optional `_parentId`, `_tags`, and shares the `_trace.started` array
-    // so the helper can walk up the chain via `_parentId` lookup.
+    before(() => spanState.enable())
+
     function makeTrace (spanDefs) {
-      const started = []
-      const trace = { started, tags: {} }
+      const spans = []
+      const traceIdentity = {}
+      let parent
       for (const def of spanDefs) {
-        const tags = def.tags || {}
-        started.push({
-          context: () => ({
-            _spanId: { toString: () => def.spanId },
-            _parentId: def.parentId ? { toString: () => def.parentId } : null,
-            getTags () { return tags },
-            _trace: trace,
-          }),
+        const context = {
+          _tags: {},
+          _trace: { tags: {} },
+          toSpanId () { return def.spanId },
+        }
+        channel('dd-trace:span:event-writer:context-initialized').publish({ context, traceIdentity })
+        const span = { context () { return context } }
+        channel('dd-trace:span:event-writer:span-started').publish({
+          span,
+          context,
+          parentContext: parent,
+          operationName: 'test',
+          startTime: 0,
         })
+        eventWriter.setTags(span, def.tags || {})
+        spans.push(span)
+        parent = context
       }
-      return started
+      return spans
     }
 
     it('returns the nearest gen_ai.* ancestor span_id', () => {

--- a/packages/dd-trace/test/noop.spec.js
+++ b/packages/dd-trace/test/noop.spec.js
@@ -49,5 +49,14 @@ describe('NoopTracer', () => {
       assert.strictEqual(typeof span.context().toSpanId, 'function')
       assert.match(span.context().toSpanId(), /^\d+$/)
     })
+
+    it('accepts internal semantic writes without recording state', () => {
+      const span = tracer.startSpan()
+
+      assert.strictEqual(span.setIntegrationName('http'), span)
+      assert.strictEqual(span.setRecording(false), span)
+      assert.strictEqual(span.setTagIfAbsent('error', 1), false)
+      assert.strictEqual(span.setTagsIfTagMatches('route', undefined, { route: '/' }), false)
+    })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -370,8 +370,10 @@ describe('OTel Context Manager', () => {
     })
 
     it('caches the proxy so repeated calls return the same object', () => {
-      ddTracer.trace('dd-active', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
         assert.strictEqual(trace.getActiveSpan(), trace.getActiveSpan())
+        assert.strictEqual(ddSpan.context()._otelSpanContext, undefined)
+        assert.strictEqual(ddSpan.context()._otelActiveSpan, undefined)
       })
     })
 

--- a/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
@@ -8,6 +8,8 @@ require('../setup/core')
 
 const { DD_MAJOR } = require('../../../../version')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE, IGNORE_OTEL_ERROR } = require('../../src/constants')
+const { registerDatadogContext } = require('../../src/opentracing/context-registry')
+const { markSpanFinished } = require('../../src/opentracing/span-lifecycle')
 const {
   addOtelEvent,
   addOtelLink,
@@ -33,10 +35,7 @@ function createMockDdSpan ({ ended = false } = {}) {
   const links = []
   let operationName
 
-  return {
-    // Match the DD span shape: `_duration` is undefined while recording, a number once
-    // finished. The helpers' `isWritable` gate reads this directly.
-    _duration: ended ? 100 : undefined,
+  const span = {
     setTag (key, value) { tags[key] = value },
     // `IGNORE_OTEL_ERROR` is a Symbol key; use ownKeys so Symbol entries are not skipped.
     addTags (kv) {
@@ -63,6 +62,9 @@ function createMockDdSpan ({ ended = false } = {}) {
     get links () { return links },
     get operationName () { return operationName },
   }
+
+  if (ended) markSpanFinished(span, 100)
+  return span
 }
 
 describe('OTel bridge helpers', () => {
@@ -418,9 +420,12 @@ describe('OTel bridge helpers', () => {
   })
 
   describe('normalizeLinkContext', () => {
-    it('returns the bridge wrapper\'s _ddContext when present', () => {
+    it('returns the bridge wrapper\'s registered Datadog context', () => {
       const ddContext = { marker: 'inner' }
-      assert.strictEqual(normalizeLinkContext({ _ddContext: ddContext }), ddContext)
+      const wrapper = {}
+      registerDatadogContext(wrapper, ddContext)
+
+      assert.strictEqual(normalizeLinkContext(wrapper), ddContext)
     })
 
     it('returns a DatadogSpanContext-shaped input as-is', () => {

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -301,6 +301,17 @@ describe('OTel Span', () => {
     assert.strictEqual(getDatadogContext(spanContext), getDatadogSpan(span).context())
   })
 
+  it('should expose immutable identifier-only legacy context compatibility', () => {
+    const span = makeSpan('name')
+    const spanContext = span.spanContext()
+    const legacyContext = span._ddSpan.context()
+
+    assert.strictEqual(legacyContext._traceId.toString(16), spanContext.traceId)
+    assert.strictEqual(legacyContext._spanId.toString(16), spanContext.spanId)
+    assert.ok(Object.isFrozen(legacyContext))
+    assert.notStrictEqual(span._ddSpan, getDatadogSpan(span))
+  })
+
   it('should expose duration', () => {
     const span = makeSpan('name')
     span.end()

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -17,6 +17,8 @@ const tracer = require('../../').init()
 
 const TracerProvider = require('../../src/opentelemetry/tracer_provider')
 const SpanContext = require('../../src/opentelemetry/span_context')
+const { getDatadogSpan } = require('../../src/opentelemetry/span-registry')
+const { getDatadogContext } = require('../../src/opentracing/context-registry')
 const { NoopSpanProcessor } = require('../../src/opentelemetry/span_processor')
 
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE, IGNORE_OTEL_ERROR } = require('../../src/constants')
@@ -43,7 +45,7 @@ describe('OTel Span', () => {
   it('should inherit service and host name from tracer', () => {
     const span = makeSpan('name')
 
-    const context = span._ddSpan.context()
+    const context = getDatadogSpan(span).context()
     assert.strictEqual(context.getTag(SERVICE_NAME), tracer._tracer._service)
     assert.strictEqual(context._hostname, tracer._hostname)
   })
@@ -55,7 +57,7 @@ describe('OTel Span', () => {
     tags.dd_llmobs_enabled = 'false'
     try {
       const span = makeSpan('name')
-      assert.strictEqual(span._ddSpan.context().getTag('dd_llmobs_enabled'), 'false')
+      assert.strictEqual(getDatadogSpan(span).context().getTag('dd_llmobs_enabled'), 'false')
     } finally {
       delete tags.dd_llmobs_enabled
     }
@@ -66,7 +68,7 @@ describe('OTel Span', () => {
     tags.custom_tag = 'from-config'
     try {
       const span = makeSpan('name', { attributes: { custom_tag: 'from-span' } })
-      assert.strictEqual(span._ddSpan.context().getTag('custom_tag'), 'from-span')
+      assert.strictEqual(getDatadogSpan(span).context().getTag('custom_tag'), 'from-span')
     } finally {
       delete tags.custom_tag
     }
@@ -83,7 +85,7 @@ describe('OTel Span', () => {
     tags[SPAN_KIND] = 'from-config-tags'
     try {
       const span = makeSpan('name', { kind: api.SpanKind.CONSUMER })
-      const context = span._ddSpan.context()
+      const context = getDatadogSpan(span).context()
       assert.strictEqual(context.getTag(SERVICE_NAME), tracer._tracer._service)
       assert.strictEqual(context.getTag(RESOURCE_NAME), 'name')
       assert.strictEqual(context.getTag(SPAN_KIND), kinds.CONSUMER)
@@ -280,14 +282,14 @@ describe('OTel Span', () => {
   it('should copy span name to resource.name', () => {
     const span = makeSpan('name')
 
-    const context = span._ddSpan.context()
+    const context = getDatadogSpan(span).context()
     assert.strictEqual(context.getTag(RESOURCE_NAME), 'name')
   })
 
   it('should copy span kind to span.kind', () => {
     const span = makeSpan('name', { kind: api.SpanKind.CONSUMER })
 
-    const context = span._ddSpan.context()
+    const context = getDatadogSpan(span).context()
     assert.strictEqual(context.getTag(SPAN_KIND), kinds.CONSUMER)
   })
 
@@ -296,14 +298,14 @@ describe('OTel Span', () => {
 
     const spanContext = span.spanContext()
     assert.ok(spanContext instanceof SpanContext)
-    assert.strictEqual(spanContext._ddContext, span._ddSpan.context())
+    assert.strictEqual(getDatadogContext(spanContext), getDatadogSpan(span).context())
   })
 
   it('should expose duration', () => {
     const span = makeSpan('name')
     span.end()
 
-    assert.strictEqual(span.duration, span._ddSpan._duration)
+    assert.strictEqual(span.duration, getDatadogSpan(span)._duration)
   })
 
   it('should expose trace provider resource', () => {
@@ -334,7 +336,7 @@ describe('OTel Span', () => {
     const span = makeSpan('original name')
     span.updateName('updated name')
 
-    assert.strictEqual(span._ddSpan.context()._name, 'updated name')
+    assert.strictEqual(getDatadogSpan(span).context()._name, 'updated name')
     assert.strictEqual(span.name, 'updated name')
   })
 
@@ -344,13 +346,13 @@ describe('OTel Span', () => {
 
     span.updateName('after end')
 
-    assert.strictEqual(span._ddSpan.context()._name, 'name')
+    assert.strictEqual(getDatadogSpan(span).context()._name, 'name')
   })
 
   it('should set attributes', () => {
     const span = makeSpan('name')
 
-    const tags = span._ddSpan.context().getTags()
+    const tags = getDatadogSpan(span).context().getTags()
 
     span.setAttribute('foo', 'bar')
     assert.strictEqual(tags.foo, 'bar')
@@ -363,7 +365,7 @@ describe('OTel Span', () => {
     it('should remap when setting attributes', () => {
       const span = makeSpan('name')
 
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       span.setAttributes({ 'http.response.status_code': 200 })
       assert.strictEqual(tags['http.status_code'], '200')
@@ -372,7 +374,7 @@ describe('OTel Span', () => {
     it('should remap when setting singular attribute', () => {
       const span = makeSpan('name')
 
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       span.setAttribute('http.response.status_code', 200)
       assert.strictEqual(tags['http.status_code'], '200')
@@ -384,7 +386,7 @@ describe('OTel Span', () => {
     const span2 = makeSpan('name2')
     const span3 = makeSpan('name3')
 
-    const { _links } = span._ddSpan
+    const { _links } = getDatadogSpan(span)
 
     span.addLink({ context: span2.spanContext() })
     assert.strictEqual(_links.length, 1)
@@ -413,7 +415,7 @@ describe('OTel Span', () => {
 
     span.end()
 
-    const formatted = spanFormat(span._ddSpan)
+    const formatted = spanFormat(getDatadogSpan(span))
     assert.ok(
       Object.hasOwn(formatted.meta, '_dd.span_links'),
       `Available keys: ${inspect(Object.keys(formatted.meta))}`
@@ -431,7 +433,7 @@ describe('OTel Span', () => {
 
   it('should add span pointers', () => {
     const span = makeSpan('name')
-    const { _links } = span._ddSpan
+    const { _links } = getDatadogSpan(span)
 
     span.addSpanPointer('pointer_kind', 'd', 'abc123')
     assert.strictEqual(_links.length, 1)
@@ -458,18 +460,18 @@ describe('OTel Span', () => {
 
   it('should set status', () => {
     const unset = makeSpan('name')
-    const unsetCtx = unset._ddSpan.context()
+    const unsetCtx = getDatadogSpan(unset).context()
     unset.setStatus({ code: 0, message: 'unset' })
     assert.ok(!unsetCtx.hasTag(ERROR_MESSAGE))
 
     const ok = makeSpan('name')
-    const okCtx = ok._ddSpan.context()
+    const okCtx = getDatadogSpan(ok).context()
     ok.setStatus({ code: 1, message: 'ok' })
     assert.ok(!okCtx.hasTag(ERROR_MESSAGE))
     assert.ok(!okCtx.hasTag(IGNORE_OTEL_ERROR))
 
     const error = makeSpan('name')
-    const errorCtx = error._ddSpan.context()
+    const errorCtx = getDatadogSpan(error).context()
     error.setStatus({ code: 2, message: 'error' })
     assert.strictEqual(errorCtx.getTag(ERROR_MESSAGE), 'error')
     assert.strictEqual(errorCtx.getTag(IGNORE_OTEL_ERROR), false)
@@ -484,13 +486,13 @@ describe('OTel Span', () => {
     const datenow = Date.now()
     span.recordException(error, datenow)
 
-    const tags = span._ddSpan.context().getTags()
+    const tags = getDatadogSpan(span).context().getTags()
     assert.strictEqual(tags[ERROR_TYPE], error.name)
     assert.strictEqual(tags[ERROR_MESSAGE], error.message)
     assert.strictEqual(tags[ERROR_STACK], error.stack)
     assert.strictEqual(tags[IGNORE_OTEL_ERROR], true)
 
-    const events = span._ddSpan._events
+    const events = getDatadogSpan(span)._events
     assert.strictEqual(events.length, 1)
     assert.deepStrictEqual(events, [{
       name: error.name,
@@ -501,20 +503,20 @@ describe('OTel Span', () => {
       startTime: datenow,
     }])
 
-    let formatted = spanFormat(span._ddSpan)
+    let formatted = spanFormat(getDatadogSpan(span))
     assert.strictEqual(formatted.error, 0)
     assert.ok(!('doNotSetTraceError' in formatted.meta))
 
     // Set error code
     span.setStatus({ code: 2, message: 'error' })
 
-    formatted = spanFormat(span._ddSpan)
+    formatted = spanFormat(getDatadogSpan(span))
     assert.strictEqual(formatted.error, 1)
 
     span.recordException(new Error('foobar'), Date.now())
 
     // Keep the error set to 1
-    formatted = spanFormat(span._ddSpan)
+    formatted = spanFormat(getDatadogSpan(span))
     assert.strictEqual(formatted.error, 1)
     assert.ok(Object.hasOwn(formatted, 'meta'), `Available keys: ${inspect(Object.keys(formatted))}`)
     assert.strictEqual(formatted.meta['error.message'], 'foobar')
@@ -536,12 +538,12 @@ describe('OTel Span', () => {
     const error = new TestError()
     span.recordException(error)
 
-    const tags = span._ddSpan.context().getTags()
+    const tags = getDatadogSpan(span).context().getTags()
     assert.strictEqual(tags[ERROR_TYPE], error.name)
     assert.strictEqual(tags[ERROR_MESSAGE], error.message)
     assert.strictEqual(tags[ERROR_STACK], error.stack)
 
-    const events = span._ddSpan._events
+    const events = getDatadogSpan(span)._events
     assert.strictEqual(events.length, 1)
     assert.deepStrictEqual(events, [{
       name: error.name,
@@ -558,7 +560,7 @@ describe('OTel Span', () => {
     const span = makeSpan('name')
     span.end()
 
-    const tags = span._ddSpan.context().getTags()
+    const tags = getDatadogSpan(span).context().getTags()
 
     span.setStatus({ code: 2, message: 'error' })
     assert.ok(
@@ -570,7 +572,7 @@ describe('OTel Span', () => {
   describe('setStatus precedence (OTel spec)', () => {
     it('OK locks the status against subsequent ERROR and UNSET writes', () => {
       const span = makeSpan('name')
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       span.setStatus({ code: 1 })
       span.setStatus({ code: 2, message: 'late error' })
@@ -581,7 +583,7 @@ describe('OTel Span', () => {
 
     it('ERROR can be overridden by a later ERROR with a fresh message', () => {
       const span = makeSpan('name')
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       span.setStatus({ code: 2, message: 'first error' })
       span.setStatus({ code: 2, message: 'second error' })
@@ -591,7 +593,7 @@ describe('OTel Span', () => {
 
     it('UNSET is always a no-op even before any successful write', () => {
       const span = makeSpan('name')
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       span.setStatus({ code: 0, message: 'ignored' })
 
@@ -612,13 +614,13 @@ describe('OTel Span', () => {
     span.recordException(new Error('after end'))
     span.updateName('after end')
 
-    const tags = span._ddSpan.context().getTags()
+    const tags = getDatadogSpan(span).context().getTags()
     assert.ok(!('after.end' in tags))
     assert.ok(!('after.end.batch' in tags))
     assert.ok(!(ERROR_MESSAGE in tags))
     assert.ok(!(ERROR_TYPE in tags))
-    assert.strictEqual(span._ddSpan._links.length, 0)
-    assert.strictEqual(span._ddSpan._events.length, 0)
+    assert.strictEqual(getDatadogSpan(span)._links.length, 0)
+    assert.strictEqual(getDatadogSpan(span)._events.length, 0)
   })
 
   it('should mark ended and expose recording state', () => {
@@ -626,13 +628,14 @@ describe('OTel Span', () => {
 
     assert.strictEqual(span.ended, false)
     assert.strictEqual(span.isRecording(), true)
-    assert.strictEqual(span._ddSpan._duration, undefined)
+    assert.strictEqual(getDatadogSpan(span)._duration, undefined)
 
     span.end()
 
     assert.strictEqual(span.ended, true)
     assert.strictEqual(span.isRecording(), false)
-    assert.ok(Object.hasOwn(span._ddSpan, '_duration'), `Available keys: ${inspect(Object.keys(span._ddSpan))}`)
+    const keys = inspect(Object.keys(getDatadogSpan(span)))
+    assert.ok(Object.hasOwn(getDatadogSpan(span), '_duration'), `Available keys: ${keys}`)
   })
 
   it('should trigger span processor events', () => {
@@ -666,8 +669,8 @@ describe('OTel Span', () => {
       { 'error.code': '403', 'unknown values': [1, ['h', 'a', [false]]] }, datenow)
     span2.addEvent('Web page loaded')
     span2.addEvent('Button changed color', { colors: [112, 215, 70], 'response.time': 134.3, success: true })
-    const events1 = span1._ddSpan._events
-    const events2 = span2._ddSpan._events
+    const events1 = getDatadogSpan(span1)._events
+    const events2 = getDatadogSpan(span2)._events
     assert.strictEqual(events1.length, 1)
     assert.deepStrictEqual(events1, [{
       name: 'Web page unresponsive',
@@ -692,7 +695,7 @@ describe('OTel Span', () => {
 
     // Numeric startTime (not hrTime array) guarantees span_format's Math.round(startTime * 1e6)
     // is finite; absent `attributes` key guarantees no { '0': s, '1': n } leak.
-    assert.deepStrictEqual(span._ddSpan._events, [
+    assert.deepStrictEqual(getDatadogSpan(span)._events, [
       { name: 'hr-time-as-second-arg', startTime: hrTimeMs },
       { name: 'date-as-second-arg', startTime: date.getTime() },
       { name: 'attrs-and-hr-time', attributes: { code: 42 }, startTime: hrTimeMs },
@@ -711,7 +714,7 @@ describe('OTel Span', () => {
     it('does not mirror http.response.status_code to http.status_code', () => {
       const span = makeSpan('my-span')
       span.setAttribute('http.response.status_code', 200)
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       assert.strictEqual(tags['http.response.status_code'], 200)
       assert.strictEqual(tags['http.status_code'], undefined)
@@ -720,7 +723,7 @@ describe('OTel Span', () => {
     it('does not set error tags on recordException', () => {
       const span = makeSpan('my-span')
       span.recordException(new Error('boom'))
-      const tags = span._ddSpan.context().getTags()
+      const tags = getDatadogSpan(span).context().getTags()
 
       assert.strictEqual(tags[ERROR_TYPE], undefined)
       assert.strictEqual(tags[ERROR_MESSAGE], undefined)
@@ -731,7 +734,7 @@ describe('OTel Span', () => {
       const span = makeSpan('original name')
       span.updateName('updated name')
 
-      assert.strictEqual(span._ddSpan.context().getTag(RESOURCE_NAME), 'updated name')
+      assert.strictEqual(getDatadogSpan(span).context().getTag(RESOURCE_NAME), 'updated name')
       assert.strictEqual(span.name, 'updated name')
     })
   })

--- a/packages/dd-trace/test/opentelemetry/span_context.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span_context.spec.js
@@ -6,6 +6,7 @@ const { describe, it } = require('mocha')
 
 require('../setup/core')
 const SpanContext = require('../../src/opentelemetry/span_context')
+const { getDatadogContext } = require('../../src/opentracing/context-registry')
 const DDSpanContext = require('../../src/opentracing/span_context')
 const id = require('../../src/id')
 const { USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP } = require('../../../../ext/priority')
@@ -14,7 +15,7 @@ const TraceState = require('../../src/opentracing/propagation/tracestate')
 describe('OTel Span Context', () => {
   it('should create new dd context if none given', () => {
     const context = new SpanContext()
-    assert.ok(context._ddContext instanceof DDSpanContext)
+    assert.ok(getDatadogContext(context) instanceof DDSpanContext)
   })
 
   it('should accept given dd context as-is', () => {
@@ -24,7 +25,7 @@ describe('OTel Span Context', () => {
       spanId,
     })
     const context = new SpanContext(ddContext)
-    assert.strictEqual(context._ddContext, ddContext)
+    assert.strictEqual(getDatadogContext(context), ddContext)
   })
 
   it('should accept object to build new dd context', () => {
@@ -33,7 +34,7 @@ describe('OTel Span Context', () => {
       traceId: spanId,
       spanId,
     })
-    const ddContext = context._ddContext
+    const ddContext = getDatadogContext(context)
     assert.ok(ddContext instanceof DDSpanContext)
     assert.strictEqual(ddContext._traceId, spanId)
     assert.strictEqual(ddContext._spanId, spanId)

--- a/packages/dd-trace/test/opentelemetry/tracer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer.spec.js
@@ -15,7 +15,9 @@ require('../../').init()
 const TracerProvider = require('../../src/opentelemetry/tracer_provider')
 const Tracer = require('../../src/opentelemetry/tracer')
 const Span = require('../../src/opentelemetry/span')
+const { getDatadogSpan } = require('../../src/opentelemetry/span-registry')
 const NoopTracer = require('../../src/noop/tracer')
+const { getDatadogContext } = require('../../src/opentracing/context-registry')
 const DatadogSpan = require('../../src/opentracing/span')
 const tracer = require('../../')
 
@@ -55,7 +57,7 @@ describe('OTel Tracer', () => {
     const span = otelTracer.startSpan('name')
     assert.ok(span instanceof Span)
 
-    const ddSpan = span._ddSpan
+    const ddSpan = getDatadogSpan(span)
     assert.ok(ddSpan instanceof DatadogSpan)
     assert.strictEqual(ddSpan._name, 'name')
   })
@@ -70,7 +72,7 @@ describe('OTel Tracer', () => {
       },
     })
 
-    const ddSpanContext = span._ddSpan.context()
+    const ddSpanContext = getDatadogSpan(span).context()
     assert.strictEqual(ddSpanContext.getTag('foo'), 'bar')
   })
 
@@ -152,7 +154,7 @@ describe('OTel Tracer', () => {
 
     otelTracer.startActiveSpan('name', (span) => {
       assert.ok(span instanceof Span)
-      assert.strictEqual(span._ddSpan, storage('legacy').getStore()?.span)
+      assert.strictEqual(getDatadogSpan(span), storage('legacy').getStore()?.span)
     })
   })
 
@@ -163,7 +165,7 @@ describe('OTel Tracer', () => {
 
     tracer.trace('dd-trace-sub', (ddSpan) => {
       const otelSpan = otelTracer.startSpan('name')
-      isChildOf(otelSpan._ddSpan, ddSpan)
+      isChildOf(getDatadogSpan(otelSpan), ddSpan)
     })
   })
 
@@ -175,7 +177,7 @@ describe('OTel Tracer', () => {
     otelTracer.startActiveSpan('name', (otelSpan) => {
       // NOTE: tracer.startSpan(...) does not use active context. Is this a bug?
       tracer.trace('dd-trace-sub', (ddSpan) => {
-        isChildOf(ddSpan, otelSpan._ddSpan)
+        isChildOf(ddSpan, getDatadogSpan(otelSpan))
       })
     })
   })
@@ -187,7 +189,7 @@ describe('OTel Tracer', () => {
 
     otelTracer.startActiveSpan('name', (outer) => {
       const inner = otelTracer.startSpan('name')
-      isChildOf(inner._ddSpan, outer._ddSpan)
+      isChildOf(getDatadogSpan(inner), getDatadogSpan(outer))
     })
   })
 
@@ -201,8 +203,8 @@ describe('OTel Tracer', () => {
         root: true,
       })
 
-      const parentContext = outer._ddSpan.context()
-      const childContext = inner._ddSpan.context()
+      const parentContext = getDatadogSpan(outer).context()
+      const childContext = getDatadogSpan(inner).context()
 
       assert.notStrictEqual(childContext.toTraceId(), parentContext.toTraceId())
       assert.notDeepStrictEqual(childContext._parentId, parentContext._spanId)
@@ -216,23 +218,23 @@ describe('OTel Tracer', () => {
     otelTracer.startActiveSpan('otel-root', async (root) => {
       await new Promise(resolve => setTimeout(resolve, 200))
       otelTracer.startActiveSpan('otel-parent1', async (parent1) => {
-        isChildOf(parent1._ddSpan, root._ddSpan)
+        isChildOf(getDatadogSpan(parent1), getDatadogSpan(root))
         await new Promise(resolve => setTimeout(resolve, 400))
         otelTracer.startActiveSpan('otel-child1', async (child) => {
-          isChildOf(child._ddSpan, parent1._ddSpan)
+          isChildOf(getDatadogSpan(child), getDatadogSpan(parent1))
           await new Promise(resolve => setTimeout(resolve, 600))
         })
       })
       const orphan1 = otelTracer.startSpan('orphan1')
-      isChildOf(orphan1._ddSpan, root._ddSpan)
+      isChildOf(getDatadogSpan(orphan1), getDatadogSpan(root))
       const ctx = api.trace.setSpan(api.context.active(), root)
 
       otelTracer.startActiveSpan('otel-parent2', ctx, async (parent2) => {
-        isChildOf(parent2._ddSpan, root._ddSpan)
+        isChildOf(getDatadogSpan(parent2), getDatadogSpan(root))
         await new Promise(resolve => setTimeout(resolve, 400))
         const ctx = api.trace.setSpan(api.context.active(), root)
         otelTracer.startActiveSpan('otel-child2', ctx, async (child) => {
-          isChildOf(child._ddSpan, parent2._ddSpan)
+          isChildOf(getDatadogSpan(child), getDatadogSpan(parent2))
           await new Promise(resolve => setTimeout(resolve, 600))
         })
       })
@@ -271,31 +273,34 @@ describe('OTel Tracer', () => {
 
     it('writes sampling priority onto the wrapped Datadog context', () => {
       const spanContext = convert(1, 'other=bleh,dd=s:2;o:synthetics;t.dm:-4')
-      assert.strictEqual(spanContext._ddContext._sampling.priority, USER_KEEP)
-      assert.strictEqual(spanContext._ddContext._trace.origin, 'synthetics')
+      const datadogContext = getDatadogContext(spanContext)
+      assert.strictEqual(datadogContext._sampling.priority, USER_KEEP)
+      assert.strictEqual(datadogContext._trace.origin, 'synthetics')
       assert.strictEqual(spanContext.traceFlags, 1)
     })
 
     it('preserves the existing _trace.started/finished/tags when writing origin', () => {
       const spanContext = convert(1, 'other=bleh,dd=s:1;o:foo')
-      assert.deepStrictEqual(spanContext._ddContext._trace.started, [])
-      assert.deepStrictEqual(spanContext._ddContext._trace.finished, [])
-      assert.deepStrictEqual(spanContext._ddContext._trace.tags, {})
-      assert.strictEqual(spanContext._ddContext._trace.origin, 'foo')
+      const datadogContext = getDatadogContext(spanContext)
+      assert.deepStrictEqual(datadogContext._trace.started, [])
+      assert.deepStrictEqual(datadogContext._trace.finished, [])
+      assert.deepStrictEqual(datadogContext._trace.tags, {})
+      assert.strictEqual(datadogContext._trace.origin, 'foo')
     })
 
     it('falls back to AUTO_REJECT/AUTO_KEEP when tracestate has no s: field', () => {
       const rejected = convert(0, 'other=bleh,dd=o:foo;t.dm:-4')
-      assert.strictEqual(rejected._ddContext._sampling.priority, AUTO_REJECT)
+      assert.strictEqual(getDatadogContext(rejected)._sampling.priority, AUTO_REJECT)
 
       const kept = convert(1, 'other=bleh,dd=o:foo;t.dm:-4')
-      assert.strictEqual(kept._ddContext._sampling.priority, AUTO_KEEP)
+      assert.strictEqual(getDatadogContext(kept)._sampling.priority, AUTO_KEEP)
     })
 
     it('falls back to AUTO_KEEP for RUM traces without a priority', () => {
       const spanContext = convert(1, 'other=bleh,dd=o:rum')
-      assert.strictEqual(spanContext._ddContext._sampling.priority, AUTO_KEEP)
-      assert.strictEqual(spanContext._ddContext._trace.origin, 'rum')
+      const datadogContext = getDatadogContext(spanContext)
+      assert.strictEqual(datadogContext._sampling.priority, AUTO_KEEP)
+      assert.strictEqual(datadogContext._trace.origin, 'rum')
     })
   })
 
@@ -305,7 +310,7 @@ describe('OTel Tracer', () => {
     const otelTracer = new Tracer({}, {}, tracerProvider)
     otelTracer.startActiveSpan('otel-top-level', async (root) => {
       tracer.trace('ddtrace-top-level', async (ddSpan) => {
-        isChildOf(ddSpan, root._ddSpan)
+        isChildOf(ddSpan, getDatadogSpan(root))
         await new Promise(resolve => setTimeout(resolve, 200))
         tracer.trace('ddtrace-child', async (ddSpanChild) => {
           isChildOf(ddSpanChild, ddSpan)
@@ -313,12 +318,12 @@ describe('OTel Tracer', () => {
         })
 
         otelTracer.startActiveSpan('otel-child', async (otelSpan) => {
-          isChildOf(otelSpan._ddSpan, ddSpan)
+          isChildOf(getDatadogSpan(otelSpan), ddSpan)
           await new Promise(resolve => setTimeout(resolve, 200))
           tracer.trace('ddtrace-grandchild', async (ddSpanGrandchild) => {
-            isChildOf(ddSpanGrandchild, otelSpan._ddSpan)
+            isChildOf(ddSpanGrandchild, getDatadogSpan(otelSpan))
             otelTracer.startActiveSpan('otel-grandchild', async (otelGrandchild) => {
-              isChildOf(otelGrandchild._ddSpan, ddSpanGrandchild)
+              isChildOf(getDatadogSpan(otelGrandchild), ddSpanGrandchild)
               await new Promise(resolve => setTimeout(resolve, 200))
             })
           })

--- a/packages/dd-trace/test/opentracing/event-writer.spec.js
+++ b/packages/dd-trace/test/opentracing/event-writer.spec.js
@@ -1,0 +1,255 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { EventWriter } = require('../../src/opentracing/event-writer')
+const {
+  getApiSecurityFramework,
+  getApiSecurityHttpRoute,
+  getAppSecRootSpan,
+  getCodeHotspotIds,
+  getHttpEndpoint,
+  getLocalRootSpan,
+  getParentSpan,
+  hasUserId,
+  hasUserSessionId,
+  shouldCollectAppSecEventHeaders,
+} = require('../../src/opentracing/span-projections')
+
+describe('EventWriter', () => {
+  let context
+  let span
+  let writer
+
+  beforeEach(() => {
+    writer = new EventWriter()
+    context = {}
+    writer.initializeContext(context, {
+      traceId: 'trace-id',
+      spanId: 'span-id',
+    })
+    context.getTags = () => Reflect.get(context, '_tags')
+    context.getTag = key => context.getTags()[key]
+    span = {
+      context () {
+        return context
+      },
+    }
+    writer.startSpan(span, {
+      context,
+      processor: {},
+      prioritySampler: {},
+      debug: false,
+      operationName: 'operation',
+      integrationName: 'integration',
+      startTime: 10,
+      links: [],
+    })
+  })
+
+  it('owns span creation and lifecycle writes', () => {
+    assert.strictEqual(span._spanContext, context)
+    assert.deepStrictEqual(context._trace.started, [span])
+    assert.strictEqual(span._duration, undefined)
+
+    assert.strictEqual(writer.finishSpan(span, 25), true)
+    assert.strictEqual(writer.finishSpan(span, 30), false)
+    assert.strictEqual(span._duration, 15)
+    assert.deepStrictEqual(context._trace.finished, [span])
+    assert.strictEqual(context._isFinished, true)
+  })
+
+  it('owns tag, trace, sampling, baggage, link and event writes', () => {
+    writer.setTag(span, 'one', 1)
+    writer.setTags(context, { two: 2 })
+    assert.strictEqual(writer.setTagsIfTagMatches(span, 'owner', undefined, { owner: 'next', route: '/a' }), true)
+    assert.strictEqual(writer.setTagsIfTagMatches(span, 'owner', 'other', { route: '/b' }), false)
+    assert.strictEqual(writer.setTagIfAbsent(span, 'one', 3), false)
+    assert.strictEqual(writer.setTagIfAbsent(span, 'three', 3), true)
+    writer.deleteTag(context, 'two')
+
+    writer.setTraceTag(span, '_dd.p.test', 'value')
+    writer.setOrigin(context, 'synthetics')
+    writer.setSamplingPriority(context, 2, 8)
+    writer.setSpanSamplingDecision(context, { sampleRate: 0.5, maxPerSecond: 10 })
+    writer.setBaggageItem(span, 'bag', 'value')
+    writer.addLink(span, { context: 'linked' })
+    writer.addEvent(span, { name: 'event' })
+
+    assert.deepStrictEqual(context.getTags(), { one: 1, three: 3, owner: 'next', route: '/a' })
+    assert.strictEqual(context._trace.tags['_dd.p.test'], 'value')
+    assert.strictEqual(context._trace.origin, 'synthetics')
+    assert.deepStrictEqual(context._sampling, { priority: 2, mechanism: 8 })
+    assert.deepStrictEqual(context._spanSampling, { sampleRate: 0.5, maxPerSecond: 10 })
+    assert.deepStrictEqual(context._baggageItems, { bag: 'value' })
+    assert.deepStrictEqual(span._links, [{ context: 'linked' }])
+    assert.deepStrictEqual(span._events, [{ name: 'event' }])
+  })
+
+  it('performs structured metadata updates atomically', () => {
+    assert.strictEqual(writer.setStructuredTagIfAbsent(span, 'body', { first: true }), true)
+    assert.strictEqual(writer.setStructuredTagIfAbsent(span, 'body', { second: true }), false)
+    assert.strictEqual(writer.appendStackTrace(span, 'rasp', { id: 1 }, 1), true)
+    assert.strictEqual(writer.appendStackTrace(span, 'rasp', { id: 2 }, 1), false)
+
+    assert.deepStrictEqual(span.meta_struct, {
+      body: { first: true },
+      '_dd.stack': {
+        rasp: [{ id: 1 }],
+      },
+    })
+  })
+
+  it('performs web and service finalization without exposing tags', () => {
+    assert.strictEqual(writer.setWebRequestTagsIfAbsent(span, {
+      'http.url': '/users/123?token=redacted',
+      'http.method': 'GET',
+    }), true)
+    assert.strictEqual(writer.setWebRequestTagsIfAbsent(span, {
+      'http.url': '/overwritten',
+    }), false)
+
+    writer.setTag(span, 'http.route', '/owned-route')
+    assert.strictEqual(writer.setHttpEndpointIfAbsent(span, url => url.split('?')[0]), false)
+    writer.deleteTag(span, 'http.route')
+    assert.strictEqual(writer.setHttpEndpointIfAbsent(span, url => url.split('?')[0]), true)
+    assert.strictEqual(writer.setHttpEndpointIfAbsent(span, () => '/overwritten'), false)
+    assert.strictEqual(writer.setWebErrorIfAbsent(span, true), true)
+    writer.setTag(span, 'error', false)
+    writer.setTag(span, 'error.message', 'owned')
+    assert.strictEqual(writer.setWebErrorIfAbsent(span, true), false)
+
+    writer.setTag(span, 'http.route', '/users/:id')
+    assert.strictEqual(writer.setWebResourceNameIfAbsent(span, 'GET'), true)
+    assert.strictEqual(writer.setWebResourceNameIfAbsent(span, 'POST'), false)
+
+    writer.setTags(span, {
+      'service.name': 'web-service',
+      '_dd.svc_src': 'web',
+    })
+    writer.resolveServiceSource(span, 'app', 'web-service', '_dd.svc_src', 'm')
+    assert.strictEqual(context.getTag('_dd.svc_src'), 'web')
+    writer.setTag(span, 'service.name', 'custom-service')
+    writer.resolveServiceSource(span, 'app', 'web-service', '_dd.svc_src', 'm')
+
+    assert.strictEqual(context.getTag('http.url'), '/users/123?token=redacted')
+    assert.strictEqual(context.getTag('http.endpoint'), '/users/123')
+    assert.strictEqual(context.getTag('resource.name'), 'GET /users/:id')
+    assert.strictEqual(context.getTag('_dd.svc_src'), 'm')
+  })
+
+  it('projects topology and selected tags from writer events', () => {
+    const childContext = {}
+    writer.initializeContext(childContext, {
+      traceId: 'trace-id',
+      spanId: 'child-id',
+      parentId: 'span-id',
+      trace: context._trace,
+    })
+    const child = { context: () => childContext }
+    writer.startSpan(child, {
+      context: childContext,
+      processor: {},
+      prioritySampler: {},
+      debug: false,
+      operationName: 'child',
+      integrationName: 'integration',
+      startTime: 11,
+      links: [],
+    })
+
+    writer.setTags(span, {
+      component: 'express',
+      'http.route': '/users/:id',
+      'span.type': 'web',
+      'http.endpoint': '/users/{id}',
+      'appsec.events.users.login.success.track': 'true',
+      'usr.id': '123',
+      'usr.session_id': 'session',
+    })
+
+    assert.strictEqual(getParentSpan(child), span)
+    assert.strictEqual(getLocalRootSpan(child), span)
+    assert.strictEqual(getAppSecRootSpan(child), span)
+    assert.deepStrictEqual(getCodeHotspotIds(child), {
+      spanId: 'child-id',
+      localRootSpanId: 'span-id',
+    })
+    assert.strictEqual(getHttpEndpoint(span), '/users/{id}')
+    assert.strictEqual(getApiSecurityFramework(span), 'express')
+    assert.strictEqual(getApiSecurityHttpRoute(span), '/users/:id')
+    assert.strictEqual(hasUserId(span), true)
+    assert.strictEqual(hasUserSessionId(span), true)
+    assert.strictEqual(shouldCollectAppSecEventHeaders(span), true)
+
+    writer.setTag(span, '_inferred_span', true)
+    assert.strictEqual(getAppSecRootSpan(child), child)
+  })
+
+  it('performs AppSec sampling and event updates atomically', () => {
+    span._prioritySampler = {
+      sample: () => writer.setSamplingPriority(context, -1),
+    }
+    assert.strictEqual(writer.sampleForApiSecurity(span), false)
+
+    writer.setTag(span, '_dd.origin', 'lambda')
+    const firstJson = writer.addAppSecEvent(span, [{ id: 1 }], '127.0.0.1')
+    const secondJson = writer.addAppSecEvent(span, [{ id: 2 }])
+
+    assert.strictEqual(firstJson, '{"triggers":[{"id":1}]}')
+    assert.strictEqual(secondJson, '{"triggers":[{"id":1},{"id":2}]}')
+    assert.strictEqual(context.getTag('_dd.origin'), 'lambda')
+    assert.strictEqual(context.getTag('network.client.ip'), '127.0.0.1')
+  })
+
+  it('preserves SDK-owned user tags in atomic AppSec updates', () => {
+    writer.setTags(span, {
+      '_dd.appsec.events.users.login.success.sdk': 'true',
+      'appsec.events.users.login.success.usr.login': 'sdk-login',
+      'usr.id': 'sdk-id',
+    })
+
+    const userIdWritten = writer.setAppSecAutoLoginTags(
+      span,
+      '_dd.appsec.events.users.login.success.sdk',
+      {
+        'appsec.events.users.login.success.track': 'true',
+        'appsec.events.users.login.success.usr.login': 'auto-login',
+        'usr.id': 'auto-id',
+      },
+      new Set(['appsec.events.users.login.success.usr.login', 'usr.id']),
+      'usr.id'
+    )
+
+    assert.strictEqual(userIdWritten, false)
+    assert.strictEqual(context.getTag('appsec.events.users.login.success.track'), 'true')
+    assert.strictEqual(context.getTag('appsec.events.users.login.success.usr.login'), 'sdk-login')
+    assert.strictEqual(context.getTag('usr.id'), 'sdk-id')
+
+    writer.deleteTag(span, '_dd.appsec.events.users.login.success.sdk')
+    assert.strictEqual(writer.setAppSecAutoLoginTags(
+      span,
+      '_dd.appsec.events.users.login.success.sdk',
+      {
+        'appsec.events.users.login.success.usr.login': 'auto-login',
+        'usr.id': 'auto-id',
+      },
+      new Set(['appsec.events.users.login.success.usr.login', 'usr.id']),
+      'usr.id'
+    ), true)
+    assert.strictEqual(context.getTag('appsec.events.users.login.success.usr.login'), 'auto-login')
+    assert.strictEqual(context.getTag('usr.id'), 'auto-id')
+
+    writer.setTag(span, '_dd.appsec.user.collection_mode', 'sdk')
+    assert.strictEqual(writer.setAppSecAutoUser(span, 'blocked-id', 'identification'), false)
+    assert.strictEqual(context.getTag('_dd.appsec.usr.id'), 'blocked-id')
+    assert.strictEqual(context.getTag('usr.id'), 'auto-id')
+    assert.strictEqual(context.getTag('_dd.appsec.user.collection_mode'), 'sdk')
+
+    writer.setTag(span, '_dd.appsec.user.collection_mode', 'identification')
+    assert.strictEqual(writer.setAppSecAutoUser(span, 'next-id', 'anonymization'), true)
+    assert.strictEqual(context.getTag('_dd.appsec.usr.id'), 'next-id')
+    assert.strictEqual(context.getTag('usr.id'), 'next-id')
+    assert.strictEqual(context.getTag('_dd.appsec.user.collection_mode'), 'anonymization')
+  })
+})

--- a/packages/dd-trace/test/opentracing/event-writer.spec.js
+++ b/packages/dd-trace/test/opentracing/event-writer.spec.js
@@ -11,8 +11,10 @@ const {
   getHttpEndpoint,
   getLocalRootSpan,
   getParentSpan,
+  hasError,
   hasUserId,
   hasUserSessionId,
+  isOutermostWebSpan,
   shouldCollectAppSecEventHeaders,
 } = require('../../src/opentracing/span-projections')
 
@@ -167,6 +169,9 @@ describe('EventWriter', () => {
       'usr.id': '123',
       'usr.session_id': 'session',
     })
+    writer.setTag(span, undefined, 'ignored by typed projections')
+    writer.setTagIfAbsent(span, null, 'ignored by typed projections')
+    writer.deleteTag(span, null)
 
     assert.strictEqual(getParentSpan(child), span)
     assert.strictEqual(getLocalRootSpan(child), span)
@@ -182,8 +187,50 @@ describe('EventWriter', () => {
     assert.strictEqual(hasUserSessionId(span), true)
     assert.strictEqual(shouldCollectAppSecEventHeaders(span), true)
 
+    writer.setTag(span, 'error', true)
+    writer.setTag(span, 'error.type', 'Error')
+    assert.strictEqual(hasError(span), true)
+    writer.deleteTag(span, 'error')
+    assert.strictEqual(hasError(span), true)
+    writer.deleteTag(span, 'error.type')
+    assert.strictEqual(hasError(span), false)
+    writer.setTag(span, 'error', true)
+    writer.clearTags(span)
+    assert.strictEqual(hasError(span), false)
+
     writer.setTag(span, '_inferred_span', true)
     assert.strictEqual(getAppSecRootSpan(child), child)
+  })
+
+  it('rebuilds projected topology after a trace chunk is processed', () => {
+    writer.setTag(span, 'span.type', 'web')
+    assert.strictEqual(isOutermostWebSpan(span), true)
+
+    writer.replaceTraceSpans(context._trace, [])
+
+    const nextContext = {}
+    writer.initializeContext(nextContext, {
+      traceId: 'trace-id',
+      spanId: 'next-id',
+      parentId: 'span-id',
+      trace: context._trace,
+    })
+    const next = { context: () => nextContext }
+    writer.startSpan(next, {
+      context: nextContext,
+      processor: {},
+      prioritySampler: {},
+      debug: false,
+      operationName: 'next',
+      integrationName: 'integration',
+      startTime: 20,
+      links: [],
+    })
+    writer.setTag(next, 'span.type', 'web')
+
+    assert.strictEqual(getParentSpan(next), undefined)
+    assert.strictEqual(getLocalRootSpan(next), next)
+    assert.strictEqual(isOutermostWebSpan(next), true)
   })
 
   it('performs AppSec sampling and event updates atomically', () => {

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -538,6 +538,26 @@ describe('Span', () => {
     })
   })
 
+  describe('setTagIfAbsent', () => {
+    it('writes only the first value and reports the atomic outcome', () => {
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      assert.strictEqual(span.setTagIfAbsent('error', 1), true)
+      assert.strictEqual(span.setTagIfAbsent('error', 2), false)
+      assert.strictEqual(span.context().getTag('error'), 1)
+    })
+  })
+
+  describe('setTagsIfTagMatches', () => {
+    it('updates an owned tag set without exposing the current value', () => {
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      assert.strictEqual(span.setTagsIfTagMatches('route', undefined, { route: '/one', resource: 'one' }), true)
+      assert.strictEqual(span.setTagsIfTagMatches('route', '/other', { route: '/two' }), false)
+      assert.deepStrictEqual(span.context().getTags(), { route: '/one', resource: 'one' })
+    })
+  })
+
   describe('addTags', () => {
     beforeEach(() => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -64,8 +64,6 @@ describe('SpanContext', () => {
       },
       _traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
       _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'),
-      _otelSpanContext: undefined,
-      _otelActiveSpan: undefined,
     }
     Object.setPrototypeOf(expected, SpanContext.prototype)
     assert.deepStrictEqual(spanContext, expected)
@@ -97,8 +95,6 @@ describe('SpanContext', () => {
       },
       _traceparent: undefined,
       _tracestate: undefined,
-      _otelSpanContext: undefined,
-      _otelActiveSpan: undefined,
     }
     Object.setPrototypeOf(expected, SpanContext.prototype)
     assert.deepStrictEqual(spanContext, expected)

--- a/packages/dd-trace/test/otel-thread-ctx.spec.js
+++ b/packages/dd-trace/test/otel-thread-ctx.spec.js
@@ -13,8 +13,15 @@ const SPAN_ID_HEX = '1112131415161718'
 const TRACE_ID_BYTES = Uint8Array.from(Buffer.from(TRACE_ID_HEX, 'hex'))
 const SPAN_ID_BYTES = Uint8Array.from(Buffer.from(SPAN_ID_HEX, 'hex'))
 
-function makeSpan ({ traceId = TRACE_ID_HEX, spanId = SPAN_ID_HEX, parentId, tags = {} } = {}) {
+function makeSpan ({
+  traceId = TRACE_ID_HEX,
+  spanId = SPAN_ID_HEX,
+  localRootSpanId = spanId,
+  parentId,
+  tags = {},
+} = {}) {
   return {
+    localRootSpanId,
     context () {
       return {
         _spanId: spanId,
@@ -34,7 +41,12 @@ function makeSpan ({ traceId = TRACE_ID_HEX, spanId = SPAN_ID_HEX, parentId, tag
 // endpoint records on.
 function makeWebSpanWithChild (webTags) {
   const parent = makeSpan({ tags: webTags })
-  const child = makeSpan({ spanId: '2122232425262728', parentId: SPAN_ID_HEX, tags: {} })
+  const child = makeSpan({
+    spanId: '2122232425262728',
+    localRootSpanId: SPAN_ID_HEX,
+    parentId: SPAN_ID_HEX,
+    tags: {},
+  })
   return { parent, child, webTags }
 }
 
@@ -68,6 +80,11 @@ describe('otel-thread-ctx', () => {
       '../../datadog-core/src/storage': overrides.storage || storageStub,
       './storage-channels': overrides.storageChannels || storageChannelsStub,
       './web-tags-cache': overrides.webTagsCache || webTagsCacheStub,
+      './opentracing/span-projections': {
+        getCodeHotspotIds: span => ({
+          localRootSpanId: { toString: () => span.localRootSpanId },
+        }),
+      },
       './log': overrides.log || log,
     })
   }
@@ -324,27 +341,16 @@ describe('otel-thread-ctx', () => {
         [SPAN_ID_HEX, 'GET /x', THREAD_NAME, THREAD_ID_STR])
     })
 
-    it('encodes the local-root-span id from the first started-spans entry', () => {
+    it('encodes the projected local-root-span id', () => {
       const rootHex = '99aabbccddeeff00'
-      const rootSpan = makeSpan({ spanId: rootHex })
-      activeSpan = makeSpan({ parentId: rootHex })
-      // Plant the root in the started-spans list of the active span's trace.
-      activeSpan.context = function () {
-        return {
-          _spanId: SPAN_ID_HEX,
-          _parentId: rootHex,
-          _trace: { started: [rootSpan] },
-          toTraceId: () => TRACE_ID_HEX.padStart(32, '0'),
-          toSpanId: () => SPAN_ID_HEX.padStart(16, '0'),
-          getTags: () => ({}),
-        }
-      }
+      activeSpan = makeSpan({ parentId: rootHex, localRootSpanId: rootHex })
       enterCh.publish()
       assert.equal(constructedContexts[0].attributes[0], rootHex)
     })
 
     it('skips re-entering on re-entry when the same context is already active', () => {
       activeSpan = makeSpan()
+      const symbols = Object.getOwnPropertySymbols(activeSpan)
       enterCh.publish()
       sinon.assert.calledOnce(setActive)
       assert.equal(constructedContexts.length, 1)
@@ -354,6 +360,7 @@ describe('otel-thread-ctx', () => {
       enterCh.publish()
       sinon.assert.calledOnce(setActive)
       assert.equal(constructedContexts.length, 1)
+      assert.deepStrictEqual(Object.getOwnPropertySymbols(activeSpan), symbols)
     })
 
     it('re-installs the same context when the active context drifts to another span and back', () => {

--- a/packages/dd-trace/test/plugins/database-dbm-hash.spec.js
+++ b/packages/dd-trace/test/plugins/database-dbm-hash.spec.js
@@ -42,12 +42,8 @@ describe('DatabasePlugin DBM Hash', () => {
       context: () => ({
         _tags: contextTags,
         getTags: () => contextTags,
-      }),
-      _spanContext: {
-        _tags: contextTags,
-        getTags: () => contextTags,
         toTraceparent: () => 'traceparent-value',
-      },
+      }),
       setTag: function (key, value) {
         this._tags = this._tags || {}
         this._tags[key] = value

--- a/packages/dd-trace/test/plugins/tracing.spec.js
+++ b/packages/dd-trace/test/plugins/tracing.spec.js
@@ -11,12 +11,20 @@ const TracingPlugin = require('../../src/plugins/tracing')
 const { SVC_SRC_KEY } = require('../../src/constants')
 const DatadogSpanContext = require('../../src/opentracing/span_context')
 const {
-  INTEGRATION_SERVICE,
   MANUAL,
   resolveServiceSource,
 } = require('../../src/service-naming/source-resolver')
 const agent = require('../plugins/agent')
 const plugins = require('../../src/plugins')
+
+function makeSpan (tags = {}) {
+  const context = new DatadogSpanContext({ tags })
+  return {
+    _spanContext: context,
+    context: () => context,
+    setTag: context.setTag.bind(context),
+  }
+}
 
 describe('TracingPlugin', () => {
   describe('startSpan method', () => {
@@ -24,9 +32,7 @@ describe('TracingPlugin', () => {
     let plugin
 
     beforeEach(() => {
-      startSpanSpy = sinon.stub().callsFake((_name, opts) => ({
-        _spanContext: new DatadogSpanContext({ tags: { ...opts.tags } }),
-      }))
+      startSpanSpy = sinon.stub().callsFake((_name, opts) => makeSpan({ ...opts.tags }))
       plugin = new TracingPlugin({
         _tracer: {
           startSpan: startSpanSpy,
@@ -131,11 +137,15 @@ describe('TracingPlugin', () => {
     })
 
     it('records the integration claim using the tracer service', () => {
-      const span = { _spanContext: new DatadogSpanContext() }
+      const span = makeSpan({
+        'service.name': 'kafka-broker',
+        [SVC_SRC_KEY]: 'kafka',
+      })
 
       plugin.stampIntegrationService(span, 'kafka-broker')
+      resolveServiceSource(span, 'tracer-default')
 
-      assert.strictEqual(span[INTEGRATION_SERVICE], 'kafka-broker')
+      assert.strictEqual(span._spanContext.getTag(SVC_SRC_KEY), 'kafka')
     })
   })
 
@@ -148,16 +158,19 @@ describe('TracingPlugin', () => {
     })
 
     it('sets service.name and stamps the integration claim', () => {
-      const span = { _spanContext: new DatadogSpanContext() }
+      const span = makeSpan({ [SVC_SRC_KEY]: 'opt.plugin' })
 
       plugin.setServiceName(span, 'express-app')
+      resolveServiceSource(span, 'tracer-default')
 
-      assert.deepStrictEqual(span._spanContext.getTags(), { 'service.name': 'express-app' })
-      assert.strictEqual(span[INTEGRATION_SERVICE], 'express-app')
+      assert.deepStrictEqual(span._spanContext.getTags(), {
+        'service.name': 'express-app',
+        [SVC_SRC_KEY]: 'opt.plugin',
+      })
     })
 
     it('detects user override at finish when service.name is later mutated', () => {
-      const span = { _spanContext: new DatadogSpanContext({ tags: { [SVC_SRC_KEY]: 'opt.plugin' } }) }
+      const span = makeSpan({ [SVC_SRC_KEY]: 'opt.plugin' })
       plugin.setServiceName(span, 'express-app')
 
       span._spanContext.setTag('service.name', 'user-svc')

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -9,6 +9,7 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('../../setup/core')
+const spanProjections = require('../../../src/opentracing/span-projections')
 
 // Test adapter: these specs predate the constructor reading canonical DD_PROFILING_*
 // names off the tracer config. Map the legacy flat option names to the (config, runtime)
@@ -664,6 +665,7 @@ describe('profilers/native/wall', () => {
       const spanCtx = { _spanId: {}, _parentId: null, _tags: {}, _trace: { started: [] } }
       const span = { context: () => spanCtx }
       spanCtx._trace.started.push(span)
+      spanProjections.startSpan(span, spanCtx)
       currentStore = { span }
 
       // First enter — sets context
@@ -698,6 +700,7 @@ describe('profilers/native/wall', () => {
       const spanCtx = { _spanId: {}, _parentId: null, _tags: {}, _trace: { started: [] } }
       const span = { context: () => spanCtx }
       spanCtx._trace.started.push(span)
+      spanProjections.startSpan(span, spanCtx)
       currentStore = { span }
 
       // First enter — sets context
@@ -787,32 +790,35 @@ describe('profilers/native/wall', () => {
     })
 
     function makeWebSpan () {
-      const tags = {}
       const spanId = {}
       const ctx = {
-        _tags: tags,
+        _tags: {},
         _spanId: spanId,
         _parentId: null,
         _trace: { started: [] },
         getTags () { return this._tags },
       }
-      const span = { context: () => ctx }
+      const span = { context: () => ctx, trace: ctx._trace }
       ctx._trace.started.push(span)
+      spanProjections.startSpan(span, ctx)
+      const tags = spanProjections.getOwnWebTags(span)
       return { span, tags, spanId }
     }
 
     function makeChildSpan (webSpanId, webSpan) {
-      const tags = { 'span.type': 'router' }
       const spanId = {}
       const ctx = {
-        _tags: tags,
+        _tags: {},
         _spanId: spanId,
         _parentId: webSpanId,
-        _trace: { started: [webSpan] },
+        _trace: webSpan.trace,
         getTags () { return this._tags },
       }
       const span = { context: () => ctx }
       ctx._trace.started.push(span)
+      spanProjections.startSpan(span, ctx)
+      spanProjections.setTag(span, 'span.type', 'router')
+      const tags = spanProjections.getOwnWebTags(span)
       return { span, tags }
     }
 
@@ -827,6 +833,7 @@ describe('profilers/native/wall', () => {
 
       // First activation: span.type not yet set → webTags cached as undefined
       currentStore = { span: webSpan }
+      const symbols = Object.getOwnPropertySymbols(webSpan)
       enterCh.publish()
       const ctx0 = localPprof.time.setContext.getCall(0).args[0]
       assert.strictEqual(ctx0.webTags, undefined)
@@ -840,6 +847,7 @@ describe('profilers/native/wall', () => {
       // The tags update channel resolves it in place — no re-activation needed
       tagsUpdateCh.publish(webSpan)
       assert.strictEqual(ctx0.webTags, webSpanTags)
+      assert.deepStrictEqual(Object.getOwnPropertySymbols(webSpan), symbols)
 
       profiler.stop()
     })

--- a/packages/dd-trace/test/service-naming/source-resolver.spec.js
+++ b/packages/dd-trace/test/service-naming/source-resolver.spec.js
@@ -7,17 +7,21 @@ const { describe, it } = require('mocha')
 require('../setup/core')
 const DatadogSpanContext = require('../../src/opentracing/span_context')
 const {
-  INTEGRATION_SERVICE,
   MANUAL,
   resolveServiceSource,
+  setIntegrationService,
 } = require('../../src/service-naming/source-resolver')
 
 const TRACER_SERVICE = 'app'
 const SVC_SRC_KEY = '_dd.svc_src'
 
 function makeSpan (tags = {}, marker) {
-  const span = { _spanContext: new DatadogSpanContext({ tags: { ...tags } }) }
-  if (marker !== undefined) span[INTEGRATION_SERVICE] = marker
+  const context = new DatadogSpanContext({ tags: { ...tags } })
+  const span = {
+    _spanContext: context,
+    context: () => context,
+  }
+  if (marker !== undefined) setIntegrationService(span, marker)
   return span
 }
 

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -107,6 +107,16 @@ describe('SpanProcessor', () => {
     assert.deepStrictEqual(finishedSpan.context().getTags(), {})
   })
 
+  it('should default to retaining no active spans when erased directly', () => {
+    trace.started = [finishedSpan]
+    trace.finished = [finishedSpan]
+
+    processor._erase(trace)
+
+    assert.deepStrictEqual(trace.started, [])
+    assert.deepStrictEqual(trace.finished, [])
+  })
+
   it('should not flush a partial trace below the flushMinSpans threshold', () => {
     trace.started = [activeSpan, finishedSpan]
     trace.finished = [finishedSpan]

--- a/packages/dd-trace/test/web-tags-cache.spec.js
+++ b/packages/dd-trace/test/web-tags-cache.spec.js
@@ -3,11 +3,18 @@
 const assert = require('node:assert/strict')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const dc = require('dc-polyfill')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('./setup/core')
 
-const webTagsCache = require('../src/web-tags-cache')
+const spanProjections = {
+  getOwnWebTags: sinon.spy(span => span.tags),
+  getParentSpan: sinon.spy(span => span.parent),
+}
+const webTagsCache = proxyquire('../src/web-tags-cache', {
+  './opentracing/span-projections': spanProjections,
+})
 
 // One trace's started-spans list, shared by every span the helpers below build,
 // mirroring how DatadogSpanContext._trace.started is shared across a trace. The
@@ -18,14 +25,8 @@ function makeTrace () {
 
 function makeSpan (trace, { spanId, parentId, tags = {} } = {}) {
   const span = {
-    context () {
-      return {
-        _spanId: spanId,
-        _parentId: parentId,
-        _trace: trace,
-        getTags: () => tags,
-      }
-    },
+    parent: trace.started.find(candidate => candidate.spanId === parentId),
+    spanId,
     tags,
   }
   trace.started.push(span)
@@ -92,13 +93,16 @@ describe('web-tags-cache', () => {
     it('walks the parent chain once and caches the answer', () => {
       const trace = makeTrace()
       const tags = { ...WEB }
-      const parent = makeSpan(trace, { spanId: 'a', tags })
+      makeSpan(trace, { spanId: 'a', tags })
       const child = makeSpan(trace, { spanId: 'b', parentId: 'a' })
-      const getTags = sinon.spy(parent.context(), 'getTags')
+      const symbols = Object.getOwnPropertySymbols(child)
+      const callsBefore = spanProjections.getOwnWebTags.callCount
       assert.equal(webTagsCache.getCachedWebTags(child), tags)
-      const callsAfterFirst = getTags.callCount
+      const callsAfterFirst = spanProjections.getOwnWebTags.callCount
       assert.equal(webTagsCache.getCachedWebTags(child), tags)
-      assert.equal(getTags.callCount, callsAfterFirst)
+      assert.ok(callsAfterFirst > callsBefore)
+      assert.equal(spanProjections.getOwnWebTags.callCount, callsAfterFirst)
+      assert.deepStrictEqual(Object.getOwnPropertySymbols(child), symbols)
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Introduces a write-only `EventWriter` boundary for mutable Span and SpanContext
state, backed by the current JavaScript representation as a compatibility layer.

- routes Span/SpanContext writes through typed EventWriter methods
- adds atomic operations for state-dependent updates such as if-absent writes,
  structured metadata caps, AppSec ownership, web finalization, and sampling
- replaces span-attached caches and bridge references with WeakMaps/private state
- moves AppSec, profiling, LLMObs, OTel, web, and plugin reads to typed event
  projections or caller-owned state
- leaves propagation, sampling, and export reads isolated for their future native
  pipeline stages

### Motivation

Span state is expected to move into a native extension where callers can emit
updates but cannot synchronously inspect mutable internal state. This establishes
the event vocabulary and ownership boundary needed for that migration without
changing the existing serialized trace output.

### Additional Notes

The OTel bridge retains a deprecated, lazy `_ddSpan.context()` compatibility
facade for the current system-test client. It exposes immutable identifiers only,
not the mutable Datadog span; the client should move to the public
`span.spanContext()` API.

Validation performed:

- core Span/EventWriter/sampling/OTel/cache: 306 passing, 2 pending
- AppSec: 2,099 passing, 2 pending
- profiling: 186 passing, 5 pending
- LLMObs SDK CI regressions: 32 passing; the full SDK run reached 629 passing,
  2 pending before 6 cassette cases were blocked by the unavailable local test
  agent; LangGraph generated versions: 4 passing
- AI generated-version CI, including streamed tool parents: passing
- LLMObs semantic-parent/lifecycle contract: 135 passing
- APM tracing-core CI: Linux, macOS, and Windows matrices passing
- span benchmark compatibility: 16 focused tests passing; 500,000-span forced-GC
  check stabilizes at 34 MiB after the first batches, and the full 2,000,000-span
  local variant completes without the prior heap exhaustion
- GraphQL generated versions: 613 passing, 36 pending
- WebdriverIO instrumentation: 42 passing
- dd-trace-api compatibility: 32 passing
- targeted plugin suites, changed-file ESLint, and `git diff --check`

Some generated `versions/` integration fixtures were absent from the initial
checkout. Full local lint also requires two pre-existing vendored proxy bundles
that were absent locally; every changed JavaScript file passes ESLint.

This PR was generated by Codex.
