### PR TITLE
test(test-optimization): cover WDIO EFD quarantine retries

### DIFF
--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -357,6 +357,60 @@ for (const version of versions) {
           })
         })
 
+        if (framework === 'mocha') {
+          it('keeps quarantine metadata on EFD retries of a new test', async () => {
+            const numRetries = 2
+            receiver.setSettings({
+              early_flake_detection: {
+                enabled: true,
+                faulty_session_threshold: 100,
+                slow_test_retries: { '5s': numRetries },
+              },
+              known_tests_enabled: true,
+              test_management: { enabled: true },
+            })
+            receiver.setKnownTests({ webdriverio: {} })
+            receiver.setTestManagementTests({
+              webdriverio: {
+                suites: {
+                  'atr-always-fail.e2e.js': {
+                    tests: {
+                      'WebdriverIO ATR fails every retry': {
+                        properties: { quarantined: true },
+                      },
+                    },
+                  },
+                },
+              },
+            })
+
+            await runScenario('atrAlwaysFails', 1, payloads => {
+              const events = getEvents(payloads)
+              const session = events.find(event => event.type === 'test_session_end').content
+              const suite = events.find(event => event.type === 'test_suite_end').content
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(tests.length, numRetries + 1)
+              for (const test of tests) {
+                assert.strictEqual(test.meta[TEST_STATUS], 'fail')
+                assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+                assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+              }
+
+              const retries = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.strictEqual(retries.length, numRetries)
+              assert.ok(retries.every(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd))
+
+              const finalAttempt = tests.find(test => TEST_FINAL_STATUS in test.meta)
+              assert.ok(finalAttempt)
+              assert.strictEqual(finalAttempt.meta[TEST_FINAL_STATUS], 'skip')
+              assert.strictEqual(finalAttempt.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+            })
+          })
+        }
+
         {
           const jasmineTest = framework === 'jasmine' ? it : it.skip
           jasmineTest('keeps skipped tests and their suite and session successful with EFD', async () => {

--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -357,59 +357,57 @@ for (const version of versions) {
           })
         })
 
-        if (framework === 'mocha') {
-          it('keeps quarantine metadata on EFD retries of a new test', async () => {
-            const numRetries = 2
-            receiver.setSettings({
-              early_flake_detection: {
-                enabled: true,
-                faulty_session_threshold: 100,
-                slow_test_retries: { '5s': numRetries },
-              },
-              known_tests_enabled: true,
-              test_management: { enabled: true },
-            })
-            receiver.setKnownTests({ webdriverio: {} })
-            receiver.setTestManagementTests({
-              webdriverio: {
-                suites: {
-                  'atr-always-fail.e2e.js': {
-                    tests: {
-                      'WebdriverIO ATR fails every retry': {
-                        properties: { quarantined: true },
-                      },
+        it('keeps quarantine metadata on EFD retries of a new test', async () => {
+          const numRetries = 2
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              faulty_session_threshold: 100,
+              slow_test_retries: { '5s': numRetries },
+            },
+            known_tests_enabled: true,
+            test_management: { enabled: true },
+          })
+          receiver.setKnownTests({ webdriverio: {} })
+          receiver.setTestManagementTests({
+            webdriverio: {
+              suites: {
+                'atr-always-fail.e2e.js': {
+                  tests: {
+                    'WebdriverIO ATR fails every retry': {
+                      properties: { quarantined: true },
                     },
                   },
                 },
               },
-            })
-
-            await runScenario('atrAlwaysFails', 1, payloads => {
-              const events = getEvents(payloads)
-              const session = events.find(event => event.type === 'test_session_end').content
-              const suite = events.find(event => event.type === 'test_suite_end').content
-              const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-              assert.strictEqual(session.meta[TEST_STATUS], 'pass')
-              assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
-              assert.strictEqual(tests.length, numRetries + 1)
-              for (const test of tests) {
-                assert.strictEqual(test.meta[TEST_STATUS], 'fail')
-                assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
-                assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
-              }
-
-              const retries = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-              assert.strictEqual(retries.length, numRetries)
-              assert.ok(retries.every(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd))
-
-              const finalAttempt = tests.find(test => TEST_FINAL_STATUS in test.meta)
-              assert.ok(finalAttempt)
-              assert.strictEqual(finalAttempt.meta[TEST_FINAL_STATUS], 'skip')
-              assert.strictEqual(finalAttempt.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
-            })
+            },
           })
-        }
+
+          await runScenario('atrAlwaysFails', 1, payloads => {
+            const events = getEvents(payloads)
+            const session = events.find(event => event.type === 'test_session_end').content
+            const suite = events.find(event => event.type === 'test_suite_end').content
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            assert.strictEqual(session.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(tests.length, numRetries + 1)
+            for (const test of tests) {
+              assert.strictEqual(test.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+              assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+            }
+
+            const retries = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retries.length, numRetries)
+            assert.ok(retries.every(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd))
+
+            const finalAttempt = tests.find(test => TEST_FINAL_STATUS in test.meta)
+            assert.ok(finalAttempt)
+            assert.strictEqual(finalAttempt.meta[TEST_FINAL_STATUS], 'skip')
+            assert.strictEqual(finalAttempt.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+          })
+        })
 
         {
           const jasmineTest = framework === 'jasmine' ? it : it.skip


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds WebdriverIO integration regression coverage proving that a quarantined new test retains quarantine metadata across all Early Flake Detection retries with both the Mocha and Jasmine adapters.

### Motivation
<!-- What inspired you to submit this pull request? -->

Follow-up to #9893. The merged production fix is shared by standalone Mocha and the WebdriverIO Mocha adapter, but its original regression test covered only standalone Mocha. Running the same WebdriverIO scenario with Jasmine also locks down the broader new-plus-quarantined invariant on its separate retry implementation.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is a test-only change and reuses the existing always-failing WebdriverIO fixture.

Verification:
- `WEBDRIVERIO_VERSION=latest ./node_modules/.bin/mocha --timeout 600000 integration-tests/webdriverio/webdriverio.test-optimization.spec.js --grep "keeps quarantine metadata on EFD retries of a new test"` (2 passing: Mocha and Jasmine)
- `./node_modules/.bin/eslint integration-tests/webdriverio/webdriverio.test-optimization.spec.js`