### PR TITLE
feat(test-optimization): submit bunyan logs agentlessly in mocha

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -27,6 +27,7 @@ describe('test optimization automatic log submission', () => {
   useSandbox([
     'mocha',
     ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
+    'bunyan',
     'jest',
     'winston',
     playwrightDependency,
@@ -65,7 +66,7 @@ describe('test optimization automatic log submission', () => {
   const testFrameworks = [
     {
       name: 'mocha',
-      command: 'mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js',
+      command: './node_modules/.bin/mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js',
     },
     {
       name: 'jest',
@@ -86,164 +87,178 @@ describe('test optimization automatic log submission', () => {
     },
   ]
 
-  testFrameworks.forEach(({ name, command, getExtraEnvVars = () => ({}) }) => {
-    if (!isLatestCucumberSupported && name === 'cucumber') return
+  const loggers = [
+    { name: 'winston', level: 'info', messageKey: 'message' },
+    { name: 'bunyan', level: 30, messageKey: 'msg', frameworks: ['mocha'] },
+  ]
 
-    context(`with ${name}`, () => {
-      it('can automatically submit logs', async () => {
-        let logIds = {}
-        let testIds = {}
+  loggers.forEach(({ name: loggerName, level: expectedLevel, messageKey, frameworks }) => {
+    testFrameworks.forEach(({ name, command, getExtraEnvVars = () => ({}) }) => {
+      if (!isLatestCucumberSupported && name === 'cucumber') return
+      if (frameworks && !frameworks.includes(name)) return
 
-        const logsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
-            payloads.forEach(({ headers }) => {
-              assert.equal(headers['dd-api-key'], '1')
+      context(`with ${loggerName} and ${name}`, () => {
+        it('can automatically submit logs', async () => {
+          let logIds = {}
+          let testIds = {}
+
+          const logsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
+              payloads.forEach(({ headers }) => {
+                assert.equal(headers['dd-api-key'], '1')
+                if (loggerName !== 'winston') {
+                  assert.equal(headers['content-type'], 'application/json')
+                }
+              })
+              const logMessages = payloads.flatMap(({ logMessage }) => logMessage)
+              const [url] = payloads.flatMap(({ url }) => url)
+
+              assert.equal(url, `/api/v2/logs?ddsource=${loggerName}&service=my-service`)
+              assert.equal(logMessages.length, 2)
+
+              logMessages.forEach(({ dd, level }) => {
+                assert.equal(level, expectedLevel)
+                assert.equal(dd.service, 'my-service')
+                assert.deepStrictEqual(['service', 'span_id', 'trace_id'], Object.keys(dd).sort())
+              })
+
+              assertObjectContains(logMessages.map(logMessage => logMessage[messageKey]), [
+                'Hello simple log!',
+                'sum function being called',
+              ])
+
+              logIds = {
+                logSpanId: logMessages[0].dd.span_id,
+                logTraceId: logMessages[0].dd.trace_id,
+              }
             })
-            const logMessages = payloads.flatMap(({ logMessage }) => logMessage)
-            const [url] = payloads.flatMap(({ url }) => url)
 
-            assert.equal(url, '/api/v2/logs?ddsource=winston&service=my-service')
-            assert.equal(logMessages.length, 2)
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testEventContent = events.find(event => event.type === 'test').content
 
-            logMessages.forEach(({ dd, level }) => {
-              assert.equal(level, 'info')
-              assert.equal(dd.service, 'my-service')
-              assert.deepStrictEqual(['service', 'span_id', 'trace_id'], Object.keys(dd).sort())
+              testIds = {
+                testSpanId: testEventContent.span_id.toString(),
+                testTraceId: testEventContent.trace_id.toString(),
+              }
             })
 
-            assertObjectContains(logMessages.map(({ message }) => message), [
-              'Hello simple log!',
-              'sum function being called',
-            ])
-
-            logIds = {
-              logSpanId: logMessages[0].dd.span_id,
-              logTraceId: logMessages[0].dd.trace_id,
+          childProcess = exec(command,
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
+                DD_API_KEY: '1',
+                DD_SERVICE: 'my-service',
+                TEST_LOGGER: loggerName,
+                ...getExtraEnvVars(),
+              },
             }
+          )
+          childProcess.stdout?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr?.on('data', (chunk) => {
+            testOutput += chunk.toString()
           })
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testEventContent = events.find(event => event.type === 'test').content
+          await Promise.all([
+            once(childProcess, 'exit'),
+            once(childProcess.stdout, 'end'),
+            once(childProcess.stderr, 'end'),
+            logsPromise,
+            eventsPromise,
+          ])
 
-            testIds = {
-              testSpanId: testEventContent.span_id.toString(),
-              testTraceId: testEventContent.trace_id.toString(),
+          const { logSpanId, logTraceId } = logIds
+          const { testSpanId, testTraceId } = testIds
+          assert.match(testOutput, /Hello simple log!/)
+          assert.match(testOutput, /sum function being called/)
+          // cucumber has `cucumber.step`, and that's the active span, not the test.
+          // logs are queried by trace id, so it should be OK
+          if (name !== 'cucumber') {
+            assert.match(testOutput, new RegExp(`"span_id":"${testSpanId}"`))
+            assert.equal(logSpanId, testSpanId)
+          }
+          assert.match(testOutput, new RegExp(`"trace_id":"${testTraceId}"`))
+          assert.equal(logTraceId, testTraceId)
+        })
+
+        it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is not set', async () => {
+          childProcess = exec(command,
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
+                DD_SERVICE: 'my-service',
+                TEST_LOGGER: loggerName,
+                ...getExtraEnvVars(),
+              },
             }
+          )
+          childProcess.stdout?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr?.on('data', (chunk) => {
+            testOutput += chunk.toString()
           })
 
-        childProcess = exec(command,
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
-              DD_API_KEY: '1',
-              DD_SERVICE: 'my-service',
-              ...getExtraEnvVars(),
-            },
-          }
-        )
-        childProcess.stdout?.on('data', (chunk) => {
-          testOutput += chunk.toString()
-        })
-        childProcess.stderr?.on('data', (chunk) => {
-          testOutput += chunk.toString()
+          let hasReceivedEvents = false
+
+          const logsPromise = receiver.assertPayloadReceived(() => {
+            hasReceivedEvents = true
+          }, ({ url }) => url.endsWith('/api/v2/logs'), 5000).catch(() => {})
+
+          await Promise.all([
+            once(childProcess, 'exit'),
+            once(childProcess.stdout, 'end'),
+            once(childProcess.stderr, 'end'),
+            logsPromise,
+          ])
+
+          assert.match(testOutput, /Hello simple log!/)
+          assert.match(testOutput, /span_id/)
+          assert.strictEqual(hasReceivedEvents, false)
         })
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          once(childProcess.stdout, 'end'),
-          once(childProcess.stderr, 'end'),
-          logsPromise,
-          eventsPromise,
-        ])
+        it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is set but DD_API_KEY is not', async () => {
+          childProcess = exec(command,
+            {
+              cwd,
+              env: {
+                ...getCiVisEvpProxyConfig(receiver.port),
+                DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
+                DD_SERVICE: 'my-service',
+                DD_TRACE_DEBUG: '1',
+                DD_TRACE_LOG_LEVEL: 'warn',
+                DD_API_KEY: '',
+                TEST_LOGGER: loggerName,
+                ...getExtraEnvVars(),
+              },
+            }
+          )
 
-        const { logSpanId, logTraceId } = logIds
-        const { testSpanId, testTraceId } = testIds
-        assert.match(testOutput, /Hello simple log!/)
-        assert.match(testOutput, /sum function being called/)
-        // cucumber has `cucumber.step`, and that's the active span, not the test.
-        // logs are queried by trace id, so it should be OK
-        if (name !== 'cucumber') {
-          assert.match(testOutput, new RegExp(`"span_id":"${testSpanId}"`))
-          assert.equal(logSpanId, testSpanId)
-        }
-        assert.match(testOutput, new RegExp(`"trace_id":"${testTraceId}"`))
-        assert.equal(logTraceId, testTraceId)
-      })
+          childProcess.stdout?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
 
-      it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is not set', async () => {
-        childProcess = exec(command,
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
-              DD_SERVICE: 'my-service',
-              ...getExtraEnvVars(),
-            },
-          }
-        )
-        childProcess.stdout?.on('data', (chunk) => {
-          testOutput += chunk.toString()
+          await Promise.all([
+            once(childProcess, 'exit'),
+            once(childProcess.stdout, 'end'),
+            once(childProcess.stderr, 'end'),
+          ])
+
+          assert.match(testOutput, /Hello simple log!/)
+          assert.match(testOutput, /no automatic log submission will be performed/)
         })
-        childProcess.stderr?.on('data', (chunk) => {
-          testOutput += chunk.toString()
-        })
-
-        let hasReceivedEvents = false
-
-        const logsPromise = receiver.assertPayloadReceived(() => {
-          hasReceivedEvents = true
-        }, ({ url }) => url.endsWith('/api/v2/logs'), 5000).catch(() => {})
-
-        await Promise.all([
-          once(childProcess, 'exit'),
-          once(childProcess.stdout, 'end'),
-          once(childProcess.stderr, 'end'),
-          logsPromise,
-        ])
-
-        assert.match(testOutput, /Hello simple log!/)
-        assert.match(testOutput, /span_id/)
-        assert.strictEqual(hasReceivedEvents, false)
-      })
-
-      it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is set but DD_API_KEY is not', async () => {
-        childProcess = exec(command,
-          {
-            cwd,
-            env: {
-              ...getCiVisEvpProxyConfig(receiver.port),
-              DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
-              DD_SERVICE: 'my-service',
-              DD_TRACE_DEBUG: '1',
-              DD_TRACE_LOG_LEVEL: 'warn',
-              DD_API_KEY: '',
-              ...getExtraEnvVars(),
-            },
-          }
-        )
-
-        childProcess.stdout?.on('data', (chunk) => {
-          testOutput += chunk.toString()
-        })
-        childProcess.stderr?.on('data', (chunk) => {
-          testOutput += chunk.toString()
-        })
-
-        await Promise.all([
-          once(childProcess, 'exit'),
-          once(childProcess.stdout, 'end'),
-          once(childProcess.stderr, 'end'),
-        ])
-
-        assert.match(testOutput, /Hello simple log!/)
-        assert.match(testOutput, /no automatic log submission will be performed/)
       })
     })
   })

--- a/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
@@ -6,7 +6,7 @@ const logger = require('./logger')
 const sum = require('./sum')
 describe('test', () => {
   it('should return true', () => {
-    logger.log('info', 'Hello simple log!')
+    logger.info('Hello simple log!')
 
     assert.strictEqual(true, true)
     assert.strictEqual(sum(1, 2), 3)

--- a/integration-tests/ci-visibility/automatic-log-submission/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/logger.js
@@ -1,12 +1,19 @@
 'use strict'
 
-const { createLogger, format, transports } = require('winston')
+let logger
 
-module.exports = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.Console(),
-  ],
-})
+if (process.env.TEST_LOGGER === 'bunyan') {
+  logger = require('bunyan').createLogger({ name: 'test-logger' })
+} else {
+  const { createLogger, format, transports } = require('winston')
+  logger = createLogger({
+    level: 'info',
+    exitOnError: false,
+    format: format.json(),
+    transports: [
+      new transports.Console(),
+    ],
+  })
+}
+
+module.exports = logger

--- a/integration-tests/ci-visibility/automatic-log-submission/sum.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/sum.js
@@ -3,6 +3,6 @@
 const logger = require('./logger')
 
 module.exports = function (a, b) {
-  logger.log('info', 'sum function being called')
+  logger.info('sum function being called')
   return a + b
 }

--- a/packages/datadog-instrumentations/src/bunyan.js
+++ b/packages/datadog-instrumentations/src/bunyan.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const wrapLogger = require('./helpers/bunyan')
-const { addHook } = require('./helpers/instrument')
+const { addHook, channel } = require('./helpers/instrument')
+
+const logSubmissionCh = channel('ci:log-submission:log')
 
 addHook({ name: 'bunyan', versions: ['>=1'] }, Logger => {
-  wrapLogger(Logger, 'bunyan')
+  wrapLogger(Logger, 'bunyan', logSubmissionCh)
   return Logger
 })

--- a/packages/datadog-instrumentations/src/helpers/bunyan.js
+++ b/packages/datadog-instrumentations/src/helpers/bunyan.js
@@ -6,17 +6,24 @@ const { channel } = require('./instrument')
 /**
  * @param {{ prototype: object }} Logger
  * @param {string} id
+ * @param {import('node:diagnostics_channel').Channel} [logSubmissionCh]
  */
-module.exports = function wrapLogger (Logger, id) {
+module.exports = function wrapLogger (Logger, id, logSubmissionCh) {
   const logCh = channel(`apm:${id}:log`)
   shimmer.wrap(Logger.prototype, '_emit', emit => {
     return function wrappedEmit (rec) {
       if (logCh.hasSubscribers) {
         const payload = { message: rec }
         logCh.publish(payload)
-        arguments[0] = payload.message
+        rec = arguments[0] = payload.message
       }
-      return emit.apply(this, arguments)
+
+      const line = emit.apply(this, arguments)
+      // `_emit(rec, true)` applies serializers without writing. Skip submission in that case.
+      if (logSubmissionCh?.hasSubscribers && logCh.hasSubscribers && !arguments[1]) {
+        logSubmissionCh.publish({ source: id, message: line ?? rec })
+      }
+      return line
     }
   })
 }

--- a/packages/datadog-plugin-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-bunyan/test/index.spec.js
@@ -4,12 +4,15 @@ const assert = require('node:assert/strict')
 const { Writable } = require('node:stream')
 const { inspect } = require('node:util')
 
+const { channel } = require('dc-polyfill')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+
+const logSubmissionCh = channel('ci:log-submission:log')
 
 describe('Plugin', () => {
   let logger
@@ -72,8 +75,18 @@ describe('Plugin', () => {
         })
 
         it('should add the trace identifiers to logger instances', () => {
+          const submittedLogs = []
+          const onLogSubmission = payload => {
+            submittedLogs.push(payload)
+          }
+          logSubmissionCh.subscribe(onLogSubmission)
+
           tracer.scope().activate(span, () => {
-            logger.info('message')
+            try {
+              logger.info('message')
+            } finally {
+              logSubmissionCh.unsubscribe(onLogSubmission)
+            }
 
             sinon.assert.called(stream.write)
 
@@ -83,7 +96,31 @@ describe('Plugin', () => {
               trace_id: span.context().toTraceId(true),
               span_id: span.context().toSpanId(),
             })
+
+            assert.strictEqual(submittedLogs.length, 1)
+            const [submittedLog] = submittedLogs
+            const submittedRecord = JSON.parse(submittedLog.message)
+            assert.strictEqual(submittedLog.source, 'bunyan')
+            assert.strictEqual(submittedRecord.msg, 'message')
+            assertObjectContains(submittedRecord.dd, record.dd)
           })
+        })
+
+        it('should not submit records when Bunyan skips emission', () => {
+          const submittedLogs = []
+          const onLogSubmission = payload => {
+            submittedLogs.push(payload)
+          }
+          logSubmissionCh.subscribe(onLogSubmission)
+
+          try {
+            logger._emit({ level: 20, msg: 'filtered message' }, true)
+          } finally {
+            logSubmissionCh.unsubscribe(onLogSubmission)
+          }
+
+          sinon.assert.notCalled(stream.write)
+          assert.strictEqual(submittedLogs.length, 0)
         })
 
         it('should not mutate the original record', () => {

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -1,14 +1,25 @@
 'use strict'
 
-const Plugin = require('../../plugins/plugin')
+const request = require('../../exporters/common/request')
 const log = require('../../log')
+const Plugin = require('../../plugins/plugin')
+
+/**
+ * @param {import('../../config/config-base')} config
+ * @param {string} source
+ * @returns {string}
+ */
+function getLogSubmissionPath (config, source) {
+  return `/api/v2/logs?${new URLSearchParams({ ddsource: source, service: config.service })}`
+}
 
 function getWinstonLogSubmissionParameters (config) {
-  const { site, service, DD_API_KEY, DD_AGENTLESS_LOG_SUBMISSION_URL } = config
+  const { site, DD_API_KEY, DD_AGENTLESS_LOG_SUBMISSION_URL } = config
+  const path = getLogSubmissionPath(config, 'winston')
 
   const defaultParameters = {
     host: `http-intake.logs.${site}`,
-    path: `/api/v2/logs?ddsource=winston&service=${service}`,
+    path,
     ssl: true,
     headers: {
       'DD-API-KEY': DD_API_KEY,
@@ -25,13 +36,58 @@ function getWinstonLogSubmissionParameters (config) {
       host: url.hostname,
       port: url.port,
       ssl: url.protocol === 'https:',
-      path: defaultParameters.path,
+      path,
       headers: defaultParameters.headers,
     }
   } catch {
     log.error('Could not parse DD_AGENTLESS_LOG_SUBMISSION_URL')
     return defaultParameters
   }
+}
+
+/**
+ * @param {import('../../config/config-base')} config
+ * @param {string} source
+ * @returns {{ url: URL, path: string, method: string, headers: Record<string, string> } | undefined}
+ */
+function getLogSubmissionRequestOptions (config, source) {
+  const headers = {
+    'DD-API-KEY': config.DD_API_KEY,
+    'Content-Type': 'application/json',
+  }
+  const path = getLogSubmissionPath(config, source)
+
+  if (config.DD_AGENTLESS_LOG_SUBMISSION_URL) {
+    try {
+      return {
+        url: new URL(config.DD_AGENTLESS_LOG_SUBMISSION_URL),
+        path,
+        method: 'POST',
+        headers,
+      }
+    } catch {
+      log.error('Could not parse DD_AGENTLESS_LOG_SUBMISSION_URL')
+    }
+  }
+
+  try {
+    return {
+      url: new URL(`https://http-intake.logs.${config.site}`),
+      path,
+      method: 'POST',
+      headers,
+    }
+  } catch {
+    log.error('Could not parse automatic log submission site: %s', config.site)
+  }
+}
+
+/**
+ * @param {string | Record<string, unknown>} message
+ * @returns {string}
+ */
+function serializeLogMessage (message) {
+  return typeof message === 'string' ? message : JSON.stringify(message)
 }
 
 class LogSubmissionPlugin extends Plugin {
@@ -46,6 +102,33 @@ class LogSubmissionPlugin extends Plugin {
 
     this.addSub('ci:log-submission:winston:add-transport', (logger) => {
       logger.add(new this.HttpClass(getWinstonLogSubmissionParameters(this.config)))
+    })
+
+    this.addSub('ci:log-submission:log', (payload) => this.#submitLog(payload))
+  }
+
+  /**
+   * Posts a correlated log record to the agentless logs intake.
+   *
+   * @param {{ source: string, message: string | Record<string, unknown> }} payload
+   * @returns {void}
+   */
+  #submitLog ({ source, message }) {
+    let serializedMessage
+    try {
+      serializedMessage = serializeLogMessage(message)
+    } catch (error) {
+      log.error('Could not serialize %s log for automatic submission', source, error)
+      return
+    }
+
+    const options = getLogSubmissionRequestOptions(this.config, source)
+    if (!options) return
+
+    request(`[${serializedMessage}]`, options, error => {
+      if (error) {
+        log.error('Error submitting %s logs', source, error)
+      }
     })
   }
 }


### PR DESCRIPTION
## Summary
- First slice of splitting https://github.com/DataDog/dd-trace-js/pull/9669: add agentless automatic log submission for Bunyan, proven with Mocha.
- After Bunyan `_emit`, publish the correlated record on `ci:log-submission:log` and POST it to the logs intake. Winston's HTTP transport is unchanged.
- Later PRs can stack Cucumber and Playwright on this branch. Jest is deferred because of its custom require engine.

## Test plan
- [x] `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER PLUGINS='bunyan' npm run test:plugins`
- [x] `./node_modules/.bin/mocha --timeout 180000 integration-tests/ci-visibility/automatic-log-submission.spec.js --grep mocha`
- [x] `./node_modules/.bin/mocha --timeout 180000 integration-tests/ci-visibility/automatic-log-submission.spec.js --grep "winston and jest"`
- [ ] CI Test Optimization integration job


Made with [Cursor](https://cursor.com)