### PR TITLE
test(test-optimization): cover Pino log submission in Playwright

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -93,7 +93,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'playwright',
       command: './node_modules/.bin/playwright test -c playwright.config.js',
-      loggerNames: ['winston', 'bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
       getExtraEnvVars: () => ({
         PW_BASE_URL: `http://localhost:${webAppPort}`,
         TEST_DIR: 'ci-visibility/automatic-log-submission-playwright',

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -76,7 +76,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'vitest',
       command: './node_modules/.bin/vitest run --config ./ci-visibility/automatic-log-submission-vitest/config.mjs',
-      loggerNames: ['bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
       getExtraEnvVars: () => ({
         NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
       }),

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -31,6 +31,7 @@ describe('test optimization automatic log submission', () => {
     ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
     'bunyan',
     'jest',
+    'pino',
     vitestDependency,
     'winston',
     playwrightDependency,
@@ -70,7 +71,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'mocha',
       command: './node_modules/.bin/mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js',
-      loggerNames: ['winston', 'bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
     },
     {
       name: 'vitest',
@@ -87,7 +88,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'cucumber',
       command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature',
-      loggerNames: ['winston', 'bunyan'],
+      loggerNames: ['winston', 'bunyan', 'pino'],
     },
     {
       name: 'playwright',
@@ -103,6 +104,7 @@ describe('test optimization automatic log submission', () => {
 
   const loggers = {
     bunyan: { level: 30, messageKey: 'msg' },
+    pino: { level: 30, messageKey: 'msg' },
     winston: { level: 'info', messageKey: 'message' },
   }
 

--- a/integration-tests/ci-visibility/automatic-log-submission/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/logger.js
@@ -4,6 +4,8 @@ let logger
 
 if (process.env.TEST_LOGGER === 'bunyan') {
   logger = require('bunyan').createLogger({ name: 'test-logger' })
+} else if (process.env.TEST_LOGGER === 'pino') {
+  logger = require('pino')({ level: 'info' })
 } else {
   const { createLogger, format, transports } = require('winston')
   logger = createLogger({


### PR DESCRIPTION
<!--
Please read https://github.com/DataDog/dd-trace-js/blob/master/CONTRIBUTING.md before submitting a pull request.
-->

### What does this PR do?

Adds Pino automatic log-submission coverage for Playwright, alongside the existing Winston and Bunyan coverage.

The Playwright lifecycle support that waits for pending log-submission requests is already provided by the merged prerequisite PRs, so this PR contains only integration-test matrix coverage and no production changes.

### Motivation

Completes Pino coverage for the non-Jest test frameworks that use the shared automatic log-submission matrix. This PR is stacked on #9981, which covers Mocha, Cucumber.js, and Vitest. The Pino instrumentation prerequisite (#9978) and Playwright lifecycle support are already merged.

### Additional Notes

- Stacked on `juan-fernandez/pino-mocha-cucumber-log-submission`; merge #9981 before this PR.
- Only adds Pino to the Playwright logger list; Winston and Bunyan coverage remains intact.
- Focused integration test:
  `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha --timeout 120000 integration-tests/ci-visibility/automatic-log-submission.spec.js --grep 'with (winston|bunyan|pino) and playwright'`
  Result: `9 passing`.
- Targeted ESLint and `git diff --check` pass.

### Checklist

- [x] Tests have been added or updated.
- [x] Documentation has been updated where necessary.
- [x] The change follows the repository coding conventions.
