### PR TITLE
fix(test-optimization): bound media upload retries

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/request.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/request.js
@@ -162,9 +162,9 @@ function requestBuffered (data, options, callback) {
 
       const responseStatus = statusCode ?? error.status
       const isRetriableError = isRetriableNetworkError(error) || isRetriableHttpStatusCode(responseStatus)
-      const reachedBackgroundAttemptLimit =
-        options.deadline === undefined && attemptIndex >= getMaxAttempts(attemptOptions)
-      if (options.retry === false || !isRetriableError || reachedBackgroundAttemptLimit) {
+      const reachedAttemptLimit = attemptIndex >= getMaxAttempts(attemptOptions) &&
+        (options.deadline === undefined || options.retryUntilDeadline === false)
+      if (options.retry === false || !isRetriableError || reachedAttemptLimit) {
         complete(error, result, statusCode, headers)
         return
       }

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -130,6 +130,7 @@ function uploadTestScreenshot (
     timeout: UPLOAD_TIMEOUT_MS,
     url,
     deadline,
+    retryUntilDeadline: false,
     signal,
   }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
@@ -70,6 +70,20 @@ describe('Test Optimization exporter request', () => {
     sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
   })
 
+  it('keeps the ordinary attempt cap when deadline retries are disabled', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 30_000, retryUntilDeadline: false }, done)
+    const error = Object.assign(new Error('unavailable'), { status: 503 })
+
+    pendingRequests[0].callback(error, null, 503, {})
+    clock.tick(6000)
+    pendingRequests[1].callback(error, null, 503, {})
+    clock.tick(6000)
+
+    assert.strictEqual(pendingRequests.length, 2)
+    sinon.assert.calledOnceWithExactly(done, error, null, 503, {})
+  })
+
   for (const statusCode of [408, 429, 500, 599]) {
     it(`retries a ${statusCode} response during a background flush`, () => {
       const done = sinon.spy()

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -38,9 +38,9 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
     )
 
     assert.ok(requestStub.calledOnce)
-    const { path, headers, deadline, signal } = requestStub.getCall(0).args[1]
+    const { path, headers, deadline, retryUntilDeadline, signal } = requestStub.getCall(0).args[1]
     const query = new URL(path, 'http://localhost:8126').searchParams
-    return { path, headers, query, deadline, signal }
+    return { path, headers, query, deadline, retryUntilDeadline, signal }
   }
 
   before(() => {
@@ -80,13 +80,14 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       assert.strictEqual(headers['X-Datadog-EVP-Subdomain'], undefined)
     })
 
-    it('forwards the deadline and AbortSignal to the media request', () => {
+    it('bounds retries while forwarding the deadline and AbortSignal to the media request', () => {
       const abortController = new AbortController()
       const deadline = Date.now() + 10_000
 
       const requestOptions = uploadForFile('screenshot.png', { deadline, signal: abortController.signal })
 
       assert.strictEqual(requestOptions.deadline, deadline)
+      assert.strictEqual(requestOptions.retryUntilDeadline, false)
       assert.strictEqual(requestOptions.signal, abortController.signal)
     })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Caps screenshot media uploads at the ordinary attempt limit during final flush. Primary trace payloads still retry until their finalization deadline.

### Motivation

Two recent changes made failed screenshot uploads retry for the full 60-second finalization window. Cypress and Playwright then kept the child process alive until the reporting harness hit its own 60-second timeout.

### Additional Notes

This PR is stacked on #10054 so CI includes the Anthropic fixture fix. Its own diff is limited to media retry behavior.

The related unit suites pass with 133 tests. The exact Cypress reporting target passes in 13.1 seconds, and the exact Playwright target passes in 29.7 seconds. ESLint and `git diff --check` also pass.
