### PR TITLE
fix(test-optimization): increase payload request concurrency

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -16,6 +16,7 @@ const {
 } = require('../../../ci-visibility/telemetry')
 const { CoverageCIVisibilityEncoder } = require('../../../encode/coverage-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
+const { getAgent } = require('../agents')
 const request = require('../request')
 const TestOptimizationRequestTracker = require('./request-tracker')
 
@@ -51,6 +52,7 @@ class Writer extends BaseWriter {
       },
       timeout: 15_000,
       url: this._url,
+      agent: getAgent(this._url),
       deadline: flushOptions?.deadline,
     }
 
@@ -61,7 +63,7 @@ class Writer extends BaseWriter {
     }
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
-    log.debug(() => `Request to the intake: ${safeJSONStringify(options)}`)
+    log.debug(() => `Request to the intake: ${safeJSONStringify({ ...options, agent: undefined })}`)
 
     const startRequestTime = Date.now()
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
@@ -6,6 +6,7 @@ const { JSONEncoder } = require('../../encode/json-encoder')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
 const BaseWriter = require('../../../exporters/common/writer')
 
+const { getAgent } = require('../agents')
 const request = require('../request')
 const TestOptimizationRequestTracker = require('./request-tracker')
 
@@ -46,6 +47,7 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
       },
       timeout: this.timeout,
       url: this._url,
+      agent: getAgent(this._url),
       deadline: flushOptions?.deadline,
     }
 
