### PR TITLE
ci(test-optimization): use dispatched workflow run id

### DIFF
--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -10,8 +10,10 @@ const DISPATCH_WORKFLOW_URL = `${API_REPOSITORY_URL}/actions/workflows/dd-trace-
 const GET_WORKFLOWS_URL = `${API_REPOSITORY_URL}/actions/runs`
 
 const POLL_INTERVAL_MS = 5000
-const MAX_WORKFLOW_POLLS = 30 * 60 / 5 // 30 minutes, polling every 5 seconds = 360 polls
-const RETRY_GRACE_PERIOD_POLLS = 60 / 5 // 1 minute, polling every 5 seconds
+const MAX_WORKFLOW_WAIT_MS = 30 * 60 * 1000
+const MAX_WORKFLOW_POLLS = MAX_WORKFLOW_WAIT_MS / POLL_INTERVAL_MS
+const RETRY_GRACE_PERIOD_MS = 60 * 1000
+const RETRY_GRACE_PERIOD_POLLS = RETRY_GRACE_PERIOD_MS / POLL_INTERVAL_MS
 const INITIAL_RUN_ATTEMPT = 1
 
 const getResponsePreview = (body) => {
@@ -151,11 +153,21 @@ const getCurrentWorkflow = (runId) => {
  *
  * @param {number} runId
  * @param {string} workflowUrl
+ * @param {number} workflowDeadline
  * @param {number} [minimumRunAttempt]
  * @returns {Promise<{ conclusion: string, run_attempt: number }>}
  */
-async function waitForWorkflowCompletion (runId, workflowUrl, minimumRunAttempt = INITIAL_RUN_ATTEMPT) {
+async function waitForWorkflowCompletion (
+  runId,
+  workflowUrl,
+  workflowDeadline,
+  minimumRunAttempt = INITIAL_RUN_ATTEMPT
+) {
   for (let poll = 0; poll < MAX_WORKFLOW_POLLS; poll++) {
+    if (Date.now() > workflowDeadline) {
+      break
+    }
+
     let currentWorkflow
     try {
       currentWorkflow = await getCurrentWorkflow(runId)
@@ -174,13 +186,16 @@ async function waitForWorkflowCompletion (runId, workflowUrl, minimumRunAttempt 
       )
     }
 
-    if (poll === MAX_WORKFLOW_POLLS - 1) {
-      throw new Error(
-        `Timeout: Workflow did not finish within 30 minutes. Check ${workflowUrl} for more details.`
-      )
+    const waitMs = Math.min(POLL_INTERVAL_MS, workflowDeadline - Date.now())
+    if (waitMs <= 0) {
+      break
     }
-    await setTimeout(POLL_INTERVAL_MS)
+    await setTimeout(waitMs)
   }
+
+  throw new Error(
+    `Timeout: Workflow did not finish within 30 minutes. Check ${workflowUrl} for more details.`
+  )
 }
 
 /**
@@ -188,10 +203,16 @@ async function waitForWorkflowCompletion (runId, workflowUrl, minimumRunAttempt 
  *
  * @param {number} runId
  * @param {number} failedRunAttempt
+ * @param {number} workflowDeadline
  * @returns {Promise<number|undefined>}
  */
-async function waitForWorkflowRetry (runId, failedRunAttempt) {
+async function waitForWorkflowRetry (runId, failedRunAttempt, workflowDeadline) {
+  const retryDeadline = Math.min(Date.now() + RETRY_GRACE_PERIOD_MS, workflowDeadline)
   for (let poll = 0; poll <= RETRY_GRACE_PERIOD_POLLS; poll++) {
+    if (Date.now() > retryDeadline) {
+      break
+    }
+
     try {
       const { run_attempt: currentRunAttempt } = await getCurrentWorkflow(runId)
       if (currentRunAttempt > failedRunAttempt) {
@@ -200,8 +221,9 @@ async function waitForWorkflowRetry (runId, failedRunAttempt) {
     } catch (e) {
       console.error('Workflow retry check failed (%s). Retry in 5 seconds.', e.message)
     }
-    if (poll < RETRY_GRACE_PERIOD_POLLS) {
-      await setTimeout(POLL_INTERVAL_MS)
+    const waitMs = Math.min(POLL_INTERVAL_MS, retryDeadline - Date.now())
+    if (poll < RETRY_GRACE_PERIOD_POLLS && waitMs > 0) {
+      await setTimeout(waitMs)
     }
   }
 
@@ -214,23 +236,25 @@ async function main () {
   const triggeredWorkflow = await triggerWorkflow()
   console.log('Triggered workflow:', triggeredWorkflow)
 
-  const { workflow_run_id: runId, html_url: workflowUrl } = triggeredWorkflow
+  const { workflow_run_id: runId } = triggeredWorkflow
   if (!runId) {
     throw new Error('Triggered workflow response did not include a run id')
   }
 
+  const workflowUrl = `https://github.com/DataDog/test-environment/actions/runs/${runId}`
   console.log(`Workflow URL: ${workflowUrl}`)
 
   // Wait an initial 1 minute, because we're sure it won't finish earlier
   await setTimeout(60000)
 
