### PR TITLE
refactor(test-optimization): share Winston log submission

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -82,7 +82,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'playwright',
       command: './node_modules/.bin/playwright test -c playwright.config.js',
-      loggerNames: ['bunyan'],
+      loggerNames: ['winston', 'bunyan'],
       getExtraEnvVars: () => ({
         PW_BASE_URL: `http://localhost:${webAppPort}`,
         TEST_DIR: 'ci-visibility/automatic-log-submission-playwright',
@@ -112,10 +112,9 @@ describe('test optimization automatic log submission', () => {
           .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
             payloads.forEach(({ headers }) => {
               assert.equal(headers['dd-api-key'], '1')
-              if (loggerName !== 'winston') {
-                assert.equal(headers['content-type'], 'application/json')
-              }
+              assert.equal(headers['content-type'], 'application/json')
             })
+            assert.equal(payloads.length, 1)
             const logMessages = payloads.flatMap(({ logMessage }) => logMessage)
             const [url] = payloads.flatMap(({ url }) => url)
 
@@ -132,6 +131,10 @@ describe('test optimization automatic log submission', () => {
               'Hello simple log!',
               'sum function being called',
             ])
+            if (loggerName === 'winston' && (name === 'mocha' || name === 'jest')) {
+              const circularLog = logMessages.find(({ message }) => message === 'Hello simple log!')
+              assert.equal(circularLog.circular.self, '[Circular]')
+            }
 
             logIds = {
               logSpanId: logMessages[0].dd.span_id,

--- a/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
@@ -6,7 +6,13 @@ const logger = require('./logger')
 const sum = require('./sum')
 describe('test', () => {
   it('should return true', () => {
-    logger.info('Hello simple log!')
+    if (process.env.TEST_LOGGER === 'winston') {
+      const circular = {}
+      circular.self = circular
+      logger.log('info', 'Hello simple log!', { circular })
+    } else {
+      logger.info('Hello simple log!')
+    }
 
     assert.strictEqual(true, true)
     assert.strictEqual(sum(1, 2), 3)

--- a/packages/datadog-instrumentations/src/winston.js
+++ b/packages/datadog-instrumentations/src/winston.js
@@ -12,12 +12,15 @@ const patched = new WeakSet()
 const configureCh = channel('ci:log-submission:winston:configure')
 const addTransport = channel('ci:log-submission:winston:add-transport')
 
-addHook({ name: 'winston', file: 'lib/winston/transports/index.js', versions: ['>=3'] }, transportsPackage => {
+addHook({ name: 'winston', versions: ['>=3'] }, winston => {
   if (configureCh.hasSubscribers) {
-    configureCh.publish(transportsPackage.Http)
+    configureCh.publish({
+      createJsonFormat: winston.format.json,
+      StreamTransport: winston.transports.Stream,
+    })
   }
 
-  return transportsPackage
+  return winston
 })
 
 addHook({ name: 'winston', file: 'lib/winston/logger.js', versions: ['>=3'] }, Logger => {

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { Writable } = require('node:stream')
+
 const request = require('../../exporters/common/request')
 const log = require('../../log')
 const Plugin = require('../../plugins/plugin')
@@ -9,37 +11,6 @@ const { FINAL_FLUSH_TIMEOUT } = require('../final-flush')
 const MAX_BATCH_BYTES = 5 * 1024 * 1024
 const MAX_BATCH_LOGS = 1000
 const BATCH_FLUSH_INTERVAL = 1000
-
-function getWinstonLogSubmissionParameters (config) {
-  const { site, service, DD_API_KEY, DD_AGENTLESS_LOG_SUBMISSION_URL } = config
-
-  const defaultParameters = {
-    host: `http-intake.logs.${site}`,
-    path: `/api/v2/logs?ddsource=winston&service=${service}`,
-    ssl: true,
-    headers: {
-      'DD-API-KEY': DD_API_KEY,
-    },
-  }
-
-  if (!DD_AGENTLESS_LOG_SUBMISSION_URL) {
-    return defaultParameters
-  }
-
-  try {
-    const url = new URL(DD_AGENTLESS_LOG_SUBMISSION_URL)
-    return {
-      host: url.hostname,
-      port: url.port,
-      ssl: url.protocol === 'https:',
-      path: defaultParameters.path,
-      headers: defaultParameters.headers,
-    }
-  } catch {
-    log.error('Could not parse DD_AGENTLESS_LOG_SUBMISSION_URL')
-    return defaultParameters
-  }
-}
 
 /**
  * @param {import('../../config/config-base')} config
@@ -87,6 +58,18 @@ class LogSubmissionPlugin extends Plugin {
   #requestTracker
   #timer
   #beforeExitHandler = () => this.#flushLogs()
+  #createWinstonJsonFormat
+  #winstonStreamClass
+  // Winston formats records inside its transports, not at logger.write time, so (unlike Bunyan/Pino)
+  // the instrumentation can't publish a post-format line. A Stream transport pipes format.json()
+  // output through this Writable into the shared sender, reusing Winston's own cycle-safe serializer.
+  #winstonOutput = new Writable({
+    decodeStrings: false,
+    write: (message, encoding, callback) => {
+      this.#enqueueLog({ source: 'winston', message })
+      callback()
+    },
+  })
 
   constructor (...args) {
     super(...args)
@@ -95,13 +78,32 @@ class LogSubmissionPlugin extends Plugin {
       done?.()
     })
 
-    this.addSub('ci:log-submission:winston:configure', (httpClass) => {
-      this.HttpClass = httpClass
+    // The main-module hook (configure) and the logger.js hook (add-transport) can fire in either
+    // order depending on how Winston is required, so buffer loggers that arrive before configure.
+    const pendingWinstonLoggers = new Set()
+    const addWinstonTransport = (logger) => {
+      if (!this.#winstonStreamClass || !this.#createWinstonJsonFormat) {
+        pendingWinstonLoggers.add(logger)
+        return
+      }
+
+      logger.add(new this.#winstonStreamClass({
+        format: this.#createWinstonJsonFormat(),
+        stream: this.#winstonOutput,
+      }))
+    }
+
+    this.addSub('ci:log-submission:winston:configure', ({ StreamTransport, createJsonFormat }) => {
+      this.#winstonStreamClass = StreamTransport
+      this.#createWinstonJsonFormat = createJsonFormat
+
+      for (const logger of pendingWinstonLoggers) {
+        addWinstonTransport(logger)
+      }
+      pendingWinstonLoggers.clear()
     })
 
-    this.addSub('ci:log-submission:winston:add-transport', (logger) => {
-      logger.add(new this.HttpClass(getWinstonLogSubmissionParameters(this.config)))
-    })
+    this.addSub('ci:log-submission:winston:add-transport', addWinstonTransport)
 
     this.addSub('ci:log-submission:log', (payload) => {
       this.#enqueueLog(payload)

--- a/packages/dd-trace/test/ci-visibility/log-submission-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/log-submission-plugin.spec.js
@@ -13,6 +13,8 @@ const { FINAL_FLUSH_TIMEOUT } = require('../../src/ci-visibility/final-flush')
 
 const logSubmissionCh = channel('ci:log-submission:log')
 const logSubmissionFlushCh = channel('ci:log-submission:flush')
+const winstonAddTransportCh = channel('ci:log-submission:winston:add-transport')
+const winstonConfigureCh = channel('ci:log-submission:winston:configure')
 const request = sinon.stub()
 const log = {
   error: sinon.stub(),
@@ -78,6 +80,35 @@ describe('LogSubmissionPlugin', () => {
       'DD-API-KEY': 'secret',
       'Content-Type': 'application/json',
     })
+  })
+
+  it('batches Winston-formatted logs through the shared sender', () => {
+    const format = {}
+    const createJsonFormat = sinon.stub().returns(format)
+    class StreamTransport {
+      constructor (options) {
+        this.options = options
+      }
+    }
+    const logger = { add: sinon.stub() }
+
+    winstonAddTransportCh.publish(logger)
+    sinon.assert.notCalled(logger.add)
+
+    winstonConfigureCh.publish({ createJsonFormat, StreamTransport })
+
+    sinon.assert.calledOnce(logger.add)
+    const transport = logger.add.firstCall.args[0]
+    assert.ok(transport instanceof StreamTransport)
+    assert.strictEqual(transport.options.format, format)
+
+    transport.options.stream.write('{"level":"info","message":"hello"}')
+    clock.tick(1000)
+
+    sinon.assert.calledOnce(request)
+    const [data, options] = request.firstCall.args
+    assert.deepStrictEqual(JSON.parse(data), [{ level: 'info', message: 'hello' }])
+    assert.strictEqual(options.path, '/api/v2/logs?ddsource=winston&service=my+service')
   })
 
   it('flushes pending Bunyan logs before exit', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Routes Winston 3 automatic log submission through the shared bounded sender merged in #9962. A public Winston stream transport receives records after logger-level formatting, applies Winston's own `format.json()` transport formatter, and passes the resulting JSON string to the existing batcher. This removes Winston's hidden HTTP transport and its separate URL/request implementation.

### Motivation
<!-- What inspired you to submit this pull request? -->

Winston can share batching, URL validation, encoded query parameters, request limits, and the API-key security boundary without copying its serialization implementation.

Winston's HTTP transport constructs its serialized buffer privately inside `_doRequest()` and does not return it. Intercepting that buffer would require suppressing or faking Node's `ClientRequest`; using Winston's public formatting and stream transport contracts avoids that fragile hook and prevents a duplicate HTTP request.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Revived: rebased onto current `master`. The Playwright worker-shutdown lifecycle (#9908) and request tracking (#9962) it originally stacked on are both merged, so this PR now stands alone.
- The transport-specific JSON formatter ensures arbitrary logger formats cannot produce a non-JSON intake body or omit correlated `dd` fields.
- Winston preserves the shared sender's one-second timer, 1,000-record limit, 5 MiB limit, request tracking, and unref behavior.
- The integration matrix verifies a single batched request, JSON content type, cycle-safe Winston serialization, correlation, and disabled submission.
- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/log-submission-plugin.spec.js` — 24 passing.
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER PLUGINS=winston npm run test:plugins:ci` — 66 passing.
- Targeted ESLint and `git diff --check` — passing.
