### PR TITLE
perf(test-optimization): avoid loading startup modules outside test mode

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -276,7 +276,9 @@ class Tracer extends NoopProxy {
         this._modules.rewriter.enable(config)
       }
 
-      if (config.DD_TRACE_ENABLED && config.testOptimization.DD_CIVISIBILITY_MANUAL_API_ENABLED) {
+      if (config.isCiVisibility &&
+        config.DD_TRACE_ENABLED &&
+        config.testOptimization.DD_CIVISIBILITY_MANUAL_API_ENABLED) {
         const TestApiManualPlugin = require('./ci-visibility/test-api-manual/test-api-manual-plugin')
         this._testApiManualPlugin = new TestApiManualPlugin(this)
         // `shouldGetEnvironmentData` is passed as false so that we only lazily calculate it
@@ -297,7 +299,7 @@ class Tracer extends NoopProxy {
         }
       }
 
-      if (config.testOptimization.DD_TEST_FAILED_TEST_REPLAY_ENABLED) {
+      if (config.isCiVisibility && config.testOptimization.DD_TEST_FAILED_TEST_REPLAY_ENABLED) {
         const getDynamicInstrumentationClient = require('./ci-visibility/dynamic-instrumentation')
         // We instantiate the client but do not start the Worker here. The worker is started lazily
         getDynamicInstrumentationClient(config)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -286,7 +286,7 @@ class Tracer extends NoopProxy {
         // are lazily configured when the library is imported.
         this._testApiManualPlugin.configure({ ...config, enabled: true }, false)
       }
-      if (config.DD_AGENTLESS_LOG_SUBMISSION_ENABLED) {
+      if (config.isCiVisibility && config.DD_AGENTLESS_LOG_SUBMISSION_ENABLED) {
         if (config.DD_API_KEY) {
           const LogSubmissionPlugin = require('./ci-visibility/log-submission/log-submission-plugin')
           const automaticLogPlugin = new LogSubmissionPlugin(this)

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -318,8 +318,10 @@ describe('TracerProxy', () => {
 
       it('only loads Test Optimization startup modules through ci/init', () => {
         const repoRoot = path.resolve(__dirname, '../../..')
+        const testOptimizationRoot = path.join(repoRoot, 'packages/dd-trace/src/ci-visibility') + path.sep
         const modules = [
           require.resolve('../src/ci-visibility/test-api-manual/test-api-manual-plugin'),
+          require.resolve('../src/ci-visibility/log-submission/log-submission-plugin'),
           require.resolve('../src/ci-visibility/dynamic-instrumentation'),
         ]
         const script = `
@@ -329,11 +331,26 @@ describe('TracerProxy', () => {
           }
           const modules = ${JSON.stringify(modules)}
           const loaded = modules.map(module => require.cache[module] !== undefined)
-          process.stdout.write(JSON.stringify(loaded), () => process.exit())
+          const testOptimizationModuleCount = Object.keys(require.cache)
+            .filter(module => module.startsWith(${JSON.stringify(testOptimizationRoot)}))
+            .length
+          process.stdout.write(JSON.stringify({ loaded, testOptimizationModuleCount }), () => process.exit())
         `
         const cases = [
-          { entrypoint: repoRoot, callInit: 'true', expected: [false, false] },
-          { entrypoint: path.join(repoRoot, 'ci/init'), callInit: 'false', expected: [true, true] },
+          {
+            entrypoint: repoRoot,
+            callInit: 'true',
+            environment: { DD_AGENTLESS_LOG_SUBMISSION_ENABLED: 'true' },
+            expected: [false, false, false],
+            expectedTestOptimizationModuleCount: 0,
+          },
+          { entrypoint: path.join(repoRoot, 'ci/init'), callInit: 'false', expected: [true, false, true] },
+          {
+            entrypoint: path.join(repoRoot, 'ci/init'),
+            callInit: 'false',
+            environment: { DD_AGENTLESS_LOG_SUBMISSION_ENABLED: 'true' },
+            expected: [true, true, true],
+          },
           {
             entrypoint: path.join(repoRoot, 'ci/init'),
             callInit: 'false',
@@ -341,7 +358,7 @@ describe('TracerProxy', () => {
               DD_CIVISIBILITY_MANUAL_API_ENABLED: 'false',
               DD_TEST_FAILED_TEST_REPLAY_ENABLED: 'false',
             },
-            expected: [false, false],
+            expected: [false, false, false],
           },
         ]
 
@@ -350,6 +367,9 @@ describe('TracerProxy', () => {
             encoding: 'utf8',
             env: {
               ...process.env,
+              DD_AGENTLESS_LOG_SUBMISSION_ENABLED: 'false',
+              DD_API_KEY: 'test-api-key',
+              DD_CIVISIBILITY_AGENTLESS_ENABLED: 'false',
               DD_CIVISIBILITY_ENABLED: 'true',
               DD_CIVISIBILITY_MANUAL_API_ENABLED: 'true',
               DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false',
@@ -364,7 +384,11 @@ describe('TracerProxy', () => {
           })
 
           assert.strictEqual(result.status, 0, result.stderr)
-          assert.deepStrictEqual(JSON.parse(result.stdout), testCase.expected)
+          const { loaded, testOptimizationModuleCount } = JSON.parse(result.stdout)
+          assert.deepStrictEqual(loaded, testCase.expected)
+          if (testCase.expectedTestOptimizationModuleCount !== undefined) {
+            assert.strictEqual(testOptimizationModuleCount, testCase.expectedTestOptimizationModuleCount)
+          }
         }
       })
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
 const { inspect } = require('node:util')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
@@ -312,6 +314,58 @@ describe('TracerProxy', () => {
         sinon.assert.calledWith(DatadogTracer, config)
         sinon.assert.calledOnceWithExactly(RemoteConfig, config)
         sinon.assert.notCalled(rewriter.enable)
+      })
+
+      it('only loads Test Optimization startup modules through ci/init', () => {
+        const repoRoot = path.resolve(__dirname, '../../..')
+        const modules = [
+          require.resolve('../src/ci-visibility/test-api-manual/test-api-manual-plugin'),
+          require.resolve('../src/ci-visibility/dynamic-instrumentation'),
+        ]
+        const script = `
+          const tracer = require(process.env.DD_TRACE_TEST_ENTRYPOINT)
+          if (process.env.DD_TRACE_TEST_CALL_INIT === 'true') {
+            tracer.init()
+          }
+          const modules = ${JSON.stringify(modules)}
+          const loaded = modules.map(module => require.cache[module] !== undefined)
+          process.stdout.write(JSON.stringify(loaded), () => process.exit())
+        `
+        const cases = [
+          { entrypoint: repoRoot, callInit: 'true', expected: [false, false] },
+          { entrypoint: path.join(repoRoot, 'ci/init'), callInit: 'false', expected: [true, true] },
+          {
+            entrypoint: path.join(repoRoot, 'ci/init'),
+            callInit: 'false',
+            environment: {
+              DD_CIVISIBILITY_MANUAL_API_ENABLED: 'false',
+              DD_TEST_FAILED_TEST_REPLAY_ENABLED: 'false',
+            },
+            expected: [false, false],
+          },
+        ]
+
+        for (const testCase of cases) {
+          const result = spawnSync(process.execPath, ['--eval', script], {
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              DD_CIVISIBILITY_ENABLED: 'true',
+              DD_CIVISIBILITY_MANUAL_API_ENABLED: 'true',
+              DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false',
+              DD_REMOTE_CONFIGURATION_ENABLED: 'false',
+              DD_TEST_FAILED_TEST_REPLAY_ENABLED: 'true',
+              DD_TRACE_ENABLED: 'true',
+              DD_TRACE_STARTUP_LOGS: 'false',
+              DD_TRACE_TEST_CALL_INIT: testCase.callInit,
+              DD_TRACE_TEST_ENTRYPOINT: testCase.entrypoint,
+              ...testCase.environment,
+            },
+          })
+
+          assert.strictEqual(result.status, 0, result.stderr)
+          assert.deepStrictEqual(JSON.parse(result.stdout), testCase.expected)
+        }
       })
 
       it('should enable the IAST rewriter when IAST is enabled', () => {


### PR DESCRIPTION
The manual API and failed-test replay flags default to enabled outside Test Optimization mode. Ordinary tracer initialization therefore loads 25 Test Optimization modules. Agentless test log submission had the same missing mode gate when explicitly enabled.

Gating these consumers reduced fresh-process Lambda initialization from 74.9 ms to 67.1 ms on Node.js 22. Node.js 24 fell from 73.1 ms to 63.6 ms.