### PR TITLE
test(test-optimization): cover Pino logs in Mocha, Cucumber, and Vitest

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -76,7 +76,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'vitest',
       command: './node_modules/.bin/vitest run --config ./ci-visibility/automatic-log-submission-vitest/config.mjs',
-      loggerNames: ['bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
       getExtraEnvVars: () => ({
         NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
       }),

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -31,6 +31,7 @@ describe('test optimization automatic log submission', () => {
     ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
     'bunyan',
     'jest',
+    'pino',
     vitestDependency,
     'winston',
     playwrightDependency,
@@ -70,7 +71,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'mocha',
       command: './node_modules/.bin/mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js',
-      loggerNames: ['winston', 'bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
     },
     {
       name: 'vitest',
@@ -87,7 +88,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'cucumber',
       command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature',
-      loggerNames: ['winston', 'bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
     },
     {
       name: 'playwright',
@@ -103,6 +104,7 @@ describe('test optimization automatic log submission', () => {
 
   const loggers = {
     bunyan: { level: 30, messageKey: 'msg' },
+    pino: { level: 30, messageKey: 'msg' },
     winston: { level: 'info', messageKey: 'message' },
   }
 

--- a/integration-tests/ci-visibility/automatic-log-submission/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/logger.js
@@ -4,6 +4,8 @@ let logger
 
 if (process.env.TEST_LOGGER === 'bunyan') {
   logger = require('bunyan').createLogger({ name: 'test-logger' })
+} else if (process.env.TEST_LOGGER === 'pino') {
+  logger = require('pino')({ level: 'info' })
 } else {
   const { createLogger, format, transports } = require('winston')
   logger = createLogger({


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds Pino to the Test Optimization automatic log submission integration matrix for Mocha, Cucumber, and Vitest, alongside Winston and Bunyan. It also restores Winston coverage in the existing Vitest matrix. Pino shares Bunyan's record shape (numeric levels with `info=30` and a `msg` message key), so it reuses the same assertion parameters and only needs a `'pino'` branch in the shared logger fixture.

No production code changes. Mocha and Cucumber use the existing process-exit flush, while Vitest uses the awaited worker-shutdown flush already on `master`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Completes non-Jest shared-matrix coverage for Pino and verifies that both Pino and Winston use Vitest's logger-agnostic final flush. The Pino submission prerequisite (#9978), Vitest lifecycle (#9963), and Winston shared sender (#9922) are already merged.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- The `loggers` map gains `pino: { level: 30, messageKey: 'msg' }`, identical to Bunyan's entry.
- `'pino'` is added to `useSandbox` so the sandbox installs it (resolves to 10.3.1, covered by the `>=6.8.0` instrumentation hook).
- Local shape check confirmed: `source: 'pino'`, `level: 30`, `msg` key, `dd` with `service`/`span_id`/`trace_id`.
- Focused Mocha and Cucumber Pino integration cases: 6 passing.
- Full Winston, Bunyan, and Pino Vitest matrix: 9 passing.
- Targeted ESLint and `git diff --check`: passing.
