### PR TITLE
fix(test-optimization): increase exporter socket concurrency

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -16,6 +16,7 @@ const {
 } = require('../../../ci-visibility/telemetry')
 const { CoverageCIVisibilityEncoder } = require('../../../encode/coverage-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
+const { getAgent } = require('../agents')
 const request = require('../request')
 const TestOptimizationRequestTracker = require('./request-tracker')
 
@@ -51,6 +52,7 @@ class Writer extends BaseWriter {
       },
       timeout: 15_000,
       url: this._url,
+      agent: getAgent(this._url),
       deadline: flushOptions?.deadline,
     }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
@@ -6,6 +6,7 @@ const { JSONEncoder } = require('../../encode/json-encoder')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
 const BaseWriter = require('../../../exporters/common/writer')
 
+const { getAgent } = require('../agents')
 const request = require('../request')
 const TestOptimizationRequestTracker = require('./request-tracker')
 
@@ -46,6 +47,7 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
       },
       timeout: this.timeout,
       url: this._url,
+      agent: getAgent(this._url),
       deadline: flushOptions?.deadline,
     }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -16,6 +16,7 @@ const {
 } = require('../../../ci-visibility/telemetry')
 const { AgentlessCiVisibilityEncoder } = require('../../../encode/agentless-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
+const { getAgent } = require('../agents')
 const request = require('../request')
 const TestOptimizationRequestTracker = require('./request-tracker')
 
@@ -52,6 +53,7 @@ class Writer extends BaseWriter {
       },
       timeout: 15_000,
       url: this._url,
+      agent: getAgent(this._url),
       deadline: flushOptions?.deadline,
     }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agents.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agents.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const http = require('node:http')
+const https = require('node:https')
+
+const { storage } = require('../../../../datadog-core')
+
+const legacyStorage = storage('legacy')
+
+const keepAlive = true
+// Test Optimization runs in test processes and flushes multiple payload types concurrently.
+const maxSockets = 8
+
+/**
+ * Creates an agent class whose socket lifecycle cannot be traced.
+ *
+ * @param {typeof http.Agent|typeof https.Agent} BaseAgent
+ * @returns {typeof http.Agent|typeof https.Agent}
+ */
+function createAgentClass (BaseAgent) {
+  class TestOptimizationAgent extends BaseAgent {
+    /**
+     * Creates a Test Optimization HTTP agent.
+     */
+    constructor () {
+      super({ keepAlive, maxSockets })
+    }
+
+    /**
+     * Creates a socket outside the active trace context.
+     *
+     * @param {...unknown} args
+     * @returns {import('node:stream').Duplex}
+     */
+    createConnection (...args) {
+      return this._noop(() => super.createConnection(...args))
+    }
+
+    /**
+     * Keeps an idle socket alive outside the active trace context.
+     *
+     * @param {...unknown} args
+     * @returns {boolean}
+     */
+    keepSocketAlive (...args) {
+      return this._noop(() => super.keepSocketAlive(...args))
+    }
+
+    /**
+     * Reuses a socket outside the active trace context.
+     *
+     * @param {...unknown} args
+     * @returns {void}
+     */
+    reuseSocket (...args) {
+      return this._noop(() => super.reuseSocket(...args))
+    }
+
+    /**
+     * Runs a socket operation without generating tracer telemetry.
+     *
+     * @template T
+     * @param {() => T} callback
+     * @returns {T}
+     */
+    _noop (callback) {
+      return legacyStorage.run({ noop: true }, callback)
+    }
+  }
+
+  return TestOptimizationAgent
+}
+
+const HttpAgent = createAgentClass(http.Agent)
+const HttpsAgent = createAgentClass(https.Agent)
+
+const httpAgent = new HttpAgent()
+const httpsAgent = new HttpsAgent()
+
+/**
+ * Selects the dedicated Test Optimization agent for an intake URL.
+ *
+ * @param {string|URL|object} url
+ * @returns {http.Agent|https.Agent}
+ */
+function getAgent (url) {
+  const isSecure = typeof url === 'string' ? url.startsWith('https:') : url?.protocol === 'https:'
+  return isSecure ? httpsAgent : httpAgent
+}
+
+module.exports = { getAgent, httpAgent, httpsAgent }

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
@@ -14,6 +14,7 @@ let encoder
 let url
 let log
 let incrementCountMetric
