### PR TITLE
feat(llmobs): add records to datasets

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3867,17 +3867,19 @@ declare namespace tracer {
       metadata?: Array<Record<string, any>>
     ) => any | Promise<any>
 
+    interface DatasetRecordOptions {
+      id?: string
+      inputData: JSONType
+      expectedOutput?: JSONType
+      metadata?: Record<string, JSONType>
+      tags?: string[]
+    }
+
     interface CreateDatasetOptions {
       /** Override the configured project for this dataset. */
       projectName?: string
       description?: string
-      records?: Array<{
-        id?: string,
-        inputData: JSONType,
-        expectedOutput?: JSONType,
-        metadata?: Record<string, JSONType>,
-        tags?: string[]
-      }>
+      records?: DatasetRecordOptions[]
     }
 
     interface ExperimentOptions {
@@ -4046,6 +4048,8 @@ declare namespace tracer {
         metadata?: Record<string, JSONType>,
         tags?: string[]
       ): Dataset
+      /** Add multiple records to the dataset. */
+      addRecords (records: DatasetRecordOptions[]): Dataset
       /** Update fields on an existing dataset record. */
       update (index: number, fields: {
         input?: JSONType

--- a/index.d.ts
+++ b/index.d.ts
@@ -3867,7 +3867,15 @@ declare namespace tracer {
       metadata?: Array<Record<string, any>>
     ) => any | Promise<any>
 
-    interface DatasetRecordOptions {
+    interface DatasetRecord {
+      id: string | null
+      input: JSONType
+      expectedOutput: JSONType
+      metadata: Record<string, JSONType>
+      tags: string[]
+    }
+
+    interface DatasetRecordNew {
       id?: string
       inputData: JSONType
       expectedOutput?: JSONType
@@ -3879,7 +3887,7 @@ declare namespace tracer {
       /** Override the configured project for this dataset. */
       projectName?: string
       description?: string
-      records?: DatasetRecordOptions[]
+      records?: DatasetRecordNew[]
     }
 
     interface ExperimentOptions {
@@ -4049,7 +4057,7 @@ declare namespace tracer {
         tags?: string[]
       ): Dataset
       /** Add multiple records to the dataset. */
-      addRecords (records: DatasetRecordOptions[]): Dataset
+      addRecords (records: DatasetRecordNew[]): Dataset
       /** Update fields on an existing dataset record. */
       update (index: number, fields: {
         input?: JSONType
@@ -4074,13 +4082,7 @@ declare namespace tracer {
       projectName (): string | null | undefined
       version (): number | null
       latestVersion (): number | null
-      records (): Array<{
-        id: string | null,
-        input: JSONType,
-        expectedOutput: JSONType,
-        metadata: Record<string, JSONType>,
-        tags: string[]
-      }>
+      records (): DatasetRecord[]
       /** Return the tags used to filter this dataset. */
       filterTags (): string[]
       /** Dashboard URL for the dataset, or null until pushed. */

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -4064,7 +4064,15 @@ declare namespace tracer {
       metadata?: Array<Record<string, any>>
     ) => any | Promise<any>
 
-    interface DatasetRecordOptions {
+    interface DatasetRecord {
+      id: string | null
+      input: JSONType
+      expectedOutput: JSONType
+      metadata: Record<string, JSONType>
+      tags: string[]
+    }
+
+    interface DatasetRecordNew {
       id?: string
       inputData: JSONType
       expectedOutput?: JSONType
@@ -4076,7 +4084,7 @@ declare namespace tracer {
       /** Override the configured project for this dataset. */
       projectName?: string
       description?: string
-      records?: DatasetRecordOptions[]
+      records?: DatasetRecordNew[]
     }
 
     interface ExperimentOptions {
@@ -4246,7 +4254,7 @@ declare namespace tracer {
         tags?: string[]
       ): Dataset
       /** Add multiple records to the dataset. */
-      addRecords (records: DatasetRecordOptions[]): Dataset
+      addRecords (records: DatasetRecordNew[]): Dataset
       /** Update fields on an existing dataset record. */
       update (index: number, fields: {
         input?: JSONType
@@ -4271,13 +4279,7 @@ declare namespace tracer {
       projectName (): string | null | undefined
       version (): number | null
       latestVersion (): number | null
-      records (): Array<{
-        id: string | null,
-        input: JSONType,
-        expectedOutput: JSONType,
-        metadata: Record<string, JSONType>,
-        tags: string[]
-      }>
+      records (): DatasetRecord[]
       /** Return the tags used to filter this dataset. */
       filterTags (): string[]
       /** Dashboard URL for the dataset, or null until pushed. */

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -4064,17 +4064,19 @@ declare namespace tracer {
       metadata?: Array<Record<string, any>>
     ) => any | Promise<any>
 
+    interface DatasetRecordOptions {
+      id?: string
+      inputData: JSONType
+      expectedOutput?: JSONType
+      metadata?: Record<string, JSONType>
+      tags?: string[]
+    }
+
     interface CreateDatasetOptions {
       /** Override the configured project for this dataset. */
       projectName?: string
       description?: string
-      records?: Array<{
-        id?: string,
-        inputData: JSONType,
-        expectedOutput?: JSONType,
-        metadata?: Record<string, JSONType>,
-        tags?: string[]
-      }>
+      records?: DatasetRecordOptions[]
     }
 
     interface ExperimentOptions {
@@ -4243,6 +4245,8 @@ declare namespace tracer {
         metadata?: Record<string, JSONType>,
         tags?: string[]
       ): Dataset
+      /** Add multiple records to the dataset. */
+      addRecords (records: DatasetRecordOptions[]): Dataset
       /** Update fields on an existing dataset record. */
       update (index: number, fields: {
         input?: JSONType

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -5,7 +5,7 @@ const snapshotPayload = require('../../../../../vendor/dist/rfdc')({ proto: fals
 
 /** @typedef {{add?: string[], remove?: string[], replace?: string[]}} TagOperations */
 /**
- * @typedef {object} DatasetRecordOptions
+ * @typedef {object} DatasetRecordNew
  * @property {string} [id]
  * @property {unknown} inputData
  * @property {unknown} [expectedOutput]
@@ -187,7 +187,7 @@ class Dataset {
 
   /**
    * Add multiple records to a dataset.
-   * @param {DatasetRecordOptions[]} records
+   * @param {DatasetRecordNew[]} records
    * @returns {Dataset} This dataset for chaining.
    */
   addRecords (records) {

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -191,18 +191,27 @@ class Dataset {
    * @returns {Dataset} This dataset for chaining.
    */
   addRecords (records) {
+    const newRecords = []
+    const recordIds = new Set(this.#recordsById.keys())
+
+    // Construct and validate the entire batch before mutating the dataset.
     for (const record of records) {
       if (record.id !== undefined && (typeof record.id !== 'string' || record.id.length === 0)) {
         throw new Error('record id must be a non-empty string')
       }
-      this.addRecord(new DatasetRecord(
+      const newRecord = new DatasetRecord(
         record.inputData,
         record.expectedOutput,
         record.metadata,
         record.id,
         record.tags
-      ))
+      )
+      if (recordIds.has(newRecord.id)) throw new Error(`Duplicate record id '${newRecord.id}'`)
+      recordIds.add(newRecord.id)
+      newRecords.push(newRecord)
     }
+
+    for (const record of newRecords) this.#addRecord(record)
     return this
   }
 

--- a/packages/dd-trace/src/llmobs/experiments/dataset.js
+++ b/packages/dd-trace/src/llmobs/experiments/dataset.js
@@ -5,6 +5,14 @@ const snapshotPayload = require('../../../../../vendor/dist/rfdc')({ proto: fals
 
 /** @typedef {{add?: string[], remove?: string[], replace?: string[]}} TagOperations */
 /**
+ * @typedef {object} DatasetRecordOptions
+ * @property {string} [id]
+ * @property {unknown} inputData
+ * @property {unknown} [expectedOutput]
+ * @property {Record<string, unknown>} [metadata]
+ * @property {string[]} [tags]
+ */
+/**
  * @typedef {object} PendingBatch
  * @property {object} attributes
  * @property {string[]} deleteRecordIds
@@ -174,6 +182,27 @@ class Dataset {
       ? recordOrInput
       : new DatasetRecord(recordOrInput, expectedOutput, metadata, null, tags)
     this.#addRecord(record)
+    return this
+  }
+
+  /**
+   * Add multiple records to a dataset.
+   * @param {DatasetRecordOptions[]} records
+   * @returns {Dataset} This dataset for chaining.
+   */
+  addRecords (records) {
+    for (const record of records) {
+      if (record.id !== undefined && (typeof record.id !== 'string' || record.id.length === 0)) {
+        throw new Error('record id must be a non-empty string')
+      }
+      this.addRecord(new DatasetRecord(
+        record.inputData,
+        record.expectedOutput,
+        record.metadata,
+        record.id,
+        record.tags
+      ))
+    }
     return this
   }
 

--- a/packages/dd-trace/src/llmobs/experiments/index.js
+++ b/packages/dd-trace/src/llmobs/experiments/index.js
@@ -2,7 +2,7 @@
 
 const log = require('../../log')
 const { ExperimentsClient } = require('./client')
-const { Dataset, DatasetRecord } = require('./dataset')
+const { Dataset } = require('./dataset')
 const { Experiment, ExternalExperiment } = require('./experiment')
 const { validateTagsList } = require('./util')
 const NoopExperiments = require('./noop')
@@ -72,21 +72,7 @@ class Experiments {
       : (descriptionOrOptions ?? {})
     const client = this.#clientForOperation(options.projectName)
     const dataset = new Dataset(client, name, options.description ?? '')
-    const recordIds = new Set()
-    if ((options.records) != null) {
-      for (const record of options.records) {
-        if (record.id !== undefined && (typeof record.id !== 'string' || record.id.length === 0)) {
-          throw new Error('record id must be a non-empty string')
-        }
-        if (record.id !== undefined) {
-          if (recordIds.has(record.id)) throw new Error(`Duplicate record id '${record.id}'`)
-          recordIds.add(record.id)
-        }
-        dataset.addRecord(
-          new DatasetRecord(record.inputData, record.expectedOutput, record.metadata, record.id, record.tags)
-        )
-      }
-    }
+    if ((options.records) != null) dataset.addRecords(options.records)
     return dataset
   }
 

--- a/packages/dd-trace/src/llmobs/experiments/noop.js
+++ b/packages/dd-trace/src/llmobs/experiments/noop.js
@@ -7,6 +7,15 @@ const NOOP_EXPERIMENT_ID = '00000000-0000-0000-0000-000000000000'
 const NOOP_SPAN_ID = '0000000000000000'
 const NOOP_TRACE_ID = '00000000000000000000000000000000'
 
+/**
+ * @typedef {object} DatasetRecordOptions
+ * @property {string} [id]
+ * @property {unknown} inputData
+ * @property {unknown} [expectedOutput]
+ * @property {Record<string, unknown>} [metadata]
+ * @property {string[]} [tags]
+ */
+
 class NoopDataset {
   #name
   #description
@@ -34,6 +43,24 @@ class NoopDataset {
       metadata: metadata ?? {},
       tags: [...(tags ?? [])],
     })
+    return this
+  }
+
+  /**
+   * Add multiple records to a dataset.
+   * @param {DatasetRecordOptions[]} records
+   * @returns {NoopDataset} This dataset for chaining.
+   */
+  addRecords (records) {
+    for (const record of records) {
+      this.#records.push({
+        id: record.id ?? null,
+        input: record.inputData,
+        expectedOutput: record.expectedOutput ?? null,
+        metadata: record.metadata ?? {},
+        tags: [...(record.tags ?? [])],
+      })
+    }
     return this
   }
 

--- a/packages/dd-trace/src/llmobs/experiments/noop.js
+++ b/packages/dd-trace/src/llmobs/experiments/noop.js
@@ -8,7 +8,7 @@ const NOOP_SPAN_ID = '0000000000000000'
 const NOOP_TRACE_ID = '00000000000000000000000000000000'
 
 /**
- * @typedef {object} DatasetRecordOptions
+ * @typedef {object} DatasetRecordNew
  * @property {string} [id]
  * @property {unknown} inputData
  * @property {unknown} [expectedOutput]
@@ -48,7 +48,7 @@ class NoopDataset {
 
   /**
    * Add multiple records to a dataset.
-   * @param {DatasetRecordOptions[]} records
+   * @param {DatasetRecordNew[]} records
    * @returns {NoopDataset} This dataset for chaining.
    */
   addRecords (records) {

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -1338,4 +1338,36 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
       },
     ])
   })
+
+  it('validates the entire addRecords batch before mutating the dataset', () => {
+    const dataset = new Dataset(client(), 'demo')
+      .addRecord(new DatasetRecord('existing', null, {}, 'existing'))
+
+    assert.throws(
+      () => dataset.addRecords([
+        { id: 'new', inputData: 'first' },
+        { id: 'existing', inputData: 'duplicate' },
+      ]),
+      /Duplicate record id 'existing'/
+    )
+    assert.deepEqual(dataset.recordIds(), ['existing'])
+
+    assert.throws(
+      () => dataset.addRecords([
+        { id: 'same', inputData: 'first' },
+        { id: 'same', inputData: 'duplicate' },
+      ]),
+      /Duplicate record id 'same'/
+    )
+    assert.deepEqual(dataset.recordIds(), ['existing'])
+
+    assert.throws(
+      () => dataset.addRecords([
+        { id: 'new', inputData: 'first' },
+        { id: 'bad', inputData: 'invalid', tags: ['malformed'] },
+      ]),
+      /Tag 'malformed' is malformed/
+    )
+    assert.deepEqual(dataset.recordIds(), ['existing'])
+  })
 })

--- a/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/experiment.spec.js
@@ -1298,4 +1298,44 @@ describe('LLMObs Experiments — dataset + experiment run', () => {
     assert.equal(dataset.records()[1].expectedOutput, 'expected')
     assert.deepEqual(dataset.records()[1].metadata, { explicit: true })
   })
+
+  it('adds multiple records with custom and generated ids', async () => {
+    const { client: c, requests } = clientWithMockBackend()
+    const dataset = new Dataset(c, 'demo')
+    const returned = dataset.addRecords([
+      {
+        id: 'custom-record',
+        inputData: 'first',
+        expectedOutput: 'one',
+        metadata: { row: 0 },
+        tags: ['tag:first'],
+      },
+      { inputData: { value: 2 } },
+    ])
+
+    assert.equal(returned, dataset)
+    const records = dataset.records()
+    assert.equal(records.length, 2)
+    assert.equal(records[0].id, 'custom-record')
+    assert.ok(records[1].id)
+
+    await dataset.push()
+
+    const attributes = requests.find(request => request.method === 'batchUpdateDatasetRecords').attributes
+    assert.deepEqual(attributes.insert_records, [
+      {
+        id: 'custom-record',
+        input: 'first',
+        expected_output: 'one',
+        metadata: { row: 0 },
+        tags: ['tag:first'],
+      },
+      {
+        id: records[1].id,
+        input: { value: 2 },
+        expected_output: null,
+        metadata: {},
+      },
+    ])
+  })
 })

--- a/packages/dd-trace/test/llmobs/experiments/index.spec.js
+++ b/packages/dd-trace/test/llmobs/experiments/index.spec.js
@@ -140,6 +140,7 @@ describe('LLMObs Experiments facade', () => {
         records: [{ inputData: 'in', expectedOutput: 'out', metadata: { source: 'test' } }],
       })
       assert.equal(typeof dataset.addRecord, 'function')
+      assert.equal(typeof dataset.addRecords, 'function')
       assert.equal(dataset.records()[0].input, 'in')
       const experiment = exp.experiment({ name: 'n', dataset, task: (i) => i })
       assert.equal(typeof experiment.run, 'function')
@@ -342,6 +343,38 @@ describe('LLMObs Experiments facade', () => {
       dataset.removeTags(0)
       dataset.replaceTags(0)
       assert.deepEqual(dataset.records()[0].tags, [])
+    })
+
+    it('adds multiple records to a no-op dataset', () => {
+      const dataset = new NoopExperiments().createDataset('d')
+      const returned = dataset.addRecords([
+        {
+          id: 'custom-record',
+          inputData: 'first',
+          expectedOutput: 'one',
+          metadata: { row: 0 },
+          tags: ['tag:first'],
+        },
+        { inputData: 'second' },
+      ])
+
+      assert.equal(returned, dataset)
+      assert.deepEqual(dataset.records(), [
+        {
+          id: 'custom-record',
+          input: 'first',
+          expectedOutput: 'one',
+          metadata: { row: 0 },
+          tags: ['tag:first'],
+        },
+        {
+          id: null,
+          input: 'second',
+          expectedOutput: null,
+          metadata: {},
+          tags: [],
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Adds `Dataset.addRecords(records)` as a JavaScript equivalent to dd-trace-py's `Dataset.extend()`.

The method accepts the same record shape used by `createDataset({ records })`, preserves custom IDs, generates IDs for records without one, and returns the dataset for chaining. Dataset creation now uses this shared path, and the no-op dataset implements the same API.

### Testing

- `./node_modules/.bin/mocha packages/dd-trace/test/llmobs/experiments/{experiment,index}.spec.js` — 77 passing
- `npm run test:llmobs:sdk` — 666 passing, 2 pending
- Targeted ESLint, syntax, and diff checks pass
- `npm run type:check` is blocked by existing errors in `vendor/dist/tlhunter-sorted-set` and `vendor/dist/ttl-set`
