### PR TITLE
docs(agents): require PR contents to serve the PR title

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,7 @@ Avoid try/catch in hot paths - validate inputs early
 - **Avoid diverging implementations**: If behavior already exists elsewhere, reuse it or extract a shared helper instead of reimplementing it in a second place.
 - **Minimal public surface**: Don't add new programmatic public APIs without an explicit case — removing them later is painful. If an internal caller needs reach, add a narrow internal method on the producer, not a public one.
 - **Small PRs**: Break large efforts into incremental, reviewable changes
+- **One PR, one purpose**: Every change in a PR must serve that PR's title. See "Scope discipline".
 - **Descriptive code**: Self-documenting with verbs in function names; comment when needed
 - **Readable formatting**: Empty lines for grouping, split complex objects, extract variables
 - **Avoid large refactors**: Iterative changes, gradual pattern introduction
@@ -368,6 +369,39 @@ Example: `feat(appsec): add new WAF rule`
 - Use template from `.github/pull_request_template.md`
 - Label: `semver-patch` (fixes only), `semver-minor` (new features), `semver-major` (breaking)
 - **All tests must pass - all-green policy, no exceptions**
+
+### Scope discipline
+
+**Every line in a PR must serve the PR title.** The title is the contract: a reviewer reading only the
+title should be able to predict the diff. If a hunk can't be justified by pointing at the title, it does
+not belong in this PR.
+
+Defer to a follow-up PR, even when the change is obviously correct and the diff is one line:
+
+- Refactors, renames, and file moves not required by the fix or feature
+- Drive-by typo, comment, formatting, lint, and style fixes in untouched code
+- Unrelated bug fixes noticed while reading nearby code
+- Dependency bumps, config tweaks, and tooling changes the change doesn't need
+- Test cleanup or added coverage for behaviour this PR doesn't touch
+- Type/JSDoc improvements outside the changed functions
+- Debug logging, scratch scripts, benchmark files kept from development
+
+When you notice one of these, do not fix it inline. Note it in the PR description under a
+"Follow-ups" heading (or open an issue), finish the scoped change, then land the deferred work as its own
+PR. Two focused PRs always beat one mixed PR — never bundle to "save a round trip".
+
+Exceptions, each narrow:
+
+- A prerequisite refactor the change genuinely cannot be built on. Land it as a **separate preparatory PR**
+  first; only inline it when splitting is truly impossible, and then say so explicitly in the PR description.
+- Mechanical fallout that must move with the change to keep the tree green (call sites of a renamed
+  internal, updated snapshots, a lint fix on a line you already had to edit).
+- A repeating shape being fixed across siblings, per "Debugging failures" — grep for all instances of the
+  *same* bug and fix them together. That is one purpose, not several.
+
+Before opening or updating a PR, re-read the diff (`git diff <base>...HEAD` / `jj diff -r <base>::@`) and
+drop or split out anything the title doesn't cover. If the title needs "and" to describe the diff, the PR
+needs splitting — don't broaden the title to fit the diff.
 
 ### Flaky tests
 


### PR DESCRIPTION
### What does this PR do?

Adds a **Scope discipline** section to `AGENTS.md` (under *Pull Requests and CI*), plus a matching
*One PR, one purpose* bullet under *Core Principles*.

The new section states that every line in a PR must be justified by the PR title, enumerates the
categories that get deferred to a follow-up PR (drive-by refactors/renames, typo and formatting fixes in
untouched code, unrelated bug fixes, dependency bumps, unrelated test coverage, JSDoc outside the changed
functions, leftover debug logging/scratch files), and names the narrow exceptions: a prerequisite refactor
landed as its own preparatory PR, mechanical fallout required to keep the tree green, and fixing all
sibling instances of the same bug (already required by *Debugging failures*).

It closes with a concrete pre-open check: re-read the diff against the base and drop anything the title
doesn't cover; if the title needs "and", split the PR instead of broadening the title.

### Motivation

Agent-authored PRs tend to accumulate unrelated content — a rename here, a typo fix there, an unrelated bug
noticed while reading nearby code. Each addition is individually defensible but collectively inflates review
surface and couples unrelated risk into one revert unit. The existing *Small PRs* bullet asks for
incremental changes but says nothing about relatedness, so this fills that gap.