-  let currentWorkflow = await waitForWorkflowCompletion(runId, workflowUrl)
+  const workflowDeadline = Date.now() + MAX_WORKFLOW_WAIT_MS
+  let currentWorkflow = await waitForWorkflowCompletion(runId, workflowUrl, workflowDeadline)
   if (currentWorkflow.conclusion !== 'success' && currentWorkflow.run_attempt === INITIAL_RUN_ATTEMPT) {
     console.log('Workflow attempt %d failed. Waiting up to 1 minute for an automatic retry.',
       currentWorkflow.run_attempt)
-    const retryRunAttempt = await waitForWorkflowRetry(runId, currentWorkflow.run_attempt)
+    const retryRunAttempt = await waitForWorkflowRetry(runId, currentWorkflow.run_attempt, workflowDeadline)
     if (retryRunAttempt !== undefined) {
-      currentWorkflow = await waitForWorkflowCompletion(runId, workflowUrl, retryRunAttempt)
+      currentWorkflow = await waitForWorkflowCompletion(runId, workflowUrl, workflowDeadline, retryRunAttempt)
     }
   }
 

--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -58,7 +58,8 @@ const getCommonHeaders = () => {
   return {
     'Content-Type': 'application/json',
     authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-    Accept: 'application/vnd.github.v3+json',
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2026-03-10',
     'user-agent': 'dd-trace benchmark tests',
   }
 }
