### PR TITLE
fix(test-optimization): retry transient HTTP responses

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/request.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/request.js
@@ -12,6 +12,14 @@ const {
 const { getRateLimitResetDelay } = require('../requests/rate-limit')
 
 /**
+ * @param {number} statusCode
+ * @returns {boolean}
+ */
+function isRetriableHttpStatusCode (statusCode) {
+  return statusCode === 408 || statusCode === 429 || (statusCode >= 500 && statusCode <= 599)
+}
+
+/**
  * @param {AbortSignal} signal
  * @returns {Error}
  */
@@ -153,15 +161,10 @@ function requestBuffered (data, options, callback) {
       }
 
       const responseStatus = statusCode ?? error.status
-      const isRetriableHttpError = options.deadline !== undefined &&
-        (responseStatus === 429 || responseStatus >= 500)
-      if (options.retry === false || (attemptIndex >= getMaxAttempts(attemptOptions) &&
-        (isRetriableNetworkError(error) || isRetriableHttpError))) {
-        complete(error, result, statusCode, headers)
-        return
-      }
-
-      if (!isRetriableNetworkError(error) && !isRetriableHttpError) {
+      const isRetriableError = isRetriableNetworkError(error) || isRetriableHttpStatusCode(responseStatus)
+      const reachedBackgroundAttemptLimit =
+        options.deadline === undefined && attemptIndex >= getMaxAttempts(attemptOptions)
+      if (options.retry === false || !isRetriableError || reachedBackgroundAttemptLimit) {
         complete(error, result, statusCode, headers)
         return
       }
@@ -170,8 +173,13 @@ function requestBuffered (data, options, callback) {
       if (responseStatus === 429) {
         const resetDelay = getRateLimitResetDelay(headers)
         if (Number.isFinite(resetDelay)) {
-          const retryRemaining = options.deadline - Date.now()
-          if (resetDelay > RATE_LIMIT_MAX_WAIT_MS || resetDelay >= retryRemaining) {
+          if (options.deadline !== undefined) {
+            const retryRemaining = options.deadline - Date.now()
+            if (resetDelay >= retryRemaining) {
+              complete(error, result, statusCode, headers)
+              return
+            }
+          } else if (resetDelay > RATE_LIMIT_MAX_WAIT_MS) {
             complete(error, result, statusCode, headers)
             return
           }

--- a/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
@@ -53,6 +53,67 @@ describe('Test Optimization exporter request', () => {
     sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
   })
 
+  it('keeps retrying transient responses while the finalization deadline has capacity', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 30_000 }, done)
+    const error = Object.assign(new Error('unavailable'), { status: 503 })
+
+    pendingRequests[0].callback(error, null, 503, {})
+    clock.tick(6000)
+    pendingRequests[1].callback(error, null, 503, {})
+    clock.tick(6000)
+    pendingRequests[2].callback(error, null, 503, {})
+    clock.tick(6000)
+    pendingRequests[3].callback(null, 'ok', 200, {})
+
+    assert.strictEqual(pendingRequests.length, 4)
+    sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
+  })
+
+  for (const statusCode of [408, 429, 500, 599]) {
+    it(`retries a ${statusCode} response during a background flush`, () => {
+      const done = sinon.spy()
+      request('payload', {}, done)
+      const error = Object.assign(new Error('transient response'), { status: statusCode })
+
+      pendingRequests[0].callback(error, null, statusCode, {})
+      clock.tick(5999)
+      assert.strictEqual(pendingRequests.length, 1)
+      clock.tick(1)
+      assert.strictEqual(pendingRequests.length, 2)
+
+      pendingRequests[1].callback(null, 'ok', 200, {})
+      sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
+    })
+  }
+
+  for (const statusCode of [409, 430, 499, 600]) {
+    it(`does not retry a ${statusCode} response`, () => {
+      const done = sinon.spy()
+      request('payload', {}, done)
+      const error = Object.assign(new Error('non-retriable response'), { status: statusCode })
+
+      pendingRequests[0].callback(error, null, statusCode, {})
+
+      assert.strictEqual(pendingRequests.length, 1)
+      sinon.assert.calledOnceWithExactly(done, error, null, statusCode, {})
+    })
+  }
+
+  it('keeps the ordinary attempt cap for background HTTP retries', () => {
+    const done = sinon.spy()
+    request('payload', {}, done)
+    const error = Object.assign(new Error('unavailable'), { status: 503 })
+
+    pendingRequests[0].callback(error, null, 503, {})
+    clock.tick(6000)
+    pendingRequests[1].callback(error, null, 503, {})
+    clock.tick(6000)
+
+    assert.strictEqual(pendingRequests.length, 2)
+    sinon.assert.calledOnceWithExactly(done, error, null, 503, {})
+  })
+
   it('uses the remaining finalization budget for a late 5xx retry', () => {
     const done = sinon.spy()
     request('payload', { deadline: Date.now() + 1000, timeout: 2000 }, done)
@@ -107,6 +168,47 @@ describe('Test Optimization exporter request', () => {
 
     assert.strictEqual(pendingRequests.length, 1)
     sinon.assert.calledOnceWithExactly(done, error, null, 429, { 'x-ratelimit-reset': '5' })
+  })
+
+  it('waits for a rate-limit reset during a background flush', () => {
+    const done = sinon.spy()
+    request('payload', {}, done)
+
+    const error = Object.assign(new Error('rate limited'), { status: 429 })
+    pendingRequests[0].callback(error, null, 429, { 'x-ratelimit-reset': '5' })
+    clock.tick(4999)
+    assert.strictEqual(pendingRequests.length, 1)
+    clock.tick(1)
+    assert.strictEqual(pendingRequests.length, 2)
+
+    pendingRequests[1].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
+  })
+
+  it('does not exceed the rate-limit wait cap during a background flush', () => {
+    const done = sinon.spy()
+    request('payload', {}, done)
+
+    const error = Object.assign(new Error('rate limited'), { status: 429 })
+    pendingRequests[0].callback(error, null, 429, { 'x-ratelimit-reset': '31' })
+
+    assert.strictEqual(pendingRequests.length, 1)
+    sinon.assert.calledOnceWithExactly(done, error, null, 429, { 'x-ratelimit-reset': '31' })
+  })
+
+  it('uses a rate-limit reset over the background cap when the finalization deadline allows it', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 45_000 }, done)
+
+    const error = Object.assign(new Error('rate limited'), { status: 429 })
+    pendingRequests[0].callback(error, null, 429, { 'x-ratelimit-reset': '31' })
+    clock.tick(30_999)
+    assert.strictEqual(pendingRequests.length, 1)
+    clock.tick(1)
+    assert.strictEqual(pendingRequests.length, 2)
+
+    pendingRequests[1].callback(null, 'ok', 200, {})
+    sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
   })
 
   it('preserves ordinary background retry scheduling without a deadline', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Retries transient HTTP 408, 429, and 500-599 responses for Test Optimization payloads during both background sends and finalization. Background sends retain the existing attempt cap, while finalization retries continue only while the existing deadline has capacity.

Rate-limit reset headers remain bounded to 30 seconds for background sends. A larger reset delay is allowed during finalization only when it fits inside the finalization deadline.

### Motivation
<!-- What inspired you to submit this pull request? -->

Background payload sends currently retry transient network errors but not transient HTTP responses, and HTTP 408 is not retried at all. This can drop a payload after a single temporary intake response even though the request is replayable.

This change is extracted from #9987 and is based directly on master. It is independent of #10018 and #10038.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR intentionally excludes socket concurrency, payload buffering/backpressure, request attempt timeouts, detachment, final-flush timeout changes, and telemetry enrichment.

Verification:

- 23 Test Optimization exporter request tests using fake timers
- Scoped coverage for the changed request path
- ESLint and git diff --check
