### PR TITLE
fix(test-optimization): use a 10-second flush interval

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -7,7 +7,7 @@ const { getEnvironmentVariable, getValueFromEnvSources } = require('../packages/
 const { isFalse, isTrue } = require('../packages/dd-trace/src/util')
 
 const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm']
-const DEFAULT_FLUSH_INTERVAL = 5000
+const DEFAULT_FLUSH_INTERVAL = 10_000
 const JEST_FLUSH_INTERVAL = 0
 const VITEST_NO_WORKER_INIT_ACTIVE_ENV = 'DD_TEST_OPT_VITEST_NO_WORKER_INIT_ACTIVE'
 const VALIDATION_MODE_ENV = '_DD_TEST_OPTIMIZATION_VALIDATION_MODE'

--- a/packages/dd-trace/test/ci-visibility/validation-init.spec.js
+++ b/packages/dd-trace/test/ci-visibility/validation-init.spec.js
@@ -97,7 +97,7 @@ describe('Test Optimization validation initialization', () => {
     assert.deepStrictEqual(tracer.init.firstCall.args[0], {
       startupLogs: false,
       isCiVisibility: true,
-      flushInterval: 5000,
+      flushInterval: 10_000,
       experimental: { exporter: 'ci_validation' },
     })
   })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Changes the default Test Optimization periodic flush interval from 5 seconds to 10 seconds. Jest workers keep their existing zero interval.

### Motivation
<!-- What inspired you to submit this pull request? -->

A longer periodic interval reduces small payload request frequency and gives the encoder more opportunity to batch events. The encoder size gate and final flush continue to send data independently of this interval.

This was extracted from #9987 so the two-line configuration change can be reviewed separately while #9987 remains the combined E2E validation branch. #10017 has merged, and this PR is now based directly on master.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verification:

- 9 Test Optimization validation-initialization unit tests
- ESLint and git diff --check
