### PR TITLE
fix(test-optimization): cap screenshot upload retries

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/request.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/request.js
@@ -162,9 +162,9 @@ function requestBuffered (data, options, callback) {
 
       const responseStatus = statusCode ?? error.status
       const isRetriableError = isRetriableNetworkError(error) || isRetriableHttpStatusCode(responseStatus)
-      const reachedBackgroundAttemptLimit =
-        options.deadline === undefined && attemptIndex >= getMaxAttempts(attemptOptions)
-      if (options.retry === false || !isRetriableError || reachedBackgroundAttemptLimit) {
+      const retryUntilDeadline = options.deadline !== undefined && options.retryUntilDeadline !== false
+      const reachedAttemptLimit = !retryUntilDeadline && attemptIndex >= getMaxAttempts(attemptOptions)
+      if (options.retry === false || !isRetriableError || reachedAttemptLimit) {
         complete(error, result, statusCode, headers)
         return
       }

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -130,6 +130,7 @@ function uploadTestScreenshot (
     timeout: UPLOAD_TIMEOUT_MS,
     url,
     deadline,
+    retryUntilDeadline: false,
     signal,
   }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/request.spec.js
@@ -70,6 +70,20 @@ describe('Test Optimization exporter request', () => {
     sinon.assert.calledOnceWithExactly(done, null, 'ok', 200, {})
   })
 
+  it('keeps the ordinary attempt cap when deadline retries are disabled', () => {
+    const done = sinon.spy()
+    request('payload', { deadline: Date.now() + 30_000, retryUntilDeadline: false }, done)
+    const error = Object.assign(new Error('unavailable'), { status: 503 })
+
+    pendingRequests[0].callback(error, null, 503, {})
+    clock.tick(6000)
+    pendingRequests[1].callback(error, null, 503, {})
+    clock.tick(6000)
+
+    assert.strictEqual(pendingRequests.length, 2)
+    sinon.assert.calledOnceWithExactly(done, error, null, 503, {})
+  })
+
   for (const statusCode of [408, 429, 500, 599]) {
     it(`retries a ${statusCode} response during a background flush`, () => {
       const done = sinon.spy()

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -38,9 +38,9 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
     )
 
     assert.ok(requestStub.calledOnce)
-    const { path, headers, deadline, signal } = requestStub.getCall(0).args[1]
+    const { path, headers, deadline, retryUntilDeadline, signal } = requestStub.getCall(0).args[1]
     const query = new URL(path, 'http://localhost:8126').searchParams
-    return { path, headers, query, deadline, signal }
+    return { path, headers, query, deadline, retryUntilDeadline, signal }
   }
 
   before(() => {
@@ -87,6 +87,7 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       const requestOptions = uploadForFile('screenshot.png', { deadline, signal: abortController.signal })
 
       assert.strictEqual(requestOptions.deadline, deadline)
+      assert.strictEqual(requestOptions.retryUntilDeadline, false)
       assert.strictEqual(requestOptions.signal, abortController.signal)
     })
 


### PR DESCRIPTION
A persistent media 5xx bypassed the ordinary retry cap because screenshot uploads have a finalization deadline. Cypress then waited until the integration process timed out.

Screenshot uploads now keep the deadline for cancellation but stop after the ordinary retry cap. Final flush requests continue to retry until their deadline.