@@ -55,7 +57,7 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
     }
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
-    log.debug(() => `Request to the logs intake: ${safeJSONStringify(options)}`)
+    log.debug(() => `Request to the logs intake: ${safeJSONStringify({ ...options, agent: undefined })}`)
 
     this.#requestTracker.send(request, data, options, (err, res) => {
       if (err) {

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -16,6 +16,7 @@ const {
 } = require('../../../ci-visibility/telemetry')
 const { AgentlessCiVisibilityEncoder } = require('../../../encode/agentless-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
+const { getAgent } = require('../agents')
 const request = require('../request')
 const TestOptimizationRequestTracker = require('./request-tracker')
 
@@ -52,6 +53,7 @@ class Writer extends BaseWriter {
       },
       timeout: 15_000,
       url: this._url,
+      agent: getAgent(this._url),
       deadline: flushOptions?.deadline,
     }
 
@@ -62,7 +64,7 @@ class Writer extends BaseWriter {
     }
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
-    log.debug(() => `Request to the intake: ${safeJSONStringify(options)}`)
+    log.debug(() => `Request to the intake: ${safeJSONStringify({ ...options, agent: undefined })}`)
 
     const startRequestTime = Date.now()
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agents.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agents.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const http = require('http')
+const https = require('https')
+
+const { createAgents } = require('../../exporters/common/agents')
+
+// Finalization can flush several Test Optimization payload types together. A dedicated pool keeps
+// that burst from queuing behind the shared exporters' single socket while preserving a hard cap.
+const maxSockets = 16
+
+const { httpAgent, httpsAgent } = createAgents(maxSockets)
+
+/**
+ * Selects the dedicated Test Optimization payload agent for an intake URL.
+ *
+ * @param {string|URL|object} url
+ * @returns {http.Agent|https.Agent}
+ */
+function getAgent (url) {
+  const protocol = url?.protocol
+  if (protocol === 'https:' || protocol === 'https') return httpsAgent
+  if (protocol === 'http:' || protocol === 'http') return httpAgent
+
+  try {
+    return new URL(url).protocol === 'https:' ? httpsAgent : httpAgent
+  } catch {
+    return String(url).startsWith('https:') ? httpsAgent : httpAgent
+  }
+}
+
+module.exports = { getAgent }

--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -7,9 +7,15 @@ const { storage } = require('../../../../datadog-core')
 const legacyStorage = storage('legacy')
 
 const keepAlive = true
-const maxSockets = 1
 
-function createAgentClass (BaseAgent) {
+/**
+ * Creates an agent class that suppresses tracing around socket lifecycle operations.
+ *
+ * @param {typeof http.Agent|typeof https.Agent} BaseAgent
+ * @param {number} maxSockets
+ * @returns {typeof http.Agent|typeof https.Agent}
+ */
+function createAgentClass (BaseAgent, maxSockets) {
   class CustomAgent extends BaseAgent {
     constructor () {
       super({ keepAlive, maxSockets })
@@ -35,10 +41,26 @@ function createAgentClass (BaseAgent) {
   return CustomAgent
 }
 
-const HttpAgent = createAgentClass(http.Agent)
-const HttpsAgent = createAgentClass(https.Agent)
+/**
+ * Creates isolated HTTP and HTTPS agents with a bounded connection pool.
+ *
+ * @param {number} maxSockets
+ * @returns {{ httpAgent: http.Agent, httpsAgent: https.Agent }}
+ */
+function createAgents (maxSockets) {
+  const HttpAgent = createAgentClass(http.Agent, maxSockets)
+  const HttpsAgent = createAgentClass(https.Agent, maxSockets)
+
+  return {
+    httpAgent: new HttpAgent(),
+    httpsAgent: new HttpsAgent(),
+  }
+}
+
+const { httpAgent, httpsAgent } = createAgents(1)
 
 module.exports = {
-  httpAgent: new HttpAgent(),
-  httpsAgent: new HttpsAgent(),
+  createAgents,
+  httpAgent,
+  httpsAgent,
 }

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -69,6 +69,7 @@ const log = require('../log')
  */
 
 let agentTelemetry = true
+let getTestOptimizationAgent
 
 /**
  * @param {import('../config/config-base')} config
@@ -145,6 +146,10 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
 
   const isCiVisibilityAgentlessMode = isCiVisibility && testOptimization.DD_CIVISIBILITY_AGENTLESS_ENABLED
 
+  if (isCiVisibility && getTestOptimizationAgent === undefined) {
+    ({ getAgent: getTestOptimizationAgent } = require('../ci-visibility/exporters/agents'))
+  }
+
   if (isCiVisibilityAgentlessMode) {
     try {
       url = testOptimization.DD_CIVISIBILITY_AGENTLESS_URL ?? new URL(getAgentlessTelemetryEndpoint(config.site))
@@ -163,6 +168,7 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
     path: isCiVisibilityAgentlessMode ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
     headers: getHeaders(config, application, reqType),
   }
+  if (isCiVisibility) options.agent = getTestOptimizationAgent(url)
 
   const data = JSON.stringify({
     api_version: 'v2',
@@ -197,6 +203,7 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
         headers: backendHeader,
         path: '/api/v2/apmtelemetry',
       }
+      if (isCiVisibility) backendOptions.agent = getTestOptimizationAgent(backendUrl)
       request(data, backendOptions, (error) => {
         if (error) {
           log.error('Error sending telemetry data', error)

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
@@ -14,6 +14,8 @@ let encoder
 let url
 let log
 let incrementCountMetric
+let agent
+let getAgent
 
 describe('CI Visibility Coverage Writer', () => {
   beforeEach(() => {
@@ -38,12 +40,15 @@ describe('CI Visibility Coverage Writer', () => {
       error: sinon.spy(),
     }
     incrementCountMetric = sinon.stub()
+    agent = {}
+    getAgent = sinon.stub().returns(agent)
 
     const CoverageCIVisibilityEncoder = function () {
       return encoder
     }
 
     CoverageWriter = proxyquire('../../../../src/ci-visibility/exporters/agentless/coverage-writer.js', {
+      '../agents': { getAgent },
       '../request': request,
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
       '../../../ci-visibility/telemetry': { incrementCountMetric },
@@ -94,6 +99,7 @@ describe('CI Visibility Coverage Writer', () => {
           url,
           path: '/api/v2/citestcov',
           method: 'POST',
+          agent,
         })
         done()
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
@@ -27,6 +27,26 @@ describe('Test Visibility DI Writer', () => {
   })
 
   context('agentless', () => {
+    it('uses the dedicated Test Optimization agent', (done) => {
+      const agent = {}
+      const request = sinon.stub().yieldsAsync(null, 'OK', 202)
+      const TestOptimizationLogsWriter = proxyquire(
+        '../../../../src/ci-visibility/exporters/agentless/di-logs-writer',
+        {
+          '../agents': { getAgent: () => agent },
+          '../request': request,
+          '../../../config': () => ({ DD_API_KEY: '1' }),
+        }
+      )
+      const logsWriter = new TestOptimizationLogsWriter({ url: 'http://www.example.com' })
+
+      logsWriter.append({ message: 'test' })
+      logsWriter.flush(() => {
+        sinon.assert.calledWithMatch(request, sinon.match.any, { agent })
+        done()
+      })
+    })
+
     it('can send logs to the logs intake', (done) => {
       const scope = nock('http://www.example.com')
         .post('/api/v2/logs', body => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -15,6 +15,8 @@ let coverageEncoder
 let url
 let log
 let incrementCountMetric
+let agent
+let getAgent
 
 describe('CI Visibility Writer', () => {
   beforeEach(() => {
@@ -37,6 +39,8 @@ describe('CI Visibility Writer', () => {
       error: sinon.spy(),
     }
     incrementCountMetric = sinon.stub()
+    agent = {}
+    getAgent = sinon.stub().returns(agent)
 
     const AgentlessCiVisibilityEncoder = function () {
       return encoder
@@ -53,6 +57,7 @@ describe('CI Visibility Writer', () => {
     }
 
     Writer = proxyquire('../../../../src/ci-visibility/exporters/agentless/writer', {
+      '../agents': { getAgent },
       '../request': request,
       '../../../encode/agentless-ci-visibility': { AgentlessCiVisibilityEncoder },
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
@@ -103,6 +108,7 @@ describe('CI Visibility Writer', () => {
           headers: {
             'Content-Type': 'application/msgpack',
           },
+          agent,
         })
         done()
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agents.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agents.spec.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const http = require('http')
+const net = require('net')
+
+const { describe, it } = require('mocha')
+
+require('../../setup/core')
+
+const createRequest = http.request
+
+const {
+  httpAgent: commonHttpAgent,
+  httpsAgent: commonHttpsAgent,
+} = require('../../../src/exporters/common/agents')
+const { getAgent } = require('../../../src/ci-visibility/exporters/agents')
+
+describe('Test Optimization exporter agents', () => {
+  const httpAgent = getAgent('http://localhost')
+  const httpsAgent = getAgent('https://localhost')
+
+  it('keeps the shared exporter agents serialized at one socket', () => {
+    assert.notStrictEqual(httpAgent, commonHttpAgent)
+    assert.notStrictEqual(httpsAgent, commonHttpsAgent)
+    assert.strictEqual(commonHttpAgent.keepAlive, true)
+    assert.strictEqual(commonHttpAgent.maxSockets, 1)
+    assert.strictEqual(commonHttpsAgent.keepAlive, true)
+    assert.strictEqual(commonHttpsAgent.maxSockets, 1)
+  })
+
+  it('configures dedicated agents with bounded concurrency and keep-alive', () => {
+    assert.strictEqual(httpAgent.keepAlive, true)
+    assert.strictEqual(httpAgent.maxSockets, 16)
+    assert.strictEqual(httpsAgent.keepAlive, true)
+    assert.strictEqual(httpsAgent.maxSockets, 16)
+  })
+
+  it('selects the agent by protocol for URL objects and strings', () => {
+    assert.strictEqual(getAgent(new URL('http://localhost')), httpAgent)
+    assert.strictEqual(getAgent('http://localhost'), httpAgent)
+    assert.strictEqual(getAgent(new URL('https://localhost')), httpsAgent)
+    assert.strictEqual(getAgent('https://localhost'), httpsAgent)
+  })
+
+  it('returns a stable singleton per protocol', () => {
+    assert.strictEqual(getAgent('http://a.example'), getAgent('http://b.example'))
+    assert.strictEqual(getAgent('https://a.example'), getAgent('https://b.example'))
+  })
+
+  it('manages the keep-alive socket lifecycle', () => {
+    const socket = new net.Socket()
+    const request = {}
+
+    assert.strictEqual(httpAgent.keepSocketAlive(socket), true)
+    httpAgent.reuseSocket(socket, request)
+    assert.strictEqual(request.reusedSocket, true)
+    socket.destroy()
+  })
+
+  it('opens sixteen same-origin connections and queues the seventeenth', async () => {
+    const agent = new httpAgent.constructor()
+    const lookupCallbacks = []
+    const lookup = (hostname, options, callback) => lookupCallbacks.push(callback)
+    const requests = new Array(17)
+
+    for (let index = 0; index < requests.length; index++) {
+      const request = createRequest({ agent, hostname: 'test.local', lookup })
+      request.on('error', () => {})
+      request.end()
+      requests[index] = request
+    }
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    try {
+      assert.strictEqual(lookupCallbacks.length, 16)
+      assert.deepStrictEqual(Object.values(agent.sockets).map(sockets => sockets.length), [16])
+      assert.deepStrictEqual(Object.values(agent.requests).map(requests => requests.length), [1])
+    } finally {
+      for (const request of requests) request.destroy()
+      agent.destroy()
+    }
+  })
+})

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -7,6 +7,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
+const { getAgent } = require('../../src/ci-visibility/exporters/agents')
 require('../setup/core')
 
 describe('sendData', () => {
@@ -51,6 +52,7 @@ describe('sendData', () => {
       hostname: '',
       port: '12345',
     })
+    assert.strictEqual(options.agent, undefined)
   })
 
   it('sends telemetry to the configured socket url', () => {
@@ -178,6 +180,7 @@ describe('sendData', () => {
     })
     const { url } = options
     assert.deepStrictEqual(url, new URL('https://instrumentation-telemetry-intake.datadoghq.eu'))
+    assert.strictEqual(options.agent, getAgent(url))
   })
 
   it('uses DD_CIVISIBILITY_AGENTLESS_URL for telemetry when the agentless intake is overridden', () => {
@@ -200,6 +203,52 @@ describe('sendData', () => {
     const options = request.getCall(0).args[1]
     const { url } = options
     assert.deepStrictEqual(url, new URL('https://my-intake.example/'))
+    assert.strictEqual(options.agent, getAgent(url))
+  })
+
+  it('uses the dedicated Test Optimization agent in agent-proxy mode', () => {
+    const url = new URL('http://127.0.0.1:8126')
+    sendDataModule.sendData(
+      {
+        isCiVisibility: true,
+        testOptimization: { DD_CIVISIBILITY_AGENTLESS_ENABLED: false },
+        tags: { 'runtime-id': '123' },
+        url,
+      },
+      application,
+      host,
+      'req-type'
+    )
+
+    sinon.assert.calledOnce(request)
+    const options = request.firstCall.args[1]
+    assert.strictEqual(options.path, '/telemetry/proxy/api/v2/apmtelemetry')
+    assert.strictEqual(options.agent, getAgent(url))
+  })
+
+  it('selects the HTTPS Test Optimization agent when falling back to the agentless backend', () => {
+    request.onFirstCall().yields(new Error('agent unreachable'))
+    request.onSecondCall().yields(null)
+
+    const url = new URL('http://127.0.0.1:8126')
+    sendDataModule.sendData(
+      {
+        DD_API_KEY: 'secret-key',
+        isCiVisibility: true,
+        site: 'datadoghq.eu',
+        tags: { 'runtime-id': '123' },
+        testOptimization: { DD_CIVISIBILITY_AGENTLESS_ENABLED: false },
+        url,
+      },
+      application,
+      host,
+      'req-type'
+    )
+
+    assert.strictEqual(request.callCount, 2)
+    assert.strictEqual(request.firstCall.args[1].agent, getAgent(url))
+    const fallbackUrl = new URL('https://instrumentation-telemetry-intake.datadoghq.eu')
+    assert.strictEqual(request.secondCall.args[1].agent, getAgent(fallbackUrl))
   })
 
   it('sends the agentless backend telemetry with a URL object when the agent request fails', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds dedicated keep-alive HTTP and HTTPS agent pools for Test Optimization payloads, bounded at 16 sockets per origin. Test-cycle events, code coverage, and Dynamic Instrumentation logs use these pools, while the shared exporter agents remain capped at one socket.

When Test Optimization is active, telemetry uses the same dedicated pool. Normal APM telemetry and other exporters keep their existing agents and limits.

### Motivation
<!-- What inspired you to submit this pull request? -->

Test Optimization can flush several payload streams together during process finalization. Sharing the single-socket exporter pool serializes that burst and can consume the bounded final-flush window before all payloads are delivered.

In the web-ui E2E workload, the 16-socket configuration completed without payload request errors; reducing the cap to four produced two errors. This change is extracted from #9987 and is based directly on master, independently of #10018.

The test-environment Remix run exposed a shutdown interaction after isolating only the Test Optimization payloads: all 26 Playwright tests and spans completed, but only `app-closing` telemetry arrived. The populated metrics and sketch requests remained queued on telemetry's separate one-socket agent after the Test Optimization final flush completed and released the process. Sharing the dedicated pool keeps their transport lifecycle aligned: if the pool is saturated, the existing final-flush timer keeps the process alive while both payload and telemetry requests drain.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR intentionally excludes retry-policy, backpressure-retention, final-flush-timeout, and Test Optimization request-lifecycle changes.

Verification:

- 23 focused Test Optimization writer and agent tests
- 23 shared-agent compatibility tests
- 12 focused telemetry transport tests with scoped coverage
- 37 common request transport tests
- test-environment Remix: 26/26 Playwright tests, 26 test spans, and valid telemetry
- Full repository lint and `git diff --check`
