### PR TITLE
fix(graphql): record collapsed JIT resolver errors

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/graphql-jit-runtime.js
+++ b/packages/datadog-instrumentations/src/helpers/graphql-jit-runtime.js
@@ -58,6 +58,7 @@
  *   ddTraceDefaultResolvers?: boolean,
  *   ddTracePlan?: BuildingJitPlan,
  *   ddTraceRuntime?: GraphqlJitRuntime,
+ *   ddTraceWrapAllResolvers?: boolean,
  *   hoistedFunctions: string[],
  *   resolvers: GraphQLResolverMap
  * }} JitCompilationContext
@@ -86,17 +87,39 @@
  *   path: (string | number)[] | undefined
  * ) => unknown} ReadDefaultInScope
  * @typedef {(variableValues: Record<string, unknown> | undefined) => object | undefined} StartExecution
+ * @typedef {(rootCtx: object, descriptorId: number, error: unknown) => void} RecordResolverError
+ * @typedef {(
+ *   rootCtx: object,
+ *   descriptorId: number,
+ *   resolver: import('graphql').GraphQLFieldResolver<unknown, unknown>,
+ *   self: unknown,
+ *   source: unknown,
+ *   args: Record<string, unknown>,
+ *   contextValue: unknown,
+ *   info: import('graphql').GraphQLResolveInfo
+ * ) => unknown} ResolveField
+ * @typedef {(
+ *   resolver: import('graphql').GraphQLFieldResolver<unknown, unknown>
+ * ) => import('graphql').GraphQLFieldResolver<unknown, unknown>} UnwrapResolver
  * @typedef {(
  *   resolver: import('graphql').GraphQLFieldResolver<unknown, unknown>
  * ) => import('graphql').GraphQLFieldResolver<unknown, unknown>} WrapResolver
  * @typedef {{
  *   createFieldMetadata: CreateFieldMetadata,
  *   readDefaultInScope: ReadDefaultInScope,
+ *   recordResolverError: RecordResolverError,
  *   resolveDefaultInvocation: ResolveDefaultInvocation,
+ *   resolveField: ResolveField,
  *   startExecution: StartExecution,
+ *   unwrapResolver: UnwrapResolver,
  *   wrapResolver: WrapResolver
  * }} GraphqlJitRuntimeOptions
  * @typedef {{
+ *   compileResolverCall: (
+ *     context: JitCompilationContext,
+ *     resolverCall: string,
+ *     descriptorId: number | undefined
+ *   ) => string,
  *   compileDefaultField: (
  *     context: ConfiguredJitCompilationContext,
  *     responsePath: unknown,
@@ -121,7 +144,9 @@
  *     input: DescriptorInput
  *   ) => number | undefined,
  *   readDefaultInScope: ReadDefaultInScope,
+ *   recordResolverError: RecordResolverError,
  *   resolveDefaultInvocation: ResolveDefaultInvocation,
+ *   resolveField: ResolveField,
  *   startExecution: StartExecution
  * }} GraphqlJitRuntime
  */
