### PR TITLE
ci(pr-title): fail PRs carrying changes their title doesn't cover

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -78,6 +78,16 @@ jobs:
                 'Use test, bench, ci, or chore.')
             }
 
+      # Everything in a PR must serve its title (AGENTS.md, "Scope discipline"). These checks look at
+      # evidence the author already supplied - commit types, file status, whitespace-only hunks - so they
+      # can't see semantic creep inside an otherwise relevant hunk. Apply the scope-exception label when a
+      # violation is deliberate, and say why in the PR description.
+      - name: Validate PR scope
+        if: steps.rename.outputs.renamed != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: await require('./scripts/pr-scope.js').reportScopeViolations({ context, core, github })
+
       - name: Sync labels with PR title
         if: >-
           steps.rename.outputs.renamed != 'true' &&

--- a/scripts/pr-scope.js
+++ b/scripts/pr-scope.js
@@ -1,0 +1,234 @@
+'use strict'
+
+/**
+ * Scope checks for pull requests: everything in a PR must serve its title.
+ *
+ * These are deterministic proxies for scope creep, not a semantic judgement. Each one keys off
+ * evidence the author already supplied (commit types, file status, whitespace-only hunks) rather
+ * than guessing intent from code. See the "Scope discipline" section of AGENTS.md.
+ *
+ * @typedef {'feat'|'fix'|'docs'|'style'|'refactor'|'perf'|'test'|'bench'|'build'|'ci'|'chore'|'revert'} CommitType
+ *
+ * @typedef {object} ConventionalSubject
+ * @property {CommitType} type
+ * @property {string} [scope]
+ *
+ * @typedef {object} PullRequestFile
+ * @property {string} filename
+ * @property {'added'|'removed'|'modified'|'renamed'|'copied'|'changed'|'unchanged'} status
+ * @property {number} changes
+ * @property {string} [patch] Unified diff. Omitted by the GitHub API for very large or binary files.
+ * @property {string} [previous_filename]
+ *
+ * @typedef {object} ScopeViolation
+ * @property {string} rule
+ * @property {string} message
+ *
+ * @typedef {object} StepBindings actions/github-script bindings, passed straight through from the workflow.
+ * @property {{ repo: { owner: string, repo: string }, payload: { pull_request: object } }} context
+ * @property {{ info: (message: string) => void, notice: (message: string) => void,
+ *   error: (message: string, properties?: { title?: string }) => void,
+ *   setFailed: (message: string) => void }} core
+ * @property {{ paginate: Function, rest: { pulls: { listFiles: Function, listCommits: Function } } }} github
+ */
+
+// Applied to a PR when a violation is deliberate; see the "Scope discipline" section of AGENTS.md.
+const EXCEPTION_LABEL = 'scope-exception'
+
+// Keep in sync with PR_TITLE_PATTERN in .github/workflows/pr-title.yml.
+const CONVENTIONAL_SUBJECT = /^(?:revert(!)?: .+|(feat|fix|docs|style|refactor|perf|test|bench|build|ci|chore)(?:\(([^)]+)\))?(!)?: .+)/
+
+// Commit types that support any change rather than adding scope of their own: a feature's tests, its
+// docs, the CI wiring it needs. A refactor, perf tweak, or second feature is scope of its own.
+const SUPPORTING_TYPES = new Set(['test', 'docs', 'ci', 'bench', 'chore'])
+
+// Title types under which a whitespace-only or pure-rename change is the point of the PR.
+const FORMATTING_TITLE_TYPES = new Set(['style', 'chore'])
+const RENAME_TITLE_TYPES = new Set(['style', 'chore', 'refactor', 'build', 'ci', 'test'])
+
+// Development leftovers. Anything matching these is a scratch artifact no PR title covers.
+const SCRATCH_PATTERNS = [
+  /^[^/]+\.(?:html|log)$/, // Reports and logs dropped at the repository root
+  /(?:^|\/)\.(?:claude|cursor|aider|pi-subagents|agents-local)\//, // Agent-tool state directories
+  /(?:^|\/)(?:scratch|tmp|temp)[-_.][^/]*$/, // scratch-notes.md, tmp.out, temp_script.js
+  /\.(?:orig|rej|bak|swp|swo)$/, // Merge and editor leftovers
+  /(?:^|\/)\.DS_Store$/,
+  /(?:^|\/)(?:npm|yarn)-debug\.log/,
+  /(?:^|\/)core\.\d+$/, // Crash dumps
+]
+
+/**
+ * @param {string} subject
+ * @returns {ConventionalSubject | undefined} Undefined when the subject isn't conventional (local WIP
+ *   commits are ignored: the squash-merge subject comes from the PR title, not from them).
+ */
+function parseConventionalSubject (subject) {
+  const match = CONVENTIONAL_SUBJECT.exec(subject)
+  if (!match) return
+  const [, revertBreaking, type, scope] = match
+  if (revertBreaking !== undefined || type === undefined) return { type: 'revert' }
+  return { type: /** @type {CommitType} */ (type), scope }
+}
+
+/**
+ * @param {string} patch Unified diff for a single file.
+ * @returns {boolean} True when added and removed lines differ only in whitespace.
+ */
+function isWhitespaceOnlyPatch (patch) {
+  const added = []
+  const removed = []
+
+  for (const line of patch.split('\n')) {
+    const marker = line[0]
+    if (marker !== '+' && marker !== '-') continue
+    if (line.startsWith('+++') || line.startsWith('---')) continue
+
+    // Comparing the sequences rather than the sets keeps a pure reorder (same lines, different order)
+    // out of this rule: it is a real change, just not a whitespace one.
+    ;(marker === '+' ? added : removed).push(line.slice(1).replaceAll(/\s+/g, ''))
+  }
+
+  if (added.length === 0 || added.length !== removed.length) return false
+  return added.every((line, index) => line === removed[index])
+}
+
+/**
+ * @param {ConventionalSubject} title
+ * @param {string[]} commitSubjects
+ * @returns {ScopeViolation[]}
+ */
+function findCommitTypeViolations (title, commitSubjects) {
+  const violations = []
+
+  for (const subject of commitSubjects) {
+    const commit = parseConventionalSubject(subject)
+    if (!commit) continue
+
+    if (commit.type !== title.type) {
+      if (SUPPORTING_TYPES.has(commit.type)) continue
+      violations.push({
+        rule: 'mixed-commit-type',
+        message: `Commit "${subject}" is a ${commit.type} change, but the PR is a ${title.type}. ` +
+          'Land it as its own PR.',
+      })
+      continue
+    }
+
+    if (title.scope && commit.scope && commit.scope !== title.scope) {
+      violations.push({
+        rule: 'mixed-commit-scope',
+        message: `Commit "${subject}" targets scope "${commit.scope}", but the PR title targets ` +
+          `"${title.scope}". Split it out or widen the PR title only if both are one change.`,
+      })
+    }
+  }
+
+  return violations
+}
+
+/**
+ * @param {ConventionalSubject} title
+ * @param {PullRequestFile[]} files
+ * @returns {ScopeViolation[]}
+ */
+function findFileViolations (title, files) {
+  const violations = []
+
+  for (const file of files) {
+    if (file.status === 'added' && SCRATCH_PATTERNS.some((pattern) => pattern.test(file.filename))) {
+      violations.push({
+        rule: 'scratch-artifact',
+        message: `${file.filename} looks like a development leftover. Remove it from the PR.`,
+      })
+      continue
+    }
+
+    if (file.status === 'renamed' && file.changes === 0 && !RENAME_TITLE_TYPES.has(title.type)) {
+      violations.push({
+        rule: 'rename-only-file',
+        message: `${file.filename} is a pure move from ${file.previous_filename} with no content change, ` +
+          `which a ${title.type} PR shouldn't carry. Land the move separately.`,
+      })
+      continue
+    }
+
+    if (file.status === 'modified' && file.patch && !FORMATTING_TITLE_TYPES.has(title.type) &&
+        isWhitespaceOnlyPatch(file.patch)) {
+      violations.push({
+        rule: 'formatting-only-file',
+        message: `${file.filename} only changes whitespace, which a ${title.type} PR shouldn't carry. ` +
+          'Land formatting separately.',
+      })
+    }
+  }
+
+  return violations
+}
+
+/**
+ * @param {object} pullRequest
+ * @param {string} pullRequest.title
+ * @param {string[]} pullRequest.commitSubjects First line of every commit on the branch.
+ * @param {PullRequestFile[]} pullRequest.files
+ * @returns {ScopeViolation[]} Empty when every change is justifiable by the title.
+ */
+function findScopeViolations ({ title, commitSubjects, files }) {
+  const parsedTitle = parseConventionalSubject(title)
+  // A non-conventional or revert title is the conventional-commit check's problem, not this one's.
+  if (!parsedTitle || parsedTitle.type === 'revert') return []
+
+  return [
+    ...findCommitTypeViolations(parsedTitle, commitSubjects),
+    ...findFileViolations(parsedTitle, files),
+  ]
+}
+
+/**
+ * Workflow entry point: reports scope violations on the pull request in context, failing the step when
+ * any are found.
+ *
+ * @param {StepBindings} bindings
+ * @returns {Promise<void>}
+ */
+async function reportScopeViolations ({ context, core, github }) {
+  const pullRequest = context.payload.pull_request
+  if ((pullRequest.labels || []).some(({ name }) => name === EXCEPTION_LABEL)) {
+    core.notice(`Skipping PR scope checks: the ${EXCEPTION_LABEL} label is applied.`)
+    return
+  }
+
+  const listAll = (endpoint) => github.paginate(endpoint, {
+    ...context.repo,
+    pull_number: pullRequest.number,
+    per_page: 100,
+  })
+  const [files, commits] = await Promise.all([
+    listAll(github.rest.pulls.listFiles),
+    listAll(github.rest.pulls.listCommits),
+  ])
+
+  const violations = findScopeViolations({
+    title: pullRequest.title || '',
+    commitSubjects: commits.map(({ commit }) => commit.message.split('\n', 1)[0]),
+    files,
+  })
+
+  if (violations.length === 0) {
+    core.info('PR scope OK.')
+    return
+  }
+
+  for (const { rule, message } of violations) {
+    core.error(message, { title: `PR scope: ${rule}` })
+  }
+  core.setFailed(`${violations.length} change(s) in this PR are not covered by its title. ` +
+    `Split them into follow-up PRs, or apply the ${EXCEPTION_LABEL} label with a justification.`)
+}
+
+module.exports = {
+  EXCEPTION_LABEL,
+  findScopeViolations,
+  isWhitespaceOnlyPatch,
+  parseConventionalSubject,
+  reportScopeViolations,
+}

