### PR TITLE
perf(trace-encoder): cache stable strings across payloads

### DIFF
--- a/benchmark/sirun/encoding/README.md
+++ b/benchmark/sirun/encoding/README.md
@@ -1,9 +1,5 @@
-Measures the agent trace encoder in isolation: a pre-built trace is encoded many
-times through a null writer so only the encoder cost is measured. The fixture
-(`trace-fixture.js`) mirrors a typical Node.js HTTP-service request (~30 spans:
-an Express root, middleware, Postgres/Redis/HTTP-client/DNS spans, one error
-span) with reused keys and hot values to match the encoder's string cache.
-`tickTrace` rewrites the per-request dynamic fields before each encode so V8 does
-not collapse the magnitude branches and stale-cache hits the encoder must
-exercise. `TRACE_SPANS=<n>` scales the trace; variants `0.4`/`0.5` cover the wire
-formats and the `*-events-*` variants the span-event paths.
+Measures agent trace encoding with pre-built HTTP-service traces. The fixtures
+include Express, Postgres, Redis, HTTP-client, DNS, and error spans. Each
+operation updates request-specific fields while it keeps common span data
+stable. The immediate-flush workload uses a ten-span API request and
+`flushInterval: 0`, then assembles one payload per trace before a no-op send.

--- a/benchmark/sirun/encoding/immediate-flush.js
+++ b/benchmark/sirun/encoding/immediate-flush.js
@@ -7,7 +7,7 @@ const guard = require('../startup-guard')
 
 const crossPayloadEncoderPath = '../../../packages/dd-trace/src/encode/0.4-cross-payload'
 const commonRequestPath = require.resolve('../../../packages/dd-trace/src/exporters/common/request')
-const OPERATIONS = Number(process.env.OPERATIONS) || 400_000
+const OPERATIONS = Number(process.env.OPERATIONS) || 300_000
 const TRACE_SPANS = Number(process.env.TRACE_SPANS) || 10
 const WARMUP_PAYLOADS = 5_000
 

--- a/benchmark/sirun/encoding/immediate-flush.js
+++ b/benchmark/sirun/encoding/immediate-flush.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { URL } = require('node:url')
+
+const guard = require('../startup-guard')
+
+const crossPayloadEncoderPath = '../../../packages/dd-trace/src/encode/0.4-cross-payload'
+const commonRequestPath = require.resolve('../../../packages/dd-trace/src/exporters/common/request')
+const OPERATIONS = Number(process.env.OPERATIONS) || 400_000
+const TRACE_SPANS = Number(process.env.TRACE_SPANS) || 10
+const WARMUP_PAYLOADS = 5_000
+
+let lastPayload
+let lastTraceCount
+let payloadCount = 0
+let createCrossPayloadAgentEncoder
+let crossPayloadEncoderAvailable = false
+let crossPayloadEncoderCreated = false
+let crossPayloadEncoderDisabled = false
+
+/**
+ * @param {Buffer} payload
+ * @param {{ headers: Record<string, string> }} options
+ */
+function captureRequest (payload, options) {
+  lastPayload = payload
+  lastTraceCount = Number(options.headers['X-Datadog-Trace-Count'])
+  payloadCount++
+}
+
+/**
+ * @param {{ flush: () => void }} writer
+ * @param {() => void} disableCrossPayloadCache
+ * @returns {import('../../../packages/dd-trace/src/encode/0.4').AgentEncoder}
+ */
+function createTrackedAgentEncoder (writer, disableCrossPayloadCache) {
+  crossPayloadEncoderCreated = true
+  const disableTrackedCrossPayloadCache = () => {
+    crossPayloadEncoderDisabled = true
+    disableCrossPayloadCache()
+  }
+  return createCrossPayloadAgentEncoder(writer, disableTrackedCrossPayloadCache)
+}
+
+Object.defineProperty(captureRequest, 'writable', { value: true })
+
+// Install the no-op egress before AgentWriter captures the request function.
+require.cache[commonRequestPath] = {
+  id: commonRequestPath,
+  filename: commonRequestPath,
+  loaded: true,
+  exports: captureRequest,
+}
+
+const AgentWriter = require('../../../packages/dd-trace/src/exporters/agent/writer')
+const { buildTrace, tickTrace } = require('./trace-fixture')
+
+let resolvedCrossPayloadEncoderPath
+try {
+  resolvedCrossPayloadEncoderPath = require.resolve(crossPayloadEncoderPath)
+} catch (error) {
+  if (error.code !== 'MODULE_NOT_FOUND') throw error
+}
+if (resolvedCrossPayloadEncoderPath !== undefined) {
+  const crossPayloadEncoder = require(resolvedCrossPayloadEncoderPath)
+  createCrossPayloadAgentEncoder = crossPayloadEncoder.createAgentEncoder
+  crossPayloadEncoder.createAgentEncoder = createTrackedAgentEncoder
+  crossPayloadEncoderAvailable = true
+}
+
+const trace = buildTrace(TRACE_SPANS)
+const writer = new AgentWriter({
+  url: new URL('http://127.0.0.1:8126'),
+  prioritySampler: { update: () => {} },
+  protocolVersion: '0.4',
+  flushInterval: 0,
+  headers: {},
+})
+
+for (let iteration = 0; iteration < WARMUP_PAYLOADS; iteration++) {
+  tickTrace(trace, iteration)
+  writer.append(trace)
+  writer.flush()
+}
+
+assert.equal(payloadCount, WARMUP_PAYLOADS)
+assert.equal(lastTraceCount, 1)
+assert.ok(lastPayload.length > 0)
+assert.equal(crossPayloadEncoderCreated, crossPayloadEncoderAvailable, 'flushInterval 0 selected the wrong encoder')
+assert.equal(crossPayloadEncoderDisabled, false, 'cross-payload cache disabled during warmup')
+
+payloadCount = 0
+guard.loopStart()
+for (let iteration = 0; iteration < OPERATIONS; iteration++) {
+  tickTrace(trace, iteration)
+  writer.append(trace)
+  writer.flush()
+}
+guard.done(0.15)
+assert.equal(payloadCount, OPERATIONS)
+assert.equal(crossPayloadEncoderDisabled, false, 'cross-payload cache disabled during the measured loop')

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -13,6 +13,15 @@
         "OPERATIONS": "31000"
       }
     },
+    "0.4-immediate-flush": {
+      "iterations": 5,
+      "run": "node immediate-flush.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node immediate-flush.js\"",
+      "env": {
+        "OPERATIONS": "400000",
+        "TRACE_SPANS": "10"
+      }
+    },
     "0.5": {
       "env": {
         "ENCODER_VERSION": "0.5",

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -14,11 +14,11 @@
       }
     },
     "0.4-immediate-flush": {
-      "iterations": 5,
+      "iterations": 7,
       "run": "node immediate-flush.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node immediate-flush.js\"",
       "env": {
-        "OPERATIONS": "400000",
+        "OPERATIONS": "300000",
         "TRACE_SPANS": "10"
       }
     },