+let agent
 
 describe('CI Visibility Coverage Writer', () => {
   beforeEach(() => {
@@ -38,6 +39,7 @@ describe('CI Visibility Coverage Writer', () => {
       error: sinon.spy(),
     }
     incrementCountMetric = sinon.stub()
+    agent = {}
 
     const CoverageCIVisibilityEncoder = function () {
       return encoder
@@ -45,6 +47,7 @@ describe('CI Visibility Coverage Writer', () => {
 
     CoverageWriter = proxyquire('../../../../src/ci-visibility/exporters/agentless/coverage-writer.js', {
       '../request': request,
+      '../agents': { getAgent: sinon.stub().returns(agent) },
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
       '../../../ci-visibility/telemetry': { incrementCountMetric },
       '../../../log': log,
@@ -94,6 +97,7 @@ describe('CI Visibility Coverage Writer', () => {
           url,
           path: '/api/v2/citestcov',
           method: 'POST',
+          agent,
         })
         done()
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
@@ -27,6 +27,25 @@ describe('Test Visibility DI Writer', () => {
   })
 
   context('agentless', () => {
+    it('uses the dedicated Test Optimization agent', (done) => {
+      const agent = {}
+      const request = sinon.stub().yieldsAsync(null, 'OK', 202)
+      const TestOptimizationLogsWriter = proxyquire(
+        '../../../../src/ci-visibility/exporters/agentless/di-logs-writer',
+        {
+          '../agents': { getAgent: sinon.stub().returns(agent) },
+          '../request': request,
+        }
+      )
+      const logsWriter = new TestOptimizationLogsWriter({ url: 'http://www.example.com' })
+
+      logsWriter.append({ message: 'test' })
+      logsWriter.flush(() => {
+        sinon.assert.calledWithMatch(request, sinon.match.any, { agent })
+        done()
+      })
+    })
+
     it('can send logs to the logs intake', (done) => {
       const scope = nock('http://www.example.com')
         .post('/api/v2/logs', body => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -15,6 +15,7 @@ let coverageEncoder
 let url
 let log
 let incrementCountMetric
+let agent
 
 describe('CI Visibility Writer', () => {
   beforeEach(() => {
@@ -37,6 +38,7 @@ describe('CI Visibility Writer', () => {
       error: sinon.spy(),
     }
     incrementCountMetric = sinon.stub()
+    agent = {}
 
     const AgentlessCiVisibilityEncoder = function () {
       return encoder
@@ -54,6 +56,7 @@ describe('CI Visibility Writer', () => {
 
     Writer = proxyquire('../../../../src/ci-visibility/exporters/agentless/writer', {
       '../request': request,
+      '../agents': { getAgent: sinon.stub().returns(agent) },
       '../../../encode/agentless-ci-visibility': { AgentlessCiVisibilityEncoder },
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
       '../../../ci-visibility/telemetry': { incrementCountMetric },
@@ -103,6 +106,7 @@ describe('CI Visibility Writer', () => {
           headers: {
             'Content-Type': 'application/msgpack',
           },
+          agent,
         })
         done()
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agents.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agents.spec.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const http = require('node:http')
+const net = require('node:net')
+
+const { describe, it } = require('mocha')
+
+require('../../setup/core')
+
+const { getAgent, httpAgent, httpsAgent } = require('../../../src/ci-visibility/exporters/agents')
+
+describe('Test Optimization exporter agents', () => {
+  it('configures dedicated agents with concurrent sockets', () => {
+    assert.strictEqual(httpAgent.keepAlive, true)
+    assert.strictEqual(httpAgent.maxSockets, 8)
+    assert.strictEqual(httpsAgent.keepAlive, true)
+    assert.strictEqual(httpsAgent.maxSockets, 8)
+  })
+
+  it('selects the agent for URL objects and strings', () => {
+    assert.strictEqual(getAgent(new URL('http://localhost')), httpAgent)
+    assert.strictEqual(getAgent('http://localhost'), httpAgent)
+    assert.strictEqual(getAgent(new URL('https://localhost')), httpsAgent)
+    assert.strictEqual(getAgent('https://localhost'), httpsAgent)
+  })
+
+  it('manages the keep-alive socket lifecycle', () => {
+    const socket = new net.Socket()
+    const request = {}
+
+    assert.strictEqual(httpAgent.keepSocketAlive(socket), true)
+    httpAgent.reuseSocket(socket, request)
+    assert.strictEqual(request.reusedSocket, true)
+    socket.destroy()
+  })
+
+  it('opens concurrent connections to the same origin', async () => {
+    const lookupCallbacks = []
+    const lookup = (hostname, options, callback) => lookupCallbacks.push(callback)
+    const requests = [
+      http.request({ agent: httpAgent, hostname: 'test.local', lookup }),
+      http.request({ agent: httpAgent, hostname: 'test.local', lookup }),
+    ]
+    for (const request of requests) {
+      request.on('error', () => {})
+      request.end()
+    }
+
+    await new Promise(resolve => setImmediate(resolve))
+    try {
+      assert.strictEqual(lookupCallbacks.length, 2)
+    } finally {
+      for (const request of requests) request.destroy()
+    }
+  })
+})


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds dedicated HTTP and HTTPS agents for Test Optimization exporters with `maxSockets: 8`, and routes event, coverage, and Dynamic Instrumentation log payloads through them. The agents retain the existing no-tracing socket lifecycle behavior.

Adds regression coverage that verifies same-origin requests can create concurrent connections and that every affected writer passes the dedicated agent to the request layer.

### Motivation
<!-- What inspired you to submit this pull request? -->

The bounded final-flush request lifecycle increased the time requests spend queued behind the tracer's shared `maxSockets: 1` agent. Under moderate CI Visibility load, requests can exhaust their deadline while waiting for the only socket and surface as network errors.

Test Optimization runs in test processes and may flush several payloads concurrently, so it can safely use a dedicated higher-concurrency pool without changing the production tracer agent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- The shared tracer agents and common request/drop behavior are unchanged.
- Targeted exporter, retry, request-tracker, and agent-proxy tests: 61 passing.
- ESLint and `git diff --check` pass for the changed files.
