### PR TITLE
ci(test-optimization): use dispatched workflow run id

### DIFF
--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -58,7 +58,8 @@ const getCommonHeaders = () => {
   return {
     'Content-Type': 'application/json',
     authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-    Accept: 'application/vnd.github.v3+json',
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2026-03-10',
     'user-agent': 'dd-trace benchmark tests',
   }
 }
@@ -66,7 +67,6 @@ const getCommonHeaders = () => {
 const triggerWorkflow = () => {
   console.log(`Commit SHA under test: ${getRefToTest()} in ${getRefName()}`)
   return new Promise((resolve, reject) => {
-    // eslint-disable-next-line
     let response = ''
     const body = JSON.stringify({
       ref: 'main',
@@ -82,34 +82,10 @@ const triggerWorkflow = () => {
           response += chunk
         })
         res.on('end', () => {
-          resolve(res.statusCode)
-        })
-      })
-    request.on('error', (error) => {
-      reject(error)
-    })
-    request.write(body)
-    request.end()
-  })
-}
-
-const getWorkflowRunsInProgress = () => {
-  return new Promise((resolve, reject) => {
-    let response = ''
-    const request = https.request(
-      `${GET_WORKFLOWS_URL}?event=workflow_dispatch`,
-      {
-        headers: getCommonHeaders(),
-      },
-      (res) => {
-        res.on('data', (chunk) => {
-          response += chunk
-        })
-        res.on('end', () => {
           try {
             resolve(parseGitHubJsonResponse({
               body: response,
-              endpoint: `${GET_WORKFLOWS_URL}?event=workflow_dispatch`,
+              endpoint: DISPATCH_WORKFLOW_URL,
               res,
             }))
           } catch (e) {
@@ -117,9 +93,10 @@ const getWorkflowRunsInProgress = () => {
           }
         })
       })
-    request.on('error', err => {
-      reject(err)
+    request.on('error', (error) => {
+      reject(error)
     })
+    request.write(body)
     request.end()
   })
 }
@@ -162,30 +139,15 @@ const getCurrentWorkflowJobs = (runId) => {
 async function main () {
   // Trigger JS GHA
   console.log('Triggering Test Optimization test environment workflow.')
-  const httpResponseCode = await triggerWorkflow()
-  console.log('GitHub API response code:', httpResponseCode)
-
-  if (httpResponseCode !== 204) {
-    throw new Error('Could not trigger workflow')
-  }
-
-  // Give some time for GH to process the request
-  await setTimeout(15000)
-
-  // Get the run ID from the workflow we just triggered
-  const workflowsInProgress = await getWorkflowRunsInProgress()
-  const { total_count: numWorkflows, workflow_runs: workflows } = workflowsInProgress
-  if (numWorkflows === 0) {
-    throw new Error('Could not find the triggered workflow')
-  }
-  // Pick the first one (most recently triggered one)
-  const [triggeredWorkflow] = workflows
-
+  const triggeredWorkflow = await triggerWorkflow()
   console.log('Triggered workflow:', triggeredWorkflow)
 
-  const { id: runId } = triggeredWorkflow || {}
+  const { workflow_run_id: runId, html_url: workflowUrl } = triggeredWorkflow
+  if (!runId) {
+    throw new Error('Triggered workflow response did not include a run id')
+  }
 
-  console.log(`Workflow URL: https://github.com/DataDog/test-environment/actions/runs/${runId}`)
+  console.log(`Workflow URL: ${workflowUrl}`)
 
   // Wait an initial 1 minute, because we're sure it won't finish earlier
   await setTimeout(60000)

--- a/benchmark/e2e-test-optimization/benchmark-run.spec.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.spec.js
@@ -1,0 +1,157 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+
+const { afterEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+/**
+ * @typedef {object} ResponseData
+ * @property {string} body
+ * @property {number} statusCode
+ */
+
+/**
+ * @typedef {object} RequestRecord
+ * @property {string} body
+ * @property {{ headers: Record<string, string> }} options
+ * @property {string} url
+ */
+
+/**
+ * @callback RequestStub
+ * @param {string} url
+ * @param {{ headers: Record<string, string> }} options
+ * @param {(response: EventEmitter & {
+ *   headers: Record<string, string>,
+ *   statusCode: number
+ * }) => void} callback
+ * @returns {EventEmitter & {
+ *   end: () => void,
+ *   write: (chunk: string) => void
+ * }}
+ */
+
+describe('test optimization end-to-end benchmark runner', () => {
+  const originalEnvironment = {
+    githubToken: process.env.GITHUB_TOKEN,
+    refName: process.env.TEST_ENVIRONMENT_REF_NAME,
+    refToTest: process.env.TEST_ENVIRONMENT_REF_TO_TEST,
+  }
+  const originalExitCode = process.exitCode
+
+  afterEach(() => {
+    restoreEnvironmentVariable('GITHUB_TOKEN', originalEnvironment.githubToken)
+    restoreEnvironmentVariable('TEST_ENVIRONMENT_REF_NAME', originalEnvironment.refName)
+    restoreEnvironmentVariable('TEST_ENVIRONMENT_REF_TO_TEST', originalEnvironment.refToTest)
+    process.exitCode = originalExitCode
+    sinon.restore()
+  })
+
+  it('polls the workflow run returned by the dispatch request', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_NAME = 'feature-branch'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const responses = [
+      {
+        body: JSON.stringify({
+          workflow_run_id: 12345,
+          run_url: 'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+          html_url: 'https://github.com/DataDog/test-environment/actions/runs/12345',
+        }),
+        statusCode: 200,
+      },
+      {
+        body: JSON.stringify({
+          jobs: [{ conclusion: 'success', status: 'completed' }],
+        }),
+        statusCode: 200,
+      },
+    ]
+    const requests = []
+    const completion = waitForSuccessfulCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    await completion
+
+    assert.strictEqual(requests.length, 2)
+    assert.strictEqual(requests[0].url,
+      'https://api.github.com/repos/DataDog/test-environment/actions/workflows/dd-trace-js-tests.yml/dispatches')
+    assert.strictEqual(requests[0].options.headers['X-GitHub-Api-Version'], '2026-03-10')
+    assert.deepStrictEqual(JSON.parse(requests[0].body), {
+      inputs: { sha: 'abc123' },
+      ref: 'main',
+    })
+    assert.strictEqual(requests[1].url,
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345/jobs')
+  })
+})
+
+/**
+ * @param {ResponseData[]} responses
+ * @param {RequestRecord[]} requests
+ * @returns {RequestStub}
+ */
+function createRequestStub (responses, requests) {
+  return (url, options, callback) => {
+    const request = new EventEmitter()
+    let body = ''
+
+    request.write = chunk => {
+      body += chunk
+    }
+    request.end = () => {
+      requests.push({ body, options, url })
+      const responseData = responses.shift()
+      const response = new EventEmitter()
+      response.headers = { 'content-type': 'application/json; charset=utf-8' }
+      response.statusCode = responseData.statusCode
+      callback(response)
+      process.nextTick(() => {
+        response.emit('data', responseData.body)
+        response.emit('end')
+      })
+    }
+    return request
+  }
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+function waitForSuccessfulCompletion () {
+  return new Promise((resolve, reject) => {
+    sinon.stub(console, 'log').callsFake(message => {
+      if (message === 'Performance overhead test successful.') {
+        resolve()
+      }
+    })
+    sinon.stub(console, 'error').callsFake(error => {
+      reject(error)
+    })
+  })
+}
+
+/**
+ * @param {string} name
+ * @param {string|undefined} value
+ * @returns {void}
+ */
+function restoreEnvironmentVariable (name, value) {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "test:integration:plugins:coverage": "yarn services && node ./integration-tests/coverage/run-suite.js \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/${SPEC:-*}*.spec.js\"",
     "test:unit:plugins": "mocha \"packages/datadog-instrumentations/test/@(${PLUGINS}).spec.js\" \"packages/datadog-plugin-@(${PLUGINS})/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/*.spec.js\"",
     "test:release": "mocha \"scripts/release/**/*.spec.js\"",
-    "test:scripts": "mocha \"scripts/helpers/**/*.spec.js\" \"scripts/*.spec.mjs\"",
+    "test:scripts": "mocha \"benchmark/e2e-test-optimization/*.spec.js\" \"benchmark/sirun/*.spec.js\" \"scripts/helpers/**/*.spec.js\" \"scripts/*.spec.mjs\"",
     "test:shimmer": "mocha \"packages/datadog-shimmer/test/**/*.spec.js\"",
     "test:shimmer:ci": "node scripts/c8-ci.js test:shimmer",
     "verify:workflow-job-names": "node scripts/verify-workflow-job-names.js",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Upgrades workflow dispatch requests to GitHub REST API version 2026-03-10 and uses the workflow_run_id returned by the dispatch response.

This removes the timing-based lookup of the most recent workflow_dispatch run and adds a focused test that verifies the exact returned run is polled.

### Motivation
<!-- What inspired you to submit this pull request? -->

Concurrent release proposal workflows dispatched two test-environment runs in the same second. Both callers selected the same run from the recent-runs API, so one caller monitored the wrong downstream workflow and reported its failure.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verification:

- npm run test:scripts (171 passing)
- npm run lint
- Scoped nyc coverage for benchmark/e2e-test-optimization/benchmark-run.js