@@ -66,7 +67,6 @@ const getCommonHeaders = () => {
 const triggerWorkflow = () => {
   console.log(`Commit SHA under test: ${getRefToTest()} in ${getRefName()}`)
   return new Promise((resolve, reject) => {
-    // eslint-disable-next-line
     let response = ''
     const body = JSON.stringify({
       ref: 'main',
@@ -82,34 +82,10 @@ const triggerWorkflow = () => {
           response += chunk
         })
         res.on('end', () => {
-          resolve(res.statusCode)
-        })
-      })
-    request.on('error', (error) => {
-      reject(error)
-    })
-    request.write(body)
-    request.end()
-  })
-}
-
-const getWorkflowRunsInProgress = () => {
-  return new Promise((resolve, reject) => {
-    let response = ''
-    const request = https.request(
-      `${GET_WORKFLOWS_URL}?event=workflow_dispatch`,
-      {
-        headers: getCommonHeaders(),
-      },
-      (res) => {
-        res.on('data', (chunk) => {
-          response += chunk
-        })
-        res.on('end', () => {
           try {
             resolve(parseGitHubJsonResponse({
               body: response,
-              endpoint: `${GET_WORKFLOWS_URL}?event=workflow_dispatch`,
+              endpoint: DISPATCH_WORKFLOW_URL,
               res,
             }))
           } catch (e) {
@@ -117,9 +93,10 @@ const getWorkflowRunsInProgress = () => {
           }
         })
       })
-    request.on('error', err => {
-      reject(err)
+    request.on('error', (error) => {
+      reject(error)
     })
+    request.write(body)
     request.end()
   })
 }
@@ -162,30 +139,15 @@ const getCurrentWorkflowJobs = (runId) => {
 async function main () {
   // Trigger JS GHA
   console.log('Triggering Test Optimization test environment workflow.')
-  const httpResponseCode = await triggerWorkflow()
-  console.log('GitHub API response code:', httpResponseCode)
-
-  if (httpResponseCode !== 204) {
-    throw new Error('Could not trigger workflow')
-  }
-
-  // Give some time for GH to process the request
-  await setTimeout(15000)
-
-  // Get the run ID from the workflow we just triggered
-  const workflowsInProgress = await getWorkflowRunsInProgress()
-  const { total_count: numWorkflows, workflow_runs: workflows } = workflowsInProgress
-  if (numWorkflows === 0) {
-    throw new Error('Could not find the triggered workflow')
-  }
-  // Pick the first one (most recently triggered one)
-  const [triggeredWorkflow] = workflows
-
+  const triggeredWorkflow = await triggerWorkflow()
   console.log('Triggered workflow:', triggeredWorkflow)
 
-  const { id: runId } = triggeredWorkflow || {}
+  const { workflow_run_id: runId, html_url: workflowUrl } = triggeredWorkflow
+  if (!runId) {
+    throw new Error('Triggered workflow response did not include a run id')
+  }
 
-  console.log(`Workflow URL: https://github.com/DataDog/test-environment/actions/runs/${runId}`)
+  console.log(`Workflow URL: ${workflowUrl}`)
 
   // Wait an initial 1 minute, because we're sure it won't finish earlier
   await setTimeout(60000)

--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -9,7 +9,10 @@ const API_REPOSITORY_URL = 'https://api.github.com/repos/DataDog/test-environmen
 const DISPATCH_WORKFLOW_URL = `${API_REPOSITORY_URL}/actions/workflows/dd-trace-js-tests.yml/dispatches`
 const GET_WORKFLOWS_URL = `${API_REPOSITORY_URL}/actions/runs`
 
-const MAX_ATTEMPTS = 30 * 60 / 5 // 30 minutes, polling every 5 seconds = 360 attempts
+const POLL_INTERVAL_MS = 5000
+const MAX_WORKFLOW_POLLS = 30 * 60 / 5 // 30 minutes, polling every 5 seconds = 360 polls
+const RETRY_GRACE_PERIOD_POLLS = 60 / 5 // 1 minute, polling every 5 seconds
+const INITIAL_RUN_ATTEMPT = 1
 
 const getResponsePreview = (body) => {
   return body.replace(/\s+/g, ' ').slice(0, 200)
@@ -101,15 +104,22 @@ const triggerWorkflow = () => {
   })
 }
 
-const getCurrentWorkflowJobs = (runId) => {
+/**
+ * Gets the latest state for a workflow run.
+ *
+ * @param {number} runId
+ * @returns {Promise<{ conclusion: string, run_attempt: number, status: string }>}
+ */
+const getCurrentWorkflow = (runId) => {
   let body = ''
   return new Promise((resolve, reject) => {
     if (!runId) {
-      reject(new Error('No job run id specified'))
+      reject(new Error('No workflow run id specified'))
       return
     }
+    const endpoint = `${GET_WORKFLOWS_URL}/${runId}`
     const request = https.request(
-      `${GET_WORKFLOWS_URL}/${runId}/jobs`,
+      endpoint,
       {
         headers: getCommonHeaders(),
       },
@@ -121,7 +131,7 @@ const getCurrentWorkflowJobs = (runId) => {
           try {
             resolve(parseGitHubJsonResponse({
               body,
-              endpoint: `${GET_WORKFLOWS_URL}/${runId}/jobs`,
+              endpoint,
               res,
             }))
           } catch (e) {
@@ -134,6 +144,68 @@ const getCurrentWorkflowJobs = (runId) => {
     })
     request.end()
   })
+}
+
+/**
+ * Waits for the current workflow attempt to finish.
+ *
+ * @param {number} runId
+ * @param {string} workflowUrl
+ * @param {number} [minimumRunAttempt]
+ * @returns {Promise<{ conclusion: string, run_attempt: number }>}
+ */
+async function waitForWorkflowCompletion (runId, workflowUrl, minimumRunAttempt = INITIAL_RUN_ATTEMPT) {
+  for (let poll = 0; poll < MAX_WORKFLOW_POLLS; poll++) {
+    let currentWorkflow
+    try {
+      currentWorkflow = await getCurrentWorkflow(runId)
+    } catch (e) {
+      console.error('Workflow check failed (%s). Retry in 5 seconds.', e.message)
+    }
+
+    if (currentWorkflow) {
+      const { conclusion, run_attempt: runAttempt, status } = currentWorkflow
+      if (runAttempt >= minimumRunAttempt && status === 'completed') {
+        return { conclusion, run_attempt: runAttempt }
+      }
+
+      console.log(
+        `Workflow ${workflowUrl} is not finished yet. [Poll ${poll + 1}/${MAX_WORKFLOW_POLLS}]`
+      )
+    }
+
+    if (poll === MAX_WORKFLOW_POLLS - 1) {
+      throw new Error(
+        `Timeout: Workflow did not finish within 30 minutes. Check ${workflowUrl} for more details.`
+      )
+    }
+    await setTimeout(POLL_INTERVAL_MS)
+  }
+}
+
+/**
+ * Waits for GitHub to create the single automatic retry allowed for a failed workflow.
+ *
+ * @param {number} runId
+ * @param {number} failedRunAttempt
+ * @returns {Promise<number|undefined>}
+ */
+async function waitForWorkflowRetry (runId, failedRunAttempt) {
+  for (let poll = 0; poll <= RETRY_GRACE_PERIOD_POLLS; poll++) {
+    try {
+      const { run_attempt: currentRunAttempt } = await getCurrentWorkflow(runId)
+      if (currentRunAttempt > failedRunAttempt) {
+        return currentRunAttempt
+      }
+    } catch (e) {
+      console.error('Workflow retry check failed (%s). Retry in 5 seconds.', e.message)
+    }
+    if (poll < RETRY_GRACE_PERIOD_POLLS) {
+      await setTimeout(POLL_INTERVAL_MS)
+    }
+  }
+
+  return undefined
 }
 
 async function main () {
@@ -152,39 +224,21 @@ async function main () {
   // Wait an initial 1 minute, because we're sure it won't finish earlier
   await setTimeout(60000)
 
-  // Poll every 5 seconds until we have a finished status, up to 30 minutes
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    let currentWorkflow
-    try {
-      currentWorkflow = await getCurrentWorkflowJobs(runId)
-    } catch (e) {
-      console.error('Workflow check failed (%s). Retry in 5 seconds.', e.message)
-      await setTimeout(5000)
-      continue
+  let currentWorkflow = await waitForWorkflowCompletion(runId, workflowUrl)
+  if (currentWorkflow.conclusion !== 'success' && currentWorkflow.run_attempt === INITIAL_RUN_ATTEMPT) {
+    console.log('Workflow attempt %d failed. Waiting up to 1 minute for an automatic retry.',
+      currentWorkflow.run_attempt)
+    const retryRunAttempt = await waitForWorkflowRetry(runId, currentWorkflow.run_attempt)
+    if (retryRunAttempt !== undefined) {
+      currentWorkflow = await waitForWorkflowCompletion(runId, workflowUrl, retryRunAttempt)
     }
-    const { jobs } = currentWorkflow
-    if (!jobs) {
-      console.error('Workflow check returned unknown object %o. Retry in 5 seconds.', currentWorkflow)
-      await setTimeout(5000)
-      continue
-    }
-    const hasAnyJobFailed = jobs
-      .some(({ status, conclusion }) => status === 'completed' && conclusion !== 'success')
-    const hasEveryJobPassed = jobs.every(
-      ({ status, conclusion }) => status === 'completed' && conclusion === 'success'
-    )
-    if (hasAnyJobFailed) {
-      throw new Error(`Performance overhead test failed.\n  Check https://github.com/DataDog/test-environment/actions/runs/${runId} for more details.`)
-    } else if (hasEveryJobPassed) {
-      console.log('Performance overhead test successful.')
-      break
-    } else {
-      console.log(`Workflow https://github.com/DataDog/test-environment/actions/runs/${runId} is not finished yet. [Attempt ${attempt + 1}/${MAX_ATTEMPTS}]`)
-    }
-    if (attempt === MAX_ATTEMPTS - 1) {
-      throw new Error(`Timeout: Workflow did not finish within 30 minutes. Check https://github.com/DataDog/test-environment/actions/runs/${runId} for more details.`)
-    }
-    await setTimeout(5000)
+  }
+
+  if (currentWorkflow.conclusion === 'success') {
+    console.log('Performance overhead test successful.')
+  } else {
+    const workflowAttemptUrl = `${workflowUrl}/attempts/${currentWorkflow.run_attempt}`
+    throw new Error(`Performance overhead test failed.\n  Check ${workflowAttemptUrl} for more details.`)
   }
 }
 

--- a/benchmark/e2e-test-optimization/benchmark-run.spec.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.spec.js
@@ -1,0 +1,157 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+
+const { afterEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+/**
+ * @typedef {object} ResponseData
+ * @property {string} body
+ * @property {number} statusCode
+ */
+
+/**
+ * @typedef {object} RequestRecord
+ * @property {string} body
+ * @property {{ headers: Record<string, string> }} options
+ * @property {string} url
+ */
+
+/**
+ * @callback RequestStub
+ * @param {string} url
+ * @param {{ headers: Record<string, string> }} options
+ * @param {(response: EventEmitter & {
+ *   headers: Record<string, string>,
+ *   statusCode: number
+ * }) => void} callback
+ * @returns {EventEmitter & {
+ *   end: () => void,
+ *   write: (chunk: string) => void
+ * }}
+ */
+
+describe('test optimization end-to-end benchmark runner', () => {
+  const originalEnvironment = {
+    githubToken: process.env.GITHUB_TOKEN,
+    refName: process.env.TEST_ENVIRONMENT_REF_NAME,
+    refToTest: process.env.TEST_ENVIRONMENT_REF_TO_TEST,
+  }
+  const originalExitCode = process.exitCode
+
+  afterEach(() => {
+    restoreEnvironmentVariable('GITHUB_TOKEN', originalEnvironment.githubToken)
+    restoreEnvironmentVariable('TEST_ENVIRONMENT_REF_NAME', originalEnvironment.refName)
+    restoreEnvironmentVariable('TEST_ENVIRONMENT_REF_TO_TEST', originalEnvironment.refToTest)
+    process.exitCode = originalExitCode
+    sinon.restore()
+  })
+
+  it('polls the workflow run returned by the dispatch request', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_NAME = 'feature-branch'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const responses = [
+      {
+        body: JSON.stringify({
+          workflow_run_id: 12345,
+          run_url: 'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+          html_url: 'https://github.com/DataDog/test-environment/actions/runs/12345',
+        }),
+        statusCode: 200,
+      },
+      {
+        body: JSON.stringify({
+          jobs: [{ conclusion: 'success', status: 'completed' }],
+        }),
+        statusCode: 200,
+      },
+    ]
+    const requests = []
+    const completion = waitForSuccessfulCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    await completion
+
+    assert.strictEqual(requests.length, 2)
+    assert.strictEqual(requests[0].url,
+      'https://api.github.com/repos/DataDog/test-environment/actions/workflows/dd-trace-js-tests.yml/dispatches')
+    assert.strictEqual(requests[0].options.headers['X-GitHub-Api-Version'], '2026-03-10')
+    assert.deepStrictEqual(JSON.parse(requests[0].body), {
+      inputs: { sha: 'abc123' },
+      ref: 'main',
+    })
+    assert.strictEqual(requests[1].url,
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345/jobs')
+  })
+})
+
+/**
+ * @param {ResponseData[]} responses
+ * @param {RequestRecord[]} requests
+ * @returns {RequestStub}
+ */
+function createRequestStub (responses, requests) {
+  return (url, options, callback) => {
+    const request = new EventEmitter()
+    let body = ''
+
+    request.write = chunk => {
+      body += chunk
+    }
+    request.end = () => {
+      requests.push({ body, options, url })
+      const responseData = responses.shift()
+      const response = new EventEmitter()
+      response.headers = { 'content-type': 'application/json; charset=utf-8' }
+      response.statusCode = responseData.statusCode
+      callback(response)
+      process.nextTick(() => {
+        response.emit('data', responseData.body)
+        response.emit('end')
+      })
+    }
+    return request
+  }
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+function waitForSuccessfulCompletion () {
+  return new Promise((resolve, reject) => {
+    sinon.stub(console, 'log').callsFake(message => {
+      if (message === 'Performance overhead test successful.') {
+        resolve()
+      }
+    })
+    sinon.stub(console, 'error').callsFake(error => {
+      reject(error)
+    })
+  })
+}
+
+/**
+ * @param {string} name
+ * @param {string|undefined} value
+ * @returns {void}
+ */
+function restoreEnvironmentVariable (name, value) {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/benchmark/e2e-test-optimization/benchmark-run.spec.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.spec.js
@@ -50,26 +50,15 @@ describe('test optimization end-to-end benchmark runner', () => {
     sinon.restore()
   })
 
-  it('polls the workflow run returned by the dispatch request', async () => {
+  it('polls the workflow run returned by the dispatch request until it succeeds', async () => {
     process.env.GITHUB_TOKEN = 'token'
     process.env.TEST_ENVIRONMENT_REF_NAME = 'feature-branch'
     process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
 
     const responses = [
-      {
-        body: JSON.stringify({
-          workflow_run_id: 12345,
-          run_url: 'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
-          html_url: 'https://github.com/DataDog/test-environment/actions/runs/12345',
-        }),
-        statusCode: 200,
-      },
-      {
-        body: JSON.stringify({
-          jobs: [{ conclusion: 'success', status: 'completed' }],
-        }),
-        statusCode: 200,
-      },
+      createDispatchResponse(),
+      createWorkflowResponse(undefined, 1, 'in_progress'),
+      createWorkflowResponse('success', 1),
     ]
     const requests = []
     const completion = waitForSuccessfulCompletion()
@@ -85,7 +74,7 @@ describe('test optimization end-to-end benchmark runner', () => {
 
     await completion
 
-    assert.strictEqual(requests.length, 2)
+    assert.strictEqual(requests.length, 3)
     assert.strictEqual(requests[0].url,
       'https://api.github.com/repos/DataDog/test-environment/actions/workflows/dd-trace-js-tests.yml/dispatches')
     assert.strictEqual(requests[0].options.headers['X-GitHub-Api-Version'], '2026-03-10')
@@ -94,9 +83,193 @@ describe('test optimization end-to-end benchmark runner', () => {
       ref: 'main',
     })
     assert.strictEqual(requests[1].url,
-      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345/jobs')
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345')
+    assert.strictEqual(requests[2].url,
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345')
+  })
+
+  it('accepts a successful automatic retry after the first attempt fails', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const responses = [
+      createDispatchResponse(),
+      createWorkflowResponse('failure', 1),
+      createWorkflowResponse(undefined, 2, 'in_progress'),
+      createWorkflowResponse('failure', 1),
+      createWorkflowResponse('success', 2),
+    ]
+    const requests = []
+    const completion = waitForSuccessfulCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    await completion
+
+    assert.strictEqual(requests.length, 5)
+    assert.deepStrictEqual(requests.slice(1).map(({ url }) => url), [
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+    ])
+  })
+
+  it('reports a failed retry using the retry-specific URL', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const responses = [
+      createDispatchResponse(),
+      createWorkflowResponse('failure', 1),
+      createWorkflowResponse(undefined, 2, 'in_progress'),
+      createWorkflowResponse('failure', 2),
+    ]
+    const requests = []
+    const completion = waitForFailedCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    const error = await completion
+
+    assert.strictEqual(error.message,
+      'Performance overhead test failed.\n' +
+      '  Check https://github.com/DataDog/test-environment/actions/runs/12345/attempts/2 for more details.')
+    assert.strictEqual(requests.length, 4)
+  })
+
+  it('does not wait for another retry when the second attempt already failed', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const responses = [
+      createDispatchResponse(),
+      createWorkflowResponse('failure', 2),
+    ]
+    const requests = []
+    const completion = waitForFailedCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    const error = await completion
+
+    assert.strictEqual(error.message,
+      'Performance overhead test failed.\n' +
+      '  Check https://github.com/DataDog/test-environment/actions/runs/12345/attempts/2 for more details.')
+    assert.strictEqual(requests.length, 2)
+  })
+
+  it('accepts a retry that starts at the end of the grace period', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const failedAttemptResponse = createWorkflowResponse('failure', 1)
+    const responses = [
+      createDispatchResponse(),
+      failedAttemptResponse,
+      ...Array.from({ length: 12 }, () => failedAttemptResponse),
+      createWorkflowResponse(undefined, 2, 'in_progress'),
+      createWorkflowResponse('success', 2),
+    ]
+    const requests = []
+    const completion = waitForSuccessfulCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    await completion
+
+    assert.strictEqual(requests.length, 16)
+  })
+
+  it('reports the first failure when no retry starts within the grace period', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const failedAttemptResponse = createWorkflowResponse('failure', 1)
+    const responses = [
+      createDispatchResponse(),
+      failedAttemptResponse,
+      ...Array.from({ length: 13 }, () => failedAttemptResponse),
+    ]
+    const requests = []
+    const completion = waitForFailedCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    const error = await completion
+
+    assert.strictEqual(error.message,
+      'Performance overhead test failed.\n' +
+      '  Check https://github.com/DataDog/test-environment/actions/runs/12345/attempts/1 for more details.')
+    assert.strictEqual(requests.length, 15)
   })
 })
+
+/**
+ * @returns {ResponseData}
+ */
+function createDispatchResponse () {
+  return {
+    body: JSON.stringify({
+      workflow_run_id: 12345,
+      run_url: 'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
+      html_url: 'https://github.com/DataDog/test-environment/actions/runs/12345',
+    }),
+    statusCode: 200,
+  }
+}
+
+/**
+ * @param {string|undefined} conclusion
+ * @param {number} runAttempt
+ * @param {string} [status]
+ * @returns {ResponseData}
+ */
+function createWorkflowResponse (conclusion, runAttempt, status = 'completed') {
+  return {
+    body: JSON.stringify({
+      conclusion,
+      run_attempt: runAttempt,
+      status,
+    }),
+    statusCode: 200,
+  }
+}
 
 /**
  * @param {ResponseData[]} responses
@@ -139,6 +312,20 @@ function waitForSuccessfulCompletion () {
     })
     sinon.stub(console, 'error').callsFake(error => {
       reject(error)
+    })
+  })
+}
+
+/**
+ * @returns {Promise<Error>}
+ */
+function waitForFailedCompletion () {
+  return new Promise((resolve) => {
+    sinon.stub(console, 'log')
+    sinon.stub(console, 'error').callsFake(error => {
+      if (error instanceof Error) {
+        resolve(error)
+      }
     })
   })
 }

--- a/benchmark/e2e-test-optimization/benchmark-run.spec.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.spec.js
@@ -238,6 +238,43 @@ describe('test optimization end-to-end benchmark runner', () => {
       '  Check https://github.com/DataDog/test-environment/actions/runs/12345/attempts/1 for more details.')
     assert.strictEqual(requests.length, 15)
   })
+
+  it('uses the original workflow deadline while waiting for a retry', async () => {
+    process.env.GITHUB_TOKEN = 'token'
+    process.env.TEST_ENVIRONMENT_REF_TO_TEST = 'abc123'
+
+    const workflowTimeoutMs = 30 * 60 * 1000
+    sinon.stub(Date, 'now')
+      .onCall(0).returns(0)
+      .onCall(1).returns(0)
+      .onCall(2).returns(workflowTimeoutMs - 1000)
+      .onCall(3).returns(workflowTimeoutMs - 1000)
+      .onCall(4).returns(workflowTimeoutMs + 1)
+
+    const responses = [
+      createDispatchResponse(),
+      createWorkflowResponse('failure', 1),
+      createWorkflowResponse(undefined, 2, 'in_progress'),
+    ]
+    const requests = []
+    const completion = waitForFailedCompletion()
+
+    proxyquire('./benchmark-run', {
+      https: {
+        request: createRequestStub(responses, requests),
+      },
+      'timers/promises': {
+        setTimeout: () => Promise.resolve(),
+      },
+    })
+
+    const error = await completion
+
+    assert.strictEqual(error.message,
+      'Timeout: Workflow did not finish within 30 minutes. ' +
+      'Check https://github.com/DataDog/test-environment/actions/runs/12345 for more details.')
+    assert.strictEqual(requests.length, 3)
+  })
 })
 
 /**
@@ -247,8 +284,6 @@ function createDispatchResponse () {
   return {
     body: JSON.stringify({
       workflow_run_id: 12345,
-      run_url: 'https://api.github.com/repos/DataDog/test-environment/actions/runs/12345',
-      html_url: 'https://github.com/DataDog/test-environment/actions/runs/12345',
     }),
     statusCode: 200,
   }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "test:integration:plugins:coverage": "yarn services && node ./integration-tests/coverage/run-suite.js \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/${SPEC:-*}*.spec.js\"",
     "test:unit:plugins": "mocha \"packages/datadog-instrumentations/test/@(${PLUGINS}).spec.js\" \"packages/datadog-plugin-@(${PLUGINS})/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/*.spec.js\"",
     "test:release": "mocha \"scripts/release/**/*.spec.js\"",
-    "test:scripts": "mocha \"benchmark/sirun/*.spec.js\" \"scripts/helpers/**/*.spec.js\" \"scripts/*.spec.mjs\"",
+    "test:scripts": "mocha \"benchmark/e2e-test-optimization/*.spec.js\" \"benchmark/sirun/*.spec.js\" \"scripts/helpers/**/*.spec.js\" \"scripts/*.spec.mjs\"",
     "test:shimmer": "mocha \"packages/datadog-shimmer/test/**/*.spec.js\"",
     "test:shimmer:ci": "node scripts/c8-ci.js test:shimmer",
     "verify:workflow-job-names": "node scripts/verify-workflow-job-names.js",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Upgrades workflow dispatch requests to GitHub REST API version `2026-03-10` and uses the `workflow_run_id` returned by the dispatch response.

This removes the timing-based lookup that could associate concurrent benchmark jobs with the same downstream `test-environment` workflow run. It also waits for the workflow attempt to finish and, after a first-attempt failure, allows one minute for the external retry system to start a second attempt on the same run. A successful retry passes the benchmark; final failures link directly to the failed attempt. Both attempts and the retry grace period share the original 30-minute polling deadline.

### Motivation
<!-- Explain why this change is needed and what problem it solves. -->

Concurrent release proposal workflows can dispatch downstream runs at nearly the same time. Looking up the newest run after dispatch is ambiguous and can cause one caller to monitor another caller's run.

Additionally, `test-environment` failures are automatically retried once. Failing immediately on the first attempt both duplicates that retry work and leaves a link whose latest view can later appear successful.

### Additional Notes
<!-- Any additional information that reviewers should know. -->

Verification:

- `npm run test:scripts` (177 passing)
- Focused ESLint on the changed JavaScript files
- Scoped nyc coverage for `benchmark-run.js`
- `npm run verify-exercised-tests`
- `npm run lint:codeowners:ci`
