### PR TITLE
test(cypress): extend reporting process timeouts

### DIFF
--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -293,7 +293,7 @@ moduleTypes.forEach(({
                 [TEST_FRAMEWORK]: 'cypress',
               },
             })
-          }, { hardTimeout: 20000 })
+          }, { hardTimeout: 60000 })
 
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -594,7 +594,7 @@ moduleTypes.forEach(({
                 [TEST_FRAMEWORK]: 'cypress',
               },
             })
-          }, { hardTimeout: 20000 })
+          }, { hardTimeout: 60000 })
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -748,7 +748,7 @@ moduleTypes.forEach(({
                   [TEST_FRAMEWORK]: 'cypress',
                 },
               })
-            }, { hardTimeout: 20000 })
+            }, { hardTimeout: 60000 })
 
         const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),
@@ -807,7 +807,7 @@ moduleTypes.forEach(({
                     [TEST_FRAMEWORK]: 'cypress',
                   },
                 })
-              }, { hardTimeout: 20000 })
+              }, { hardTimeout: 60000 })
 
           const [[exitCode]] = await Promise.all([
             once(childProcess, 'exit'),
@@ -870,7 +870,7 @@ moduleTypes.forEach(({
             framework: event.content.meta?.[TEST_FRAMEWORK],
             error: event.content.meta?.[ERROR_MESSAGE],
           })), null, 2)}\nCypress output:\n${testOutput}`)
-          }, { hardTimeout: 20000 })
+          }, { hardTimeout: 60000 })
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -994,7 +994,7 @@ moduleTypes.forEach(({
                   [TEST_FRAMEWORK]: 'cypress',
                 },
               })
-            }, { hardTimeout: 20000 })
+            }, { hardTimeout: 60000 })
         const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),
           receiverPromise,


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Extends the hard timeout from 20 to 60 seconds for six Cypress reporting integration cases. This matches the timeout already used by neighboring Cypress cases while retaining the suite's 80-second upper bound.

### Motivation
<!-- What inspired you to submit this pull request? -->

GitHub Actions job https://github.com/DataDog/dd-trace-js/actions/runs/31478666267/job/93738296245 failed when Cypress startup exceeded the 20-second process guard under runner contention. Cypress subsequently reported that the specs passed, and the workflow retry passed, confirming that the failures were false timeouts rather than reporting regressions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verified with:

- Targeted ESLint for both changed specs.
- `integration-tests/ci-visibility-intake.spec.js` (9 passing).
- The four affected Cypress 12 ESM reporting cases (4 passing).
- The analogous Cypress 12 ESM instrumentation case (1 passing).


