### PR TITLE
fix(telemetry): report tracer error logs

### DIFF
--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -56,20 +56,13 @@ const log = {
   },
 
   error (...args) {
-    publishFormatted(errorChannel, formatted => {
-      const stackTraceLimitBackup = Error.stackTraceLimit
-      Error.stackTraceLimit = 0
-      const newError = new Error(formatted)
-      Error.stackTraceLimit = stackTraceLimitBackup
-      Error.captureStackTrace(newError, log.error)
-      return newError
-    }, ...args)
+    publishError(...args)
     return log
   },
 
   errorWithoutTelemetry (...args) {
     args.push(NO_TRANSMIT)
-    publishFormatted(errorChannel, null, ...args)
+    publishError(...args)
     return log
   },
 
@@ -97,6 +90,21 @@ function publishFormatted (ch, formatter, ...args) {
     // TODO: replace it with Error(message, { cause }) when cause has broad support
     if (formatted) ch.publish(formatter?.(formatted) || formatted)
     if (cause) ch.publish(cause)
+  }
+}
+
+function publishError (...args) {
+  if (!errorChannel.hasSubscribers) return
+
+  const { formatted, cause, sendViaTelemetry } = getErrorLog(Log.parse(...args))
+  if (formatted) {
+    const error = new Error(formatted, { cause })
+    error.sendViaTelemetry = sendViaTelemetry
+    Error.captureStackTrace(error, log.error)
+    errorChannel.publish(error)
+  } else if (cause) {
+    if (!sendViaTelemetry) cause.sendViaTelemetry = false
+    errorChannel.publish(cause)
   }
 }
 

--- a/packages/dd-trace/src/telemetry/logs/format-error.js
+++ b/packages/dd-trace/src/telemetry/logs/format-error.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * @param {{ message?: string, cause?: Error, stack?: string, constructor?: Function,
+ *   sendViaTelemetry?: boolean }} error
+ * @returns {{ level: 'ERROR', count: number, message: string, stack_trace?: string,
+ *   errorType?: string } | undefined}
+ */
+module.exports = function formatError (error) {
+  if (!error || error.sendViaTelemetry === false) return
+
+  const cause = error.cause ?? error
+  const message = error.message ?? 'Generic Error'
+  if (!message && !cause.stack) return
+
+  const telemetryLog = {
+    level: 'ERROR',
+    count: 1,
+    message,
+  }
+
+  if (cause.stack) {
+    telemetryLog.stack_trace = cause.stack
+    telemetryLog.errorType = cause.constructor.name
+  }
+
+  return telemetryLog
+}

--- a/packages/dd-trace/src/telemetry/logs/index.js
+++ b/packages/dd-trace/src/telemetry/logs/index.js
@@ -2,6 +2,7 @@
 
 const dc = require('dc-polyfill')
 const { sendData } = require('../send-data')
+const formatError = require('./format-error')
 const logCollector = require('./log-collector')
 
 const telemetryLog = dc.channel('datadog:telemetry:log')
@@ -37,24 +38,9 @@ function onLog (log) {
   }
 }
 
