### PR TITLE
fix(undici): do not activate request span when there is no parent store

### DIFF
--- a/packages/datadog-plugin-undici/src/index.js
+++ b/packages/datadog-plugin-undici/src/index.js
@@ -118,7 +118,10 @@ class UndiciPlugin extends HttpClientPlugin {
     })
 
     // Enter the span context
-    storage('legacy').enterWith({ ...store, span })
+    // Only when there is a surrounding store to return to.
+    if (store) {
+      storage('legacy').enterWith({ ...store, span })
+    }
   }
 
   #onNativeRequestBodySent ({ request }) {

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -39,6 +39,7 @@ describe('Plugin', () => {
   let express
   let fetch
   let appListener
+  let tracer
 
   describe('undici-fetch', () => {
     withVersions('undici', 'undici', NODE_MAJOR < 20 ? '<7.11.0' : '*', (version, moduleName, resolvedVersion) => {
@@ -118,7 +119,8 @@ describe('Plugin', () => {
           return agent.load('undici', {
             service: 'test',
           })
-            .then(() => {
+            .then(loadedTracer => {
+              tracer = loadedTracer
               express = require('express')
               fetch = require(`../../../versions/undici@${version}`, {}).get()
             })
@@ -537,6 +539,43 @@ describe('Plugin', () => {
                 .catch(() => {})
             })
           })
+
+          requestTest('should not leave the request span active after undici.request() with no parent span', done => {
+            const app = express()
+
+            app.get('/user', (req, res) => {
+              res.status(200).send('OK')
+            })
+
+            appListener = server(app, port => {
+              fetch.request(`http://localhost:${port}/user`)
+                .then(({ body }) => body.dump())
+                .then(() => {
+                  assert.strictEqual(tracer.scope().active(), null)
+
+                  const traceIds = new Set()
+                  for (let i = 0; i < 2; i++) {
+                    tracer.trace('independent-work', span => {
+                      traceIds.add(span.context().toTraceId())
+                    })
+                  }
+                  assert.strictEqual(traceIds.size, 2)
+
+                  done()
+                })
+                .catch(done)
+            })
+          })
+
+          requestTest('should not leave the request span active after a connection error in undici.request()', done => {
+            fetch.request('http://localhost:7357/user')
+              .catch(() => {})
+              .then(() => {
+                assert.strictEqual(tracer.scope().active(), null)
+                done()
+              })
+              .catch(done)
+          })
         }
       })
       describe('with service configuration', () => {
@@ -842,7 +881,8 @@ describe('Plugin', () => {
           return agent.load('undici', {
             service: 'test',
           })
-            .then(() => {
+            .then(loadedTracer => {
+              tracer = loadedTracer
               express = require('express')
               fetch = require(`../../../versions/undici@${version}`, {}).get()
             })
@@ -920,6 +960,8 @@ describe('Plugin', () => {
           })
           const { body } = await fetch.request(`http://localhost:${downstreamPort}/data`, { dispatcher })
           await Promise.all([body.text(), tracePromise])
+
+          assert.strictEqual(tracer.scope().active(), null)
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
Only enter the span context when there is a parent store to return to, mirroring the existing guard in the finish handlers. 

### Motivation
The undici:request:create handler runs synchronously inside the caller's frame, so enterWith leaks the span into every continuation the caller registers afterwards and no later channel event fires in the caller's chain to undo it. With no surrounding store, the finished span was pinned as the ambient context and every subsequent trace parented under it, merging independent operations into a single trace (#9387).

### Additional Notes
The parented-case leak (later spans in the caller parenting under the finished client span within the same trace) is pre-existing and unchanged; fixing that requires real wrap semantics around Dispatcher.request rather than bare diagnostics-channel publishes.