### PR TITLE
test: reject async work in synchronous Mocha tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1054,7 +1054,6 @@ export default [
       'mocha/consistent-structure': 'off',
       'mocha/limit-timeout': ['error', { mode: 'disallowDisabled' }],
       'mocha/max-top-level-suites': ['error', { limit: 1 }],
-      'mocha/no-async-in-sync-tests': 'off',
       'mocha/no-conditional-tests': 'off',
       'mocha/no-mocha-arrows': 'off',
       'mocha/no-pending-tests': 'off',
@@ -1144,6 +1143,14 @@ export default [
     },
     rules: {
       'sonarjs/stable-tests': 'off',
+    },
+  },
+  {
+    // This fixture loads a module after Jest has finished the test to exercise the resulting test-suite error.
+    name: 'dd-trace/tests/jest-off-timing-import-fixture',
+    files: ['integration-tests/ci-visibility/jest-bad-import/jest-bad-import-test.js'],
+    rules: {
+      'mocha/no-async-in-sync-tests': ['error', { allowedAsyncMethods: ['setTimeout'] }],
     },
   },
   {

--- a/packages/datadog-plugin-undici/test/instrumentation.spec.js
+++ b/packages/datadog-plugin-undici/test/instrumentation.spec.js
@@ -244,7 +244,7 @@ describe('undici instrumentation', () => {
           const throwingRequest = new Request(throwingHandler, controller)
           assert.throws(
             () => throwingRequest[methodName](101, headers, socket),
-            error => error === expectedError
+            thrownError => thrownError === expectedError
           )
           assert.deepStrictEqual(messages.at(-1), {
             error: expectedError,

--- a/packages/dd-trace/test/ci-visibility/execution-lock.spec.js
+++ b/packages/dd-trace/test/ci-visibility/execution-lock.spec.js
@@ -36,11 +36,11 @@ describe('test optimization validation execution lock', () => {
 
     assert.throws(
       () => acquireExecutionLock({ out, approvedPlanSha256: 'a'.repeat(64) }),
-      error => {
-        assert.strictEqual(error.validationExitCode, 2)
-        assert.strictEqual(error.suppressReport, true)
-        assert.strictEqual(error.validationBlocker.kind, 'execution-lock-exists')
-        assert.match(error.validationBlocker.recommendation, /confirming no validation process is active/)
+      lockError => {
+        assert.strictEqual(lockError.validationExitCode, 2)
+        assert.strictEqual(lockError.suppressReport, true)
+        assert.strictEqual(lockError.validationBlocker.kind, 'execution-lock-exists')
+        assert.match(lockError.validationBlocker.recommendation, /confirming no validation process is active/)
         return true
       }
     )

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -314,8 +314,8 @@ describe('mocha hooks setup', () => {
     }
 
     try {
-      hook.run((err) => {
-        hookError = err
+      hook.run((callbackError) => {
+        hookError = callbackError
       })
     } finally {
       clearTimeout.call(hook)
@@ -334,8 +334,8 @@ describe('mocha hooks setup', () => {
     let hookError
 
     hook.allowUncaught = true
-    hook.run((err) => {
-      hookError = err
+    hook.run((callbackError) => {
+      hookError = callbackError
     })
 
     assert.ok(hookError instanceof Error)
@@ -355,7 +355,7 @@ describe('mocha hooks setup', () => {
       hook.run(() => {
         throw failure
       })
-    }, error => error === failure)
+    }, thrownError => thrownError === failure)
   })
 
   it('does not swallow test errors after a promise hook completes with allow uncaught enabled', async () => {


### PR DESCRIPTION
`mocha/no-async-in-sync-tests` catches scheduled or callback-based work that a synchronous test can finish before. The delayed Jest import remains explicitly allowed because that fixture verifies the resulting test-suite error.