### PR TITLE
fix(openfeature): harden agentless exposure fallback

### DIFF
--- a/packages/dd-trace/src/agent/info.js
+++ b/packages/dd-trace/src/agent/info.js
@@ -17,7 +17,7 @@ module.exports = {
  * Fetches agent information from the /info endpoint
  * @param {URL} url - The agent URL
  * @param {Function} callback - Callback function with signature (err, agentInfo)
- * @param {{ deadline?: number, signal?: AbortSignal }} [options] - Request finalization options
+ * @param {{ deadline?: number, signal?: AbortSignal, retry?: boolean }} [options] - Request finalization options
  * @param {Function} [makeRequest] - Request implementation
  */
 function fetchAgentInfo (url, callback, options = {}, makeRequest = request) {

--- a/packages/dd-trace/src/evp_proxy/discovery.js
+++ b/packages/dd-trace/src/evp_proxy/discovery.js
@@ -30,9 +30,9 @@ const TRAILING_SLASHES = /\/+$/
  * retry policy. A valid response without a compatible path returns no route.
  * Discovery sends no events, so the caller can safely select direct intake
  * after either result. The caller also owns later delivery failures. Exposure
- * delivery uses retries and can therefore produce duplicates. After local
- * retries fail, the caller can retry through direct intake and use that route
- * for future batches.
+ * delivery replays a batch through direct intake after a definitive local
+ * rejection. After an ambiguous local failure, it switches future batches to
+ * direct intake without replaying the failed batch.
  *
  * Reference implementations:
  *
@@ -106,11 +106,12 @@ function selectEVPProxyPath (agentInfo, { supportedPaths, requiredHeaders = [] }
  * @param {string[]} options.supportedPaths - Supported paths in preference order
  * @param {string[]} [options.requiredHeaders] - Headers that the proxy must forward unchanged to intake. Each
  * header must appear in `evp_proxy_allowed_headers`. Do not include routing headers that the Agent consumes.
+ * @param {boolean} [options.retry] - Whether the Agent information request retries connection failures
  * @param {(error: Error|null, route?: {url: URL, basePath: string}) => void} callback - Result callback
  * @returns {void}
  */
 function discoverEVPProxy (url, options, callback) {
-  fetchAgentInfo(url, (error, agentInfo) => {
+  const handleAgentInfo = (error, agentInfo) => {
     if (error) {
       callback(error)
       return
@@ -124,7 +125,14 @@ function discoverEVPProxy (url, options, callback) {
 
     log.debug('EVP proxy route %s discovered through the configured local receiver', basePath)
     callback(null, { url, basePath })
-  })
+  }
+
+  if (options.retry === undefined) {
+    fetchAgentInfo(url, handleAgentInfo)
+    return
+  }
+
+  fetchAgentInfo(url, handleAgentInfo, { retry: options.retry })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -258,7 +258,7 @@ class BaseFFEWriter {
   }
 
   /**
-   * Sends an encoded batch and retries it through direct intake after a local route failure.
+   * Sends an encoded batch and switches to direct intake after supported local route failures.
    *
    * @param {string} payload - Encoded event batch
    * @param {number} eventCount - Event count
@@ -283,14 +283,14 @@ class BaseFFEWriter {
 
       if (fallbackRoute && isAmbiguousNetworkFailure(error)) {
         log.debug(
-          '%s retrying through direct intake and switching future batches from %s%s after ambiguous failure',
+          '%s switching future batches from %s%s to direct intake after ambiguous failure without replaying the batch',
           this.constructor.name,
           route.url.href,
           route.endpoint
         )
         this.#activateRoute(fallbackRoute)
         this._fallbackRoute = undefined
-        this.#sendRequest(payload, eventCount, fallbackRoute)
+        log.error('Failed to send events to %s%s: %s', route.url.href, route.endpoint, error.message)
         return
       }
 

--- a/packages/dd-trace/src/openfeature/writers/util.js
+++ b/packages/dd-trace/src/openfeature/writers/util.js
@@ -67,6 +67,7 @@ function setAgentlessStrategy (config, setWriterEnabledValue) {
   const directRoute = createDirectEVPRoute(config, EVP_EVENT_PLATFORM_SUBDOMAIN)
 
   discoverEVPProxy(config.url, {
+    retry: false,
     supportedPaths: [EVP_PROXY_PATH_V4, EVP_PROXY_PATH_V2],
   }, (error, localRoute) => {
     if (localRoute) {

--- a/packages/dd-trace/test/evp_proxy/discovery.spec.js
+++ b/packages/dd-trace/test/evp_proxy/discovery.spec.js
@@ -120,6 +120,17 @@ describe('EVP proxy discovery', () => {
       })
     })
 
+    it('passes an explicit retry policy to the Agent information request', (done) => {
+      fetchAgentInfo.yields(null, { endpoints: ['/evp_proxy/v2'] })
+
+      discoverEVPProxy(url, { ...options, retry: false }, (error, route) => {
+        assert.ifError(error)
+        assert.strictEqual(route.basePath, '/evp_proxy/v2')
+        sinon.assert.calledOnceWithExactly(fetchAgentInfo, url, sinon.match.func, { retry: false })
+        done()
+      })
+    })
+
     it('returns information request errors', (done) => {
       const expectedError = new Error('Agent unavailable')
       fetchAgentInfo.yields(expectedError)

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -523,7 +523,7 @@ describe('OpenFeature Exposures Writer', () => {
       ['broken pipe', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })],
       ['timeout', Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' })],
     ]) {
-      it(`should retry ambiguous local ${name} through direct intake and switch future batches`, async () => {
+      it(`should not replay ambiguous local ${name} and should switch future batches to direct intake`, async () => {
         const localUrl = new URL('http://serverless-init:8126')
         const directUrl = new URL('https://event-platform-intake.datadoghq.com')
         request.onFirstCall().yieldsAsync(error, null, statusCode)
@@ -546,15 +546,21 @@ describe('OpenFeature Exposures Writer', () => {
         writer.flush()
         await clock.tickAsync(0)
 
-        sinon.assert.calledTwice(request)
+        sinon.assert.calledOnce(request)
         assert.strictEqual(request.firstCall.args[1].url, localUrl)
-        assert.strictEqual(request.secondCall.args[1].url, directUrl)
+        sinon.assert.calledWithExactly(
+          log.error,
+          'Failed to send events to %s%s: %s',
+          'http://serverless-init:8126/',
+          '/evp_proxy/v4/api/v2/exposures',
+          error.message
+        )
 
         writer.append(exposureEvent)
         writer.flush()
 
-        sinon.assert.calledThrice(request)
-        assert.strictEqual(request.thirdCall.args[1].url, directUrl)
+        sinon.assert.calledTwice(request)
+        assert.strictEqual(request.secondCall.args[1].url, directUrl)
       })
     }
 

--- a/packages/dd-trace/test/openfeature/writers/util.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/util.spec.js
@@ -84,6 +84,7 @@ describe('OpenFeature exposure delivery strategy', () => {
     setExposureDeliveryStrategy(config, setWriterEnabledValue)
 
     sinon.assert.calledOnceWithExactly(discoverEVPProxy, config.url, {
+      retry: false,
       supportedPaths: ['/evp_proxy/v4', '/evp_proxy/v2'],
     }, sinon.match.func)
     sinon.assert.calledOnceWithExactly(setWriterEnabledValue, true, {
@@ -108,6 +109,7 @@ describe('OpenFeature exposure delivery strategy', () => {
     setExposureDeliveryStrategy(config, setWriterEnabledValue)
 
     sinon.assert.calledOnceWithExactly(discoverEVPProxy, config.url, {
+      retry: false,
       supportedPaths: ['/evp_proxy/v4', '/evp_proxy/v2'],
     }, sinon.match.func)
     sinon.assert.calledOnceWithMatch(setWriterEnabledValue, true, {


### PR DESCRIPTION
## Motivation

Agentless exposure delivery queries the local `/info` endpoint before selecting a local EVP proxy or direct intake. The current request inherits exporter retries, delaying direct intake when no local receiver is available. After `ECONNRESET`, `EPIPE`, or `ETIMEDOUT`, it also replays the same batch directly even though the local receiver may have accepted it.

## Changes

- Disable retries for agentless `/info` route discovery.
- Allow EVP discovery callers to set the Agent information request retry policy.
- Switch future exposure batches to direct intake after ambiguous local failures without replaying the failed batch.
- Cover the discovery option and exposure route transition behavior.

## Decisions

- Remote Configuration discovery keeps its existing retry behavior.
- Definitive local failures continue to replay the current batch through direct intake.
- HTTP 429 and 5xx responses keep the selected local route.

## Validation

- 68 focused EVP discovery, exposure routing, and exposure writer tests pass.
- Targeted ESLint checks pass.
- [DataDog/system-tests#7602](https://github.com/DataDog/system-tests/pull/7602) covers exposure delivery through Agent, agentless direct, and agentless sidecar routes.