### PR TITLE
chore(codeowners): remove dd-trace-js from profiling-js ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -389,23 +389,23 @@
 /.github/workflows/llmobs.yml @DataDog/dd-trace-js @DataDog/ml-observability @dd-octo-sts
 /.github/workflows/openfeature.yml @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk @dd-octo-sts
 /.github/workflows/pr-title.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/profiling.yml @DataDog/dd-trace-js @DataDog/profiling-js @dd-octo-sts
+/.github/workflows/profiling.yml @DataDog/profiling-js @dd-octo-sts
 /.github/workflows/system-tests.yml @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
 /.github/workflows/test-optimization.yml @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
 
 # Profiling
-/benchmark/sirun/profiler/ @DataDog/dd-trace-js @DataDog/profiling-js
+/benchmark/sirun/profiler/ @DataDog/profiling-js
 
-/integration-tests/profiler/ @DataDog/dd-trace-js @DataDog/profiling-js
+/integration-tests/profiler/ @DataDog/profiling-js
 
-/packages/dd-trace/*/profiling/ @DataDog/dd-trace-js @DataDog/profiling-js
-/packages/dd-trace/src/otel-thread-ctx.js @DataDog/dd-trace-js @DataDog/profiling-js
-/packages/dd-trace/src/profiler.js @DataDog/dd-trace-js @DataDog/profiling-js
-/packages/dd-trace/src/storage-channels.js @DataDog/dd-trace-js @DataDog/profiling-js @DataDog/apm-sdk-capabilities-js
-/packages/dd-trace/src/web-tags-cache.js @DataDog/dd-trace-js @DataDog/profiling-js
-/packages/dd-trace/test/exporters/common/form-data.spec.js @DataDog/dd-trace-js @DataDog/profiling-js
-/packages/dd-trace/test/otel-thread-ctx.spec.js @DataDog/dd-trace-js @DataDog/profiling-js
-/packages/dd-trace/test/web-tags-cache.spec.js @DataDog/dd-trace-js @DataDog/profiling-js
+/packages/dd-trace/*/profiling/ @DataDog/profiling-js
+/packages/dd-trace/src/otel-thread-ctx.js @DataDog/profiling-js
+/packages/dd-trace/src/profiler.js @DataDog/profiling-js
+/packages/dd-trace/src/storage-channels.js @DataDog/profiling-js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/web-tags-cache.js @DataDog/profiling-js
+/packages/dd-trace/test/exporters/common/form-data.spec.js @DataDog/profiling-js
+/packages/dd-trace/test/otel-thread-ctx.spec.js @DataDog/profiling-js
+/packages/dd-trace/test/web-tags-cache.spec.js @DataDog/profiling-js
 
 # Language Platform
 /* @DataDog/dd-trace-js @DataDog/lang-platform-js


### PR DESCRIPTION
### What does this PR do?
Removes @DataDog/dd-trace-js as a co-owner of paths owned by @DataDog/profiling-js.

### Motivation
Transfer ownership responsibility to the owning team.

### Additional Notes
Tests were not run because this changes CODEOWNERS metadata only.

*Generated by Codex.*