--- a/packages/dd-trace/src/encode/0.4-cross-payload.js
+++ b/packages/dd-trace/src/encode/0.4-cross-payload.js
@@ -27,11 +27,11 @@ class CrossPayloadAgentEncoder extends AgentEncoder {
    * @returns {Buffer}
    */
   _cacheString (value, stable = false) {
-    if (!stable) return AgentEncoder.prototype._cacheString.call(this, value)
+    if (!stable) return super._cacheString(value)
 
     const crossPayloadState = this.#crossPayloadState
     if (crossPayloadState === undefined || value.length === 0 || value.length > CROSS_PAYLOAD_STRING_LIMIT) {
-      return AgentEncoder.prototype._cacheString.call(this, value)
+      return super._cacheString(value)
     }
 
     const learning = crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
@@ -51,10 +51,10 @@ class CrossPayloadAgentEncoder extends AgentEncoder {
       crossPayloadState.missCount++
     }
     if (!learning || crossPayloadState.payloadStableStrings?.[value] !== true) {
-      return AgentEncoder.prototype._cacheString.call(this, value)
+      return super._cacheString(value)
     }
 
-    let entry = AgentEncoder.prototype._cacheString.call(this, value)
+    let entry = super._cacheString(value)
     if (entry.length > CROSS_PAYLOAD_STRING_LIMIT) return entry
 
     const previousPayloadStrings = crossPayloadState.previousPayloadStrings
@@ -136,11 +136,6 @@ function prepareCrossPayloadReset (crossPayloadState) {
   const lowUse = !learning && crossPayloadState.hitCount < crossPayloadState.missCount
   if (lowUse) {
     crossPayloadState.lowUseCount++
-  } else if (!learning && crossPayloadState.hitCount > 0) {
-    crossPayloadState.lowUseCount = 0
-  }
-
-  if (lowUse) {
     if (crossPayloadState.lowUseCount >= 2) return false
     crossPayloadState.learningPayloadCount = 0
     crossPayloadState.stringCount = 0
@@ -151,6 +146,9 @@ function prepareCrossPayloadReset (crossPayloadState) {
     crossPayloadState.hitCount = 0
     crossPayloadState.missCount = 0
     return true
+  }
+  if (!learning && crossPayloadState.hitCount > 0) {
+    crossPayloadState.lowUseCount = 0
   }
 
   if (learning) {

--- a/packages/dd-trace/src/encode/0.4-cross-payload.js
+++ b/packages/dd-trace/src/encode/0.4-cross-payload.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { AgentEncoder } = require('./0.4')
-const { normalizeSpan } = require('./tags-processors')
 
 const CROSS_PAYLOAD_CACHE_LIMIT = 256
 const CROSS_PAYLOAD_CANDIDATE_LIMIT = 512
@@ -24,46 +23,28 @@ class CrossPayloadAgentEncoder extends AgentEncoder {
   }
 
   /**
-   * @param {object[]} trace
-   */
-  encode (trace) {
-    const crossPayloadState = crossPayloadStates.get(this)
-    if (crossPayloadState !== undefined &&
-      crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT) {
-      for (const span of trace) {
-        normalizeSpan(span)
-        if (span.type) markPayloadString(crossPayloadState, span.type)
-        markPayloadString(crossPayloadState, span.name)
-        markPayloadString(crossPayloadState, span.resource)
-        markPayloadString(crossPayloadState, span.service)
-        if (span.meta) {
-          markMapKeys(crossPayloadState, span.meta)
-        }
-        if (span.metrics) {
-          markMapKeys(crossPayloadState, span.metrics)
-        }
-      }
-    }
-    super.encode(trace)
-  }
-
-  /**
    * @param {string} value
+   * @param {boolean} [stable]
    * @returns {Buffer}
    */
-  _cacheString (value) {
+  _cacheString (value, stable = false) {
     const crossPayloadState = crossPayloadStates.get(this)
     if (crossPayloadState === undefined || value.length === 0 || value.length > CROSS_PAYLOAD_STRING_LIMIT) {
       return AgentEncoder.prototype._cacheString.call(this, value)
     }
 
     const learning = crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
+    if (learning && stable) markPayloadString(crossPayloadState, value)
     const retainedEntry = crossPayloadState.stringMap?.[value]
     if (retainedEntry !== undefined) {
       if (!learning && crossPayloadState.hitCount < CROSS_PAYLOAD_MISS_LIMIT) {
         crossPayloadState.hitCount++
       }
-      return retainedEntry
+      const start = this._stringBytes.length
+      this._stringBytes.set(retainedEntry)
+      const entry = this._stringBytes.buffer.subarray(start, start + retainedEntry.length)
+      this._stringMap[value] = entry
+      return entry
     }
     if (!learning && crossPayloadState.missCount < CROSS_PAYLOAD_MISS_LIMIT) {
       crossPayloadState.missCount++
@@ -136,28 +117,13 @@ function createCrossPayloadState () {
  * @param {string} value
  */
 function markPayloadString (crossPayloadState, value) {
-  if (value.length === 0 ||
-    value.length > CROSS_PAYLOAD_STRING_LIMIT ||
-    crossPayloadState.payloadStableStringCount >= CROSS_PAYLOAD_CANDIDATE_LIMIT ||
+  if (crossPayloadState.payloadStableStringCount >= CROSS_PAYLOAD_CANDIDATE_LIMIT ||
     crossPayloadState.payloadStableStrings?.[value] !== undefined) {
     return
   }
   crossPayloadState.payloadStableStrings ??= Object.create(null)
   crossPayloadState.payloadStableStrings[value] = true
   crossPayloadState.payloadStableStringCount++
-}
-
-/**
- * @param {ReturnType<typeof createCrossPayloadState>} crossPayloadState
- * @param {Record<string, unknown>} value
- */
-function markMapKeys (crossPayloadState, value) {
-  for (const key of Object.keys(value)) {
-    const entryValue = value[key]
-    if (typeof entryValue === 'string' || typeof entryValue === 'number') {
-      markPayloadString(crossPayloadState, key)
-    }
-  }
 }
 
 /**

--- a/packages/dd-trace/src/encode/0.4-cross-payload.js
+++ b/packages/dd-trace/src/encode/0.4-cross-payload.js
@@ -1,0 +1,205 @@
+'use strict'
+
+const { AgentEncoder } = require('./0.4')
+const { normalizeSpan } = require('./tags-processors')
+
+const CROSS_PAYLOAD_CACHE_LIMIT = 256
+const CROSS_PAYLOAD_CANDIDATE_LIMIT = 512
+const CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT = 8
+const CROSS_PAYLOAD_MISS_LIMIT = 32
+const CROSS_PAYLOAD_STRING_LIMIT = 256
+const crossPayloadStates = new WeakMap()
+
+class CrossPayloadAgentEncoder extends AgentEncoder {
+  #disableCrossPayloadCache
+
+  /**
+   * @param {{ flush: () => void }} writer
+   * @param {() => void} disableCrossPayloadCache
+   */
+  constructor (writer, disableCrossPayloadCache) {
+    super(writer)
+    this.#disableCrossPayloadCache = disableCrossPayloadCache
+    crossPayloadStates.set(this, createCrossPayloadState())
+  }
+
+  /**
+   * @param {object[]} trace
+   */
+  encode (trace) {
+    const crossPayloadState = crossPayloadStates.get(this)
+    if (crossPayloadState !== undefined &&
+      crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT) {
+      for (const span of trace) {
+        normalizeSpan(span)
+        if (span.type) markPayloadString(crossPayloadState, span.type)
+        markPayloadString(crossPayloadState, span.name)
+        markPayloadString(crossPayloadState, span.resource)
+        markPayloadString(crossPayloadState, span.service)
+        if (span.meta) {
+          markMapKeys(crossPayloadState, span.meta)
+        }
+        if (span.metrics) {
+          markMapKeys(crossPayloadState, span.metrics)
+        }
+      }
+    }
+    super.encode(trace)
+  }
+
+  /**
+   * @param {string} value
+   * @returns {Buffer}
+   */
+  _cacheString (value) {
+    const crossPayloadState = crossPayloadStates.get(this)
+    if (crossPayloadState === undefined || value.length === 0 || value.length > CROSS_PAYLOAD_STRING_LIMIT) {
+      return AgentEncoder.prototype._cacheString.call(this, value)
+    }
+
+    const learning = crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
+    const retainedEntry = crossPayloadState.stringMap?.[value]
+    if (retainedEntry !== undefined) {
+      if (!learning && crossPayloadState.hitCount < CROSS_PAYLOAD_MISS_LIMIT) {
+        crossPayloadState.hitCount++
+      }
+      return retainedEntry
+    }
+    if (!learning && crossPayloadState.missCount < CROSS_PAYLOAD_MISS_LIMIT) {
+      crossPayloadState.missCount++
+    }
+    if (!learning || crossPayloadState.payloadStableStrings?.[value] !== true) {
+      return AgentEncoder.prototype._cacheString.call(this, value)
+    }
+
+    let entry = AgentEncoder.prototype._cacheString.call(this, value)
+    if (entry.length > CROSS_PAYLOAD_STRING_LIMIT) return entry
+
+    const previousPayloadStrings = crossPayloadState.previousPayloadStrings
+    if (previousPayloadStrings?.[value] !== undefined &&
+      crossPayloadState.stringCount < CROSS_PAYLOAD_CACHE_LIMIT) {
+      entry = Buffer.from(entry)
+      crossPayloadState.stringMap ??= Object.create(null)
+      crossPayloadState.stringMap[value] = entry
+      crossPayloadState.stringCount++
+    }
+    return entry
+  }
+
+  /** @returns {Buffer} */
+  makePayload () {
+    this.#prepareReset()
+    return super.makePayload()
+  }
+
+  /** @returns {void} */
+  reset () {
+    this.#prepareReset()
+    super.reset()
+  }
+
+  /** @returns {void} */
+  #prepareReset () {
+    const crossPayloadState = crossPayloadStates.get(this)
+    if (crossPayloadState !== undefined && !prepareCrossPayloadReset(crossPayloadState)) {
+      crossPayloadStates.delete(this)
+      this.#disableCrossPayloadCache()
+    }
+  }
+}
+
+/**
+ * @param {{ flush: () => void }} writer
+ * @param {() => void} disableCrossPayloadCache
+ * @returns {AgentEncoder}
+ */
+function createAgentEncoder (writer, disableCrossPayloadCache) {
+  return new CrossPayloadAgentEncoder(writer, disableCrossPayloadCache)
+}
+
+function createCrossPayloadState () {
+  return {
+    hitCount: 0,
+    learningPayloadCount: 0,
+    lowUseCount: 0,
+    missCount: 0,
+    payloadStableStringCount: 0,
+    payloadStableStrings: undefined,
+    previousPayloadStrings: undefined,
+    stringCount: 0,
+    stringMap: undefined,
+  }
+}
+
+/**
+ * @param {ReturnType<typeof createCrossPayloadState>} crossPayloadState
+ * @param {string} value
+ */
+function markPayloadString (crossPayloadState, value) {
+  if (value.length === 0 ||
+    value.length > CROSS_PAYLOAD_STRING_LIMIT ||
+    crossPayloadState.payloadStableStringCount >= CROSS_PAYLOAD_CANDIDATE_LIMIT ||
+    crossPayloadState.payloadStableStrings?.[value] !== undefined) {
+    return
+  }
+  crossPayloadState.payloadStableStrings ??= Object.create(null)
+  crossPayloadState.payloadStableStrings[value] = true
+  crossPayloadState.payloadStableStringCount++
+}
+
+/**
+ * @param {ReturnType<typeof createCrossPayloadState>} crossPayloadState
+ * @param {Record<string, unknown>} value
+ */
+function markMapKeys (crossPayloadState, value) {
+  for (const key of Object.keys(value)) {
+    const entryValue = value[key]
+    if (typeof entryValue === 'string' || typeof entryValue === 'number') {
+      markPayloadString(crossPayloadState, key)
+    }
+  }
+}
+
+/**
+ * @param {ReturnType<typeof createCrossPayloadState>} crossPayloadState
+ * @returns {boolean}
+ */
+function prepareCrossPayloadReset (crossPayloadState) {
+  const learning = crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
+  const lowUse = !learning && crossPayloadState.hitCount < crossPayloadState.missCount
+  if (lowUse) {
+    crossPayloadState.lowUseCount++
+  } else if (!learning && crossPayloadState.hitCount > 0) {
+    crossPayloadState.lowUseCount = 0
+  }
+
+  if (lowUse) {
+    if (crossPayloadState.lowUseCount >= 2) return false
+    crossPayloadState.learningPayloadCount = 0
+    crossPayloadState.stringCount = 0
+    crossPayloadState.stringMap = undefined
+    crossPayloadState.payloadStableStrings = undefined
+    crossPayloadState.payloadStableStringCount = 0
+    crossPayloadState.previousPayloadStrings = undefined
+    crossPayloadState.hitCount = 0
+    crossPayloadState.missCount = 0
+    return true
+  }
+
+  if (learning) {
+    crossPayloadState.learningPayloadCount++
+    if (crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT) {
+      crossPayloadState.previousPayloadStrings = crossPayloadState.payloadStableStrings
+    } else {
+      crossPayloadState.previousPayloadStrings = undefined
+      if (crossPayloadState.stringMap === undefined) return false
+    }
+  }
+  crossPayloadState.payloadStableStrings = undefined
+  crossPayloadState.payloadStableStringCount = 0
+  crossPayloadState.hitCount = 0
+  crossPayloadState.missCount = 0
+  return true
+}
+
+module.exports = { createAgentEncoder }

--- a/packages/dd-trace/src/encode/0.4-cross-payload.js
+++ b/packages/dd-trace/src/encode/0.4-cross-payload.js
@@ -7,10 +7,10 @@ const CROSS_PAYLOAD_CANDIDATE_LIMIT = 512
 const CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT = 8
 const CROSS_PAYLOAD_MISS_LIMIT = 32
 const CROSS_PAYLOAD_STRING_LIMIT = 256
-const crossPayloadStates = new WeakMap()
 
 class CrossPayloadAgentEncoder extends AgentEncoder {
   #disableCrossPayloadCache
+  #crossPayloadState = createCrossPayloadState()
 
   /**
    * @param {{ flush: () => void }} writer
@@ -19,7 +19,6 @@ class CrossPayloadAgentEncoder extends AgentEncoder {
   constructor (writer, disableCrossPayloadCache) {
     super(writer)
     this.#disableCrossPayloadCache = disableCrossPayloadCache
-    crossPayloadStates.set(this, createCrossPayloadState())
   }
 
   /**
@@ -28,13 +27,15 @@ class CrossPayloadAgentEncoder extends AgentEncoder {
    * @returns {Buffer}
    */
   _cacheString (value, stable = false) {
-    const crossPayloadState = crossPayloadStates.get(this)
+    if (!stable) return AgentEncoder.prototype._cacheString.call(this, value)
+
+    const crossPayloadState = this.#crossPayloadState
     if (crossPayloadState === undefined || value.length === 0 || value.length > CROSS_PAYLOAD_STRING_LIMIT) {
       return AgentEncoder.prototype._cacheString.call(this, value)
     }
 
     const learning = crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
-    if (learning && stable) markPayloadString(crossPayloadState, value)
+    if (learning) markPayloadString(crossPayloadState, value)
     const retainedEntry = crossPayloadState.stringMap?.[value]
     if (retainedEntry !== undefined) {
       if (!learning && crossPayloadState.hitCount < CROSS_PAYLOAD_MISS_LIMIT) {
@@ -81,9 +82,9 @@ class CrossPayloadAgentEncoder extends AgentEncoder {
 
   /** @returns {void} */
   #prepareReset () {
-    const crossPayloadState = crossPayloadStates.get(this)
+    const crossPayloadState = this.#crossPayloadState
     if (crossPayloadState !== undefined && !prepareCrossPayloadReset(crossPayloadState)) {
-      crossPayloadStates.delete(this)
+      this.#crossPayloadState = undefined
       this.#disableCrossPayloadCache()
     }
   }

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -12,11 +12,13 @@ const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
 // strings this long (events JSON, stack traces, large query bodies) — they
 // are unique per span, so the cache hit rate stays near zero anyway.
 const STRING_CACHE_BYPASS_LIMIT = 1024
-// Cross-payload entries retain their encoded bytes and source string. Promote
-// only consecutive repeats, and cap both generations so cardinality cannot
-// turn the cache into unbounded process-lifetime state.
+// Cross-payload entries retain encoded span identity fields and map keys.
+// Promote only consecutive repeats, and cap both generations so cardinality
+// cannot turn the cache into unbounded process-lifetime state.
 const CROSS_PAYLOAD_CACHE_LIMIT = 256
 const CROSS_PAYLOAD_CANDIDATE_LIMIT = 512
+const CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT = 8
+const CROSS_PAYLOAD_MISS_LIMIT = 32
 const CROSS_PAYLOAD_STRING_LIMIT = 256
 
 // Pre-encoded static keys + value-prefix bytes; the hot encode loop emits
@@ -239,11 +241,7 @@ function lazyEncodedTraceBufferLogger (bytes, start, end) {
 }
 
 class AgentEncoder {
-  #crossPayloadStringMap
-  #crossPayloadStringCount = 0
-  #previousPayloadStrings
-  #payloadStrings
-  #payloadStringCount = 0
+  #crossPayloadState
 
   #limit
   #writer
@@ -258,6 +256,21 @@ class AgentEncoder {
     this.#writer = writer
     this._reset()
     this.#config = getConfig()
+    if (this.constructor === AgentEncoder && this.#config.flushInterval === 0) {
+      this.#crossPayloadState = {
+        activeForPayload: true,
+        cacheDisabled: false,
+        hitCount: 0,
+        learningPayloadCount: 0,
+        lowUseCount: 0,
+        missCount: 0,
+        payloadStringCount: 0,
+        payloadStrings: undefined,
+        previousPayloadStrings: undefined,
+        stringCount: 0,
+        stringMap: undefined,
+      }
+    }
     this.#debugEncoding = this.#config.DD_TRACE_ENCODING_DEBUG
     // Pick the per-span formatter once so the hot loop pays no per-span
     // config check. The native path keeps the raw `span_events` slot for
@@ -332,6 +345,7 @@ class AgentEncoder {
 
     const formatSpan = this.#formatSpan
     const stringMap = this._stringMap
+    const cacheAcrossPayloads = this.#crossPayloadState !== undefined
     // Snapshot the string buffer so we can detect a mid-encode resize and
     // release the old backing store afterwards (see `#refreshStringCache`).
     const stringBufferAtStart = this._stringBytes.buffer
@@ -351,11 +365,19 @@ class AgentEncoder {
       // Replaces up to ten separate `bytes.reserve` calls per span with one.
       let typeEntry
       if (span.type) {
-        typeEntry = stringMap[span.type] ?? this._cacheString(span.type)
+        typeEntry = stringMap[span.type] ?? (cacheAcrossPayloads
+          ? this.#cacheStringAcrossPayloads(span.type)
+          : this._cacheString(span.type))
       }
-      const nameEntry = stringMap[span.name] ?? this._cacheString(span.name)
-      const resourceEntry = stringMap[span.resource] ?? this._cacheString(span.resource)
-      const serviceEntry = stringMap[span.service] ?? this._cacheString(span.service)
+      const nameEntry = stringMap[span.name] ?? (cacheAcrossPayloads
+        ? this.#cacheStringAcrossPayloads(span.name)
+        : this._cacheString(span.name))
+      const resourceEntry = stringMap[span.resource] ?? (cacheAcrossPayloads
+        ? this.#cacheStringAcrossPayloads(span.resource)
+        : this._cacheString(span.resource))
+      const serviceEntry = stringMap[span.service] ?? (cacheAcrossPayloads
+        ? this.#cacheStringAcrossPayloads(span.service)
+        : this._cacheString(span.service))
       const nameLen = nameEntry.length
       const resourceLen = resourceEntry.length
       const serviceLen = serviceEntry.length
@@ -476,7 +498,7 @@ class AgentEncoder {
   #refreshStringCache () {
     const newBuffer = this._stringBytes.buffer
     const stringMap = this._stringMap
-    const crossPayloadStringMap = this.#crossPayloadStringMap
+    const crossPayloadStringMap = this.#crossPayloadState?.stringMap
     for (const key of Object.keys(stringMap)) {
       const old = stringMap[key]
       if (crossPayloadStringMap?.[key] === old) continue
@@ -485,9 +507,40 @@ class AgentEncoder {
   }
 
   _reset () {
-    this.#previousPayloadStrings = this.#payloadStrings
-    this.#payloadStrings = undefined
-    this.#payloadStringCount = 0
+    let crossPayloadState = this.#crossPayloadState
+    if (crossPayloadState !== undefined) {
+      crossPayloadState.previousPayloadStrings = undefined
+      if (!crossPayloadState.cacheDisabled &&
+        crossPayloadState.lowUseCount > 0 &&
+        crossPayloadState.hitCount >= CROSS_PAYLOAD_MISS_LIMIT * 2 &&
+        crossPayloadState.missCount < CROSS_PAYLOAD_MISS_LIMIT) {
+        crossPayloadState.lowUseCount = 0
+      }
+      if (crossPayloadState.cacheDisabled) {
+        if (crossPayloadState.lowUseCount >= 2) {
+          this.#crossPayloadState = undefined
+          crossPayloadState = undefined
+        } else {
+          crossPayloadState.cacheDisabled = false
+          crossPayloadState.learningPayloadCount = 0
+          crossPayloadState.stringCount = 0
+          crossPayloadState.stringMap = undefined
+        }
+      }
+      if (crossPayloadState !== undefined) {
+        if (this._stringMap !== undefined) {
+          crossPayloadState.learningPayloadCount++
+        }
+        if (crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT) {
+          crossPayloadState.previousPayloadStrings = crossPayloadState.payloadStrings
+        }
+        crossPayloadState.payloadStrings = undefined
+        crossPayloadState.payloadStringCount = 0
+        crossPayloadState.hitCount = 0
+        crossPayloadState.missCount = 0
+        crossPayloadState.activeForPayload = false
+      }
+    }
     this._traceCount = 0
     this._traceBytes.reset()
     this._stringCount = 0
@@ -495,6 +548,9 @@ class AgentEncoder {
     this._stringMap = Object.create(null)
 
     this._cacheString('')
+    if (crossPayloadState !== undefined) {
+      crossPayloadState.activeForPayload = true
+    }
   }
 
   // TODO: Use BigInt instead.
@@ -558,39 +614,65 @@ class AgentEncoder {
     bytes.buffer.set(entry, offset)
   }
 
-  /**
-   * @param {string} value
-   */
   _cacheString (value) {
     let entry = this._stringMap[value]
     if (entry === undefined) {
-      entry = this.#crossPayloadStringMap?.[value]
-      if (entry !== undefined) {
-        this._stringMap[value] = entry
-        return entry
-      }
-
       this._stringCount++
       const start = this._stringBytes.length
       const written = this._stringBytes.write(value)
       entry = this._stringBytes.buffer.subarray(start, start + written)
       this._stringMap[value] = entry
+    }
+    return entry
+  }
 
-      if (entry.length <= CROSS_PAYLOAD_STRING_LIMIT) {
-        const previousPayloadStrings = this.#previousPayloadStrings
-        const repeated = previousPayloadStrings?.[value] !== undefined
-
-        if (repeated && this.#crossPayloadStringCount < CROSS_PAYLOAD_CACHE_LIMIT) {
-          entry = Buffer.from(entry)
-          this.#crossPayloadStringMap ??= Object.create(null)
-          this.#crossPayloadStringMap[value] = entry
-          this.#crossPayloadStringCount++
+  /**
+   * @param {string} value
+   */
+  #cacheStringAcrossPayloads (value) {
+    const crossPayloadState = this.#crossPayloadState
+    let learningAcrossPayloads = false
+    if (crossPayloadState.activeForPayload) {
+      learningAcrossPayloads = crossPayloadState.learningPayloadCount <
+        CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
+      if (crossPayloadState.stringMap !== undefined) {
+        const entry = crossPayloadState.stringMap[value]
+        if (entry !== undefined) {
+          crossPayloadState.hitCount++
           this._stringMap[value] = entry
-        } else if (!repeated && this.#payloadStringCount < CROSS_PAYLOAD_CANDIDATE_LIMIT) {
-          this.#payloadStrings ??= Object.create(null)
-          this.#payloadStrings[value] = true
-          this.#payloadStringCount++
+          return entry
         }
+      }
+      if (!learningAcrossPayloads) {
+        crossPayloadState.missCount++
+        if (crossPayloadState.missCount === CROSS_PAYLOAD_MISS_LIMIT) {
+          crossPayloadState.activeForPayload = false
+          if (crossPayloadState.hitCount < CROSS_PAYLOAD_MISS_LIMIT * 2) {
+            crossPayloadState.cacheDisabled = true
+            crossPayloadState.lowUseCount++
+          }
+        }
+      }
+    }
+
+    let entry = this._cacheString(value)
+
+    if (crossPayloadState.activeForPayload && learningAcrossPayloads &&
+      crossPayloadState.stringCount < CROSS_PAYLOAD_CACHE_LIMIT &&
+      entry.length <= CROSS_PAYLOAD_STRING_LIMIT) {
+      const previousPayloadStrings = crossPayloadState.previousPayloadStrings
+      const repeated = previousPayloadStrings?.[value] !== undefined
+
+      if (repeated) {
+        entry = Buffer.from(entry)
+        crossPayloadState.stringMap ??= Object.create(null)
+        crossPayloadState.stringMap[value] = entry
+        crossPayloadState.stringCount++
+        this._stringMap[value] = entry
+      } else if (crossPayloadState.payloadStringCount < CROSS_PAYLOAD_CANDIDATE_LIMIT) {
+        crossPayloadState.payloadStrings ??= Object.create(null)
+        crossPayloadState.payloadStrings[value] = true
+        crossPayloadState.payloadStringCount++
       }
     }
     return entry
@@ -626,13 +708,16 @@ class AgentEncoder {
     const countOffset = headerOffset + keyPrefixLen
 
     const stringMap = this._stringMap
+    const cacheAcrossPayloads = this.#crossPayloadState !== undefined
     let count = 0
 
     for (const key of Object.keys(value)) {
       const entryValue = value[key]
       if (typeof entryValue !== 'string' && typeof entryValue !== 'number') continue
 
-      const keyEntry = stringMap[key] ?? this._cacheString(key)
+      const keyEntry = stringMap[key] ?? (cacheAcrossPayloads
+        ? this.#cacheStringAcrossPayloads(key)
+        : this._cacheString(key))
       const keyEntryLen = keyEntry.length
       const writeOffset = bytes.length
 

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -339,11 +339,11 @@ class AgentEncoder {
       // Replaces up to ten separate `bytes.reserve` calls per span with one.
       let typeEntry
       if (span.type) {
-        typeEntry = stringMap[span.type] ?? this._cacheString(span.type)
+        typeEntry = stringMap[span.type] ?? this._cacheString(span.type, true)
       }
-      const nameEntry = stringMap[span.name] ?? this._cacheString(span.name)
-      const resourceEntry = stringMap[span.resource] ?? this._cacheString(span.resource)
-      const serviceEntry = stringMap[span.service] ?? this._cacheString(span.service)
+      const nameEntry = stringMap[span.name] ?? this._cacheString(span.name, true)
+      const resourceEntry = stringMap[span.resource] ?? this._cacheString(span.resource, true)
+      const serviceEntry = stringMap[span.service] ?? this._cacheString(span.service, true)
       const nameLen = nameEntry.length
       const resourceLen = resourceEntry.length
       const serviceLen = serviceEntry.length
@@ -589,7 +589,7 @@ class AgentEncoder {
       const entryValue = value[key]
       if (typeof entryValue !== 'string' && typeof entryValue !== 'number') continue
 
-      const keyEntry = stringMap[key] ?? this._cacheString(key)
+      const keyEntry = stringMap[key] ?? this._cacheString(key, true)
       const keyEntryLen = keyEntry.length
       const writeOffset = bytes.length
 

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -12,6 +12,12 @@ const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
 // strings this long (events JSON, stack traces, large query bodies) — they
 // are unique per span, so the cache hit rate stays near zero anyway.
 const STRING_CACHE_BYPASS_LIMIT = 1024
+// Cross-payload entries retain their encoded bytes and source string. Promote
+// only consecutive repeats, and cap both generations so cardinality cannot
+// turn the cache into unbounded process-lifetime state.
+const CROSS_PAYLOAD_CACHE_LIMIT = 256
+const CROSS_PAYLOAD_CANDIDATE_LIMIT = 512
+const CROSS_PAYLOAD_STRING_LIMIT = 256
 
 // Pre-encoded static keys + value-prefix bytes; the hot encode loop emits
 // each via one Uint8Array.set instead of routing through the string cache.
@@ -233,6 +239,12 @@ function lazyEncodedTraceBufferLogger (bytes, start, end) {
 }
 
 class AgentEncoder {
+  #crossPayloadStringMap
+  #crossPayloadStringCount = 0
+  #previousPayloadStrings
+  #payloadStrings
+  #payloadStringCount = 0
+
   #limit
   #writer
   #config
@@ -464,13 +476,18 @@ class AgentEncoder {
   #refreshStringCache () {
     const newBuffer = this._stringBytes.buffer
     const stringMap = this._stringMap
+    const crossPayloadStringMap = this.#crossPayloadStringMap
     for (const key of Object.keys(stringMap)) {
       const old = stringMap[key]
+      if (crossPayloadStringMap?.[key] === old) continue
       stringMap[key] = newBuffer.subarray(old.byteOffset, old.byteOffset + old.length)
     }
   }
 
   _reset () {
+    this.#previousPayloadStrings = this.#payloadStrings
+    this.#payloadStrings = undefined
+    this.#payloadStringCount = 0
     this._traceCount = 0
     this._traceBytes.reset()
     this._stringCount = 0
@@ -541,14 +558,40 @@ class AgentEncoder {
     bytes.buffer.set(entry, offset)
   }
 
+  /**
+   * @param {string} value
+   */
   _cacheString (value) {
     let entry = this._stringMap[value]
     if (entry === undefined) {
+      entry = this.#crossPayloadStringMap?.[value]
+      if (entry !== undefined) {
+        this._stringMap[value] = entry
+        return entry
+      }
+
       this._stringCount++
       const start = this._stringBytes.length
       const written = this._stringBytes.write(value)
       entry = this._stringBytes.buffer.subarray(start, start + written)
       this._stringMap[value] = entry
+
+      if (entry.length <= CROSS_PAYLOAD_STRING_LIMIT) {
+        const previousPayloadStrings = this.#previousPayloadStrings
+        const repeated = previousPayloadStrings?.[value] !== undefined
+
+        if (repeated && this.#crossPayloadStringCount < CROSS_PAYLOAD_CACHE_LIMIT) {
+          entry = Buffer.from(entry)
+          this.#crossPayloadStringMap ??= Object.create(null)
+          this.#crossPayloadStringMap[value] = entry
+          this.#crossPayloadStringCount++
+          this._stringMap[value] = entry
+        } else if (!repeated && this.#payloadStringCount < CROSS_PAYLOAD_CANDIDATE_LIMIT) {
+          this.#payloadStrings ??= Object.create(null)
+          this.#payloadStrings[value] = true
+          this.#payloadStringCount++
+        }
+      }
     }
     return entry
   }

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -12,14 +12,6 @@ const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
 // strings this long (events JSON, stack traces, large query bodies) — they
 // are unique per span, so the cache hit rate stays near zero anyway.
 const STRING_CACHE_BYPASS_LIMIT = 1024
-// Cross-payload entries retain encoded span identity fields and map keys.
-// Promote only consecutive repeats, and cap both generations so cardinality
-// cannot turn the cache into unbounded process-lifetime state.
-const CROSS_PAYLOAD_CACHE_LIMIT = 256
-const CROSS_PAYLOAD_CANDIDATE_LIMIT = 512
-const CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT = 8
-const CROSS_PAYLOAD_MISS_LIMIT = 32
-const CROSS_PAYLOAD_STRING_LIMIT = 256
 
 // Pre-encoded static keys + value-prefix bytes; the hot encode loop emits
 // each via one Uint8Array.set instead of routing through the string cache.
@@ -241,8 +233,6 @@ function lazyEncodedTraceBufferLogger (bytes, start, end) {
 }
 
 class AgentEncoder {
-  #crossPayloadState
-
   #limit
   #writer
   #config
@@ -256,21 +246,6 @@ class AgentEncoder {
     this.#writer = writer
     this._reset()
     this.#config = getConfig()
-    if (this.constructor === AgentEncoder && this.#config.flushInterval === 0) {
-      this.#crossPayloadState = {
-        activeForPayload: true,
-        cacheDisabled: false,
-        hitCount: 0,
-        learningPayloadCount: 0,
-        lowUseCount: 0,
-        missCount: 0,
-        payloadStringCount: 0,
-        payloadStrings: undefined,
-        previousPayloadStrings: undefined,
-        stringCount: 0,
-        stringMap: undefined,
-      }
-    }
     this.#debugEncoding = this.#config.DD_TRACE_ENCODING_DEBUG
     // Pick the per-span formatter once so the hot loop pays no per-span
     // config check. The native path keeps the raw `span_events` slot for
@@ -345,7 +320,6 @@ class AgentEncoder {
 
     const formatSpan = this.#formatSpan
     const stringMap = this._stringMap
-    const cacheAcrossPayloads = this.#crossPayloadState !== undefined
     // Snapshot the string buffer so we can detect a mid-encode resize and
     // release the old backing store afterwards (see `#refreshStringCache`).
     const stringBufferAtStart = this._stringBytes.buffer
@@ -365,19 +339,11 @@ class AgentEncoder {
       // Replaces up to ten separate `bytes.reserve` calls per span with one.
       let typeEntry
       if (span.type) {
-        typeEntry = stringMap[span.type] ?? (cacheAcrossPayloads
-          ? this.#cacheStringAcrossPayloads(span.type)
-          : this._cacheString(span.type))
+        typeEntry = stringMap[span.type] ?? this._cacheString(span.type)
       }
-      const nameEntry = stringMap[span.name] ?? (cacheAcrossPayloads
-        ? this.#cacheStringAcrossPayloads(span.name)
-        : this._cacheString(span.name))
-      const resourceEntry = stringMap[span.resource] ?? (cacheAcrossPayloads
-        ? this.#cacheStringAcrossPayloads(span.resource)
-        : this._cacheString(span.resource))
-      const serviceEntry = stringMap[span.service] ?? (cacheAcrossPayloads
-        ? this.#cacheStringAcrossPayloads(span.service)
-        : this._cacheString(span.service))
+      const nameEntry = stringMap[span.name] ?? this._cacheString(span.name)
+      const resourceEntry = stringMap[span.resource] ?? this._cacheString(span.resource)
+      const serviceEntry = stringMap[span.service] ?? this._cacheString(span.service)
       const nameLen = nameEntry.length
       const resourceLen = resourceEntry.length
       const serviceLen = serviceEntry.length
@@ -498,49 +464,13 @@ class AgentEncoder {
   #refreshStringCache () {
     const newBuffer = this._stringBytes.buffer
     const stringMap = this._stringMap
-    const crossPayloadStringMap = this.#crossPayloadState?.stringMap
     for (const key of Object.keys(stringMap)) {
       const old = stringMap[key]
-      if (crossPayloadStringMap?.[key] === old) continue
       stringMap[key] = newBuffer.subarray(old.byteOffset, old.byteOffset + old.length)
     }
   }
 
   _reset () {
-    let crossPayloadState = this.#crossPayloadState
-    if (crossPayloadState !== undefined) {
-      crossPayloadState.previousPayloadStrings = undefined
-      if (!crossPayloadState.cacheDisabled &&
-        crossPayloadState.lowUseCount > 0 &&
-        crossPayloadState.hitCount >= CROSS_PAYLOAD_MISS_LIMIT * 2 &&
-        crossPayloadState.missCount < CROSS_PAYLOAD_MISS_LIMIT) {
-        crossPayloadState.lowUseCount = 0
-      }
-      if (crossPayloadState.cacheDisabled) {
-        if (crossPayloadState.lowUseCount >= 2) {
-          this.#crossPayloadState = undefined
-          crossPayloadState = undefined
-        } else {
-          crossPayloadState.cacheDisabled = false
-          crossPayloadState.learningPayloadCount = 0
-          crossPayloadState.stringCount = 0
-          crossPayloadState.stringMap = undefined
-        }
-      }
-      if (crossPayloadState !== undefined) {
-        if (this._stringMap !== undefined) {
-          crossPayloadState.learningPayloadCount++
-        }
-        if (crossPayloadState.learningPayloadCount < CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT) {
-          crossPayloadState.previousPayloadStrings = crossPayloadState.payloadStrings
-        }
-        crossPayloadState.payloadStrings = undefined
-        crossPayloadState.payloadStringCount = 0
-        crossPayloadState.hitCount = 0
-        crossPayloadState.missCount = 0
-        crossPayloadState.activeForPayload = false
-      }
-    }
     this._traceCount = 0
     this._traceBytes.reset()
     this._stringCount = 0
@@ -548,9 +478,6 @@ class AgentEncoder {
     this._stringMap = Object.create(null)
 
     this._cacheString('')
-    if (crossPayloadState !== undefined) {
-      crossPayloadState.activeForPayload = true
-    }
   }
 
   // TODO: Use BigInt instead.
@@ -626,58 +553,6 @@ class AgentEncoder {
     return entry
   }
 
-  /**
-   * @param {string} value
-   */
-  #cacheStringAcrossPayloads (value) {
-    const crossPayloadState = this.#crossPayloadState
-    let learningAcrossPayloads = false
-    if (crossPayloadState.activeForPayload) {
-      learningAcrossPayloads = crossPayloadState.learningPayloadCount <
-        CROSS_PAYLOAD_LEARNING_PAYLOAD_LIMIT
-      if (crossPayloadState.stringMap !== undefined) {
-        const entry = crossPayloadState.stringMap[value]
-        if (entry !== undefined) {
-          crossPayloadState.hitCount++
-          this._stringMap[value] = entry
-          return entry
-        }
-      }
-      if (!learningAcrossPayloads) {
-        crossPayloadState.missCount++
-        if (crossPayloadState.missCount === CROSS_PAYLOAD_MISS_LIMIT) {
-          crossPayloadState.activeForPayload = false
-          if (crossPayloadState.hitCount < CROSS_PAYLOAD_MISS_LIMIT * 2) {
-            crossPayloadState.cacheDisabled = true
-            crossPayloadState.lowUseCount++
-          }
-        }
-      }
-    }
-
-    let entry = this._cacheString(value)
-
-    if (crossPayloadState.activeForPayload && learningAcrossPayloads &&
-      crossPayloadState.stringCount < CROSS_PAYLOAD_CACHE_LIMIT &&
-      entry.length <= CROSS_PAYLOAD_STRING_LIMIT) {
-      const previousPayloadStrings = crossPayloadState.previousPayloadStrings
-      const repeated = previousPayloadStrings?.[value] !== undefined
-
-      if (repeated) {
-        entry = Buffer.from(entry)
-        crossPayloadState.stringMap ??= Object.create(null)
-        crossPayloadState.stringMap[value] = entry
-        crossPayloadState.stringCount++
-        this._stringMap[value] = entry
-      } else if (crossPayloadState.payloadStringCount < CROSS_PAYLOAD_CANDIDATE_LIMIT) {
-        crossPayloadState.payloadStrings ??= Object.create(null)
-        crossPayloadState.payloadStrings[value] = true
-        crossPayloadState.payloadStringCount++
-      }
-    }
-    return entry
-  }
-
   _writeArrayPrefix (buffer, offset, count) {
     buffer[offset++] = 0xDD
     buffer.writeUInt32BE(count, offset)
@@ -708,16 +583,13 @@ class AgentEncoder {
     const countOffset = headerOffset + keyPrefixLen
 
     const stringMap = this._stringMap
-    const cacheAcrossPayloads = this.#crossPayloadState !== undefined
     let count = 0
 
     for (const key of Object.keys(value)) {
       const entryValue = value[key]
       if (typeof entryValue !== 'string' && typeof entryValue !== 'number') continue
 
-      const keyEntry = stringMap[key] ?? (cacheAcrossPayloads
-        ? this.#cacheStringAcrossPayloads(key)
-        : this._cacheString(key))
+      const keyEntry = stringMap[key] ?? this._cacheString(key)
       const keyEntryLen = keyEntry.length
       const writeOffset = bytes.length
 

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -12,7 +12,7 @@ class AgentExporter {
   constructor (config, prioritySampler) {
     this.#serverlessDeliveryTracker = createServerlessDeliveryTracker()
     this._config = config
-    const { lookup, protocolVersion, stats = {}, apmTracingEnabled } = config
+    const { lookup, protocolVersion, stats = {}, apmTracingEnabled, flushInterval } = config
     this._url = config.url
 
     const headers = {}
@@ -25,6 +25,7 @@ class AgentExporter {
       prioritySampler,
       lookup,
       protocolVersion,
+      flushInterval,
       headers,
       deliveryTracker: this.#serverlessDeliveryTracker,
     })

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -25,14 +25,13 @@ class AgentWriter extends BaseWriter {
       beforeFirstFlush: () => firstFlushChannel.publish(),
       retainOnBackpressure: isTestOptimization,
     })
-    const { prioritySampler, lookup, protocolVersion, headers } = args[0]
-    const AgentEncoder = getEncoder(protocolVersion)
+    const { prioritySampler, lookup, protocolVersion, flushInterval, headers } = args[0]
 
     this._prioritySampler = prioritySampler
     this._lookup = lookup
     this._protocolVersion = protocolVersion
     this._headers = headers
-    this._encoder = new AgentEncoder(this)
+    this._encoder = createEncoder(protocolVersion, flushInterval, this)
     if (isTestOptimization) {
       this.#request = require('../../ci-visibility/exporters/request')
       const TestOptimizationRequestTracker = require('../../ci-visibility/exporters/agentless/request-tracker')
@@ -115,10 +114,26 @@ class AgentWriter extends BaseWriter {
   }
 }
 
-function getEncoder (protocolVersion) {
-  return protocolVersion === '0.5'
-    ? require('../../encode/0.5').AgentEncoder
-    : require('../../encode/0.4').AgentEncoder
+/**
+ * @param {string} protocolVersion
+ * @param {number | undefined} flushInterval
+ * @param {AgentWriter} writer
+ * @returns {import('../../encode/0.4').AgentEncoder}
+ */
+function createEncoder (protocolVersion, flushInterval, writer) {
+  if (protocolVersion === '0.5') {
+    const { AgentEncoder } = require('../../encode/0.5')
+    return new AgentEncoder(writer)
+  }
+  if (flushInterval === 0) {
+    const { createAgentEncoder } = require('../../encode/0.4-cross-payload')
+    const disableCrossPayloadCache = () => {
+      writer._encoder = createEncoder('0.4', undefined, writer)
+    }
+    return createAgentEncoder(writer, disableCrossPayloadCache)
+  }
+  const { AgentEncoder } = require('../../encode/0.4')
+  return new AgentEncoder(writer)
 }
 
 function makeRequest (version, data, count, url, headers, lookup, flushOptions, request, requestTracker, cb) {

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -221,18 +221,21 @@ describe('encode', () => {
       data[0].resource = identity
       data[0].meta = { stable: value }
       const write = sinon.spy(encoder._stringBytes, 'write')
+      const cacheString = sinon.spy(encoder, '_cacheString')
+      const trace = new Array(50).fill(data[0])
 
-      encoder.encode(data)
+      encoder.encode(trace)
       const first = encoder.makePayload()
-      encoder.encode(data)
+      encoder.encode(trace)
       const second = encoder.makePayload()
-      encoder.encode(data)
+      encoder.encode(trace)
       const third = encoder.makePayload()
 
       assert.deepStrictEqual(second, first)
       assert.deepStrictEqual(third, first)
       assert.strictEqual(write.withArgs(identity).callCount, 2)
       assert.strictEqual(write.withArgs(value).callCount, 3)
+      assert.strictEqual(cacheString.withArgs(identity).callCount, 3)
     })
 
     it('should not retain encoded strings across buffered payloads', () => {

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -166,6 +166,115 @@ describe('encode', () => {
       assert.strictEqual(payload[4], 0)
     })
 
+    it('should reuse encoded short strings across payloads without changing the wire', () => {
+      const value = 'stable-across-payloads'
+      data[0].meta = { stable: value }
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      encoder.encode(data)
+      const first = encoder.makePayload()
+      encoder.encode(data)
+      const second = encoder.makePayload()
+      encoder.encode(data)
+      const third = encoder.makePayload()
+
+      assert.deepStrictEqual(second, first)
+      assert.deepStrictEqual(third, first)
+      assert.strictEqual(write.withArgs(value).callCount, 2)
+    })
+
+    it('should only promote strings repeated in consecutive payloads', () => {
+      const value = 'non-consecutive-value'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      encoder._cacheString(value)
+      encoder.reset()
+      encoder._cacheString('intervening-value')
+      encoder.reset()
+      encoder._cacheString(value)
+      encoder.reset()
+      encoder._cacheString(value)
+      encoder.reset()
+      encoder._cacheString(value)
+
+      assert.strictEqual(write.withArgs(value).callCount, 3)
+    })
+
+    it('should bound cross-payload entries by their encoded UTF-8 byte length', () => {
+      const accepted = 'a'.repeat(251)
+      const rejected = 'é'.repeat(126)
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      for (let payload = 0; payload < 3; payload++) {
+        encoder._cacheString(accepted)
+        encoder._cacheString(rejected)
+        encoder.reset()
+      }
+
+      assert.strictEqual(write.withArgs(accepted).callCount, 2)
+      assert.strictEqual(write.withArgs(rejected).callCount, 3)
+    })
+
+    it('should retain at most 256 encoded strings across payloads', () => {
+      const accepted = []
+      for (let i = 0; i < 255; i++) {
+        accepted.push(`retained-${i}`)
+      }
+      const rejected = 'retained-256'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      for (const value of accepted) {
+        encoder._cacheString(value)
+      }
+      encoder._cacheString(rejected)
+      encoder.reset()
+      for (const value of accepted) {
+        encoder._cacheString(value)
+      }
+      encoder._cacheString(rejected)
+      encoder.reset()
+      encoder._cacheString(accepted[254])
+      encoder._cacheString(rejected)
+
+      assert.strictEqual(write.withArgs(accepted[254]).callCount, 2)
+      assert.strictEqual(write.withArgs(rejected).callCount, 3)
+    })
+
+    it('should track at most 512 cross-payload candidates', () => {
+      const candidates = []
+      for (let i = 0; i < 513; i++) {
+        candidates.push(`candidate-${i}`)
+      }
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      encoder.reset()
+      for (const value of candidates) {
+        encoder._cacheString(value)
+      }
+      encoder.reset()
+      encoder._cacheString(candidates[511])
+      encoder._cacheString(candidates[512])
+      encoder.reset()
+      encoder._cacheString(candidates[511])
+      encoder._cacheString(candidates[512])
+
+      assert.strictEqual(write.withArgs(candidates[511]).callCount, 2)
+      assert.strictEqual(write.withArgs(candidates[512]).callCount, 3)
+    })
+
+    it('should cache special object keys safely across payloads', () => {
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      for (let payload = 0; payload < 3; payload++) {
+        encoder._cacheString('__proto__')
+        encoder._cacheString('constructor')
+        encoder.reset()
+      }
+
+      assert.strictEqual(write.withArgs('__proto__').callCount, 2)
+      assert.strictEqual(write.withArgs('constructor').callCount, 2)
+    })
+
     it('should log adding an encoded trace to the buffer if enabled', () => {
       const debugConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false, DD_TRACE_ENCODING_DEBUG: true })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
@@ -241,6 +350,15 @@ describe('encode', () => {
       // entry is left pointing at a now-orphaned ArrayBuffer; the public
       // surface does not expose this retention directly.
       const longSuffix = 'x'.repeat(80)
+      const retainedStrings = new Set([
+        '',
+        'name',
+        'resource',
+        'service',
+        'foo',
+        `k_0_${longSuffix}`,
+        `v_0_${longSuffix}`,
+      ])
       const dataToEncode = []
       for (let i = 0; i < 30000; i++) {
         dataToEncode.push({
@@ -258,6 +376,10 @@ describe('encode', () => {
           duration: 1,
         })
       }
+      encoder.encode([dataToEncode[0]])
+      encoder.makePayload()
+      encoder.encode([dataToEncode[0]])
+      encoder.makePayload()
       const initialBuffer = encoder._stringBytes.buffer
 
       encoder.encode(dataToEncode)
@@ -266,7 +388,12 @@ describe('encode', () => {
       assert.notStrictEqual(initialBuffer, finalBuffer, '_stringBytes must have resized for this test to be meaningful')
       let staleEntries = 0
       for (const key of Object.keys(encoder._stringMap)) {
-        if (encoder._stringMap[key].buffer !== finalBuffer.buffer) staleEntries++
+        const buffer = encoder._stringMap[key].buffer
+        if (retainedStrings.has(key)) {
+          if (buffer === initialBuffer.buffer) staleEntries++
+        } else if (buffer !== finalBuffer.buffer) {
+          staleEntries++
+        }
       }
       assert.strictEqual(staleEntries, 0)
     })

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -39,19 +39,25 @@ describe('encode', () => {
   let encodePayload
   let cacheStringPayloads
   let cacheLowReusePayload
+  let disableCrossPayloadCache
 
   describe('without configuration', () => {
     beforeEach(() => {
       logger = {
         debug: sinon.stub(),
       }
-      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false, flushInterval: 0 })
-      const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
+      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false })
+      const { createAgentEncoder } = proxyquire('../../src/encode/0.4-cross-payload', {
         '../log': logger,
         '../config': getConfig,
+        './0.4': proxyquire('../../src/encode/0.4', {
+          '../log': logger,
+          '../config': getConfig,
+        }),
       })
       writer = { flush: sinon.spy() }
-      encoder = new AgentEncoder(writer)
+      disableCrossPayloadCache = sinon.spy()
+      encoder = createAgentEncoder(writer, disableCrossPayloadCache)
       data = [{
         trace_id: id('1234abcd1234abcd'),
         span_id: id('1234abcd1234abcd'),
@@ -230,7 +236,7 @@ describe('encode', () => {
     })
 
     it('should not retain encoded strings across buffered payloads', () => {
-      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false, flushInterval: 2000 })
+      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
         '../log': logger,
         '../config': getConfig,
@@ -317,6 +323,23 @@ describe('encode', () => {
       assert.strictEqual(write.withArgs(candidates[508]).callCount, 3)
     })
 
+    it('should not let long strings consume cross-payload candidate entries', () => {
+      const candidates = []
+      for (let index = 0; index < 509; index++) {
+        candidates.push(`${index}-${'a'.repeat(257)}`)
+      }
+      const accepted = 'candidate-after-long-strings'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      data[0].meta = metaFromKeys([...candidates, accepted])
+      encodePayload()
+      data[0].meta = metaFromKeys([accepted])
+      encodePayload()
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(accepted).callCount, 2)
+    })
+
     it('should stop learning cross-payload strings after 8 payloads', () => {
       const accepted = 'learned-in-payload-8'
       const rejected = 'first-seen-in-payload-8'
@@ -337,9 +360,9 @@ describe('encode', () => {
       assert.strictEqual(write.withArgs(rejected).callCount, 3)
     })
 
-    it('should relearn after the first payload with 32 misses and fewer than 64 hits', () => {
+    it('should relearn after 32 misses with fewer than 32 hits', () => {
       const retained = []
-      for (let index = 0; index < 59; index++) {
+      for (let index = 0; index < 27; index++) {
         retained.push(`insufficient-retained-${index}`)
       }
       const write = sinon.spy(encoder._stringBytes, 'write')
@@ -354,15 +377,32 @@ describe('encode', () => {
       encodePayload()
 
       cacheLowReusePayload(retained, 'second-miss')
-      data[0].meta = metaFromKeys([retained[58]])
+      data[0].meta = metaFromKeys([retained[26]])
       encodePayload()
 
-      assert.strictEqual(write.withArgs(retained[58]).callCount, 3)
+      assert.strictEqual(write.withArgs(retained[26]).callCount, 3)
+    })
+
+    it('should relearn after a low-cardinality payload stops using the cache', () => {
+      const retained = 'retained-before-low-cardinality-payload'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      cacheStringPayloads([retained], 8)
+      data[0].type = 'new-type'
+      data[0].name = 'new-name'
+      data[0].resource = 'new-resource'
+      data[0].service = 'new-service'
+      data[0].meta = metaFromKeys(['new-key'])
+      encodePayload()
+      data[0].meta = metaFromKeys([retained])
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(retained).callCount, 3)
     })
 
     it('should disable cross-payload caching after two low-reuse payloads', () => {
       const retained = []
-      for (let index = 0; index < 59; index++) {
+      for (let index = 0; index < 27; index++) {
         retained.push(`disabled-retained-${index}`)
       }
       const value = 'stable-after-two-low-reuse-payloads'
@@ -379,6 +419,7 @@ describe('encode', () => {
       encodePayload()
 
       assert.strictEqual(write.withArgs(value).callCount, 3)
+      sinon.assert.calledOnce(disableCrossPayloadCache)
     })
 
     it('should disable cross-payload caching when no strings repeat during learning', () => {
@@ -413,11 +454,12 @@ describe('encode', () => {
       encodePayload()
 
       assert.strictEqual(write.withArgs(value).callCount, 3)
+      sinon.assert.calledOnce(disableCrossPayloadCache)
     })
 
-    it('should keep cross-payload caching after 32 misses with 64 hits', () => {
+    it('should keep cross-payload caching after 32 misses with 32 hits', () => {
       const retained = []
-      for (let index = 0; index < 60; index++) {
+      for (let index = 0; index < 28; index++) {
         retained.push(`useful-retained-${index}`)
       }
       const write = sinon.spy(encoder._stringBytes, 'write')
@@ -425,30 +467,26 @@ describe('encode', () => {
       cacheStringPayloads(retained, 8)
 
       cacheLowReusePayload(retained, 'useful-miss')
-      data[0].meta = metaFromKeys([retained[59]])
+      data[0].meta = metaFromKeys([retained[27]])
       encodePayload()
 
-      assert.strictEqual(write.withArgs(retained[59]).callCount, 2)
+      assert.strictEqual(write.withArgs(retained[27]).callCount, 2)
     })
 
     it('should clear a low-reuse strike after a useful payload', () => {
       const retained = []
-      for (let index = 0; index < 60; index++) {
+      for (let index = 0; index < 27; index++) {
         retained.push(`recovered-retained-${index}`)
       }
       const value = 'stable-after-low-reuse-recovery'
       const write = sinon.spy(encoder._stringBytes, 'write')
 
       cacheStringPayloads(retained, 8)
-      cacheLowReusePayload(retained.slice(0, 59), 'first-recovery-miss')
+      cacheLowReusePayload(retained, 'first-recovery-miss')
       cacheStringPayloads(retained, 8)
-      const keys = retained.slice()
-      for (let miss = 0; miss < 31; miss++) {
-        keys.push(`useful-recovery-miss-${miss}`)
-      }
-      data[0].meta = metaFromKeys(keys)
+      data[0].meta = metaFromKeys([retained[0]])
       encodePayload()
-      cacheLowReusePayload(retained.slice(0, 59), 'second-recovery-miss')
+      cacheLowReusePayload(retained, 'second-recovery-miss')
 
       data[0].meta = metaFromKeys([value])
       encodePayload()

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -19,18 +19,33 @@ function randString (length) {
   }).join('')
 }
 
+/**
+ * @param {string[]} keys
+ * @returns {Record<string, number>}
+ */
+function metaFromKeys (keys) {
+  const meta = Object.create(null)
+  for (const key of keys) {
+    meta[key] = 1
+  }
+  return meta
+}
+
 describe('encode', () => {
   let encoder
   let writer
   let logger
   let data
+  let encodePayload
+  let cacheStringPayloads
+  let cacheLowReusePayload
 
   describe('without configuration', () => {
     beforeEach(() => {
       logger = {
         debug: sinon.stub(),
       }
-      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false })
+      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false, flushInterval: 0 })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
         '../log': logger,
         '../config': getConfig,
@@ -56,6 +71,34 @@ describe('encode', () => {
         duration: 456,
         links: [],
       }]
+      encodePayload = () => {
+        encoder.encode(data)
+        return encoder.makePayload()
+      }
+      /**
+       * @param {string[]} values
+       * @param {number} payloadCount
+       */
+      cacheStringPayloads = (values, payloadCount) => {
+        data[0].meta = metaFromKeys(values)
+        data[0].metrics = Object.create(null)
+        for (let payload = 0; payload < payloadCount; payload++) {
+          encodePayload()
+        }
+      }
+      /**
+       * @param {string[]} retained
+       * @param {string} missPrefix
+       */
+      cacheLowReusePayload = (retained, missPrefix) => {
+        const keys = retained.slice()
+        for (let miss = 0; miss < 32; miss++) {
+          keys.push(`${missPrefix}-${miss}`)
+        }
+        data[0].meta = metaFromKeys(keys)
+        data[0].metrics = Object.create(null)
+        encodePayload()
+      }
     })
 
     it('should encode to msgpack', () => {
@@ -167,7 +210,9 @@ describe('encode', () => {
     })
 
     it('should reuse encoded short strings across payloads without changing the wire', () => {
-      const value = 'stable-across-payloads'
+      const identity = 'stable-resource-across-payloads'
+      const value = 'stable-value-across-payloads'
+      data[0].resource = identity
       data[0].meta = { stable: value }
       const write = sinon.spy(encoder._stringBytes, 'write')
 
@@ -180,22 +225,45 @@ describe('encode', () => {
 
       assert.deepStrictEqual(second, first)
       assert.deepStrictEqual(third, first)
-      assert.strictEqual(write.withArgs(value).callCount, 2)
+      assert.strictEqual(write.withArgs(identity).callCount, 2)
+      assert.strictEqual(write.withArgs(value).callCount, 3)
+    })
+
+    it('should not retain encoded strings across buffered payloads', () => {
+      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false, flushInterval: 2000 })
+      const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
+        '../log': logger,
+        '../config': getConfig,
+      })
+      const bufferedEncoder = new AgentEncoder(writer)
+      const value = 'stable-resource-across-buffered-payloads'
+      data[0].resource = value
+      const write = sinon.spy(bufferedEncoder._stringBytes, 'write')
+
+      bufferedEncoder.encode(data)
+      const first = bufferedEncoder.makePayload()
+      bufferedEncoder.encode(data)
+      const second = bufferedEncoder.makePayload()
+      bufferedEncoder.encode(data)
+      const third = bufferedEncoder.makePayload()
+
+      assert.deepStrictEqual(second, first)
+      assert.deepStrictEqual(third, first)
+      assert.strictEqual(write.withArgs(value).callCount, 3)
     })
 
     it('should only promote strings repeated in consecutive payloads', () => {
       const value = 'non-consecutive-value'
       const write = sinon.spy(encoder._stringBytes, 'write')
 
-      encoder._cacheString(value)
-      encoder.reset()
-      encoder._cacheString('intervening-value')
-      encoder.reset()
-      encoder._cacheString(value)
-      encoder.reset()
-      encoder._cacheString(value)
-      encoder.reset()
-      encoder._cacheString(value)
+      data[0].resource = value
+      encodePayload()
+      data[0].resource = 'intervening-value'
+      encodePayload()
+      data[0].resource = value
+      encodePayload()
+      encodePayload()
+      encodePayload()
 
       assert.strictEqual(write.withArgs(value).callCount, 3)
     })
@@ -206,9 +274,8 @@ describe('encode', () => {
       const write = sinon.spy(encoder._stringBytes, 'write')
 
       for (let payload = 0; payload < 3; payload++) {
-        encoder._cacheString(accepted)
-        encoder._cacheString(rejected)
-        encoder.reset()
+        data[0].meta = metaFromKeys([accepted, rejected])
+        encodePayload()
       }
 
       assert.strictEqual(write.withArgs(accepted).callCount, 2)
@@ -217,58 +284,186 @@ describe('encode', () => {
 
     it('should retain at most 256 encoded strings across payloads', () => {
       const accepted = []
-      for (let i = 0; i < 255; i++) {
+      for (let i = 0; i < 252; i++) {
         accepted.push(`retained-${i}`)
       }
-      const rejected = 'retained-256'
+      const rejected = 'retained-253'
       const write = sinon.spy(encoder._stringBytes, 'write')
 
-      for (const value of accepted) {
-        encoder._cacheString(value)
-      }
-      encoder._cacheString(rejected)
-      encoder.reset()
-      for (const value of accepted) {
-        encoder._cacheString(value)
-      }
-      encoder._cacheString(rejected)
-      encoder.reset()
-      encoder._cacheString(accepted[254])
-      encoder._cacheString(rejected)
+      data[0].meta = metaFromKeys([...accepted, rejected])
+      encodePayload()
+      encodePayload()
+      data[0].meta = metaFromKeys([accepted[251], rejected])
+      encodePayload()
 
-      assert.strictEqual(write.withArgs(accepted[254]).callCount, 2)
+      assert.strictEqual(write.withArgs(accepted[251]).callCount, 2)
       assert.strictEqual(write.withArgs(rejected).callCount, 3)
     })
 
     it('should track at most 512 cross-payload candidates', () => {
       const candidates = []
-      for (let i = 0; i < 513; i++) {
+      for (let i = 0; i < 509; i++) {
         candidates.push(`candidate-${i}`)
       }
       const write = sinon.spy(encoder._stringBytes, 'write')
 
-      encoder.reset()
-      for (const value of candidates) {
-        encoder._cacheString(value)
-      }
-      encoder.reset()
-      encoder._cacheString(candidates[511])
-      encoder._cacheString(candidates[512])
-      encoder.reset()
-      encoder._cacheString(candidates[511])
-      encoder._cacheString(candidates[512])
+      data[0].meta = metaFromKeys(candidates)
+      encodePayload()
+      data[0].meta = metaFromKeys([candidates[507], candidates[508]])
+      encodePayload()
+      encodePayload()
 
-      assert.strictEqual(write.withArgs(candidates[511]).callCount, 2)
-      assert.strictEqual(write.withArgs(candidates[512]).callCount, 3)
+      assert.strictEqual(write.withArgs(candidates[507]).callCount, 2)
+      assert.strictEqual(write.withArgs(candidates[508]).callCount, 3)
+    })
+
+    it('should stop learning cross-payload strings after 8 payloads', () => {
+      const accepted = 'learned-in-payload-8'
+      const rejected = 'first-seen-in-payload-8'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      for (let payload = 1; payload < 7; payload++) {
+        data[0].resource = `filler-${payload}`
+        encodePayload()
+      }
+      data[0].resource = accepted
+      encodePayload()
+      data[0].name = rejected
+      encodePayload()
+      encodePayload()
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(accepted).callCount, 2)
+      assert.strictEqual(write.withArgs(rejected).callCount, 3)
+    })
+
+    it('should relearn after the first payload with 32 misses and fewer than 64 hits', () => {
+      const retained = []
+      for (let index = 0; index < 59; index++) {
+        retained.push(`insufficient-retained-${index}`)
+      }
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      cacheStringPayloads(retained, 10)
+
+      const keys = retained.slice()
+      for (let miss = 0; miss < 31; miss++) {
+        keys.push(`first-miss-${miss}`)
+      }
+      data[0].meta = metaFromKeys(keys)
+      encodePayload()
+
+      cacheLowReusePayload(retained, 'second-miss')
+      data[0].meta = metaFromKeys([retained[58]])
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(retained[58]).callCount, 3)
+    })
+
+    it('should disable cross-payload caching after two low-reuse payloads', () => {
+      const retained = []
+      for (let index = 0; index < 59; index++) {
+        retained.push(`disabled-retained-${index}`)
+      }
+      const value = 'stable-after-two-low-reuse-payloads'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      cacheStringPayloads(retained, 8)
+      cacheLowReusePayload(retained, 'first-low-reuse-miss')
+      cacheStringPayloads(retained, 8)
+      cacheLowReusePayload(retained, 'second-low-reuse-miss')
+
+      data[0].meta = metaFromKeys([value])
+      encodePayload()
+      encodePayload()
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(value).callCount, 3)
+    })
+
+    it('should disable cross-payload caching when no strings repeat during learning', () => {
+      const value = 'stable-after-fully-unique-learning'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+      let sequence = 0
+      const encodeUniquePayload = () => {
+        const keys = []
+        for (let key = 0; key < 32; key++) {
+          keys.push(`unique-key-${sequence}-${key}`)
+        }
+        data[0].type = `unique-type-${sequence}`
+        data[0].name = `unique-name-${sequence}`
+        data[0].resource = `unique-resource-${sequence}`
+        data[0].service = `unique-service-${sequence}`
+        data[0].meta = metaFromKeys(keys)
+        data[0].metrics = Object.create(null)
+        sequence++
+        encodePayload()
+      }
+
+      for (let payload = 0; payload < 9; payload++) {
+        encodeUniquePayload()
+      }
+      for (let payload = 0; payload < 8; payload++) {
+        encodeUniquePayload()
+      }
+
+      data[0].resource = value
+      encodePayload()
+      encodePayload()
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(value).callCount, 3)
+    })
+
+    it('should keep cross-payload caching after 32 misses with 64 hits', () => {
+      const retained = []
+      for (let index = 0; index < 60; index++) {
+        retained.push(`useful-retained-${index}`)
+      }
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      cacheStringPayloads(retained, 8)
+
+      cacheLowReusePayload(retained, 'useful-miss')
+      data[0].meta = metaFromKeys([retained[59]])
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(retained[59]).callCount, 2)
+    })
+
+    it('should clear a low-reuse strike after a useful payload', () => {
+      const retained = []
+      for (let index = 0; index < 60; index++) {
+        retained.push(`recovered-retained-${index}`)
+      }
+      const value = 'stable-after-low-reuse-recovery'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+
+      cacheStringPayloads(retained, 8)
+      cacheLowReusePayload(retained.slice(0, 59), 'first-recovery-miss')
+      cacheStringPayloads(retained, 8)
+      const keys = retained.slice()
+      for (let miss = 0; miss < 31; miss++) {
+        keys.push(`useful-recovery-miss-${miss}`)
+      }
+      data[0].meta = metaFromKeys(keys)
+      encodePayload()
+      cacheLowReusePayload(retained.slice(0, 59), 'second-recovery-miss')
+
+      data[0].meta = metaFromKeys([value])
+      encodePayload()
+      encodePayload()
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(value).callCount, 2)
     })
 
     it('should cache special object keys safely across payloads', () => {
       const write = sinon.spy(encoder._stringBytes, 'write')
 
       for (let payload = 0; payload < 3; payload++) {
-        encoder._cacheString('__proto__')
-        encoder._cacheString('constructor')
-        encoder.reset()
+        data[0].meta = metaFromKeys(['__proto__', 'constructor'])
+        encodePayload()
       }
 
       assert.strictEqual(write.withArgs('__proto__').callCount, 2)

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -238,6 +238,21 @@ describe('encode', () => {
       assert.strictEqual(cacheString.withArgs(identity).callCount, 3)
     })
 
+    it('should not probe retained strings for dynamic values', () => {
+      const identity = 'stable-resource-used-as-dynamic-value'
+      const write = sinon.spy(encoder._stringBytes, 'write')
+      data[0].resource = identity
+
+      encodePayload()
+      encodePayload()
+      encodePayload()
+      data[0].resource = 'different-resource'
+      data[0].meta = { dynamic: identity }
+      encodePayload()
+
+      assert.strictEqual(write.withArgs(identity).callCount, 3)
+    })
+
     it('should not retain encoded strings across buffered payloads', () => {
       const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -78,6 +78,10 @@ describe('Exporter', () => {
       exporter = new Exporter({ url, flushInterval }, prioritySampler)
     })
 
+    it('should pass the interval to the writer', () => {
+      assert.strictEqual(writerOptions.flushInterval, flushInterval)
+    })
+
     it('should not flush if export has not been called', (done) => {
       exporter = new Exporter({ url, flushInterval }, prioritySampler)
       setTimeout(() => {
@@ -112,6 +116,10 @@ describe('Exporter', () => {
   describe('when interval is set to 0', () => {
     beforeEach(() => {
       exporter = new Exporter({ url, flushInterval: 0 })
+    })
+
+    it('should pass the interval to the writer', () => {
+      assert.strictEqual(writerOptions.flushInterval, 0)
     })
 
     it('should flush right away when interval is set to 0', () => {

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -22,6 +22,8 @@ function describeWriter (protocolVersion) {
   let url
   let prioritySampler
   let log
+  let AgentEncoder
+  let createAgentEncoder
 
   beforeEach((done) => {
     span = 'formatted'
@@ -51,14 +53,14 @@ function describeWriter (protocolVersion) {
       errorWithoutTelemetry: sinon.spy(),
     }
 
-    const AgentEncoder = function () {
-      return encoder
-    }
+    AgentEncoder = sinon.stub().returns(encoder)
+    createAgentEncoder = sinon.stub().returns(encoder)
 
     Writer = proxyquire('../../../src/exporters/agent/writer', {
       '../common/request': request,
       '../../ci-visibility/exporters/request': request,
       '../../encode/0.4': { AgentEncoder },
+      '../../encode/0.4-cross-payload': { createAgentEncoder },
       '../../encode/0.5': { AgentEncoder },
       '../../../../../package.json': { version: 'tracerVersion' },
       '../../log': log,
@@ -67,6 +69,50 @@ function describeWriter (protocolVersion) {
 
     process.nextTick(done)
   })
+
+  if (protocolVersion === '0.4') {
+    it('should use the cross-payload encoder for a zero flush interval', () => {
+      AgentEncoder.resetHistory()
+      createAgentEncoder.resetHistory()
+
+      writer = new Writer({ url, prioritySampler, protocolVersion, flushInterval: 0 })
+
+      sinon.assert.calledOnceWithExactly(createAgentEncoder, writer, sinon.match.func)
+      sinon.assert.notCalled(AgentEncoder)
+    })
+
+    it('should switch to the regular encoder when cross-payload caching is disabled', () => {
+      AgentEncoder.resetHistory()
+      createAgentEncoder.resetHistory()
+
+      writer = new Writer({ url, prioritySampler, protocolVersion, flushInterval: 0 })
+      const disableCrossPayloadCache = createAgentEncoder.firstCall.args[1]
+      disableCrossPayloadCache()
+
+      sinon.assert.calledOnceWithExactly(AgentEncoder, writer)
+      assert.strictEqual(writer._encoder, encoder)
+    })
+
+    it('should keep the regular encoder for a nonzero flush interval', () => {
+      AgentEncoder.resetHistory()
+      createAgentEncoder.resetHistory()
+
+      writer = new Writer({ url, prioritySampler, protocolVersion, flushInterval: 2000 })
+
+      sinon.assert.notCalled(createAgentEncoder)
+      sinon.assert.calledOnceWithExactly(AgentEncoder, writer)
+    })
+  } else {
+    it('should keep the 0.5 encoder independent of the flush interval', () => {
+      AgentEncoder.resetHistory()
+      createAgentEncoder.resetHistory()
+
+      writer = new Writer({ url, prioritySampler, protocolVersion, flushInterval: 0 })
+
+      sinon.assert.notCalled(createAgentEncoder)
+      sinon.assert.calledOnceWithExactly(AgentEncoder, writer)
+    })
+  }
 
   describe('append', () => {
     it('should append a trace', () => {
@@ -287,7 +333,7 @@ describe('Writer', () => {
     assert.strictEqual(writerOptions[1].retainOnBackpressure, true)
   })
 
-  describe('0.4', () => describeWriter(0.4))
+  describe('0.4', () => describeWriter('0.4'))
 
-  describe('0.5', () => describeWriter(0.5))
+  describe('0.5', () => describeWriter('0.5'))
 })


### PR DESCRIPTION
Reuse encoded span identity strings and tag keys across immediate 0.4 trace payloads. The cache retains at most 256 strings, tracks at most 512 candidates, and rejects retained entries above 256 encoded bytes. Low-reuse workloads switch back to the regular encoder, while buffered and 0.5 writers use that encoder throughout.

On Node 22.23.1 (V8 12.4.254.21-node.56), three alternating isolated-process pairs used a 1 s warm-up and seven 250 ms trials per process. Small payloads decreased from 654.4 to 443.1 ns/trace. Payloads with 96 tags decreased from 20,302 to 15,474 ns/trace.

An immediate-flush Sirun workload uses representative ten-span requests with `flushInterval: 0`. It runs seven 300,000-trace samples on both the base and candidate sources. Benchmark CI applies Linux CPU affinity and provides the stability result.