@@ -136,16 +161,22 @@
 function createGraphqlJitRuntime ({
   createFieldMetadata,
   readDefaultInScope,
+  recordResolverError,
   resolveDefaultInvocation,
+  resolveField,
   startExecution,
+  unwrapResolver,
   wrapResolver,
 }) {
   const runtime = {
     compileDefaultField,
+    compileResolverCall,
     finalizeCompilation,
+    recordResolverError,
     registerField,
     readDefaultInScope,
     resolveDefaultInvocation,
+    resolveField,
     startExecution,
   }
 
@@ -191,13 +222,57 @@ function createGraphqlJitRuntime ({
         field.parentPathKey = undefined
       }
     }
-    for (const name of Object.keys(context.resolvers)) {
-      context.resolvers[name] = wrapResolver(context.resolvers[name])
+    /* istanbul ignore next: this fallback is for an unsupported future compiler source shape. */
+    if (context.ddTraceWrapAllResolvers) {
+      for (const name of Object.keys(context.resolvers)) {
+        context.resolvers[name] = wrapResolver(context.resolvers[name])
+      }
     }
-
     return {
       fields: plan.fields,
     }
+  }
+
+  /**
+   * @param {JitCompilationContext} context
+   * @param {string} resolverCall
+   * @param {number | undefined} descriptorId
+   * @returns {string}
+   */
+  function compileResolverCall (context, resolverCall, descriptorId) {
+    const openParenthesis = resolverCall.indexOf('(')
+    /* istanbul ignore next: a future compiler may change its resolver-call source shape. */
+    if (openParenthesis === -1 || resolverCall.at(-1) !== ')') {
+      context.ddTraceWrapAllResolvers = true
+      return resolverCall
+    }
+
+    const resolver = resolverCall.slice(0, openParenthesis)
+    const resolverPrefix = '__context.resolvers.'
+    /* istanbul ignore next: a future compiler may change its resolver-map access shape. */
+    if (!resolver.startsWith(resolverPrefix)) {
+      context.ddTraceWrapAllResolvers = true
+      return resolverCall
+    }
+
+    const resolverName = resolver.slice(resolverPrefix.length)
+    /* istanbul ignore next: a future compiler may change its private response-path shape. */
+    if (descriptorId === undefined) {
+      context.resolvers[resolverName] = wrapResolver(context.resolvers[resolverName])
+      return resolverCall
+    }
+    context.resolvers[resolverName] = unwrapResolver(context.resolvers[resolverName])
+
+    const args = resolverCall.slice(openParenthesis + 1, -1)
+    return `__context.ddTrace === undefined
+      ? ${resolverCall}
+      : __context.ddTrace.jitRuntime.resolveField(
+        __context.ddTrace,
+        ${descriptorId},
+        ${resolver},
+        __context.resolvers,
+        ${args}
+      )`
   }
 
   /**

--- a/packages/datadog-instrumentations/src/helpers/graphql-jit-runtime.js
+++ b/packages/datadog-instrumentations/src/helpers/graphql-jit-runtime.js
@@ -264,15 +264,18 @@ function createGraphqlJitRuntime ({
     context.resolvers[resolverName] = unwrapResolver(context.resolvers[resolverName])
 
     const args = resolverCall.slice(openParenthesis + 1, -1)
-    return `__context.ddTrace === undefined
-      ? ${resolverCall}
-      : __context.ddTrace.jitRuntime.resolveField(
+    return `__context.ddTrace !== undefined &&
+      (!__context.ddTrace.depthDisabled ||
+        __context.ddTrace.hasIastSub ||
+        __context.ddTrace.hasResolverSub)
+      ? __context.ddTrace.jitRuntime.resolveField(
         __context.ddTrace,
         ${descriptorId},
         ${resolver},
         __context.resolvers,
         ${args}
-      )`
+      )
+      : ${resolverCall}`
   }
 
   /**

--- a/packages/datadog-instrumentations/src/helpers/graphql-jit-runtime.js
+++ b/packages/datadog-instrumentations/src/helpers/graphql-jit-runtime.js
@@ -58,7 +58,6 @@
  *   ddTraceDefaultResolvers?: boolean,
  *   ddTracePlan?: BuildingJitPlan,
  *   ddTraceRuntime?: GraphqlJitRuntime,
- *   ddTraceWrapAllResolvers?: boolean,
  *   hoistedFunctions: string[],
  *   resolvers: GraphQLResolverMap
  * }} JitCompilationContext
@@ -118,6 +117,7 @@
  *   compileResolverCall: (
  *     context: JitCompilationContext,
  *     resolverCall: string,
+ *     resolverName: string,
  *     descriptorId: number | undefined
  *   ) => string,
  *   compileDefaultField: (
@@ -210,53 +210,15 @@ function createGraphqlJitRuntime ({
   }
 
   /**
-   * @param {JitCompilationContext & { ddTracePlan: BuildingJitPlan }} context
-   * @returns {JitPlan}
-   */
-  function finalizeCompilation (context) {
-    const plan = context.ddTracePlan
-
-    for (const field of plan.fields) {
-      if (field.parentPathKey !== undefined) {
-        field.parentId = plan.fieldsByPath.get(field.parentPathKey)?.id
-        field.parentPathKey = undefined
-      }
-    }
-    /* istanbul ignore next: this fallback is for an unsupported future compiler source shape. */
-    if (context.ddTraceWrapAllResolvers) {
-      for (const name of Object.keys(context.resolvers)) {
-        context.resolvers[name] = wrapResolver(context.resolvers[name])
-      }
-    }
-    return {
-      fields: plan.fields,
-    }
-  }
-
-  /**
    * @param {JitCompilationContext} context
    * @param {string} resolverCall
+   * @param {string} resolverName
    * @param {number | undefined} descriptorId
    * @returns {string}
    */
-  function compileResolverCall (context, resolverCall, descriptorId) {
+  function compileResolverCall (context, resolverCall, resolverName, descriptorId) {
     const openParenthesis = resolverCall.indexOf('(')
-    /* istanbul ignore next: a future compiler may change its resolver-call source shape. */
-    if (openParenthesis === -1 || resolverCall.at(-1) !== ')') {
-      context.ddTraceWrapAllResolvers = true
-      return resolverCall
-    }
-
     const resolver = resolverCall.slice(0, openParenthesis)
-    const resolverPrefix = '__context.resolvers.'
-    /* istanbul ignore next: a future compiler may change its resolver-map access shape. */
-    if (!resolver.startsWith(resolverPrefix)) {
-      context.ddTraceWrapAllResolvers = true
-      return resolverCall
-    }
-
-    const resolverName = resolver.slice(resolverPrefix.length)
-    /* istanbul ignore next: a future compiler may change its private response-path shape. */
     if (descriptorId === undefined) {
       context.resolvers[resolverName] = wrapResolver(context.resolvers[resolverName])
       return resolverCall
@@ -347,6 +309,24 @@ function createGraphqlJitRuntime ({
   }
 
   return { configureCompilationContext, runtime }
+}
+
+/**
+ * @param {JitCompilationContext & { ddTracePlan: BuildingJitPlan }} context
+ * @returns {JitPlan}
+ */
+function finalizeCompilation (context) {
+  const plan = context.ddTracePlan
+
+  for (const field of plan.fields) {
+    if (field.parentPathKey !== undefined) {
+      field.parentId = plan.fieldsByPath.get(field.parentPathKey)?.id
+      field.parentPathKey = undefined
+    }
+  }
+  return {
+    fields: plan.fields,
+  }
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -434,6 +434,9 @@ function configureGraphqlJitDeferredField (_state, node) {
   assert.strictEqual(executionErrors.length, 1, 'configureGraphqlJitDeferredField: execution error not found')
   assert.strictEqual(emptyErrors.length, 1, 'configureGraphqlJitDeferredField: empty error not found')
 
+  const [resolverCall] = resolverCalls
+  assertGraphqlJitResolverCall(resolverCall.init)
+
   const [descriptor] = parse(`
     const ddTraceDescriptorId = context.ddTraceRuntime?.registerField(context, responsePath, {
       fieldName,
@@ -460,14 +463,41 @@ function configureGraphqlJitDeferredField (_state, node) {
         ddTraceDescriptorId + ', err), "")'
   `).body[0].expression
 
-  const [resolverCall] = resolverCalls
   const replacement = parse(`
     context.ddTraceRuntime === undefined
       ? DD_CALL
-      : context.ddTraceRuntime.compileResolverCall(context, DD_CALL, ddTraceDescriptorId)
+      : context.ddTraceRuntime.compileResolverCall(context, DD_CALL, resolverName, ddTraceDescriptorId)
   `).body[0].expression
   replaceIdentifier(replacement, 'DD_CALL', resolverCall.init)
   resolverCall.init = replacement
+}
+
+/**
+ * @param {import('estree').Expression | null} source
+ */
+function assertGraphqlJitResolverCall (source) {
+  assert.strictEqual(source?.type, 'TemplateLiteral', 'configureGraphqlJitDeferredField: unsupported resolver call')
+
+  const { expressions, quasis } = source
+  assert.ok(expressions.length >= 2, 'configureGraphqlJitDeferredField: resolver call expressions not found')
+  assert.ok(quasis.length >= 3, 'configureGraphqlJitDeferredField: resolver call segments not found')
+  assert.strictEqual(
+    expressions[0].name,
+    'GLOBAL_EXECUTION_CONTEXT',
+    'configureGraphqlJitDeferredField: execution context not found'
+  )
+  assert.strictEqual(
+    quasis[1].value.raw,
+    '.resolvers.',
+    'configureGraphqlJitDeferredField: resolver map access not found'
+  )
+  assert.strictEqual(
+    expressions[1].name,
+    'resolverName',
+    'configureGraphqlJitDeferredField: resolver name not found'
+  )
+  assert.ok(quasis[2].value.raw.startsWith('('), 'configureGraphqlJitDeferredField: resolver call not found')
+  assert.ok(quasis.at(-1).value.raw.endsWith(')'), 'configureGraphqlJitDeferredField: resolver call end not found')
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -410,6 +410,12 @@ function configureGraphqlJitExecute (_state, node, _parent, ancestry) {
 function configureGraphqlJitDeferredField (_state, node) {
   const declarations = query(node, 'VariableDeclaration:has(VariableDeclarator[id.name="resolverCall"])')
   const resolverCalls = query(node, 'VariableDeclarator[id.name="resolverCall"]')
+  const executionErrorDeclarations = query(
+    node,
+    'VariableDeclaration:has(VariableDeclarator[id.name="executionError"])'
+  )
+  const executionErrors = query(node, 'VariableDeclarator[id.name="executionError"]')
+  const emptyErrors = query(node, 'VariableDeclarator[id.name="emptyError"]')
   assert.strictEqual(
     declarations.length,
     1,
@@ -420,6 +426,13 @@ function configureGraphqlJitDeferredField (_state, node) {
     1,
     'configureGraphqlJitDeferredField: resolver call not found'
   )
+  assert.strictEqual(
+    executionErrorDeclarations.length,
+    1,
+    'configureGraphqlJitDeferredField: execution error declaration not found'
+  )
+  assert.strictEqual(executionErrors.length, 1, 'configureGraphqlJitDeferredField: execution error not found')
+  assert.strictEqual(emptyErrors.length, 1, 'configureGraphqlJitDeferredField: empty error not found')
 
   const [descriptor] = parse(`
     const ddTraceDescriptorId = context.ddTraceRuntime?.registerField(context, responsePath, {
@@ -430,15 +443,28 @@ function configureGraphqlJitDeferredField (_state, node) {
     })
   `).body
   assert(
-    insertBeforeStatement(node.body, declarations[0], [descriptor]),
+    insertBeforeStatement(node.body, executionErrorDeclarations[0], [descriptor]),
     'configureGraphqlJitDeferredField: could not insert descriptor'
   )
 
+  executionErrors[0].init.arguments[4] = parse(`
+    ddTraceDescriptorId === undefined
+      ? 'err'
+      : '(__context.ddTrace?.jitRuntime.recordResolverError(__context.ddTrace, ' +
+        ddTraceDescriptorId + ', err), err)'
+  `).body[0].expression
+  emptyErrors[0].init.arguments[3] = parse(`
+    ddTraceDescriptorId === undefined
+      ? '""'
+      : '(__context.ddTrace?.jitRuntime.recordResolverError(__context.ddTrace, ' +
+        ddTraceDescriptorId + ', err), "")'
+  `).body[0].expression
+
   const [resolverCall] = resolverCalls
   const replacement = parse(`
-    DD_CALL.slice(0, -1) +
-      (ddTraceDescriptorId === undefined ? '' : ', ' + ddTraceDescriptorId) +
-      ')'
+    context.ddTraceRuntime === undefined
+      ? DD_CALL
+      : context.ddTraceRuntime.compileResolverCall(context, DD_CALL, ddTraceDescriptorId)
   `).body[0].expression
   replaceIdentifier(replacement, 'DD_CALL', resolverCall.init)
   resolverCall.init = replacement

--- a/packages/datadog-plugin-graphql/DETAILS.md
+++ b/packages/datadog-plugin-graphql/DETAILS.md
@@ -34,7 +34,7 @@ Orchestrion applies the instrumentation entries in order. Some entries wrap a fu
 | --- | --- | --- |
 | `buildCompilationContext` | Publish the returned compilation context | Let the plugin attach `ddTraceRuntime` and an empty `ddTracePlan` |
 | `compileObjectType` | Add a branch for an inlined default field | Replace its generated property read with a guarded runtime call |
-| `compileDeferredField` | Register the field and append its descriptor ID to the generated resolver call | Preserve field identity after the compiler hoists the resolver |
+| `compileDeferredField` | Validate and replace the generated resolver call, then add error recording | Preserve field identity and per-invocation failures after the compiler hoists the resolver |
 | `createBoundQuery` | Finalize the plan and add `ddTrace` to the generated execution context | Connect reusable compilation data to one request |
 | The returned query | Add the standard execution wrapper, then adjust that wrapper | Give the plugin the document, schema, plan, and resolver map |
 
@@ -60,7 +60,7 @@ The `buildCompilationContext` completion subscriber calls `configureCompilationC
 
 The rewritten compiler calls the bridge while it generates a query. It records field descriptors and emits calls back to the same bridge.
 
-`finalizeCompilation` replaces temporary parent path keys with descriptor IDs. It also wraps the resolver map.
+`finalizeCompilation` replaces temporary parent path keys with descriptor IDs.
 
 The compilation plan changes names as it crosses each boundary:
 
@@ -104,7 +104,7 @@ The field code reaches compilation data through `rootCtx.jitPlan`.
 
 | Field shape | Generated operation | Datadog connection | Runtime entry |
 | --- | --- | --- | --- |
-| Deferred resolver call | Call through the hoisted resolver map | A private fifth argument contains the descriptor ID | `resolveJitField` |
+| Deferred resolver call | Guarded call through the hoisted resolver map | Generated dispatch contains the descriptor ID | `resolveCompiledJitField` |
 | Inlined default property read | Direct read from the parent result | A conditional expression surrounds the original read | `resolveJitDefaultInvocation` |
 
 These names describe the generated shapes. `alwaysDefer` can create a resolver call for a field that originally used default resolution.
@@ -113,11 +113,15 @@ These names describe the generated shapes. `alwaysDefer` can create a resolver c
 
 `graphql-jit` puts each resolver call in its deferred list. Later, `compileDeferredField` writes the call into the generated query source.
 
-`configureGraphqlJitDeferredField` inserts `registerField` before that source is built. It appends the returned descriptor ID to the resolver call.
+`configureGraphqlJitDeferredField` validates the call template and inserts `registerField` before the source is built.
+It passes the source, resolver name, and descriptor ID to `compileResolverCall`.
 
-`finalizeCompilation` wraps every function in the hoisted resolver map. The wrapper reads the fifth argument and uses it to select `rootCtx.jitPlan.fields[descriptorId]`.
+For a registered field, `compileResolverCall` restores the original resolver in the map. The generated fast path calls that resolver directly.
 
-The wrapper then calls `resolveJitField`. `invokeResolver` removes the private argument before it calls user code, so the public resolver signature does not change.
+When observation is active, the generated branch calls `resolveCompiledJitField` with the descriptor ID and original resolver.
+The compiler error branches call `recordResolverError` with the same descriptor ID.
+
+When field registration fails, `compileResolverCall` keeps the generated call. It wraps that resolver for normal GraphQL instrumentation.
 
 ### Inlined default property reads
 
@@ -163,7 +167,7 @@ Their collapsed path is `users.*.profile.name`. Uncollapsed tracing combines the
 
 This split lets one compiled plan serve all list items. It also lets configuration decide whether list positions count toward the resolver depth.
 
-Both paths resolve a `JitFieldDescriptor` from `rootCtx.jitPlan`. The deferred wrapper performs the lookup before `resolveJitField`.
+Both paths resolve a `JitFieldDescriptor` from `rootCtx.jitPlan`. The deferred dispatch passes the descriptor ID to `resolveCompiledJitField`.
 
 `resolveJitDefaultInvocation` performs the lookup internally.
 

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -382,10 +382,15 @@ class GraphQLExecutePlugin extends TracingPlugin {
       instrumentedArgs.delete(ctx.ddInstrumentedArgs)
     }
 
-    const releaseBeforeExecuteHook = ctx.ddRootCtx?.resolveHooksPending === true
-    if (releaseBeforeExecuteHook) releaseRootContext(ctx.ddRootCtx, finishPendingFields)
+    const rootCtx = ctx.ddRootCtx
+    const releaseBeforeExecuteHook = rootCtx?.resolveHooksPending === true
+    if (releaseBeforeExecuteHook) {
+      releaseRootContext(rootCtx, finishPendingFields)
+    } else if (rootCtx?.jitResolveHooksPending === true) {
+      runResolveHooks(rootCtx)
+    }
     this.config.hooks.execute(span, ctx.ddArgs, res)
-    if (!releaseBeforeExecuteHook) releaseRootContext(ctx.ddRootCtx, finishPendingFields)
+    if (!releaseBeforeExecuteHook) releaseRootContext(rootCtx, finishPendingFields)
     span.finish()
   }
 
@@ -496,6 +501,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
         if (error) recordResolveError(field, error)
         if (this.config.hooks.resolve) {
           field.resolveHookContext = createResolveHookContext(field, field.error, result)
+          rootCtx.jitResolveHooksPending = true
         }
         return
       }
@@ -1492,14 +1498,14 @@ function tagExecutionErrors (config, span, errors) {
 function releaseRootContext (rootCtx, finishPendingFields) {
   const endTime = rootCtx.executeSpan._getTime()
   if (rootCtx.resolveFields !== undefined) {
+    if (rootCtx.resolveHooksPending || rootCtx.jitResolveHooksPending) {
+      runResolveHooks(rootCtx)
+    }
     for (let field = rootCtx.resolveFields; field; field = field.nextResolveField) {
       const holder = field.currentStore?.graphqlResolveField
       if (holder?.field === field) {
         holder.field = undefined
         field.currentStore.graphqlResolveField = undefined
-      }
-      if (field.resolveHookContext) {
-        rootCtx.config.hooks.resolve(field.span, field.resolveHookContext)
       }
       field.span.finish(field.endTime > PENDING_FIELD_END_TIME ? field.endTime : endTime)
     }
@@ -1512,6 +1518,21 @@ function releaseRootContext (rootCtx, finishPendingFields) {
   // Resolver-created async resources retain copied stores that all share this owner.
   for (const key of Object.keys(rootCtx)) {
     rootCtx[key] = undefined
+  }
+}
+
+/**
+ * @param {object} rootCtx
+ */
+function runResolveHooks (rootCtx) {
+  rootCtx.resolveHooksPending = undefined
+  rootCtx.jitResolveHooksPending = undefined
+
+  for (let field = rootCtx.resolveFields; field; field = field.nextResolveField) {
+    if (field.resolveHookContext === undefined) continue
+
+    rootCtx.config.hooks.resolve(field.span, field.resolveHookContext)
+    field.resolveHookContext = undefined
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -492,6 +492,13 @@ class GraphQLExecutePlugin extends TracingPlugin {
         }
         return
       }
+      if (field.isSharedJitField) {
+        if (error) recordResolveError(field, error)
+        if (this.config.hooks.resolve) {
+          field.resolveHookContext = createResolveHookContext(field, field.error, result)
+        }
+        return
+      }
       this.#completeResolveSpan(field, error, result)
       return
     }
@@ -520,14 +527,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
     if (error) span.setTag('error', error)
 
     if (this.config.hooks.resolve) {
-      this.config.hooks.resolve(span, {
-        fieldName: field.fieldName,
-        path: field.pathString,
-        error: error || null,
-        // Any thenable from any realm — keep undefined so the hook doesn't
-        // accidentally see the unresolved promise.
-        result: typeof result?.then === 'function' ? undefined : result,
-      })
+      this.config.hooks.resolve(span, createResolveHookContext(field, error, result))
     }
   }
 }
@@ -543,15 +543,13 @@ function wrapResolve (resolve, isJit = false) {
   if (typeof resolve !== 'function' || (!isJit && patchedResolvers.has(resolve))) return resolve
 
   // Replace a schema wrapper with the execution-local JIT variant instead of nesting both.
-  resolve = originalResolvers.get(resolve) ?? resolve
+  resolve = unwrapResolve(resolve)
   if (isJit) {
     const jitResolver = jitResolvers.get(resolve)
     if (jitResolver !== undefined) return jitResolver
   }
 
   function resolveAsync (source, args, contextValue, info) {
-    const descriptorId = isJit ? arguments[4] : undefined
-
     const hasIastSub = iastResolveCh.hasSubscribers
     const hasResolverSub = resolverStartCh.hasSubscribers
 
@@ -565,10 +563,6 @@ function wrapResolve (resolve, isJit = false) {
       ? legacyStorage.getStore()?.graphqlRootCtx
       : contexts.get(contextValue) ?? legacyStorage.getStore()?.graphqlRootCtx
     if (!rootCtx) return invokeResolver(resolve, this, arguments, isJit)
-
-    if (descriptorId !== undefined) {
-      return resolveJitField(resolve, this, arguments, args, info, rootCtx, rootCtx.jitPlan.fields[descriptorId])
-    }
 
     const infoPath = info?.path
     const config = rootCtx.config
@@ -703,15 +697,25 @@ function wrapResolve (resolve, isJit = false) {
 
 /**
  * @param {GraphQLFieldResolver} resolve
- * @param {unknown} self
- * @param {ArgumentsList} callArguments
- * @param {Record<string, unknown>} args
- * @param {import('graphql').GraphQLResolveInfo} info
+ * @returns {GraphQLFieldResolver}
+ */
+function unwrapResolve (resolve) {
+  return originalResolvers.get(resolve) ?? resolve
+}
+
+/**
  * @param {object} rootCtx
- * @param {JitDescriptor} descriptor
+ * @param {number} descriptorId
+ * @param {GraphQLFieldResolver} resolve
+ * @param {unknown} self
+ * @param {unknown} source
+ * @param {Record<string, unknown>} args
+ * @param {unknown} contextValue
+ * @param {import('graphql').GraphQLResolveInfo} info
  * @returns {unknown}
  */
-function resolveJitField (resolve, self, callArguments, args, info, rootCtx, descriptor) {
+function resolveCompiledJitField (rootCtx, descriptorId, resolve, self, source, args, contextValue, info) {
+  const descriptor = rootCtx.jitPlan.fields[descriptorId]
   const config = rootCtx.config
   const path = config.collapse ? undefined : pathToArray(info.path)
   const pathString = path ? path.join('.') : descriptor.collapsedPath
@@ -738,7 +742,7 @@ function resolveJitField (resolve, self, callArguments, args, info, rootCtx, des
 
   const depth = config.countListIndices ? descriptor.pathDepth : descriptor.selectionDepth
   if (rootCtx.depthDisabled || (config.depth >= 0 && config.depth < depth)) {
-    return invokeResolver(resolve, self, callArguments, true)
+    return resolve.call(self, source, args, contextValue, info)
   }
 
   let field
@@ -750,7 +754,10 @@ function resolveJitField (resolve, self, callArguments, args, info, rootCtx, des
   }
   if (field) {
     field.endTime = REUSED_FIELD_END_TIME
-    return callInCollapsedScope(resolve, self, callArguments, field, true)
+    if (legacyStorage.getStore() !== field.currentStore) {
+      legacyStorage.enterWith(field.currentStore)
+    }
+    return resolve.call(self, source, args, contextValue, info)
   }
 
   field = startJitField(
@@ -769,13 +776,15 @@ function resolveJitField (resolve, self, callArguments, args, info, rootCtx, des
   const finishField = (error, result) => {
     rootCtx.plugin?.completeResolveSpan(rootCtx, field, error, result)
   }
-  return callInAsyncScope(
+  return callCompiledJitInAsyncScope(
     resolve,
     self,
-    callArguments,
+    source,
+    args,
+    contextValue,
+    info,
     field.currentStore,
-    finishField,
-    true
+    finishField
   )
 }
 
@@ -803,6 +812,7 @@ function startJitField (rootCtx, descriptor, pathString, path, variableValues, i
     span: null,
     parentStore: null,
     currentStore: null,
+    isSharedJitField: rootCtx.config.collapse && descriptor.pathDepth !== descriptor.selectionDepth,
     tags: rootCtx.config.collapse && !rootCtx.config.source ? descriptor.tags : undefined,
   }
   if (rootCtx.config.collapse) {
@@ -824,6 +834,18 @@ function startJitField (rootCtx, descriptor, pathString, path, variableValues, i
   const executeSpan = rootCtx.executeSpan
   rootCtx.plugin.startResolveSpan(field, rootCtx, executeSpan, executeSpan._getTime(), variableValues, parentField)
   return field
+}
+
+/**
+ * @param {object} rootCtx
+ * @param {number} descriptorId
+ * @param {unknown} error
+ */
+function recordJitResolverError (rootCtx, descriptorId, error) {
+  const field = rootCtx?.jitFields?.[descriptorId]
+  if (!field?.isSharedJitField) return
+
+  recordResolveError(field, error)
 }
 
 /**
@@ -1080,6 +1102,53 @@ function callInCollapsedScope (fn, thisArg, args, field, isJit) {
     legacyStorage.enterWith(field.currentStore)
   }
   return invokeResolver(fn, thisArg, args, isJit)
+}
+
+/**
+ * @param {GraphQLFieldResolver} resolve
+ * @param {unknown} self
+ * @param {unknown} source
+ * @param {Record<string, unknown>} args
+ * @param {unknown} contextValue
+ * @param {import('graphql').GraphQLResolveInfo} info
+ * @returns {unknown}
+ */
+function invokeCompiledJitResolver (resolve, self, source, args, contextValue, info) {
+  return resolve.call(self, source, args, contextValue, info)
+}
+
+/**
+ * @param {GraphQLFieldResolver} resolve
+ * @param {unknown} self
+ * @param {unknown} source
+ * @param {Record<string, unknown>} args
+ * @param {unknown} contextValue
+ * @param {import('graphql').GraphQLResolveInfo} info
+ * @param {object} store
+ * @param {(error: unknown, result?: unknown) => void} callback
+ * @returns {unknown}
+ */
+function callCompiledJitInAsyncScope (resolve, self, source, args, contextValue, info, store, callback) {
+  try {
+    const result = legacyStorage.run(
+      store,
+      invokeCompiledJitResolver,
+      resolve,
+      self,
+      source,
+      args,
+      contextValue,
+      info
+    )
+    if (result !== null && typeof result === 'object' && typeof result.then === 'function') {
+      return observeThenable(result, callback)
+    }
+    callback(null, result)
+    return result
+  } catch (error) {
+    callback(error)
+    throw error
+  }
 }
 
 /**
@@ -1490,5 +1559,8 @@ function addVariableTags (config, span, variableValues) {
 
 module.exports = GraphQLExecutePlugin
 module.exports.readJitDefaultInScope = readJitDefaultInScope
-module.exports.wrapJitResolve = wrapJitResolve
+module.exports.recordJitResolverError = recordJitResolverError
+module.exports.resolveCompiledJitField = resolveCompiledJitField
 module.exports.resolveJitDefaultInvocation = resolveJitDefaultInvocation
+module.exports.unwrapJitResolve = unwrapResolve
+module.exports.wrapJitResolve = wrapJitResolve

--- a/packages/datadog-plugin-graphql/src/jit.js
+++ b/packages/datadog-plugin-graphql/src/jit.js
@@ -5,7 +5,14 @@ const createGraphqlJitRuntime = require('../../datadog-instrumentations/src/help
 const GraphQLExecutePlugin = require('./execute')
 const { getBaseTypeName } = require('./utils')
 
-const { readJitDefaultInScope, resolveJitDefaultInvocation, wrapJitResolve } = GraphQLExecutePlugin
+const {
+  readJitDefaultInScope,
+  recordJitResolverError,
+  resolveCompiledJitField,
+  resolveJitDefaultInvocation,
+  unwrapJitResolve,
+  wrapJitResolve,
+} = GraphQLExecutePlugin
 
 /**
  * @typedef {import('graphql').ExecutionArgs} ExecutionArguments
@@ -30,8 +37,11 @@ const patchedResolverMaps = new WeakSet()
 const { configureCompilationContext, runtime: jitRuntime } = createGraphqlJitRuntime({
   createFieldMetadata,
   readDefaultInScope: readJitDefaultInScope,
+  recordResolverError: recordJitResolverError,
   resolveDefaultInvocation: resolveJitDefaultInvocation,
+  resolveField: resolveCompiledJitField,
   startExecution,
+  unwrapResolver: unwrapJitResolve,
   wrapResolver: wrapJitResolve,
 })
 

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -12,8 +12,12 @@ const { after, before, describe, it } = require('mocha')
 const semifies = require('../../../vendor/dist/semifies')
 const { assertObjectContains, sandboxCwd, useSandbox } = require('../../../integration-tests/helpers')
 const createGraphqlJitRuntime = require('../../datadog-instrumentations/src/helpers/graphql-jit-runtime')
+const { parse, query } = require('../../datadog-instrumentations/src/helpers/rewriter/compiler')
 const rewriterInstrumentations = require('../../datadog-instrumentations/src/helpers/rewriter/instrumentations')
 const { rewrite } = require('../../datadog-instrumentations/src/helpers/rewriter')
+const {
+  configureGraphqlJitDeferredField,
+} = require('../../datadog-instrumentations/src/helpers/rewriter/transforms')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const { expectedSchema } = require('./naming')
@@ -291,23 +295,15 @@ describe('Plugin', () => {
       })
       const resolverCallSource = '__context.resolvers.resolver(source, args, contextValue, info)'
 
-      for (const unsupportedCall of ['resolver', 'resolver(source)']) {
-        const fallbackContext = {
-          ddTracePlan: { fields: [] },
-          resolvers: { resolver },
-        }
-        assert.strictEqual(runtime.compileResolverCall(fallbackContext, unsupportedCall, 0), unsupportedCall)
-        assert.strictEqual(fallbackContext.ddTraceWrapAllResolvers, true)
-        assert.deepStrictEqual(runtime.finalizeCompilation(fallbackContext), { fields: [] })
-        assert.strictEqual(fallbackContext.resolvers.resolver, resolver)
-      }
-
       const unregisteredContext = { resolvers: { resolver } }
-      assert.strictEqual(runtime.compileResolverCall(unregisteredContext, resolverCallSource), resolverCallSource)
+      assert.strictEqual(
+        runtime.compileResolverCall(unregisteredContext, resolverCallSource, 'resolver'),
+        resolverCallSource
+      )
       assert.strictEqual(unregisteredContext.resolvers.resolver, resolver)
 
       const context = { resolvers: { resolver } }
-      const resolverCall = runtime.compileResolverCall(context, resolverCallSource, 0)
+      const resolverCall = runtime.compileResolverCall(context, resolverCallSource, 'resolver', 0)
       assert.strictEqual(context.resolvers.resolver, resolver)
       assert.match(resolverCall, /jitRuntime\.resolveField/)
       assert.match(resolverCall, /depthDisabled/)
@@ -397,6 +393,44 @@ void generatedResolver
             `${filePath} retained its compilation context as ${format}`
           )
           assert.doesNotMatch(queryWrapper, /const __apm\$traced =/, `${filePath} retained the traced closure as ${format}`)
+        }
+      })
+
+      it('rejects unsupported resolver call source shapes in the rewriter', () => {
+        const installedVersion = require(join(packageRoot, 'package.json')).version
+        const filePaths = new Set()
+        for (const { module } of rewriterInstrumentations) {
+          if (module.name === 'graphql-jit' && semifies(installedVersion, module.versionRange)) {
+            filePaths.add(module.filePath)
+          }
+        }
+
+        for (const filePath of filePaths) {
+          const content = readFileSync(join(packageRoot, filePath), 'utf8')
+          const isModule = filePath.endsWith('.mjs') || filePath.includes('/esm/')
+          for (const testCase of [
+            {
+              source: '.resolvers.$' + '{resolverName}(',
+              replacement: '.resolver.$' + '{resolverName}(',
+              error: /resolver map access not found/,
+            },
+            {
+              source: '$' + '{executionInfo})`',
+              replacement: '$' + '{executionInfo}`',
+              error: /resolver call end not found/,
+            },
+          ]) {
+            const unsupported = content.replace(testCase.source, testCase.replacement)
+            assert.notStrictEqual(unsupported, content, `${filePath} did not contain ${testCase.source}`)
+
+            const ast = parse(unsupported, { isModule })
+            const deferredFields = query(ast, 'FunctionDeclaration[id.name="compileDeferredField"]')
+            assert.strictEqual(deferredFields.length, 1)
+            assert.throws(
+              () => configureGraphqlJitDeferredField({}, deferredFields[0]),
+              testCase.error
+            )
+          }
         }
       })
 

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -310,6 +310,7 @@ describe('Plugin', () => {
       const resolverCall = runtime.compileResolverCall(context, resolverCallSource, 0)
       assert.strictEqual(context.resolvers.resolver, resolver)
       assert.match(resolverCall, /jitRuntime\.resolveField/)
+      assert.match(resolverCall, /depthDisabled/)
 
       if (generatedCodeLinter === undefined) return
 
@@ -1366,6 +1367,32 @@ void generatedResolver
                 items: [{ value: 'one' }, { value: 'two' }],
               })
               assert.deepStrictEqual(hookCalls, [{ error: undefined, result: 'one' }])
+
+              let releaseFirstResolver = () => {}
+              const firstResolver = new Promise(resolve => {
+                releaseFirstResolver = resolve
+              })
+              hookCalls.length = 0
+              items = [
+                { value: firstResolver },
+                { error: 'later resolver error' },
+              ]
+              const pendingResult = executeWithTrace(
+                () => query({}, {}, {}),
+                new RegExp(operationName)
+              )
+              releaseFirstResolver('one')
+              const delayedResult = await pendingResult
+              assert.deepStrictEqual(delayedResult.data, {
+                items: [{ value: 'one' }, { value: null }],
+              })
+              assert.deepStrictEqual(delayedResult.errors.map(error => error.message), [
+                'later resolver error',
+              ])
+              assert.deepStrictEqual(hookCalls, [{
+                error: 'later resolver error',
+                result: undefined,
+              }])
             }
           }
         } finally {

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -11,6 +11,7 @@ const { after, before, describe, it } = require('mocha')
 
 const semifies = require('../../../vendor/dist/semifies')
 const { assertObjectContains, sandboxCwd, useSandbox } = require('../../../integration-tests/helpers')
+const createGraphqlJitRuntime = require('../../datadog-instrumentations/src/helpers/graphql-jit-runtime')
 const rewriterInstrumentations = require('../../datadog-instrumentations/src/helpers/rewriter/instrumentations')
 const { rewrite } = require('../../datadog-instrumentations/src/helpers/rewriter')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -22,6 +23,15 @@ const generatedCodeLinter = semifies(process.version, require('eslint/package.js
   : undefined
 
 function noop () {}
+
+/**
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+function identity (value) {
+  return value
+}
 
 /**
  * @param {WeakRef<object>} reference
@@ -267,6 +277,56 @@ describe('Plugin', () => {
       )
     }
 
+    it('generates lint-clean resolver dispatch', async () => {
+      function resolver () {}
+
+      const { runtime } = createGraphqlJitRuntime({
+        createFieldMetadata: noop,
+        recordResolverError: noop,
+        resolveDefaultInvocation: noop,
+        resolveField: noop,
+        startExecution: noop,
+        unwrapResolver: identity,
+        wrapResolver: identity,
+      })
+      const resolverCallSource = '__context.resolvers.resolver(source, args, contextValue, info)'
+
+      for (const unsupportedCall of ['resolver', 'resolver(source)']) {
+        const fallbackContext = {
+          ddTracePlan: { fields: [] },
+          resolvers: { resolver },
+        }
+        assert.strictEqual(runtime.compileResolverCall(fallbackContext, unsupportedCall, 0), unsupportedCall)
+        assert.strictEqual(fallbackContext.ddTraceWrapAllResolvers, true)
+        assert.deepStrictEqual(runtime.finalizeCompilation(fallbackContext), { fields: [] })
+        assert.strictEqual(fallbackContext.resolvers.resolver, resolver)
+      }
+
+      const unregisteredContext = { resolvers: { resolver } }
+      assert.strictEqual(runtime.compileResolverCall(unregisteredContext, resolverCallSource), resolverCallSource)
+      assert.strictEqual(unregisteredContext.resolvers.resolver, resolver)
+
+      const context = { resolvers: { resolver } }
+      const resolverCall = runtime.compileResolverCall(context, resolverCallSource, 0)
+      assert.strictEqual(context.resolvers.resolver, resolver)
+      assert.match(resolverCall, /jitRuntime\.resolveField/)
+
+      if (generatedCodeLinter === undefined) return
+
+      const source = `'use strict'
+
+function generatedResolver (__context, source, args, contextValue, info) {
+  return ${resolverCall}
+}
+
+void generatedResolver
+`
+      const [{ messages }] = await generatedCodeLinter.lintText(source, {
+        filePath: join(__dirname, '../src/generated-resolver-dispatch.js'),
+      })
+      assert.deepStrictEqual(messages, [])
+    })
+
     withVersions('graphql', 'graphql-jit', '>=0.7.0', version => {
       const packageRoot = join(__dirname, '../../../versions', `graphql-jit@${version}`, 'node_modules/graphql-jit')
 
@@ -373,6 +433,20 @@ describe('Plugin', () => {
           assert.strictEqual(resolve.parent_id.toString(), execute.span_id.toString())
         })
         assert.deepStrictEqual(result.data, { hello: 'Ada' })
+      })
+
+      it('does not nest schema and compiled resolver instrumentation', async () => {
+        const localSchema = buildSchema()
+        const document = graphql.parse('query ReusedSchema { hello }')
+
+        await executeWithTrace(() => graphql.execute({ schema: localSchema, document }), /ReusedSchema/)
+
+        const { query } = compileQuery(localSchema, document)
+        const result = await executeWithTrace(() => query({}, {}, {}), /ReusedSchema/, traces => {
+          const resolves = traces[0].filter(span => span.name === 'graphql.resolve')
+          assert.strictEqual(resolves.length, 1)
+        })
+        assert.deepStrictEqual(result.data, { hello: 'world' })
       })
 
       it('releases operation inputs retained through resolver timers', async function () {
@@ -1161,6 +1235,141 @@ describe('Plugin', () => {
           } finally {
             if (withResolverSubscriber) resolverStartChannel.unsubscribe(noop)
           }
+        }
+      })
+
+      it('records errors from every collapsed explicit resolver invocation', async () => {
+        const tracer = require('../../dd-trace')
+
+        try {
+          for (const testCase of [
+            {
+              name: 'Sync',
+              error: 'sync sibling error',
+              hookError: 'sync sibling error',
+              fail (message) {
+                throw new Error(message)
+              },
+            },
+            {
+              name: 'Async',
+              error: 'async sibling error',
+              hookError: 'async sibling error',
+              fail (message) {
+                return Promise.reject(new Error(message))
+              },
+            },
+            {
+              name: 'Falsy',
+              error: '',
+              hookError: 'GraphQL resolver rejected without an error',
+              fail () {
+                // eslint-disable-next-line prefer-promise-reject-errors -- Exercise a falsy rejection.
+                return Promise.reject()
+              },
+            },
+          ]) {
+            const hookCalls = []
+            let items = [
+              { value: 'one' },
+              { error: testCase.error },
+              { value: 'three' },
+            ]
+            const Item = new graphql.GraphQLObjectType({
+              name: `Collapsed${testCase.name}ErrorItem`,
+              fields: {
+                value: {
+                  type: graphql.GraphQLString,
+                  resolve (source) {
+                    return source.error !== undefined ? testCase.fail(source.error) : source.value
+                  },
+                },
+              },
+            })
+            const errorSchema = new graphql.GraphQLSchema({
+              query: new graphql.GraphQLObjectType({
+                name: `Collapsed${testCase.name}ErrorQuery`,
+                fields: {
+                  items: {
+                    type: new graphql.GraphQLList(Item),
+                    resolve: () => items,
+                  },
+                },
+              }),
+            })
+            const operationName = `Collapsed${testCase.name}SiblingError`
+
+            tracer.use('graphql', {
+              collapse: true,
+              hooks: {
+                resolve (_span, field) {
+                  if (field.fieldName === 'value') {
+                    hookCalls.push({
+                      error: field.error?.message,
+                      result: field.result,
+                    })
+                  }
+                },
+              },
+            })
+            const compiled = compileQuery(
+              errorSchema,
+              graphql.parse(`query ${operationName} { items { value } }`),
+              undefined,
+              { debug: true }
+            )
+            const compilation = compiled.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation
+            assert.match(compilation, /jitRuntime\.resolveField/)
+            assert.match(compilation, /jitRuntime\.recordResolverError/)
+            const { query } = compiled
+            const result = await executeWithTrace(() => query({}, {}, {}), new RegExp(operationName), traces => {
+              const resolve = traces[0].find(span =>
+                span.name === 'graphql.resolve' && span.meta['graphql.field.name'] === 'value')
+              assert.ok(resolve, 'expected the collapsed value span')
+              assert.strictEqual(resolve.error, 1)
+            })
+
+            assert.deepStrictEqual(result.data, {
+              items: [
+                { value: 'one' },
+                { value: null },
+                { value: 'three' },
+              ],
+            })
+            assert.strictEqual(result.errors.length, 1)
+            assert.strictEqual(result.errors[0].message, testCase.error)
+            assert.deepStrictEqual(hookCalls, [{
+              error: testCase.hookError,
+              result: undefined,
+            }])
+
+            if (testCase.name === 'Sync') {
+              hookCalls.length = 0
+              items = [
+                { error: 'first resolver error' },
+                { error: 'second resolver error' },
+              ]
+              const repeatedResult = await executeWithTrace(() => query({}, {}, {}), new RegExp(operationName))
+              assert.deepStrictEqual(repeatedResult.errors.map(error => error.message), [
+                'first resolver error',
+                'second resolver error',
+              ])
+              assert.deepStrictEqual(hookCalls, [{
+                error: 'first resolver error',
+                result: undefined,
+              }])
+
+              hookCalls.length = 0
+              items = [{ value: 'one' }, { value: 'two' }]
+              const successfulResult = await executeWithTrace(() => query({}, {}, {}), new RegExp(operationName))
+              assert.deepStrictEqual(successfulResult.data, {
+                items: [{ value: 'one' }, { value: 'two' }],
+              })
+              assert.deepStrictEqual(hookCalls, [{ error: undefined, result: 'one' }])
+            }
+          }
+        } finally {
+          tracer.use('graphql', { variables: ['id', 'name'] })
         }
       })
 

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -882,6 +882,27 @@ void generatedResolver
 
       it('runs the execute hook before collapsed JIT resolver spans finish', async () => {
         const tracer = require('../../dd-trace')
+        const Item = new graphql.GraphQLObjectType({
+          name: 'HookOrderItem',
+          fields: {
+            value: {
+              type: graphql.GraphQLString,
+              resolve: source => source.value,
+            },
+          },
+        })
+        const hookSchema = new graphql.GraphQLSchema({
+          query: new graphql.GraphQLObjectType({
+            name: 'HookOrderQuery',
+            fields: {
+              items: {
+                type: new graphql.GraphQLList(Item),
+                resolve: () => [{ value: 'one' }, { value: 'two' }],
+              },
+            },
+          }),
+        })
+        const hookOrder = []
         let resolveSpan
         let resolveFinishedAtExecute
 
@@ -890,24 +911,30 @@ void generatedResolver
          * @param {{ fieldName: string }} field
          */
         function resolveHook (span, field) {
-          if (field.fieldName === 'hello') resolveSpan = span
+          if (field.fieldName === 'value') {
+            hookOrder.push('resolve')
+            resolveSpan = span
+          }
         }
 
         function executeHook () {
+          hookOrder.push('execute')
           resolveFinishedAtExecute = resolveSpan?._duration !== undefined
         }
 
         try {
           tracer.use('graphql', {
+            collapse: true,
             variables: ['id', 'name'],
             hooks: { execute: executeHook, resolve: resolveHook },
           })
-          const { query } = compileQuery(schema, graphql.parse('query HookOrder { hello }'))
+          const { query } = compileQuery(hookSchema, graphql.parse('query HookOrder { items { value } }'))
           const result = await executeWithTrace(() => query({}, {}, {}), /HookOrder/)
 
           assert.strictEqual(resolveFinishedAtExecute, false)
           assert.ok(resolveSpan, 'expected the resolve hook to receive the resolver span')
-          assert.deepStrictEqual(result.data, { hello: 'world' })
+          assert.deepStrictEqual(hookOrder, ['resolve', 'execute'])
+          assert.deepStrictEqual(result.data, { items: [{ value: 'one' }, { value: 'two' }] })
         } finally {
           tracer.use('graphql', { variables: ['id', 'name'] })
         }
@@ -1271,6 +1298,7 @@ void generatedResolver
             },
           ]) {
             const hookCalls = []
+            const hookOrder = []
             let items = [
               { value: 'one' },
               { error: testCase.error },
@@ -1303,8 +1331,12 @@ void generatedResolver
             tracer.use('graphql', {
               collapse: true,
               hooks: {
+                execute () {
+                  hookOrder.push('execute')
+                },
                 resolve (_span, field) {
                   if (field.fieldName === 'value') {
+                    hookOrder.push('resolve')
                     hookCalls.push({
                       error: field.error?.message,
                       result: field.result,
@@ -1343,6 +1375,7 @@ void generatedResolver
               error: testCase.hookError,
               result: undefined,
             }])
+            assert.deepStrictEqual(hookOrder, ['resolve', 'execute'])
 
             if (testCase.name === 'Sync') {
               hookCalls.length = 0


### PR DESCRIPTION
Collapsed GraphQL JIT fields observe only the first resolver completion. A later list sibling can fail without marking the shared span or resolve hook.

The compiler records later failures in the existing synchronous and asynchronous error branches. Compiler-owned dispatch avoids a completion observer and resolver wrapper on the hot path.

On Node 24.18.0 and V8 13.6, a 50,000-item collapsed query improved from 87.8–90.9 to 45.8–48.9 ns per resolver.