### PR TITLE
refactor(test-optimization): use shared EVP proxy path helpers

### DIFF
--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const getConfig = require('../../config')
-const request = require('../requests/request')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../evp_proxy/path')
 const id = require('../../id')
 const log = require('../../log')
-
 const {
   incrementCountMetric,
   distributionMetric,
@@ -14,8 +14,8 @@ const {
   TELEMETRY_KNOWN_TESTS_RESPONSE_TESTS,
   TELEMETRY_KNOWN_TESTS_RESPONSE_BYTES,
 } = require('../../ci-visibility/telemetry')
-
 const { getNumFromKnownTests } = require('../../plugins/util/test')
+const request = require('../requests/request')
 const { buildCacheKey, writeToCache, withCache } = require('../requests/fs-cache')
 const { validateKnownTestsResponse } = require('../test-optimization-http-cache-schema')
 
@@ -162,8 +162,8 @@ function fetchFromApi ({
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/ci/libraries/tests`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/ci/libraries/tests')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
   } else {
     const { DD_API_KEY } = getConfig()
     if (!DD_API_KEY) {

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -8,6 +8,8 @@ const request = require('../request')
 const { fetchAgentInfo } = require('../../../agent/info')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
 
+// Product-specific discovery: newest advertised version, skip v3 (citestcycle), gzip if >= v4.
+// Shared `evp_proxy` discovery is an explicit path allowlist and does not cover this contract.
 const AGENT_EVP_PROXY_PATH_PREFIX = '/evp_proxy/v'
 const AGENT_EVP_PROXY_PATH_REGEX = /\/evp_proxy\/v(\d+)\/?/
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -1,7 +1,9 @@
 'use strict'
 const getConfig = require('../../../config')
-const log = require('../../../log')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../../evp_proxy/path')
 const { safeJSONStringify } = require('../../../exporters/common/util')
+const log = require('../../../log')
 
 const {
   incrementCountMetric,
@@ -53,9 +55,9 @@ class Writer extends BaseWriter {
     }
 
     if (this._evpProxyPrefix) {
-      options.path = `${this._evpProxyPrefix}/api/v2/citestcov`
+      options.path = joinEVPProxyPath(this._evpProxyPrefix, '/api/v2/citestcov')
       delete options.headers['dd-api-key']
-      options.headers['X-Datadog-EVP-Subdomain'] = 'citestcov-intake'
+      options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'citestcov-intake'
     }
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -1,5 +1,7 @@
 'use strict'
 const getConfig = require('../../../config')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../../evp_proxy/path')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 const log = require('../../../log')
 
@@ -54,9 +56,9 @@ class Writer extends BaseWriter {
     }
 
     if (this._evpProxyPrefix) {
-      options.path = `${this._evpProxyPrefix}/api/v2/citestcycle`
+      options.path = joinEVPProxyPath(this._evpProxyPrefix, '/api/v2/citestcycle')
       delete options.headers['dd-api-key']
-      options.headers['X-Datadog-EVP-Subdomain'] = 'citestcycle-intake'
+      options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'citestcycle-intake'
     }
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -4,6 +4,8 @@ const fs = require('fs')
 const path = require('path')
 
 const getConfig = require('../../../config')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../../evp_proxy/path')
 const FormData = require('../../../exporters/common/form-data')
 const request = require('../../../exporters/common/request')
 
@@ -83,8 +85,8 @@ function getCommitsToUpload ({ url, repositoryUrl, latestCommits, isEvpProxy, ev
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/git/repository/search_commits`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/git/repository/search_commits')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
     delete options.headers['dd-api-key']
   }
 
@@ -179,8 +181,8 @@ function uploadPackFile ({ url, isEvpProxy, evpProxyPrefix, packFileToUpload, re
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/git/repository/packfile`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/git/repository/packfile')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
     delete options.headers['dd-api-key']
   }
 

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const getConfig = require('../../config')
-const request = require('../requests/request')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../evp_proxy/path')
 const log = require('../../log')
 const {
   incrementCountMetric,
@@ -13,6 +14,7 @@ const {
   TELEMETRY_ITR_SKIPPABLE_TESTS_RESPONSE_TESTS,
   TELEMETRY_ITR_SKIPPABLE_TESTS_RESPONSE_BYTES,
 } = require('../../ci-visibility/telemetry')
+const request = require('../requests/request')
 const { buildCacheKey, writeToCache, withCache } = require('../requests/fs-cache')
 const { validateSkippableTestsResponse } = require('../test-optimization-http-cache-schema')
 
@@ -227,8 +229,8 @@ function fetchFromApi ({
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/ci/tests/skippable`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/ci/tests/skippable')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
   } else {
     const { DD_API_KEY } = getConfig()
     if (!DD_API_KEY) {

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const getConfig = require('../../config')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../evp_proxy/path')
 const id = require('../../id')
 const log = require('../../log')
 const { EARLY_FLAKE_DETECTION_RETRY_BUCKETS, createEfdRetryPolicy } = require('../efd-retry-policy')
@@ -238,8 +240,8 @@ function getLibraryConfiguration ({
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/libraries/tests/services/setting`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/libraries/tests/services/setting')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
   } else {
     if (!config.DD_API_KEY) {
       return done(new Error('Request to settings endpoint was not done because Datadog API key is not defined.'))

--- a/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
@@ -4,6 +4,8 @@ const { closeSync, constants, fstatSync, openSync, readFileSync } = require('nod
 const { gzipSync } = require('node:zlib')
 
 const getConfig = require('../../config')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../evp_proxy/path')
 const FormData = require('../../exporters/common/form-data')
 const request = require('../../exporters/common/request')
 const log = require('../../log')
@@ -98,8 +100,8 @@ function uploadCoverageReport (
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/cicovreprt`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'ci-intake'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/cicovreprt')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'ci-intake'
   } else {
     options.path = '/api/v2/cicovreprt'
     options.headers['dd-api-key'] = DD_API_KEY

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -4,6 +4,8 @@ const { readFileSync } = require('node:fs')
 const { extname } = require('node:path')
 
 const getConfig = require('../../config')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../evp_proxy/path')
 const log = require('../../log')
 const request = require('../exporters/request')
 
@@ -134,8 +136,8 @@ function uploadTestScreenshot (
   if (isEvpProxy) {
     // Agent mode: prefix the evp_proxy path, tell the proxy which subdomain to forward to, and
     // drop the API key — the Agent injects it. The query params survive the proxy.
-    options.path = `${evpProxyPrefix}${basePath}?${query}`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = `${joinEVPProxyPath(evpProxyPrefix, basePath)}?${query}`
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
   } else {
     options.headers['DD-API-KEY'] = DD_API_KEY
   }

--- a/packages/dd-trace/src/ci-visibility/test-management/get-test-management-tests.js
+++ b/packages/dd-trace/src/ci-visibility/test-management/get-test-management-tests.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const getConfig = require('../../config')
-const request = require('../requests/request')
+const { EVP_SUBDOMAIN_HEADER_NAME } = require('../../evp_proxy/constants')
+const { joinEVPProxyPath } = require('../../evp_proxy/path')
 const id = require('../../id')
 const log = require('../../log')
-
 const {
   incrementCountMetric,
   distributionMetric,
@@ -14,7 +14,7 @@ const {
   TELEMETRY_TEST_MANAGEMENT_TESTS_RESPONSE_TESTS,
   TELEMETRY_TEST_MANAGEMENT_TESTS_RESPONSE_BYTES,
 } = require('../telemetry')
-
+const request = require('../requests/request')
 const { buildCacheKey, writeToCache, withCache } = require('../requests/fs-cache')
 const { validateTestManagementTestsResponse } = require('../test-optimization-http-cache-schema')
 
@@ -132,8 +132,8 @@ function fetchFromApi ({
   }
 
   if (isEvpProxy) {
-    options.path = `${evpProxyPrefix}/api/v2/test/libraries/test-management/tests`
-    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.path = joinEVPProxyPath(evpProxyPrefix, '/api/v2/test/libraries/test-management/tests')
+    options.headers[EVP_SUBDOMAIN_HEADER_NAME] = 'api'
   } else {
     const { DD_API_KEY } = getConfig()
     if (!DD_API_KEY) {


### PR DESCRIPTION
### What does this PR do?

Prototype of adopting the shared EVP proxy helpers from #9738 in Test Optimization.

Request sites now use `EVP_SUBDOMAIN_HEADER_NAME` and `joinEVPProxyPath()` instead of concatenating `/evp_proxy/vN` and hardcoding `X-Datadog-EVP-Subdomain`. Product intake subdomains (`citestcycle-intake`, `citestcov-intake`, `ci-intake`, `api`) stay local.

Agent-proxy `/info` discovery is unchanged: newest advertised version, skip v3 for citestcycle, gzip if `>= v4`, and APM `AgentWriter` fallback when no compatible proxy is advertised.

### Motivation

#9738 extracted a shared EVP route contract for Feature Flags and left Test Optimization on its own path. The mechanical pieces (header name + slash-safe path join) are a drop-in. Shared `discoverEVPProxy` / `createDirectEVPRoute` are not: they use an explicit path allowlist, do not pass abort/deadline through `fetchAgentInfo`, and treat missing `/info` as a cue for direct intake — none of which matches Test Optimization's contract.

### Additional Notes

This is a prototype. Follow-ups, if wanted:

- Extend `discoverEVPProxy` to forward `fetchAgentInfo` options, then consider an explicit `[v4, v2]` allowlist (safer than "newest", given the v3 citestcycle break; would stop auto-following a future v5).
- `createDirectEVPRoute` is a poor fit: agentless TO talks to several intakes and is selected by config, not as a discovery fallback.

### Test plan

- [x] `packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/early-flake-detection/get-known-tests.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/intelligent-test-runner/get-skippable-suites.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/test-management/get-test-management-tests.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/requests/get-library-configuration.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/requests/upload-coverage-report.spec.js`
- [x] `packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js`


Made with [Cursor](https://cursor.com)