### PR TITLE
feat(appsec): extract API Security schemas in Lambda

### DIFF
--- a/packages/dd-trace/src/appsec/api_security/sampler.js
+++ b/packages/dd-trace/src/appsec/api_security/sampler.js
@@ -138,7 +138,8 @@ function isNotFound (statusCode) {
 
 /**
  * @param {string} method
- * @param {string|null} route A route string, an empty string (still a valid route), or `null`
+ * @param {string|undefined} route A route string, an empty string (still a valid route), or
+ *   `undefined`
  * @param {number|string} statusCode
  * @returns {string}
  */

--- a/packages/dd-trace/src/appsec/api_security/sampler.js
+++ b/packages/dd-trace/src/appsec/api_security/sampler.js
@@ -50,9 +50,9 @@ function disable () {
  * @param {object} request
  * @param {string} request.method
  * @param {number|string} request.statusCode
- * @param {string|null} request.route Tri-state: a route string, an empty string (still a valid
- *   route — dd-trace-js represents the express root path '/' as an empty path segment), or
- *   `null` meaning no route information at all.
+ * @param {string|undefined} request.route Tri-state: a route string, an empty string (still a
+ *   valid route — dd-trace-js represents the express root path '/' as an empty path segment), or
+ *   `undefined` meaning no route information at all.
  * @param {boolean} [request.blocked] Whether the response was blocked by ASM
  * @param {boolean} record When true and the decision is SAMPLE, records the endpoint in the TTL cache
  * @returns {'sample' | 'missing_route' | 'skip'}
@@ -62,14 +62,14 @@ function sampleRootSpanRequest (rootSpan, request, record = false) {
 
   if (!rootSpan) return SamplingDecision.SKIP
 
-  if (isRejected(rootSpan)) return SamplingDecision.SKIP
-
   const { method, statusCode, route, blocked = false } = request ?? {}
 
   if (!method || !statusCode) {
     log.warn('[ASM] Unsupported groupkey for API security')
     return SamplingDecision.SKIP
   }
+
+  if (isRejected(rootSpan)) return SamplingDecision.SKIP
 
   if (isRoutelessRecord(route, record)) {
     if (isNotFound(statusCode) || blocked) return SamplingDecision.SKIP
@@ -120,12 +120,12 @@ function sampleRequest (req, res, record = false) {
 /**
  * Whether this is a request with no route information
  *
- * @param {string|null} route
+ * @param {string|undefined} route
  * @param {boolean} record
  * @returns {boolean}
  */
 function isRoutelessRecord (route, record) {
-  return record && route === null
+  return record && route === undefined
 }
 
 /**
@@ -149,8 +149,8 @@ function buildSamplingKey (method, route, statusCode) {
 /**
  * @param {{ paths?: string[], span?: object }} [context] Web context of the request
  * @param {number|string} statusCode
- * @returns {string|null} A route string, an empty string (still a valid route), or `null` when no
- *   route information is available.
+ * @returns {string|undefined} A route string, an empty string (still a valid route), or
+ *   `undefined` when no route information is available.
  */
 function getRouteOrEndpoint (context, statusCode) {
   // The router plugin populates `context.paths` whenever the framework matched something.
@@ -162,12 +162,10 @@ function getRouteOrEndpoint (context, statusCode) {
     return paths.join('')
   }
 
-  if (isNotFound(statusCode)) return null
+  if (isNotFound(statusCode)) return
 
   const endpoint = context?.span?.context()?.getTag?.('http.endpoint')
   if (endpoint) return endpoint
-
-  return null
 }
 
 /**

--- a/packages/dd-trace/src/appsec/lambda.js
+++ b/packages/dd-trace/src/appsec/lambda.js
@@ -117,15 +117,13 @@ function onLambdaEndInvocation (data) {
         persistent[addresses.HTTP_INCOMING_RESPONSE_HEADERS] = filteredHeaders
       }
 
-      const samplingDecision = statusCode
-        ? apiSecurity.sampleRootSpanRequest(span, {
-          method,
-          statusCode,
-          route: route ?? null,
-          // The tracer does not block in Lambda yet, so a response is never a blocked one.
-          blocked: false,
-        }, true)
-        : apiSecurity.SamplingDecision.SKIP
+      const samplingDecision = apiSecurity.sampleRootSpanRequest(span, {
+        method,
+        statusCode,
+        route,
+        // The tracer does not block in Lambda yet, so a response is never a blocked one.
+        blocked: false,
+      }, true)
 
       if (samplingDecision === apiSecurity.SamplingDecision.SAMPLE) {
         persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }

--- a/packages/dd-trace/src/appsec/lambda.js
+++ b/packages/dd-trace/src/appsec/lambda.js
@@ -3,7 +3,9 @@
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
 
 const log = require('../log')
+const { isEmpty } = require('../util')
 const addresses = require('./addresses')
+const apiSecurity = require('./api_security')
 const Reporter = require('./reporter')
 const waf = require('./waf')
 
@@ -22,7 +24,7 @@ const activeInvocations = new WeakMap()
  */
 function onLambdaStartInvocation (data) {
   try {
-    const { span, headers, method, path, query, body, clientIp, pathParams, cookies } = data
+    const { span, headers, method, path, query, body, clientIp, pathParams, cookies, route } = data
 
     if (!span) {
       log.warn('[ASM] No span provided in Lambda start invocation')
@@ -30,7 +32,7 @@ function onLambdaStartInvocation (data) {
     }
 
     const req = { headers: headers ?? {} }
-    activeInvocations.set(span, req)
+    activeInvocations.set(span, { req, method, route })
 
     span.addTags({
       '_dd.appsec.enabled': 1,
@@ -80,8 +82,8 @@ function onLambdaStartInvocation (data) {
 }
 
 /**
- * Maps response data to WAF addresses, runs a final WAF pass,
- * disposes the WAF context, and finishes the request report.
+ * Maps response data to WAF addresses, takes the API Security sampling decision, runs a final
+ * WAF pass, disposes the WAF context, and finishes the request report.
  *
  * @param {{ span: object, statusCode: string | undefined,
  *           responseHeaders: Record<string, string> | undefined }} data
@@ -99,27 +101,39 @@ function onLambdaEndInvocation (data) {
       return
     }
 
-    const req = activeInvocations.get(span)
+    const { req, method, route } = activeInvocations.get(span)
     activeInvocations.delete(span)
 
-    let hasPersistentData = false
     const persistent = {}
 
     if (statusCode) {
       persistent[addresses.HTTP_INCOMING_RESPONSE_CODE] = String(statusCode)
-      hasPersistentData = true
     }
 
     if (responseHeaders) {
       const filteredHeaders = { ...responseHeaders }
       delete filteredHeaders['set-cookie']
       persistent[addresses.HTTP_INCOMING_RESPONSE_HEADERS] = filteredHeaders
-      hasPersistentData = true
     }
 
-    if (hasPersistentData) {
-      waf.run({ persistent }, req, undefined, span)
+    const samplingDecision = apiSecurity.sampleRootSpanRequest(span, {
+      method,
+      statusCode,
+      route: route ?? null,
+      // The tracer does not block in Lambda yet, so a response is never a blocked one.
+      blocked: false,
+    }, true)
+
+    if (samplingDecision === apiSecurity.SamplingDecision.SAMPLE) {
+      persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }
     }
+
+    let wafResult
+    if (!isEmpty(persistent)) {
+      wafResult = waf.run({ persistent }, req, undefined, span)
+    }
+
+    apiSecurity.reportRootSpanRequest(span, samplingDecision, wafResult)
 
     waf.disposeContext(req)
 

--- a/packages/dd-trace/src/appsec/lambda.js
+++ b/packages/dd-trace/src/appsec/lambda.js
@@ -116,13 +116,15 @@ function onLambdaEndInvocation (data) {
       persistent[addresses.HTTP_INCOMING_RESPONSE_HEADERS] = filteredHeaders
     }
 
-    const samplingDecision = apiSecurity.sampleRootSpanRequest(span, {
-      method,
-      statusCode,
-      route: route ?? null,
-      // The tracer does not block in Lambda yet, so a response is never a blocked one.
-      blocked: false,
-    }, true)
+    const samplingDecision = statusCode
+      ? apiSecurity.sampleRootSpanRequest(span, {
+        method,
+        statusCode,
+        route: route ?? null,
+        // The tracer does not block in Lambda yet, so a response is never a blocked one.
+        blocked: false,
+      }, true)
+      : apiSecurity.SamplingDecision.SKIP
 
     if (samplingDecision === apiSecurity.SamplingDecision.SAMPLE) {
       persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }

--- a/packages/dd-trace/src/appsec/lambda.js
+++ b/packages/dd-trace/src/appsec/lambda.js
@@ -104,42 +104,46 @@ function onLambdaEndInvocation (data) {
     const { req, method, route } = activeInvocations.get(span)
     activeInvocations.delete(span)
 
-    const persistent = {}
+    try {
+      const persistent = {}
 
-    if (statusCode) {
-      persistent[addresses.HTTP_INCOMING_RESPONSE_CODE] = String(statusCode)
+      if (statusCode) {
+        persistent[addresses.HTTP_INCOMING_RESPONSE_CODE] = String(statusCode)
+      }
+
+      if (responseHeaders) {
+        const filteredHeaders = { ...responseHeaders }
+        delete filteredHeaders['set-cookie']
+        persistent[addresses.HTTP_INCOMING_RESPONSE_HEADERS] = filteredHeaders
+      }
+
+      const samplingDecision = statusCode
+        ? apiSecurity.sampleRootSpanRequest(span, {
+          method,
+          statusCode,
+          route: route ?? null,
+          // The tracer does not block in Lambda yet, so a response is never a blocked one.
+          blocked: false,
+        }, true)
+        : apiSecurity.SamplingDecision.SKIP
+
+      if (samplingDecision === apiSecurity.SamplingDecision.SAMPLE) {
+        persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }
+      }
+
+      let wafResult
+      if (!isEmpty(persistent)) {
+        wafResult = waf.run({ persistent }, req, undefined, span)
+      }
+
+      apiSecurity.reportRootSpanRequest(span, samplingDecision, wafResult)
+    } finally {
+      // The execution environment outlives the invocation, so the native WAF context and the
+      // module-level metrics queue must be released even if the work above threw.
+      waf.disposeContext(req)
+
+      Reporter.finishRequest(req, null, {}, undefined, span)
     }
-
-    if (responseHeaders) {
-      const filteredHeaders = { ...responseHeaders }
-      delete filteredHeaders['set-cookie']
-      persistent[addresses.HTTP_INCOMING_RESPONSE_HEADERS] = filteredHeaders
-    }
-
-    const samplingDecision = statusCode
-      ? apiSecurity.sampleRootSpanRequest(span, {
-        method,
-        statusCode,
-        route: route ?? null,
-        // The tracer does not block in Lambda yet, so a response is never a blocked one.
-        blocked: false,
-      }, true)
-      : apiSecurity.SamplingDecision.SKIP
-
-    if (samplingDecision === apiSecurity.SamplingDecision.SAMPLE) {
-      persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }
-    }
-
-    let wafResult
-    if (!isEmpty(persistent)) {
-      wafResult = waf.run({ persistent }, req, undefined, span)
-    }
-
-    apiSecurity.reportRootSpanRequest(span, samplingDecision, wafResult)
-
-    waf.disposeContext(req)
-
-    Reporter.finishRequest(req, null, {}, undefined, span)
   } catch (err) {
     log.error('[ASM] Error in Lambda end-invocation handler', err)
   }

--- a/packages/dd-trace/test/appsec/api_security/sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security/sampler.spec.js
@@ -522,7 +522,7 @@ describe('API Security Sampler', () => {
     })
 
     describe('missing route', () => {
-      const routeless = { ...request, route: null }
+      const routeless = { ...request, route: undefined }
 
       it('returns MISSING_ROUTE when there is no route', () => {
         assert.strictEqual(

--- a/packages/dd-trace/test/appsec/lambda.spec.js
+++ b/packages/dd-trace/test/appsec/lambda.spec.js
@@ -285,6 +285,19 @@ describe('AppSec Lambda handler', () => {
       sinon.assert.calledOnce(log.error)
     })
 
+    it('should release the WAF context and finish the report when the work throws', () => {
+      const span = fakeSpan()
+
+      lambda.onLambdaStartInvocation({ span, headers: {}, method: 'GET', path: '/' })
+      waf.run.throws(new Error('boom'))
+
+      lambda.onLambdaEndInvocation({ span, statusCode: '200' })
+
+      sinon.assert.calledOnce(waf.disposeContext)
+      sinon.assert.calledOnce(Reporter.finishRequest)
+      sinon.assert.calledOnce(log.error)
+    })
+
     it('should use the same synthetic req key across WAF run, dispose, and finishRequest', () => {
       const span = fakeSpan()
 

--- a/packages/dd-trace/test/appsec/lambda.spec.js
+++ b/packages/dd-trace/test/appsec/lambda.spec.js
@@ -6,6 +6,8 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
+const { AUTO_REJECT, USER_REJECT } = require('../../../../ext/priority')
+
 describe('AppSec Lambda handler', () => {
   let lambda
   let waf
@@ -14,9 +16,10 @@ describe('AppSec Lambda handler', () => {
   let log
   let addresses
 
-  const fakeSpan = () => {
+  const fakeSpan = (sampling) => {
     const tags = {}
     const spanContext = {
+      _sampling: sampling,
       getTag (key) { return tags[key] },
     }
     return {
@@ -393,6 +396,34 @@ describe('AppSec Lambda handler', () => {
       const other = invoke(fakeSpan(), { statusCode: '201' })
 
       assert.deepStrictEqual(other[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
+    })
+
+    it('should not sample when the trace is rejected', () => {
+      const persistent = invoke(fakeSpan({ priority: AUTO_REJECT }))
+
+      assert.equal(persistent[addresses.WAF_CONTEXT_PROCESSOR], undefined)
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestSchemaMetric)
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestNoSchemaMetric)
+      sinon.assert.notCalled(telemetry.incrementApiSecMissingRouteMetric)
+    })
+
+    it('should not sample when the trace is rejected by the user', () => {
+      const persistent = invoke(fakeSpan({ priority: USER_REJECT }))
+
+      assert.equal(persistent[addresses.WAF_CONTEXT_PROCESSOR], undefined)
+    })
+
+    it('should not report missing_route for a rejected trace without route', () => {
+      invoke(fakeSpan({ priority: AUTO_REJECT }), { route: undefined })
+
+      sinon.assert.notCalled(telemetry.incrementApiSecMissingRouteMetric)
+    })
+
+    it('should leave the TTL slot free after a rejected trace', () => {
+      invoke(fakeSpan({ priority: AUTO_REJECT }))
+      const kept = invoke(fakeSpan())
+
+      assert.deepStrictEqual(kept[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
     })
 
     it('should report missing_route when the event carried no route', () => {

--- a/packages/dd-trace/test/appsec/lambda.spec.js
+++ b/packages/dd-trace/test/appsec/lambda.spec.js
@@ -307,6 +307,163 @@ describe('AppSec Lambda handler', () => {
       assert.deepStrictEqual(startKey, { headers: { host: 'example.com' } })
     })
   })
+
+  describe('API Security', () => {
+    let apiSecurity
+    let telemetry
+
+    // The real sampler is used here on purpose: the sampling key is built from the method and
+    // route published on the start-invocation channel, and that plumbing is what these cases
+    // are about. Only the telemetry sink is stubbed.
+    beforeEach(() => {
+      telemetry = {
+        incrementApiSecRequestSchemaMetric: sinon.stub(),
+        incrementApiSecRequestNoSchemaMetric: sinon.stub(),
+        incrementApiSecMissingRouteMetric: sinon.stub(),
+      }
+
+      apiSecurity = proxyquire('../../src/appsec/api_security', {
+        '../telemetry': telemetry,
+      })
+
+      apiSecurity.configure({
+        appsec: { DD_API_SECURITY_ENABLED: true, DD_API_SECURITY_SAMPLE_DELAY: 30 },
+        apmTracingEnabled: true,
+      })
+
+      lambda = proxyquire('../../src/appsec/lambda', {
+        '../log': log,
+        './waf': waf,
+        './reporter': Reporter,
+        '../priority_sampler': { keepTrace },
+        './api_security': apiSecurity,
+      })
+    })
+
+    afterEach(() => {
+      // The sampler holds module-level state, so the TTL cache has to be cleared between cases.
+      apiSecurity.disable()
+    })
+
+    const invoke = (span, options = {}) => {
+      const { method = 'GET', statusCode = '200' } = options
+      // Not a destructuring default: these cases need to pass an explicit undefined route.
+      const route = 'route' in options ? options.route : '/api/{id}'
+
+      lambda.onLambdaStartInvocation({ span, headers: {}, method, path: '/api/1', route })
+      waf.run.resetHistory()
+      lambda.onLambdaEndInvocation({ span, statusCode })
+      return waf.run.firstCall?.args[0].persistent
+    }
+
+    it('should add the extract-schema processor when the invocation is sampled', () => {
+      const persistent = invoke(fakeSpan())
+
+      assert.deepStrictEqual(persistent[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
+    })
+
+    it('should not add the processor when API Security is disabled', () => {
+      apiSecurity.disable()
+
+      const persistent = invoke(fakeSpan())
+
+      assert.equal(persistent[addresses.WAF_CONTEXT_PROCESSOR], undefined)
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestSchemaMetric)
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestNoSchemaMetric)
+      sinon.assert.notCalled(telemetry.incrementApiSecMissingRouteMetric)
+    })
+
+    it('should not add the processor on a second invocation of the same endpoint', () => {
+      const first = invoke(fakeSpan())
+      const second = invoke(fakeSpan())
+
+      assert.deepStrictEqual(first[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
+      assert.equal(second[addresses.WAF_CONTEXT_PROCESSOR], undefined)
+    })
+
+    it('should sample again when the route differs', () => {
+      invoke(fakeSpan(), { route: '/api/{id}' })
+      const other = invoke(fakeSpan(), { route: '/other/{id}' })
+
+      assert.deepStrictEqual(other[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
+    })
+
+    it('should sample again when the status code differs', () => {
+      invoke(fakeSpan(), { statusCode: '200' })
+      const other = invoke(fakeSpan(), { statusCode: '201' })
+
+      assert.deepStrictEqual(other[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
+    })
+
+    it('should report missing_route when the event carried no route', () => {
+      const span = fakeSpan()
+      span.setTag('component', 'aws-lambda')
+
+      const persistent = invoke(span, { route: undefined })
+
+      assert.equal(persistent[addresses.WAF_CONTEXT_PROCESSOR], undefined)
+      sinon.assert.calledOnceWithExactly(telemetry.incrementApiSecMissingRouteMetric, 'aws-lambda')
+    })
+
+    it('should not report missing_route on a 404 without route', () => {
+      const persistent = invoke(fakeSpan(), { route: undefined, statusCode: '404' })
+
+      assert.equal(persistent[addresses.WAF_CONTEXT_PROCESSOR], undefined)
+      sinon.assert.notCalled(telemetry.incrementApiSecMissingRouteMetric)
+    })
+
+    it('should skip sampling when the invocation has no status code', () => {
+      const span = fakeSpan()
+      lambda.onLambdaStartInvocation({ span, headers: {}, method: 'GET', path: '/', route: '/api/{id}' })
+      waf.run.resetHistory()
+
+      lambda.onLambdaEndInvocation({ span })
+
+      sinon.assert.notCalled(waf.run)
+      sinon.assert.notCalled(telemetry.incrementApiSecMissingRouteMetric)
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestNoSchemaMetric)
+    })
+
+    it('should emit request.schema when the WAF returned schema attributes', () => {
+      const span = fakeSpan()
+      span.setTag('component', 'aws-lambda')
+      waf.run.returns({ attributes: { '_dd.appsec.s.req.body': [] } })
+
+      invoke(span)
+
+      sinon.assert.calledOnceWithExactly(telemetry.incrementApiSecRequestSchemaMetric, 'aws-lambda')
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestNoSchemaMetric)
+    })
+
+    it('should emit request.no_schema when the WAF returned no schema attributes', () => {
+      const span = fakeSpan()
+      span.setTag('component', 'aws-lambda')
+
+      invoke(span)
+
+      sinon.assert.calledOnceWithExactly(telemetry.incrementApiSecRequestNoSchemaMetric, 'aws-lambda')
+      sinon.assert.notCalled(telemetry.incrementApiSecRequestSchemaMetric)
+    })
+
+    it('should keep the response addresses alongside the processor', () => {
+      const span = fakeSpan()
+      lambda.onLambdaStartInvocation({ span, headers: {}, method: 'GET', path: '/', route: '/api/{id}' })
+      waf.run.resetHistory()
+
+      lambda.onLambdaEndInvocation({
+        span,
+        statusCode: '200',
+        responseHeaders: { 'content-type': 'application/json', 'set-cookie': 'foo=bar' },
+      })
+
+      const { persistent } = waf.run.firstCall.args[0]
+      assert.equal(persistent[addresses.HTTP_INCOMING_RESPONSE_CODE], '200')
+      assert.deepStrictEqual(persistent[addresses.HTTP_INCOMING_RESPONSE_HEADERS], {
+        'content-type': 'application/json',
+      })
+      assert.deepStrictEqual(persistent[addresses.WAF_CONTEXT_PROCESSOR], { 'extract-schema': true })
+    })
+  })
 })
 
 // ─── WAF path safety: contract enforcement for non-HTTP req ───────────────────


### PR DESCRIPTION
### What does this PR do?
Wires API Security into the Lambda diagnostic channels.
`method` and `route` are now carried from start-invocation to end-invocation, where they feed the sampling decision. When the invocation is sampled, the `extract-schema` processor is added to the final WAF pass and the resulting `_dd.appsec.s.*` attributes land on the root span.

### Motivation
API Security was unavailable on Lambda: the sampler was coupled to Node HTTP `req`/`res`, which do not exist there. The previous PR extracted a transport-agnostic core; this one is the Lambda entry point for it.

[APPSEC-68818](https://datadoghq.atlassian.net/browse/APPSEC-68818)

### Additional Notes

#### Contracts with the layer
- `statusCode` arrives as a **normalized string** (`extractHTTPStatusCodeTag`), never a number: `"502"` for a buffered handler returning `undefined`, `"200"` for streaming or an HTTP trigger with no status, `undefined` for non-HTTP triggers. That is why the sampler's 404 check coerces with `Number()`.
- `blocked` is hardcoded `false`: the layer publishes no blocking verdict, and the tracer does not block in Lambda yet.
- Non-HTTP triggers (SQS, SNS, Kinesis, …) never reach the sampler. The layer skips start-invocation for them, so the `activeInvocations` lookup misses and the handler returns early.

#### Cleanup guarantee
The layer publishes `end-invocation` from a `finally` block with no try/catch of its own, so a throwing subscriber would replace the customer handler's real result. WAF context disposal and `Reporter.finishRequest` are therefore in a `finally` here: the execution environment outlives the invocation, and `finishRequest` clears the module-level `metricsQueue`, which would otherwise leak WAF metrics onto the next invocation's span.

Standalone billing comes for free: `keepTrace` lives in the shared core.



[APPSEC-68818]: https://datadoghq.atlassian.net/browse/APPSEC-68818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