### PR TITLE
chore(codeowners): remove dd-trace-js from dd-octo-sts ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -347,51 +347,51 @@
 /packages/dd-trace/test/openfeature/ @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk
 
 # CI
-/.github/actions/**/action.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/actions/**/action.yaml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
+/.github/actions/**/action.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/actions/**/action.yaml @DataDog/lang-platform-js @dd-octo-sts
 /.github/actions/upload-coverage-artifact/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
-/.github/actions/upload-coverage-artifact/action.yml @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
-/.github/actions/upload-coverage-artifact/action.yaml @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
+/.github/actions/upload-coverage-artifact/action.yml @DataDog/ci-app-libraries @dd-octo-sts
+/.github/actions/upload-coverage-artifact/action.yaml @DataDog/ci-app-libraries @dd-octo-sts
 /.github/actions/upload-junit-artifacts/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
-/.github/actions/upload-junit-artifacts/action.yml @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
-/.github/actions/upload-junit-artifacts/action.yaml @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
+/.github/actions/upload-junit-artifacts/action.yml @DataDog/ci-app-libraries @dd-octo-sts
+/.github/actions/upload-junit-artifacts/action.yaml @DataDog/ci-app-libraries @dd-octo-sts
 /.github/editorconfig-checker/ @DataDog/dd-trace-js @Datadog/lang-platform-js
 /.github/playwright/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /.github/selenium/ @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /.github/chainguard/ @DataDog/dd-trace-js @DataDog/sdlc-security
 /.github/codeql_config.yml @DataDog/dd-trace-js @DataDog/sdlc-security
