### PR TITLE
feat(openfeature): send serial_id on exposure events

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@eslint/plugin-kit": "^0.7.2",
-    "@datadog/openfeature-node-server": "2.1.0",
+    "@datadog/openfeature-node-server": "2.2.0",
     "@msgpack/msgpack": "^3.1.3",
     "@openfeature/core": "^1.12.0",
     "@openfeature/server-sdk": "~1.23.0",

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -37,6 +37,7 @@ const PENDING_MAX_EVENTS = 1000
  * @property {string} flag.key - Flag key
  * @property {object} variant - Variant information
  * @property {string} variant.key - Variant key
+ * @property {number} [serial_id] - Serial id of the split the subject landed in
  * @property {object} subject - Subject (user/entity) information
  * @property {string} subject.id - Subject identifier
  * @property {string} [subject.type] - Subject type
@@ -215,6 +216,7 @@ class ExposuresWriter extends BaseFFEWriter {
         variant: {
           key: event.variant?.key || event['variant.key'],
         },
+        ...(typeof event.serial_id === 'number' ? { serial_id: event.serial_id } : {}),
         subject: {
           id: event.subject?.id || event['subject.id'],
           type: event.subject?.type,

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -216,7 +216,7 @@ class ExposuresWriter extends BaseFFEWriter {
         variant: {
           key: event.variant?.key || event['variant.key'],
         },
-        ...(typeof event.serial_id === 'number' ? { serial_id: event.serial_id } : {}),
+        serial_id: typeof event.serial_id === 'number' ? event.serial_id : undefined,
         subject: {
           id: event.subject?.id || event['subject.id'],
           type: event.subject?.type,

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -205,7 +205,7 @@ class ExposuresWriter extends BaseFFEWriter {
   makePayload (events) {
     const formattedEvents = events.map(event => {
       /** @type {ExposureEvent} */
-      return {
+      const formatted = {
         timestamp: event.timestamp || Date.now(),
         allocation: {
           key: event.allocation?.key || event['allocation.key'],
@@ -216,13 +216,18 @@ class ExposuresWriter extends BaseFFEWriter {
         variant: {
           key: event.variant?.key || event['variant.key'],
         },
-        serial_id: typeof event.serial_id === 'number' ? event.serial_id : undefined,
         subject: {
           id: event.subject?.id || event['subject.id'],
           type: event.subject?.type,
           attributes: event.subject?.attributes,
         },
       }
+
+      if (typeof event.serial_id === 'number') {
+        formatted.serial_id = event.serial_id
+      }
+
+      return formatted
     })
 
     return {

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -268,6 +268,38 @@ describe('OpenFeature Exposures Writer', () => {
       })
     })
 
+    it('should include serial_id when present', () => {
+      const payload = writer.makePayload([{ ...exposureEvent, serial_id: 340132 }])
+
+      assert.deepStrictEqual(payload.exposures[0], {
+        timestamp: 1672531200000,
+        allocation: { key: 'allocation_123' },
+        flag: { key: 'test_flag' },
+        variant: { key: 'A' },
+        serial_id: 340132,
+        subject: {
+          id: 'user_123',
+          type: 'user',
+          attributes: { plan: 'premium' },
+        },
+      })
+    })
+
+    it('should include a serial_id of zero', () => {
+      const payload = writer.makePayload([{ ...exposureEvent, serial_id: 0 }])
+
+      assert.strictEqual(payload.exposures[0].serial_id, 0)
+    })
+
+    it('should omit serial_id when absent', () => {
+      const payload = writer.makePayload([exposureEvent])
+
+      assert.ok(
+        !Object.hasOwn(payload.exposures[0], 'serial_id'),
+        `Available keys: ${inspect(Object.keys(payload.exposures[0]))}`
+      )
+    })
+
     it('should handle optional config values', () => {
       const writerWithoutOptionals = new ExposuresWriter({
         ...config,

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -260,6 +260,7 @@ describe('OpenFeature Exposures Writer', () => {
         allocation: { key: 'allocation_123' },
         flag: { key: 'test_flag' },
         variant: { key: 'A' },
+        serial_id: undefined,
         subject: {
           id: 'user_123',
           type: 'user',
@@ -291,14 +292,24 @@ describe('OpenFeature Exposures Writer', () => {
       assert.strictEqual(payload.exposures[0].serial_id, 0)
     })
 
-    it('should omit serial_id when absent', () => {
-      const payload = writer.makePayload([exposureEvent])
+    // The intake declares serial_id as an integer and rejects the whole exposure on a type
+    // mismatch, so anything non-numeric has to leave the encoded payload entirely.
+    for (const [label, serialId] of [
+      ['absent', undefined],
+      ['null', null],
+      ['a string', '340132'],
+      ['a boolean', true],
+    ]) {
+      it(`should omit serial_id when it is ${label}`, () => {
+        const event = { ...exposureEvent }
+        if (serialId !== undefined) {
+          event.serial_id = serialId
+        }
+        const encoded = JSON.stringify(writer.makePayload([event]))
 
-      assert.ok(
-        !Object.hasOwn(payload.exposures[0], 'serial_id'),
-        `Available keys: ${inspect(Object.keys(payload.exposures[0]))}`
-      )
-    })
+        assert.ok(!encoded.includes('serial_id'), `Encoded payload: ${encoded}`)
+      })
+    }
 
     it('should handle optional config values', () => {
       const writerWithoutOptionals = new ExposuresWriter({

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -260,7 +260,6 @@ describe('OpenFeature Exposures Writer', () => {
         allocation: { key: 'allocation_123' },
         flag: { key: 'test_flag' },
         variant: { key: 'A' },
-        serial_id: undefined,
         subject: {
           id: 'user_123',
           type: 'user',

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -8,7 +8,7 @@
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.18.1",
-        "@datadog/openfeature-node-server": "2.1.0",
+        "@datadog/openfeature-node-server": "2.2.0",
         "@datadog/sketches-js": "2.1.1",
         "@datadog/source-map": "npm:source-map@^0.6.0",
         "@isaacs/ttlcache": "^2.1.5",
@@ -70,21 +70,21 @@
       }
     },
     "node_modules/@datadog/flagging-core": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-2.0.2.tgz",
-      "integrity": "sha512-2+oWyqz/EMNXtsgyW3NtueFgL0TciWInyMg/6bEUZhfr7UgPzCQ88Nag9FGoPCig19F/tHXE5hLiQccjkRUMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-2.1.0.tgz",
+      "integrity": "sha512-d43cXWx5Uxzi8SMUgSelOr6u6akNS4Pu4EZlLXvnPkEAxSo+NY2OiStnGOh5Y6ZlROd2v741SOH97zHTML99iw==",
       "license": "Apache-2.0",
       "dependencies": {
         "spark-md5": "^3.0.2"
       }
     },
     "node_modules/@datadog/openfeature-node-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.1.0.tgz",
-      "integrity": "sha512-6nzVv7d5budwJTqh/k52L7cUcl3bNsg/zYrWAniHVBlf2cyYH2dH20xwZ40kEkBVfhoaJRelQIg0qbNeoVmJlw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-2.2.0.tgz",
+      "integrity": "sha512-4ttAHzM80mV3NnrANzcCYsA98LGgiXineLYvCcagwFKjAEvWfs3i/wDscEDXVedYbPjRJEcqIuF/Pvi+Zx6pdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/flagging-core": "2.0.2"
+        "@datadog/flagging-core": "2.1.0"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@apm-js-collab/code-transformer": "^0.18.1",
-    "@datadog/openfeature-node-server": "2.1.0",
+    "@datadog/openfeature-node-server": "2.2.0",
     "@datadog/sketches-js": "2.1.1",
     "@datadog/source-map": "npm:source-map@^0.6.0",
     "@isaacs/ttlcache": "^2.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,10 +245,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
   integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
-"@datadog/flagging-core@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@datadog/flagging-core/-/flagging-core-2.0.2.tgz#333d7a5701306f7311861c1c0a3ce0be6138cc38"
-  integrity sha512-2+oWyqz/EMNXtsgyW3NtueFgL0TciWInyMg/6bEUZhfr7UgPzCQ88Nag9FGoPCig19F/tHXE5hLiQccjkRUMWQ==
+"@datadog/flagging-core@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/flagging-core/-/flagging-core-2.1.0.tgz#672854a2c057c90f31e1905a845bdf88cc81066f"
+  integrity sha512-d43cXWx5Uxzi8SMUgSelOr6u6akNS4Pu4EZlLXvnPkEAxSo+NY2OiStnGOh5Y6ZlROd2v741SOH97zHTML99iw==
   dependencies:
     spark-md5 "^3.0.2"
 
@@ -279,12 +279,12 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/openfeature-node-server@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/openfeature-node-server/-/openfeature-node-server-2.1.0.tgz#28a6eba85bfda1ad4c7564812a19364c255b14cf"
-  integrity sha512-6nzVv7d5budwJTqh/k52L7cUcl3bNsg/zYrWAniHVBlf2cyYH2dH20xwZ40kEkBVfhoaJRelQIg0qbNeoVmJlw==
+"@datadog/openfeature-node-server@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@datadog/openfeature-node-server/-/openfeature-node-server-2.2.0.tgz#e85964d06c23c7f64e39dd0e5e54a04c2048fcbc"
+  integrity sha512-4ttAHzM80mV3NnrANzcCYsA98LGgiXineLYvCcagwFKjAEvWfs3i/wDscEDXVedYbPjRJEcqIuF/Pvi+Zx6pdg==
   dependencies:
-    "@datadog/flagging-core" "2.0.2"
+    "@datadog/flagging-core" "2.1.0"
 
 "@datadog/pprof@5.18.1":
   version "5.18.1"


### PR DESCRIPTION
### What does this PR do?

Sends the `serial_id` field on exposure events.

`ExposuresWriter.makePayload` rebuilds each event from a fixed field list, so the field the provider sets was discarded before the event reached the intake. This adds it to that list, and bumps the vendored `@datadog/openfeature-node-server` to `2.2.0` — the first release whose `@datadog/flagging-core` builds the field.

### Motivation

A holdout is compiled into an ordinary allocation before an SDK receives it, so an exposure event shows no holdout. The serial id of the split the subject landed in is the only link back. The exposures worker accepts a top-level `serial_id` and resolves the holdout from it.

The rest of the pipeline is complete: the UFC compiler puts a serial id on each split, and the provider now builds the field. Node exposures carry no serial id until this change.

### Additional Notes

The gate is conditional, not unconditional. Two reasons:

- `deepStrictEqual` in the existing `should format exposure events correctly` test treats a present-but-`undefined` key as a mismatch, so an unconditional assignment fails a test that was already there.
- A truthiness check would drop a serial id of `0`. Serial ids are zero-based per org, so `0` is the first one issued in every org and sits on the oldest allocation.

Four `Test_FFE_Exposure_*_Serial_Id` classes in system-tests are declared `missing_feature (EX-3412)` for nodejs. They pass with this change, so they report `xpass` until a release contains it and the manifest moves to a version gate.

### Test instructions

```bash
npx mocha packages/dd-trace/test/openfeature/writers/exposures.spec.js
```

47 passing. Three new cases: present, `0`, and absent.

Each was shown to fail without its fix:

| Mutation | Failures |
|---|---|
| Unconditional `serial_id: event.serial_id` | 2 — the absent case, and the pre-existing `should format exposure events correctly` |
| Truthiness gate `event.serial_id ? …` | 1 — the `0` case |
| Line removed | 2 — the present case and the `0` case |

The full `packages/dd-trace/test/openfeature/**` suite is 234 passing against the new vendored SDK.

System-tests were run locally against this branch with `binaries/dd-trace-js`, express4 weblog:

| Build | Result |
|---|---|
| This branch | 4 xpassed |
| This branch, `makePayload` line removed | 4 xfailed |

The vendor bump alone is not sufficient; both halves are needed.

*This description was generated by Claude.*
