### PR TITLE
fix(electron): skip extraction without IPC carrier

### DIFF
--- a/packages/datadog-plugin-electron/src/ipc.js
+++ b/packages/datadog-plugin-electron/src/ipc.js
@@ -46,7 +46,11 @@ class ElectronRendererReceivePlugin extends ConsumerPlugin {
 
     if (channel?.startsWith('datadog:')) return
 
-    const childOf = this._tracer.extract('text_map', args.at(-1))
+    let childOf
+    const carrier = args.at(-1)
+    if (carrier !== undefined) {
+      childOf = this._tracer.extract('text_map', carrier)
+    }
 
     if (childOf) {
       args.pop()

--- a/packages/datadog-plugin-electron/test/app/main.js
+++ b/packages/datadog-plugin-electron/test/app/main.js
@@ -21,6 +21,7 @@ app.on('ready', () => {
         case 'request': return onRequest(msg)
         case 'send': return onSend()
         case 'receive': return onReceive()
+        case 'receive-untraced': return onReceiveUntraced()
         case 'handle': return onHandle()
         case 'utility-request': return onUtilityRequest(msg)
       }
@@ -65,6 +66,19 @@ function onReceive () {
 
   loadWindow(win => {
     win.webContents.send('datadog:test:send')
+  })
+}
+
+function onReceiveUntraced () {
+  const listener = () => {
+    ipcMain.off('set-title-untraced', listener)
+    process.send({ name: 'receive-untraced-complete' })
+  }
+
+  ipcMain.on('set-title-untraced', listener)
+
+  loadWindow(win => {
+    win.webContents.send('datadog:test:send-untraced')
   })
 }
 

--- a/packages/datadog-plugin-electron/test/app/preload.js
+++ b/packages/datadog-plugin-electron/test/app/preload.js
@@ -19,6 +19,10 @@ ipcRenderer.on('datadog:test:send', () => {
   setImmediate(() => ipcRenderer.send('set-title', 'Test'))
 })
 
+ipcRenderer.on('datadog:test:send-untraced', () => {
+  setImmediate(() => ipcRenderer.postMessage('set-title-untraced', undefined))
+})
+
 ipcRenderer.on('datadog:test:invoke', () => {
   setImmediate(() => ipcRenderer.invoke('get-data'))
 })

--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -18,6 +18,7 @@ describe('Plugin', () => {
   let child
   let listener
   let port
+  let undefinedExtractCount
 
   before(done => {
     const server = http.createServer((req, res) => {
@@ -37,6 +38,7 @@ describe('Plugin', () => {
 
   withVersions('electron', ['electron'], version => {
     const startApp = done => {
+      undefinedExtractCount = 0
       const electron = require(`../../../versions/electron@${version}`).get()
 
       const args = [join(__dirname, 'app', 'main')]
@@ -54,7 +56,13 @@ describe('Plugin', () => {
       })
 
       child.on('error', done)
-      child.on('message', msg => msg === 'ready' && done())
+      child.on('message', msg => {
+        if (msg === 'ready') {
+          undefinedExtractCount = 0
+          return done()
+        }
+        if (msg?.name === 'extract-with-undefined') undefinedExtractCount++
+      })
     }
 
     describe('electron', () => {
@@ -147,6 +155,32 @@ describe('Plugin', () => {
             .catch(done)
 
           child.send({ name: 'receive' })
+        })
+
+        it('should not extract an absent carrier for uninstrumented renderer IPC', done => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const span = traces.flat().find(s => s.name === 'electron.main.receive')
+            assert.ok(span, 'expected electron.main.receive span')
+            assert.strictEqual(span.resource, 'set-title-untraced')
+          }, { timeoutMs: TRACE_TIMEOUT_MS })
+          const completionPromise = new Promise(resolve => {
+            const onMessage = msg => {
+              if (msg?.name !== 'receive-untraced-complete') return
+              child.off('message', onMessage)
+              resolve()
+            }
+
+            child.on('message', onMessage)
+          })
+
+          child.send({ name: 'receive-untraced' })
+
+          Promise.all([tracePromise, completionPromise])
+            .then(() => {
+              assert.strictEqual(undefinedExtractCount, 0)
+              done()
+            })
+            .catch(done)
         })
 
         it('should do automatic instrumentation for main IPC when handling', done => {

--- a/packages/datadog-plugin-electron/test/tracer.js
+++ b/packages/datadog-plugin-electron/test/tracer.js
@@ -9,7 +9,7 @@ const logger = globalThis.logger = {
   error: (...args) => console.error(...args),
 }
 
-require('../../dd-trace')
+const tracer = require('../../dd-trace')
   .init({
     service: 'test',
     env: 'tester',
@@ -18,3 +18,9 @@ require('../../dd-trace')
     plugins: false,
   })
   .use('electron', true)
+
+const extract = tracer._tracer.extract
+tracer._tracer.extract = function (format, carrier) {
+  if (carrier === undefined) process.send?.({ name: 'extract-with-undefined' })
+  return extract.call(this, format, carrier)
+}


### PR DESCRIPTION
### What does this PR do?

Avoids calling `tracer.extract()` when Electron renderer IPC does not include a propagation carrier. The receive span is still created as a root span for uninstrumented renderer messages.

Adds a regression test that sends an uninstrumented `ipcRenderer.postMessage()` through the real Electron IPC path and verifies that extraction is not attempted with `undefined`.

### Motivation

Electron IPC messages can arrive without the carrier appended by the renderer instrumentation. The Electron plugin should treat that carrier as optional instead of passing `undefined` to the propagation layer.

### Additional Notes

This is the caller-side companion to #9980 and remains independently safe if the propagation-layer guard changes separately.

Validation:

- `PLUGINS=electron npm run test:plugins` (72 passing)
- `PLUGINS=electron npm run test:plugins:ci` (72 passing; changed production lines covered)
- `npm run lint`
