### PR TITLE
fix(llmobs): flush events synchronously in AWS Lambda

### DIFF
--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -15,8 +15,8 @@ const {
   EVP_SUBDOMAIN_HEADER_NAME,
   EVP_PROXY_AGENT_BASE_PATH,
 } = require('../constants/writers')
-const { parseResponseAndLog } = require('./util')
 const { DATADOG_MINI_AGENT_PATH } = require('../../constants')
+const { parseResponseAndLog } = require('./util')
 
 // In Lambda, the execution environment can freeze between invocations, so a buffered
 // flush (interval timer or process 'beforeExit', which only ever fires once per
@@ -217,6 +217,13 @@ class BaseLLMObsWriter {
     this._endpoint = endpoint
 
     logger.debug(`Configuring ${this.constructor.name} to ${this.url}`)
+
+    // In Lambda mode there's no periodic/beforeExit fallback, so events appended
+    // before this resolves (e.g. while fetchAgentInfo() is in flight) would
+    // otherwise never get flushed.
+    if (this._flushOnAppend) {
+      this.flush()
+    }
   }
 
   _getUrlAndPath () {

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('node:fs')
 const { URL, format } = require('node:url')
 const path = require('node:path')
 const request = require('../../exporters/common/request')
@@ -15,6 +16,15 @@ const {
   EVP_PROXY_AGENT_BASE_PATH,
 } = require('../constants/writers')
 const { parseResponseAndLog } = require('./util')
+const { DATADOG_MINI_AGENT_PATH } = require('../../constants')
+
+// In Lambda, the execution environment can freeze between invocations, so a buffered
+// flush (interval timer or process 'beforeExit', which only ever fires once per
+// container) may never run before the next event is dropped. Mirrors the same check
+// used to force synchronous flushing of APM traces in config/index.js.
+function isRunningInLambda () {
+  return Boolean(getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME')) && !fs.existsSync(DATADOG_MINI_AGENT_PATH)
+}
 
 class LLMObsBuffer {
   constructor ({ events, size, routing = {}, isDefault = false, limit = 1000 }) {
@@ -51,15 +61,19 @@ class BaseLLMObsWriter {
     this._baseEndpoint = endpoint // should not be unset
     this._intake = intake
 
-    this._periodic = setInterval(() => {
-      this.flush()
-    }, this._interval)
-    this._periodic.unref?.()
+    this._flushOnAppend = isRunningInLambda()
 
-    const destroyer = this.destroy.bind(this)
-    globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(destroyer)
+    if (!this._flushOnAppend) {
+      this._periodic = setInterval(() => {
+        this.flush()
+      }, this._interval)
+      this._periodic.unref?.()
 
-    this.#destroyer = destroyer
+      const destroyer = this.destroy.bind(this)
+      globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(destroyer)
+
+      this.#destroyer = destroyer
+    }
   }
 
   // Split on protocol separator to preserve it
@@ -108,6 +122,11 @@ class BaseLLMObsWriter {
 
     buffer.size += eventSize
     buffer.events.push(event)
+
+    if (this._flushOnAppend) {
+      this.flush()
+    }
+
     return true
   }
 
@@ -185,6 +204,8 @@ class BaseLLMObsWriter {
       globalThis[Symbol.for('dd-trace')].beforeExitHandlers.delete(this.#destroyer)
       this.flush()
       this.#destroyer = undefined
+    } else if (this._flushOnAppend) {
+      this.flush()
     }
   }
 

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fs = require('node:fs')
 const { URL, format } = require('node:url')
 const path = require('node:path')
 const request = require('../../exporters/common/request')
@@ -15,16 +14,7 @@ const {
   EVP_SUBDOMAIN_HEADER_NAME,
   EVP_PROXY_AGENT_BASE_PATH,
 } = require('../constants/writers')
-const { DATADOG_MINI_AGENT_PATH } = require('../../constants')
 const { parseResponseAndLog } = require('./util')
-
-// In Lambda, the execution environment can freeze between invocations, so a buffered
-// flush (interval timer or process 'beforeExit', which only ever fires once per
-// container) may never run before the next event is dropped. Mirrors the same check
-// used to force synchronous flushing of APM traces in config/index.js.
-function isRunningInLambda () {
-  return Boolean(getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME')) && !fs.existsSync(DATADOG_MINI_AGENT_PATH)
-}
 
 class LLMObsBuffer {
   constructor ({ events, size, routing = {}, isDefault = false, limit = 1000 }) {
@@ -43,12 +33,19 @@ class LLMObsBuffer {
 
 class BaseLLMObsWriter {
   #destroyer
+  // In Lambda, `config.flushInterval` is forced to 0 (see config/index.js) because the execution
+  // environment can freeze between invocations, so a buffered flush (interval timer or process
+  // 'beforeExit', which only ever fires once per container) may never run before the next event
+  // is dropped. Evaluated once here rather than re-read on every append().
+  #flushOnAppend
   /** @type {Map<string, LLMObsBuffer>} */
   #multiTenantBuffers = new Map()
 
-  constructor ({ interval, timeout, eventType, config, endpoint, intake }) {
-    this._interval = interval ?? getEnvironmentVariable('_DD_LLMOBS_FLUSH_INTERVAL') ?? 1000 // 1s
-    this._timeout = timeout ?? getEnvironmentVariable('_DD_LLMOBS_TIMEOUT') ?? 5000 // 5s
+  constructor ({ eventType, config, endpoint, intake }) {
+    // Falls back to the tracer-wide flush interval for a consistent default across writers,
+    // but stays independently overridable so tests can flush the LLMObs writer faster than APM.
+    this._interval = getEnvironmentVariable('_DD_LLMOBS_FLUSH_INTERVAL') ?? config.flushInterval ?? 1000 // 1s
+    this._timeout = getEnvironmentVariable('_DD_LLMOBS_TIMEOUT') ?? 5000 // 5s
     this._eventType = eventType
 
     /** @type {LLMObsBuffer} */
@@ -61,9 +58,9 @@ class BaseLLMObsWriter {
     this._baseEndpoint = endpoint // should not be unset
     this._intake = intake
 
-    this._flushOnAppend = isRunningInLambda()
+    this.#flushOnAppend = config.flushInterval === 0
 
-    if (!this._flushOnAppend) {
+    if (!this.#flushOnAppend) {
       this._periodic = setInterval(() => {
         this.flush()
       }, this._interval)
@@ -123,7 +120,7 @@ class BaseLLMObsWriter {
     buffer.size += eventSize
     buffer.events.push(event)
 
-    if (this._flushOnAppend) {
+    if (this.#flushOnAppend) {
       this.flush()
     }
 
@@ -204,7 +201,7 @@ class BaseLLMObsWriter {
       globalThis[Symbol.for('dd-trace')].beforeExitHandlers.delete(this.#destroyer)
       this.flush()
       this.#destroyer = undefined
-    } else if (this._flushOnAppend) {
+    } else if (this.#flushOnAppend) {
       this.flush()
     }
   }
@@ -221,7 +218,7 @@ class BaseLLMObsWriter {
     // In Lambda mode there's no periodic/beforeExit fallback, so events appended
     // before this resolves (e.g. while fetchAgentInfo() is in flight) would
     // otherwise never get flushed.
-    if (this._flushOnAppend) {
+    if (this.#flushOnAppend) {
       this.flush()
     }
   }

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -4,6 +4,7 @@ const { URL, format } = require('node:url')
 const path = require('node:path')
 const request = require('../../exporters/common/request')
 const { getEnvironmentVariable } = require('../../config/helper')
+const { isLambdaExtensionPresent } = require('../../serverless')
 
 const logger = require('../../log')
 
@@ -33,10 +34,12 @@ class LLMObsBuffer {
 
 class BaseLLMObsWriter {
   #destroyer
-  // In Lambda, `config.flushInterval` is forced to 0 (see config/index.js) because the execution
-  // environment can freeze between invocations, so a buffered flush (interval timer or process
-  // 'beforeExit', which only ever fires once per container) may never run before the next event
-  // is dropped. Evaluated once here rather than re-read on every append().
+  // In Lambda, the execution environment can freeze between invocations, so a buffered flush
+  // (interval timer or process 'beforeExit', which only ever fires once per container) may never
+  // run before the next event is dropped. `config.flushInterval` is forced to 0 (see config/index.js)
+  // when there's no extension to hand events off to, and when the extension IS present, flushing on
+  // append is cheap (a local call to a co-located sidecar) so it's worth doing eagerly there too.
+  // Evaluated once here rather than re-read on every append().
   #flushOnAppend
   /** @type {Map<string, LLMObsBuffer>} */
   #multiTenantBuffers = new Map()
@@ -58,7 +61,7 @@ class BaseLLMObsWriter {
     this._baseEndpoint = endpoint // should not be unset
     this._intake = intake
 
-    this.#flushOnAppend = config.flushInterval === 0
+    this.#flushOnAppend = config.flushInterval === 0 || isLambdaExtensionPresent()
 
     if (!this.#flushOnAppend) {
       this._periodic = setInterval(() => {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const fs = require('node:fs')
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
+const { DATADOG_LAMBDA_EXTENSION_PATH, DATADOG_MINI_AGENT_PATH } = require('./constants')
 
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
@@ -32,6 +34,17 @@ function getIsAzureFunction () {
 
 function getIsFlexConsumptionAzureFunction () {
   return getIsAzureFunction() && getEnvironmentVariable('WEBSITE_SKU') === 'FlexConsumption'
+}
+
+/**
+ * Whether the Datadog Lambda Extension (or mini agent) is running alongside the function,
+ * i.e. traces/events can be handed off to a local sidecar instead of an external intake.
+ */
+function isLambdaExtensionPresent () {
+  return getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME') !== undefined && (
+    fs.existsSync(DATADOG_LAMBDA_EXTENSION_PATH) ||
+    fs.existsSync(DATADOG_MINI_AGENT_PATH)
+  )
 }
 
 function isInServerlessEnvironment () {
@@ -84,5 +97,6 @@ module.exports = {
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  isLambdaExtensionPresent,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -192,6 +192,21 @@ describe('BaseLLMObsWriter', () => {
       assert.strictEqual(writer._buffer.events.length, 0)
       sinon.assert.calledOnce(request)
     })
+
+    it('flushes an event appended before the agent strategy resolves', () => {
+      writer = new BaseLLMObsWriter(options)
+      writer.makePayload = (events) => ({ events })
+
+      writer.append({ foo: 'bar' })
+
+      assert.strictEqual(writer._buffer.events.length, 1)
+      sinon.assert.notCalled(request)
+
+      writer.setAgentless(true)
+
+      assert.strictEqual(writer._buffer.events.length, 0)
+      sinon.assert.calledOnce(request)
+    })
   })
 
   describe('flush', () => {

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -176,6 +176,24 @@ describe('BaseLLMObsWriter', () => {
     sinon.assert.calledWith(logger.warn, 'BaseLLMObsWriter event buffer full (limit is 1000), dropping event')
   })
 
+  describe('in a Lambda environment', () => {
+    useEnv({
+      AWS_LAMBDA_FUNCTION_NAME: 'my-function',
+    })
+
+    it('flushes synchronously on append instead of using a periodic timer', () => {
+      writer = new BaseLLMObsWriter(options)
+      writer.setAgentless(true)
+      writer.makePayload = (events) => ({ events })
+
+      writer.append({ foo: 'bar' })
+
+      assert.strictEqual(writer._periodic, undefined)
+      assert.strictEqual(writer._buffer.events.length, 0)
+      sinon.assert.calledOnce(request)
+    })
+  })
+
   describe('flush', () => {
     it('flushes a buffer in agentless mode', () => {
       writer = new BaseLLMObsWriter(options)

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -210,6 +210,31 @@ describe('BaseLLMObsWriter', () => {
     })
   })
 
+  describe('when the Lambda extension is present', () => {
+    beforeEach(() => {
+      BaseLLMObsWriter = proxyquire('../../../src/llmobs/writers/base', {
+        '../../exporters/common/request': request,
+        '../../log': logger,
+        '../../serverless': { isLambdaExtensionPresent: () => true },
+        './util': proxyquire('../../../src/llmobs/writers/util', {
+          '../../log': logger,
+        }),
+      })
+    })
+
+    it('flushes synchronously on append instead of using a periodic timer', () => {
+      writer = new BaseLLMObsWriter(options)
+      writer.setAgentless(false)
+      writer.makePayload = (events) => ({ events })
+
+      writer.append({ foo: 'bar' })
+
+      assert.strictEqual(writer._periodic, undefined)
+      assert.strictEqual(writer._buffer.events.length, 0)
+      sinon.assert.calledOnce(request)
+    })
+  })
+
   describe('flush', () => {
     it('flushes a buffer in agentless mode', () => {
       writer = new BaseLLMObsWriter(options)

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -44,6 +44,7 @@ describe('BaseLLMObsWriter', () => {
         site: 'site.com',
         url: new URL('http://localhost:8126'),
         DD_API_KEY: 'test',
+        flushInterval: 1000,
       },
     }
   })
@@ -176,9 +177,9 @@ describe('BaseLLMObsWriter', () => {
     sinon.assert.calledWith(logger.warn, 'BaseLLMObsWriter event buffer full (limit is 1000), dropping event')
   })
 
-  describe('in a Lambda environment', () => {
-    useEnv({
-      AWS_LAMBDA_FUNCTION_NAME: 'my-function',
+  describe('when flushInterval is 0 (e.g. in a Lambda environment)', () => {
+    beforeEach(() => {
+      options.config.flushInterval = 0
     })
 
     it('flushes synchronously on append instead of using a periodic timer', () => {

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -3,11 +3,49 @@
 const assert = require('node:assert/strict')
 
 const { describe, it, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
 
 require('./setup/core')
 
 const { getServerlessPlatformTags, enableGCPPubSubPushSubscription } = require('../src/serverless')
 const agent = require('./plugins/agent')
+
+describe('isLambdaExtensionPresent', () => {
+  const originalFunctionName = process.env.AWS_LAMBDA_FUNCTION_NAME
+
+  afterEach(() => {
+    if (originalFunctionName === undefined) delete process.env.AWS_LAMBDA_FUNCTION_NAME
+    else process.env.AWS_LAMBDA_FUNCTION_NAME = originalFunctionName
+  })
+
+  function isLambdaExtensionPresentWithFs (existsSync) {
+    return proxyquire('../src/serverless', {
+      'node:fs': { existsSync },
+    }).isLambdaExtensionPresent
+  }
+
+  it('is false outside of Lambda', () => {
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME
+    assert.strictEqual(isLambdaExtensionPresentWithFs(() => true)(), false)
+  })
+
+  it('is false in Lambda when neither the extension nor the mini agent is present', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-function'
+    assert.strictEqual(isLambdaExtensionPresentWithFs(() => false)(), false)
+  })
+
+  it('is true in Lambda when the extension is present', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-function'
+    const existsSync = (path) => path === '/opt/extensions/datadog-agent'
+    assert.strictEqual(isLambdaExtensionPresentWithFs(existsSync)(), true)
+  })
+
+  it('is true in Lambda when the mini agent is present', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-function'
+    const existsSync = (path) => path === '/tmp/datadog/mini_agent_ready'
+    assert.strictEqual(isLambdaExtensionPresentWithFs(existsSync)(), true)
+  })
+})
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE


### PR DESCRIPTION
## Summary
`BaseLLMObsWriter` buffers events on a 1s `setInterval` (`.unref()`'d, so it can't keep the process alive) and flushes on the process `beforeExit` event as a backstop. In Lambda, the execution environment can freeze between invocations before that timer ever fires, and `beforeExit` is registered once per process lifetime (`process.once('beforeExit', ...)` in `packages/dd-trace/index.js`), not once per invocation — so on a warm container, at most one invocation's events ever get flushed, and everything else is silently dropped until the container is recycled.

This surfaced as `ml_obs.trace` being emitted unreliably (far below the number of invocations) for node Lambda functions in `serverless-e2e-tests`.

## What changed
Mirrors the existing `AWS_LAMBDA_FUNCTION_NAME` check already used to force synchronous flushing of APM traces (`config/index.js`'s `flushInterval = 0`): in `BaseLLMObsWriter`, detect the same condition and flush immediately after `append()` instead of relying on the interval/`beforeExit` path.

## Validation
Deployed a patched `Datadog-Node22-x`/`Datadog-Node24-x` layer to a sandbox Lambda stack (`serverless-e2e-tests`' `lambda-features`), invoked each runtime 3 times, and confirmed `ml_obs.trace` = 3/3 for both node22 and node24 in Datadog — previously the stock layer produced 1/6 and 0/6 respectively across 6 invocations each.