### PR TITLE
feat(llmobs): capture inline images for openai chat completions and responses

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/openai-agents/utils.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai-agents/utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { extractContentParts, extractTextFromContentItem } = require('../openai/utils')
+const { INPUT_TYPE_IMAGE } = require('../openai/constants')
+const { extractContentParts, extractResponseInputContent, extractTextFromContentItem } = require('../openai/utils')
 const { safeJsonParse } = require('../../util')
 
 /**
@@ -8,14 +9,30 @@ const { safeJsonParse } = require('../../util')
  * provider-specific image or audio inputs.
  *
  * @param {Array<object>} parts
- * @returns {{ content: string, audioParts: Array<{ mimeType: string, content: string }> }}
+ * @returns {{
+ *   content: string,
+ *   audioParts: Array<{ mimeType: string, content: string }>,
+ *   imageParts: Array<{ mimeType: string, content: string }>,
+ * }}
  */
 function extractMessageContent (parts) {
   const contentParts = []
   const audioParts = []
+  const imageParts = []
 
   for (const part of parts) {
     if (!part) continue
+
+    // Responses-shape images are handled before the text path: `extractTextFromContentItem` returns
+    // the raw `image_url` for an `input_image`, which would splice an entire inline base64 payload
+    // into the text instead of attaching it as an image part.
+    if (part.type === INPUT_TYPE_IMAGE) {
+      const extracted = extractResponseInputContent([part])
+      if (extracted.content) contentParts.push(extracted.content)
+      if (extracted.imageParts.length > 0) imageParts.push(...extracted.imageParts)
+      continue
+    }
+
     const text = extractTextFromContentItem(part)
     if (text) {
       contentParts.push(text)
@@ -25,9 +42,10 @@ function extractMessageContent (parts) {
     const extracted = extractContentParts([part])
     if (extracted.content) contentParts.push(extracted.content)
     if (extracted.audioParts.length > 0) audioParts.push(...extracted.audioParts)
+    if (extracted.imageParts.length > 0) imageParts.push(...extracted.imageParts)
   }
 
-  return { content: contentParts.join(''), audioParts }
+  return { content: contentParts.join(''), audioParts, imageParts }
 }
 
 /**
@@ -72,6 +90,7 @@ function normalizeChatCompletionMessage (message) {
     content: message.content ?? '',
   }
   if (message.audioParts?.length > 0) normalized.audioParts = message.audioParts
+  if (message.imageParts?.length > 0) normalized.imageParts = message.imageParts
   const toolCalls = extractChatCompletionToolCalls(message)
   if (toolCalls.length > 0) normalized.toolCalls = toolCalls
   if (message.tool_call_id) normalized.toolId = message.tool_call_id
@@ -105,16 +124,18 @@ function extractInputMessages (input, instructions) {
 
         let content = ''
         let audioParts
+        let imageParts
         if (Array.isArray(item.content)) {
           const extracted = extractMessageContent(item.content)
           content = extracted.content
           audioParts = extracted.audioParts
+          imageParts = extracted.imageParts
         } else if (typeof item.content === 'string') {
           content = item.content
         }
 
-        const message = normalizeChatCompletionMessage({ ...item, content, role, audioParts })
-        if (content || message.audioParts || message.toolCalls || message.toolId) {
+        const message = normalizeChatCompletionMessage({ ...item, content, role, audioParts, imageParts })
+        if (content || message.audioParts || message.imageParts || message.toolCalls || message.toolId) {
           messages.push(message)
         }
       } else if (item.type === 'function_call') {

--- a/packages/dd-trace/src/llmobs/plugins/openai/constants.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/constants.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { EVP_EVENT_SIZE_LIMIT } = require('../../constants/writers')
+
 const INPUT_TYPE_IMAGE = 'input_image'
 const INPUT_TYPE_FILE = 'input_file'
 const INPUT_TYPE_TEXT = 'input_text'
@@ -7,6 +9,23 @@ const INPUT_TYPE_TEXT = 'input_text'
 const IMAGE_FALLBACK = '[image]'
 const FILE_FALLBACK = '[file]'
 const AUDIO_FALLBACK = '[audio]'
+const IMAGE_TOO_LARGE_FALLBACK = '[image omitted: too large]'
+
+// A single inline image may take at most 80% of the per-event budget. An image past this on its own
+// would push the event over EVP_EVENT_SIZE_LIMIT, and the writer then drops the span's input AND
+// output wholesale (`writers/spans.js#_truncateSpanEvent`), losing the prompt text too; a marker
+// keeps the message instead. Same 0.8 fraction as dd-trace-py, though the byte value differs because
+// this limit is 5 MiB where dd-trace-py's is 5 MB.
+//
+// This bounds one image, NOT a request: several images that each fit can still exceed the event limit
+// together and trigger the same whole-IO drop, and audio parts count toward no budget at all. A
+// running per-request budget is the real fix; dd-trace-py has the identical gap (MLOB-6408).
+const MAX_IMAGE_CONTENT_BYTES = Math.floor(EVP_EVENT_SIZE_LIMIT * 0.8)
+
+// Longest text we will record for an image we could not capture (a remote URL or a `file_id`). Real
+// references are far shorter; anything longer is a payload masquerading as a reference, so it becomes
+// a marker rather than being spliced into the message text.
+const MAX_IMAGE_REFERENCE_LENGTH = 2048
 
 // OpenAI audio `format` values that don't map cleanly to `audio/<format>`.
 const AUDIO_MIME_TYPES = {
@@ -18,6 +37,9 @@ module.exports = {
   INPUT_TYPE_FILE,
   INPUT_TYPE_TEXT,
   IMAGE_FALLBACK,
+  IMAGE_TOO_LARGE_FALLBACK,
+  MAX_IMAGE_CONTENT_BYTES,
+  MAX_IMAGE_REFERENCE_LENGTH,
   FILE_FALLBACK,
   AUDIO_FALLBACK,
   AUDIO_MIME_TYPES,

--- a/packages/dd-trace/src/llmobs/plugins/openai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/index.js
@@ -11,8 +11,8 @@ const { AUDIO_MIME_TYPES } = require('./constants')
 const {
   extractChatTemplateFromInstructions,
   normalizePromptVariables,
-  extractTextFromContentItem,
   extractContentParts,
+  extractResponseInputContent,
   hasMultimodalInputs,
   getOpenAIModelProvider,
 } = require('./utils')
@@ -32,17 +32,19 @@ function isIterable (obj) {
 }
 
 // Flattens multimodal chat input messages (array `content`) into readable text plus structured
-// `audioParts`, leaving plain-string messages untouched. Model-agnostic: keys off message
-// structure, so it works for any audio-capable chat model (gpt-audio*, gpt-4o-audio-preview, ...).
+// `audioParts` and `imageParts`, leaving plain-string messages untouched. Model-agnostic: keys off
+// message structure, so it works for any audio- or vision-capable chat model (gpt-audio*,
+// gpt-4o-audio-preview, gpt-4o, ...).
 function flattenChatInputMessages (messages) {
   if (!Array.isArray(messages)) return messages
 
   return messages.map(message => {
     if (!Array.isArray(message?.content)) return message
 
-    const { content, audioParts } = extractContentParts(message.content)
+    const { content, audioParts, imageParts } = extractContentParts(message.content)
     const flattenedMessage = { ...message, content }
     if (audioParts.length) flattenedMessage.audioParts = audioParts
+    if (imageParts.length) flattenedMessage.imageParts = imageParts
     return flattenedMessage
   })
 }
@@ -294,17 +296,20 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
           if (!role) continue
 
           let content = ''
+          let imageParts
           if (Array.isArray(item.content)) {
-            const textParts = item.content
-              .map(extractTextFromContentItem)
-              .filter(Boolean)
-            content = textParts.join('')
+            const extracted = extractResponseInputContent(item.content)
+            content = extracted.content
+            if (extracted.imageParts.length) imageParts = extracted.imageParts
           } else if (typeof item.content === 'string') {
             content = item.content
           }
 
-          if (content) {
-            inputMessages.push({ role, content })
+          // An image-only message carries no text, so it would otherwise be dropped here.
+          if (content || imageParts) {
+            const inputMessage = { role, content }
+            if (imageParts) inputMessage.imageParts = imageParts
+            inputMessages.push(inputMessage)
           }
         } else if (item.type === 'function_call') {
           inputMessages.push({

--- a/packages/dd-trace/src/llmobs/plugins/openai/utils.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/utils.js
@@ -1,11 +1,14 @@
 'use strict'
 
 const { UNKNOWN_MODEL_PROVIDER } = require('../../constants/tags')
-const { audioMimeTypeFromFormat, formatAudioPart } = require('../../util')
+const { audioMimeTypeFromFormat, formatAudioPart, imagePartFromDataUri, isDataUri } = require('../../util')
 const {
   INPUT_TYPE_IMAGE,
   INPUT_TYPE_FILE,
   IMAGE_FALLBACK,
+  IMAGE_TOO_LARGE_FALLBACK,
+  MAX_IMAGE_CONTENT_BYTES,
+  MAX_IMAGE_REFERENCE_LENGTH,
   FILE_FALLBACK,
   AUDIO_FALLBACK,
   AUDIO_MIME_TYPES,
@@ -123,26 +126,67 @@ function hasMultimodalInputs (variables) {
 }
 
 /**
- * Flattens an array of OpenAI chat message content parts into readable text plus structured audio.
+ * Decides how one OpenAI image reference is recorded.
  *
- * Text parts are concatenated (newline-joined),
- * images collapse to an `[image]` marker, and `input_audio` parts with data are captured as audio
- * parts (rendered as a player). The `[audio]` marker is only emitted as a fallback when an audio
- * part carries no data.
+ * Returns `{ imagePart }` for an inline base64 image small enough to ship, `{ marker }` for a data
+ * URI that cannot be attached — either too large, or one we could not parse — and `undefined` only
+ * when the reference is not inline at all (a remote `https://` URL or a `file_id`), in which case the
+ * caller keeps whatever text reference it already recorded.
+ *
+ * An unparseable data URI must return a marker rather than `undefined`: it still carries its entire
+ * payload, so letting the caller fall back to the raw reference would splice megabytes of base64
+ * into the message text, uncapped. dd-trace-py guards the same case the same way.
+ *
+ * Exactly one of the two fields is ever set; this is the only function that builds the result.
+ *
+ * @param {string | undefined} imageUrl
+ * @returns {{ imagePart?: { mimeType: string, content: string }, marker?: string } | undefined}
+ */
+function captureInlineImage (imageUrl) {
+  const imagePart = imagePartFromDataUri(imageUrl)
+  if (!imagePart) return isDataUri(imageUrl) ? { marker: IMAGE_FALLBACK } : undefined
+
+  // Measured in bytes, not UTF-16 units: valid base64 is ASCII so the two agree, but a payload with
+  // multi-byte characters would otherwise pass a byte-named cap at twice the size.
+  return Buffer.byteLength(imagePart.content) > MAX_IMAGE_CONTENT_BYTES
+    ? { marker: IMAGE_TOO_LARGE_FALLBACK }
+    : { imagePart }
+}
+
+/**
+ * Flattens an array of OpenAI chat message content parts into readable text plus structured media.
+ *
+ * Text parts are concatenated (newline-joined). `input_audio` parts with data are captured as audio
+ * parts (rendered as a player), and `image_url` parts carrying an inline base64 data URI are
+ * captured as image parts (rendered inline). A remote image URL still collapses to an `[image]`
+ * marker, since only the reference is available and fetching it is not the tracer's job. The
+ * `[audio]` marker is only emitted as a fallback when an audio part carries no data.
  *
  * @param {Array<object>} parts - Array of content parts from a chat message `content`
- * @returns {{ content: string, audioParts: Array<{ mimeType: string, content: string }> }}
+ * @returns {{
+ *   content: string,
+ *   audioParts: Array<{ mimeType: string, content: string }>,
+ *   imageParts: Array<{ mimeType: string, content: string }>,
+ * }}
  */
 function extractContentParts (parts) {
   const extracted = []
   const audioParts = []
+  const imageParts = []
 
   for (const part of parts) {
     const partType = part?.type ?? ''
     if (partType === 'text') {
       extracted.push(part.text ?? '')
     } else if (partType === 'image_url') {
-      extracted.push(IMAGE_FALLBACK)
+      // `{ url }` is the documented shape; a bare string is tolerated as the SDK accepts it.
+      const captured = captureInlineImage(part.image_url?.url ?? part.image_url)
+      if (captured?.imagePart) {
+        // Captured as a structured image part, so no text marker is needed.
+        imageParts.push(captured.imagePart)
+      } else {
+        extracted.push(captured?.marker ?? IMAGE_FALLBACK)
+      }
     } else if (partType === 'input_audio') {
       const inputAudio = part.input_audio ?? {}
       const data = inputAudio.data
@@ -158,7 +202,53 @@ function extractContentParts (parts) {
     }
   }
 
-  return { content: extracted.join('\n'), audioParts }
+  return { content: extracted.join('\n'), audioParts, imageParts }
+}
+
+/**
+ * Splits a Responses-API input content array into text plus structured image parts.
+ *
+ * Text handling matches `extractTextFromContentItem` joined with no separator, which is what this
+ * replaced. The only behavioural change is that an `input_image` carrying an inline base64 data URI
+ * becomes a structured image part instead of having its entire payload spliced into the text.
+ *
+ * @param {Array<object>} parts - Array of content items from a Responses-API input message
+ * @returns {{ content: string, imageParts: Array<{ mimeType: string, content: string }> }}
+ */
+function extractResponseInputContent (parts) {
+  const texts = []
+  const imageParts = []
+
+  for (const part of parts) {
+    if (part?.type === INPUT_TYPE_IMAGE) {
+      // An `input_image` carrying alt text is off-schema but reaches us; keep the text, and capture
+      // the image alongside it rather than letting one silently replace the other.
+      if (part.text) texts.push(part.text)
+
+      const captured = captureInlineImage(part.image_url)
+      if (captured?.imagePart) {
+        imageParts.push(captured.imagePart)
+      } else if (captured?.marker) {
+        texts.push(captured.marker)
+      } else if (!part.text) {
+        // Not inline, so record the reference itself — bounded. `captureInlineImage` only recognises
+        // a well-formed `data:` URI; a payload that merely *fails* to look like one (a leading space,
+        // an array that string-coerces, raw base64 with no scheme at all) would otherwise be spliced
+        // in whole and uncapped. The length bound is what actually makes "a payload is never emitted
+        // as text" hold, instead of relying on recognising every malformed spelling of a data URI.
+        const reference = part.image_url || part.file_id
+        texts.push(typeof reference === 'string' && reference.length <= MAX_IMAGE_REFERENCE_LENGTH
+          ? reference
+          : IMAGE_FALLBACK)
+      }
+      continue
+    }
+
+    const text = extractTextFromContentItem(part)
+    if (text) texts.push(text)
+  }
+
+  return { content: texts.join(''), imageParts }
 }
 
 /**
@@ -184,6 +274,7 @@ module.exports = {
   normalizePromptVariables,
   extractTextFromContentItem,
   extractContentParts,
+  extractResponseInputContent,
   hasMultimodalInputs,
   getOpenAIModelProvider,
 }

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -501,7 +501,7 @@ function audioMimeTypeFromFormat (fmt, mimeTypeLookup = {}) {
   return mimeTypeLookup[fmt] ?? `audio/${fmt}`
 }
 
-// Builds an audio part from raw audio bytes (base64-encoded) or an existing base64 string. Only
+// Builds a media part from raw bytes (base64-encoded) or an existing base64 string. Only
 // Buffer/Uint8Array inputs are base64-encoded; any other shape is passed through so a malformed
 // auto-instrumented payload can't throw (the tagger soft-skips a non-string `content`).
 /**
@@ -509,11 +509,72 @@ function audioMimeTypeFromFormat (fmt, mimeTypeLookup = {}) {
  * @param {string} mimeType
  * @returns {{ mimeType: string, content: string }}
  */
-function formatAudioPart (data, mimeType) {
+function formatMediaPart (data, mimeType) {
   const content = Buffer.isBuffer(data) || ArrayBuffer.isView(data)
     ? Buffer.from(data).toString('base64')
     : data
   return { mimeType, content }
+}
+
+// Audio and image parts share a wire shape, so they share the builder. Both names are
+// exported so call sites read for the modality they handle.
+const formatAudioPart = formatMediaPart
+const formatImagePart = formatMediaPart
+
+const DATA_URI_PREFIX = 'data:'
+const BASE64_MARKER = ';base64'
+const IMAGE_MIME_PREFIX = 'image/'
+// `image/` plus a subtype and any parameters; RFC 6838 caps a subtype at 127 characters.
+const MAX_MEDIA_TYPE_LENGTH = 255
+
+// True when the reference is an inline `data:` URI, whatever its media type or encoding.
+//
+// Callers need this to tell "not inline, so keep the remote reference as text" apart from "inline but
+// unparseable, which must never be recorded verbatim" — a data URI we failed to parse still carries
+// its whole payload, so falling back to the raw reference would emit megabytes of base64 as text.
+// Only the 5-character prefix is lowercased; lowercasing the whole URL would copy the payload.
+/**
+ * @param {string | undefined} url
+ * @returns {url is string} - a type predicate, so callers narrow `url` before slicing it
+ */
+function isDataUri (url) {
+  return typeof url === 'string' &&
+    url.slice(0, DATA_URI_PREFIX.length).toLowerCase() === DATA_URI_PREFIX
+}
+
+// Parses a base64 `data:` URI carrying an image into an image part.
+//
+// Returns undefined for anything that isn't an inline base64 image — a remote `https://` link, a
+// `file_id` reference, a non-image media type, a non-base64 (percent-encoded) data URI, or a
+// malformed one. Pair it with `isDataUri` so an unparseable data URI becomes a marker rather than
+// raw text. Media-type parameters (`;charset=...`) are dropped to match the `mime_type` the backend
+// expects. Scheme and media type are matched case-insensitively, as dd-trace-py's regex is.
+//
+// Whitespace inside the payload is deliberately not stripped: a well-formed data URI has none,
+// base64 decoders tolerate it, and scanning a multi-megabyte string on every image would cost
+// more than it saves. This differs from dd-trace-py, which normalizes it.
+/**
+ * @param {string | undefined} url - a caller may pass an absent reference straight through
+ * @returns {{ mimeType: string, content: string } | undefined}
+ */
+function imagePartFromDataUri (url) {
+  if (!isDataUri(url)) return
+
+  // A media type plus its parameters is short. Bailing on an oversized header keeps a crafted one
+  // from being copied and, worse, emitted as a multi-megabyte `mime_type` that bypasses the content
+  // cap entirely. Checked before any slice of the header is taken.
+  const comma = url.indexOf(',')
+  if (comma === -1 || comma - DATA_URI_PREFIX.length > MAX_MEDIA_TYPE_LENGTH) return
+
+  const header = url.slice(DATA_URI_PREFIX.length, comma)
+  if (header.slice(-BASE64_MARKER.length).toLowerCase() !== BASE64_MARKER) return
+
+  // `header` ends with `;base64`, so there is always at least one semicolon to slice on.
+  const mimeType = header.slice(0, header.indexOf(';')).toLowerCase()
+  if (!mimeType.startsWith(IMAGE_MIME_PREFIX) || mimeType.length === IMAGE_MIME_PREFIX.length) return
+
+  const base64 = url.slice(comma + 1)
+  return base64 ? formatImagePart(base64, mimeType) : undefined
 }
 
 module.exports = {
@@ -523,9 +584,12 @@ module.exports = {
   encodeUnicode,
   findGenAIAncestorSpanId,
   generateLlmObsTraceId,
+  imagePartFromDataUri,
+  isDataUri,
   llmObsTraceIdToWire,
   normalizeLlmObsTraceId,
   formatAudioPart,
+  formatImagePart,
   resolveAgentAttribution,
   stripTagsetEntry,
   validateCostTags,

--- a/packages/dd-trace/test/llmobs/cassettes/openai/openai_chat_completions_post_345f0067.json
+++ b/packages/dd-trace/test/llmobs/cassettes/openai/openai_chat_completions_post_345f0067.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "headers": {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      "Accept-Encoding": "gzip,deflate",
+      "Connection": "keep-alive"
+    },
+    "body": "{\n  \"model\": \"gpt-4o\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"What is in this image?\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=\"\n          }\n        }\n      ]\n    }\n  ]\n}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "Connection": "keep-alive",
+      "Content-Type": "application/json",
+      "openai-version": "2020-10-01",
+      "x-request-id": "req_inlineimagebase64capture0001"
+    },
+    "body": "{\n  \"id\": \"chatcmpl-CImageInlineB64Capture0000000\",\n  \"object\": \"chat.completion\",\n  \"created\": 1757967709,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"The image is a single solid-colored pixel, too small to show any discernible subject.\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 40,\n    \"completion_tokens\": 18,\n    \"total_tokens\": 58,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_inlineimage01\"\n}"
+  }
+}

--- a/packages/dd-trace/test/llmobs/openai-agents-utils.spec.js
+++ b/packages/dd-trace/test/llmobs/openai-agents-utils.spec.js
@@ -63,6 +63,45 @@ describe('openai-agents utils', () => {
       )
     })
 
+    it('captures a Chat Completions inline base64 image', () => {
+      const input = [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is in this image?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+        ],
+      }]
+
+      assert.deepStrictEqual(
+        extractInputMessages(input),
+        [{
+          role: 'user',
+          content: 'what is in this image?',
+          imageParts: [{ mimeType: 'image/png', content: 'iVBORw0KGgo=' }],
+        }]
+      )
+    })
+
+    it('captures a Responses inline base64 image instead of inlining it into the text', () => {
+      const input = [{
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'inspect ' },
+          { type: 'input_image', image_url: 'data:image/jpeg;base64,/9j/4AAQ' },
+        ],
+      }]
+
+      assert.deepStrictEqual(
+        extractInputMessages(input),
+        [{
+          role: 'user',
+          content: 'inspect ',
+          imageParts: [{ mimeType: 'image/jpeg', content: '/9j/4AAQ' }],
+        }]
+      )
+    })
+
     it('ignores null items and preserves image and file input parts', () => {
       const input = [
         null,

--- a/packages/dd-trace/test/llmobs/openai-utils.spec.js
+++ b/packages/dd-trace/test/llmobs/openai-utils.spec.js
@@ -1,9 +1,19 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { getOpenAIModelProvider } = require('../../src/llmobs/plugins/openai/utils')
+const {
+  extractContentParts,
+  extractResponseInputContent,
+  getOpenAIModelProvider,
+} = require('../../src/llmobs/plugins/openai/utils')
 const OpenAiLLMObsPlugin = require('../../src/llmobs/plugins/openai')
+const { MAX_IMAGE_CONTENT_BYTES, MAX_IMAGE_REFERENCE_LENGTH } = require('../../src/llmobs/plugins/openai/constants')
 const { UNKNOWN_MODEL_PROVIDER } = require('../../src/llmobs/constants/tags')
+const { EVP_EVENT_SIZE_LIMIT } = require('../../src/llmobs/constants/writers')
+
+const PNG_B64 = 'iVBORw0KGgo='
+const PNG_DATA_URI = `data:image/png;base64,${PNG_B64}`
+const REMOTE_URL = 'https://raw.githubusercontent.com/github/explore/main/topics/python/python.png'
 
 describe('getOpenAIModelProvider', () => {
   it('returns openai for openai.com URLs', () => {
@@ -27,6 +37,241 @@ describe('getOpenAIModelProvider', () => {
 
   it('defaults to unknown provider for an empty string', () => {
     assert.strictEqual(getOpenAIModelProvider(''), UNKNOWN_MODEL_PROVIDER)
+  })
+})
+
+describe('extractContentParts', () => {
+  it('captures an inline base64 image and leaves no text marker', () => {
+    assert.deepStrictEqual(
+      extractContentParts([
+        { type: 'text', text: 'What is in this image?' },
+        { type: 'image_url', image_url: { url: PNG_DATA_URI } },
+      ]),
+      {
+        content: 'What is in this image?',
+        audioParts: [],
+        imageParts: [{ mimeType: 'image/png', content: PNG_B64 }],
+      }
+    )
+  })
+
+  it('accepts a bare-string image_url as well as the documented { url } shape', () => {
+    assert.deepStrictEqual(
+      extractContentParts([{ type: 'image_url', image_url: PNG_DATA_URI }]),
+      { content: '', audioParts: [], imageParts: [{ mimeType: 'image/png', content: PNG_B64 }] }
+    )
+  })
+
+  it('keeps the [image] marker for a remote URL', () => {
+    assert.deepStrictEqual(
+      extractContentParts([
+        { type: 'text', text: 'What is in this image?' },
+        { type: 'image_url', image_url: { url: REMOTE_URL } },
+      ]),
+      { content: 'What is in this image?\n[image]', audioParts: [], imageParts: [] }
+    )
+  })
+
+  it('captures several images from one message independently', () => {
+    assert.deepStrictEqual(
+      extractContentParts([
+        { type: 'image_url', image_url: { url: PNG_DATA_URI } },
+        { type: 'text', text: 'and' },
+        { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,/9j/4AAQ' } },
+      ]),
+      {
+        content: 'and',
+        audioParts: [],
+        imageParts: [
+          { mimeType: 'image/png', content: PNG_B64 },
+          { mimeType: 'image/jpeg', content: '/9j/4AAQ' },
+        ],
+      }
+    )
+  })
+
+  it('captures audio and image parts from the same message independently', () => {
+    assert.deepStrictEqual(
+      extractContentParts([
+        { type: 'image_url', image_url: { url: PNG_DATA_URI } },
+        { type: 'input_audio', input_audio: { data: 'aGVsbG8=', format: 'wav' } },
+      ]),
+      {
+        content: '',
+        audioParts: [{ mimeType: 'audio/wav', content: 'aGVsbG8=' }],
+        imageParts: [{ mimeType: 'image/png', content: PNG_B64 }],
+      }
+    )
+  })
+
+  it('captures an image exactly at the size cap', () => {
+    const content = 'A'.repeat(MAX_IMAGE_CONTENT_BYTES)
+    assert.deepStrictEqual(
+      extractContentParts([{ type: 'image_url', image_url: { url: `data:image/png;base64,${content}` } }]),
+      { content: '', audioParts: [], imageParts: [{ mimeType: 'image/png', content }] }
+    )
+  })
+
+  it('replaces an image one byte over the size cap with a marker', () => {
+    const content = 'A'.repeat(MAX_IMAGE_CONTENT_BYTES + 1)
+    assert.deepStrictEqual(
+      extractContentParts([
+        { type: 'text', text: 'describe this' },
+        { type: 'image_url', image_url: { url: `data:image/png;base64,${content}` } },
+      ]),
+      { content: 'describe this\n[image omitted: too large]', audioParts: [], imageParts: [] }
+    )
+  })
+
+  it('keeps the [image] marker for a malformed data URI rather than emitting the payload', () => {
+    assert.deepStrictEqual(
+      extractContentParts([{ type: 'image_url', image_url: { url: 'data:image/png,notbase64' } }]),
+      { content: '[image]', audioParts: [], imageParts: [] }
+    )
+  })
+
+  it('keeps the [image] marker when image_url is missing entirely', () => {
+    assert.deepStrictEqual(
+      extractContentParts([{ type: 'image_url' }]),
+      { content: '[image]', audioParts: [], imageParts: [] }
+    )
+  })
+})
+
+describe('extractResponseInputContent', () => {
+  it('captures an inline base64 image from an input_image part', () => {
+    assert.deepStrictEqual(
+      extractResponseInputContent([
+        { type: 'input_text', text: 'What is in this image?' },
+        { type: 'input_image', image_url: PNG_DATA_URI },
+      ]),
+      { content: 'What is in this image?', imageParts: [{ mimeType: 'image/png', content: PNG_B64 }] }
+    )
+  })
+
+  it('records a remote URL as a text reference, unchanged from before', () => {
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: REMOTE_URL }]),
+      { content: REMOTE_URL, imageParts: [] }
+    )
+  })
+
+  it('records a file_id reference as text', () => {
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', file_id: 'file-abc123' }]),
+      { content: 'file-abc123', imageParts: [] }
+    )
+  })
+
+  it('joins text with no separator', () => {
+    assert.deepStrictEqual(
+      extractResponseInputContent([
+        { type: 'input_text', text: 'a' },
+        { type: 'input_text', text: 'b' },
+      ]),
+      { content: 'ab', imageParts: [] }
+    )
+  })
+
+  it('replaces an oversized inline image with a marker instead of splicing it into the text', () => {
+    const content = 'A'.repeat(MAX_IMAGE_CONTENT_BYTES + 1)
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: `data:image/png;base64,${content}` }]),
+      { content: '[image omitted: too large]', imageParts: [] }
+    )
+  })
+
+  it('captures an image-only message, which carries no text at all', () => {
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: PNG_DATA_URI }]),
+      { content: '', imageParts: [{ mimeType: 'image/png', content: PNG_B64 }] }
+    )
+  })
+
+  // Regression: an unparseable data URI used to fall through to `extractTextFromContentItem`, which
+  // returns the raw `image_url`. That spliced the entire base64 payload into the message text,
+  // uncapped — the exact leak the marker exists to prevent. One case per way the parse can fail.
+  for (const [name, url] of [
+    ['percent-encoded, not base64', 'data:image/svg+xml,%3Csvg%2F%3E'],
+    ['no comma', 'data:image/png;base64'],
+    ['no media type', 'data:;base64,aGVsbG8='],
+    ['non-image media type', 'data:text/plain;base64,aGVsbG8='],
+    ['empty payload', 'data:image/png;base64,'],
+  ]) {
+    it(`marks an unparseable data URI (${name}) instead of emitting it verbatim`, () => {
+      assert.deepStrictEqual(
+        extractResponseInputContent([{ type: 'input_image', image_url: url }]),
+        { content: '[image]', imageParts: [] }
+      )
+    })
+  }
+
+  it('captures a data URI whose scheme or base64 marker is uppercase', () => {
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: `DATA:image/png;BASE64,${PNG_B64}` }]),
+      { content: '', imageParts: [{ mimeType: 'image/png', content: PNG_B64 }] }
+    )
+  })
+
+  // Recognising a malformed data URI is not enough on its own: a payload that merely fails to look
+  // like one still has to be kept out of the text. Bounding the reference length is what guarantees
+  // that, so these are the near-miss spellings that would otherwise be spliced in whole.
+  for (const [name, imageUrl] of [
+    ['a leading space', ` data:image/png;base64,${'A'.repeat(4096)}`],
+    ['a leading newline', `\ndata:image/png;base64,${'A'.repeat(4096)}`],
+    ['an array that string-coerces', [`data:image/png;base64,${'A'.repeat(4096)}`]],
+    ['no scheme at all', 'A'.repeat(4096)],
+  ]) {
+    it(`marks an over-long reference with ${name} instead of recording it`, () => {
+      assert.deepStrictEqual(
+        extractResponseInputContent([{ type: 'input_image', image_url: imageUrl }]),
+        { content: '[image]', imageParts: [] }
+      )
+    })
+  }
+
+  it('records a reference at the length bound and marks the first one over', () => {
+    const atBound = `https://example.com/${'a'.repeat(MAX_IMAGE_REFERENCE_LENGTH - 20)}`
+    assert.strictEqual(atBound.length, MAX_IMAGE_REFERENCE_LENGTH)
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: atBound }]),
+      { content: atBound, imageParts: [] }
+    )
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: atBound + 'a' }]),
+      { content: '[image]', imageParts: [] }
+    )
+  })
+
+  it('keeps alt text on an input_image and captures the image alongside it', () => {
+    // Off-schema but seen in the wild. Previously the text and the image each dropped the other.
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', text: 'ALT', image_url: PNG_DATA_URI }]),
+      { content: 'ALT', imageParts: [{ mimeType: 'image/png', content: PNG_B64 }] }
+    )
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', text: 'ALT', image_url: REMOTE_URL }]),
+      { content: 'ALT', imageParts: [] }
+    )
+  })
+
+  it('rejects a multi-byte payload that would pass a UTF-16 length check', () => {
+    // 'é' is one UTF-16 unit but two bytes, so a `.length` cap would admit twice the byte budget.
+    const payload = 'é'.repeat(MAX_IMAGE_CONTENT_BYTES)
+    assert.strictEqual(payload.length, MAX_IMAGE_CONTENT_BYTES)
+    assert.deepStrictEqual(
+      extractResponseInputContent([{ type: 'input_image', image_url: `data:image/png;base64,${payload}` }]),
+      { content: '[image omitted: too large]', imageParts: [] }
+    )
+  })
+})
+
+describe('MAX_IMAGE_CONTENT_BYTES', () => {
+  it('is 80% of the per-event size limit', () => {
+    // Pinned so a change to the fraction or to EVP_EVENT_SIZE_LIMIT is a deliberate, visible edit —
+    // the cap tests above import the constant, so they alone would not catch a drift.
+    assert.strictEqual(MAX_IMAGE_CONTENT_BYTES, Math.floor(EVP_EVENT_SIZE_LIMIT * 0.8))
+    assert.strictEqual(MAX_IMAGE_CONTENT_BYTES, 4 * 1024 * 1024)
   })
 })
 

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
@@ -19,6 +19,10 @@ const {
 const MODEL_AUDIO = 'gpt-audio-mini-2025-12-15'
 const MODEL_IMAGE = 'gpt-4o-2024-08-06'
 
+// A real 1x1 PNG (68 bytes), so the inline-image cassette is reproducible and the API accepts it as
+// a genuine image. Counterpart to makeWavClip below.
+const PNG_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='
+
 // Deterministic real WAV bytes for a short mono 16-bit sine tone, so the audio-input cassette is
 // reproducible and the API accepts it as genuine audio.
 function makeWavClip ({ seconds = 0.4, freq = 440, rate = 16000 } = {}) {
@@ -333,6 +337,53 @@ describe('integrations', () => {
             },
           ],
           metadata: { modalities: ['text', 'audio'], audio: { voice: 'alloy', format: 'mp3' } },
+          tags: { ml_app: 'test', integration: 'openai' },
+          metrics: {
+            cache_read_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            input_tokens: MOCK_NUMBER,
+            output_tokens: MOCK_NUMBER,
+            total_tokens: MOCK_NUMBER,
+          },
+        })
+      })
+
+      // The request side is what this exercises, so the response in this cassette
+      // (openai_chat_completions_post_345f0067.json) is hand-authored rather than recorded: a real
+      // gpt-4o reply to a 1x1 PNG adds nothing, and recording needs a live API key. The assertion
+      // that matters — the inline image becoming an `image_parts` entry — comes from the real
+      // request travelling through the plugin, tagger and span writer.
+      it('submits a chat completion span with an inline base64 image captured as an image part', async () => {
+        await openai.chat.completions.create({
+          model: 'gpt-4o',
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'What is in this image?' },
+                { type: 'image_url', image_url: { url: `data:image/png;base64,${PNG_B64}` } },
+              ],
+            },
+          ],
+        })
+
+        const { apmSpans, llmobsSpans } = await getEvents()
+        assertLlmObsSpanEvent(llmobsSpans[0], {
+          span: apmSpans[0],
+          spanKind: 'llm',
+          name: 'OpenAI.createChatCompletion',
+          modelName: MODEL_IMAGE,
+          modelProvider: 'openai',
+          // Inline image is captured as a structured part (rendered inline), so no [image] marker.
+          inputMessages: [
+            {
+              role: 'user',
+              content: 'What is in this image?',
+              image_parts: [{ mime_type: 'image/png', content: PNG_B64 }],
+            },
+          ],
+          outputMessages: [{ role: 'assistant', content: MOCK_STRING }],
+          metadata: {},
           tags: { ml_app: 'test', integration: 'openai' },
           metrics: {
             cache_read_input_tokens: 0,

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -7,6 +7,7 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { INPUT_PROMPT } = require('../../src/llmobs/constants/tags')
 const { writeBridgeTags, findGenAIAncestorSpanId, normalizeLlmObsTraceId } = require('../../src/llmobs/util')
+const { extractContentParts } = require('../../src/llmobs/plugins/openai/utils')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 
 function unserializableObject () {
@@ -1113,6 +1114,27 @@ describe('tagger', () => {
               role: 'user',
               content: 'both',
               audio_parts: [{ mime_type: 'audio/wav', content: 'aGVsbG8=' }],
+              image_parts: [{ mime_type: 'image/png', content: 'iVBORw0KGgo=' }],
+            },
+          ])
+        })
+
+        // Pins the contract between the OpenAI integration and the tagger: the parts an
+        // auto-instrumented request produces must be accepted verbatim and renamed to the wire
+        // shape. A camelCase/snake_case drift on either side fails here rather than silently
+        // dropping every auto-captured image.
+        it('accepts the image parts the OpenAI integration extracts from a request', () => {
+          const { content, imageParts } = extractContentParts([
+            { type: 'text', text: 'what is in this image?' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+          ])
+
+          tagger._register(span)
+          tagger.tagLLMIO(span, [{ role: 'user', content, imageParts }], undefined)
+          assert.deepStrictEqual(Tagger.tagMap.get(span)['_ml_obs.meta.input.messages'], [
+            {
+              role: 'user',
+              content: 'what is in this image?',
               image_parts: [{ mime_type: 'image/png', content: 'iVBORw0KGgo=' }],
             },
           ])

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -12,8 +12,11 @@ const {
   encodeUnicode,
   findGenAIAncestorSpanId,
   generateLlmObsTraceId,
+  imagePartFromDataUri,
+  isDataUri,
   llmObsTraceIdToWire,
   formatAudioPart,
+  formatImagePart,
   getFunctionArguments,
   normalizeLlmObsTraceId,
   stripTagsetEntry,
@@ -530,6 +533,132 @@ describe('util', () => {
     it('passes through non-binary, non-string input unchanged (tagger soft-skips it)', () => {
       const result = formatAudioPart(5, 'audio/wav')
       assert.deepStrictEqual(result, { mimeType: 'audio/wav', content: 5 })
+    })
+  })
+
+  describe('formatImagePart', () => {
+    it('passes through an existing base64 string', () => {
+      assert.deepStrictEqual(
+        formatImagePart('iVBORw0KGgo=', 'image/png'),
+        { mimeType: 'image/png', content: 'iVBORw0KGgo=' }
+      )
+    })
+
+    it('base64-encodes Buffer and Uint8Array input', () => {
+      const expected = Buffer.from('hello').toString('base64')
+      assert.deepStrictEqual(
+        formatImagePart(Buffer.from('hello'), 'image/png'),
+        { mimeType: 'image/png', content: expected }
+      )
+      assert.deepStrictEqual(
+        formatImagePart(new Uint8Array([104, 101, 108, 108, 111]), 'image/png'),
+        { mimeType: 'image/png', content: expected }
+      )
+    })
+
+    it('passes through non-binary, non-string input unchanged (tagger soft-skips it)', () => {
+      assert.deepStrictEqual(formatImagePart(5, 'image/png'), { mimeType: 'image/png', content: 5 })
+    })
+  })
+
+  describe('imagePartFromDataUri', () => {
+    it('parses a base64 image data URI into an image part', () => {
+      assert.deepStrictEqual(
+        imagePartFromDataUri('data:image/png;base64,iVBORw0KGgo='),
+        { mimeType: 'image/png', content: 'iVBORw0KGgo=' }
+      )
+    })
+
+    it('lowercases the mime type and drops media-type parameters', () => {
+      assert.deepStrictEqual(
+        imagePartFromDataUri('data:IMAGE/JPEG;charset=utf-8;base64,/9j/4AAQ'),
+        { mimeType: 'image/jpeg', content: '/9j/4AAQ' }
+      )
+    })
+
+    it('keeps the payload verbatim, including base64 padding and whitespace', () => {
+      // Whitespace is deliberately not stripped; see the note on imagePartFromDataUri.
+      assert.deepStrictEqual(
+        imagePartFromDataUri('data:image/gif;base64,R0lG\nODdh'),
+        { mimeType: 'image/gif', content: 'R0lG\nODdh' }
+      )
+    })
+
+    it('returns undefined for a remote URL rather than fetching it', () => {
+      assert.strictEqual(imagePartFromDataUri('https://example.com/cat.png'), undefined)
+      assert.strictEqual(imagePartFromDataUri('http://example.com/cat.png'), undefined)
+    })
+
+    it('returns undefined for a percent-encoded (non-base64) data URI', () => {
+      assert.strictEqual(imagePartFromDataUri('data:image/svg+xml,%3Csvg%2F%3E'), undefined)
+    })
+
+    it('returns undefined for a non-image media type', () => {
+      assert.strictEqual(imagePartFromDataUri('data:text/plain;base64,aGVsbG8='), undefined)
+      assert.strictEqual(imagePartFromDataUri('data:audio/wav;base64,aGVsbG8='), undefined)
+    })
+
+    it('returns undefined for a data URI with no media type', () => {
+      assert.strictEqual(imagePartFromDataUri('data:;base64,aGVsbG8='), undefined)
+      assert.strictEqual(imagePartFromDataUri('data:image/;base64,aGVsbG8='), undefined)
+    })
+
+    it('returns undefined for a malformed data URI', () => {
+      assert.strictEqual(imagePartFromDataUri('data:image/png;base64'), undefined)
+      assert.strictEqual(imagePartFromDataUri('data:'), undefined)
+      assert.strictEqual(imagePartFromDataUri(''), undefined)
+    })
+
+    it('returns undefined for an empty payload', () => {
+      assert.strictEqual(imagePartFromDataUri('data:image/png;base64,'), undefined)
+    })
+
+    it('returns undefined when leading whitespace defeats the prefix', () => {
+      // Guards against a mega-payload being emitted by a near-miss parse.
+      assert.strictEqual(imagePartFromDataUri('  data:image/png;base64,iVBORw0KGgo='), undefined)
+    })
+
+    it('returns undefined for a non-string input', () => {
+      assert.strictEqual(imagePartFromDataUri(undefined), undefined)
+      assert.strictEqual(imagePartFromDataUri(5), undefined)
+      assert.strictEqual(imagePartFromDataUri({ url: 'data:image/png;base64,iVBORw0KGgo=' }), undefined)
+    })
+
+    it('returns undefined for an oversized media type rather than emitting it as mime_type', () => {
+      // Without a bound this parses, and the huge media type lands on the wire as `mime_type`,
+      // bypassing the content cap entirely.
+      const crafted = `data:image/${'a'.repeat(4096)};base64,iVBORw0KGgo=`
+      assert.strictEqual(imagePartFromDataUri(crafted), undefined)
+    })
+
+    it('matches the scheme, base64 marker and media type case-insensitively', () => {
+      // dd-trace-py's equivalent regex is re.IGNORECASE; a case-sensitive parse would reject these
+      // and, on the Responses path, splice the whole payload into the message text instead.
+      const expected = { mimeType: 'image/png', content: 'iVBORw0KGgo=' }
+      assert.deepStrictEqual(imagePartFromDataUri('DATA:image/png;base64,iVBORw0KGgo='), expected)
+      assert.deepStrictEqual(imagePartFromDataUri('data:image/png;BASE64,iVBORw0KGgo='), expected)
+      assert.deepStrictEqual(imagePartFromDataUri('DATA:IMAGE/PNG;BASE64,iVBORw0KGgo='), expected)
+    })
+  })
+
+  describe('isDataUri', () => {
+    it('recognizes a data URI regardless of scheme case', () => {
+      assert.strictEqual(isDataUri('data:image/png;base64,AAAA'), true)
+      assert.strictEqual(isDataUri('DATA:image/png;base64,AAAA'), true)
+      // Unparseable but still inline: the caller must emit a marker, never the raw payload.
+      assert.strictEqual(isDataUri('data:image/svg+xml,%3Csvg%2F%3E'), true)
+      assert.strictEqual(isDataUri('data:'), true)
+    })
+
+    it('rejects a remote reference, so its text is kept as-is', () => {
+      assert.strictEqual(isDataUri('https://example.com/cat.png'), false)
+      assert.strictEqual(isDataUri('file-abc123'), false)
+      assert.strictEqual(isDataUri('  data:image/png;base64,AAAA'), false)
+    })
+
+    it('rejects non-strings', () => {
+      assert.strictEqual(isDataUri(undefined), false)
+      assert.strictEqual(isDataUri(5), false)
     })
   })
 })


### PR DESCRIPTION
# feat(llmobs): capture inline images for openai chat completions and responses

Labels: `semver-minor`

## What does this PR do?

Populates `image_parts` automatically on LLMObs spans for inline (base64 / `data:` URI) images sent
through the OpenAI integration, covering Chat Completions input, the Responses API input, and
openai-agents.

## Motivation

`image_parts` shipped as a typed field on LLMObs chat messages in 6.10.0 (backported to 5.121.0),
and the backend and UI already consume it. Until now nothing populated it automatically, so the
field only ever appeared when a customer called `llmobs.annotate()` by hand. `audio_parts` already
has automatic capture (`plugins/openai/index.js:43`, `plugins/openai-agents/utils.js:107`), so
images were the remaining asymmetry.

`#9684` shipped the manual path and explicitly deferred provider auto-capture to a follow-up. This
is that follow-up.

## Provider surfaces covered

| Surface | Status | Notes |
|---|---|---|
| Chat Completions input (`messages[].content[].image_url`) | ✅ | both the `{ url }` object and bare-string forms |
| Responses API input (`input[].content[].input_image`) | ⚠️ wired, gated | extraction is in place but a pre-existing gate blocks it for the common shape — see "Pre-existing gate" below |
| openai-agents (both shapes) | ✅ | second consumer of the shared extractor |
| Chat Completions output | ➖ | chat completions return no image modality; nothing to capture |
| Responses output (`image_generation_call`, `computer_call_output`) | ❌ deferred | JS does not model these item types today; dd-trace-py `#19690` draws the same boundary |
| Bedrock | ❌ out of scope | verified: no media path exists at all. `plugins/bedrockruntime.js` and the aws-sdk `bedrockruntime/utils.js` have zero image handling; Converse emits `` `[Unsupported content type: ${type}]` `` and `invokeModel` filters to text only. Building one is its own PR, and the audio precedent (`#9083`) drew the same line. |

## A pre-existing bug this also fixes

On master, `extractTextFromContentItem` returns `contentItem.image_url` **as text** for an
`input_image`. For a `data:` URI that spliced a multi-megabyte base64 blob directly into the message
content, inflating the span and likely tripping the 5 MB truncation, which blanks the span's input
**and** output rather than just the image. Routing that path through the capture helper fixes it.
Remote URLs and `file_id` references render exactly as before.

## Why the size cap is not optional

Without a per-image cap this feature would be a net regression: on overflow the writer does not trim
the image, it drops the span's whole input and output. An over-cap image therefore degrades to a
text marker rather than being admitted.

## Additional notes

Capture is unconditional, matching the audio precedent and the dd-trace-py integrations. The opt-out
is a span processor deleting the `image_parts` key.

## How to test

```
npm run test:llmobs:sdk
```

Suite is green at 683 passing. Note that the LLMObs specs need the testagent running
(`docker compose up -d testagent`); without it several specs fail with `fetch failed`, which is
unrelated to this change.

Unit coverage spans both the Chat Completions and Responses shapes, the openai-agents path, the
`{ url }` and bare-string forms, over-cap degradation to a marker, and regression pins asserting
that non-image content is unchanged.

## Cumulative size, for the reviewers who asked on #19148

The cap here is **per image**. N images that each fit can still push the event over the limit
together, and on overflow the writer drops the span's whole input and output rather than trimming.

That is the same open gap as the merged Python PRs, not something this change introduces, and the
fix belongs writer-side rather than in each integration. Calling it out explicitly so it is not
re-litigated per-provider.

## Live capture status

A Before/After repro script is included and runs end to end against the AI Gateway: real model
responses, HTTP 200 on both surfaces. Live preprod screenshots are **pending** because those runs
produced no LLMObs spans, and the cause is not yet identified.

What is established: the request is traced as a generic `fetch` span, so the tracer is active and the
call is reaching the provider. Ruled out so far: the installed SDK is inside the instrumentation's
supported version range, and the hook target files exist in it.

Not established, and deliberately not asserted here: why the integration does not produce a span.
This is being tracked separately. It is independent of this diff, and the unit and cassette coverage
in this PR is unaffected.


## Pre-existing gate on the Responses input path

Verified live: a Responses API call with `input: [{ role, content: [input_text, input_image] }]`
emits a span with **`"input":{}`** — no messages, no image parts.

Cause is on master, not in this diff: `plugins/openai/index.js:293` gates the input loop on
`item.type === 'message'`. The Responses API allows an input item to omit `type` when it carries
`role` + `content`, which is the shape the SDK's own examples use, so those items match no branch and
are dropped before `extractResponseInputContent` is ever called.

So the Responses extraction added here is correct but currently unreachable for the common shape. The
Chat Completions path is unaffected and verified end to end:

```json
"input":{"messages":[{"role":"user","content":"What colour is this pixel?",
  "image_parts":[{"mime_type":"image/png","content":"iVBORw0KGgo..."}]}]}
```

The gate fix is a one-line widening (`item.type === 'message' || (!item.type && item.role)`) and is
deliberately **not** in this PR, since it changes pre-existing behaviour on a path this change does
not otherwise touch. Filed separately.
