### PR TITLE
feat(test-optimization): support Pino and Bunyan in Jest

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -84,6 +84,7 @@ describe('test optimization automatic log submission', () => {
     {
       name: 'jest',
       command: 'node ./node_modules/jest/bin/jest --config ./ci-visibility/automatic-log-submission/config-jest.js',
+      loggerNames: ['winston', 'bunyan', 'pino'],
     },
     {
       name: 'cucumber',

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/bunyan-mock-test.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/bunyan-mock-test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const bunyan = require('bunyan')
+
+jest.mock('bunyan', () => ({
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+  })),
+}))
+
+describe('bunyan mock test', () => {
+  it('uses the Bunyan mock', () => {
+    const logger = bunyan.createLogger()
+    logger.info('test')
+    expect(bunyan.createLogger).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledTimes(1)
+  })
+})

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/logger-resolver.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/logger-resolver.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const path = require('node:path')
+
+/**
+ * @param {string} request
+ * @param {{ defaultResolver: (request: string, options: object) => string }} options
+ * @returns {string}
+ */
+module.exports = function loggerResolver (request, options) {
+  if (request === process.env.TEST_LOGGER) {
+    return path.join(__dirname, 'mapped-logger.js')
+  }
+  return options.defaultResolver(request, options)
+}

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/mapped-logger-test.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/mapped-logger-test.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const loggerModule = require(process.env.TEST_LOGGER)
+
+describe(`${process.env.TEST_LOGGER} mapped logger test`, () => {
+  it('uses the mapped logger', () => {
+    expect(loggerModule).toEqual({ mapped: true })
+  })
+})

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/mapped-logger.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/mapped-logger.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = { mapped: true }

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/pino-mock-test.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/pino-mock-test.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const pino = require('pino')
+
+jest.mock('pino', () => jest.fn(() => ({
+  info: jest.fn(),
+})))
+
+describe('pino mock test', () => {
+  it('uses the Pino mock', () => {
+    const logger = pino()
+    logger.info('test')
+    expect(pino).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledTimes(1)
+  })
+})

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/test-sequencer.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/test-sequencer.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const Sequencer = require('@jest/test-sequencer').default
+
+module.exports = class TestSequencer extends Sequencer {
+  /**
+   * @param {Array<{ path: string }>} tests
+   * @returns {Array<{ path: string }>}
+   */
+  sort (tests) {
+    return tests.sort((a, b) => a.path.localeCompare(b.path))
+  }
+}

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/z-real-logger-test.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/z-real-logger-test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const loggerName = process.env.TEST_LOGGER
+const logger = loggerName === 'pino'
+  ? require('pino')()
+  : require('bunyan').createLogger({ name: 'test-logger' })
+
+describe(`${loggerName} real logger test`, () => {
+  it('uses the real logger after another suite mocks it', () => {
+    logger.info('real logger after mock')
+  })
+})

--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -40,6 +40,9 @@ function getJestRunArgs (options) {
   if (options.randomize) {
     args.push('--randomize', `--seed=${options.seed}`, '--showSeed')
   }
+  if (options.testSequencer) {
+    args.push('--testSequencer', options.testSequencer)
+  }
 
   return args
 }
@@ -120,6 +123,10 @@ if (process.env.JEST_RANDOMIZE) {
 
 if (process.env.JEST_TEST_NAME_PATTERN) {
   options.testNamePattern = process.env.JEST_TEST_NAME_PATTERN
+}
+
+if (process.env.TEST_SEQUENCER) {
+  options.testSequencer = process.env.TEST_SEQUENCER
 }
 
 if (process.env.USE_JEST_RUN) {

--- a/integration-tests/config-jest.js
+++ b/integration-tests/config-jest.js
@@ -27,6 +27,14 @@ if (process.env.CONFIG_TRANSFORM) {
   config.transform = JSON.parse(process.env.CONFIG_TRANSFORM)
 }
 
+if (process.env.CONFIG_MODULE_NAME_MAPPER) {
+  config.moduleNameMapper = JSON.parse(process.env.CONFIG_MODULE_NAME_MAPPER)
+}
+
+if (process.env.CONFIG_RESOLVER) {
+  config.resolver = process.env.CONFIG_RESOLVER
+}
+
 if (process.env.JEST_THROWING_REPORTER) {
   config.reporters = ['<rootDir>/ci-visibility/jest-reporter-throws.js']
 }

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -78,9 +78,11 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
     ...getBabelDependencies(JEST_VERSION),
     '@happy-dom/jest-environment',
-    'office-addin-mock',
-    'winston',
+    'bunyan',
     'jest-image-snapshot',
+    'office-addin-mock',
+    'pino',
+    'winston',
   ].filter(Boolean), true)
 
   before(function () {
@@ -3573,6 +3575,100 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       const [code] = await once(childProcess, 'exit')
       assert.strictEqual(code, 0, `Jest should pass but failed with code ${code}`)
     })
