### PR TITLE
perf(iast): avoid loading rewriter when disabled

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -259,7 +259,9 @@ class Tracer extends NoopProxy {
 
       this.#updateTracing(config)
 
-      this._modules.rewriter.enable(config)
+      if (config.iast.enabled) {
+        this._modules.rewriter.enable(config)
+      }
 
       if (config.DD_TRACE_ENABLED && config.testOptimization.DD_CIVISIBILITY_MANUAL_API_ENABLED) {
         const TestApiManualPlugin = require('./ci-visibility/test-api-manual/test-api-manual-plugin')

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -35,6 +35,7 @@ describe('TracerProxy', () => {
   let aiguard
   let telemetry
   let iast
+  let rewriter
   let openfeature
   let PluginManager
   let pluginManager
@@ -205,6 +206,11 @@ describe('TracerProxy', () => {
       disable: sinon.spy(),
     }
 
+    rewriter = {
+      enable: sinon.spy(),
+      disable: sinon.spy(),
+    }
+
     openfeature = {
       enable: sinon.spy(),
       disable: sinon.spy(),
@@ -259,6 +265,7 @@ describe('TracerProxy', () => {
       './profiler': profiler,
       './appsec': appsec,
       './appsec/iast': iast,
+      './appsec/iast/taint-tracking/rewriter': rewriter,
       './aiguard': aiguard,
       './telemetry': telemetry,
       './remote_config': RemoteConfig,
@@ -288,6 +295,15 @@ describe('TracerProxy', () => {
         sinon.assert.calledWith(Config, options)
         sinon.assert.calledWith(DatadogTracer, config)
         sinon.assert.calledOnceWithExactly(RemoteConfig, config)
+        sinon.assert.notCalled(rewriter.enable)
+      })
+
+      it('should enable the IAST rewriter when IAST is enabled', () => {
+        config.iast.enabled = true
+
+        proxy.init()
+
+        sinon.assert.calledOnceWithExactly(rewriter.enable, config)
       })
 
       it('should not initialize twice', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Only enables and loads the IAST rewriter when IAST is configured. The existing IAST-enabled path is preserved.

### Motivation
<!-- What inspired you to submit this pull request? -->
Tracer startup currently loads the rewriter even when IAST is disabled. Test Optimization does not enable IAST, so this adds unrelated startup work to every Jest process.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
A one-file startup microbenchmark measured 54.51% and 57.29% lower cost in two fresh runs. The cumulative TIA benchmark reached its best observed overhead after this change: 408.85 ms versus the 642.56 ms baseline, with the exact coverage map preserved.

Verification:
- ESLint on the changed files
- `./node_modules/.bin/mocha packages/dd-trace/test/proxy.spec.js` (76 passing)