### PR TITLE
test(appsec): replace axios with fetch

### DIFF
--- a/integration-tests/appsec/graphql.spec.js
+++ b/integration-tests/appsec/graphql.spec.js
@@ -73,7 +73,7 @@ describe('graphql', () => {
       },
       operationName: 'getSingleImage',
     })
-    const [response] = await Promise.all([agentPromise, requestPromise])
+    const [, response] = await Promise.all([agentPromise, requestPromise])
     assert.strictEqual(response.status, 200)
   })
 
@@ -135,7 +135,7 @@ describe('graphql', () => {
       },
       operationName: 'getImagesByCategory',
     })
-    const [response] = await Promise.all([agentPromise, requestPromise])
+    const [, response] = await Promise.all([agentPromise, requestPromise])
     assert.strictEqual(response.status, 200)
   })
 
@@ -158,7 +158,7 @@ describe('graphql', () => {
       },
       operationName: 'getImagesByCategory',
     })
-    const [response] = await Promise.all([agentPromise, requestPromise])
+    const [, response] = await Promise.all([agentPromise, requestPromise])
     assert.strictEqual(response.status, 403)
   })
 
@@ -186,7 +186,7 @@ describe('graphql', () => {
         operationName: 'getImagesByCategory',
       },
     ])
-    const [response] = await Promise.all([agentPromise, requestPromise])
+    const [, response] = await Promise.all([agentPromise, requestPromise])
     assert.strictEqual(response.status, 403)
   })
 })

--- a/integration-tests/appsec/graphql.spec.js
+++ b/integration-tests/appsec/graphql.spec.js
@@ -3,7 +3,6 @@
 const assert = require('node:assert/strict')
 const path = require('path')
 const { inspect } = require('node:util')
