### PR TITLE
test(test-optimization): cover Bunyan log submission in Mocha and Cucumber

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/logger.js
@@ -1,12 +1,3 @@
 'use strict'
 
-const { createLogger, format, transports } = require('winston')
-
-module.exports = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.Console(),
-  ],
-})
+module.exports = require('../../automatic-log-submission/logger')

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
@@ -12,5 +12,5 @@ Then('I should have made a log', async function () {
 })
 
 When('we run a test', async function () {
-  logger.log('info', 'Hello simple log!')
+  logger.info('Hello simple log!')
 })

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/sum.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/sum.js
@@ -3,6 +3,6 @@
 const logger = require('./logger')
 
 module.exports = function (a, b) {
-  logger.log('info', 'sum function being called')
+  logger.info('sum function being called')
   return a + b
 }

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -76,6 +76,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'cucumber',
       command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature',
+      loggerNames: ['winston', 'bunyan'],
     },
     {
       name: 'playwright',

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -27,6 +27,7 @@ describe('test optimization automatic log submission', () => {
   useSandbox([
     'mocha',
     ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
+    'bunyan',
     'jest',
     'winston',
     playwrightDependency,
@@ -65,7 +66,8 @@ describe('test optimization automatic log submission', () => {
   const testFrameworks = [
     {
       name: 'mocha',
-      command: 'mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js',
+      command: './node_modules/.bin/mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js',
+      loggerNames: ['winston', 'bunyan'],
     },
     {
       name: 'jest',
@@ -86,10 +88,19 @@ describe('test optimization automatic log submission', () => {
     },
   ]
 
-  testFrameworks.forEach(({ name, command, getExtraEnvVars = () => ({}) }) => {
+  const loggers = {
+    bunyan: { level: 30, messageKey: 'msg' },
+    winston: { level: 'info', messageKey: 'message' },
+  }
+
+  testFrameworks.flatMap(framework => {
+    return (framework.loggerNames || ['winston']).map(loggerName => ({ ...framework, loggerName }))
+  }).forEach(({ name, command, getExtraEnvVars = () => ({}), loggerName }) => {
     if (!isLatestCucumberSupported && name === 'cucumber') return
 
-    context(`with ${name}`, () => {
+    const { level: expectedLevel, messageKey } = loggers[loggerName]
+
+    context(`with ${loggerName} and ${name}`, () => {
       it('can automatically submit logs', async () => {
         let logIds = {}
         let testIds = {}
@@ -98,20 +109,23 @@ describe('test optimization automatic log submission', () => {
           .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
             payloads.forEach(({ headers }) => {
               assert.equal(headers['dd-api-key'], '1')
+              if (loggerName !== 'winston') {
+                assert.equal(headers['content-type'], 'application/json')
+              }
             })
             const logMessages = payloads.flatMap(({ logMessage }) => logMessage)
             const [url] = payloads.flatMap(({ url }) => url)
 
-            assert.equal(url, '/api/v2/logs?ddsource=winston&service=my-service')
+            assert.equal(url, `/api/v2/logs?ddsource=${loggerName}&service=my-service`)
             assert.equal(logMessages.length, 2)
 
             logMessages.forEach(({ dd, level }) => {
-              assert.equal(level, 'info')
+              assert.equal(level, expectedLevel)
               assert.equal(dd.service, 'my-service')
               assert.deepStrictEqual(['service', 'span_id', 'trace_id'], Object.keys(dd).sort())
             })
 
-            assertObjectContains(logMessages.map(({ message }) => message), [
+            assertObjectContains(logMessages.map(logMessage => logMessage[messageKey]), [
               'Hello simple log!',
               'sum function being called',
             ])
@@ -142,6 +156,7 @@ describe('test optimization automatic log submission', () => {
               DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
               DD_API_KEY: '1',
               DD_SERVICE: 'my-service',
+              TEST_LOGGER: loggerName,
               ...getExtraEnvVars(),
             },
           }
@@ -183,6 +198,7 @@ describe('test optimization automatic log submission', () => {
               ...getCiVisAgentlessConfig(receiver.port),
               DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
               DD_SERVICE: 'my-service',
+              TEST_LOGGER: loggerName,
               ...getExtraEnvVars(),
             },
           }
@@ -224,6 +240,7 @@ describe('test optimization automatic log submission', () => {
               DD_TRACE_DEBUG: '1',
               DD_TRACE_LOG_LEVEL: 'warn',
               DD_API_KEY: '',
+              TEST_LOGGER: loggerName,
               ...getExtraEnvVars(),
             },
           }

--- a/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
@@ -6,7 +6,7 @@ const logger = require('./logger')
 const sum = require('./sum')
 describe('test', () => {
   it('should return true', () => {
-    logger.log('info', 'Hello simple log!')
+    logger.info('Hello simple log!')
 
     assert.strictEqual(true, true)
     assert.strictEqual(sum(1, 2), 3)

--- a/integration-tests/ci-visibility/automatic-log-submission/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/logger.js
@@ -1,12 +1,19 @@
 'use strict'
 
-const { createLogger, format, transports } = require('winston')
+let logger
 
-module.exports = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.Console(),
-  ],
-})
+if (process.env.TEST_LOGGER === 'bunyan') {
+  logger = require('bunyan').createLogger({ name: 'test-logger' })
+} else {
+  const { createLogger, format, transports } = require('winston')
+  logger = createLogger({
+    level: 'info',
+    exitOnError: false,
+    format: format.json(),
+    transports: [
+      new transports.Console(),
+    ],
+  })
+}
+
+module.exports = logger

--- a/integration-tests/ci-visibility/automatic-log-submission/sum.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/sum.js
@@ -3,6 +3,6 @@
 const logger = require('./logger')
 
 module.exports = function (a, b) {
-  logger.log('info', 'sum function being called')
+  logger.info('sum function being called')
   return a + b
 }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Extends the automatic log-submission integration matrix with Bunyan for Mocha and Cucumber.js. Both frameworks reuse the shared logger fixture selected through `TEST_LOGGER`.

### Motivation
<!-- What inspired you to submit this pull request? -->

The common Bunyan support merged in #9906. This test-only PR verifies that Bunyan logs emitted during active Mocha and Cucumber.js tests carry test trace/span correlation and reach the logs intake, while keeping framework lifecycle changes in separate PRs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Based directly on `master`; the production support from #9906 is already merged.
- Contains integration-test changes only.
- Jest remains excluded because of its custom module engine.
- Vitest, Playwright, and WebdriverIO are handled separately because their workers require explicit final-flush lifecycle integration.
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha --timeout 120000 integration-tests/ci-visibility/automatic-log-submission.spec.js` — 18 passing.
