### PR TITLE
test(llmobs): support updated AI tool span parents

### DIFF
--- a/packages/dd-trace/test/llmobs/plugins/ai/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/index.spec.js
@@ -66,6 +66,20 @@ function getAiSdkAnthropicOrGoogleRange (vercelAiVersion) {
 }
 
 /**
+ * Starting with ai@5.0.241 and ai@6.0.260, tool execution is activated under the model span instead of the workflow
+ * span.
+ *
+ * @param {string} vercelAiVersion
+ * @param {Array<{span_id: string}>} llmobsSpans
+ * @returns {string}
+ */
+function getToolSpanParentId (vercelAiVersion, llmobsSpans) {
+  const toolRunsUnderModel = semifies(vercelAiVersion, '>=5.0.241 <6.0.0') ||
+    semifies(vercelAiVersion, '>=6.0.260 <7.0.0')
+  return (toolRunsUnderModel ? llmobsSpans[1] : llmobsSpans[0]).span_id
+}
+
+/**
  * @param {string} versionRange
  * @param {(
  *   version: string,
@@ -828,7 +842,7 @@ describe('Plugin', () => {
 
       assertLlmObsSpanEvent(llmobsSpans[2], {
         span: apmSpans[2],
-        parentId: llmobsSpans[0].span_id,
+        parentId: getToolSpanParentId(realVersion, llmobsSpans),
         /**
          * Before `ai@4.0.2` with `@ai-sdk/openai@1.3.23`, the stream implementation did not finish the initial llm
          * spans first to associate the tool call id with the tool itself (by matching descriptions).
@@ -1227,7 +1241,7 @@ describe('Plugin', () => {
 
         assertLlmObsSpanEvent(llmobsSpans[2], {
           span: apmSpans[2],
-          parentId: llmobsSpans[0].span_id,
+          parentId: getToolSpanParentId(realVersion, llmobsSpans),
           name: 'weather',
           spanKind: 'tool',
           inputValue: JSON.stringify({ location: 'Tokyo' }),


### PR DESCRIPTION
## Summary

Update the AI LLMObs test expectations for newer Vercel AI SDK releases. Starting with `ai@5.0.241` and `ai@6.0.260`, tool execution is nested under the model span rather than the workflow span.

The assertions continue to expect workflow parenting for older supported versions and use the model span for the newer behavior.

## Validation

- `npx mocha packages/dd-trace/test/llmobs/plugins/ai/index.spec.js --grep 'created a span for a tool call from a stream|ToolLoopAgent.stream' --reporter dot`
- Full AI plugin spec: 220 passing
- ESLint passes
