### PR TITLE
test(agent): tolerate exporter socket resets

### DIFF
--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -157,6 +157,13 @@ function waitForExporterTransition (socket) {
 }
 
 /**
+ * @param {import('node:net').Socket} socket
+ */
+function waitForSocketClose (socket) {
+  return new Promise(resolve => socket.once('close', resolve))
+}
+
+/**
  * @param {string} origin
  */
 async function waitForExporterIdle (origin) {
@@ -931,7 +938,7 @@ module.exports = {
     await waitForExporterIdle(origin)
 
     const exporterSockets = httpAgent.freeSockets[origin] ?? []
-    const exporterSocketsClosed = exporterSockets.map(socket => once(socket, 'close'))
+    const exporterSocketsClosed = exporterSockets.map(waitForSocketClose)
 
     await Promise.all([serverClosed, ...exporterSocketsClosed])
     this.server = null

--- a/packages/dd-trace/test/plugins/agent.spec.js
+++ b/packages/dd-trace/test/plugins/agent.spec.js
@@ -62,6 +62,43 @@ describe('test agent helper', () => {
       assert.strictEqual(origin in httpAgent.requests, false)
     })
 
+    it('finishes closing when an exporter socket resets', async () => {
+      const tracer = await agent.load([])
+      const origin = httpAgent.getName({ host: '127.0.0.1', port: agent.port })
+      const traceReceived = agent.assertSomeTraces(() => {})
+
+      tracer.trace('test', () => {})
+      await traceReceived
+
+      while (!(origin in httpAgent.freeSockets)) {
+        await once(httpAgent, 'free')
+      }
+
+      const [exporterSocket] = httpAgent.freeSockets[origin]
+      const resetError = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })
+      const resetObserved = once(exporterSocket, 'error')
+
+      /**
+       * @param {string} event
+       */
+      function resetAfterCloseListener (event) {
+        if (event !== 'close') return
+
+        exporterSocket.removeListener('newListener', resetAfterCloseListener)
+        queueMicrotask(() => {
+          exporterSocket.emit('error', resetError)
+          exporterSocket.destroy()
+        })
+      }
+      exporterSocket.on('newListener', resetAfterCloseListener)
+
+      const [, [observedReset]] = await Promise.all([agent.close(), resetObserved])
+      assert.strictEqual(observedReset, resetError)
+      assert.strictEqual(origin in httpAgent.sockets, false)
+      assert.strictEqual(origin in httpAgent.freeSockets, false)
+      assert.strictEqual(origin in httpAgent.requests, false)
+    })
+
     it('finishes closing with active and queued exporter requests', async () => {
       const remoteConfigurationEnabled = process.env.DD_REMOTE_CONFIGURATION_ENABLED
       const telemetryEnabled = process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED


### PR DESCRIPTION
### What does this PR do?

Wait for exporter sockets to close without rejecting when they emit an intermediate reset during mock-agent teardown.

### Motivation

An exporter socket can emit `error` before `close` when teardown ends its server-side peer. `events.once(socket, 'close')` rejects on that error, so an otherwise complete teardown fails the suite with `ECONNRESET`.

The regression test pins the reset and verifies the active, free, and queued exporter pools are empty afterward.
