### PR TITLE
test: disallow pending Mocha tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1056,7 +1056,7 @@ export default [
       'mocha/max-top-level-suites': ['error', { limit: 1 }],
       'mocha/no-conditional-tests': 'off',
       'mocha/no-mocha-arrows': 'off',
-      'mocha/no-pending-tests': 'off',
+      'mocha/no-pending-tests': ['error', { allowSkippedWithComment: true }],
       'mocha/no-root-hooks': 'off',
       'mocha/no-setup-in-suite': 'off',
       'n/handle-callback-err': 'off',
@@ -1113,9 +1113,6 @@ export default [
         jest: 'readonly',
       },
     },
-    rules: {
-      'mocha/no-pending-tests': 'off',
-    },
   },
   {
     // jest-docblock's `@datadog {"unskippable": true}` tag reads as a malformed
@@ -1124,6 +1121,29 @@ export default [
     files: ['packages/datadog-plugin-jest/test/fixtures/**/*.js'],
     rules: {
       'jsdoc/valid-types': 'off',
+    },
+  },
+  {
+    // These fixtures must report skipped tests to verify Test Optimization status handling.
+    name: 'dd-trace/test-optimization/pending-test-fixtures',
+    files: [
+      'integration-tests/ci-visibility/jest-plugin-tests/jest-test.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/skip-describe.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/skipping-with-after-each.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/skipping.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/suite-level-fail-skip-describe.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/suite-level-fail-test.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/suite-level-pass.js',
+      'integration-tests/ci-visibility/mocha-skips/skip-test.js',
+      'integration-tests/ci-visibility/test-early-flake-detection/focused-test.js',
+      'integration-tests/ci-visibility/test-early-flake-detection/skipped-and-todo-test.js',
+      'integration-tests/ci-visibility/test-management/test-attempt-to-fix-skip.js',
+      'integration-tests/webdriverio/fixtures/jasmine-attempt-to-fix-skipped.e2e.js',
+      'integration-tests/webdriverio/fixtures/jasmine-efd-skipped.e2e.js',
+      'integration-tests/webdriverio/fixtures/jasmine-statuses.e2e.js',
+    ],
+    rules: {
+      'mocha/no-pending-tests': 'off',
     },
   },
   {

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -178,6 +178,7 @@ describe('Plugin', () => {
 
         it('should keep the caller span active while creating a request', async function () {
           if (!hasNativeDiagnostics) {
+            // Native diagnostics are unavailable before undici 4.7.0 and in undici 5.0.
             this.skip()
             return
           }
@@ -203,6 +204,7 @@ describe('Plugin', () => {
 
         it('should finish the request span when the server accepts an upgrade', async function () {
           if (!satisfies(resolvedVersion, '>=4.7.0')) {
+            // Upgrade diagnostics are unavailable before undici 4.7.0.
             this.skip()
             return
           }
@@ -254,6 +256,7 @@ describe('Plugin', () => {
 
         it('should not use the accepted-upgrade fallback when the server rejects an upgrade', async function () {
           if (!satisfies(resolvedVersion, '>=4.7.0')) {
+            // Upgrade diagnostics are unavailable before undici 4.7.0.
             this.skip()
             return
           }
@@ -279,6 +282,7 @@ describe('Plugin', () => {
 
         it('should finish the request span when an accepted-upgrade handler throws', async function () {
           if (!hasNativeDiagnostics) {
+            // Native diagnostics are unavailable before undici 4.7.0 and in undici 5.0.
             this.skip()
             return
           }

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.express.plugin.spec.js
@@ -28,7 +28,6 @@ describe('Path traversal analyzer', () => {
   withVersions('express', 'express', version => {
     if (semver.intersects(version, '<=4.10.5') && NODE_MAJOR >= 24) {
       // Express 4.10.5 and older cannot start on Node.js 24.
-      describe.skip(`refusing to run tests as express@${version} is incompatible with Node.js ${NODE_MAJOR}`)
       return
     }
     withVersions('express', 'ejs', _ => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.express.plugin.spec.js
@@ -27,7 +27,10 @@ describe('Path traversal analyzer', () => {
 
   withVersions('express', 'express', version => {
     if (semver.intersects(version, '<=4.10.5') && NODE_MAJOR >= 24) {
-      // Express 4.10.5 and older cannot start on Node.js 24.
+      it(`refusing to run tests as express@${version} is incompatible with Node.js ${NODE_MAJOR}`, function () {
+        // Express 4.10.5 and older cannot start on Node.js 24.
+        this.skip()
+      })
       return
     }
     withVersions('express', 'ejs', _ => {

--- a/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
@@ -17,6 +17,64 @@ const { withVersions } = require('../setup/mocha')
 const { getConfigFresh } = require('../helpers/config')
 const { blockedTemplateJson: json, setTestBlockingTemplates } = require('./utils')
 
+/**
+ * @param {string} cookieVersion
+ * @param {string} fastifyVersion
+ */
+function isCookieVersionUnsupported (cookieVersion, fastifyVersion) {
+  return (
+    semver.intersects(cookieVersion, '6') &&
+      semver.intersects(fastifyVersion, '<3 || 3.9.2')
+  ) || (
+    semver.intersects(cookieVersion, '>=7 <10') &&
+      semver.intersects(fastifyVersion, '<4 || >=5')
+  ) || (
+    semver.intersects(cookieVersion, '>=10 <12') &&
+      semver.intersects(fastifyVersion, '<5 || >=6')
+  )
+}
+
+/**
+ * @param {string} multipartVersion
+ * @param {string} fastifyVersion
+ */
+function isMultipartVersionUnsupported (multipartVersion, fastifyVersion) {
+  return (
+    semver.intersects(multipartVersion, '6') &&
+      semver.intersects(fastifyVersion, '<3 || >=5')
+  ) || (
+    semver.intersects(multipartVersion, '>=7 <9') &&
+      semver.intersects(fastifyVersion, '<4 || >=5')
+  ) || (
+    semver.intersects(multipartVersion, '>=9 <11') &&
+      semver.intersects(fastifyVersion, '<5 || >=6')
+  )
+}
+
+describe('Fastify plugin version compatibility', () => {
+  it('identifies unsupported cookie pairs without closing future majors', () => {
+    assert.strictEqual(isCookieVersionUnsupported('6.0.0', '2.0.0'), true)
+    assert.strictEqual(isCookieVersionUnsupported('6.0.0', '3.9.2'), true)
+    assert.strictEqual(isCookieVersionUnsupported('6.0.0', '4.0.0'), false)
+    assert.strictEqual(isCookieVersionUnsupported('9.0.0', '5.0.0'), true)
+    assert.strictEqual(isCookieVersionUnsupported('9.0.0', '4.0.0'), false)
+    assert.strictEqual(isCookieVersionUnsupported('11.0.0', '6.0.0'), true)
+    assert.strictEqual(isCookieVersionUnsupported('11.0.0', '5.0.0'), false)
+    assert.strictEqual(isCookieVersionUnsupported('12.0.0', '6.0.0'), false)
+  })
+
+  it('identifies unsupported multipart pairs without closing future majors', () => {
+    assert.strictEqual(isMultipartVersionUnsupported('6.0.0', '2.0.0'), true)
+    assert.strictEqual(isMultipartVersionUnsupported('6.0.0', '4.0.0'), false)
+    assert.strictEqual(isMultipartVersionUnsupported('6.0.0', '5.0.0'), true)
+    assert.strictEqual(isMultipartVersionUnsupported('8.0.0', '3.0.0'), true)
+    assert.strictEqual(isMultipartVersionUnsupported('8.0.0', '4.0.0'), false)
+    assert.strictEqual(isMultipartVersionUnsupported('10.0.0', '6.0.0'), true)
+    assert.strictEqual(isMultipartVersionUnsupported('10.0.0', '5.0.0'), false)
+    assert.strictEqual(isMultipartVersionUnsupported('11.0.0', '6.0.0'), false)
+  })
+})
+
 withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersion) => {
   describe('Suspicious request blocking - query', () => {
     let app, server, requestBody, axios
@@ -420,13 +478,6 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
 
   describe('Suspicious request blocking - cookie', () => {
     withVersions('fastify', '@fastify/cookie', (cookieVersion, _, cookieLoadedVersion) => {
-      // Cookie 6 supports Fastify 3+, while majors 7-9 and 10+ target Fastify 4 and 5 respectively.
-      const supported =
-        semver.intersects(cookieLoadedVersion, '6') && semver.intersects(fastifyLoadedVersion, '>=3') ||
-        semver.intersects(cookieLoadedVersion, '>=7 <10') && semver.intersects(fastifyLoadedVersion, '4') ||
-        semver.intersects(cookieLoadedVersion, '>=10') && semver.intersects(fastifyLoadedVersion, '5')
-      if (!supported || semver.intersects(fastifyLoadedVersion, '3.9.2')) return
-
       const hookConfigurations = [
         'onRequest',
         'preParsing',
@@ -439,6 +490,11 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
           let server, requestCookie, axios
 
           before(async function () {
+            if (isCookieVersionUnsupported(cookieLoadedVersion, fastifyLoadedVersion)) {
+              // @fastify/cookie does not support this Fastify version.
+              this.skip()
+            }
+
             await agent.load(['fastify', '@fastify/cookie', 'http'], { client: false })
             const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
             const fastifyCookie = require(`../../../../versions/@fastify/cookie@${cookieVersion}`).get()
@@ -516,16 +572,14 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
 
   describe('Suspicious request blocking - multipart', () => {
     withVersions('fastify', '@fastify/multipart', (multipartVersion, _, multipartLoadedVersion) => {
-      // Multipart 6 works with Fastify 3-4, 7-8 support Fastify 4, and 9+ supports Fastify 5.
-      const supported = semver.intersects(multipartLoadedVersion, '6') &&
-          semver.intersects(fastifyLoadedVersion, '>=3 <5') ||
-        semver.intersects(multipartLoadedVersion, '>=7 <9') && semver.intersects(fastifyLoadedVersion, '4') ||
-        semver.intersects(multipartLoadedVersion, '>=9') && semver.intersects(fastifyLoadedVersion, '5')
-      if (!supported) return
-
       let server, uploadSpy, axios
 
       before(async function () {
+        if (isMultipartVersionUnsupported(multipartLoadedVersion, fastifyLoadedVersion)) {
+          // @fastify/multipart does not support this Fastify version.
+          this.skip()
+        }
+
         await agent.load(['fastify', '@fastify/multipart', 'http'], { client: false })
         const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
         const fastifyMultipart = require(`../../../../versions/@fastify/multipart@${multipartVersion}`).get()

--- a/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
@@ -17,14 +17,6 @@ const { withVersions } = require('../setup/mocha')
 const { getConfigFresh } = require('../helpers/config')
 const { blockedTemplateJson: json, setTestBlockingTemplates } = require('./utils')
 
-// The version matrices below necessarily pair plugin majors with fastify majors they reject. fastify core
-// reports that while booting (during `listen`) as FST_ERR_PLUGIN_VERSION_MISMATCH; older fastify-plugin
-// builds throw a plain Error carrying the same "expected '<range>' fastify version" text instead. Either
-// means "skip this unsupported combo", not a real failure.
-function isFastifyPluginVersionMismatch (error) {
-  return error.code === 'FST_ERR_PLUGIN_VERSION_MISMATCH' || /expected '.+?' fastify version/.test(error.message)
-}
-
 withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersion) => {
   describe('Suspicious request blocking - query', () => {
     let app, server, requestBody, axios
@@ -427,7 +419,14 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
   })
 
   describe('Suspicious request blocking - cookie', () => {
-    withVersions('fastify', '@fastify/cookie', cookieVersion => {
+    withVersions('fastify', '@fastify/cookie', (cookieVersion, _, cookieLoadedVersion) => {
+      // Cookie 6 supports Fastify 3+, while majors 7-9 and 10+ target Fastify 4 and 5 respectively.
+      const supported =
+        semver.intersects(cookieLoadedVersion, '6') && semver.intersects(fastifyLoadedVersion, '>=3') ||
+        semver.intersects(cookieLoadedVersion, '>=7 <10') && semver.intersects(fastifyLoadedVersion, '4') ||
+        semver.intersects(cookieLoadedVersion, '>=10') && semver.intersects(fastifyLoadedVersion, '5')
+      if (!supported || semver.intersects(fastifyLoadedVersion, '3.9.2')) return
+
       const hookConfigurations = [
         'onRequest',
         'preParsing',
@@ -440,16 +439,6 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
           let server, requestCookie, axios
 
           before(async function () {
-            if (semver.intersects(fastifyLoadedVersion, '3.9.2')) {
-              // Fastify 3.9.2 is incompatible with @fastify/cookie >=6
-              this.skip()
-            }
-
-            if (hook === 'preParsing' && semver.intersects(fastifyLoadedVersion, '2')) {
-              // Fastify 2.x cannot run the preParsing hook fixture.
-              this.skip()
-            }
-
             await agent.load(['fastify', '@fastify/cookie', 'http'], { client: false })
             const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
             const fastifyCookie = require(`../../../../versions/@fastify/cookie@${cookieVersion}`).get()
@@ -469,16 +458,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
               reply.send('DONE')
             })
 
-            try {
-              await app.listen({ host: '127.0.0.1', port: 0 })
-            } catch (error) {
-              if (isFastifyPluginVersionMismatch(error)) {
-                // The installed plugin version is incompatible with this Fastify matrix entry.
-                this.skip()
-                return
-              }
-              throw error
-            }
+            await app.listen({ host: '127.0.0.1', port: 0 })
 
             server = app.server
             const { port } = /** @type {import('net').AddressInfo} */ (server.address())
@@ -536,30 +516,16 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
 
   describe('Suspicious request blocking - multipart', () => {
     withVersions('fastify', '@fastify/multipart', (multipartVersion, _, multipartLoadedVersion) => {
+      // Multipart 6 works with Fastify 3-4, 7-8 support Fastify 4, and 9+ supports Fastify 5.
+      const supported = semver.intersects(multipartLoadedVersion, '6') &&
+          semver.intersects(fastifyLoadedVersion, '>=3 <5') ||
+        semver.intersects(multipartLoadedVersion, '>=7 <9') && semver.intersects(fastifyLoadedVersion, '4') ||
+        semver.intersects(multipartLoadedVersion, '>=9') && semver.intersects(fastifyLoadedVersion, '5')
+      if (!supported) return
+
       let server, uploadSpy, axios
 
-      // The skips in this section are complex because of the incompatibilities between Fastify and @fastify/multipart
-      // We are not testing every major version of those libraries because of the complexity of the tests
       before(async function () {
-        // @fastify/multipart is not compatible with Fastify 2.x
-        if (semver.intersects(fastifyLoadedVersion, '2')) {
-          this.skip()
-        }
-
-        // This Fastify version is working only with @fastify/multipart 6
-        if (semver.intersects(fastifyLoadedVersion, '3.9.2') && semver.intersects(multipartLoadedVersion, '>=7')) {
-          this.skip()
-        }
-
-        // Fastify 5 drop le support pour multipart <7
-        if (semver.intersects(fastifyLoadedVersion, '>=5') && semver.intersects(multipartLoadedVersion, '<7.0.0')) {
-          this.skip()
-        }
-
-        if (semver.intersects(multipartLoadedVersion, '>=9.4.0') && semver.intersects(fastifyLoadedVersion, '<4')) {
-          this.skip()
-        }
-
         await agent.load(['fastify', '@fastify/multipart', 'http'], { client: false })
         const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
         const fastifyMultipart = require(`../../../../versions/@fastify/multipart@${multipartVersion}`).get()
@@ -573,14 +539,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
           reply.send('DONE')
         })
 
-        try {
-          await app.listen({ host: '127.0.0.1', port: 0 })
-        } catch (error) {
-          if (isFastifyPluginVersionMismatch(error)) {
-            return this.skip()
-          }
-          throw error
-        }
+        await app.listen({ host: '127.0.0.1', port: 0 })
 
         server = app.server
         const { port } = /** @type {import('net').AddressInfo} */ (server.address())

--- a/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
@@ -40,7 +40,6 @@ describe('RASP - lfi', () => {
   withVersions('express', 'express', expressVersion => {
     if (semver.intersects(expressVersion, '<=4.10.5') && NODE_MAJOR >= 24) {
       // Express 4.10.5 and older cannot start on Node.js 24.
-      describe.skip(`refusing to run tests as express@${expressVersion} is incompatible with Node.js ${NODE_MAJOR}`)
       return
     }
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
@@ -39,7 +39,10 @@ describe('RASP - lfi', () => {
 
   withVersions('express', 'express', expressVersion => {
     if (semver.intersects(expressVersion, '<=4.10.5') && NODE_MAJOR >= 24) {
-      // Express 4.10.5 and older cannot start on Node.js 24.
+      it(`refusing to run tests as express@${expressVersion} is incompatible with Node.js ${NODE_MAJOR}`, function () {
+        // Express 4.10.5 and older cannot start on Node.js 24.
+        this.skip()
+      })
       return
     }
 


### PR DESCRIPTION
`mocha/no-pending-tests` now rejects skipped tests by default. Unsupported platform and dependency combinations are conditionally not registered; only Test Optimization fixtures that assert skipped-test reporting remain exempt.