### PR TITLE
fix(test-optimization): enrich payload error telemetry

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -79,11 +79,11 @@ class Writer extends BaseWriter {
       if (err) {
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
-          { endpoint: 'code_coverage', statusCode }
+          { endpoint: 'code_coverage', statusCode, errorType: statusCode ? undefined : err.code }
         )
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
-          { endpoint: 'code_coverage' }
+          { endpoint: 'code_coverage', statusCode, errorType: statusCode ? undefined : err.code }
         )
         log.error('Error sending CI coverage payload', err)
         done(err)

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
@@ -5,6 +5,11 @@ const { safeJSONStringify } = require('../../../exporters/common/util')
 const { JSONEncoder } = require('../../encode/json-encoder')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
 const BaseWriter = require('../../../exporters/common/writer')
+const {
+  incrementCountMetric,
+  TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
+  TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
+} = require('../../../ci-visibility/telemetry')
 
 const { getAgent } = require('../agents')
 const { MAX_DI_LOG_BUFFERED_BYTES } = require('../limits')
@@ -60,8 +65,16 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Request to the logs intake: ${safeJSONStringify({ ...options, agent: undefined })}`)
 
-    this.#requestTracker.send(request, data, options, (err, res) => {
+    this.#requestTracker.send(request, data, options, (err, res, statusCode) => {
       if (err) {
+        incrementCountMetric(
+          TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
+          { endpoint: 'di_logs', statusCode, errorType: statusCode ? undefined : err.code }
+        )
+        incrementCountMetric(
+          TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
+          { endpoint: 'di_logs', statusCode, errorType: statusCode ? undefined : err.code }
+        )
         log.error('Error sending DI logs payload', err)
         done(err)
         return

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -80,11 +80,11 @@ class Writer extends BaseWriter {
       if (err) {
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
-          { endpoint: 'test_cycle', statusCode }
+          { endpoint: 'test_cycle', statusCode, errorType: statusCode ? undefined : err.code }
         )
         incrementCountMetric(
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
-          { endpoint: 'test_cycle' }
+          { endpoint: 'test_cycle', statusCode, errorType: statusCode ? undefined : err.code }
         )
         log.error('Error sending CI agentless payload', err)
         done(err)

--- a/packages/dd-trace/src/ci-visibility/telemetry.js
+++ b/packages/dd-trace/src/ci-visibility/telemetry.js
@@ -45,10 +45,16 @@ function formatMetricTags (tagsDictionary) {
   return Object.keys(tagsDictionary).reduce((/** @type {string[]} */ acc, tagKey) => {
     if (tagKey === 'statusCode') {
       const statusCode = tagsDictionary[tagKey]
-      if (isStatusCode400(statusCode)) {
-        acc.push(`status_code:${statusCode}`)
+      if (statusCode) {
+        acc.push(`status_code:${statusCode}`, `error_type:${getErrorTypeFromStatusCode(statusCode)}`)
+      } else if (!tagsDictionary.errorType) {
+        acc.push('error_type:network')
       }
-      acc.push(`error_type:${getErrorTypeFromStatusCode(statusCode)}`)
+      return acc
+    }
+    if (tagKey === 'errorType') {
+      const errorType = tagsDictionary[tagKey]
+      if (errorType) acc.push(`error_type:${errorType}`)
       return acc
     }
     const formattedTagKey = /** @type {string} */(formattedTags[tagKey] || tagKey)
@@ -129,11 +135,8 @@ const TELEMETRY_TEST_MANAGEMENT_TESTS_ERRORS = 'test_management_tests.request_er
 const TELEMETRY_TEST_MANAGEMENT_TESTS_RESPONSE_TESTS = 'test_management_tests.response_tests'
 const TELEMETRY_TEST_MANAGEMENT_TESTS_RESPONSE_BYTES = 'test_management_tests.response_bytes'
 
-function isStatusCode400 (statusCode) {
-  return statusCode >= 400 && statusCode < 500
-}
-
 function getErrorTypeFromStatusCode (statusCode) {
+  if (typeof statusCode !== 'number') return 'network'
   if (statusCode >= 400 && statusCode < 500) {
     return 'status_code_4xx_response'
   }

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
@@ -106,7 +106,7 @@ describe('CI Visibility Coverage Writer', () => {
     })
 
     it('should log request errors', done => {
-      const error = new Error('boom')
+      const error = Object.assign(new Error('boom'), { code: 'ETIMEDOUT' })
 
       request.yields(error)
 
@@ -123,8 +123,13 @@ describe('CI Visibility Coverage Writer', () => {
         sinon.assert.calledWith(log.error, 'Error sending CI coverage payload', error)
         sinon.assert.calledWithExactly(
           incrementCountMetric,
+          'endpoint_payload.requests_errors',
+          { endpoint: 'code_coverage', statusCode: undefined, errorType: 'ETIMEDOUT' }
+        )
+        sinon.assert.calledWithExactly(
+          incrementCountMetric,
           'endpoint_payload.dropped',
-          { endpoint: 'code_coverage' }
+          { endpoint: 'code_coverage', statusCode: undefined, errorType: 'ETIMEDOUT' }
         )
         done()
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
@@ -77,6 +77,36 @@ describe('Test Visibility DI Writer', () => {
       })
     })
 
+    it('reports enriched telemetry when a payload is dropped', (done) => {
+      const error = Object.assign(new Error('reset'), { code: 'ECONNRESET' })
+      const incrementCountMetric = sinon.stub()
+      const request = sinon.stub().yieldsAsync(error, null, undefined)
+      const TestOptimizationLogsWriter = proxyquire(
+        '../../../../src/ci-visibility/exporters/agentless/di-logs-writer',
+        {
+          '../request': request,
+          '../../../ci-visibility/telemetry': { incrementCountMetric },
+          '../../../config': () => ({ DD_API_KEY: '1' }),
+        }
+      )
+      const logsWriter = new TestOptimizationLogsWriter({ url: 'http://www.example.com' })
+
+      logsWriter.append({ message: 'test' })
+      logsWriter.flush(() => {
+        sinon.assert.calledWithExactly(
+          incrementCountMetric,
+          'endpoint_payload.requests_errors',
+          { endpoint: 'di_logs', statusCode: undefined, errorType: 'ECONNRESET' }
+        )
+        sinon.assert.calledWithExactly(
+          incrementCountMetric,
+          'endpoint_payload.dropped',
+          { endpoint: 'di_logs', statusCode: undefined, errorType: 'ECONNRESET' }
+        )
+        done()
+      })
+    })
+
     it('logs an error if the request fails', (done) => {
       const logErrorSpy = sinon.spy(log, 'error')
 

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -116,7 +116,7 @@ describe('CI Visibility Writer', () => {
 
     describe('when request fails', function () {
       it('should log request errors', done => {
-        const error = new Error('boom')
+        const error = Object.assign(new Error('boom'), { code: 'ECONNRESET' })
 
         request.yields(error)
 
@@ -126,8 +126,13 @@ describe('CI Visibility Writer', () => {
           sinon.assert.calledWith(log.error, 'Error sending CI agentless payload', error)
           sinon.assert.calledWithExactly(
             incrementCountMetric,
+            'endpoint_payload.requests_errors',
+            { endpoint: 'test_cycle', statusCode: undefined, errorType: 'ECONNRESET' }
+          )
+          sinon.assert.calledWithExactly(
+            incrementCountMetric,
             'endpoint_payload.dropped',
-            { endpoint: 'test_cycle' }
+            { endpoint: 'test_cycle', statusCode: undefined, errorType: 'ECONNRESET' }
           )
           done()
         })

--- a/packages/dd-trace/test/ci-visibility/telemetry.spec.js
+++ b/packages/dd-trace/test/ci-visibility/telemetry.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+describe('Test Optimization telemetry', () => {
+  let count
+  let incrementCountMetric
+  let namespace
+
+  beforeEach(() => {
+    count = { inc: sinon.stub() }
+    namespace = { count: sinon.stub().returns(count) }
+    const telemetry = proxyquire('../../src/ci-visibility/telemetry', {
+      '../telemetry/metrics': { manager: { namespace: sinon.stub().returns(namespace) } },
+    })
+    incrementCountMetric = telemetry.incrementCountMetric
+  })
+
+  it('reports the HTTP status and status class for endpoint failures', () => {
+    incrementCountMetric('endpoint_payload.requests_errors', {
+      endpoint: 'test_cycle',
+      statusCode: 503,
+      errorType: undefined,
+    })
+
+    sinon.assert.calledOnceWithExactly(namespace.count, 'endpoint_payload.requests_errors', [
+      'endpoint:test_cycle',
+      'status_code:503',
+      'error_type:status_code_5xx_response',
+    ])
+  })
+
+  it('reports the underlying network error type when there is no HTTP response', () => {
+    incrementCountMetric('endpoint_payload.requests_errors', {
+      endpoint: 'test_cycle',
+      statusCode: undefined,
+      errorType: 'ECONNRESET',
+    })
+
+    sinon.assert.calledOnceWithExactly(namespace.count, 'endpoint_payload.requests_errors', [
+      'endpoint:test_cycle',
+      'error_type:ECONNRESET',
+    ])
+  })
+
+  it('falls back to the generic network classification without a specific error type', () => {
+    incrementCountMetric('endpoint_payload.requests_errors', {
+      endpoint: 'test_cycle',
+      statusCode: undefined,
+      errorType: undefined,
+    })
+
+    sinon.assert.calledOnceWithExactly(namespace.count, 'endpoint_payload.requests_errors', [
+      'endpoint:test_cycle',
+      'error_type:network',
+    ])
+  })
+})


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Enriches Test Optimization payload failure telemetry with HTTP status codes and concrete network or delivery lifecycle error types. The same request-error and dropped-payload metrics now cover test-cycle, code-coverage, and Dynamic Instrumentation log payloads.

### Motivation
<!-- What inspired you to submit this pull request? -->

Payload delivery failures were grouped too broadly, which made it difficult to distinguish backend responses from network, timeout, backpressure, and queue-limit failures during high-volume test sessions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is a draft stacked on #10044 because it consumes the delivery lifecycle error codes introduced there.

Verification:
- 21 focused Test Optimization telemetry and writer tests pass
- Changed-path coverage: 93.43% statements, 80.35% branches, 95.30% lines
- npm run lint passes
