### PR TITLE
ci(serverless): temporarily allow benchmark failures

### DIFF
--- a/.gitlab/benchmarks/gitlab-ci.yml
+++ b/.gitlab/benchmarks/gitlab-ci.yml
@@ -22,6 +22,8 @@ variables:
   BASE_CI_IMAGE_PLATFORM: linux/amd64
 
   SLS_CI_BRANCH: main
+  # Temporary until the serverless-tools Node.js amd64 layer size limit is updated.
+  RELEASE_ALLOW_BENCHMARK_FAILURES: "true"
 
   # Benchmark's env variables. Modify to tweak benchmark parameters.
   UNCONFIDENCE_THRESHOLD: "2.0"


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Temporarily makes the downstream `benchmark-serverless` trigger non-blocking by enabling its existing `RELEASE_ALLOW_BENCHMARK_FAILURES` rule. The benchmark continues to run and report failures.

### Motivation
<!-- What inspired you to submit this pull request? -->

The serverless-tools Node.js amd64 layer-size check has a 23,552 KB absolute limit, while the layer built from dd-trace-js `master` is already 23,587 KB. As a result, the downstream check fails every branch regardless of whether its change caused the regression.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Remove the temporary variable after the serverless-tools Node.js amd64 limit is updated. This does not skip the downstream pipeline; it preserves the layer-size and cold-start results while preventing the known failure from blocking dd-trace-js CI.

Validation:

- Parsed `.gitlab/benchmarks/gitlab-ci.yml` and asserted that the variable activates the existing `allow_failure` rule.
- `git diff --check`

