### PR TITLE
test(test-optimization): cover Bunyan log submission in Cucumber

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/logger.js
@@ -1,12 +1,3 @@
 'use strict'
 
-const { createLogger, format, transports } = require('winston')
-
-module.exports = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.Console(),
-  ],
-})
+module.exports = require('../../automatic-log-submission/logger')

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
@@ -12,5 +12,5 @@ Then('I should have made a log', async function () {
 })
 
 When('we run a test', async function () {
-  logger.log('info', 'Hello simple log!')
+  logger.info('Hello simple log!')
 })

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/sum.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/sum.js
@@ -3,6 +3,6 @@
 const logger = require('./logger')
 
 module.exports = function (a, b) {
-  logger.log('info', 'sum function being called')
+  logger.info('sum function being called')
   return a + b
 }

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -76,6 +76,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'cucumber',
       command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature',
+      loggerNames: ['winston', 'bunyan'],
     },
     {
       name: 'playwright',


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Extends the automatic log-submission integration matrix with Bunyan for Cucumber.js. The Cucumber fixture reuses the shared `TEST_LOGGER` selection added by the Mocha slice.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is the second framework-specific slice of Bunyan support. It verifies that logs emitted during an active Cucumber scenario contain test trace and span correlation and reach the intake without adding Cucumber-specific production behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Stacked on #9920; the common Bunyan sender from #9906 is already merged into `master`.
- Contains integration-test changes only.
- Jest remains excluded because its custom module engine needs a separate change.
- Refreshed stack-head validation: `./node_modules/.bin/mocha --timeout 600000 integration-tests/ci-visibility/automatic-log-submission.spec.js` — 21 passing.
- Targeted ESLint and `git diff --check` — passing.
