### PR TITLE
fix(mocha): preserve quarantine across EFD retries

### DIFF
--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -7412,6 +7412,69 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.strictEqual(exitCode, 0)
       })
 
+      onlyLatestIt('can quarantine a new test retried by EFD', async () => {
+        const numRetries = 3
+        receiver.setKnownTests({
+          mocha: {
+            'ci-visibility/test-management/test-quarantine-1.js': [
+              'quarantine tests can pass normally',
+            ],
+          },
+        })
+        receiver.setSettings({
+          known_tests_enabled: true,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: { '5s': numRetries },
+            faulty_session_threshold: 100,
+          },
+          test_management: { enabled: true },
+        })
+
+        childProcess = exec(
+          'node node_modules/mocha/bin/mocha ./ci-visibility/test-management/test-quarantine-1.js',
+          {
+            cwd,
+            env: getCiVisAgentlessConfig(receiver.port),
+          }
+        )
+        childProcess.stdout?.on('data', data => { testOutput += data })
+        childProcess.stderr?.on('data', data => { testOutput += data })
+
+        const testAssertionsPromise = receiver
+          .gatherPayloadsUntilChildExit(childProcess, ({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === 'quarantine tests can quarantine a test')
+
+            assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(tests.length, numRetries + 1)
+            for (const test of tests) {
+              assert.strictEqual(test.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+              assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+            }
+
+            const retries = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retries.length, numRetries)
+            assert.ok(retries.every(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd))
+
+            const finalTests = tests.filter(test => TEST_FINAL_STATUS in test.meta)
+            assert.strictEqual(finalTests.length, 1)
+            assert.strictEqual(finalTests[0].meta[TEST_FINAL_STATUS], 'skip')
+          }, { hardTimeout: 60_000 })
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          testAssertionsPromise,
+        ])
+        assert.match(testOutput, /Quarantined: 1 test run; 1 failure did not affect the test session\./)
+        assert.strictEqual(exitCode, 0, testOutput)
+      })
+
       onlyLatestIt('can quarantine tests retried by Mocha that eventually pass', async () => {
         receiver.setSettings({
           test_management: { enabled: true },

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -299,6 +299,9 @@ function retryTest (test, numRetries, tags, retryPolicy) {
         clonedTest[tag] = true
       }
     }
+    if (clonedTest._ddIsQuarantined && !clonedTest._ddIsAttemptToFix) {
+      testsQuarantined.add(clonedTest)
+    }
   }
 }
 
@@ -1146,7 +1149,7 @@ function getRunTestsWrapper (runTests, config) {
                 retryTest(
                   test,
                   config.earlyFlakeDetectionRetryPolicy.schedulingRetryCount,
-                  ['_ddIsModified', '_ddIsEfdRetry'],
+                  ['_ddIsModified', '_ddIsEfdRetry', test._ddIsQuarantined && '_ddIsQuarantined'],
                   config.earlyFlakeDetectionRetryPolicy
                 )
               }
@@ -1165,7 +1168,7 @@ function getRunTestsWrapper (runTests, config) {
             retryTest(
               test,
               config.earlyFlakeDetectionRetryPolicy.schedulingRetryCount,
-              ['_ddIsNew', '_ddIsEfdRetry'],
+              ['_ddIsNew', '_ddIsEfdRetry', test._ddIsQuarantined && '_ddIsQuarantined'],
               config.earlyFlakeDetectionRetryPolicy
             )
           }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Preserves Test Management quarantine metadata on Mocha tests cloned for Early Flake Detection retries and registers those clones as quarantined for result handling.

### Motivation
<!-- What inspired you to submit this pull request? -->

A quarantined test can also be classified as new or modified because Test Management and EFD use independent inputs. Mocha's EFD clones dropped the quarantine marker, so their failures could affect the process exit code. WebdriverIO's Mocha path shares this instrumentation.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verified with:

- the new Mocha EFD + quarantine regression test
- the existing Mocha native-retry + quarantine sibling test
- targeted ESLint for both changed files
