### PR TITLE
chore(codeowners): remove dd-trace-js from debugger-nodejs ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,18 +45,18 @@
 /packages/dd-trace/*/standalone @DataDog/dd-trace-js @DataDog/asm-js
 
 # Debugger
-/benchmark/sirun/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/benchmark/sirun/debugger/ @DataDog/debugger-nodejs
 
-/integration-tests/code-origin/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/integration-tests/code-origin-remote-config.spec.js @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/integration-tests/code-origin.spec.js @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/integration-tests/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/integration-tests/code-origin/ @DataDog/debugger-nodejs
+/integration-tests/code-origin-remote-config.spec.js @DataDog/debugger-nodejs
+/integration-tests/code-origin.spec.js @DataDog/debugger-nodejs
+/integration-tests/debugger/ @DataDog/debugger-nodejs
 
-/packages/datadog-code-origin/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/packages/datadog-plugin-*/**/code_origin.* @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/packages/dd-trace/src/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/packages/dd-trace/test/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
-/packages/dd-trace/test/plugins/util/stacktrace.spec.js @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/datadog-code-origin/ @DataDog/debugger-nodejs
+/packages/datadog-plugin-*/**/code_origin.* @DataDog/debugger-nodejs
+/packages/dd-trace/src/debugger/ @DataDog/debugger-nodejs
+/packages/dd-trace/test/debugger/ @DataDog/debugger-nodejs
+/packages/dd-trace/test/plugins/util/stacktrace.spec.js @DataDog/debugger-nodejs
 
 # Serverless
 /packages/dd-trace/src/lambda/ @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
@@ -381,7 +381,7 @@
 /.github/workflows/apm-integrations.yml @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
 /.github/workflows/aiguard.yml @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
 /.github/workflows/appsec.yml @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
-/.github/workflows/debugger.yml @DataDog/dd-trace-js @DataDog/debugger-nodejs @dd-octo-sts
+/.github/workflows/debugger.yml @DataDog/debugger-nodejs @dd-octo-sts
 /.github/workflows/instrumentation.yml @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
 /.github/workflows/electron.yml @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
 /.github/workflows/release.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts


### PR DESCRIPTION
### What does this PR do?
Removes @DataDog/dd-trace-js as a co-owner of paths owned by @DataDog/debugger-nodejs.

### Motivation
Transfer ownership responsibility to the owning team.

### Additional Notes
Tests were not run because this changes CODEOWNERS metadata only.

*Generated by Codex.*