### PR TITLE
feat(test-optimization): submit Pino logs agentlessly

### DIFF
--- a/packages/datadog-instrumentations/src/pino.js
+++ b/packages/datadog-instrumentations/src/pino.js
@@ -6,6 +6,8 @@ const {
   addHook,
 } = require('./helpers/instrument')
 
+const logSubmissionCh = channel('ci:log-submission:log')
+
 /**
  * @param {string} symbol
  * @param {(original: Function) => Function} wrapper
@@ -36,13 +38,22 @@ function wrapAsJson (asJson) {
     obj = arguments[0] = obj || {}
 
     // Caller-provided `dd` wins -- skip the splice so a bespoke `dd` survives.
+    let line
     if (!jsonCh.hasSubscribers || Object.hasOwn(obj, 'dd')) {
-      return asJson.apply(this, arguments)
+      line = asJson.apply(this, arguments)
+    } else {
+      const payload = { line: asJson.apply(this, arguments) }
+      jsonCh.publish(payload)
+      line = payload.line
     }
 
-    const payload = { line: asJson.apply(this, arguments) }
-    jsonCh.publish(payload)
-    return payload.line
+    // Submit the serialized line for agentless log collection only when trace
+    // correlation is active, matching the Bunyan contract.
+    if (jsonCh.hasSubscribers && logSubmissionCh.hasSubscribers) {
+      logSubmissionCh.publish({ source: 'pino', message: line })
+    }
+
+    return line
   }
 }
 

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 const { Writable } = require('node:stream')
 
+const { channel } = require('dc-polyfill')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 const semver = require('semver')
 const sinon = require('sinon')
@@ -11,6 +12,8 @@ const { NODE_MAJOR } = require('../../../version')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withExports, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+
+const logSubmissionCh = channel('ci:log-submission:log')
 
 describe('Plugin', () => {
   let logger
@@ -98,6 +101,35 @@ describe('Plugin', () => {
           }
         })
 
+        describe('with disabled plugin', () => {
+          beforeEach(async () => {
+            tracer = await agent.load('pino', { enabled: false })
+          })
+
+          it('should not submit logs', function () {
+            const submittedLogs = []
+            const onLogSubmission = payload => {
+              submittedLogs.push(payload)
+            }
+            logSubmissionCh.subscribe(onLogSubmission)
+
+            try {
+              setupTest()
+
+              if (!logger) {
+                this.skip()
+              }
+
+              logger.info('message')
+            } finally {
+              logSubmissionCh.unsubscribe(onLogSubmission)
+            }
+
+            assert.strictEqual(submittedLogs.length, 0)
+            sinon.assert.called(stream.write)
+          })
+        })
+
         describe('with configuration', () => {
           beforeEach(() => {
             return agent.load('pino', { logInjection: true })
@@ -112,21 +144,34 @@ describe('Plugin', () => {
           })
 
           it('should add the trace identifiers to logger instances', () => {
-            tracer.scope().activate(span, () => {
-              logger.info('message')
+            let submittedLog
+            const onLogSubmission = payload => {
+              submittedLog = payload
+            }
+            logSubmissionCh.subscribe(onLogSubmission)
 
-              sinon.assert.called(stream.write)
+            try {
+              tracer.scope().activate(span, () => {
+                logger.info('message')
 
-              const record = JSON.parse(stream.write.firstCall.args[0].toString())
+                sinon.assert.called(stream.write)
 
-              assertObjectContains(record.dd, {
-                trace_id: span.context().toTraceId(true),
-                span_id: span.context().toSpanId(),
+                const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+                assertObjectContains(record.dd, {
+                  trace_id: span.context().toTraceId(true),
+                  span_id: span.context().toSpanId(),
+                })
+
+                assert.ok('msg' in record)
+                assert.deepStrictEqual(record.msg, 'message')
+
+                assert.strictEqual(submittedLog.source, 'pino')
+                assert.deepStrictEqual(JSON.parse(submittedLog.message), record)
               })
-
-              assert.ok('msg' in record)
-              assert.deepStrictEqual(record.msg, 'message')
-            })
+            } finally {
+              logSubmissionCh.unsubscribe(onLogSubmission)
+            }
           })
 
           it('should support errors', () => {
@@ -171,15 +216,28 @@ describe('Plugin', () => {
           })
 
           it('should not overwrite a caller-supplied dd field', () => {
-            tracer.scope().activate(span, () => {
-              logger.info({ dd: { custom: 'value' } }, 'message')
+            let submittedLog
+            const onLogSubmission = payload => {
+              submittedLog = payload
+            }
+            logSubmissionCh.subscribe(onLogSubmission)
 
-              sinon.assert.called(stream.write)
+            try {
+              tracer.scope().activate(span, () => {
+                logger.info({ dd: { custom: 'value' } }, 'message')
 
-              const record = JSON.parse(stream.write.firstCall.args[0].toString())
+                sinon.assert.called(stream.write)
 
-              assert.deepStrictEqual(record.dd, { custom: 'value' })
-            })
+                const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+                assert.deepStrictEqual(record.dd, { custom: 'value' })
+
+                assert.strictEqual(submittedLog.source, 'pino')
+                assert.deepStrictEqual(JSON.parse(submittedLog.message).dd, { custom: 'value' })
+              })
+            } finally {
+              logSubmissionCh.unsubscribe(onLogSubmission)
+            }
           })
 
           it('should not inject trace_id or span_id without an active span', () => {

--- a/packages/datadog-plugin-pino/test/unit.spec.js
+++ b/packages/datadog-plugin-pino/test/unit.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 
-const { describe, it } = require('mocha')
+const { after, before, describe, it } = require('mocha')
 const { channel } = require('dc-polyfill')
 const { storage } = require('../../datadog-core')
 
@@ -25,12 +25,19 @@ const tracer = new Tracer(getConfig({
 const plugin = new PinoPlugin({
   _tracer: tracer,
 })
-plugin.configure({
-  logInjection: true,
-  enabled: true,
-})
 
 describe('PinoPlugin', () => {
+  before(() => {
+    plugin.configure({
+      logInjection: true,
+      enabled: true,
+    })
+  })
+
+  after(() => {
+    plugin.configure(false)
+  })
+
   it('splices trace correlation into pino JSON output', () => {
     const data = { line: '{"level":30,"msg":"hello"}' }
     jsonCh.publish(data)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds framework-independent Pino support to Test Optimization automatic log submission. Pino's serialized JSON line is published to the shared `ci:log-submission:log` channel only when trace correlation is active, then sent to the logs intake in bounded, source-aware batches by the existing sender.

The publish happens inside the existing `asJson` wrapper, so it reuses the same serialized line trace correlation already produces — no separate `write`/`streamWrite`/legacy-method wrappers are needed. Submission is gated on both log injection and log submission being active, matching the Bunyan contract. The source-agnostic log-submission plugin already covers Pino as a batching source in `log-submission-plugin.spec.js`, so no plugin changes are needed.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is the Pino equivalent of the Bunyan prerequisites PR (#9906), extracted so Pino support can be reviewed independently from test-framework lifecycle behavior. Per-framework integration coverage (Mocha, Cucumber, Playwright, Vitest, WebdriverIO) stacks on top in follow-up PRs, the same way it did for Bunyan (#9920 and the runner-specific slices). Jest is excluded for now because it requires deeper changes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- This PR contains no Jest, Bunyan, or test-framework-specific behavior.
- Automatic log submission follows the tracer lifecycle: disabling tracing disables correlation and submission.
- Caller-provided `dd` fields remain unchanged.
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha packages/datadog-plugin-pino/test/unit.spec.js` — 10 passing.
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha --timeout 60000 packages/datadog-plugin-pino/test/index.spec.js` — 254 passing across pino 2.0.0 → 10.x (trace-correlation submission, disabled-plugin no-submission, and caller-supplied `dd` all exercised).
- `./node_modules/.bin/mocha packages/dd-trace/test/ci-visibility/log-submission-plugin.spec.js` — 23 passing (no regression).
- Targeted ESLint and `git diff --check` — passing.
