### PR TITLE
chore(ci): add test-optimization files to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,6 +133,7 @@
 /packages/datadog-plugin-cypress/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/datadog-plugin-playwright/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/datadog-plugin-vitest/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-plugin-nyc/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/dd-trace/src/plugins/util/git.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/dd-trace/src/plugins/ci_plugin.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/dd-trace/test/ci-visibility/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
@@ -178,6 +179,24 @@
 /packages/datadog-instrumentations/src/cypress.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/playwright.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/vitest.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest-main.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest-main-no-worker-init.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest-util.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest-worker.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cucumber-worker-threads.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cypress-config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cypress-legacy-finalizers.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/playwright-browser-scripts.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/playwright-reporter.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/webdriverio.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/nyc.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/jest/coverage-backfill.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/test/vitest-main.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/test/webdriverio.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/test/nyc.spec.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/test/fixtures/jasmine-core.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/test/fixtures/mocha-regular-worker.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/test/fixtures/webdriverio-* @DataDog/dd-trace-js @DataDog/ci-app-libraries
 
 /integration-tests/ci-visibility/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /integration-tests/cucumber/ @DataDog/dd-trace-js @DataDog/ci-app-libraries


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Adds `packages/datadog-instrumentations/src/vitest-worker.js` and other missing test-framework / coverage files to the **Test Optimization** section of `.github/CODEOWNERS`, owned by `@DataDog/ci-app-libraries`.

Files added:
- `packages/datadog-plugin-nyc/` — registered coverage plugin that was entirely unowned
- `packages/datadog-instrumentations/src/vitest-worker.js` (and companions `vitest-main.js`, `vitest-main-no-worker-init.js`, `vitest-util.js`)
- `packages/datadog-instrumentations/src/cucumber-worker-threads.js`
- `packages/datadog-instrumentations/src/cypress-config.js`, `cypress-legacy-finalizers.js`
- `packages/datadog-instrumentations/src/playwright-browser-scripts.js`, `playwright-reporter.js`
- `packages/datadog-instrumentations/src/webdriverio.js`, `nyc.js`, `jest/coverage-backfill.js`
- `packages/datadog-instrumentations/test/vitest-main.spec.js`, `webdriverio.spec.js`, `nyc.spec.js`
- `packages/datadog-instrumentations/test/fixtures/jasmine-core.js`, `mocha-regular-worker.js`, `webdriverio-*`

### Motivation
These test-optimization files previously fell through to the broader `/packages/datadog-instrumentations/` rule owned by `@DataDog/apm-idm-js`, even though they are test-framework / coverage specific and should be owned by the Test Optimization team (`@DataDog/ci-app-libraries`). The existing Test Optimization section already listed the "main" instrumentation entry points (`jest.js`, `mocha/`, `cucumber.js`, `cypress.js`, `playwright.js`, `vitest.js`) but missed the companion worker/main/util files, the nyc coverage plugin, and the corresponding spec/fixture files.

### Additional Notes
- Draft while the team confirms the full list of files that should map to Test Optimization.
- The `webdriverio-*` glob covers the six `webdriverio-*.mjs`/`webdriverio-*.js` fixture files used by `webdriverio.spec.js`.
- No production code changes; CODEOWNERS only.
