### PR TITLE
ci(release): warn about overdue releases

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -56,11 +56,11 @@ jobs:
           RELEASE_LINES: ${{ needs.check-branches.outputs.release-lines }}
         run: |
           releases=$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" | jq -s 'add')
-          now=$(date -u +%s)
-          stale_lines=()
-          minimum_age=
-          maximum_age=
-          should_warn=false
+          today=$(date -u +%F)
+          today_epoch=$(date -u -d "$today" +%s)
+          warning_lines=()
+          minimum_calendar_age=
+          maximum_business_age=
 
           while IFS= read -r line; do
             published_at=$(jq -r --arg prefix "v${line}." '
@@ -73,49 +73,57 @@ jobs:
               exit 1
             fi
 
-            published=$(date -d "$published_at" +%s)
-            age=$(((now - published) / 86400))
+            release_date=${published_at%%T*}
+            release_epoch=$(date -u -d "$release_date" +%s)
+            calendar_age=$(((today_epoch - release_epoch) / 86400))
+            cursor=$release_date
+            business_age=0
 
-            if ((age < 7)); then
+            while [ "$cursor" != "$today" ]; do
+              cursor=$(date -u -d "$cursor + 1 day" +%F)
+              day_of_week=$(date -u -d "$cursor" +%u)
+              if ((day_of_week <= 5)); then
+                business_age=$((business_age + 1))
+              fi
+            done
+
+            if ((business_age != 5 && business_age < 8)); then
               continue
             fi
 
-            stale_lines+=("v${line}")
+            warning_lines+=("v${line}")
 
-            if [ -z "$minimum_age" ] || ((age < minimum_age)); then
-              minimum_age=$age
+            if [ -z "$minimum_calendar_age" ] || ((calendar_age < minimum_calendar_age)); then
+              minimum_calendar_age=$calendar_age
             fi
 
-            if [ -z "$maximum_age" ] || ((age > maximum_age)); then
-              maximum_age=$age
+            if [ -z "$maximum_business_age" ] || ((business_age > maximum_business_age)); then
+              maximum_business_age=$business_age
             fi
 
-            if (((age - 7) % 3 == 0)); then
-              should_warn=true
-            fi
           done < <(jq -r '.[]' <<< "$RELEASE_LINES")
 
-          if [ "$should_warn" != true ]; then
+          if ((${#warning_lines[@]} == 0)); then
             echo "warn=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if ((${#stale_lines[@]} == 1)); then
-            release_subject="Release line ${stale_lines[0]}"
+          if ((${#warning_lines[@]} == 1)); then
+            release_subject="Release line ${warning_lines[0]}"
             release_verb=has
             release_noun=release
           else
-            last_index=$((${#stale_lines[@]} - 1))
-            release_lines=${stale_lines[0]}
+            last_index=$((${#warning_lines[@]} - 1))
+            release_lines=${warning_lines[0]}
             for ((index = 1; index < last_index; index++)); do
-              release_lines+=", ${stale_lines[index]}"
+              release_lines+=", ${warning_lines[index]}"
             done
-            release_subject="Release lines ${release_lines} and ${stale_lines[last_index]}"
+            release_subject="Release lines ${release_lines} and ${warning_lines[last_index]}"
             release_verb=have
             release_noun=releases
           fi
 
-          if ((maximum_age >= 14)); then
+          if ((maximum_business_age >= 8)); then
             icon=:rotating_light:
           else
             icon=:warning:
@@ -123,7 +131,7 @@ jobs:
 
           {
             echo "warn=true"
-            echo "days=$minimum_age"
+            echo "days=$minimum_calendar_age"
             echo "icon=$icon"
             echo "release-noun=$release_noun"
             echo "release-subject=$release_subject"

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -36,6 +36,117 @@ jobs:
           done
           echo "release-lines=[$(IFS=,; echo "${lines[*]}")]" >> "$GITHUB_OUTPUT"
 
+  release-warning:
+    needs: check-branches
+    if: >
+      github.event_name == 'schedule' &&
+      needs.check-branches.outputs.release-lines != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-js
+          policy: release-proposal
+      - id: release-age
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          RELEASE_LINES: ${{ needs.check-branches.outputs.release-lines }}
+        run: |
+          releases=$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" | jq -s 'add')
+          now=$(date -u +%s)
+          stale_lines=()
+          minimum_age=
+          maximum_age=
+          should_warn=false
+
+          while IFS= read -r line; do
+            published_at=$(jq -r --arg prefix "v${line}." '
+              map(select(.draft == false and (.tag_name | startswith($prefix)))) |
+              max_by(.published_at).published_at // empty
+            ' <<< "$releases")
+
+            if [ -z "$published_at" ]; then
+              echo "No published release found for v${line}.x" >&2
+              exit 1
+            fi
+
+            published=$(date -d "$published_at" +%s)
+            age=$(((now - published) / 86400))
+
+            if ((age < 7)); then
+              continue
+            fi
+
+            stale_lines+=("v${line}")
+
+            if [ -z "$minimum_age" ] || ((age < minimum_age)); then
+              minimum_age=$age
+            fi
+
+            if [ -z "$maximum_age" ] || ((age > maximum_age)); then
+              maximum_age=$age
+            fi
+
+            if (((age - 7) % 3 == 0)); then
+              should_warn=true
+            fi
+          done < <(jq -r '.[]' <<< "$RELEASE_LINES")
+
+          if [ "$should_warn" != true ]; then
+            echo "warn=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ((${#stale_lines[@]} == 1)); then
+            release_subject="Release line ${stale_lines[0]}"
+            release_verb=has
+            release_noun=release
+          else
+            last_index=$((${#stale_lines[@]} - 1))
+            release_lines=${stale_lines[0]}
+            for ((index = 1; index < last_index; index++)); do
+              release_lines+=", ${stale_lines[index]}"
+            done
+            release_subject="Release lines ${release_lines} and ${stale_lines[last_index]}"
+            release_verb=have
+            release_noun=releases
+          fi
+
+          if ((maximum_age >= 14)); then
+            icon=:rotating_light:
+          else
+            icon=:warning:
+          fi
+
+          echo "warn=true" >> "$GITHUB_OUTPUT"
+          echo "days=$minimum_age" >> "$GITHUB_OUTPUT"
+          echo "icon=$icon" >> "$GITHUB_OUTPUT"
+          echo "release-noun=$release_noun" >> "$GITHUB_OUTPUT"
+          echo "release-subject=$release_subject" >> "$GITHUB_OUTPUT"
+          echo "release-verb=$release_verb" >> "$GITHUB_OUTPUT"
+      - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v2.1.0
+        if: steps.release-age.outputs.warn == 'true'
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: >-
+                    ${{ steps.release-age.outputs.icon }}
+                    *${{ steps.release-age.outputs.release-subject }}*
+                    ${{ steps.release-age.outputs.release-verb }} gone at least
+                    ${{ steps.release-age.outputs.days }} days without a release.
+                    Consider cutting the next
+                    ${{ steps.release-age.outputs.release-noun }} soon.
+
   create-proposal:
     needs: check-branches
     if: needs.check-branches.outputs.release-lines != '[]'

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -121,12 +121,14 @@ jobs:
             icon=:warning:
           fi
 
-          echo "warn=true" >> "$GITHUB_OUTPUT"
-          echo "days=$minimum_age" >> "$GITHUB_OUTPUT"
-          echo "icon=$icon" >> "$GITHUB_OUTPUT"
-          echo "release-noun=$release_noun" >> "$GITHUB_OUTPUT"
-          echo "release-subject=$release_subject" >> "$GITHUB_OUTPUT"
-          echo "release-verb=$release_verb" >> "$GITHUB_OUTPUT"
+          {
+            echo "warn=true"
+            echo "days=$minimum_age"
+            echo "icon=$icon"
+            echo "release-noun=$release_noun"
+            echo "release-subject=$release_subject"
+            echo "release-verb=$release_verb"
+          } >> "$GITHUB_OUTPUT"
       - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v2.1.0
         if: steps.release-age.outputs.warn == 'true'
         with:


### PR DESCRIPTION
### What does this PR do?

Adds scheduled Slack warnings when maintained release lines have gone too long without a published GitHub release.

Each release line is evaluated independently using weekday age:
- Business day 5: send the first warning.
- Business days 6-7: do not warn.
- Business day 8 onward: send a severe warning every business day until a new release is published.

The Slack message displays elapsed calendar days, including weekends, while business days are used only to control notification timing.

### Motivation

Release proposals currently warn about large commit queues, but there is no time-based reminder when a release has not happened for an extended period.

### Additional Notes

The maintained release lines are derived from the existing check-branches output rather than duplicated in the warning job. Manual workflow dispatches do not send this warning.

Validation:
- YAML diagnostics
- Actionlint
- git diff --check