### PR TITLE
chore(deps): bump @datadog/wasm-js-rewriter to 5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "@datadog/native-iast-taint-tracking": "4.2.0",
     "@datadog/native-metrics": "3.1.2",
     "@datadog/pprof": "5.18.0",
-    "@datadog/wasm-js-rewriter": "5.0.3",
+    "@datadog/wasm-js-rewriter": "5.0.4",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/api-logs": "<1.0.0",
     "oxc-parser": "^0.132.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,10 +295,10 @@
     pprof-format "^2.3.1"
     source-map "^0.8.0"
 
-"@datadog/wasm-js-rewriter@5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.3.tgz#815b0969595628b558b1aa8235965c351edc6adb"
-  integrity sha512-XfumKHD5RTTvqiwMmTEWqvix472tIofPDA78+wFLMWJ6xxJBlJRbJ//sMT9bNYlSgau9JYB9S38EeMdf4xFhGw==
+"@datadog/wasm-js-rewriter@5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.4.tgz#6d0973cefd82ee5bea30c3aa4e3bcfdb35ef169f"
+  integrity sha512-tSjbk51dkNzFMM3P/7y82tyrBj/9CWnPzcVb1JB8TUea/PIholdXSPuGC5F975YvvGB8KDujfmJIacN+EmuXMg==
   dependencies:
     js-yaml "^4.3.1"
     lru-cache "^7.14.0"


### PR DESCRIPTION
### What does this PR do?
Bumps `@datadog/wasm-js-rewriter` to 5.0.4

### Motivation
Fixes https://github.com/DataDog/dd-trace-js/issues/9836


