### PR TITLE
refactor(eslint): detect direct literal joins

### DIFF
--- a/eslint-rules/eslint-no-unnecessary-array-join.mjs
+++ b/eslint-rules/eslint-no-unnecessary-array-join.mjs
@@ -9,6 +9,8 @@ export default {
     messages: {
       buildStringDirectly:
         'Build "{{name}}" directly as a string instead of collecting string fragments in an array before joining.',
+      buildLiteralStringDirectly:
+        'Build this string directly instead of joining an array literal.',
     },
   },
 
@@ -96,6 +98,18 @@ export default {
           node: joinCall,
           messageId: 'buildStringDirectly',
           data: { name: node.id.name },
+        })
+      },
+
+      /**
+       * @param {import('estree').CallExpression} node
+       */
+      CallExpression (node) {
+        if (!isLiteralJoin(node)) return
+
+        context.report({
+          node,
+          messageId: 'buildLiteralStringDirectly',
         })
       },
     }
@@ -195,4 +209,65 @@ function isKnownNonStringExpression (node, sourceCode, seen = new Set()) {
   }
 
   return false
+}
+
+/**
+ * @param {import('estree').CallExpression} node
+ * @returns {boolean}
+ */
+function isLiteralJoin (node) {
+  if (
+    node.optional ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.computed ||
+    node.callee.optional ||
+    node.callee.property.type !== 'Identifier' ||
+    node.callee.property.name !== 'join' ||
+    node.callee.object.type !== 'ArrayExpression' ||
+    node.arguments.length > 1 ||
+    !isStaticSeparator(node.arguments[0])
+  ) {
+    return false
+  }
+
+  const { elements } = node.callee.object
+  if (elements.some(element => element === null || element.type === 'SpreadElement')) return false
+
+  return isNameJoin(elements, node.arguments[0]) || isConditionalTextJoin(node, elements, node.arguments[0])
+}
+
+/**
+ * @param {Array<import('estree').Expression>} elements
+ * @param {import('estree').Expression | import('estree').SpreadElement | undefined} separator
+ * @returns {boolean}
+ */
+function isNameJoin (elements, separator) {
+  return (
+    separator?.type === 'Literal' &&
+    separator.value === '.' &&
+    elements.length === 2 &&
+    elements.every(element =>
+      element.type === 'MemberExpression' &&
+      !element.computed &&
+      !element.optional &&
+      element.property.type === 'Identifier' &&
+      element.property.name === 'name'
+    )
+  )
+}
+
+/**
+ * @param {import('estree').CallExpression} node
+ * @param {Array<import('estree').Expression>} elements
+ * @param {import('estree').Expression | import('estree').SpreadElement | undefined} separator
+ * @returns {boolean}
+ */
+function isConditionalTextJoin (node, elements, separator) {
+  return (
+    node.parent.type === 'ConditionalExpression' &&
+    separator?.type === 'Literal' &&
+    separator.value === '\n' &&
+    elements.length > 1 &&
+    elements.every(element => element.type === 'Literal' || element.type === 'TemplateLiteral')
+  )
 }

--- a/eslint-rules/eslint-no-unnecessary-array-join.test.mjs
+++ b/eslint-rules/eslint-no-unnecessary-array-join.test.mjs
@@ -9,6 +9,8 @@ const ruleTester = new RuleTester({
 ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').Rule.RuleModule} */ (rule), {
   valid: [
     "const parts = ['a']; parts.join('')",
+    "const parts = ['a']; parts.join(separator)",
+    "[...parts].join('')",
     "const parts = []; parts.push('a'); consume(parts); parts.join('')",
     "const parts = []; parts.push('a'); parts.join(separator)",
     "const parts = []; parts.push('a'); parts.join(`$" + '{separator}`)',
@@ -54,6 +56,35 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
     `,
   ],
   invalid: [
+    {
+      code: "[this.constructor.name, generateStream.name].join('.')",
+      errors: [{ messageId: 'buildLiteralStringDirectly' }],
+    },
+    {
+      code: `
+        const body = isEsm
+          ? [
+              \`import originalConfig from \${JSON.stringify(pathToFileURL(originalConfigFile).href)}\`,
+              \`import cypressConfig from \${JSON.stringify(pathToFileURL(cypressConfigPath).href)}\`,
+              '',
+              'export default cypressConfig.wrapConfig(originalConfig)',
+              '',
+            ].join('\\n')
+          : [
+              \`const cypressConfig = require(\${JSON.stringify(cypressConfigPath)})\`,
+              \`const originalExports = require(\${JSON.stringify(originalConfigFile)})\`,
+              'const originalConfig = originalExports && originalExports.__esModule',
+              '  ? originalExports.default',
+              '  : originalExports',
+              'module.exports = cypressConfig.wrapConfig(originalConfig)',
+              '',
+            ].join('\\n')
+      `,
+      errors: [
+        { messageId: 'buildLiteralStringDirectly' },
+        { messageId: 'buildLiteralStringDirectly' },
+      ],
+    },
     {
       code: "const parts = []; parts.push('a'); parts.join()",
       errors: [{ messageId: 'buildStringDirectly', data: { name: 'parts' } }],

--- a/packages/datadog-instrumentations/src/google-cloud-vertexai.js
+++ b/packages/datadog-instrumentations/src/google-cloud-vertexai.js
@@ -13,7 +13,7 @@ function wrapGenerate (generate) {
     const ctx = {
       request,
       instance: this,
-      resource: [this.constructor.name, generate.name].join('.'),
+      resource: `${this.constructor.name}.${generate.name}`,
     }
 
     return vertexaiTracingChannel.tracePromise(generate, ctx, this, ...arguments)
@@ -29,7 +29,7 @@ function wrapGenerateStream (generateStream) {
     const ctx = {
       request,
       instance: this,
-      resource: [this.constructor.name, generateStream.name].join('.'),
+      resource: `${this.constructor.name}.${generateStream.name}`,
       stream: true,
     }
 


### PR DESCRIPTION
Direct literal joins allocate an intermediate array when the string can be built directly. The rule covers paired .name members and conditional newline-delimited text.