### PR TITLE
fix(propagation): guard invalid text map carriers at input boundaries

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -338,7 +338,10 @@ class TextMapPropagator {
    * @returns {DatadogSpanContext | null}
    */
   extract (carrier) {
-    if (!carrier || typeof carrier !== 'object') return null
+    if (!carrier || typeof carrier !== 'object') {
+      if (this.#config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT !== 'ignore') removeAllBaggageItems()
+      return null
+    }
 
     const spanContext = this.#extractSpanContext(carrier)
     if (spanContext === undefined) return null

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -647,6 +647,9 @@ class TextMapPropagator {
    * @returns {DatadogSpanContext | undefined}
    */
   #extractSpanContext (carrier) {
+    // No carrier means nothing to extract; some extractors below don't guard against this.
+    if (carrier == null) return
+
     let context
     let datadogContext
     let style = ''

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -338,6 +338,8 @@ class TextMapPropagator {
    * @returns {DatadogSpanContext | null}
    */
   extract (carrier) {
+    if (!carrier || typeof carrier !== 'object') return null
+
     const spanContext = this.#extractSpanContext(carrier)
     if (spanContext === undefined) return null
 
@@ -647,9 +649,6 @@ class TextMapPropagator {
    * @returns {DatadogSpanContext | undefined}
    */
   #extractSpanContext (carrier) {
-    // No carrier means nothing to extract; some extractors below don't guard against this.
-    if (carrier == null) return
-
     let context
     let datadogContext
     let style = ''
@@ -753,7 +752,6 @@ class TextMapPropagator {
    * @returns {DatadogSpanContext | undefined}
    */
   #extractDatadogContext (carrier) {
-    if (!carrier) return
     const traceId = readDatadogTraceId(carrier)
     if (!traceId) return
     const spanContext = extractGenericContext(traceId, readDatadogParentId(carrier), 10)
@@ -788,6 +786,8 @@ class TextMapPropagator {
     } catch {
       return
     }
+    if (!parsed || typeof parsed !== 'object') return
+
     const spanContext = this.#extractDatadogContext(parsed)
     if (!spanContext) return
 
@@ -911,7 +911,7 @@ class TextMapPropagator {
    */
   #extractBaggageItems (carrier, spanContext, extractBaggage) {
     removeAllBaggageItems()
-    if (!carrier || !extractBaggage) return
+    if (!extractBaggage) return
     const header = readBaggage(carrier)
     if (!header) return
 

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -724,6 +724,12 @@ describe('TextMapPropagator', () => {
       assert.strictEqual(propagator.extract(null), null)
     })
 
+    it('should return null when the carrier is not an object', () => {
+      const carrier = Object.assign(() => {}, textMap)
+
+      assert.strictEqual(propagator.extract(carrier), null)
+    })
+
     it('should extract a span context from the carrier', () => {
       const carrier = textMap
       const spanContext = propagator.extract(carrier)
@@ -1204,6 +1210,10 @@ describe('TextMapPropagator', () => {
 
     it('should return null for an aws-sqsd header that parses to null', () => {
       assert.strictEqual(propagator.extract({ 'x-aws-sqsd-attr-_datadog': 'null' }), null)
+    })
+
+    it('should return null for an aws-sqsd header that parses to a non-object', () => {
+      assert.strictEqual(propagator.extract({ 'x-aws-sqsd-attr-_datadog': '"carrier"' }), null)
     })
 
     it('should return null when the carrier carries a trace id but no parent id', () => {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -717,11 +717,28 @@ describe('TextMapPropagator', () => {
 
   describe('extract', () => {
     it('should return null instead of throwing when the carrier is undefined', () => {
+      setBaggageItem('stale', 'leftover')
+
       assert.strictEqual(propagator.extract(undefined), null)
+      assert.deepStrictEqual(getAllBaggageItems(), {})
     })
 
     it('should return null instead of throwing when the carrier is null', () => {
+      setBaggageItem('stale', 'leftover')
+
       assert.strictEqual(propagator.extract(null), null)
+      assert.deepStrictEqual(getAllBaggageItems(), {})
+    })
+
+    it('should clear pre-existing baggage when the carrier is a primitive', () => {
+      setBaggageItem('stale', 'leftover')
+      const outboundCarrier = {}
+
+      assert.strictEqual(propagator.extract('payload'), null)
+      propagator.inject(undefined, outboundCarrier)
+
+      assert.deepStrictEqual(getAllBaggageItems(), {})
+      assert.strictEqual(outboundCarrier.baggage, undefined)
     })
 
     it('should return null when the carrier is not an object', () => {
@@ -2338,6 +2355,7 @@ describe('TextMapPropagator', () => {
 
       afterEach(() => {
         delete process.env.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
+        removeAllBaggageItems()
       })
 
       it('should reset span links when Trace_Propagation_Behavior_Extract is set to ignore', () => {
@@ -2373,6 +2391,7 @@ describe('TextMapPropagator', () => {
       })
 
       it('should not extract baggage when Trace_Propagation_Behavior_Extract is set to ignore', () => {
+        setBaggageItem('existing', 'value')
         process.env.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT = 'ignore'
         config = getConfigFresh({
           tracePropagationStyle: {
@@ -2388,7 +2407,17 @@ describe('TextMapPropagator', () => {
         propagator = new TextMapPropagator(config)
         propagator.extract(textMap)
 
-        assert.deepStrictEqual(getAllBaggageItems(), {})
+        assert.deepStrictEqual(getAllBaggageItems(), { existing: 'value' })
+      })
+
+      it('should preserve existing baggage for an invalid carrier when extraction behavior is ignore', () => {
+        setBaggageItem('existing', 'value')
+        process.env.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT = 'ignore'
+        config = getConfigFresh()
+        propagator = new TextMapPropagator(config)
+
+        assert.strictEqual(propagator.extract('payload'), null)
+        assert.deepStrictEqual(getAllBaggageItems(), { existing: 'value' })
       })
 
       it('returns null without throwing when ignore mode has no matching extractors', () => {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -716,6 +716,14 @@ describe('TextMapPropagator', () => {
   })
 
   describe('extract', () => {
+    it('should return null instead of throwing when the carrier is undefined', () => {
+      assert.strictEqual(propagator.extract(undefined), null)
+    })
+
+    it('should return null instead of throwing when the carrier is null', () => {
+      assert.strictEqual(propagator.extract(null), null)
+    })
+
     it('should extract a span context from the carrier', () => {
       const carrier = textMap
       const spanContext = propagator.extract(carrier)


### PR DESCRIPTION
### What does this PR do?

- Returns `null` when a text-map carrier is absent or not an object.
- Rejects non-object SQSD JSON payloads before treating them as carriers.
- Clears stale baggage for invalid carriers under normal extraction, while preserving `ignore` behavior.

### Motivation

Electron IPC can pass `undefined` or an arbitrary payload as the candidate carrier. Header reads then threw and `Tracer#extract()` logged an error for every affected IPC call. Invalid carriers must also follow the existing baggage cleanup contract to prevent stale baggage from reaching later outgoing requests.
