### PR TITLE
feat(llmobs): auto-track managed prompts

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -3,12 +3,7 @@
 const log = require('../../log')
 const { storage: llmobsStorage } = require('../storage')
 const telemetry = require('../telemetry')
-const {
-  INPUT_PROMPT,
-  INSTRUMENTATION_METHOD_AUTO,
-  PROMPT_TRACKING_INSTRUMENTATION_METHOD,
-} = require('../constants/tags')
-const { getTrackedPrompt } = require('../prompts/tracking')
+const { captureTrackedPrompt } = require('../prompts/tracking')
 
 const TracingPlugin = require('../../plugins/tracing')
 const LLMObsTagger = require('../tagger')
@@ -37,17 +32,19 @@ class LLMObsPlugin extends TracingPlugin {
     const parentStore = llmobsStorage.getStore()
     const apmStore = ctx.currentStore
     const span = apmStore?.span
+    const prompt = captureTrackedPrompt(ctx) ?? parentStore?.prompt
 
     const registerOptions = this.getLLMObsSpanRegisterOptions(ctx)
 
     // register options may not be set for operations we do not trace with llmobs
     // ie OpenAI fine tuning jobs, file jobs, etc.
+    if (registerOptions || prompt) {
+      ctx.llmobs = { parent: parentStore, prompt }
+      llmobsStorage.enterWith({ ...parentStore, span: registerOptions ? span : parentStore?.span, prompt })
+    }
+
     if (registerOptions) {
       telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, integration: this.constructor.integration })
