### PR TITLE
test(install): pin standardwebhooks for Anthropic fixtures

### DIFF
--- a/packages/datadog-plugin-anthropic/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-anthropic/test/integration-test/client.spec.js
@@ -14,6 +14,7 @@ const {
   stopProc,
 } = require('../../../../integration-tests/helpers')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
+const { resolutions } = require('../../../dd-trace/test/plugins/versions/package.json')
 
 describe('esm', () => {
   let agent
@@ -22,6 +23,7 @@ describe('esm', () => {
   withVersions('anthropic', ['@anthropic-ai/sdk'], version => {
     useSandbox([
       `@anthropic-ai/sdk@${version}`,
+      `standardwebhooks@${resolutions.standardwebhooks}`,
     ], false, [
       './packages/datadog-plugin-anthropic/test/integration-test/*',
     ])

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "license": "BSD-3-Clause",
   "private": true,
+  "resolutions": {
+    "standardwebhooks": "1.0.0"
+  },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "5.0.57",
     "@ai-sdk/anthropic": "4.0.39",

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -12,7 +12,7 @@ const semver = require('semver')
 const externals = require('../packages/dd-trace/test/plugins/externals')
 const { getInstrumentation } = require('../packages/dd-trace/test/setup/helpers/load-inst')
 const { getCappedRange, resolvePluginVersions } = require('../packages/dd-trace/test/plugins/versions')
-const latests = require('../packages/dd-trace/test/plugins/versions/package.json').dependencies
+const { dependencies: latests, resolutions } = require('../packages/dd-trace/test/plugins/versions/package.json')
 const { isRelativeRequire } = require('../packages/datadog-instrumentations/src/helpers/shared-utils')
 const exec = require('./helpers/exec')
 const mapWithConcurrency = require('./helpers/concurrency')
@@ -354,6 +354,7 @@ async function assertWorkspaces () {
     version: '1.0.0',
     license: 'BSD-3-Clause',
     private: true,
+    resolutions,
     workspaces: {
       packages: [...workspaces].sort(),
     },


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Pins `standardwebhooks` to 1.0.0 in generated plugin-version workspaces and the Anthropic ESM integration sandbox. It also restores support for carrying dependency resolutions from the test-version manifest into generated workspaces.

### Motivation

`standardwebhooks` 1.1.0 is CommonJS but depends on ESM-only `@stablelib/base64` 2. This breaks the latest Anthropic SDK fixtures on Node 18 with `ERR_REQUIRE_ESM`. The pin can be removed after upstream publishes a CommonJS-compatible release.

### Additional Notes

The lifecycle suite passed with 43 tests on Node 18 and Node 26. Twenty fresh Node 18 SDK loads passed. The ESM sandbox also loaded all four tested SDK versions on Node 18; without the local CI VCR service, those requests stopped at the expected connection error rather than `ERR_REQUIRE_ESM`. ESLint and `git diff --check` passed.
