### PR TITLE
feat(openfeature): add API key fingerprint header

### DIFF
--- a/packages/dd-trace/src/api-key-fingerprint.js
+++ b/packages/dd-trace/src/api-key-fingerprint.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { createHash } = require('node:crypto')
+
+const BASE62_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const BASE62_RADIX = 62n
+const SHA256_BASE62_LENGTH = 43
+
+/**
+ * Creates the canonical stable identifier for a Datadog API key.
+ *
+ * @param {string} apiKey - Datadog API key
+ * @returns {string} Prefixed, fixed-width SHA-256 fingerprint
+ */
+function createAPIKeyFingerprint (apiKey) {
+  const digest = createHash('sha256').update(apiKey).digest()
+  let value = BigInt(`0x${digest.toString('hex')}`)
+  let encoded = ''
+
+  do {
+    encoded = BASE62_ALPHABET[Number(value % BASE62_RADIX)] + encoded
+    value /= BASE62_RADIX
+  } while (value > 0n)
+
+  return `rijn_${encoded.padStart(SHA256_BASE62_LENGTH, '0')}`
+}
+
+module.exports = { createAPIKeyFingerprint }

--- a/packages/dd-trace/src/openfeature/agentless_configuration_source.js
+++ b/packages/dd-trace/src/openfeature/agentless_configuration_source.js
@@ -4,6 +4,7 @@
 
 const { setTimeout: sleep } = require('node:timers/promises')
 
+const { createAPIKeyFingerprint } = require('../api-key-fingerprint')
 const request = require('../exporters/common/request')
 const { getClientLibraryHeaders } = require('../exporters/common/client-library-headers')
 const log = require('../log')
@@ -138,7 +139,10 @@ class AgentlessConfigurationSource {
   #request (signal) {
     const headers = getClientLibraryHeaders()
     headers['Accept-Encoding'] = 'gzip'
-    if (this.#config.apiKey) headers['DD-API-KEY'] = this.#config.apiKey
+    if (this.#config.apiKey) {
+      headers['DD-API-KEY'] = this.#config.apiKey
+      headers['DD-API-KEY-FINGERPRINT'] = createAPIKeyFingerprint(this.#config.apiKey)
+    }
     if (this.#etag) headers['If-None-Match'] = this.#etag
 
     /**

--- a/packages/dd-trace/test/api-key-fingerprint.spec.js
+++ b/packages/dd-trace/test/api-key-fingerprint.spec.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const { createAPIKeyFingerprint } = require('../src/api-key-fingerprint')
+
+describe('API key fingerprint', () => {
+  for (const [apiKey, fingerprint] of [
+    ['padding-171', 'rijn_053ybBRXypQt9AC6UIlqH1YCFYSV1rQl8HCDIcBZs3D'],
+    ['!@#$%^𐍈한€हИ£', 'rijn_eFLHeyLxwaiNs2hY16pjkjNjVSHWRgf2rlveKc8YA1K'],
+    ['secret', 'rijn_amLaG4Pd6h6t9VtJna81k744P1DYxGHzIJ6ECO3OOMj'],
+    ['system-tests-mock-api-key', 'rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU'],
+  ]) {
+    it(`creates the canonical fixed-width fingerprint for ${JSON.stringify(apiKey)}`, () => {
+      const result = createAPIKeyFingerprint(apiKey)
+
+      assert.strictEqual(result, fingerprint)
+      assert.strictEqual(result.length, 48)
+    })
+  }
+})

--- a/packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js
+++ b/packages/dd-trace/test/openfeature/agentless_configuration_source.spec.js
@@ -149,6 +149,10 @@ describe('AgentlessConfigurationSource', () => {
     assert.strictEqual(requests[0].options.retry, false)
     assert.strictEqual(requests[0].options.timeout, 2000)
     assert.strictEqual(requests[0].options.headers['DD-API-KEY'], 'test-api-key')
+    assert.strictEqual(
+      requests[0].options.headers['DD-API-KEY-FINGERPRINT'],
+      'rijn_i8Jug5ocjALL7JZiV1a8HzXqkwDRKcE7hK9IouPQwio'
+    )
     assert.strictEqual(requests[0].options.headers['Accept-Encoding'], 'gzip')
     assert.strictEqual(requests[0].options.headers['DD-Client-Library-Language'], 'nodejs')
     assert.strictEqual(requests[0].options.headers['DD-Client-Library-Version'], VERSION)
@@ -184,7 +188,7 @@ describe('AgentlessConfigurationSource', () => {
     config.endpoint = new URL('http://flags.dev.internal:8080/custom/ufc')
     delete config.apiKey
     nock('http://flags.dev.internal:8080', {
-      badheaders: ['dd-api-key'],
+      badheaders: ['dd-api-key', 'dd-api-key-fingerprint'],
       reqheaders: {
         'accept-encoding': 'gzip',
       },
@@ -501,6 +505,7 @@ describe('AgentlessConfigurationSource', () => {
     await flush()
 
     assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-API-KEY'), false)
+    assert.strictEqual(Object.hasOwn(requests[0].options.headers, 'DD-API-KEY-FINGERPRINT'), false)
     sinon.assert.calledOnceWithExactly(
       log.warn,
       'Feature Flagging agentless endpoint returned HTTP %d; verify endpoint authentication',


### PR DESCRIPTION
## Motivation

Managed agentless Feature Flagging configuration requests authenticate with a Datadog API key and require the canonical cross-SDK fingerprint.

## Changes

- Add an internal API-key fingerprint helper using SHA-256 and fixed-width base62 encoding.
- Attach `DD-API-KEY-FINGERPRINT` beside `DD-API-KEY` when polling the managed Datadog UFC endpoint.
- Cover the cross-SDK golden vectors, including leading-zero padding and Unicode input.
- Verify missing credentials and operator-owned custom endpoints omit both Datadog authentication headers.

## Decisions

- Fingerprint only managed Datadog UFC requests because custom endpoints intentionally do not receive the Datadog API key.
- Keep the helper internal rather than expanding the public package API.
- Retain the canonical `rijn_` prefix and 43-character encoded digest contract.

## Validation

- Focused Mocha suite: 56 passing across fingerprint, managed/custom UFC, and configuration selection coverage.
- Targeted ESLint passed for all changed source and test files.