+  })
+
+  context('Pino and Bunyan module loading', () => {
+    for (const loggerName of ['pino', 'bunyan']) {
+      for (const resolutionType of ['moduleNameMapper', 'custom resolver']) {
+        it(`respects Jest ${resolutionType} for ${loggerName}`, async () => {
+          let testOutput = ''
+          const resolutionConfig = resolutionType === 'moduleNameMapper'
+            ? {
+                CONFIG_MODULE_NAME_MAPPER: JSON.stringify({
+                  [`^${loggerName}$`]: '<rootDir>/ci-visibility/jest-mock-bypass-require/mapped-logger.js',
+                }),
+              }
+            : {
+                CONFIG_RESOLVER: '<rootDir>/ci-visibility/jest-mock-bypass-require/logger-resolver.js',
+              }
+
+          childProcess = exec(
+            runTestsCommand,
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                ...resolutionConfig,
+                TEST_LOGGER: loggerName,
+                TESTS_TO_RUN: 'jest-mock-bypass-require/mapped-logger-test',
+                USE_CONFIG_FILE: '1',
+                USE_JEST_RUN: '1',
+              },
+            }
+          )
+          childProcess.stdout.on('data', chunk => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr.on('data', chunk => {
+            testOutput += chunk.toString()
+          })
+
+          const [code] = await once(childProcess, 'exit')
+          assert.strictEqual(code, 0, `Jest should pass but failed with code ${code}: ${testOutput}`)
+        })
+      }
+
+      it(`instruments ${loggerName} after another suite mocks it`, async () => {
+        let testOutput = ''
+        const logsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
+            assert.strictEqual(payloads.length, 1, testOutput)
+
+            const [{ headers, logMessage, url }] = payloads
+            assert.strictEqual(headers['content-type'], 'application/json')
+            assert.strictEqual(headers['dd-api-key'], 'api-key')
+            assert.strictEqual(url, `/api/v2/logs?ddsource=${loggerName}&service=my-service`)
+            assert.strictEqual(logMessage.length, 1)
+
+            const [{ dd, msg }] = logMessage
+            assert.strictEqual(msg, 'real logger after mock')
+            assert.strictEqual(dd.service, 'my-service')
+            assert.match(dd.trace_id, /^\d+$/)
+            assert.match(dd.span_id, /^\d+$/)
+          })
+
+        childProcess = exec(
+          runTestsCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
+              DD_API_KEY: 'api-key',
+              DD_SERVICE: 'my-service',
+              TEST_LOGGER: loggerName,
+              TEST_SEQUENCER: './ci-visibility/jest-mock-bypass-require/test-sequencer.js',
+              TESTS_TO_RUN: `jest-mock-bypass-require/(${loggerName}-mock|z-real-logger)-test`,
+              USE_JEST_RUN: '1',
+            },
+          }
+        )
+        childProcess.stdout.on('data', chunk => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', chunk => {
+          testOutput += chunk.toString()
+        })
+
+        const [[code]] = await Promise.all([
+          once(childProcess, 'exit'),
+          logsPromise,
+        ])
+
+        assert.strictEqual(code, 0, `Jest should pass but failed with code ${code}: ${testOutput}`)
+      })
+    }
   })
 
   context('seed suffix normalization', () => {

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -3582,6 +3582,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       for (const resolutionType of ['moduleNameMapper', 'custom resolver']) {
         it(`respects Jest ${resolutionType} for ${loggerName}`, async () => {
           let testOutput = ''
+          // Ensure the native bypass still defers to Jest when its resolution is customized.
           const resolutionConfig = resolutionType === 'moduleNameMapper'
             ? {
                 CONFIG_MODULE_NAME_MAPPER: JSON.stringify({
@@ -3648,6 +3649,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
               DD_API_KEY: 'api-key',
               DD_SERVICE: 'my-service',
               TEST_LOGGER: loggerName,
+              // Run the mocked suite first to expose bypass state leaking between Jest runtimes.
               TEST_SEQUENCER: './ci-visibility/jest-mock-bypass-require/test-sequencer.js',
               TESTS_TO_RUN: `jest-mock-bypass-require/(${loggerName}-mock|z-real-logger)-test`,
               USE_JEST_RUN: '1',

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -3727,6 +3727,8 @@ if (DD_MAJOR < 6) {
 }
 
 const LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE = new Set([
+  'bunyan',
+  'pino',
   'selenium-webdriver',
   'selenium-webdriver/chrome',
   'selenium-webdriver/edge',
@@ -3784,8 +3786,6 @@ function wrapJestObject (jestObject, suiteFilePath) {
   wrappedJestObjects.add(jestObject)
 
   shimmer.wrap(jestObject, 'mock', mock => function (moduleName) {
-    // If the library is mocked with `jest.mock`, we don't want to bypass jest's own require engine
-    LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.delete(moduleName)
     recordMockedFile(suiteFilePath, moduleName)
     return mock.apply(this, arguments)
   })
@@ -3868,6 +3868,31 @@ function requireOutsideJestRequireEngine (runtime, moduleName) {
   return require(moduleName)
 }
 
+/**
+ * @param {object} runtime
+ * @param {string} from
+ * @param {string} moduleName
+ * @returns {string | undefined}
+ */
+function getJestBypassModulePath (runtime, from, moduleName) {
+  if (!LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.has(moduleName)) return
+
+  try {
+    let jestModulePath
+    if (typeof runtime._resolveCjsModule === 'function') {
+      jestModulePath = runtime._resolveCjsModule(from, moduleName)
+    } else if (typeof runtime.cjsLoader?.resolution?.resolveCjs === 'function') {
+      jestModulePath = runtime.cjsLoader.resolution.resolveCjs(from, moduleName)
+    } else {
+      // Jest 24-27 uses this name for its synchronous CommonJS resolver.
+      jestModulePath = runtime._resolveModule(from, moduleName)
+    }
+    if (jestModulePath === createRequire(from).resolve(moduleName)) return jestModulePath
+  } catch {
+    // Let Jest produce its own resolution error or load a resolver-only module.
+  }
+}
+
 function formatDefaultStackTrace (error, structuredStackTrace) {
   const errorString = Error.prototype.toString.call(error)
   if (structuredStackTrace.length === 0) return errorString
@@ -3894,7 +3919,11 @@ addHook({
   shimmer.wrap(Runtime.prototype, 'requireModule', requireModule => function (from, moduleName) {
     wrapJestGlobalsForRuntime(this)
     try {
-      const returnedValue = requireModule.apply(this, arguments)
+      // Jest calls requireModule only after deciding that the module should not be mocked.
+      const bypassModulePath = getJestBypassModulePath(this, from, moduleName)
+      const returnedValue = bypassModulePath
+        ? requireOutsideJestRequireEngine(this, bypassModulePath)
+        : requireModule.apply(this, arguments)
       if (moduleName === '@jest/globals') {
         wrapConcurrentJestGlobalsForRuntime(this, returnedValue)
       }
@@ -3923,11 +3952,6 @@ addHook({
       return formatDefaultStackTrace(error, filteredStackTrace)
     }
     try {
-      // TODO: do this for every library that we instrument
-      if (LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.has(moduleName)) {
-        // To bypass jest's own require engine
-        return requireOutsideJestRequireEngine(this, moduleName)
-      }
       let returnedValue
       try {
         returnedValue = requireModuleOrMock.apply(this, arguments)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds automatic log-submission support for Pino and Bunyan in CommonJS Jest tests.

Jest normally loads these packages through its custom module engine, which prevents dd-trace's native module hooks from installing their existing correlation and log-publication wrappers. This change adds both logger packages to the native-require bypass and moves that bypass after Jest has chosen real versus mocked loading.

The bypass only applies when Jest's resolved module path agrees with native Node.js resolution, preserving `moduleNameMapper` and custom resolver behavior. Jest mocks remain suite-local and a later suite in the same worker can still load and instrument the real logger.

### Motivation
<!-- What inspired you to submit this pull request? -->

Pino and Bunyan automatic log submission already works with the other supported Test Optimization frameworks, but Jest's custom CommonJS loader prevented their instrumentation from running. Winston already uses this Jest bypass.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Based on current `master`, including #9982.
- No Pino/Bunyan instrumentation, serialization, sender, or lifecycle code changes.
- Automatic log-submission matrix:
  `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha --timeout 180000 integration-tests/ci-visibility/automatic-log-submission.spec.js --grep 'with (winston|bunyan|pino) and jest'`
  Result: `9 passing`.
- Latest Jest module-loading regressions:
  `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER ./node_modules/.bin/mocha --timeout 180000 integration-tests/jest/jest.test-management.spec.js --grep 'Pino and Bunyan module loading'`
  Result: `6 passing`.
- Oldest supported Jest module-loading regressions:
  `env -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER JEST_VERSION=oldest ./node_modules/.bin/mocha --timeout 180000 integration-tests/jest/jest.test-management.spec.js --grep 'Pino and Bunyan module loading'`
  Result: `6 passing` on Jest 28.0.0.
- Targeted ESLint and `git diff --check` pass.