--- a/scripts/pr-scope.spec.mjs
+++ b/scripts/pr-scope.spec.mjs
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+
+import { describe, it } from 'mocha'
+import YAML from 'yaml'
+
+const require = createRequire(import.meta.url)
+const {
+  EXCEPTION_LABEL,
+  findScopeViolations,
+  isWhitespaceOnlyPatch,
+  parseConventionalSubject,
+  reportScopeViolations,
+} = require('./pr-scope.js')
+
+const modified = (filename, patch) => ({ filename, status: 'modified', changes: 2, patch })
+
+const bindings = ({ title, labels = [], commits = [], files = [] }) => {
+  const recorded = { errors: [], failures: [], notices: [], infos: [] }
+  const listFiles = Symbol('listFiles')
+  const listCommits = Symbol('listCommits')
+
+  return {
+    recorded,
+    context: {
+      repo: { owner: 'DataDog', repo: 'dd-trace-js' },
+      payload: { pull_request: { number: 1, title, labels } },
+    },
+    core: {
+      info: (message) => recorded.infos.push(message),
+      notice: (message) => recorded.notices.push(message),
+      error: (message, properties) => recorded.errors.push({ message, ...properties }),
+      setFailed: (message) => recorded.failures.push(message),
+    },
+    github: {
+      paginate: (endpoint, options) => {
+        assert.deepStrictEqual(options, { owner: 'DataDog', repo: 'dd-trace-js', pull_number: 1, per_page: 100 })
+        return Promise.resolve(endpoint === listFiles ? files : commits)
+      },
+      rest: { pulls: { listFiles, listCommits } },
+    },
+  }
+}
+
+const workflow = YAML.parse(fs.readFileSync(new URL('../.github/workflows/pr-title.yml', import.meta.url), 'utf8'))
+const job = workflow.jobs['conventional-commit']
+
+describe('PR scope checks', () => {
+  it('is wired into the PR title workflow', () => {
+    const step = job.steps.find(({ name }) => name === 'Validate PR scope')
+
+    assert.notStrictEqual(step, undefined)
+    assert.strictEqual(
+      step.with.script.trim(),
+      "await require('./scripts/pr-scope.js').reportScopeViolations({ context, core, github })"
+    )
+  })
+
+  it('shares the conventional-commit pattern with the PR title workflow', () => {
+    const { PR_TITLE_PATTERN } = job.env
+    const [accepted, rejected] = [
+      ['feat(appsec): add rule', 'revert: feat(appsec): add rule', 'chore!: drop node 18'],
+      ['add a rule', 'nope(appsec): add rule', ''],
+    ]
+
+    for (const title of accepted) {
+      assert.ok(new RegExp(PR_TITLE_PATTERN).test(title), `${title} should match the workflow pattern`)
+      assert.notStrictEqual(parseConventionalSubject(title), undefined, `${title} should parse`)
+    }
+    for (const title of rejected) {
+      assert.ok(!new RegExp(PR_TITLE_PATTERN).test(title), `${title} should not match the workflow pattern`)
+      assert.strictEqual(parseConventionalSubject(title), undefined, `${title} should not parse`)
+    }
+  })
+
+  it('parses type, scope, and reverts', () => {
+    assert.deepStrictEqual(parseConventionalSubject('fix(pg): stop leaking'), { type: 'fix', scope: 'pg' })
+    assert.deepStrictEqual(parseConventionalSubject('perf!: drop the cache'), { type: 'perf', scope: undefined })
+    assert.deepStrictEqual(parseConventionalSubject('revert: fix(pg): stop leaking'), { type: 'revert' })
+    assert.deepStrictEqual(parseConventionalSubject('revert!: fix(pg): stop leaking'), { type: 'revert' })
+  })
+
+  it('ignores non-conventional and revert titles', () => {
+    const files = [{ filename: 'notes.html', status: 'added', changes: 1 }]
+
+    for (const title of ['wip', 'revert: fix(pg): stop leaking']) {
+      assert.deepStrictEqual(findScopeViolations({ title, commitSubjects: ['refactor(pg): tidy'], files }), [])
+    }
+  })
+
+  it('accepts a PR whose commits all serve the title', () => {
+    const violations = findScopeViolations({
+      title: 'feat(pg): report query plans',
+      commitSubjects: [
+        'feat(pg): report query plans',
+        'test(pg): cover query plan reporting',
+        'docs: document query plans',
+        'wip',
+      ],
+      files: [
+        { filename: 'packages/datadog-plugin-pg/src/index.js', status: 'modified', changes: 20, patch: '@@\n+plan\n' },
+        { filename: 'packages/datadog-plugin-pg/test/index.spec.js', status: 'added', changes: 30 },
+      ],
+    })
+
+    assert.deepStrictEqual(violations, [])
+  })
+
+  it('flags a commit whose type is scope of its own, but not supporting types', () => {
+    const violations = findScopeViolations({
+      title: 'fix(pg): stop leaking connections',
+      commitSubjects: [
+        'fix(pg): stop leaking connections',
+        'refactor(pg): extract a helper',
+        'perf(pg): reuse the buffer',
+        'chore(pg): bump a comment',
+      ],
+      files: [],
+    })
+
+    assert.deepStrictEqual(violations.map(({ rule }) => rule), ['mixed-commit-type', 'mixed-commit-type'])
+    assert.match(violations[0].message, /refactor(.+)but the PR is a fix/)
+  })
+
+  it('flags a commit that targets a different scope', () => {
+    const violations = findScopeViolations({
+      title: 'fix(pg): stop leaking connections',
+      commitSubjects: ['fix(pg): stop leaking connections', 'fix(kafkajs): stop leaking connections'],
+      files: [],
+    })
+
+    assert.deepStrictEqual(violations.map(({ rule }) => rule), ['mixed-commit-scope'])
+    assert.match(violations[0].message, /"kafkajs"/)
+  })
+
+  it('accepts an unscoped commit under a scoped title', () => {
+    const violations = findScopeViolations({
+      title: 'fix(pg): stop leaking connections',
+      commitSubjects: ['fix: stop leaking connections'],
+      files: [],
+    })
+
+    assert.deepStrictEqual(violations, [])
+  })
+
+  it('flags whitespace-only file changes unless the title is about formatting', () => {
+    const patch = '@@ -1,2 +1,2 @@\n-const a = 1\n-  const b = 2\n+const  a  =  1\n+const b = 2\n'
+    const files = [modified('packages/dd-trace/src/index.js', patch)]
+
+    assert.deepStrictEqual(
+      findScopeViolations({ title: 'fix(core): stop leaking', commitSubjects: [], files })
+        .map(({ rule }) => rule),
+      ['formatting-only-file']
+    )
+    for (const title of ['style(core): reformat', 'chore(core): reformat']) {
+      assert.deepStrictEqual(findScopeViolations({ title, commitSubjects: [], files }), [])
+    }
+  })
+
+  it('does not treat semantic changes or additions as whitespace-only', () => {
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n-const a = 1\n+const a = 2\n'), false)
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n+const a = 1\n'), false)
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n-const a = 1\n'), false)
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n+++ b/a.js\n--- a/a.js\n'), false)
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n-const a = 1\n+  const a = 1\n'), true)
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n-\n+  \n'), true)
+    // A reorder keeps the same lines, but it is a real change rather than a whitespace one.
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n-const a = 1\n-const b = 2\n+const b = 2\n+const a = 1\n'), false)
+    // Uneven hunks (a reindent that also drops a line) fall out of this rule rather than guessing.
+    assert.strictEqual(isWhitespaceOnlyPatch('@@\n-const a = 1\n-const b = 2\n+  const a = 1\n'), false)
+  })
+
+  it('flags pure renames only under titles that are not about moving files', () => {
+    const files = [{
+      filename: 'packages/dd-trace/src/b.js',
+      previous_filename: 'packages/dd-trace/src/a.js',
+      status: 'renamed',
+      changes: 0,
+    }]
+
+    for (const title of ['fix(core): stop leaking', 'feat(core): add a thing', 'docs: explain a thing']) {
+      assert.deepStrictEqual(
+        findScopeViolations({ title, commitSubjects: [], files }).map(({ rule }) => rule),
+        ['rename-only-file'],
+        title
+      )
+    }
+    for (const title of ['refactor(core): move a.js', 'chore: move a.js', 'test: move a spec']) {
+      assert.deepStrictEqual(findScopeViolations({ title, commitSubjects: [], files }), [], title)
+    }
+  })
+
+  it('accepts a rename that also changes content', () => {
+    const violations = findScopeViolations({
+      title: 'fix(core): stop leaking',
+      commitSubjects: [],
+      files: [{
+        filename: 'packages/dd-trace/src/b.js',
+        previous_filename: 'packages/dd-trace/src/a.js',
+        status: 'renamed',
+        changes: 4,
+        patch: '@@\n-const a = 1\n+const a = 2\n',
+      }],
+    })
+
+    assert.deepStrictEqual(violations, [])
+  })
+
+  it('flags added scratch artifacts', () => {
+    const scratch = [
+      'report.html',
+      'debug.log',
+      '.claude/settings.json',
+      'packages/dd-trace/.pi-subagents/artifacts/out.md',
+      'scratch-notes.md',
+      'packages/dd-trace/tmp.out',
+      'packages/dd-trace/src/index.js.orig',
+      '.DS_Store',
+      'npm-debug.log.1',
+      'core.12345',
+    ]
+
+    for (const filename of scratch) {
+      assert.deepStrictEqual(
+        findScopeViolations({
+          title: 'fix(core): stop leaking',
+          commitSubjects: [],
+          files: [{ filename, status: 'added', changes: 1 }],
+        }).map(({ rule }) => rule),
+        ['scratch-artifact'],
+        filename
+      )
+    }
+  })
+
+  it('does not flag legitimate files that resemble scratch artifacts', () => {
+    const legitimate = [
+      'packages/dd-trace/test/fixtures/page.html',
+      'docs/index.html',
+      'packages/dd-trace/src/templates/log.js',
+      'integration-tests/temperature.js',
+      'packages/datadog-plugin-http/src/client.js',
+    ]
+
+    for (const filename of legitimate) {
+      assert.deepStrictEqual(
+        findScopeViolations({
+          title: 'fix(core): stop leaking',
+          commitSubjects: [],
+          files: [{ filename, status: 'added', changes: 1 }],
+        }),
+        [],
+        filename
+      )
+    }
+  })
+
+  it('does not flag scratch-looking paths that were only modified or removed', () => {
+    for (const status of ['modified', 'removed']) {
+      assert.deepStrictEqual(
+        findScopeViolations({
+          title: 'fix(core): stop leaking',
+          commitSubjects: [],
+          files: [{ filename: 'report.html', status, changes: 1 }],
+        }),
+        []
+      )
+    }
+  })
+})
+
+describe('PR scope workflow step', () => {
+  it('passes a PR whose changes serve its title', async () => {
+    const { recorded, ...step } = bindings({
+      title: 'fix(pg): stop leaking connections',
+      commits: [{ commit: { message: 'fix(pg): stop leaking connections\n\nBody line.' } }],
+      files: [modified('packages/datadog-plugin-pg/src/index.js', '@@\n+a\n')],
+    })
+
+    await reportScopeViolations(step)
+
+    assert.deepStrictEqual(recorded.failures, [])
+    assert.deepStrictEqual(recorded.infos, ['PR scope OK.'])
+  })
+
+  it('annotates every violation and fails the step', async () => {
+    const { recorded, ...step } = bindings({
+      title: 'fix(pg): stop leaking connections',
+      commits: [{ commit: { message: 'refactor(pg): extract a helper' } }],
+      files: [{ filename: 'report.html', status: 'added', changes: 1 }],
+    })
+
+    await reportScopeViolations(step)
+
+    assert.deepStrictEqual(
+      recorded.errors.map(({ title }) => title),
+      ['PR scope: mixed-commit-type', 'PR scope: scratch-artifact']
+    )
+    assert.strictEqual(recorded.failures.length, 1)
+    assert.match(recorded.failures[0], /^2 change\(s\) in this PR are not covered by its title\./)
+    assert.match(recorded.failures[0], new RegExp(EXCEPTION_LABEL))
+  })
+
+  it('skips every check when the exception label is applied', async () => {
+    const { recorded, ...step } = bindings({
+      title: 'fix(pg): stop leaking connections',
+      labels: [{ name: 'semver-patch' }, { name: EXCEPTION_LABEL }],
+      commits: [{ commit: { message: 'refactor(pg): extract a helper' } }],
+      files: [{ filename: 'report.html', status: 'added', changes: 1 }],
+    })
+
+    await reportScopeViolations(step)
+
+    assert.deepStrictEqual(recorded.failures, [])
+    assert.deepStrictEqual(recorded.errors, [])
+    assert.deepStrictEqual(recorded.notices, [`Skipping PR scope checks: the ${EXCEPTION_LABEL} label is applied.`])
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds a `Validate PR scope` step to the existing `Pull Request Title` workflow, backed by a new
`scripts/pr-scope.js` module, that fails a PR carrying changes its title doesn't cover. Four
deterministic rules:

| Rule | Fails when | Allowed under |
| --- | --- | --- |
| `mixed-commit-type` | a commit's conventional type is outside the title's | `test`, `docs`, `ci`, `bench`, `chore` commits support any change |
| `mixed-commit-scope` | a commit's scope differs from the title's scope | unscoped commits, or a title without a scope |
| `formatting-only-file` | a modified file's hunks differ only in whitespace | `style`, `chore` titles |
| `rename-only-file` | a pure move with no content change | `style`, `chore`, `refactor`, `build`, `ci`, `test` titles |
| `scratch-artifact` | an added file is a development leftover (root-level report/log, agent-tool state dir, `scratch-*`/`tmp.*`, `.orig`/`.rej`, crash dump) | never |

Applying the `scope-exception` label skips the whole step, for the cases where a violation is deliberate.

### Motivation

`AGENTS.md` (in #10028) asks that everything in a PR serve its title, but nothing enforced it, so drive-by
refactors, stray reformatting, unrequested file moves and development leftovers kept riding along with
scoped changes — each individually defensible, collectively inflating review surface and coupling
unrelated risk into one revert unit.

Every rule keys off evidence the author already supplied (commit types, file status, whitespace-only
hunks) rather than judging intent, so false positives are limited to cases the label covers. The
deliberate gap: an unrelated one-line fix inside a file the PR legitimately touches, committed under the
right type, passes all five rules. Catching that needs a semantic reviewer, not this check.

### Additional Notes

- The step lives in the existing `conventional-commit` job, so it reuses that required check rather than
  adding one to `all-green`. `PR_TITLE_PATTERN` and the module's parser are pinned to each other by a test.
- The workflow is `pull_request_target` and checks out the base revision, so this step never executes
  PR-authored code — which also means the rules here only take effect for PRs opened after this merges,
  including this one.
- **Requires a `scope-exception` label to be created in repo settings** before the escape hatch works;
  until then the step can't be bypassed.
- Tests: `npm run test:scripts` (`scripts/pr-scope.spec.mjs`, 15 cases; existing `scripts/pr-title.spec.mjs`
  still passes). The new spec also compiles the inline workflow script to catch syntax errors locally.
- Follow-up: reference this check from the `Scope discipline` section of `AGENTS.md` once #10028 lands
  (kept out of here to avoid a conflicting edit to the same section).
- `rename-only-file` relies on the files API reporting `changes: 0` for a pure rename, verified against
  #9670, which contains both shapes: `appsec/blocked_templates.js` -> `appsec/blocking/templates.js` is
  reported as `status: renamed, changes: 0` with no `patch`, while `appsec/blocking.js` ->
  `appsec/blocking/index.js` is `status: renamed, changes: 32` with a patch. The rule fires on the former
  and ignores the latter. When a move falls below GitHub's rename-similarity threshold it is reported as an
  add plus a delete instead, and the rule stays silent — it fails open, never falsely.