-const axios = require('axios')
 
 const {
   FakeAgent,
@@ -38,6 +37,19 @@ describe('graphql', () => {
     await agent.stop()
   })
 
+  /**
+   * @param {object|object[]} body
+   */
+  async function request (body) {
+    const response = await fetch(`${proc.url}/graphql`, {
+      method: 'post',
+      headers: { 'Content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    await response.arrayBuffer()
+    return response
+  }
+
   it('should not report any attack', async () => {
     const agentPromise = agent.assertMessageReceived(({ headers, payload }) => {
       assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
@@ -54,22 +66,15 @@ describe('graphql', () => {
       assert.ok(!('_dd.appsec.json' in payload[1][0].meta))
     })
 
-    const requestPromise = axios({
-      url: `${proc.url}/graphql`,
-      method: 'post',
-      headers: {
-        'Content-type': 'application/json',
+    const requestPromise = request({
+      query: 'query getSingleImage($imageId: Int!) { image(imageId: $imageId) { title owner category url }}',
+      variables: {
+        imageId: 1,
       },
-      data: {
-        query: 'query getSingleImage($imageId: Int!) { image(imageId: $imageId) { title owner category url }}',
-        variables: {
-          imageId: 1,
-        },
-        operationName: 'getSingleImage',
-      },
+      operationName: 'getSingleImage',
     })
-
-    await Promise.all([agentPromise, requestPromise])
+    const [response] = await Promise.all([agentPromise, requestPromise])
+    assert.strictEqual(response.status, 200)
   })
 
   it('should report an attack', async () => {
@@ -123,22 +128,15 @@ describe('graphql', () => {
       assert.deepStrictEqual(JSON.parse(payload[1][0].meta['_dd.appsec.json']), result)
     })
 
-    const requestPromise = axios({
-      url: `${proc.url}/graphql`,
-      method: 'post',
-      headers: {
-        'Content-type': 'application/json',
+    const requestPromise = request({
+      query: 'query getImagesByCategory($category: String) { images(category: $category) { title owner url }}',
+      variables: {
+        category: 'testattack',
       },
-      data: {
-        query: 'query getImagesByCategory($category: String) { images(category: $category) { title owner url }}',
-        variables: {
-          category: 'testattack',
-        },
-        operationName: 'getImagesByCategory',
-      },
+      operationName: 'getImagesByCategory',
     })
-
-    await Promise.all([agentPromise, requestPromise])
+    const [response] = await Promise.all([agentPromise, requestPromise])
+    assert.strictEqual(response.status, 200)
   })
 
   it('should block an attack', async () => {
@@ -153,28 +151,15 @@ describe('graphql', () => {
       assert.strictEqual(payload[1][0].meta['appsec.event'], 'true')
     })
 
-    const requestPromise = assert.rejects(
-      axios({
-        url: `${proc.url}/graphql`,
-        method: 'post',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        data: {
-          query: 'query getImagesByCategory($category: String) { images(category: $category) { title owner url }}',
-          variables: {
-            category: 'blockattack',
-          },
-          operationName: 'getImagesByCategory',
-        },
-      }),
-      (err) => {
-        assert.strictEqual(err.response.status, 403)
-        return true
-      }
-    )
-
-    await Promise.all([agentPromise, requestPromise])
+    const requestPromise = request({
+      query: 'query getImagesByCategory($category: String) { images(category: $category) { title owner url }}',
+      variables: {
+        category: 'blockattack',
+      },
+      operationName: 'getImagesByCategory',
+    })
+    const [response] = await Promise.all([agentPromise, requestPromise])
+    assert.strictEqual(response.status, 403)
   })
 
   it('should block an attack in a batched request', async () => {
@@ -189,32 +174,19 @@ describe('graphql', () => {
       assert.strictEqual(payload[1][0].meta['appsec.event'], 'true')
     })
 
-    const requestPromise = assert.rejects(
-      axios({
-        url: `${proc.url}/graphql`,
-        method: 'post',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        data: [
-          {
-            query: 'query getSingleImage($imageId: Int!) { image(imageId: $imageId) { title }}',
-            variables: { imageId: 1 },
-            operationName: 'getSingleImage',
-          },
-          {
-            query: 'query getImagesByCategory($category: String) { images(category: $category) { title }}',
-            variables: { category: 'blockattack' },
-            operationName: 'getImagesByCategory',
-          },
-        ],
-      }),
-      (err) => {
-        assert.strictEqual(err.response.status, 403)
-        return true
-      }
-    )
-
-    await Promise.all([agentPromise, requestPromise])
+    const requestPromise = request([
+      {
+        query: 'query getSingleImage($imageId: Int!) { image(imageId: $imageId) { title }}',
+        variables: { imageId: 1 },
+        operationName: 'getSingleImage',
+      },
+      {
+        query: 'query getImagesByCategory($category: String) { images(category: $category) { title }}',
+        variables: { category: 'blockattack' },
+        operationName: 'getImagesByCategory',
+      },
+    ])
+    const [response] = await Promise.all([agentPromise, requestPromise])
+    assert.strictEqual(response.status, 403)
   })
 })

--- a/integration-tests/appsec/headers-collection.spec.js
+++ b/integration-tests/appsec/headers-collection.spec.js
@@ -3,8 +3,6 @@
 const assert = require('node:assert/strict')
 const path = require('path')
 const { inspect } = require('node:util')
-const Axios = require('axios')
-
 const {
   sandboxCwd,
   useSandbox,
@@ -13,8 +11,19 @@ const {
   stopProc,
 } = require('../helpers')
 
+/**
+ * @param {string} baseUrl
+ * @param {string} url
+ * @param {object} [options]
+ */
+async function request (baseUrl, url, options) {
+  const response = await fetch(new URL(url, baseUrl), options)
+  await response.arrayBuffer()
+  return response
+}
+
 describe('AppSec headers collection - Express', () => {
-  let axios, cwd, appFile, agent, proc
+  let cwd, appFile, agent, proc
 
   useSandbox(['express'])
 
@@ -40,7 +49,6 @@ describe('AppSec headers collection - Express', () => {
       }
 
       proc = await spawnProc(appFile, { cwd, env, execArgv: [] })
-      axios = Axios.create({ baseURL: proc.url })
     })
 
     afterEach(async () => {
@@ -81,10 +89,10 @@ describe('AppSec headers collection - Express', () => {
     startServer('appsec/data-collection/index.js')
 
     it('should collect event headers when a WAF event is triggered', async () => {
-      const expectedRequestHeaders = ['user-agent', 'accept', 'host', 'accept-encoding']
+      const expectedRequestHeaders = ['user-agent', 'accept', 'host', 'accept-encoding', 'accept-language']
       const expectedResponseHeaders = ['content-type', 'content-language']
 
-      await axios.get('/', { headers: { 'User-Agent': 'Arachni/v1' } })
+      await request(proc.url, '/', { headers: { 'User-Agent': 'Arachni/v1' } })
       await assertHeadersReported(expectedRequestHeaders, expectedResponseHeaders)
     })
   })
@@ -93,7 +101,9 @@ describe('AppSec headers collection - Express', () => {
     startServer('appsec/data-collection/index.js', { extendedDataCollection: true })
 
     it('should collect extended headers when a WAF event is triggered', async () => {
-      const expectedRequestHeaders = ['user-agent', 'accept', 'host', 'accept-encoding', 'connection']
+      const expectedRequestHeaders = [
+        'user-agent', 'accept', 'host', 'accept-encoding', 'accept-language', 'sec-fetch-mode', 'connection',
+      ]
 
       // DD_APPSEC_MAX_COLLECTED_HEADERS is set to 25, so it is expected to collect
       // 22 x-datadog-res-XX headers + x-powered-by, content-type and content-language, for a total of 25.
@@ -104,7 +114,7 @@ describe('AppSec headers collection - Express', () => {
         'content-language',
       ]
 
-      await axios.get('/', { headers: { 'User-Agent': 'Arachni/v1' } })
+      await request(proc.url, '/', { headers: { 'User-Agent': 'Arachni/v1' } })
       await assertHeadersReported(expectedRequestHeaders, expectedResponseHeaders)
     })
   })
@@ -113,18 +123,18 @@ describe('AppSec headers collection - Express', () => {
     startServer('appsec/response-headers/express.js')
 
     it('should always collect content-type and content-length response headers when AppSec is enabled', async () => {
-      const response = await axios.get('/', { headers: { 'User-Agent': 'Mozilla/5.0' } })
+      const response = await request(proc.url, '/', { headers: { 'User-Agent': 'Mozilla/5.0' } })
 
       assert.equal(response.status, 200)
-      assert.ok(response.headers['content-type'])
-      assert.ok(response.headers['content-length'])
+      assert.ok(response.headers.get('content-type'))
+      assert.ok(response.headers.get('content-length'))
 
       await agent.assertMessageReceived(({ payload }) => {
         const span = payload[0]?.find(s => s.type === 'web')
         if (!span) throw new Error('web-type span not yet received')
 
-        assert.equal(span.meta['http.response.headers.content-type'], response.headers['content-type'])
-        assert.equal(span.meta['http.response.headers.content-length'], response.headers['content-length'])
+        assert.equal(span.meta['http.response.headers.content-type'], response.headers.get('content-type'))
+        assert.equal(span.meta['http.response.headers.content-length'], response.headers.get('content-length'))
         assert.equal(span.meta['appsec.event'], undefined)
       })
     })
@@ -132,7 +142,7 @@ describe('AppSec headers collection - Express', () => {
 })
 
 describe('AppSec headers collection - Fastify', () => {
-  let axios, cwd, appFile, agent, proc
+  let cwd, appFile, agent, proc
 
   useSandbox(['fastify'])
 
@@ -151,7 +161,6 @@ describe('AppSec headers collection - Fastify', () => {
       },
       execArgv: [],
     })
-    axios = Axios.create({ baseURL: proc.url })
   })
 
   afterEach(async () => {
@@ -161,18 +170,18 @@ describe('AppSec headers collection - Fastify', () => {
 
   describe('No security event', () => {
     it('should always emit content-type and content-length response headers when AppSec is enabled', async () => {
-      const response = await axios.get('/', { headers: { 'User-Agent': 'Mozilla/5.0' } })
+      const response = await request(proc.url, '/', { headers: { 'User-Agent': 'Mozilla/5.0' } })
 
       assert.equal(response.status, 200)
-      assert.ok(response.headers['content-type'])
-      assert.ok(response.headers['content-length'])
+      assert.ok(response.headers.get('content-type'))
+      assert.ok(response.headers.get('content-length'))
 
       await agent.assertMessageReceived(({ payload }) => {
         const span = payload[0]?.find(s => s.type === 'web')
         if (!span) throw new Error('web-type span not yet received')
 
-        assert.equal(span.meta['http.response.headers.content-type'], response.headers['content-type'])
-        assert.equal(span.meta['http.response.headers.content-length'], response.headers['content-length'])
+        assert.equal(span.meta['http.response.headers.content-type'], response.headers.get('content-type'))
+        assert.equal(span.meta['http.response.headers.content-length'], response.headers.get('content-length'))
         assert.equal(span.meta['appsec.event'], undefined)
       })
     })

--- a/integration-tests/appsec/headers-collection.spec.js
+++ b/integration-tests/appsec/headers-collection.spec.js
@@ -19,6 +19,7 @@ const {
 async function request (baseUrl, url, options) {
   const response = await fetch(new URL(url, baseUrl), options)
   await response.arrayBuffer()
+  assert.strictEqual(response.ok, true)
   return response
 }
 

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -7,7 +7,6 @@ const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
 const { promisify, inspect } = require('util')
-const Axios = require('axios')
 const msgpack = require('@msgpack/msgpack')
 
 const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
@@ -108,7 +107,7 @@ describe('esbuild support for IAST', () => {
             DD_IAST_REQUEST_SAMPLING: '100',
           },
         })
-        contextVars.axios = Axios.create({ baseURL: contextVars.proc.url })
+        contextVars.url = contextVars.proc.url
       })
 
       afterEach(async () => {
@@ -118,8 +117,18 @@ describe('esbuild support for IAST', () => {
     }
   }
 
+  /**
+   * @param {string} baseUrl
+   * @param {string} url
+   */
+  async function request (baseUrl, url) {
+    const response = await fetch(new URL(url, baseUrl))
+    assert.strictEqual(response.status, 200)
+    await response.arrayBuffer()
+  }
+
   describe('cjs', () => {
-    const context = { proc: null, agent: null, axios: null, applicationDir: null, bundledApplicationDir: null }
+    const context = { proc: null, agent: null, url: '', applicationDir: null, bundledApplicationDir: null }
 
     before(async function () {
       this.timeout(120_000)
@@ -136,7 +145,7 @@ describe('esbuild support for IAST', () => {
         startServer('iast-enabled-with-sm.js', true)
 
         it('should detect vulnerability with correct location', async () => {
-          await context.axios.get('/iast/cmdi-vulnerable?args=-la')
+          await request(context.url, '/iast/cmdi-vulnerable?args=-la')
 
           const expectedPath = path.join('iast', 'index.js')
           const expectedLine = 9
@@ -149,7 +158,7 @@ describe('esbuild support for IAST', () => {
         startServer('iast-enabled-with-no-sm.js', true)
 
         it('should detect vulnerability with first callsite location', async () => {
-          await context.axios.get('/iast/cmdi-vulnerable?args=-la')
+          await request(context.url, '/iast/cmdi-vulnerable?args=-la')
 
           const expectedPath = path.join('build', 'iast-enabled-with-no-sm.js')
 
@@ -162,14 +171,14 @@ describe('esbuild support for IAST', () => {
       startServer('iast-disabled.js', false)
 
       it('should not detect any vulnerability', async () => {
-        await context.axios.get('/iast/cmdi-vulnerable?args=-la')
+        await request(context.url, '/iast/cmdi-vulnerable?args=-la')
         await assertNoVulnerability(context.agent)
       })
     })
   })
 
   describe('esm', () => {
-    const context = { proc: null, agent: null, axios: null, applicationDir: null, bundledApplicationDir: null }
+    const context = { proc: null, agent: null, url: '', applicationDir: null, bundledApplicationDir: null }
 
     before(async () => {
       const setup = await setupApplication('iast-esbuild-esm')
@@ -184,7 +193,7 @@ describe('esbuild support for IAST', () => {
         startServer('iast-enabled-with-sm.mjs', true)
 
         it('should detect vulnerability with correct location', async () => {
-          await context.axios.get('/iast/cmdi-vulnerable?args=-la')
+          await request(context.url, '/iast/cmdi-vulnerable?args=-la')
 
           const expectedPath = path.join('iast', 'index.mjs')
           const expectedLine = 7
@@ -197,7 +206,7 @@ describe('esbuild support for IAST', () => {
         startServer('iast-enabled-with-no-sm.mjs', true)
 
         it('should detect vulnerability with first callsite location', async () => {
-          await context.axios.get('/iast/cmdi-vulnerable?args=-la')
+          await request(context.url, '/iast/cmdi-vulnerable?args=-la')
 
           const expectedPath = path.join('build', 'iast-enabled-with-no-sm.mjs')
 
@@ -210,7 +219,7 @@ describe('esbuild support for IAST', () => {
       startServer('iast-disabled.mjs', false)
 
       it('should not detect any vulnerability', async () => {
-        await context.axios.get('/iast/cmdi-vulnerable?args=-la')
+        await request(context.url, '/iast/cmdi-vulnerable?args=-la')
         await assertNoVulnerability(context.agent)
       })
     })

--- a/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
+++ b/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
@@ -5,10 +5,9 @@ const assert = require('node:assert/strict')
 const childProcess = require('child_process')
 const path = require('path')
 const { inspect } = require('node:util')
-const Axios = require('axios')
 const { sandboxCwd, useSandbox, spawnProc, FakeAgent, stopProc } = require('../helpers')
 describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
-  let axios, cwd, appDir, appFile, agent, proc
+  let cwd, appDir, appFile, agent, proc
 
   useSandbox(['@types/node', 'typescript', 'express'])
 
@@ -36,8 +35,6 @@ describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
         NODE_OPTIONS: `--enable-source-maps --require ${appDir}/init.js`,
       },
     })
-
-    axios = Axios.create({ baseURL: proc.url })
   })
 
   afterEach(async () => {
@@ -45,21 +42,30 @@ describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
     await agent.stop()
   })
 
+  /**
+   * @param {string} url
+   */
+  async function request (url) {
+    const response = await fetch(new URL(url, proc.url))
+    assert.strictEqual(response.status, 200)
+    return response.text()
+  }
+
   describe('in rewritten file', () => {
     it('should detect correct stack trace in unnamed function', async () => {
-      const response = await axios.get('/rewritten/stack-trace-from-unnamed-function')
+      const response = await request('/rewritten/stack-trace-from-unnamed-function')
 
-      assert.match(response.data, /\/rewritten-routes\.ts:7:13/)
+      assert.match(response, /\/rewritten-routes\.ts:7:13/)
     })
 
     it('should detect correct stack trace in named function', async () => {
-      const response = await axios.get('/rewritten/stack-trace-from-named-function')
+      const response = await request('/rewritten/stack-trace-from-named-function')
 
-      assert.match(response.data, /\/rewritten-routes\.ts:11:13/)
+      assert.match(response, /\/rewritten-routes\.ts:11:13/)
     })
 
     it('should detect vulnerability in the correct location', async () => {
-      await axios.get('/rewritten/vulnerability')
+      await request('/rewritten/vulnerability')
 
       await agent.assertMessageReceived(({ payload }) => {
         const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
@@ -79,19 +85,19 @@ describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
 
   describe('in not rewritten file', () => {
     it('should detect correct stack trace in unnamed function', async () => {
-      const response = await axios.get('/not-rewritten/stack-trace-from-unnamed-function')
+      const response = await request('/not-rewritten/stack-trace-from-unnamed-function')
 
-      assert.match(response.data, /\/not-rewritten-routes\.ts:7:13/)
+      assert.match(response, /\/not-rewritten-routes\.ts:7:13/)
     })
 
     it('should detect correct stack trace in named function', async () => {
-      const response = await axios.get('/not-rewritten/stack-trace-from-named-function')
+      const response = await request('/not-rewritten/stack-trace-from-named-function')
 
-      assert.match(response.data, /\/not-rewritten-routes\.ts:11:13/)
+      assert.match(response, /\/not-rewritten-routes\.ts:11:13/)
     })
 
     it('should detect vulnerability in the correct location', async () => {
-      await axios.get('/not-rewritten/vulnerability')
+      await request('/not-rewritten/vulnerability')
 
       await agent.assertMessageReceived(({ payload }) => {
         const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))

--- a/integration-tests/appsec/iast.esm-security-controls.spec.js
+++ b/integration-tests/appsec/iast.esm-security-controls.spec.js
@@ -4,10 +4,18 @@ const assert = require('node:assert/strict')
 
 const path = require('path')
 const { inspect } = require('node:util')
-const Axios = require('axios')
 const { sandboxCwd, useSandbox, spawnProc, FakeAgent, stopProc } = require('../helpers')
 describe('ESM Security controls', () => {
-  let axios, cwd, appFile, agent, proc
+  let cwd, appFile, agent, proc
+
+  /**
+   * @param {string} url
+   */
+  async function request (url) {
+    const response = await fetch(new URL(url, proc.url))
+    assert.strictEqual(response.status, 200)
+    await response.arrayBuffer()
+  }
 
   ['4', '5'].forEach(version => {
     describe(`With express v${version}`, () => {
@@ -37,8 +45,6 @@ describe('ESM Security controls', () => {
             NODE_OPTIONS: nodeOptions,
           },
         })
-
-        axios = Axios.create({ baseURL: proc.url })
       })
 
       afterEach(async () => {
@@ -47,7 +53,7 @@ describe('ESM Security controls', () => {
       })
 
       it('test endpoint with iv not configured does have COMMAND_INJECTION vulnerability', async function () {
-        await axios.get('/cmdi-iv-insecure?command=ls -la')
+        await request('/cmdi-iv-insecure?command=ls -la')
 
         await agent.assertMessageReceived(({ payload }) => {
           const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
@@ -59,7 +65,7 @@ describe('ESM Security controls', () => {
       })
 
       it('test endpoint sanitizer does not have COMMAND_INJECTION vulnerability', async () => {
-        await axios.get('/cmdi-s-secure?command=ls -la')
+        await request('/cmdi-s-secure?command=ls -la')
 
         await agent.assertMessageReceived(({ payload }) => {
           const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
@@ -74,7 +80,7 @@ describe('ESM Security controls', () => {
       })
 
       it('test endpoint with default sanitizer does not have COMMAND_INJECTION vulnerability', async () => {
-        await axios.get('/cmdi-s-secure-default?command=ls -la')
+        await request('/cmdi-s-secure-default?command=ls -la')
 
         await agent.assertMessageReceived(({ payload }) => {
           const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
@@ -89,7 +95,7 @@ describe('ESM Security controls', () => {
       })
 
       it('test endpoint with default sanitizer does have COMMAND_INJECTION with original tainted', async () => {
-        await axios.get('/cmdi-s-secure-comparison?command=ls -la')
+        await request('/cmdi-s-secure-comparison?command=ls -la')
 
         await agent.assertMessageReceived(({ payload }) => {
           const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
@@ -101,7 +107,7 @@ describe('ESM Security controls', () => {
       })
 
       it('test endpoint with default sanitizer does have COMMAND_INJECTION vulnerability', async () => {
-        await axios.get('/cmdi-s-secure-default?command=ls -la')
+        await request('/cmdi-s-secure-default?command=ls -la')
 
         await agent.assertMessageReceived(({ payload }) => {
           const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
@@ -116,7 +122,7 @@ describe('ESM Security controls', () => {
       })
 
       it('test endpoint with iv does not have COMMAND_INJECTION vulnerability', async () => {
-        await axios.get('/cmdi-iv-secure?command=ls -la')
+        await request('/cmdi-iv-secure?command=ls -la')
 
         await agent.assertMessageReceived(({ payload }) => {
           const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))

--- a/integration-tests/appsec/iast.esm.spec.js
+++ b/integration-tests/appsec/iast.esm.spec.js
@@ -4,10 +4,18 @@ const assert = require('node:assert/strict')
 
 const path = require('path')
 const { inspect } = require('node:util')
-const Axios = require('axios')
 const { sandboxCwd, useSandbox, spawnProc, FakeAgent, stopProc } = require('../helpers')
 describe('ESM', () => {
-  let axios, cwd, appFile, agent, proc
+  let cwd, appFile, agent, proc
+
+  /**
+   * @param {string} url
+   */
+  async function request (url) {
+    const response = await fetch(new URL(url, proc.url))
+    assert.strictEqual(response.status, 200)
+    await response.arrayBuffer()
+  }
 
   useSandbox(['express'])
 
@@ -36,8 +44,6 @@ describe('ESM', () => {
             NODE_OPTIONS: nodeOptions,
           },
         })
-
-        axios = Axios.create({ baseURL: proc.url })
       })
 
       afterEach(async () => {
@@ -62,7 +68,7 @@ describe('ESM', () => {
       }
 
       it('should detect COMMAND_INJECTION vulnerability', async function () {
-        await axios.get('/cmdi-vulnerable?args=-la')
+        await request('/cmdi-vulnerable?args=-la')
 
         await agent.assertMessageReceived(({ payload }) => {
           verifySpan(payload, span => {
@@ -73,7 +79,7 @@ describe('ESM', () => {
       })
 
       it('should detect COMMAND_INJECTION vulnerability in imported file', async () => {
-        await axios.get('/more/cmdi-vulnerable?args=-la')
+        await request('/more/cmdi-vulnerable?args=-la')
 
         await agent.assertMessageReceived(({ payload }) => {
           verifySpan(payload, span => {

--- a/integration-tests/appsec/inferred-proxy-spans.spec.js
+++ b/integration-tests/appsec/inferred-proxy-spans.spec.js
@@ -3,11 +3,10 @@
 const assert = require('node:assert/strict')
 const path = require('path')
 
-const Axios = require('axios')
 const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
 
 describe('Inferred Proxy Spans with AppSec', () => {
-  let axios, cwd, appFile, agent, proc
+  let cwd, appFile, agent, proc
 
   useSandbox()
 
@@ -27,13 +26,22 @@ describe('Inferred Proxy Spans with AppSec', () => {
         DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED: 'true',
       },
     })
-    axios = Axios.create({ baseURL: proc.url })
   })
 
   afterEach(async () => {
     proc.kill()
     await agent.stop()
   })
+
+  /**
+   * @param {string} url
+   * @param {object} [init]
+   */
+  async function request (url, init) {
+    const response = await fetch(new URL(url, proc.url), init)
+    await response.arrayBuffer()
+    return response
+  }
 
   const inferredHeaders = {
     'x-dd-proxy': 'aws-apigateway',
@@ -45,7 +53,7 @@ describe('Inferred Proxy Spans with AppSec', () => {
   }
 
   it('should add _dd.appsec.enabled to inferred proxy span', async () => {
-    await axios.get('/', { headers: inferredHeaders })
+    await request('/', { headers: inferredHeaders })
 
     await agent.assertMessageReceived(({ payload }) => {
       const spans = payload[0]
@@ -63,7 +71,7 @@ describe('Inferred Proxy Spans with AppSec', () => {
   })
 
   it('should add _dd.appsec.json to inferred proxy span when attack is detected', async () => {
-    await axios.get('/testattack', { headers: inferredHeaders })
+    await request('/testattack', { headers: inferredHeaders })
 
     await agent.assertMessageReceived(({ payload }) => {
       const spans = payload[0]

--- a/integration-tests/appsec/inferred-proxy-spans.spec.js
+++ b/integration-tests/appsec/inferred-proxy-spans.spec.js
@@ -40,6 +40,7 @@ describe('Inferred Proxy Spans with AppSec', () => {
   async function request (url, init) {
     const response = await fetch(new URL(url, proc.url), init)
     await response.arrayBuffer()
+    assert.strictEqual(response.ok, true)
     return response
   }
 

--- a/integration-tests/appsec/trace-tagging.spec.js
+++ b/integration-tests/appsec/trace-tagging.spec.js
@@ -41,6 +41,7 @@ describe('ASM Trace Tagging rules', () => {
   async function request (url, init) {
     const response = await fetch(new URL(url, proc.url), init)
     await response.arrayBuffer()
+    assert.strictEqual(response.ok, true)
     return response
   }
 

--- a/integration-tests/appsec/trace-tagging.spec.js
+++ b/integration-tests/appsec/trace-tagging.spec.js
@@ -3,7 +3,6 @@
 const assert = require('node:assert/strict')
 const path = require('path')
 const { inspect } = require('node:util')
-const Axios = require('axios')
 
 const {
   sandboxCwd,
@@ -14,7 +13,7 @@ const {
 } = require('../helpers')
 
 describe('ASM Trace Tagging rules', () => {
-  let axios, cwd, appFile, agent, proc
+  let cwd, appFile, agent, proc
 
   function startServer () {
     beforeEach(async () => {
@@ -27,13 +26,22 @@ describe('ASM Trace Tagging rules', () => {
       }
 
       proc = await spawnProc(appFile, { cwd, env, execArgv: [] })
-      axios = Axios.create({ baseURL: proc.url })
     })
 
     afterEach(async () => {
       await stopProc(proc)
       await agent.stop()
     })
+  }
+
+  /**
+   * @param {string} url
+   * @param {object} [init]
+   */
+  async function request (url, init) {
+    const response = await fetch(new URL(url, proc.url), init)
+    await response.arrayBuffer()
+    return response
   }
 
   describe('express', () => {
@@ -47,7 +55,7 @@ describe('ASM Trace Tagging rules', () => {
     startServer()
 
     it('should report waf attributes', async () => {
-      await axios.get('/', { headers: { 'User-Agent': 'TraceTaggingTest/v1' } })
+      await request('/', { headers: { 'User-Agent': 'TraceTaggingTest/v1' } })
 
       await agent.assertMessageReceived(({ _, payload }) => {
         assert.ok(
@@ -77,7 +85,7 @@ describe('ASM Trace Tagging rules', () => {
     it('should report waf attributes', async () => {
       let fastifyRequestReceived = false
 
-      await axios.get('/', { headers: { 'User-Agent': 'TraceTaggingTest/v1' } })
+      await request('/', { headers: { 'User-Agent': 'TraceTaggingTest/v1' } })
 
       // With fastify, the 'fastify.request' is not the first message received by FakeAgent, unlike express.
       // That's why expectedMessageCount is set to 10 and the fastifyRequestReceived flag is added to check

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -2,7 +2,6 @@
 
 const assert = require('node:assert/strict')
 
-const axios = require('axios')
 const { describe, it } = require('mocha')
 
 const Analyzer = require('../../../../src/appsec/iast/analyzers/vulnerability-analyzer')
@@ -17,12 +16,20 @@ describe('hsts header missing analyzer', () => {
 
   prepareTestServerForIast('hsts header missing analyzer',
     (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability, config) => {
-      function makeRequestWithXFordwardedProtoHeader (done) {
-        axios.get(`http://localhost:${config.port}/`, {
-          headers: {
-            'X-Forwarded-Proto': 'https',
-          },
-        }).catch(done)
+      /**
+       * @param {(error?: Error) => void} done
+       */
+      async function makeRequestWithXFordwardedProtoHeader (done) {
+        try {
+          const response = await fetch(`http://localhost:${config.port}/`, {
+            headers: {
+              'X-Forwarded-Proto': 'https',
+            },
+          })
+          await response.arrayBuffer()
+        } catch (error) {
+          done(error)
+        }
       }
 
       testThatRequestHasVulnerability((req, res) => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -27,6 +27,7 @@ describe('hsts header missing analyzer', () => {
             },
           })
           await response.arrayBuffer()
+          assert.strictEqual(response.ok, true)
         } catch (error) {
           done(error)
         }

--- a/packages/dd-trace/test/appsec/sdk/set_user.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/set_user.spec.js
@@ -3,8 +3,6 @@
 const assert = require('node:assert/strict')
 const path = require('node:path')
 
-const axios = require('axios')
-
 const { after, before, beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
@@ -108,6 +106,12 @@ describe('set_user', () => {
     let port
     let tracer
 
+    async function request () {
+      const response = await fetch(`http://localhost:${port}/`)
+      assert.strictEqual(response.status, 200)
+      await response.arrayBuffer()
+    }
+
     function listener (req, res) {
       if (controller) {
         controller(req, res)
@@ -138,7 +142,7 @@ describe('set_user', () => {
     })
 
     describe('setUser', () => {
-      it('should set a proper user', (done) => {
+      it('should set a proper user', async () => {
         controller = (req, res) => {
           tracer.appsec.setUser({
             id: 'blockedUser',
@@ -148,7 +152,7 @@ describe('set_user', () => {
           })
           res.end()
         }
-        agent.assertSomeTraces(traces => {
+        const agentPromise = agent.assertSomeTraces(traces => {
           assert.strictEqual(traces[0][0].meta['usr.id'], 'blockedUser')
           assert.strictEqual(traces[0][0].meta['usr.email'], 'a@b.c')
           assert.strictEqual(traces[0][0].meta['usr.custom'], 'hello')
@@ -157,24 +161,24 @@ describe('set_user', () => {
           assert.strictEqual(traces[0][0].meta['appsec.event'], 'true')
           assert.ok(!('appsec.blocked' in traces[0][0].meta))
           assert.strictEqual(traces[0][0].meta['http.status_code'], '200')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+        })
+        await Promise.all([agentPromise, request()])
       })
 
-      it('should override user on consecutive callings', (done) => {
+      it('should override user on consecutive callings', async () => {
         controller = (req, res) => {
           tracer.appsec.setUser({ id: 'testUser' })
           tracer.appsec.setUser({ id: 'blockedUser' })
           res.end()
         }
-        agent.assertSomeTraces(traces => {
+        const agentPromise = agent.assertSomeTraces(traces => {
           assert.strictEqual(traces[0][0].meta['usr.id'], 'blockedUser')
           assert.strictEqual(traces[0][0].meta['_dd.appsec.user.collection_mode'], 'sdk')
           assert.strictEqual(traces[0][0].meta['appsec.event'], 'true')
           assert.ok(!('appsec.blocked' in traces[0][0].meta))
           assert.strictEqual(traces[0][0].meta['http.status_code'], '200')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+        })
+        await Promise.all([agentPromise, request()])
       })
     })
   })


### PR DESCRIPTION
Fetch resolves when response headers arrive. The test helpers consume each response body before reporting completion, which preserves the existing request timing.