### PR TITLE
test(test-optimization): cover Pino and Winston logs in WebdriverIO

### DIFF
--- a/integration-tests/webdriverio/fixtures/automatic-log-submission-logger.js
+++ b/integration-tests/webdriverio/fixtures/automatic-log-submission-logger.js
@@ -1,0 +1,21 @@
+'use strict'
+
+let logger
+
+if (process.env.TEST_LOGGER === 'bunyan') {
+  logger = require('bunyan').createLogger({ name: 'test-logger' })
+} else if (process.env.TEST_LOGGER === 'pino') {
+  logger = require('pino')({ level: 'info' })
+} else {
+  const { createLogger, format, transports } = require('winston')
+  logger = createLogger({
+    level: 'info',
+    exitOnError: false,
+    format: format.json(),
+    transports: [
+      new transports.Console(),
+    ],
+  })
+}
+
+module.exports = logger

--- a/integration-tests/webdriverio/fixtures/automatic-log-submission.e2e.js
+++ b/integration-tests/webdriverio/fixtures/automatic-log-submission.e2e.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 
-const logger = require('bunyan').createLogger({ name: 'test-logger' })
+const logger = require('./automatic-log-submission-logger')
 
 describe('WebdriverIO automatic log submission', () => {
   it('logs from an active Test Optimization span', () => {

--- a/integration-tests/webdriverio/fixtures/wdio.conf.js
+++ b/integration-tests/webdriverio/fixtures/wdio.conf.js
@@ -34,7 +34,7 @@ const baseConfig = {
 const scenarioConfig = {
   automaticLogSubmission: {
     after () {
-      require('bunyan').createLogger({ name: 'after-hook-logger' }).info('Hello from WebdriverIO after hook!')
+      require('./automatic-log-submission-logger').info('Hello from WebdriverIO after hook!')
     },
     maxInstances: 1,
     specs: ['./automatic-log-submission.e2e.js'],

--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -166,6 +166,8 @@ for (const version of versions) {
       `@wdio/local-runner@${version}`,
       `@wdio/mocha-framework@${version}`,
       'bunyan',
+      'pino',
+      'winston',
     ], true, [
       './integration-tests/webdriverio/fixtures/*',
       './integration-tests/ci-visibility/dynamic-instrumentation/dependency.js',
@@ -303,70 +305,88 @@ for (const version of versions) {
 
         if (version === 'latest') {
           describe('automatic log submission', () => {
-            it('submits correlated Bunyan logs', async () => {
-              await runScenario('automaticLogSubmission', 1, payloads => {
-                const logRequests = getLogRequests(payloads)
+            const loggers = {
+              bunyan: { level: 30, messageKey: 'msg' },
+              pino: { level: 30, messageKey: 'msg' },
+              winston: { level: 'info', messageKey: 'message' },
+            }
 
-                assert.ok(logRequests.length > 0)
-                for (const logRequest of logRequests) {
-                  assert.strictEqual(logRequest.headers['dd-api-key'], '1')
-                  assert.strictEqual(logRequest.headers['content-type'], 'application/json')
-                  assert.strictEqual(logRequest.url, '/api/v2/logs?ddsource=bunyan&service=my-service')
-                }
+            for (const [loggerName, { level: expectedLevel, messageKey }] of Object.entries(loggers)) {
+              describe(`with ${loggerName}`, () => {
+                it('submits correlated logs', async () => {
+                  await runScenario('automaticLogSubmission', 1, payloads => {
+                    const logRequests = getLogRequests(payloads)
 
-                const logMessages = logRequests.flatMap(({ logMessage }) => logMessage)
-                assert.strictEqual(logMessages.length, 2)
+                    assert.ok(logRequests.length > 0)
+                    for (const logRequest of logRequests) {
+                      assert.strictEqual(logRequest.headers['dd-api-key'], '1')
+                      assert.strictEqual(logRequest.headers['content-type'], 'application/json')
+                      assert.strictEqual(
+                        logRequest.url,
+                        `/api/v2/logs?ddsource=${loggerName}&service=my-service`
+                      )
+                    }
 
-                const logMessage = logMessages.find(({ msg }) => msg === 'Hello from WebdriverIO!')
-                const afterHookLogMessage = logMessages.find(
-                  ({ msg }) => msg === 'Hello from WebdriverIO after hook!'
-                )
-                const test = getEvents(payloads).find(event => event.type === 'test').content
+                    const logMessages = logRequests.flatMap(({ logMessage }) => logMessage)
+                    assert.strictEqual(logMessages.length, 2)
 
-                assert.ok(logMessage)
-                assert.strictEqual(logMessage.level, 30)
-                assert.deepStrictEqual(Object.keys(logMessage.dd).sort(), ['service', 'span_id', 'trace_id'])
-                assert.strictEqual(logMessage.dd.service, 'my-service')
-                assert.strictEqual(logMessage.dd.span_id, test.span_id.toString())
-                assert.strictEqual(logMessage.dd.trace_id, test.trace_id.toString())
-                assert.ok(afterHookLogMessage)
-                assert.strictEqual(afterHookLogMessage.level, 30)
-              }, {
-                DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
-                DD_SERVICE: 'my-service',
+                    const logMessage = logMessages.find(
+                      logMessage => logMessage[messageKey] === 'Hello from WebdriverIO!'
+                    )
+                    const afterHookLogMessage = logMessages.find(
+                      logMessage => logMessage[messageKey] === 'Hello from WebdriverIO after hook!'
+                    )
+                    const test = getEvents(payloads).find(event => event.type === 'test').content
+
+                    assert.ok(logMessage)
+                    assert.strictEqual(logMessage.level, expectedLevel)
+                    assert.deepStrictEqual(Object.keys(logMessage.dd).sort(), ['service', 'span_id', 'trace_id'])
+                    assert.strictEqual(logMessage.dd.service, 'my-service')
+                    assert.strictEqual(logMessage.dd.span_id, test.span_id.toString())
+                    assert.strictEqual(logMessage.dd.trace_id, test.trace_id.toString())
+                    assert.ok(afterHookLogMessage)
+                    assert.strictEqual(afterHookLogMessage.level, expectedLevel)
+                  }, {
+                    DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+                    DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
+                    DD_SERVICE: 'my-service',
+                    TEST_LOGGER: loggerName,
+                  })
+
+                  assert.match(testOutput, /Hello from WebdriverIO!/)
+                })
+
+                it('does not submit logs when automatic submission is disabled', async () => {
+                  await runScenario('automaticLogSubmission', 1, payloads => {
+                    assert.strictEqual(getLogRequests(payloads).length, 0)
+                  }, {
+                    DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
+                    DD_SERVICE: 'my-service',
+                    TEST_LOGGER: loggerName,
+                  })
+
+                  assert.match(testOutput, /Hello from WebdriverIO!/)
+                  assert.match(testOutput, /span_id/)
+                })
+
+                it('does not submit logs when the API key is missing', async () => {
+                  await runScenario('automaticLogSubmission', 1, payloads => {
+                    assert.strictEqual(getLogRequests(payloads).length, 0)
+                  }, {
+                    ...getCiVisEvpProxyConfig(receiver.port),
+                    DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+                    DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
+                    DD_API_KEY: '',
+                    DD_SERVICE: 'my-service',
+                    NODE_OPTIONS: '-r dd-trace/ci/init --import dd-trace/register.js',
+                    TEST_LOGGER: loggerName,
+                  })
+
+                  assert.match(testOutput, /Hello from WebdriverIO!/)
+                  assert.match(testOutput, /span_id/)
+                })
               })
-
-              assert.match(testOutput, /Hello from WebdriverIO!/)
-            })
-
-            it('does not submit Bunyan logs when automatic submission is disabled', async () => {
-              await runScenario('automaticLogSubmission', 1, payloads => {
-                assert.strictEqual(getLogRequests(payloads).length, 0)
-              }, {
-                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
-                DD_SERVICE: 'my-service',
-              })
-
-              assert.match(testOutput, /Hello from WebdriverIO!/)
-              assert.match(testOutput, /span_id/)
-            })
-
-            it('does not submit Bunyan logs when the API key is missing', async () => {
-              await runScenario('automaticLogSubmission', 1, payloads => {
-                assert.strictEqual(getLogRequests(payloads).length, 0)
-              }, {
-                ...getCiVisEvpProxyConfig(receiver.port),
-                DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
-                DD_API_KEY: '',
-                DD_SERVICE: 'my-service',
-                NODE_OPTIONS: '-r dd-trace/ci/init --import dd-trace/register.js',
-              })
-
-              assert.match(testOutput, /Hello from WebdriverIO!/)
-              assert.match(testOutput, /span_id/)
-            })
+            }
           })
         }
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds Pino and Winston to the existing WebdriverIO Test Optimization automatic log submission integration coverage, alongside Bunyan. The matrix exercises all three loggers with both the Mocha and Jasmine adapters, including correlated submission, disabled automatic submission, and missing-API-key behavior.

The WebdriverIO fixture selects the logger through `TEST_LOGGER`, and the assertions preserve each logger's source, level, and message-field shape. No production code changes are included.

### Motivation
<!-- What inspired you to submit this pull request? -->

Completes non-Jest WebdriverIO coverage now that Pino submission (#9978), Winston's shared sender (#9922), and WebdriverIO's awaited worker-shutdown flush (#9964) are all on `master`. The lifecycle and sender are logger-agnostic; this PR verifies that contract for both remaining structured loggers.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Based directly on `master`; this PR is not stacked on the shared Mocha/Cucumber/Vitest or Playwright matrix PRs.
- Covers the latest supported WebdriverIO release under both Mocha and Jasmine.
- Verifies the test log's `dd.service`, decimal `dd.trace_id`, and `dd.span_id`, plus final `after`-hook delivery before worker exit.
- Verifies no log intake requests when automatic submission is disabled or the API key is missing.
- `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha --timeout 180000 integration-tests/webdriverio/webdriverio.test-optimization.spec.js --grep 'automatic log submission'` — 18 passing.
- Targeted ESLint and `git diff --check` — passing.
