### PR TITLE
chore(codeowners): assign AGENTS.md owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -409,6 +409,7 @@
 
 # Language Platform
 /* @DataDog/dd-trace-js @DataDog/lang-platform-js
+/AGENTS.md @DataDog/dd-trace-js @DataDog/lang-platform-js
 /openfeature.d.ts @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
 /openfeature.js @DataDog/dd-trace-js @DataDog/lang-platform-js @DataDog/feature-flagging-and-experimentation-sdk
 


### PR DESCRIPTION
### What does this PR do?

Adds an explicit CODEOWNERS entry for the root `AGENTS.md`, assigning `@DataDog/dd-trace-js` and `@DataDog/lang-platform-js`.

### Motivation

Ensure changes to repository-wide agent guidance request review from Language Platform.

### Additional Notes

No runtime behavior changes.