### PR TITLE
fix(test-optimization): forward worker error logs

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const dc = require('dc-polyfill')
+
 const {
   JEST_WORKER_COVERAGE_PAYLOAD_CODE,
   JEST_WORKER_TRACE_PAYLOAD_CODE,
@@ -19,7 +21,16 @@ const {
 } = require('../../../plugins/util/test')
 const getConfig = require('../../../config')
 const { getEnvironmentVariable } = require('../../../config/helper')
+const formatError = require('../../../telemetry/logs/format-error')
 const Writer = require('./writer')
+
+const errorLog = dc.channel('datadog:log:error')
+let telemetryWriter
+
+errorLog.subscribe((error) => {
+  const log = formatError(error)
+  if (log) telemetryWriter?.append({ type: 'log', log })
+})
 
 function getInterprocessTraceCode () {
   const { DD_PLAYWRIGHT_WORKER, DD_VITEST_WORKER } = getConfig()
@@ -97,7 +108,8 @@ function getInterprocessTelemetryCode () {
  * Currently used by Jest, Cucumber and Mocha workers.
  */
 class TestWorkerCiVisibilityExporter {
-  constructor () {
+  /** @param {import('../../../config/config-base')} [config] */
+  constructor (config) {
     const interprocessTraceCode = getInterprocessTraceCode()
     const interprocessCoverageCode = getInterprocessCoverageCode()
     const interprocessLogsCode = getInterprocessLogsCode()
@@ -108,6 +120,9 @@ class TestWorkerCiVisibilityExporter {
     this._logsWriter = new Writer(interprocessLogsCode)
     if (interprocessTelemetryCode) {
       this._telemetryWriter = new Writer(interprocessTelemetryCode)
+      telemetryWriter = config?.telemetry?.DD_TELEMETRY_LOG_COLLECTION_ENABLED === false
+        ? undefined
+        : this._telemetryWriter
       this.exportTelemetry = function (telemetryEvent) {
         this._telemetryWriter.append(telemetryEvent)
       }

--- a/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/test-worker/writer.js
@@ -60,7 +60,7 @@ class Writer {
       try {
         vitestWorkerPort.postMessage(payload)
       } catch (error) {
-        log.error('Error posting message to vitest worker port', error)
+        log.errorWithoutTelemetry('Error posting message to vitest worker port', error)
       } finally {
         onDone()
       }
@@ -70,7 +70,7 @@ class Writer {
     // child_process workers (jest default, cucumber)
     if (process.send) {
       process.send(payload, (error) => {
-        if (error) log.error('Error sending message to parent process', error)
+        if (error) log.errorWithoutTelemetry('Error sending message to parent process', error)
         onDone(error)
       })
       return
@@ -82,7 +82,7 @@ class Writer {
       try {
         parentPort.postMessage(payload)
       } catch (error) {
-        log.error('Error posting message to parent port', error)
+        log.errorWithoutTelemetry('Error posting message to parent port', error)
         onDone(error)
         return
       }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -6,6 +6,8 @@ const realClearTimeout = clearTimeout
 
 const { threadId } = require('node:worker_threads')
 
+const dc = require('dc-polyfill')
+
 const { storage } = require('../../../datadog-core')
 const { COMPONENT } = require('../constants')
 const log = require('../log')
@@ -96,6 +98,7 @@ const {
   DD_CAPABILITIES_TEST_IMPACT_ANALYSIS,
 } = require('./util/test')
 
+const telemetryLog = dc.channel('datadog:telemetry:log')
 const legacyStorage = storage('legacy')
 const DI_OPERATION_TIMEOUT_MS = 2000
 const DI_LOGGER_THREAD_ID = threadId === 0 ? `pid:${process.pid}` : `pid:${process.pid};tid:${threadId}`
@@ -475,6 +478,8 @@ module.exports = class CiPlugin extends Plugin {
           this.telemetry.count(event.name, event.tags, event.value)
         } else if (event.type === 'distribution') {
           this.telemetry.distribution(event.name, event.tags, event.measure)
+        } else if (event.type === 'log') {
+          telemetryLog.publish(event.log)
         }
       }
     })

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -305,30 +305,41 @@ describe('CiPlugin', () => {
 
   it('consumes worker telemetry for every test framework', () => {
     const plugin = createPlugin('vitest_worker', true)
+    const onTelemetryLog = sinon.stub()
+    const telemetryLog = dc.channel('datadog:telemetry:log')
+    telemetryLog.subscribe(onTelemetryLog)
 
-    dc.channel('ci:vitest:worker-report:telemetry').publish(JSON.stringify([
-      {
-        type: 'ciVisEvent',
-        name: 'code_coverage_started',
-        testLevel: 'suite',
-        testFramework: 'vitest',
-        isUnsupportedCIProvider: false,
-        tags: { library: 'v8' },
-      },
-      {
-        type: 'count',
-        name: 'itr_unskippable',
-        tags: { testLevel: 'suite' },
-        value: 2,
-      },
-      {
-        type: 'distribution',
-        name: 'code_coverage.files',
-        tags: {},
-        measure: 3,
-      },
-    ]))
-    plugin.configure(false)
+    try {
+      dc.channel('ci:vitest:worker-report:telemetry').publish(JSON.stringify([
+        {
+          type: 'ciVisEvent',
+          name: 'code_coverage_started',
+          testLevel: 'suite',
+          testFramework: 'vitest',
+          isUnsupportedCIProvider: false,
+          tags: { library: 'v8' },
+        },
+        {
+          type: 'count',
+          name: 'itr_unskippable',
+          tags: { testLevel: 'suite' },
+          value: 2,
+        },
+        {
+          type: 'distribution',
+          name: 'code_coverage.files',
+          tags: {},
+          measure: 3,
+        },
+        {
+          type: 'log',
+          log: { level: 'ERROR', count: 1, message: 'worker error' },
+        },
+      ]))
+    } finally {
+      plugin.configure(false)
+      telemetryLog.unsubscribe(onTelemetryLog)
+    }
 
     sinon.assert.calledWith(incrementCountMetric, 'code_coverage_started', {
       testLevel: 'suite',
@@ -338,6 +349,11 @@ describe('CiPlugin', () => {
     })
     sinon.assert.calledWith(incrementCountMetric, 'itr_unskippable', { testLevel: 'suite' }, 2)
     sinon.assert.calledWith(distributionMetric, 'code_coverage.files', {}, 3)
+    sinon.assert.calledOnceWithExactly(onTelemetryLog, {
+      level: 'ERROR',
+      count: 1,
+      message: 'worker error',
+    }, 'datadog:telemetry:log')
   })
 
   it('defers worker suite events when the exporter supports late test suite updates', () => {

--- a/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js
@@ -8,6 +8,7 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('../../../../../dd-trace/test/setup/core')
+const log = require('../../../../src/log')
 const TestWorkerCiVisibilityExporter = proxyquire('../../../../src/ci-visibility/exporters/test-worker', {
   '../../../config': () => proxyquire.noPreserveCache()('../../../../src/config', {})(),
 })
@@ -15,6 +16,7 @@ const TestWorkerCiVisibilityExporter = proxyquire('../../../../src/ci-visibility
 const {
   JEST_WORKER_TRACE_PAYLOAD_CODE,
   JEST_WORKER_COVERAGE_PAYLOAD_CODE,
+  JEST_WORKER_TELEMETRY_PAYLOAD_CODE,
   CUCUMBER_WORKER_TRACE_PAYLOAD_CODE,
   CUCUMBER_WORKER_TELEMETRY_PAYLOAD_CODE,
   MOCHA_WORKER_LOGS_PAYLOAD_CODE,
@@ -29,6 +31,25 @@ const {
 
 describe('CI Visibility Test Worker Exporter', () => {
   let send, originalSend
+
+  function exportErrorLog (telemetryCode) {
+    const cause = new Error('worker cause')
+    const workerExporter = new TestWorkerCiVisibilityExporter()
+
+    log.error('worker error', cause)
+    workerExporter.flush()
+
+    sinon.assert.calledWith(send, [telemetryCode, JSON.stringify([{
+      type: 'log',
+      log: {
+        level: 'ERROR',
+        count: 1,
+        message: 'worker error',
+        stack_trace: cause.stack,
+        errorType: 'Error',
+      },
+    }])])
+  }
 
   beforeEach(() => {
     send = sinon.spy()
@@ -68,6 +89,21 @@ describe('CI Visibility Test Worker Exporter', () => {
       sinon.assert.calledWith(send,
         [JEST_WORKER_COVERAGE_PAYLOAD_CODE, JSON.stringify([coverage, coverageSecond])]
       )
+    })
+
+    it('can export error logs', () => {
+      exportErrorLog(JEST_WORKER_TELEMETRY_PAYLOAD_CODE)
+    })
+
+    it('does not export error logs when telemetry log collection is disabled', () => {
+      const workerExporter = new TestWorkerCiVisibilityExporter({
+        telemetry: { DD_TELEMETRY_LOG_COLLECTION_ENABLED: false },
+      })
+
+      log.error('worker error', new Error('worker cause'))
+      workerExporter.flush()
+
+      sinon.assert.notCalled(send)
     })
 
     it('signals completion after all queued payloads flush', () => {
@@ -164,6 +200,10 @@ describe('CI Visibility Test Worker Exporter', () => {
       )
     })
 
+    it('can export error logs', () => {
+      exportErrorLog(CUCUMBER_WORKER_TELEMETRY_PAYLOAD_CODE)
+    })
+
     it('signals completion after traces flush', () => {
       const callbacks = []
       send = sinon.stub().callsFake((payload, callback) => {
@@ -217,6 +257,10 @@ describe('CI Visibility Test Worker Exporter', () => {
       sinon.assert.calledWith(send, [MOCHA_WORKER_TELEMETRY_PAYLOAD_CODE, JSON.stringify([telemetry])])
     })
 
+    it('can export error logs', () => {
+      exportErrorLog(MOCHA_WORKER_TELEMETRY_PAYLOAD_CODE)
+    })
+
     it('can export DI logs', () => {
       process.env.MOCHA_WORKER_ID = 'webdriverio'
       const testEnvironmentMetadata = { testFramework: 'webdriverio' }
@@ -243,6 +287,11 @@ describe('CI Visibility Test Worker Exporter', () => {
   })
 
   context('when writing from a WebdriverIO worker', () => {
+    afterEach(() => {
+      delete process.env.MOCHA_WORKER_ID
+      delete process.env._DD_TEST_OPTIMIZATION_WEBDRIVERIO_WORKER
+    })
+
     it('wraps traces in a filtered WebdriverIO worker event', () => {
       const trace = [{ type: 'test' }]
       const WebdriverioWriter = proxyquire('../../../../src/ci-visibility/exporters/test-worker/writer', {
@@ -260,6 +309,53 @@ describe('CI Visibility Test Worker Exporter', () => {
         name: 'workerEvent',
         args: [MOCHA_WORKER_TRACE_PAYLOAD_CODE, JSON.stringify([trace])],
       })
+    })
+
+    it('wraps error logs in a filtered WebdriverIO worker event', () => {
+      process.env.MOCHA_WORKER_ID = 'webdriverio'
+      process.env._DD_TEST_OPTIMIZATION_WEBDRIVERIO_WORKER = 'true'
+      const cause = new Error('worker cause')
+      const workerExporter = new TestWorkerCiVisibilityExporter()
+
+      log.error('worker error', cause)
+      workerExporter.flush()
+
+      sinon.assert.calledWith(send, {
+        origin: 'datadog',
+        name: 'workerEvent',
+        args: [MOCHA_WORKER_TELEMETRY_PAYLOAD_CODE, JSON.stringify([{
+          type: 'log',
+          log: {
+            level: 'ERROR',
+            count: 1,
+            message: 'worker error',
+            stack_trace: cause.stack,
+            errorType: 'Error',
+          },
+        }])],
+      })
+    })
+  })
+
+  context('when writing through a worker thread parent port', () => {
+    it('reports a parent port error', () => {
+      delete process.send
+      const error = new Error('parent port closed')
+      const onDone = sinon.spy()
+      const ParentPortWriter = proxyquire('../../../../src/ci-visibility/exporters/test-worker/writer', {
+        'node:worker_threads': {
+          isMainThread: false,
+          parentPort: {
+            postMessage: () => { throw error },
+          },
+        },
+      })
+      const writer = new ParentPortWriter(MOCHA_WORKER_TRACE_PAYLOAD_CODE)
+
+      writer.append([{ type: 'test' }])
+      writer.flush(onDone)
+
+      sinon.assert.calledOnceWithExactly(onDone, error)
     })
   })
 
@@ -287,6 +383,10 @@ describe('CI Visibility Test Worker Exporter', () => {
       playwrightWorkerExporter.exportTelemetry(telemetry)
       playwrightWorkerExporter.flush()
       sinon.assert.calledWith(send, [PLAYWRIGHT_WORKER_TELEMETRY_PAYLOAD_CODE, JSON.stringify([telemetry])])
+    })
+
+    it('can export error logs', () => {
+      exportErrorLog(PLAYWRIGHT_WORKER_TELEMETRY_PAYLOAD_CODE)
     })
 
     it('does not break if process.send is undefined', () => {
@@ -342,6 +442,11 @@ describe('CI Visibility Test Worker Exporter', () => {
       )
     })
 
+    it('can export error logs', () => {
+      process.env.DD_VITEST_WORKER = '1'
+      exportErrorLog(VITEST_WORKER_TELEMETRY_PAYLOAD_CODE)
+    })
+
     it('wraps the payload for legacy tinypool workers (vitest <4)', () => {
       process.env.TINYPOOL_WORKER_ID = '1'
       const trace = [{ type: 'test' }]
@@ -372,6 +477,26 @@ describe('CI Visibility Test Worker Exporter', () => {
       vitestWorkerExporter.flush()
       sinon.assert.calledWith(postMessage, [VITEST_WORKER_TRACE_PAYLOAD_CODE, JSON.stringify([trace])])
       sinon.assert.notCalled(send)
+    })
+
+    it('completes a flush when the worker port rejects the payload', () => {
+      process.env.DD_VITEST_WORKER = '1'
+      delete process.send
+      const error = new Error('worker port closed')
+      const onDone = sinon.spy()
+      globalThis.__vitest_worker__ = {
+        ctx: {
+          port: {
+            postMessage: () => { throw error },
+          },
+        },
+      }
+      const vitestWorkerExporter = new TestWorkerCiVisibilityExporter()
+
+      vitestWorkerExporter.export([{ type: 'test' }])
+      vitestWorkerExporter.flush(onDone)
+
+      sinon.assert.calledOnceWithExactly(onDone, undefined)
     })
 
     it('does not break if process.send is undefined', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Forwards `log.error()` records emitted by Test Optimization workers through the existing worker telemetry IPC channel to the coordinator's telemetry log collector.

This applies to Jest, Cucumber, Mocha, Playwright, Vitest, and WebdriverIO. It keeps full instrumentation telemetry disabled in workers, honors `DD_TELEMETRY_LOG_COLLECTION_ENABLED`, and prevents worker IPC transport failures from recursively entering the same telemetry transport.

### Motivation
<!-- What inspired you to submit this pull request? -->

Test workers intentionally disable their own telemetry clients and already forward metric events to the coordinator, but error logs had no corresponding bridge. Errors emitted from worker-only Test Optimization code therefore never reached telemetry intake.

This PR is stacked on #9943 and uses its common error formatter.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verified with:

- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/exporters/test-worker/exporter.spec.js` (33 passing)
- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/ci-plugin.spec.js` (27 passing)
- targeted NYC coverage of the worker exporter and writer
- targeted ESLint for all five changed files
