### PR TITLE
fix(test-optimization): release Playwright worker on flush failure

### DIFF
--- a/integration-tests/ci-visibility/playwright-flush-error/flush-error-test.js
+++ b/integration-tests/ci-visibility/playwright-flush-error/flush-error-test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const tracer = require('dd-trace')
+const { expect, test } = require('@playwright/test')
+
+test('finishes when trace flushing throws', () => {
+  tracer._tracer._exporter.flush = () => {
+    throw new Error('test flush failure')
+  }
+
+  expect(1 + 2).toBe(3)
+})

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -1219,6 +1219,23 @@ versions.forEach((version) => {
         const [exitCode] = await once(proc, 'exit')
         assert.strictEqual(exitCode, 0)
       })
+
+      it('finishes if worker trace flushing throws synchronously', async (receiver, run) => {
+        const proc = run(
+          './node_modules/.bin/playwright test -c playwright.config.js',
+          {
+            cwd,
+            timeout: 30000,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: './ci-visibility/playwright-flush-error',
+            },
+          }
+        )
+
+        const [exitCode] = await once(proc, 'exit')
+        assert.strictEqual(exitCode, 0)
+      })
     }
 
     const fullyParallelConfigValue = [true, false]

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -523,7 +523,15 @@ class PlaywrightPlugin extends CiPlugin {
 
       finishAllTraceSpans(span)
       if (this._tracerConfig.DD_PLAYWRIGHT_WORKER) {
-        this.tracer._exporter.flush(onDone)
+        try {
+          this.tracer._exporter.flush(onDone)
+        } catch (error) {
+          // A synchronous flush failure must still release the worker, otherwise it hangs.
+          // Log rather than rethrow: an exception from this diagnostics-channel subscriber
+          // would surface as an uncaught error in the worker and crash the user's test run.
+          onDone?.()
+          log.error('Error flushing traces at Playwright worker shutdown', error)
+        }
       }
     })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Wraps the Playwright worker trace flush in a `try/catch` so a synchronous `_exporter.flush` failure still calls `onDone`. Without it, a throwing flush leaves the worker waiting for a completion callback that never arrives, so the worker hangs instead of reporting the failure and exiting.

### Motivation
<!-- What inspired you to submit this pull request? -->

Extracted from the combined Pino/Bunyan log submission PR (#9669), where it was bundled with the larger completion-barrier work. This robustness fix is independent of that mechanism and applies to `master` as-is: master calls `this.tracer._exporter.flush(onDone)` with no guard at the worker completion path, so a synchronous throw hangs the worker.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Draft: extracted as a standalone fix off `master`; does not depend on #9669, #9978, or any log-submission work.
- Adds a regression test (`playwright-flush-error`) that stubs `_exporter.flush` to throw and asserts the process still exits with code 0.
- The session-level flush path (non-worker) is intentionally left untouched to match the original scope; only the worker completion path that gates on `DD_PLAYWRIGHT_WORKER` is guarded.
- Targeted ESLint and `git diff --check` — passing.