-
-      ctx.llmobs = {} // initialize context-based namespace
-      llmobsStorage.enterWith({ ...parentStore, span })
-      ctx.llmobs.parent = parentStore
 
       this._tagger.registerLLMObsSpan(span, {
         parent: parentStore?.span,
@@ -61,13 +58,7 @@ class LLMObsPlugin extends TracingPlugin {
     const enabled = this._tracerConfig.llmobs.DD_LLMOBS_ENABLED
     if (!enabled) return
 
-    // only attempt to restore the context if the current span was an LLMObs span
-    const apmStore = ctx.currentStore
-    const span = apmStore?.span
-    if (!LLMObsTagger.tagMap.has(span)) return
-
-    const parentStore = ctx.llmobs.parent
-    llmobsStorage.enterWith(parentStore)
+    if (ctx.llmobs) llmobsStorage.enterWith(ctx.llmobs.parent)
   }
 
   asyncEnd (ctx) {
@@ -88,20 +79,8 @@ class LLMObsPlugin extends TracingPlugin {
 
     this.setLLMObsTags(ctx)
 
-    if (LLMObsTagger.getSpanKind(span) !== 'llm' || LLMObsTagger.tagMap.get(span)?.[INPUT_PROMPT]) return
-
     try {
-      const prompt = getTrackedPrompt(
-        ctx.args?.[0], ctx.arguments?.[0], ctx.options, ctx.request, ctx.event
-      )
-      if (!prompt) return
-
-      this._tagger.tagPrompt(span, prompt, true)
-      if (LLMObsTagger.tagMap.get(span)?.[INPUT_PROMPT]) {
-        this._tagger.tagSpanTags(span, {
-          [PROMPT_TRACKING_INSTRUMENTATION_METHOD]: INSTRUMENTATION_METHOD_AUTO,
-        })
-      }
+      this._tagger.tagAutoPrompt(span, ctx.llmobs?.prompt)
     } catch (error) {
       log.debug('Failed to automatically track managed prompt: %s', error.message)
     }

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -3,6 +3,12 @@
 const log = require('../../log')
 const { storage: llmobsStorage } = require('../storage')
 const telemetry = require('../telemetry')
+const {
+  INPUT_PROMPT,
+  INSTRUMENTATION_METHOD_AUTO,
+  PROMPT_TRACKING_INSTRUMENTATION_METHOD,
+} = require('../constants/tags')
+const { getTrackedPrompt } = require('../prompts/tracking')
 
 const TracingPlugin = require('../../plugins/tracing')
 const LLMObsTagger = require('../tagger')
@@ -81,6 +87,24 @@ class LLMObsPlugin extends TracingPlugin {
     }
 
     this.setLLMObsTags(ctx)
+
+    if (LLMObsTagger.getSpanKind(span) !== 'llm' || LLMObsTagger.tagMap.get(span)?.[INPUT_PROMPT]) return
+
+    try {
+      const prompt = getTrackedPrompt(
+        ctx.args?.[0], ctx.arguments?.[0], ctx.options, ctx.request, ctx.event
+      )
+      if (!prompt) return
+
+      this._tagger.tagPrompt(span, prompt, true)
+      if (LLMObsTagger.tagMap.get(span)?.[INPUT_PROMPT]) {
+        this._tagger.tagSpanTags(span, {
+          [PROMPT_TRACKING_INSTRUMENTATION_METHOD]: INSTRUMENTATION_METHOD_AUTO,
+        })
+      }
+    } catch (error) {
+      log.debug('Failed to automatically track managed prompt: %s', error.message)
+    }
   }
 
   configure (config) {

--- a/packages/dd-trace/src/llmobs/prompts/prompt.js
+++ b/packages/dd-trace/src/llmobs/prompts/prompt.js
@@ -53,11 +53,12 @@ class ManagedPrompt {
    * @returns {string | Array<{role: string, content: string}>}
    */
   format (variables = {}) {
-    if (typeof this.template === 'string') return render(this.template, variables)
-    const rendered = this.template.map(message => ({
-      role: message.role,
-      content: render(message.content, variables),
-    }))
+    const rendered = typeof this.template === 'string'
+      ? render(this.template, variables)
+      : this.template.map(message => ({
+        role: message.role,
+        content: render(message.content, variables),
+      }))
     return trackPrompt(rendered, this.toAnnotation(variables))
   }
 

--- a/packages/dd-trace/src/llmobs/prompts/prompt.js
+++ b/packages/dd-trace/src/llmobs/prompts/prompt.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { trackPrompt } = require('./tracking')
+
 const VARIABLE_PATTERN = /\{\{?\s*(\w+)\s*\}\}?/g
 const PROMPT_SOURCES = new Set(['registry', 'cache', 'fallback', 'ff', 'resolve'])
 
@@ -52,7 +54,11 @@ class ManagedPrompt {
    */
   format (variables = {}) {
     if (typeof this.template === 'string') return render(this.template, variables)
-    return this.template.map(message => ({ role: message.role, content: render(message.content, variables) }))
+    const rendered = this.template.map(message => ({
+      role: message.role,
+      content: render(message.content, variables),
+    }))
+    return trackPrompt(rendered, this.toAnnotation(variables))
   }
 
   /**

--- a/packages/dd-trace/src/llmobs/prompts/tracking.js
+++ b/packages/dd-trace/src/llmobs/prompts/tracking.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const trackedPrompts = new WeakMap()
+
+function trackPrompt (rendered, prompt) {
+  if (Array.isArray(rendered)) trackedPrompts.set(rendered, prompt)
+  return rendered
+}
+
+function getTrackedPrompt (...values) {
+  for (const value of values) {
+    if (!value || typeof value !== 'object') continue
+
+    const prompt = trackedPrompts.get(value)
+    if (prompt) return prompt
+
+    if (Array.isArray(value)) continue
+
+    let candidates
+    try {
+      candidates = Object.values(value)
+    } catch {
+      continue
+    }
+
+    for (const candidate of candidates) {
+      if (candidate && typeof candidate === 'object') {
+        const prompt = trackedPrompts.get(candidate)
+        if (prompt) return prompt
+      }
+    }
+  }
+}
+
+module.exports = { getTrackedPrompt, trackPrompt }

--- a/packages/dd-trace/src/llmobs/prompts/tracking.js
+++ b/packages/dd-trace/src/llmobs/prompts/tracking.js
@@ -1,35 +1,87 @@
 'use strict'
 
 const trackedPrompts = new WeakMap()
+let config
 
-function trackPrompt (rendered, prompt) {
-  if (Array.isArray(rendered)) trackedPrompts.set(rendered, prompt)
-  return rendered
+/**
+ * Use the tracer's live configuration when deciding whether renders need a carrier.
+ * @param {import('../../config/config-base')} tracerConfig
+ * @returns {void}
+ */
+function configurePromptTracking (tracerConfig) {
+  config = tracerConfig
 }
 
-function getTrackedPrompt (...values) {
-  for (const value of values) {
-    if (!value || typeof value !== 'object') continue
+function trackPrompt (rendered, prompt) {
+  if (!config?.llmobs?.DD_LLMOBS_ENABLED) return rendered
 
-    const prompt = trackedPrompts.get(value)
-    if (prompt) return prompt
+  const tracked = typeof rendered === 'string' ? new Object(rendered) : rendered
+  trackedPrompts.set(tracked, prompt)
+  return tracked
+}
 
-    if (Array.isArray(value)) continue
+/**
+ * Capture the first exact managed-prompt carrier in an instrumented call and replace a boxed text
+ * carrier with its primitive value before the library receives it.
+ * @param {unknown} ctx
+ * @returns {Record<string, unknown> | undefined}
+ */
+function captureTrackedPrompt (ctx) {
+  if (!ctx || typeof ctx !== 'object') return
+  const context = /** @type {Record<string, unknown>} */ (ctx)
 
-    let candidates
-    try {
-      candidates = Object.values(value)
-    } catch {
-      continue
+  for (const field of ['args', 'arguments']) {
+    const args = context[field]
+    if (!Array.isArray(args)) continue
+
+    for (let index = 0; index < args.length; index++) {
+      const result = captureValue(args[index])
+      if (!result) continue
+      args[index] = result.value
+      return result.prompt
     }
+  }
 
-    for (const candidate of candidates) {
-      if (candidate && typeof candidate === 'object') {
-        const prompt = trackedPrompts.get(candidate)
-        if (prompt) return prompt
-      }
-    }
+  for (const field of ['options', 'request', 'event']) {
+    const result = captureValue(context[field])
+    if (!result) continue
+    context[field] = result.value
+    return result.prompt
   }
 }
 
-module.exports = { getTrackedPrompt, trackPrompt }
+/**
+ * Capture an exact carrier or a carrier used as a direct field of one call argument.
+ * @param {unknown} value
+ * @returns {{value: unknown, prompt: Record<string, unknown>} | undefined}
+ */
+function captureValue (value) {
+  if (!value || typeof value !== 'object') return
+
+  const prompt = trackedPrompts.get(value)
+  if (prompt) {
+    return { value: Array.isArray(value) ? value : value.valueOf(), prompt }
+  }
+
+  let entries
+  try {
+    entries = Object.entries(value)
+  } catch {
+    return
+  }
+
+  for (const [key, candidate] of entries) {
+    if (!candidate || typeof candidate !== 'object') continue
+    const prompt = trackedPrompts.get(candidate)
+    if (!prompt) continue
+
+    if (!Array.isArray(candidate)) {
+      try {
+        value[key] = candidate.valueOf()
+      } catch {}
+    }
+    return { value, prompt }
+  }
+}
+
+module.exports = { captureTrackedPrompt, configurePromptTracking, trackPrompt }

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -31,6 +31,7 @@ const { storage } = require('./storage')
 const telemetry = require('./telemetry')
 const LLMObsTagger = require('./tagger')
 const { createExperiments } = require('./experiments')
+const { configurePromptTracking } = require('./prompts/tracking')
 
 // communicating with writer
 const evalMetricAppendCh = channel('llmobs:eval-metric:append')
@@ -64,6 +65,7 @@ class LLMObs extends NoopLLMObs {
     this._llmobsModule = llmobsModule
     this._tagger = new LLMObsTagger(config)
     this.#provider = provider
+    configurePromptTracking(config)
   }
 
   get enabled () {

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -48,6 +48,7 @@ const {
   ROUTING_API_KEY,
   ROUTING_SITE,
   PROMPT_TRACKING_INSTRUMENTATION_METHOD,
+  INSTRUMENTATION_METHOD_AUTO,
   INSTRUMENTATION_METHOD_ANNOTATED,
   SAMPLE_RATE,
   SAMPLING_DECISION,
@@ -553,6 +554,21 @@ class LLMObsTagger {
     }
 
     this.tagSpanTags(span, { [PROMPT_TRACKING_INSTRUMENTATION_METHOD]: INSTRUMENTATION_METHOD_ANNOTATED })
+  }
+
+  /**
+   * Tag an automatically carried managed prompt without replacing an explicit annotation.
+   * @param {import('../opentracing/span')} span
+   * @param {Record<string, unknown> | undefined} prompt
+   * @returns {void}
+   */
+  tagAutoPrompt (span, prompt) {
+    if (!prompt || registry.get(span)?.[SPAN_KIND] !== 'llm' || registry.get(span)?.[INPUT_PROMPT]) return
+
+    this.tagPrompt(span, prompt, true)
+    if (registry.get(span)?.[INPUT_PROMPT]) {
+      this.tagSpanTags(span, { [PROMPT_TRACKING_INSTRUMENTATION_METHOD]: INSTRUMENTATION_METHOD_AUTO })
+    }
   }
 
   changeKind (span, newKind) {

--- a/packages/dd-trace/test/llmobs/plugins/base.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/base.spec.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const promptTracking = require('../../../src/llmobs/prompts/tracking')
+
+describe('LLMObsPlugin managed prompt tracking', () => {
+  let currentStore
+  let plugin
+
+  class TracingPlugin {
+    constructor (_tracer, tracerConfig) {
+      this._tracerConfig = tracerConfig
+    }
+  }
+
+  class Tagger {
+    constructor () {
+      this.registerLLMObsSpan = sinon.spy()
+      this.tagAutoPrompt = sinon.spy()
+    }
+  }
+
+  const storage = {
+    getStore: () => currentStore,
+    enterWith: store => { currentStore = store },
+  }
+  const LLMObsPlugin = proxyquire('../../../src/llmobs/plugins/base', {
+    '../../plugins/tracing': TracingPlugin,
+    '../storage': { storage },
+    '../tagger': Tagger,
+    '../telemetry': { incrementLLMObsSpanStartCount () {} },
+  })
+
+  class TestPlugin extends LLMObsPlugin {
+    static integration = 'test'
+
+    getLLMObsSpanRegisterOptions () {
+      return { kind: 'llm' }
+    }
+
+    setLLMObsTags (ctx) {
+      ctx.tagged = true
+    }
+  }
+
+  beforeEach(() => {
+    const config = { llmobs: { DD_LLMOBS_ENABLED: true } }
+    promptTracking.configurePromptTracking(config)
+    plugin = new TestPlugin(null, config)
+  })
+
+  afterEach(() => {
+    promptTracking.configurePromptTracking({ llmobs: { DD_LLMOBS_ENABLED: false } })
+  })
+
+  it('captures, propagates, tags, and restores an exact prompt carrier through the shared lifecycle', () => {
+    const parentSpan = {}
+    const parentStore = { span: parentSpan }
+    const span = {}
+    const prompt = { id: 'managed', version: '1', template: 'Hello' }
+    const request = { prompt: promptTracking.trackPrompt('Hello', prompt) }
+    const ctx = { args: [request], currentStore: { span } }
+    currentStore = parentStore
+
+    plugin.start(ctx)
+
+    assert.strictEqual(request.prompt, 'Hello')
+    assert.deepStrictEqual(currentStore, { span, prompt })
+    sinon.assert.calledOnceWithExactly(plugin._tagger.registerLLMObsSpan, span, {
+      parent: parentSpan,
+      integration: 'test',
+      kind: 'llm',
+    })
+
+    plugin.asyncEnd(ctx)
+    assert.strictEqual(ctx.tagged, true)
+    sinon.assert.calledOnceWithExactly(plugin._tagger.tagAutoPrompt, span, prompt)
+
+    plugin.end(ctx)
+    assert.strictEqual(currentStore, parentStore)
+  })
+})

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
@@ -6,6 +6,7 @@ const { describe, it, beforeEach } = require('mocha')
 const semifies = require('semifies')
 
 const { withVersions } = require('../../../setup/mocha')
+const ManagedPrompt = require('../../../../src/llmobs/prompts/prompt')
 
 const {
   useLlmObs,
@@ -177,6 +178,69 @@ describe('integrations', () => {
           },
           tags: { ml_app: 'test', integration: 'openai' },
         })
+      })
+
+      it('automatically tracks a formatted managed prompt', async () => {
+        const prompt = new ManagedPrompt({
+          id: 'greeting',
+          version: '1',
+          source: 'registry',
+          template: [
+            { role: 'system', content: 'You are a {persona} assistant.' },
+            { role: 'user', content: '{message}' },
+          ],
+        })
+        const messages = prompt.format({ persona: 'helpful', message: 'Hello, OpenAI!' })
+
+        await openai.chat.completions.create({
+          model: 'gpt-3.5-turbo',
+          messages,
+          temperature: 0.5,
+          stream: false,
+          max_tokens: 100,
+          n: 1,
+          user: 'dd-trace-test',
+        })
+
+        const { llmobsSpans } = await getEvents()
+        assertPromptTracking(llmobsSpans[0], {
+          id: 'greeting',
+          version: '1',
+          variables: { persona: 'helpful', message: 'Hello, OpenAI!' },
+          chat_template: [
+            { role: 'system', content: 'You are a {persona} assistant.' },
+            { role: 'user', content: '{message}' },
+          ],
+        }, messages)
+      })
+
+      it('does not replace explicit prompt tracking', async () => {
+        const managedPrompt = new ManagedPrompt({
+          id: 'managed',
+          version: '1',
+          source: 'registry',
+          template: [
+            { role: 'system', content: 'You are a {persona} assistant.' },
+            { role: 'user', content: '{message}' },
+          ],
+        })
+
+        await global._ddtrace.llmobs.annotationContext({
+          prompt: { id: 'explicit', version: '2', template: 'Explicit prompt' },
+        }, () => openai.chat.completions.create({
+          model: 'gpt-3.5-turbo',
+          messages: managedPrompt.format({ persona: 'helpful', message: 'Hello, OpenAI!' }),
+          temperature: 0.5,
+          stream: false,
+          max_tokens: 100,
+          n: 1,
+          user: 'dd-trace-test',
+        }))
+
+        const { llmobsSpans } = await getEvents()
+        assert.strictEqual(llmobsSpans[0].meta.input.prompt.id, 'explicit')
+        assert(llmobsSpans[0].tags.includes('prompt_tracking_instrumentation_method:annotated'))
+        assert(!llmobsSpans[0].tags.includes('prompt_tracking_instrumentation_method:auto'))
       })
 
       it('submits an embedding span', async () => {

--- a/packages/dd-trace/test/llmobs/prompts/prompt.spec.js
+++ b/packages/dd-trace/test/llmobs/prompts/prompt.spec.js
@@ -2,12 +2,20 @@
 
 const assert = require('node:assert/strict')
 
-const { describe, it } = require('mocha')
+const { afterEach, beforeEach, describe, it } = require('mocha')
 
 const ManagedPrompt = require('../../../src/llmobs/prompts/prompt')
 const promptTracking = require('../../../src/llmobs/prompts/tracking')
 
 describe('ManagedPrompt', () => {
+  beforeEach(() => {
+    promptTracking.configurePromptTracking({ llmobs: { DD_LLMOBS_ENABLED: true } })
+  })
+
+  afterEach(() => {
+    promptTracking.configurePromptTracking({ llmobs: { DD_LLMOBS_ENABLED: false } })
+  })
+
   it('renders text safely and builds a string-valued annotation', () => {
     const prompt = new ManagedPrompt({
       id: 'greeting',
@@ -18,7 +26,10 @@ describe('ManagedPrompt', () => {
       promptVersionUuid: 'version-uuid',
     })
 
-    assert.strictEqual(prompt.format({ name: 'Ada', count: 3 }), 'Hello Ada, 3 times; {missing}')
+    const rendered = prompt.format({ name: 'Ada', count: 3 })
+
+    assert.strictEqual(String(rendered), 'Hello Ada, 3 times; {missing}')
+    assert.strictEqual(typeof rendered, 'object')
     assert.deepStrictEqual(prompt.toAnnotation({ name: 'Ada', count: 3, enabled: false }), {
       id: 'greeting',
       version: '1',
@@ -28,6 +39,31 @@ describe('ManagedPrompt', () => {
       promptVersionUuid: 'version-uuid',
     })
     assert.ok(Object.isFrozen(prompt))
+  })
+
+  it('tracks equal rendered text by exact call-site carrier', () => {
+    const first = new ManagedPrompt({ id: 'first', version: '1', source: 'registry', template: 'Hello {name}' })
+    const second = new ManagedPrompt({ id: 'second', version: '2', source: 'registry', template: 'Hello {name}' })
+    const firstRendered = first.format({ name: 'Ada' })
+    const secondRendered = second.format({ name: 'Ada' })
+    const firstCall = { args: [{ prompt: firstRendered }] }
+    const secondCall = { arguments: [secondRendered] }
+
+    assert.deepStrictEqual(
+      promptTracking.captureTrackedPrompt(secondCall),
+      second.toAnnotation({ name: 'Ada' })
+    )
+    assert.strictEqual(secondCall.arguments[0], 'Hello Ada')
+    assert.deepStrictEqual(promptTracking.captureTrackedPrompt(firstCall), first.toAnnotation({ name: 'Ada' }))
+    assert.strictEqual(firstCall.args[0].prompt, 'Hello Ada')
+    assert.strictEqual(promptTracking.captureTrackedPrompt({ args: [String(firstRendered)] }), undefined)
+  })
+
+  it('returns a primitive string when prompt tracking is disabled', () => {
+    promptTracking.configurePromptTracking({ llmobs: { DD_LLMOBS_ENABLED: false } })
+    const prompt = new ManagedPrompt({ id: 'greeting', version: '1', source: 'fallback', template: 'Hello' })
+
+    assert.strictEqual(prompt.format(), 'Hello')
   })
 
   it('copies, freezes, and renders chat templates without mutation', () => {
@@ -74,16 +110,20 @@ describe('ManagedPrompt', () => {
     assert.ok(Array.isArray(firstRendered))
     assert.deepStrictEqual(firstRendered, [{ role: 'user', content: 'Hello Ada' }])
     assert.deepStrictEqual(JSON.parse(JSON.stringify(firstRendered)), firstRendered)
-    assert.deepStrictEqual(promptTracking.getTrackedPrompt(firstRendered), first.toAnnotation({ name: 'Ada' }))
-    assert.deepStrictEqual(promptTracking.getTrackedPrompt(secondRendered), second.toAnnotation({ name: 'Ada' }))
     assert.deepStrictEqual(
-      promptTracking.getTrackedPrompt({ messages: secondRendered }),
+      promptTracking.captureTrackedPrompt({ args: [{ messages: firstRendered }] }),
+      first.toAnnotation({ name: 'Ada' })
+    )
+    assert.deepStrictEqual(
+      promptTracking.captureTrackedPrompt({ args: [{ messages: secondRendered }] }),
       second.toAnnotation({ name: 'Ada' })
     )
-    assert.strictEqual(promptTracking.getTrackedPrompt([...firstRendered]), undefined)
-    assert.strictEqual(promptTracking.getTrackedPrompt(new Proxy({}, {
-      ownKeys () { throw new Error('nope') },
-    })), undefined)
+    assert.strictEqual(promptTracking.captureTrackedPrompt({ args: [[...firstRendered]] }), undefined)
+    assert.strictEqual(promptTracking.captureTrackedPrompt({
+      args: [new Proxy({}, {
+        ownKeys () { throw new Error('nope') },
+      })],
+    }), undefined)
   })
 
   it('supports string, chat, object, and synchronous callable fallbacks', () => {
@@ -96,7 +136,7 @@ describe('ManagedPrompt', () => {
       return 'Lazy'
     })
 
-    assert.strictEqual(string.format({ name: 'A' }), 'Hello A')
+    assert.strictEqual(String(string.format({ name: 'A' })), 'Hello A')
     assert.deepStrictEqual(chat.format({ name: 'B' }), [{ role: 'user', content: 'Hi B' }])
     assert.strictEqual(object.version, 'local-v1')
     assert.strictEqual(callable.template, 'Lazy')

--- a/packages/dd-trace/test/llmobs/prompts/prompt.spec.js
+++ b/packages/dd-trace/test/llmobs/prompts/prompt.spec.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 
 const ManagedPrompt = require('../../../src/llmobs/prompts/prompt')
+const promptTracking = require('../../../src/llmobs/prompts/tracking')
 
 describe('ManagedPrompt', () => {
   it('renders text safely and builds a string-valued annotation', () => {
@@ -51,6 +52,38 @@ describe('ManagedPrompt', () => {
     const annotation = prompt.toAnnotation()
     annotation.template[0].content = 'changed annotation'
     assert.strictEqual(prompt.template[0].content, 'You are {{ persona }}.')
+  })
+
+  it('tracks the exact rendered chat value without changing its JavaScript shape', () => {
+    const first = new ManagedPrompt({
+      id: 'first',
+      version: '1',
+      source: 'registry',
+      template: [{ role: 'user', content: 'Hello {name}' }],
+    })
+    const second = new ManagedPrompt({
+      id: 'second',
+      version: '2',
+      source: 'registry',
+      template: [{ role: 'user', content: 'Hello {name}' }],
+    })
+
+    const firstRendered = first.format({ name: 'Ada' })
+    const secondRendered = second.format({ name: 'Ada' })
+
+    assert.ok(Array.isArray(firstRendered))
+    assert.deepStrictEqual(firstRendered, [{ role: 'user', content: 'Hello Ada' }])
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(firstRendered)), firstRendered)
+    assert.deepStrictEqual(promptTracking.getTrackedPrompt(firstRendered), first.toAnnotation({ name: 'Ada' }))
+    assert.deepStrictEqual(promptTracking.getTrackedPrompt(secondRendered), second.toAnnotation({ name: 'Ada' }))
+    assert.deepStrictEqual(
+      promptTracking.getTrackedPrompt({ messages: secondRendered }),
+      second.toAnnotation({ name: 'Ada' })
+    )
+    assert.strictEqual(promptTracking.getTrackedPrompt([...firstRendered]), undefined)
+    assert.strictEqual(promptTracking.getTrackedPrompt(new Proxy({}, {
+      ownKeys () { throw new Error('nope') },
+    })), undefined)
   })
 
   it('supports string, chat, object, and synchronous callable fallbacks', () => {

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const { beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const { INPUT_PROMPT } = require('../../src/llmobs/constants/tags')
+const { INPUT_PROMPT, PROMPT_TRACKING_INSTRUMENTATION_METHOD, TAGS } = require('../../src/llmobs/constants/tags')
 const { writeBridgeTags, findGenAIAncestorSpanId, normalizeLlmObsTraceId } = require('../../src/llmobs/util')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 
@@ -1330,6 +1330,27 @@ describe('tagger', () => {
     })
 
     describe('tagPrompt', () => {
+      it('tags a carried prompt as automatic', () => {
+        tagger.registerLLMObsSpan(span, { kind: 'llm' })
+        tagger.tagAutoPrompt(span, { id: 'managed', version: '1', template: 'Hello {name}' })
+
+        assert.strictEqual(Tagger.tagMap.get(span)[INPUT_PROMPT].id, 'managed')
+        assert.deepStrictEqual(Tagger.tagMap.get(span)[TAGS], {
+          [PROMPT_TRACKING_INSTRUMENTATION_METHOD]: 'auto',
+        })
+      })
+
+      it('does not replace an explicitly annotated prompt', () => {
+        tagger.registerLLMObsSpan(span, { kind: 'llm' })
+        tagger.tagPrompt(span, { id: 'explicit', version: '1', template: 'Explicit' })
+        tagger.tagAutoPrompt(span, { id: 'managed', version: '2', template: 'Managed' })
+
+        assert.strictEqual(Tagger.tagMap.get(span)[INPUT_PROMPT].id, 'explicit')
+        assert.deepStrictEqual(Tagger.tagMap.get(span)[TAGS], {
+          [PROMPT_TRACKING_INSTRUMENTATION_METHOD]: 'annotated',
+        })
+      })
+
       it('serializes managed prompt UUIDs under backend keys', () => {
         tagger.registerLLMObsSpan(span, { kind: 'llm' })
         tagger.tagPrompt(span, {


### PR DESCRIPTION
### What does this PR do?

Automatically tracks managed text and chat prompts when the exact value returned by `format()` is passed directly to a supported auto-instrumented LLM call.

#### Usage

```javascript
const prompt = await tracer.llmobs.getPrompt('greeting')

await openai.chat.completions.create({
  messages: prompt.format({ name: user.name }),
})
```

No `annotationContext()` call is needed. Explicit prompt annotations still take precedence.

#### Flow

```text
prompt.format() ──> exact managed-prompt carrier ──> shared LLMObs plugin lifecycle
                                                           │
                                                           ├─ provider receives the plain rendered value
                                                           └─ matching LLM span receives prompt metadata
```

Copies or rebuilt values do not inherit tracking. Provider-specific lifecycle outliers are intentionally deferred.

Stacked on #10015.
