### PR TITLE
fix(serverless): coalesce overlapping Vercel telemetry flushes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@
 /packages/dd-trace/src/flush.js @DataDog/dd-trace-js @DataDog/apm-serverless @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/lambda/ @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/azure_metadata.spec.js @DataDog/dd-trace-js @DataDog/apm-serverless
+/packages/dd-trace/test/fixtures/vercel-telemetry-coalescing.js @DataDog/dd-trace-js @DataDog/apm-serverless
 /packages/dd-trace/test/serverless.spec.js @DataDog/dd-trace-js @DataDog/apm-serverless
 /packages/dd-trace/test/plugins/util/inferred_proxy.spec.js @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
 

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -8,6 +8,7 @@ const request = require('./request')
 const { safeJSONStringify } = require('./util')
 
 const firstFlushChannel = channel('dd-trace:exporter:first-flush')
+const noop = () => {}
 
 class Writer {
   #deliveryTracker
@@ -39,7 +40,7 @@ class Writer {
    * @param {{ deadline?: number }} [options]
    * @returns {void}
    */
-  flushDirect (done = () => {}, options) {
+  flushDirect (done = noop, options) {
     const count = this._encoder.count()
 
     if (!request.writable && options?.deadline === undefined) {

--- a/packages/dd-trace/src/flush.js
+++ b/packages/dd-trace/src/flush.js
@@ -43,12 +43,16 @@ function registerTelemetryFlusher (flusher, options) {
  * @param {{ timeout?: number }} [options]
  * @param {TraceFlushers} [traceFlushers]
  */
-function flushServerlessTelemetry (done, options, traceFlushers = {}) {
-  const { trace: traceFlusher, spanStats: spanStatsFlusher } = traceFlushers
+function flushServerlessTelemetry (done, options, traceFlushers) {
+  const traceFlusher = traceFlushers?.trace
+  const spanStatsFlusher = traceFlushers?.spanStats
   // TODO: Include DSM after DataStreamsProcessor exposes a completion-aware flush API.
   let pending = telemetryFlushers.size + postTraceTelemetryFlushers.size +
     (typeof traceFlusher === 'function' ? 1 : 0) +
     (typeof spanStatsFlusher === 'function' ? 1 : 0)
+
+  if (pending === 0) return done?.()
+
   let completed = false
   let timeout
 
@@ -62,7 +66,6 @@ function flushServerlessTelemetry (done, options, traceFlushers = {}) {
     if (--pending === 0) finish()
   }
 
-  if (pending === 0) return finish()
   if (options?.timeout) {
     timeout = setTimeout(() => {
       log.warn('Timed out waiting for telemetry flush after %dms', options.timeout)

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -159,24 +159,38 @@ class BaseLLMObsWriter {
 
     for (const [apiKey, buffer] of this.#multiTenantBuffers) {
       if (buffer.events.length === 0) continue
+      const site = buffer.routing.site || this._config.site
+      const maskedApiKey = apiKey ? `****${apiKey.slice(-4)}` : ''
+      let options
+      let url
+      try {
+        options = {
+          headers: {
+            'Content-Type': 'application/json',
+            'DD-API-KEY': apiKey,
+          },
+          method: 'POST',
+          timeout: this._timeout,
+          url: new URL(format({
+            protocol: 'https:',
+            hostname: `${this._intake}.${site}`,
+          })),
+          path: this._baseEndpoint,
+        }
+        url = this.#buildUrl(options.url.href, options.path)
+      } catch (error) {
+        buffer.clear()
+        logger.error(
+          'Failed to route LLMObs %s events for API key %s: %s',
+          this._eventType,
+          maskedApiKey,
+          error.message
+        )
+        continue
+      }
+
       const events = buffer.events
       buffer.clear()
-      const site = buffer.routing.site || this._config.site
-      const options = {
-        headers: {
-          'Content-Type': 'application/json',
-          'DD-API-KEY': apiKey,
-        },
-        method: 'POST',
-        timeout: this._timeout,
-        url: new URL(format({
-          protocol: 'https:',
-          hostname: `${this._intake}.${site}`,
-        })),
-        path: this._baseEndpoint,
-      }
-      const url = this.#buildUrl(options.url.href, options.path)
-      const maskedApiKey = apiKey ? `****${apiKey.slice(-4)}` : ''
       log.debug('Encoding and flushing multi-tenant buffer for %s', maskedApiKey)
       requests.push({ events, options, url })
     }

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -17,13 +17,20 @@ const {
 } = require('../constants/writers')
 const { parseResponseAndLog } = require('./util')
 
+const MAX_BUFFER_EVENTS = 1000
+
 class LLMObsBuffer {
-  constructor ({ events, size, routing = {}, isDefault = false, limit = 1000 }) {
+  /**
+   * @param {{
+   *   events: Record<string, unknown>[],
+   *   size: number,
+   *   routing?: { apiKey?: string, site?: string }
+   * }} options
+   */
+  constructor ({ events, size, routing = {} }) {
     this.events = events
     this.size = size
     this.routing = routing
-    this.isDefault = isDefault
-    this.limit = limit
   }
 
   clear () {
@@ -46,7 +53,7 @@ class BaseLLMObsWriter {
     this._eventType = eventType
 
     /** @type {LLMObsBuffer} */
-    this._buffer = new LLMObsBuffer({ events: [], size: 0, isDefault: true })
+    this._buffer = new LLMObsBuffer({ events: [], size: 0 })
 
     /** @type {import('../../config/config-base')} */
     this._config = config
@@ -102,8 +109,8 @@ class BaseLLMObsWriter {
   append (event, routing, byteLength) {
     const buffer = this._getBuffer(routing)
 
-    if (buffer.events.length >= buffer.limit) {
-      logger.warn(`${this.constructor.name} event buffer full (limit is ${buffer.limit}), dropping event`)
+    if (buffer.events.length >= MAX_BUFFER_EVENTS) {
+      logger.warn(`${this.constructor.name} event buffer full (limit is ${MAX_BUFFER_EVENTS}), dropping event`)
       telemetry.recordDroppedPayload(1, this._eventType, 'buffer_full')
       return false
     }
@@ -158,7 +165,10 @@ class BaseLLMObsWriter {
     }
 
     for (const [apiKey, buffer] of this.#multiTenantBuffers) {
-      if (buffer.events.length === 0) continue
+      if (buffer.events.length === 0) {
+        this.#multiTenantBuffers.delete(apiKey)
+        continue
+      }
       const site = buffer.routing.site || this._config.site
       const maskedApiKey = `****${apiKey.slice(-4)}`
       let options
@@ -180,6 +190,7 @@ class BaseLLMObsWriter {
         url = this.#buildUrl(options.url.href, options.path)
       } catch (error) {
         buffer.clear()
+        this.#multiTenantBuffers.delete(apiKey)
         logger.error(
           'Failed to route LLMObs %s events for API key %s: %s',
           this._eventType,
@@ -191,11 +202,11 @@ class BaseLLMObsWriter {
 
       const events = buffer.events
       buffer.clear()
+      this.#multiTenantBuffers.delete(apiKey)
       log.debug('Encoding and flushing multi-tenant buffer for %s', maskedApiKey)
       requests.push({ events, options, url })
     }
 
-    this.#cleanupEmptyBuffers()
     return requests
   }
 
@@ -206,14 +217,6 @@ class BaseLLMObsWriter {
       parseResponseAndLog(err, code, events.length, url, this._eventType)
       done?.()
     })
-  }
-
-  #cleanupEmptyBuffers () {
-    for (const [key, buffer] of this.#multiTenantBuffers) {
-      if (buffer.events.length === 0) {
-        this.#multiTenantBuffers.delete(key)
-      }
-    }
   }
 
   makePayload (events) {}

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -160,7 +160,7 @@ class BaseLLMObsWriter {
     for (const [apiKey, buffer] of this.#multiTenantBuffers) {
       if (buffer.events.length === 0) continue
       const site = buffer.routing.site || this._config.site
-      const maskedApiKey = apiKey ? `****${apiKey.slice(-4)}` : ''
+      const maskedApiKey = `****${apiKey.slice(-4)}`
       let options
       let url
       try {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -3,6 +3,7 @@
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
 
 const IS_AWS_LAMBDA_MICROVM = getEnvironmentVariable('AWS_LAMBDA_MICROVM_IMAGE_ARN') !== undefined
+const isVercelAtStartup = getEnvironmentVariable('VERCEL') === '1'
 
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
@@ -61,7 +62,7 @@ function getServerlessPlatformTags (platform = getServerlessPlatform()) {
  * @returns {{ isVercel: boolean }}
  */
 function getServerlessPlatform () {
-  return { isVercel: getEnvironmentVariable('VERCEL') === '1' }
+  return { isVercel: supportsServerlessTelemetryRetention() }
 }
 
 /**
@@ -71,7 +72,7 @@ function getServerlessPlatform () {
  * @returns {boolean}
  */
 function supportsServerlessTelemetryRetention () {
-  return getServerlessPlatform().isVercel
+  return isVercelAtStartup || getEnvironmentVariable('VERCEL') === '1'
 }
 
 /**

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -72,7 +72,7 @@ function getServerlessPlatform () {
  * @returns {boolean}
  */
 function supportsServerlessTelemetryRetention () {
-  return isVercelAtStartup || getEnvironmentVariable('VERCEL') === '1'
+  return isVercelAtStartup
 }
 
 /**

--- a/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
+++ b/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
@@ -18,11 +18,8 @@ class TelemetryDeliveryTracker {
     const delivery = { callbacks: done ? [done] : [] }
     this.#deliveries.add(delivery)
 
-    let completed = false
     const complete = () => {
-      if (completed) return
-      completed = true
-      this.#deliveries.delete(delivery)
+      if (!this.#deliveries.delete(delivery)) return
       for (const callback of delivery.callbacks) callback()
     }
 
@@ -41,14 +38,13 @@ class TelemetryDeliveryTracker {
   waitForIdle (done) {
     if (!done) return
 
-    const deliveries = [...this.#deliveries]
-    if (deliveries.length === 0) return done()
+    let pending = this.#deliveries.size
+    if (pending === 0) return done()
 
-    let pending = deliveries.length
     const complete = () => {
       if (--pending === 0) done()
     }
-    for (const delivery of deliveries) delivery.callbacks.push(complete)
+    for (const delivery of this.#deliveries) delivery.callbacks.push(complete)
   }
 }
 

--- a/packages/dd-trace/src/serverless/vercel.js
+++ b/packages/dd-trace/src/serverless/vercel.js
@@ -63,7 +63,7 @@ function registerVercelTelemetryRetention (tracer) {
   if (existing) return existing
 
   if (typeof tracer?.flushAll !== 'function') return
-  let activeFlush
+  let flushInProgress = false
   let queuedFlush
 
   /**
@@ -72,9 +72,13 @@ function registerVercelTelemetryRetention (tracer) {
   const startFlush = flush => {
     flushVercelTelemetry(tracer, () => {
       flush.complete()
-      activeFlush = queuedFlush
+      const nextFlush = queuedFlush
       queuedFlush = undefined
-      if (activeFlush) startFlush(activeFlush)
+      if (nextFlush) {
+        startFlush(nextFlush)
+      } else {
+        flushInProgress = false
+      }
     })
   }
   const flushRequest = () => {
@@ -84,12 +88,12 @@ function registerVercelTelemetryRetention (tracer) {
     const { waitUntil } = requestContext
     if (typeof waitUntil !== 'function') return
 
-    const start = activeFlush === undefined
-    let flush
-    if (start) {
-      flush = activeFlush = createVercelFlush()
+    const shouldStart = !flushInProgress
+    const flush = queuedFlush ?? createVercelFlush()
+    if (shouldStart) {
+      flushInProgress = true
     } else {
-      flush = queuedFlush ??= createVercelFlush()
+      queuedFlush = flush
     }
 
     try {
@@ -97,7 +101,7 @@ function registerVercelTelemetryRetention (tracer) {
     } catch (error) {
       log.warn('Unable to retain Vercel telemetry:', error)
     }
-    if (start) startFlush(flush)
+    if (shouldStart) startFlush(flush)
   }
   // The HTTP finish channel activates its response wrapper directly. HTTP/2 needs
   // a passive request-start subscriber before it can bind response emit events.

--- a/packages/dd-trace/src/serverless/vercel.js
+++ b/packages/dd-trace/src/serverless/vercel.js
@@ -17,6 +17,19 @@ const vercelRetentionHandlers = new WeakMap()
  */
 
 /**
+ * @typedef {{ complete: () => void, promise: Promise<void> }} VercelFlush
+ */
+
+/**
+ * @returns {VercelFlush}
+ */
+function createVercelFlush () {
+  let complete
+  const promise = new Promise(resolve => { complete = resolve })
+  return { complete, promise }
+}
+
+/**
  * @param {TelemetryFlusher} tracer
  * @param {() => void} done
  * @returns {void}
@@ -30,25 +43,6 @@ function flushVercelTelemetry (tracer, done) {
       done()
     }
   })
-}
-
-function registerVercelRequestFlush (tracer) {
-  const requestContext = getVercelRequestContext()
-  if (!requestContext) return
-
-  const { waitUntil } = requestContext
-  if (typeof waitUntil !== 'function') return
-
-  // Retain the invocation synchronously, then flush after the response completes.
-  let done
-  const pending = new Promise(resolve => { done = resolve })
-  try {
-    waitUntil(pending)
-    flushVercelTelemetry(tracer, done)
-  } catch (error) {
-    log.warn('Unable to retain Vercel telemetry:', error)
-    done()
-  }
 }
 
 function getVercelRequestContext () {
@@ -69,9 +63,44 @@ function registerVercelTelemetryRetention (tracer) {
   if (existing) return existing
 
   if (typeof tracer?.flushAll !== 'function') return
+  let activeFlush
+  let queuedFlush
+
+  /**
+   * @param {VercelFlush} flush
+   */
+  const startFlush = flush => {
+    flushVercelTelemetry(tracer, () => {
+      flush.complete()
+      activeFlush = queuedFlush
+      queuedFlush = undefined
+      if (activeFlush) startFlush(activeFlush)
+    })
+  }
+  const flushRequest = () => {
+    const requestContext = getVercelRequestContext()
+    if (!requestContext) return
+
+    const { waitUntil } = requestContext
+    if (typeof waitUntil !== 'function') return
+
+    const start = activeFlush === undefined
+    let flush
+    if (start) {
+      flush = activeFlush = createVercelFlush()
+    } else {
+      flush = queuedFlush ??= createVercelFlush()
+    }
+
+    try {
+      waitUntil(flush.promise)
+    } catch (error) {
+      log.warn('Unable to retain Vercel telemetry:', error)
+    }
+    if (start) startFlush(flush)
+  }
   // The HTTP finish channel activates its response wrapper directly. HTTP/2 needs
   // a passive request-start subscriber before it can bind response emit events.
-  const flushRequest = () => registerVercelRequestFlush(tracer)
   const flushHttp2Response = ({ eventName }) => {
     if (eventName === 'close') flushRequest()
   }

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -98,36 +98,34 @@ describe('dogstatsd', () => {
     MetricsAggregationClient = dogstatsd.MetricsAggregationClient
     createMetricsAggregationClient = dogstatsd.createMetricsAggregationClient
 
-    httpData = []
+    httpData = undefined
     statusCode = 200
     sockets = []
-    httpServer = http.createServer((req, res) => {
-      assert.strictEqual(req.method, 'POST')
-      assert.strictEqual(req.url, '/dogstatsd/v2/proxy')
+
+    /**
+     * @param {import('node:http').IncomingMessage} request
+     * @param {import('node:http').ServerResponse} response
+     */
+    function handleRequest (request, response) {
+      assert.strictEqual(request.method, 'POST')
+      assert.strictEqual(request.url, '/dogstatsd/v2/proxy')
       const requestData = []
-      req.on('data', data => requestData.push(data))
-      req.on('end', () => {
-        httpData = requestData
-        res.statusCode = statusCode
-        res.end()
+      request.on('data', data => requestData.push(data))
+      request.on('end', () => {
+        httpData = Buffer.concat(requestData)
+        response.statusCode = statusCode
+        response.end()
       })
-    }).listen(0, () => {
+    }
+
+    httpServer = http.createServer(handleRequest).listen(0, () => {
       httpPort = httpServer.address().port
       if (os.platform() === 'win32') {
         done()
         return
       }
       udsPath = path.join(os.tmpdir(), `test-dogstatsd-dd-trace-uds-${Math.random()}`)
-      httpUdsServer = http.createServer((req, res) => {
-        assert.strictEqual(req.method, 'POST')
-        assert.strictEqual(req.url, '/dogstatsd/v2/proxy')
-        const requestData = []
-        req.on('data', data => requestData.push(data))
-        req.on('end', () => {
-          httpData = requestData
-          res.end()
-        })
-      }).listen(udsPath, () => {
+      httpUdsServer = http.createServer(handleRequest).listen(udsPath, () => {
         done()
       })
       httpUdsServer.on('connection', socket => sockets.push(socket))
@@ -172,7 +170,6 @@ describe('dogstatsd', () => {
 
   /**
    * @param {{ flush: (done: () => void) => void }} dogstatsdClient
-   * @returns {Promise<void>}
    */
   function flushClient (dogstatsdClient) {
     return new Promise(resolve => dogstatsdClient.flush(resolve))
@@ -948,7 +945,7 @@ describe('dogstatsd', () => {
     client.gauge('test.avg2', 2)
     await flushClient(client)
 
-    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:0|g\ntest.avg2:2|g\n')
+    assert.strictEqual(httpData.toString(), 'test.avg:0|g\ntest.avg2:2|g\n')
   })
 
   it('should support HTTP via port', async () => {
@@ -960,18 +957,7 @@ describe('dogstatsd', () => {
     client.gauge('test.avg2', 2)
     await flushClient(client)
 
-    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
-  })
-
-  it('calls the flush callback after the HTTP proxy responds', async () => {
-    client = createDogStatsDClient({
-      metricsProxyUrl: `http://localhost:${httpPort}`,
-    })
-
-    client.gauge('test.avg', 1)
-    await flushClient(client)
-
-    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\n')
+    assert.strictEqual(httpData.toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
   })
 
   it('should support HTTP via URL object', async () => {
@@ -983,7 +969,7 @@ describe('dogstatsd', () => {
     client.gauge('test.avg2', 2)
     await flushClient(client)
 
-    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
+    assert.strictEqual(httpData.toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
   })
 
   it('should fail over to UDP when receiving HTTP 404 error from agent', async () => {

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -32,6 +32,7 @@ describe('dogstatsd', () => {
   let httpServer
   let httpPort
   let httpData
+  let resolveHttpRequest
   let httpUdsServer
   let udsPath
   let statusCode
@@ -99,6 +100,7 @@ describe('dogstatsd', () => {
     createMetricsAggregationClient = dogstatsd.createMetricsAggregationClient
 
     httpData = undefined
+    resolveHttpRequest = undefined
     statusCode = 200
     sockets = []
 
@@ -115,6 +117,9 @@ describe('dogstatsd', () => {
         httpData = Buffer.concat(requestData)
         response.statusCode = statusCode
         response.end()
+        const resolve = resolveHttpRequest
+        resolveHttpRequest = undefined
+        resolve?.(httpData)
       })
     }
 
@@ -173,6 +178,15 @@ describe('dogstatsd', () => {
    */
   function flushClient (dogstatsdClient) {
     return new Promise(resolve => dogstatsdClient.flush(resolve))
+  }
+
+  /**
+   * @returns {Promise<Buffer>}
+   */
+  function waitForHttpRequest () {
+    return new Promise(resolve => {
+      resolveHttpRequest = resolve
+    })
   }
 
   function createCustomMetrics (CustomMetricsCtor = CustomMetrics) {
@@ -602,32 +616,22 @@ describe('dogstatsd', () => {
 
     it('uses HTTP transport tags and a separate telemetry payload', async () => {
       const now = sinon.stub(performance, 'now').returns(0)
-      const payloads = []
-      const telemetryReceived = new Promise(resolve => {
-        assertData = () => {
-          payloads.push(Buffer.concat(httpData).toString())
-          httpData.length = 0
-
-          if (payloads.length === 1) {
-            now.returns(10_000)
-            client.flush()
-            return
-          }
-
-          resolve()
-        }
-      })
 
       try {
         client = createTelemetryClient({ metricsProxyUrl: `http://localhost:${httpPort}` })
         client.gauge('test.avg', 1)
+        const metricsReceived = waitForHttpRequest()
         client.flush()
 
-        await telemetryReceived
+        const metrics = await metricsReceived
+        now.returns(10_000)
+        const telemetryReceived = waitForHttpRequest()
+        client.flush()
+        const telemetry = await telemetryReceived
 
-        assert.strictEqual(payloads[0], 'test.avg:1|g\n')
-        assert.match(payloads[1], /datadog\.dogstatsd\.client\.metrics:1\|c\|/)
-        assert.match(payloads[1], /client_transport:http/)
+        assert.strictEqual(metrics.toString(), 'test.avg:1|g\n')
+        assert.match(telemetry.toString(), /datadog\.dogstatsd\.client\.metrics:1\|c\|/)
+        assert.match(telemetry.toString(), /client_transport:http/)
       } finally {
         now.restore()
       }
@@ -668,9 +672,7 @@ describe('dogstatsd', () => {
       const udpSent = new Promise(resolve => {
         resolveUdp = resolve
       })
-      const httpAttempted = new Promise(resolve => {
-        assertData = resolve
-      })
+      const httpAttempted = waitForHttpRequest()
       udp4.send = sinon.stub().callsFake((buffer, offset, length, port, address, callback) => {
         callback?.()
         resolveUdp()
@@ -683,19 +685,14 @@ describe('dogstatsd', () => {
         client.flush()
 
         await Promise.all([httpAttempted, udpSent])
-        httpData.length = 0
-
-        const telemetryReceived = new Promise(resolve => {
-          assertData = resolve
-        })
         now.returns(10_000)
+        const telemetryReceived = waitForHttpRequest()
         client.flush()
 
-        await telemetryReceived
+        const telemetry = await telemetryReceived
 
-        const telemetry = Buffer.concat(httpData).toString()
-        assert.match(telemetry, /client_transport:http/)
-        assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_sent:13\|c\|/)
+        assert.match(telemetry.toString(), /client_transport:http/)
+        assert.match(telemetry.toString(), /datadog\.dogstatsd\.client\.bytes_sent:13\|c\|/)
       } finally {
         now.restore()
       }

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { once } = require('node:events')
 const http = require('node:http')
 const path = require('node:path')
 const os = require('node:os')
@@ -35,7 +36,6 @@ describe('dogstatsd', () => {
   let udsPath
   let statusCode
   let sockets
-  let assertData
   let docker
   let log
   let registerTelemetryFlusher
@@ -100,16 +100,16 @@ describe('dogstatsd', () => {
 
     httpData = []
     statusCode = 200
-    assertData = undefined
     sockets = []
     httpServer = http.createServer((req, res) => {
       assert.strictEqual(req.method, 'POST')
       assert.strictEqual(req.url, '/dogstatsd/v2/proxy')
-      req.on('data', d => httpData.push(d))
+      const requestData = []
+      req.on('data', data => requestData.push(data))
       req.on('end', () => {
+        httpData = requestData
         res.statusCode = statusCode
         res.end()
-        setTimeout(() => assertData && assertData(httpData))
       })
     }).listen(0, () => {
       httpPort = httpServer.address().port
@@ -121,10 +121,11 @@ describe('dogstatsd', () => {
       httpUdsServer = http.createServer((req, res) => {
         assert.strictEqual(req.method, 'POST')
         assert.strictEqual(req.url, '/dogstatsd/v2/proxy')
-        req.on('data', d => httpData.push(d))
+        const requestData = []
+        req.on('data', data => requestData.push(data))
         req.on('end', () => {
+          httpData = requestData
           res.end()
-          setTimeout(() => assertData && assertData(httpData))
         })
       }).listen(udsPath, () => {
         done()
@@ -134,12 +135,15 @@ describe('dogstatsd', () => {
     httpServer.on('connection', socket => sockets.push(socket))
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    const closeEvents = [once(httpServer, 'close')]
     httpServer.close()
     if (httpUdsServer) {
+      closeEvents.push(once(httpUdsServer, 'close'))
       httpUdsServer.close()
     }
-    sockets.forEach(socket => socket.destroy())
+    for (const socket of sockets) socket.destroy()
+    await Promise.all(closeEvents)
   })
 
   function createDogStatsDClient (options) {
@@ -164,6 +168,14 @@ describe('dogstatsd', () => {
       tags: [],
       ...options,
     })
+  }
+
+  /**
+   * @param {{ flush: (done: () => void) => void }} dogstatsdClient
+   * @returns {Promise<void>}
+   */
+  function flushClient (dogstatsdClient) {
+    return new Promise(resolve => dogstatsdClient.flush(resolve))
   }
 
   function createCustomMetrics (CustomMetricsCtor = CustomMetrics) {
@@ -927,93 +939,55 @@ describe('dogstatsd', () => {
   })
 
   const udsIt = os.platform() === 'win32' ? it.skip : it
-  udsIt('should support HTTP via unix domain socket', (done) => {
-    assertData = () => {
-      try {
-        assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:0|g\ntest.avg2:2|g\n')
-        done()
-      } catch (e) {
-        done(e)
-      }
-    }
-
+  udsIt('should support HTTP via unix domain socket', async () => {
     client = createDogStatsDClient({
       metricsProxyUrl: `unix://${udsPath}`,
     })
 
     client.gauge('test.avg', 0)
     client.gauge('test.avg2', 2)
-    client.flush()
+    await flushClient(client)
+
+    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:0|g\ntest.avg2:2|g\n')
   })
 
-  it('should support HTTP via port', (done) => {
-    assertData = () => {
-      try {
-        assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
-        done()
-      } catch (e) {
-        done(e)
-      }
-    }
-
+  it('should support HTTP via port', async () => {
     client = createDogStatsDClient({
       metricsProxyUrl: `http://localhost:${httpPort}`,
     })
 
     client.gauge('test.avg', 1)
     client.gauge('test.avg2', 2)
-    client.flush()
+    await flushClient(client)
+
+    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
   })
 
-  it('calls the flush callback after the HTTP proxy responds', (done) => {
+  it('calls the flush callback after the HTTP proxy responds', async () => {
     client = createDogStatsDClient({
       metricsProxyUrl: `http://localhost:${httpPort}`,
     })
 
     client.gauge('test.avg', 1)
-    client.flush(() => {
-      try {
-        assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\n')
-        done()
-      } catch (error) {
-        done(error)
-      }
-    })
+    await flushClient(client)
+
+    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\n')
   })
 
-  it('should support HTTP via URL object', (done) => {
-    assertData = () => {
-      try {
-        assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
-        done()
-      } catch (e) {
-        done(e)
-      }
-    }
-
+  it('should support HTTP via URL object', async () => {
     client = createDogStatsDClient({
       metricsProxyUrl: new URL(`http://localhost:${httpPort}`),
     })
 
     client.gauge('test.avg', 1)
     client.gauge('test.avg2', 2)
-    client.flush()
+    await flushClient(client)
+
+    assert.strictEqual(Buffer.concat(httpData).toString(), 'test.avg:1|g\ntest.avg2:2|g\n')
   })
 
-  it('should fail over to UDP when receiving HTTP 404 error from agent', (done) => {
-    assertData = () => {
-      setTimeout(() => {
-        try {
-          sinon.assert.called(udp4.send)
-          assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.count:10|c\n')
-          assert.strictEqual(udp4.send.firstCall.args[2], 16)
-          done()
-        } catch (e) {
-          done(e)
-        }
-      })
-    }
-
+  it('should fail over to UDP when receiving HTTP 404 error from agent', async () => {
+    udp4.send = sinon.stub().yields()
     statusCode = 404
 
     client = createDogStatsDClient({
@@ -1022,7 +996,11 @@ describe('dogstatsd', () => {
 
     client.increment('test.count', 10)
 
-    client.flush()
+    await flushClient(client)
+
+    sinon.assert.called(udp4.send)
+    assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.count:10|c\n')
+    assert.strictEqual(udp4.send.firstCall.args[2], 16)
   })
 
   it('should fail over to UDP when receiving network error from agent', (done) => {

--- a/packages/dd-trace/test/fixtures/vercel-telemetry-coalescing.js
+++ b/packages/dd-trace/test/fixtures/vercel-telemetry-coalescing.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { channel } = require('dc-polyfill')
+
+const { registerVercelTelemetryRetention } = require('../../src/serverless/vercel')
+
+const requestContext = Symbol.for('@vercel/request-context')
+const retained = []
+const flushes = []
+
+function immediate () {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+/**
+ * @param {Promise<void>} promise
+ */
+function waitUntil (promise) {
+  retained.push(promise)
+}
+
+globalThis[requestContext] = {
+  get: () => ({ waitUntil }),
+}
+
+const unregister = registerVercelTelemetryRetention({
+  /**
+   * @param {() => void} done
+   */
+  flushAll (done) {
+    flushes.push(done)
+  },
+})
+
+async function main () {
+  try {
+    const finishChannel = channel('apm:http:server:request:finish')
+    finishChannel.publish({ req: {} })
+    await immediate()
+    finishChannel.publish({ req: {} })
+    finishChannel.publish({ req: {} })
+    await immediate()
+
+    assert.strictEqual(retained.length, 3)
+    assert.strictEqual(retained[1], retained[2])
+    assert.strictEqual(flushes.length, 1)
+
+    let activeSettled = false
+    let queuedSettled = false
+    async function observeActive () {
+      await retained[0]
+      activeSettled = true
+    }
+    async function observeQueued () {
+      await retained[1]
+      queuedSettled = true
+    }
+    const activeObserved = observeActive()
+    const queuedObserved = observeQueued()
+    flushes[0]()
+    await immediate()
+
+    assert.strictEqual(activeSettled, true)
+    assert.strictEqual(queuedSettled, false)
+    assert.strictEqual(flushes.length, 2)
+
+    flushes[1]()
+    await Promise.all([activeObserved, queuedObserved])
+    assert.strictEqual(queuedSettled, true)
+
+    finishChannel.publish({ req: {} })
+    await immediate()
+    assert.strictEqual(retained.length, 4)
+    assert.notStrictEqual(retained[3], retained[2])
+    assert.strictEqual(flushes.length, 3)
+    flushes[2]()
+    await retained[3]
+  } finally {
+    unregister()
+  }
+}
+
+main()

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -36,9 +36,24 @@ describe('module', () => {
   let registerTelemetryFlusher
   let unregisterTelemetryFlusher
   let originalVercel
+  let llmobsModuleProxyRequireMeta
 
   /** @type {import('sinon').SinonStub} */
   let startupLogStub
+
+  function loadLlmobsModule () {
+    llmobsModule = proxyquire('../../../dd-trace/src/llmobs', llmobsModuleProxyRequireMeta)
+    removeDestroyHandler()
+  }
+
+  function loadLlmobsModuleOnVercel () {
+    process.env.VERCEL = '1'
+    llmobsModuleProxyRequireMeta['../serverless'] = proxyquire.noPreserveCache()(
+      '../../../dd-trace/src/serverless',
+      {}
+    )
+    loadLlmobsModule()
+  }
 
   beforeEach(() => {
     originalVercel = process.env.VERCEL
@@ -62,7 +77,7 @@ describe('module', () => {
     unregisterTelemetryFlusher = sinon.stub()
     registerTelemetryFlusher = sinon.stub().returns(unregisterTelemetryFlusher)
 
-    const llmobsModuleProxyRequireMeta = {
+    llmobsModuleProxyRequireMeta = {
       './writers/spans': LLMObsSpanWriterSpy,
       './writers/evaluations': LLMObsEvalMetricsWriterSpy,
       '../flush': { registerTelemetryFlusher },
@@ -91,9 +106,7 @@ describe('module', () => {
       }
     }
 
-    llmobsModule = proxyquire('../../../dd-trace/src/llmobs', llmobsModuleProxyRequireMeta)
-
-    removeDestroyHandler()
+    loadLlmobsModule()
   })
 
   afterEach(() => {
@@ -467,7 +480,7 @@ describe('module', () => {
   })
 
   it('registers both LLMObs writers for lifecycle flushing', () => {
-    process.env.VERCEL = '1'
+    loadLlmobsModuleOnVercel()
     llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
     const done = sinon.spy()
     const spanWriter = LLMObsSpanWriterSpy.firstCall.returnValue
@@ -488,7 +501,7 @@ describe('module', () => {
   })
 
   it('continues flushing when one LLMObs writer throws', () => {
-    process.env.VERCEL = '1'
+    loadLlmobsModuleOnVercel()
     llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
     const done = sinon.spy()
     const spanWriter = LLMObsSpanWriterSpy.firstCall.returnValue
@@ -515,7 +528,7 @@ describe('module', () => {
   })
 
   it('retains destroyed writers until every lifecycle flush completes', () => {
-    process.env.VERCEL = '1'
+    loadLlmobsModuleOnVercel()
     const retiredUnregister = sinon.stub()
     registerTelemetryFlusher.onSecondCall().returns(retiredUnregister)
     llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
@@ -537,7 +550,7 @@ describe('module', () => {
   })
 
   it('retires reinitialized writers until their destroy callbacks complete', () => {
-    process.env.VERCEL = '1'
+    loadLlmobsModuleOnVercel()
     const initialUnregister = sinon.stub()
     const retiredUnregister = sinon.stub()
     const replacementUnregister = sinon.stub()
@@ -571,7 +584,7 @@ describe('module', () => {
   })
 
   it('completes transport selection for writers retired during initialization', () => {
-    process.env.VERCEL = '1'
+    loadLlmobsModuleOnVercel()
     llmobsModule.enable({ llmobs: { mlApp: 'test' } })
     const spanWriter = LLMObsSpanWriterSpy.firstCall.returnValue
     const evalWriter = LLMObsEvalMetricsWriterSpy.firstCall.returnValue

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -52,6 +52,7 @@ describe('module', () => {
       '../../../dd-trace/src/serverless',
       {}
     )
+    proxyquire.preserveCache()
     loadLlmobsModule()
   }
 

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -280,6 +280,29 @@ describe('BaseLLMObsWriter', () => {
       )
     })
 
+    it('isolates an invalid route from valid buffers', () => {
+      writer = new BaseLLMObsWriter(options)
+      writer.setAgentless(true)
+      writer.makePayload = (events) => ({ events })
+      writer.append({ foo: 'default' })
+      writer.append({ foo: 'invalid' }, { apiKey: 'invalid', site: 'invalid site' })
+      writer.append({ foo: 'valid' }, { apiKey: 'valid', site: 'valid.site.com' })
+
+      writer.flush()
+      writer.flush()
+
+      sinon.assert.calledTwice(request)
+      const events = request.getCalls().map(call => JSON.parse(call.args[0]).events[0])
+      assert.deepStrictEqual(events, [{ foo: 'default' }, { foo: 'valid' }])
+      sinon.assert.calledWith(
+        logger.error,
+        'Failed to route LLMObs %s events for API key %s: %s',
+        undefined,
+        '****alid',
+        'Invalid URL'
+      )
+    })
+
     it('waits for an export already in flight', () => {
       process.env.VERCEL = '1'
       writer = new BaseLLMObsWriter(options)

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -294,7 +294,7 @@ describe('BaseLLMObsWriter', () => {
       sinon.assert.calledTwice(request)
       const events = request.getCalls().map(call => JSON.parse(call.args[0]).events[0])
       assert.deepStrictEqual(events, [{ foo: 'default' }, { foo: 'valid' }])
-      sinon.assert.calledWith(
+      sinon.assert.calledOnceWithExactly(
         logger.error,
         'Failed to route LLMObs %s events for API key %s: %s',
         undefined,

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -21,7 +21,8 @@ describe('BaseLLMObsWriter', () => {
 
   function getBaseLLMObsWriter () {
     const serverless = proxyquire.noPreserveCache()('../../../src/serverless', {})
-    return proxyquire.noPreserveCache()('../../../src/llmobs/writers/base', {
+    proxyquire.preserveCache()
+    return proxyquire('../../../src/llmobs/writers/base', {
       '../../exporters/common/request': request,
       '../../log': logger,
       '../../serverless': serverless,
@@ -310,6 +311,10 @@ describe('BaseLLMObsWriter', () => {
       writer.append({ foo: 'valid' }, { apiKey: 'valid', site: 'valid.site.com' })
 
       writer.flush()
+
+      sinon.assert.calledTwice(request)
+      sinon.assert.calledOnce(logger.error)
+
       writer.flush()
 
       sinon.assert.calledTwice(request)

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -19,6 +19,18 @@ describe('BaseLLMObsWriter', () => {
   let options
   let logger
 
+  function getBaseLLMObsWriter () {
+    const serverless = proxyquire.noPreserveCache()('../../../src/serverless', {})
+    return proxyquire.noPreserveCache()('../../../src/llmobs/writers/base', {
+      '../../exporters/common/request': request,
+      '../../log': logger,
+      '../../serverless': serverless,
+      './util': proxyquire('../../../src/llmobs/writers/util', {
+        '../../log': logger,
+      }),
+    })
+  }
+
   beforeEach(() => {
     request = sinon.stub()
     logger = {
@@ -26,13 +38,7 @@ describe('BaseLLMObsWriter', () => {
       warn: sinon.stub(),
       error: sinon.stub(),
     }
-    BaseLLMObsWriter = proxyquire('../../../src/llmobs/writers/base', {
-      '../../exporters/common/request': request,
-      '../../log': logger,
-      './util': proxyquire('../../../src/llmobs/writers/util', {
-        '../../log': logger,
-      }),
-    })
+    BaseLLMObsWriter = getBaseLLMObsWriter()
 
     clock = sinon.useFakeTimers({
       toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
@@ -224,6 +230,21 @@ describe('BaseLLMObsWriter', () => {
       assert.strictEqual(requestOptions.headers['DD-API-KEY'], 'key-a')
     })
 
+    it('does not flush an empty routed buffer left by a failed append', () => {
+      writer = new BaseLLMObsWriter(options)
+      writer.setAgentless(true)
+      const event = {}
+      event.self = event
+
+      assert.throws(
+        () => writer.append(event, { apiKey: 'key-a', site: 'site-a.com' }),
+        { name: 'TypeError' }
+      )
+      writer.flush()
+
+      sinon.assert.notCalled(request)
+    })
+
     it('does not flush when agentless property is not set', () => {
       writer = new BaseLLMObsWriter(options)
       writer.makePayload = (events) => ({ events })
@@ -305,6 +326,7 @@ describe('BaseLLMObsWriter', () => {
 
     it('waits for an export already in flight', () => {
       process.env.VERCEL = '1'
+      BaseLLMObsWriter = getBaseLLMObsWriter()
       writer = new BaseLLMObsWriter(options)
       writer.setAgentless(true)
       writer.makePayload = (events) => ({ events })
@@ -323,6 +345,7 @@ describe('BaseLLMObsWriter', () => {
 
     it('waits for every request drained at the flush boundary', () => {
       process.env.VERCEL = '1'
+      BaseLLMObsWriter = getBaseLLMObsWriter()
       writer = new BaseLLMObsWriter(options)
       writer.setAgentless(true)
       writer.makePayload = (events) => ({ events })
@@ -343,6 +366,7 @@ describe('BaseLLMObsWriter', () => {
 
     it('continues after a boundary request throws while waiting for earlier requests', () => {
       process.env.VERCEL = '1'
+      BaseLLMObsWriter = getBaseLLMObsWriter()
       writer = new BaseLLMObsWriter(options)
       writer.setAgentless(true)
       writer.makePayload = (events) => ({ events })

--- a/packages/dd-trace/test/opentelemetry/logs.spec.js
+++ b/packages/dd-trace/test/opentelemetry/logs.spec.js
@@ -20,6 +20,14 @@ const BatchLogRecordProcessor = require('../../src/opentelemetry/logs/batch_log_
 
 const identityRefreshChannel = channel('datadog:identity:refresh')
 
+function getVercelBatchLogRecordProcessor () {
+  process.env.VERCEL = '1'
+  const serverless = proxyquire.noPreserveCache()('../../src/serverless', {})
+  return proxyquire.noPreserveCache()('../../src/opentelemetry/logs/batch_log_processor', {
+    '../../serverless': serverless,
+  })
+}
+
 /**
  * @param {object} type protobufjs Type instance for the OTLP service message
  * @param {object} message Decoded protobufjs Message
@@ -147,10 +155,10 @@ describe('OpenTelemetry Logs', () => {
 
   describe('Logs Export', () => {
     it('waits for an in-flight export during forceFlush', () => {
-      process.env.VERCEL = '1'
+      const VercelBatchLogRecordProcessor = getVercelBatchLogRecordProcessor()
       let exportDone
       let flushDone
-      const processor = new BatchLogRecordProcessor({
+      const processor = new VercelBatchLogRecordProcessor({
         export: (records, done) => { exportDone = done },
         flush: (done) => { flushDone = done },
       }, 60_000, 1)
@@ -167,7 +175,7 @@ describe('OpenTelemetry Logs', () => {
     })
 
     it('drains queued batches and waits for earlier size-triggered exports', () => {
-      process.env.VERCEL = '1'
+      const VercelBatchLogRecordProcessor = getVercelBatchLogRecordProcessor()
       const batches = []
       const callbacks = []
       const flushCallbacks = []
@@ -176,7 +184,7 @@ describe('OpenTelemetry Logs', () => {
         if (activeExports !== 0) return
         while (flushCallbacks.length > 0) flushCallbacks.shift()()
       }
-      const processor = new BatchLogRecordProcessor({
+      const processor = new VercelBatchLogRecordProcessor({
         export: (records, done) => {
           batches.push(records)
           activeExports++
@@ -209,9 +217,9 @@ describe('OpenTelemetry Logs', () => {
     })
 
     it('waits for an earlier export when the boundary batch throws', () => {
-      process.env.VERCEL = '1'
+      const VercelBatchLogRecordProcessor = getVercelBatchLogRecordProcessor()
       let priorFlushDone
-      const processor = new BatchLogRecordProcessor({
+      const processor = new VercelBatchLogRecordProcessor({
         export: sinon.stub()
           .onFirstCall().callsFake(() => {})
           .onSecondCall().throws(new Error('encode failed')),
@@ -230,10 +238,10 @@ describe('OpenTelemetry Logs', () => {
     })
 
     it('does not wait for records emitted after the flush boundary', () => {
-      process.env.VERCEL = '1'
+      const VercelBatchLogRecordProcessor = getVercelBatchLogRecordProcessor()
       const exports = []
       let firstExportDone
-      const processor = new BatchLogRecordProcessor({
+      const processor = new VercelBatchLogRecordProcessor({
         export: (records, done) => {
           exports.push(records.map(record => record.body))
           if (records[0].body === 'before') firstExportDone = done

--- a/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_exporter.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics/otlp_span_stats_exporter.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 const http = require('node:http')
 const { describe, it, before, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { channel } = require('dc-polyfill')
 
@@ -18,6 +19,18 @@ const identityRefreshChannel = channel('datadog:identity:refresh')
 
 const RESOURCE_ATTRS = { 'service.name': 'svc' }
 const BUCKET_SIZE_NS = 10 * 1e9
+
+function getVercelOtlpStatsExporter () {
+  process.env.VERCEL = '1'
+  const serverless = proxyquire.noPreserveCache()('../../../src/serverless', {})
+  const OtlpHttpExporterBase = proxyquire.noPreserveCache()(
+    '../../../src/opentelemetry/otlp/otlp_http_exporter_base',
+    { '../../serverless': serverless }
+  )
+  return proxyquire.noPreserveCache()('../../../src/opentelemetry/metrics/otlp_span_stats_exporter', {
+    '../otlp/otlp_http_exporter_base': OtlpHttpExporterBase,
+  }).OtlpStatsExporter
+}
 
 before(() => processTags.initialize())
 
@@ -268,8 +281,12 @@ describe('OtlpStatsExporter', () => {
       callback(mockRes)
       return mockReq
     })
-    process.env.VERCEL = '1'
-    const serverlessExporter = new OtlpStatsExporter('http://localhost:4318/v1/metrics', 'http/json', RESOURCE_ATTRS)
+    const VercelOtlpStatsExporter = getVercelOtlpStatsExporter()
+    const serverlessExporter = new VercelOtlpStatsExporter(
+      'http://localhost:4318/v1/metrics',
+      'http/json',
+      RESOURCE_ATTRS
+    )
     const flushed = sinon.spy()
 
     serverlessExporter.export(makeDrained([makeSpan()]), BUCKET_SIZE_NS)
@@ -294,8 +311,12 @@ describe('OtlpStatsExporter', () => {
       callback(mockRes)
       return mockReq
     })
-    process.env.VERCEL = '1'
-    const serverlessExporter = new OtlpStatsExporter('http://localhost:4318/v1/metrics', 'http/json', RESOURCE_ATTRS)
+    const VercelOtlpStatsExporter = getVercelOtlpStatsExporter()
+    const serverlessExporter = new VercelOtlpStatsExporter(
+      'http://localhost:4318/v1/metrics',
+      'http/json',
+      RESOURCE_ATTRS
+    )
     const flushed = sinon.spy()
 
     serverlessExporter.export(makeDrained([makeSpan()]), BUCKET_SIZE_NS)

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -15,13 +15,9 @@ require('./setup/core')
 
 const {
   enableGCPPubSubPushSubscription,
-  initializeServerlessTelemetry,
 } = require('../src/serverless')
 const { registerVercelTelemetryRetention } = require('../src/serverless/vercel')
-const { flushServerlessTelemetry, registerTelemetryFlusher } = require('../src/flush')
-const Tracer = require('../src/tracer')
-const { initializeOpenTelemetryLogs } = require('../src/opentelemetry/logs')
-const { initializeOpenTelemetryMetrics } = require('../src/opentelemetry/metrics')
+const { flushServerlessTelemetry } = require('../src/flush')
 const TelemetryDeliveryTracker = require('../src/serverless/telemetry-delivery-tracker')
 const agent = require('./plugins/agent')
 const { getConfigFresh } = require('./helpers/config')
@@ -30,19 +26,29 @@ function getServerlessFresh () {
   return proxyquire.noPreserveCache()('../src/serverless', {})
 }
 
+function getServerlessModulesFresh () {
+  const serverless = getServerlessFresh()
+  const flush = proxyquire.noPreserveCache()('../src/flush', {
+    './serverless': serverless,
+  })
+  return { flush, serverless }
+}
+
 describe('TelemetryDeliveryTracker', () => {
-  it('is created only for Vercel', () => {
+  it('snapshots Vercel detection at module load', () => {
     const originalVercel = process.env.VERCEL
     try {
       delete process.env.VERCEL
-      let serverless = getServerlessFresh()
-      assert.strictEqual(serverless.createServerlessDeliveryTracker(), undefined)
-      assert.strictEqual(serverless.supportsServerlessTelemetryRetention(), false)
+      const nonVercelServerless = getServerlessFresh()
 
       process.env.VERCEL = '1'
-      serverless = getServerlessFresh()
-      assert.ok(serverless.createServerlessDeliveryTracker() instanceof TelemetryDeliveryTracker)
-      assert.strictEqual(serverless.supportsServerlessTelemetryRetention(), true)
+      assert.strictEqual(nonVercelServerless.createServerlessDeliveryTracker(), undefined)
+      assert.strictEqual(nonVercelServerless.supportsServerlessTelemetryRetention(), false)
+
+      const vercelServerless = getServerlessFresh()
+      delete process.env.VERCEL
+      assert.ok(vercelServerless.createServerlessDeliveryTracker() instanceof TelemetryDeliveryTracker)
+      assert.strictEqual(vercelServerless.supportsServerlessTelemetryRetention(), true)
     } finally {
       if (originalVercel === undefined) delete process.env.VERCEL
       else process.env.VERCEL = originalVercel
@@ -296,7 +302,18 @@ describe('Vercel telemetry retention', () => {
 
     let unregister
     try {
-      const config = getConfigFresh({ service: 'serverless-flush' })
+      const { flush, serverless } = getServerlessModulesFresh()
+      const Tracer = proxyquire.noPreserveCache()('../src/tracer', {
+        './flush': flush,
+        './serverless': serverless,
+      })
+      const { initializeOpenTelemetryLogs } = proxyquire.noPreserveCache()('../src/opentelemetry/logs', {
+        '../../flush': flush,
+      })
+      const { initializeOpenTelemetryMetrics } = proxyquire.noPreserveCache()('../src/opentelemetry/metrics', {
+        '../../flush': flush,
+      })
+      const config = getConfigFresh({ service: 'serverless-flush' }, { '../serverless': serverless })
       const tracer = new Tracer(config)
       initializeOpenTelemetryLogs(config)
       initializeOpenTelemetryMetrics(config)
@@ -343,7 +360,7 @@ describe('Vercel telemetry retention', () => {
       },
     }
 
-    const unregister = initializeServerlessTelemetry(tracer)
+    const unregister = getServerlessFresh().initializeServerlessTelemetry(tracer)
     try {
       nextFinishChannel.publish({})
       assert.strictEqual(retained, undefined)
@@ -513,9 +530,10 @@ describe('Vercel telemetry retention', () => {
       flushes++
       completeTelemetry.push(done)
     }
-    const unregisterTelemetry = registerTelemetryFlusher(telemetryFlusher)
+    const { flush } = getServerlessModulesFresh()
+    const unregisterTelemetry = flush.registerTelemetryFlusher(telemetryFlusher)
     const unregister = registerVercelTelemetryRetention({
-      flushAll: (done, options) => flushServerlessTelemetry(done, options),
+      flushAll: (done, options) => flush.flushServerlessTelemetry(done, options),
     })
     try {
       channel('apm:http:server:request:finish').publish({})

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -8,15 +8,12 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const { logs } = require('@opentelemetry/api-logs')
 const { metrics } = require('@opentelemetry/api')
 const { channel } = require('dc-polyfill')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('./setup/core')
 
 const {
-  getServerlessPlatformTags,
-  getServerlessPlatform,
-  supportsServerlessTelemetryRetention,
-  createServerlessDeliveryTracker,
   enableGCPPubSubPushSubscription,
   initializeServerlessTelemetry,
 } = require('../src/serverless')
@@ -29,21 +26,36 @@ const TelemetryDeliveryTracker = require('../src/serverless/telemetry-delivery-t
 const agent = require('./plugins/agent')
 const { getConfigFresh } = require('./helpers/config')
 
+function getServerlessFresh () {
+  return proxyquire.noPreserveCache()('../src/serverless', {})
+}
+
 describe('TelemetryDeliveryTracker', () => {
   it('is created only for Vercel', () => {
     const originalVercel = process.env.VERCEL
     try {
       delete process.env.VERCEL
-      assert.strictEqual(createServerlessDeliveryTracker(), undefined)
-      assert.strictEqual(supportsServerlessTelemetryRetention(), false)
+      let serverless = getServerlessFresh()
+      assert.strictEqual(serverless.createServerlessDeliveryTracker(), undefined)
+      assert.strictEqual(serverless.supportsServerlessTelemetryRetention(), false)
 
       process.env.VERCEL = '1'
-      assert.ok(createServerlessDeliveryTracker() instanceof TelemetryDeliveryTracker)
-      assert.strictEqual(supportsServerlessTelemetryRetention(), true)
+      serverless = getServerlessFresh()
+      assert.ok(serverless.createServerlessDeliveryTracker() instanceof TelemetryDeliveryTracker)
+      assert.strictEqual(serverless.supportsServerlessTelemetryRetention(), true)
     } finally {
       if (originalVercel === undefined) delete process.env.VERCEL
       else process.env.VERCEL = originalVercel
     }
+  })
+
+  it('completes immediately without active deliveries', () => {
+    const tracker = new TelemetryDeliveryTracker()
+    let done = 0
+
+    tracker.waitForIdle(() => { done++ })
+
+    assert.strictEqual(done, 1)
   })
 
   it('joins deliveries that were active at the retention boundary', () => {
@@ -73,6 +85,28 @@ describe('TelemetryDeliveryTracker', () => {
     complete.shift()()
     assert.strictEqual(done, 1)
     complete.shift()()
+    assert.strictEqual(done, 1)
+  })
+
+  it('completes a delivery only once', () => {
+    const tracker = new TelemetryDeliveryTracker()
+    let complete
+    let done = 0
+
+    tracker.track(callback => { complete = callback }, () => { done++ })
+    complete()
+    complete()
+
+    assert.strictEqual(done, 1)
+  })
+})
+
+describe('flushServerlessTelemetry', () => {
+  it('completes immediately without configured pipelines', () => {
+    let done = 0
+
+    flushServerlessTelemetry(() => { done++ })
+
     assert.strictEqual(done, 1)
   })
 })
@@ -172,7 +206,7 @@ describe('Vercel span metadata', () => {
       VERCEL_PROJECT_ID: 'prj_123',
     }
 
-    assert.deepStrictEqual(getServerlessPlatformTags(), [
+    assert.deepStrictEqual(getServerlessFresh().getServerlessPlatformTags(), [
       'vercel.project_id', 'prj_123',
       'vercel.environment', 'preview',
     ])
@@ -185,7 +219,7 @@ describe('Vercel span metadata', () => {
       VERCEL_ENV: 'preview',
     }
 
-    assert.deepStrictEqual(getServerlessPlatformTags(), [
+    assert.deepStrictEqual(getServerlessFresh().getServerlessPlatformTags(), [
       'vercel.environment', 'preview',
     ])
   })
@@ -193,7 +227,7 @@ describe('Vercel span metadata', () => {
   it('records the Vercel environment in configuration', () => {
     process.env = { ...environment, VERCEL: '1' }
 
-    assert.strictEqual(getServerlessPlatform().isVercel, true)
+    assert.strictEqual(getServerlessFresh().getServerlessPlatform().isVercel, true)
   })
 })
 

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -554,42 +554,11 @@ describe('Vercel telemetry retention', () => {
     }
   })
 
-  it('coalesces overlapping Vercel responses into one queued flush', async () => {
-    const retained = []
-    const flushes = []
-    globalThis[requestContext] = {
-      get: () => ({ waitUntil: promise => { retained.push(promise) } }),
-    }
-    const unregister = registerVercelTelemetryRetention({
-      flushAll (done) {
-        flushes.push(done)
-      },
-    })
-    try {
-      channel('apm:http:server:request:finish').publish({ req: {} })
-      await new Promise(resolve => setImmediate(resolve))
-      channel('apm:http:server:request:finish').publish({ req: {} })
-      channel('apm:http:server:request:finish').publish({ req: {} })
-      await new Promise(resolve => setImmediate(resolve))
+  it('coalesces overlapping Vercel responses into one queued flush', () => {
+    const fixture = require.resolve('./fixtures/vercel-telemetry-coalescing')
+    const result = spawnSync(process.execPath, [fixture], { encoding: 'utf8', timeout: 5_000 })
 
-      // Other tracers initialized by this file can share this request context;
-      // the callback count below isolates this test's tracer.
-      assert.ok(retained.length >= 3)
-      assert.strictEqual(flushes.length, 1)
-      flushes[0]()
-      await new Promise(resolve => setImmediate(resolve))
-      assert.strictEqual(flushes.length, 2)
-      flushes[1]()
-      await Promise.all(retained)
-
-      channel('apm:http:server:request:finish').publish({ req: {} })
-      await new Promise(resolve => setImmediate(resolve))
-      assert.strictEqual(flushes.length, 3)
-      flushes[2]()
-      await Promise.all(retained)
-    } finally {
-      unregister()
-    }
+    assert.strictEqual(result.status, 0, result.stderr)
   })
 
   it('passes Vercel retention timeout to the telemetry flush barrier', async () => {

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -342,6 +342,26 @@ describe('Vercel telemetry retention', () => {
     }
   })
 
+  it('skips retention without a Vercel waitUntil boundary', async () => {
+    let flushes = 0
+    const unregister = registerVercelTelemetryRetention({
+      flushAll () {
+        flushes++
+      },
+    })
+    try {
+      delete globalThis[requestContext]
+      channel('apm:http:server:request:finish').publish({})
+      globalThis[requestContext] = { get: () => ({}) }
+      channel('apm:http:server:request:finish').publish({})
+      await new Promise(resolve => setImmediate(resolve))
+
+      assert.strictEqual(flushes, 0)
+    } finally {
+      unregister()
+    }
+  })
+
   it('retains an instrumented HTTP request without HTTP tracing plugins', () => {
     const vercelModule = require.resolve('../src/serverless/vercel')
     const instrumentationRegister = require.resolve('../../datadog-instrumentations/src/helpers/register')
@@ -430,15 +450,18 @@ describe('Vercel telemetry retention', () => {
     assert.strictEqual(result.status, 0, result.stderr)
   })
 
-  it('logs a Vercel waitUntil registration failure', () => {
+  it('logs a Vercel waitUntil registration failure and still flushes', async () => {
     const error = new Error('request context closed')
     const warn = sinon.stub(require('../src/log'), 'warn')
     globalThis[requestContext] = { get: () => ({ waitUntil: () => { throw error } }) }
-    const unregister = registerVercelTelemetryRetention({ flushAll () {} })
+    const flushAll = sinon.spy(done => done())
+    const unregister = registerVercelTelemetryRetention({ flushAll })
 
     try {
       channel('apm:http:server:request:finish').publish({})
+      await new Promise(resolve => setImmediate(resolve))
       sinon.assert.calledWith(warn, 'Unable to retain Vercel telemetry:', error)
+      sinon.assert.calledOnce(flushAll)
     } finally {
       unregister()
       warn.restore()
@@ -479,7 +502,7 @@ describe('Vercel telemetry retention', () => {
     }
   })
 
-  it('retains telemetry again when an outer Vercel response follows a nested request', async () => {
+  it('coalesces overlapping Vercel responses into one queued flush', async () => {
     const retained = []
     const flushes = []
     globalThis[requestContext] = {
@@ -494,14 +517,18 @@ describe('Vercel telemetry retention', () => {
       channel('apm:http:server:request:finish').publish({ req: {} })
       await new Promise(resolve => setImmediate(resolve))
       channel('apm:http:server:request:finish').publish({ req: {} })
+      channel('apm:http:server:request:finish').publish({ req: {} })
       await new Promise(resolve => setImmediate(resolve))
 
       // Other tracers initialized by this file can share this request context;
       // the callback count below isolates this test's tracer.
-      assert.ok(retained.length >= 2)
-      assert.strictEqual(flushes.length, 2)
+      assert.ok(retained.length >= 3)
+      assert.strictEqual(flushes.length, 1)
       flushes[0]()
+      await new Promise(resolve => setImmediate(resolve))
+      assert.strictEqual(flushes.length, 2)
       flushes[1]()
+      await Promise.all(retained)
     } finally {
       unregister()
     }

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -529,6 +529,12 @@ describe('Vercel telemetry retention', () => {
       assert.strictEqual(flushes.length, 2)
       flushes[1]()
       await Promise.all(retained)
+
+      channel('apm:http:server:request:finish').publish({ req: {} })
+      await new Promise(resolve => setImmediate(resolve))
+      assert.strictEqual(flushes.length, 3)
+      flushes[2]()
+      await Promise.all(retained)
     } finally {
       unregister()
     }

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -52,10 +52,24 @@ describe('Tracer', () => {
 
   describe('flushAll', () => {
     let originalVercel
+    let flushServerlessTelemetry
+    let registerTelemetryFlusher
 
     beforeEach(() => {
       originalVercel = process.env.VERCEL
       process.env.VERCEL = '1'
+      const serverless = proxyquire('../src/serverless', {})
+      const flush = proxyquire('../src/flush', { './serverless': serverless })
+      const VercelTracer = proxyquire('../src/tracer', {
+        './flush': flush,
+        './serverless': serverless,
+      })
+      tracer = new VercelTracer(config)
+      tracer._exporter.setUrl = sinon.stub()
+      tracer._exporter.export = sinon.stub()
+      tracer._prioritySampler.configure = sinon.stub()
+      flushServerlessTelemetry = flush.flushServerlessTelemetry
+      registerTelemetryFlusher = flush.registerTelemetryFlusher
     })
 
     afterEach(() => {
@@ -64,7 +78,6 @@ describe('Tracer', () => {
     })
 
     it('flushes registered telemetry pipelines with the configured trace exporter', () => {
-      const { registerTelemetryFlusher } = require('../src/flush')
       tracer._exporter.flush = sinon.stub().callsFake(done => done())
       const telemetryFlusher = sinon.stub().callsFake(done => done())
       const unregister = registerTelemetryFlusher(telemetryFlusher)
@@ -79,7 +92,6 @@ describe('Tracer', () => {
     })
 
     it('flushes post-trace telemetry after the trace exporter completes', () => {
-      const { registerTelemetryFlusher } = require('../src/flush')
       let traceDone
       tracer._exporter.flush = sinon.stub().callsFake(done => { traceDone = done })
       const runtimeMetricsFlusher = sinon.stub().callsFake(done => done())
@@ -96,7 +108,6 @@ describe('Tracer', () => {
     })
 
     it('flushes registered telemetry pipelines without a trace exporter', () => {
-      const { flushServerlessTelemetry, registerTelemetryFlusher } = require('../src/flush')
       const telemetryFlusher = sinon.stub().callsFake(done => done())
       const unregister = registerTelemetryFlusher(telemetryFlusher)
       const done = sinon.spy()
@@ -109,7 +120,6 @@ describe('Tracer', () => {
     })
 
     it('waits for callback flushers that return a synchronous status', () => {
-      const { flushServerlessTelemetry, registerTelemetryFlusher } = require('../src/flush')
       let flushDone
       const telemetryFlusher = sinon.stub().callsFake(done => {
         flushDone = done
@@ -130,7 +140,6 @@ describe('Tracer', () => {
     })
 
     it('bounds configured telemetry flushing', () => {
-      const { flushServerlessTelemetry, registerTelemetryFlusher } = require('../src/flush')
       const timeout = sinon.stub(global, 'setTimeout')
       const clearTimeout = sinon.stub(global, 'clearTimeout')
       const done = sinon.spy()
@@ -151,12 +160,13 @@ describe('Tracer', () => {
     })
 
     it('does not retain telemetry flushers outside a supported platform', () => {
-      const { flushServerlessTelemetry, registerTelemetryFlusher } = require('../src/flush')
       delete process.env.VERCEL
+      const serverless = proxyquire('../src/serverless', {})
+      const flush = proxyquire('../src/flush', { './serverless': serverless })
       const telemetryFlusher = sinon.stub()
-      const unregister = registerTelemetryFlusher(telemetryFlusher)
+      const unregister = flush.registerTelemetryFlusher(telemetryFlusher)
 
-      flushServerlessTelemetry(sinon.spy())
+      flush.flushServerlessTelemetry(sinon.spy())
 
       sinon.assert.notCalled(telemetryFlusher)
       unregister()


### PR DESCRIPTION
Overlapping Vercel responses start concurrent telemetry flushes and retain each response independently, which can create unbounded exporter waiters. This keeps one active flush and one queued generation, so every response remains retained without duplicate concurrent flush work.

An invalid LLMObs tenant site can abort request staging for every later buffer. This drops and logs only the unroutable tenant batch, allowing valid default and tenant buffers to flush.

This is also mainly a performance improvement for empty serverless flush paths. Node 22.23.1 / V8 12.4, seven trials with the best and worst dropped:

1. Empty tracker waits improve from 10.68 ns to 5.09 ns.
2. Empty telemetry coordination improves from 15.12 ns to 10.20 ns.
3. Empty writer flushes improve from 8.00 ns to 5.08 ns.
4. Non-Vercel detection improves from 145.92 ns to 3.85 ns.

Refs: https://github.com/DataDog/dd-trace-js/pull/9735