### PR TITLE
fix(profiler): reapply custom label keys when starting the profiler

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -95,6 +95,10 @@ class Profiler extends EventEmitter {
     for (const key of keys) {
       this.#customLabelKeys.add(key)
     }
+    this.#applyCustomLabelKeys()
+  }
+
+  #applyCustomLabelKeys () {
     if (this.#profilers) {
       for (const profiler of this.#profilers) {
         profiler.setCustomLabelKeys?.(this.#customLabelKeys)
@@ -180,6 +184,9 @@ class Profiler extends EventEmitter {
     this.#profilers = profilers
     this.#uploadCompression = uploadCompression
     this.#systemInfoReport = systemInfoReport
+    if (this.#customLabelKeys.size > 0) {
+      this.#applyCustomLabelKeys()
+    }
 
     this._setInterval()
     // Log errors if the source map finder fails, but don't prevent the rest

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -180,6 +180,35 @@ describe('profiler', function () {
       )
     })
 
+    it('should apply custom label keys set before start to the started profilers', async () => {
+      wallProfiler.setCustomLabelKeys = sinon.stub()
+      profiler.setCustomLabelKeys(['endpoint', 'resource'])
+
+      await profiler.start(makeStartOptions())
+
+      sinon.assert.calledOnce(wallProfiler.setCustomLabelKeys)
+      assert.deepStrictEqual(
+        [...wallProfiler.setCustomLabelKeys.firstCall.args[0]],
+        ['endpoint', 'resource']
+      )
+    })
+
+    it('should reapply custom label keys to profilers created by a later start', async () => {
+      wallProfiler.setCustomLabelKeys = sinon.stub()
+      await profiler.start(makeStartOptions())
+      profiler.setCustomLabelKeys(['endpoint', 'resource'])
+      profiler.stop()
+
+      wallProfiler.setCustomLabelKeys.resetHistory()
+      await profiler.start(makeStartOptions())
+
+      sinon.assert.calledOnce(wallProfiler.setCustomLabelKeys)
+      assert.deepStrictEqual(
+        [...wallProfiler.setCustomLabelKeys.firstCall.args[0]],
+        ['endpoint', 'resource']
+      )
+    })
+
     it('should delegate runWithLabels to the first profiler that supports it', async () => {
       wallProfiler.runWithLabels = sinon.stub().callsFake((labels, fn) => fn())
       await profiler.start(makeStartOptions())


### PR DESCRIPTION
### What does this PR do?

Ensures `Profiler#start()` reapplies previously declared custom label keys to all profilers.

### Motivation
`setCustomLabelKeys()` only propagated keys to `#profilers` when that array already existed, so calling `setCustomLabelKeys()` while profiling was disabled had no effect once profiling was later enabled. In the future,  keys set before a disable/re-enable (e.g. remote-config toggle) cycle would've been dropped on the subsequent `start()`

This meant pprof would not treat the declared custom labels as low-cardinality, and profile payloads could grow larger than expected.

Raised by a bot review comment on #9626: https://github.com/DataDog/dd-trace-js/pull/9626#discussion_r3823887282.