### PR TITLE
fix(vitest): preserve quarantine EFD final status

### DIFF
--- a/integration-tests/vitest/vitest.no-worker-init.spec.js
+++ b/integration-tests/vitest/vitest.no-worker-init.spec.js
@@ -1824,6 +1824,7 @@ describe('impacted test', () => {
             assert.strictEqual(retry.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
           }
           assert.strictEqual(tests.at(-1).meta[TEST_FINAL_STATUS], 'skip')
+          assert.strictEqual(tests.at(-1).meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
         },
         { hardTimeout: 60_000 }
       )

--- a/integration-tests/vitest/vitest.no-worker-init.spec.js
+++ b/integration-tests/vitest/vitest.no-worker-init.spec.js
@@ -1759,6 +1759,83 @@ describe('impacted test', () => {
       assert.strictEqual(exitCode, 0, testOutput)
     })
 
+    it('preserves quarantine final status for a new test retried by EFD', async () => {
+      const testSuite = 'ci-visibility/vitest-tests/test-quarantine.mjs'
+      const testName = 'quarantine tests can quarantine a test'
+      const numRetries = 2
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': numRetries,
+          },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
+        test_management: { enabled: true },
+      })
+      receiver.setKnownTests({
+        vitest: {
+          [testSuite]: [
+            'quarantine tests can pass normally',
+            'quarantine tests can quarantine a passing test',
+          ],
+        },
+      })
+      receiver.setTestManagementTests({
+        vitest: {
+          suites: {
+            [testSuite]: {
+              tests: {
+                [testName]: {
+                  properties: {
+                    quarantined: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const runPromise = runVitest({
+        TEST_DIR: testSuite,
+        POOL_CONFIG: 'forks',
+      })
+      const payloadsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url === '/api/v2/citestcycle',
+        payloads => {
+          const events = getEvents(payloads)
+          const tests = getTestsByName(getEventContents(events, 'test'), testName)
+          const [testSession] = getEventContents(events, 'test_session_end')
+
+          assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(tests.length, numRetries + 1)
+          for (const test of tests) {
+            assert.strictEqual(test.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+          }
+
+          assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+          for (const retry of tests.slice(1)) {
+            assert.strictEqual(retry.meta[TEST_IS_RETRY], 'true')
+            assert.strictEqual(retry.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+          }
+          assert.strictEqual(tests.at(-1).meta[TEST_FINAL_STATUS], 'skip')
+        },
+        { hardTimeout: 60_000 }
+      )
+
+      const exitCode = await Promise.all([
+        runPromise,
+        payloadsPromise,
+      ]).then(([exitCode]) => exitCode)
+
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
     latestVitestIt('uses legacy EFD faultiness detection in no-worker mode', async () => {
       receiver.setSettings({
         early_flake_detection: {

--- a/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
+++ b/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
@@ -1095,8 +1095,7 @@ function getRepeatedTestReport (task, testName, testSuiteAbsolutePath, testPrope
         testProperties,
         type,
         statuses,
-        isFinalAttempt,
-        hasFailure
+        isFinalAttempt
       ),
       isRetry: index > 0,
       status: attemptStatus,
@@ -1136,11 +1135,10 @@ function getRepeatedTestReport (task, testName, testSuiteAbsolutePath, testPrope
  * @param {'attempt_to_fix'|'early_flake_detection'|'external'} type
  * @param {string[]} statuses
  * @param {boolean} isFinalAttempt
- * @param {boolean} hasFailure
  * @returns {boolean}
  */
-function hasFailedAllManagedRetries (task, testProperties, type, statuses, isFinalAttempt, hasFailure) {
-  if (!isFinalAttempt || !hasFailure || statuses.length === 0 || !statuses.every(status => status === 'fail')) {
+function hasFailedAllManagedRetries (task, testProperties, type, statuses, isFinalAttempt) {
+  if (!isFinalAttempt || statuses.length === 0 || !statuses.every(status => status === 'fail')) {
     return false
   }
 
@@ -1275,7 +1273,6 @@ function reportFinalTestAttempt (testReport) {
         testProperties,
         'external',
         ['fail'],
-        true,
         true
       ),
       isRetry: (result?.retryCount || 0) > 0 || (result?.repeatCount || 0) > 0,

--- a/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
+++ b/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js
@@ -1058,7 +1058,7 @@ function getRepeatedTestReport (task, testName, testSuiteAbsolutePath, testPrope
   const errors = browserEnvironment
     ? normalizeVitestBrowserErrors(result?.errors)
     : result?.errors || []
-  const finalAttemptStatus = finalStatus(statuses)
+  const finalAttemptStatus = finalStatus(statuses, testProperties)
   const hasFailure = finalAttemptStatus === 'fail'
   const attempts = []
   const attemptCount = getRepeatedAttemptCount(task, statuses)
@@ -1165,7 +1165,8 @@ function getAttemptToFixFinalStatus (statuses) {
   return statuses.includes('fail') ? 'fail' : 'pass'
 }
 
-function getEarlyFlakeDetectionFinalStatus (statuses) {
+function getEarlyFlakeDetectionFinalStatus (statuses, testProperties) {
+  if (testProperties.isDisabled || testProperties.isQuarantined) return 'skip'
   return statuses.includes('pass') ? 'pass' : 'fail'
 }
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Emits a skipped final status for quarantined or disabled Vitest tests retried by EFD through the no-worker-init reporter shared with Browser Mode.

### Motivation
<!-- What inspired you to submit this pull request? -->

The no-worker/browser path preserved quarantine metadata and the process outcome, but computed an all-failing EFD final status without Test Management properties. Its final retry could therefore report `test.final_status:fail` instead of `skip`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verified with:

- the new EFD + quarantine regression test on Vitest 3.2.6 and latest
- the existing no-worker Test Management sibling test on both versions
- targeted ESLint for both changed files