-/.github/workflows/*.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/*.yaml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/codeql-analysis.yml @DataDog/dd-trace-js @DataDog/sdlc-security @dd-octo-sts
-/.github/workflows/mirror-image.yml @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
-/.github/workflows/all-green.yml @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
-/.github/workflows/audit.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/custom-node-version-dispatch.yml @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
-/.github/workflows/dependabot-automation.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js @dd-octo-sts
-/.github/workflows/flakiness.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/platform.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/project.yml @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
-/.github/workflows/release-proposal.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/release-validate.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/stale.yml @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
-/.github/workflows/update-3rdparty-licenses.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/*.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/*.yaml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/codeql-analysis.yml @DataDog/sdlc-security @dd-octo-sts
+/.github/workflows/mirror-image.yml @Datadog/lang-platform-js @dd-octo-sts
+/.github/workflows/all-green.yml @Datadog/lang-platform-js @dd-octo-sts
+/.github/workflows/audit.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/custom-node-version-dispatch.yml @Datadog/lang-platform-js @dd-octo-sts
+/.github/workflows/dependabot-automation.yml @DataDog/lang-platform-js @DataDog/apm-sdk-capabilities-js @dd-octo-sts
+/.github/workflows/flakiness.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/platform.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/project.yml @Datadog/lang-platform-js @dd-octo-sts
+/.github/workflows/release-proposal.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/release-validate.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/stale.yml @Datadog/lang-platform-js @dd-octo-sts
+/.github/workflows/update-3rdparty-licenses.yml @DataDog/lang-platform-js @dd-octo-sts
 
-/.github/workflows/apm-capabilities.yml @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @dd-octo-sts
-/.github/workflows/eslint-rules.yml @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @dd-octo-sts
-/.github/workflows/apm-integrations.yml @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
-/.github/workflows/aiguard.yml @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
-/.github/workflows/appsec.yml @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
-/.github/workflows/debugger.yml @DataDog/dd-trace-js @DataDog/debugger-nodejs @dd-octo-sts
-/.github/workflows/instrumentation.yml @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
-/.github/workflows/electron.yml @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
-/.github/workflows/release.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/serverless.yml @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless @dd-octo-sts
-/.github/workflows/llmobs.yml @DataDog/dd-trace-js @DataDog/ml-observability @dd-octo-sts
-/.github/workflows/openfeature.yml @DataDog/dd-trace-js @DataDog/feature-flagging-and-experimentation-sdk @dd-octo-sts
-/.github/workflows/pr-title.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/workflows/profiling.yml @DataDog/dd-trace-js @DataDog/profiling-js @dd-octo-sts
-/.github/workflows/system-tests.yml @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
-/.github/workflows/test-optimization.yml @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
+/.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js @dd-octo-sts
+/.github/workflows/eslint-rules.yml @DataDog/apm-sdk-capabilities-js @dd-octo-sts
+/.github/workflows/apm-integrations.yml @DataDog/apm-idm-js @dd-octo-sts
+/.github/workflows/aiguard.yml @DataDog/asm-js @dd-octo-sts
+/.github/workflows/appsec.yml @DataDog/asm-js @dd-octo-sts
+/.github/workflows/debugger.yml @DataDog/debugger-nodejs @dd-octo-sts
+/.github/workflows/instrumentation.yml @DataDog/apm-idm-js @dd-octo-sts
+/.github/workflows/electron.yml @DataDog/apm-idm-js @dd-octo-sts
+/.github/workflows/release.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/serverless.yml @DataDog/serverless-aws @DataDog/apm-serverless @dd-octo-sts
+/.github/workflows/llmobs.yml @DataDog/ml-observability @dd-octo-sts
+/.github/workflows/openfeature.yml @DataDog/feature-flagging-and-experimentation-sdk @dd-octo-sts
+/.github/workflows/pr-title.yml @DataDog/lang-platform-js @dd-octo-sts
+/.github/workflows/profiling.yml @DataDog/profiling-js @dd-octo-sts
+/.github/workflows/system-tests.yml @DataDog/asm-js @dd-octo-sts
+/.github/workflows/test-optimization.yml @DataDog/ci-app-libraries @dd-octo-sts
 
 # Profiling
 /benchmark/sirun/profiler/ @DataDog/dd-trace-js @DataDog/profiling-js
@@ -543,19 +543,19 @@
 /packages/dd-trace/src/plugin_manager.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/apm-idm-js
 
 # Automated dependency updates
-/package.json @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/yarn.lock @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/docs/package.json @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/lang-platform-js @dd-octo-sts
-/docs/yarn.lock @DataDog/dd-trace-js @DataDog/apm-idm-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/actions/datadog-ci/package.json @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/.github/actions/datadog-ci/yarn.lock @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/vendor/package.json @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/vendor/package-lock.json @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
-/packages/dd-trace/test/plugins/versions/package.json @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
-/integration-tests/esbuild/package.json @DataDog/dd-trace-js @DataDog/apm-idm-js @dd-octo-sts
-/integration-tests/appsec/iast-esbuild-esm/package.json @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
-/integration-tests/appsec/iast-esbuild-cjs/package.json @DataDog/dd-trace-js @DataDog/asm-js @dd-octo-sts
-/.github/editorconfig-checker/Dockerfile @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
-/.github/playwright/Dockerfile @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
-/.github/selenium/Dockerfile @DataDog/dd-trace-js @DataDog/ci-app-libraries @dd-octo-sts
-/benchmark/sirun/Dockerfile* @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
+/package.json @DataDog/lang-platform-js @dd-octo-sts
+/yarn.lock @DataDog/lang-platform-js @dd-octo-sts
+/docs/package.json @DataDog/apm-idm-js @DataDog/lang-platform-js @dd-octo-sts
+/docs/yarn.lock @DataDog/apm-idm-js @DataDog/lang-platform-js @dd-octo-sts
+/.github/actions/datadog-ci/package.json @DataDog/lang-platform-js @dd-octo-sts
+/.github/actions/datadog-ci/yarn.lock @DataDog/lang-platform-js @dd-octo-sts
+/vendor/package.json @DataDog/lang-platform-js @dd-octo-sts
+/vendor/package-lock.json @DataDog/lang-platform-js @dd-octo-sts
+/packages/dd-trace/test/plugins/versions/package.json @DataDog/apm-idm-js @dd-octo-sts
+/integration-tests/esbuild/package.json @DataDog/apm-idm-js @dd-octo-sts
+/integration-tests/appsec/iast-esbuild-esm/package.json @DataDog/asm-js @dd-octo-sts
+/integration-tests/appsec/iast-esbuild-cjs/package.json @DataDog/asm-js @dd-octo-sts
+/.github/editorconfig-checker/Dockerfile @Datadog/lang-platform-js @dd-octo-sts
+/.github/playwright/Dockerfile @DataDog/ci-app-libraries @dd-octo-sts
+/.github/selenium/Dockerfile @DataDog/ci-app-libraries @dd-octo-sts
+/benchmark/sirun/Dockerfile* @DataDog/lang-platform-js @dd-octo-sts


### PR DESCRIPTION
### What does this PR do?
Removes @DataDog/dd-trace-js as a co-owner of paths owned by @dd-octo-sts.

### Motivation
Transfer ownership responsibility to the owning team.

### Additional Notes
Tests were not run because this changes CODEOWNERS metadata only.

*Generated by Codex.*