-function onErrorLog (msg) {
-  const { message, cause, sendViaTelemetry } = msg
-  if (!sendViaTelemetry || (!message && !cause)) return
-
-  const telLog = {
-    level: 'ERROR',
-    count: 1,
-
-    // existing log.error(err) without message will be reported as 'Generic Error'
-    message: message ?? 'Generic Error',
-  }
-
-  if (cause) {
-    telLog.stack_trace = cause.stack
-    telLog.errorType = cause.constructor.name
-  }
-
-  onLog(telLog)
+function onErrorLog (error) {
+  const telemetryLog = formatError(error)
+  if (telemetryLog) onLog(telemetryLog)
 }
 
 function start (config) {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -367,13 +367,14 @@ describe('log', () => {
       })
 
       it('should allow a message + Error', () => {
-        log.error('this is an error', new Error('cause'))
+        const cause = new Error('cause')
 
-        sinon.assert.called(console.error)
+        log.error('this is an error', cause)
+
+        sinon.assert.calledOnce(console.error)
         assert.ok(console.error.firstCall.args[0] instanceof Error)
         assert.strictEqual(console.error.firstCall.args[0].message, 'this is an error')
-        assert.ok(console.error.secondCall.args[0] instanceof Error)
-        assert.strictEqual(console.error.secondCall.args[0].message, 'cause')
+        assert.strictEqual(console.error.firstCall.args[0].cause, cause)
       })
 
       it('should allow a templated message', () => {
@@ -385,13 +386,14 @@ describe('log', () => {
       })
 
       it('should allow a templated message + Error', () => {
-        log.error('this is an error of type: %s code: %i', 'ERR', 42, new Error('cause'))
+        const cause = new Error('cause')
 
-        sinon.assert.called(console.error)
+        log.error('this is an error of type: %s code: %i', 'ERR', 42, cause)
+
+        sinon.assert.calledOnce(console.error)
         assert.ok(console.error.firstCall.args[0] instanceof Error)
         assert.strictEqual(console.error.firstCall.args[0].message, 'this is an error of type: ERR code: 42')
-        assert.ok(console.error.secondCall.args[0] instanceof Error)
-        assert.strictEqual(console.error.secondCall.args[0].message, 'cause')
+        assert.strictEqual(console.error.firstCall.args[0].cause, cause)
       })
 
       it('should allow a message + Error + LogConfig', () => {
@@ -400,16 +402,19 @@ describe('log', () => {
         sinon.assert.called(console.error)
         assert.ok(console.error.firstCall.args[0] instanceof Error)
         assert.strictEqual(console.error.firstCall.args[0].message, 'this is an error with a log config')
+        assert.strictEqual(console.error.firstCall.args[0].sendViaTelemetry, false)
       })
 
       it('should allow a message + NoTransmitError', () => {
-        log.error('this is an error without a log config', new log.NoTransmitError('bad underlying thing'))
+        const cause = new log.NoTransmitError('bad underlying thing')
 
-        sinon.assert.called(console.error)
+        log.error('this is an error without a log config', cause)
+
+        sinon.assert.calledOnce(console.error)
         assert.ok(console.error.firstCall.args[0] instanceof Error)
         assert.strictEqual(console.error.firstCall.args[0].message, 'this is an error without a log config')
-        assert.ok(console.error.secondCall.args[0] instanceof Error)
-        assert.strictEqual(console.error.secondCall.args[0].message, 'bad underlying thing')
+        assert.strictEqual(console.error.firstCall.args[0].cause, cause)
+        assert.strictEqual(console.error.firstCall.args[0].sendViaTelemetry, false)
       })
     })
 

--- a/packages/dd-trace/test/telemetry/logs/index.spec.js
+++ b/packages/dd-trace/test/telemetry/logs/index.spec.js
@@ -8,8 +8,6 @@ const { match } = sinon
 
 require('../../setup/core')
 
-const { Log } = require('../../../src/log/log')
-
 describe('telemetry logs', () => {
   let defaultConfig
   let telemetryLog
@@ -149,40 +147,60 @@ describe('telemetry logs', () => {
       it('should be called when an Error object is published to datadog:log:error', () => {
         const error = new Error('message')
         const stack = error.stack
-        errorLog.publish({ cause: error, sendViaTelemetry: true })
+        errorLog.publish(error)
 
         sinon.assert.calledOnceWithExactly(logCollectorAdd, match({
-          message: 'Generic Error',
+          message: 'message',
           level: 'ERROR',
           errorType: 'Error',
           stack_trace: stack,
         }))
       })
 
-      it('should be called when an error string is published to datadog:log:error', () => {
-        errorLog.publish({ message: 'custom error message', sendViaTelemetry: true })
+      it('should use the outer message and the cause stack', () => {
+        const cause = new Error('cause')
+        const error = new Error('custom error message', { cause })
+        errorLog.publish(error)
 
         sinon.assert.calledOnceWithExactly(logCollectorAdd, match({
           message: 'custom error message',
           level: 'ERROR',
-          stack_trace: undefined,
+          stack_trace: cause.stack,
         }))
       })
 
       it('should not be called when an invalid object is published to datadog:log:error', () => {
-        errorLog.publish({ invalid: 'field', sendViaTelemetry: true })
-
-        sinon.assert.notCalled(logCollectorAdd)
-      })
-
-      it('should not be called when an object without message and stack is published to datadog:log:error', () => {
-        errorLog.publish(Log.parse(() => new Error('error')))
+        errorLog.publish()
 
         sinon.assert.notCalled(logCollectorAdd)
       })
 
       it('should not be called when an error contains sendViaTelemetry:false', () => {
-        errorLog.publish({ message: 'custom error message', sendViaTelemetry: false })
+        const error = new Error('custom error message')
+        error.sendViaTelemetry = false
+        errorLog.publish(error)
+
+        sinon.assert.notCalled(logCollectorAdd)
+      })
+
+      it('should collect an actual log.error call once', () => {
+        const cause = new Error('cause')
+        const log = require('../../../src/log')
+
+        log.error('custom error message', cause)
+
+        sinon.assert.calledOnceWithExactly(logCollectorAdd, match({
+          message: 'custom error message',
+          level: 'ERROR',
+          errorType: 'Error',
+          stack_trace: cause.stack,
+        }))
+      })
+
+      it('should not collect an actual log.errorWithoutTelemetry call', () => {
+        const log = require('../../../src/log')
+
+        log.errorWithoutTelemetry('custom error message', new Error('cause'))
 
         sinon.assert.notCalled(logCollectorAdd)
       })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Publishes each tracer `log.error()` call as one structured error record and preserves its telemetry opt-in state. The shared telemetry log collector now formats standalone and wrapped errors consistently, using the outer message and the underlying cause's stack and type.

This changes `log.error(message, cause)` from two diagnostic-channel events to one `Error` with `cause`, while `errorWithoutTelemetry()` remains visible to configured loggers and is explicitly excluded from telemetry.

### Motivation
<!-- What inspired you to submit this pull request? -->

The central logger parsed errors into a record containing `message`, `cause`, and `sendViaTelemetry`, but discarded that record when publishing to `datadog:log:error`. The telemetry consumer expected those discarded fields, so normal tracer errors from any product were dropped instead of reaching telemetry intake.

For example, Profiling reports failures from profile compression, capture, encoding, and submission with the following pattern:

```js
try {
  // Capture, encode, or submit a profile.
} catch (error) {
  log.error(error)
}
```

Before this change, `log.error(error)` published the original `Error` to `datadog:log:error` without a `sendViaTelemetry` property. The configured tracer logger could still print it locally, but the telemetry consumer interpreted the missing property as disabled and discarded the record. No telemetry `logs` payload described the Profiling failure.

After this change, an error is eligible for telemetry unless it is explicitly marked `sendViaTelemetry: false`. The collector formats the Profiling failure using its message, stack, and error type, then sanitizes and deduplicates it before sending it through the telemetry `logs` request. The same fix applies to shared `log.error()` calls from other tracer products.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verified with:

- `./node_modules/.bin/mocha packages/dd-trace/test/log.spec.js` (52 passing)
- `./node_modules/.bin/mocha packages/dd-trace/test/telemetry/logs/index.spec.js` (18 passing)
- targeted NYC coverage of the changed logger and telemetry paths
- `npm run lint`
