### PR TITLE
feat(instrumentation): add async Orchestrion context callbacks

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -7,7 +7,7 @@ const log = require('../../../../dd-trace/src/log')
 const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
 const {
   awaitContextCallback,
-  awaitContextCallbackAtStart,
+  awaitContextCallbackAtTryStart,
   configureGraphqlJitCompileObject,
   configureGraphqlJitDeferredField,
   configureGraphqlJitExecute,
@@ -47,7 +47,7 @@ const matcherEsm = create(instrumentations, dcPolyfillEsm)
 
 for (const matcher of [matcherCjs, matcherEsm]) {
   matcher.addTransform('awaitContextCallback', awaitContextCallback)
-  matcher.addTransform('awaitContextCallbackAtStart', awaitContextCallbackAtStart)
+  matcher.addTransform('awaitContextCallbackAtTryStart', awaitContextCallbackAtTryStart)
   matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
   matcher.addTransform('configureGraphqlJitCompileObject', configureGraphqlJitCompileObject)
   matcher.addTransform('configureGraphqlJitDeferredField', configureGraphqlJitDeferredField)

--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -7,6 +7,7 @@ const log = require('../../../../dd-trace/src/log')
 const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
 const {
   awaitContextCallback,
+  awaitContextCallbackAtStart,
   configureGraphqlJitCompileObject,
   configureGraphqlJitDeferredField,
   configureGraphqlJitExecute,
@@ -46,6 +47,7 @@ const matcherEsm = create(instrumentations, dcPolyfillEsm)
 
 for (const matcher of [matcherCjs, matcherEsm]) {
   matcher.addTransform('awaitContextCallback', awaitContextCallback)
+  matcher.addTransform('awaitContextCallbackAtStart', awaitContextCallbackAtStart)
   matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
   matcher.addTransform('configureGraphqlJitCompileObject', configureGraphqlJitCompileObject)
   matcher.addTransform('configureGraphqlJitDeferredField', configureGraphqlJitDeferredField)

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -37,7 +37,8 @@ module.exports = {
  * @param {{
  *   transformOptions?: {
  *     callbackArgumentNames?: string[],
- *     callbackName?: string
+ *     callbackName?: string,
+ *     callbackThis?: boolean
  *   }
  * }} state
  * @param {import('estree').IfStatement} node
@@ -49,7 +50,7 @@ function awaitContextCallback (state, node, _parent, ancestry) {
   assert(node.type === 'IfStatement' && node.consequent?.type === 'BlockStatement',
     'awaitContextCallback: expected an if statement with a block body')
 
-  const { callbackArgumentNames = [], callbackName } = state.transformOptions ?? {}
+  const { callbackArgumentNames = [], callbackName, callbackThis = false } = state.transformOptions ?? {}
 
   assert(identifierPattern.test(callbackName), 'awaitContextCallback: callbackName must be an identifier')
   assert(callbackArgumentNames.every(name => identifierPattern.test(name)),
@@ -85,12 +86,16 @@ function awaitContextCallback (state, node, _parent, ancestry) {
   }
 
   const originalStatements = node.consequent.body
+  const callbackArguments = callbackArgumentNames.join(', ')
+  const callbackInvocation = callbackThis
+    ? `${callbackVariable}.call(this${callbackArguments ? `, ${callbackArguments}` : ''})`
+    : `${callbackVariable}(${callbackArguments})`
   const callbackStatements = parse(`
     async function wrapper () {
       const ${callbackVariable} = __apm$ctx.${callbackName};
       if (typeof ${callbackVariable} === 'function') {
         try {
-          await ${callbackVariable}(${callbackArgumentNames.join(', ')});
+          await ${callbackInvocation};
         } catch {}
         if (true) {}
       } else {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -59,13 +59,18 @@ function awaitContextCallback (state, node, _parent, ancestry) {
   )
   if (!generatedCallback) return
 
-  const { callbackBranch, callbackStatements } = generatedCallback
+  const { callbackStatements, callbackVariable } = generatedCallback
+  const callbackBranch = parse(`
+    if (typeof ${callbackVariable} === 'function') {
+    } else {
+    }
+  `).body[0]
   callbackBranch.consequent.body.push(clone(node))
   callbackBranch.alternate = {
     type: 'BlockStatement',
     body: originalStatements,
   }
-  node.consequent.body = callbackStatements
+  node.consequent.body = [...callbackStatements, callbackBranch]
 }
 
 /**
@@ -103,8 +108,8 @@ function awaitContextCallbackAtTryStart (state, node, _parent, ancestry) {
  * @param {import('estree').Node[]} ancestry
  * @param {string} transformName
  * @returns {{
- *   callbackBranch: import('estree').IfStatement,
- *   callbackStatements: import('estree').Statement[]
+ *   callbackStatements: import('estree').Statement[],
+ *   callbackVariable: string
  * }|undefined}
  */
 function createAwaitedContextCallback (state, insertionTarget, ancestry, transformName) {
@@ -147,18 +152,19 @@ function createAwaitedContextCallback (state, insertionTarget, ancestry, transfo
     : `${callbackVariable}(${callbackArguments})`
   const callbackStatements = parse(`
     async function wrapper () {
-      const ${callbackVariable} = __apm$ctx.${callbackName};
-      if (typeof ${callbackVariable} === 'function') {
-        try {
+      let ${callbackVariable};
+      try {
+        ${callbackVariable} = __apm$ctx.${callbackName};
+        if (typeof ${callbackVariable} === 'function') {
           await ${callbackInvocation};
-        } catch {}
-      }
+        }
+      } catch {}
     }
   `).body[0].body.body
 
   return {
-    callbackBranch: callbackStatements[1],
     callbackStatements,
+    callbackVariable,
   }
 }
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -73,7 +73,7 @@ function awaitContextCallback (state, node, _parent, ancestry) {
  *
  * @param {Parameters<typeof awaitContextCallback>[0]} state
  * @param {import('estree').Node} node
- * @param {import('estree').Node} parent
+ * @param {import('estree').Node} _parent
  * @param {import('estree').Node[]} ancestry
  * @returns {void}
  */

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -78,9 +78,11 @@ function awaitContextCallback (state, node, _parent, ancestry) {
  * @returns {void}
  */
 function awaitContextCallbackAtTryStart (state, node, _parent, ancestry) {
-  const tryStatement = node.type === 'TryStatement'
-    ? node
-    : ancestry.find(ancestor => ancestor.type === 'TryStatement')
+  let tryStatement = node.type === 'TryStatement' ? node : undefined
+  for (const ancestor of ancestry) {
+    if (tryStatement || functionTypes.has(ancestor.type)) break
+    if (ancestor.type === 'TryStatement') tryStatement = ancestor
+  }
   assert(tryStatement?.block?.type === 'BlockStatement',
     'awaitContextCallbackAtTryStart: expected an enclosing try statement with a block body')
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -19,7 +19,7 @@ const identifierPattern = /^[$A-Z_a-z][$\w]*$/
 
 module.exports = {
   awaitContextCallback,
-  awaitContextCallbackAtStart,
+  awaitContextCallbackAtTryStart,
   configureGraphqlJitCompileObject,
   configureGraphqlJitDeferredField,
   configureGraphqlJitExecute,
@@ -50,11 +50,67 @@ function awaitContextCallback (state, node, _parent, ancestry) {
   assert(node.type === 'IfStatement' && node.consequent?.type === 'BlockStatement',
     'awaitContextCallback: expected an if statement with a block body')
 
+  const originalStatements = node.consequent.body
+  const generatedCallback = createAwaitedContextCallback(
+    state,
+    node.consequent,
+    ancestry,
+    'awaitContextCallback'
+  )
+  if (!generatedCallback) return
+
+  const { callbackBranch, callbackStatements } = generatedCallback
+  callbackBranch.consequent.body.push(clone(node))
+  callbackBranch.alternate = {
+    type: 'BlockStatement',
+    body: originalStatements,
+  }
+  node.consequent.body = callbackStatements
+}
+
+/**
+ * Awaits an optional context callback before entering the matched node's enclosing try block.
+ *
+ * @param {Parameters<typeof awaitContextCallback>[0]} state
+ * @param {import('estree').Node} node
+ * @param {import('estree').Node} parent
+ * @param {import('estree').Node[]} ancestry
+ * @returns {void}
+ */
+function awaitContextCallbackAtTryStart (state, node, _parent, ancestry) {
+  const tryStatement = node.type === 'TryStatement'
+    ? node
+    : ancestry.find(ancestor => ancestor.type === 'TryStatement')
+  assert(tryStatement?.block?.type === 'BlockStatement',
+    'awaitContextCallbackAtTryStart: expected an enclosing try statement with a block body')
+
+  const generatedCallback = createAwaitedContextCallback(
+    state,
+    tryStatement.block,
+    ancestry,
+    'awaitContextCallbackAtTryStart'
+  )
+  if (!generatedCallback) return
+
+  tryStatement.block.body.unshift(...generatedCallback.callbackStatements)
+}
+
+/**
+ * @param {Parameters<typeof awaitContextCallback>[0]} state
+ * @param {import('estree').BlockStatement} insertionTarget
+ * @param {import('estree').Node[]} ancestry
+ * @param {string} transformName
+ * @returns {{
+ *   callbackBranch: import('estree').IfStatement,
+ *   callbackStatements: import('estree').Statement[]
+ * }|undefined}
+ */
+function createAwaitedContextCallback (state, insertionTarget, ancestry, transformName) {
   const { callbackArgumentNames = [], callbackName, callbackThis = false } = state.transformOptions ?? {}
 
-  assert(identifierPattern.test(callbackName), 'awaitContextCallback: callbackName must be an identifier')
-  assert(callbackArgumentNames.every(name => identifierPattern.test(name)),
-    'awaitContextCallback: callbackArgumentNames must be identifiers')
+  assert(identifierPattern.test(callbackName), `${transformName}: callbackName must be an identifier`)
+  assert(Array.isArray(callbackArgumentNames) && callbackArgumentNames.every(name => identifierPattern.test(name)),
+    `${transformName}: callbackArgumentNames must be identifiers`)
 
   let enclosingFunction
   let hasTraceWrapper = false
@@ -77,15 +133,12 @@ function awaitContextCallback (state, node, _parent, ancestry) {
     hasTraceWrapper ||= hasContextBinding && hasTracedBinding
   }
 
-  assert(enclosingFunction?.async, 'awaitContextCallback: expected an enclosing async function')
-  assert(hasTraceWrapper, 'awaitContextCallback: expected an enclosing trace wrapper')
+  assert(enclosingFunction?.async, `${transformName}: expected an enclosing async function`)
+  assert(hasTraceWrapper, `${transformName}: expected an enclosing trace wrapper`)
 
   const callbackVariable = `__apm$${callbackName}`
-  if (query(node, `[id.name="${callbackVariable}"]`).length > 0) {
-    return
-  }
+  if (query(insertionTarget, `[id.name="${callbackVariable}"]`).length > 0) return
 
-  const originalStatements = node.consequent.body
   const callbackArguments = callbackArgumentNames.join(', ')
   const callbackInvocation = callbackThis
     ? `${callbackVariable}.call(this${callbackArguments ? `, ${callbackArguments}` : ''})`
@@ -97,40 +150,14 @@ function awaitContextCallback (state, node, _parent, ancestry) {
         try {
           await ${callbackInvocation};
         } catch {}
-        if (true) {}
-      } else {
       }
     }
   `).body[0].body.body
 
-  const callbackBranch = callbackStatements[1]
-  const recheckedBranch = callbackBranch.consequent.body[1]
-  recheckedBranch.test = clone(node.test)
-  recheckedBranch.consequent.body.push(...clone(originalStatements))
-  recheckedBranch.alternate = clone(node.alternate)
-  callbackBranch.alternate.body.push(...originalStatements)
-  node.consequent.body = callbackStatements
-}
-
-/**
- * Awaits an optional context callback before entering the matched node's enclosing try block.
- *
- * @param {Parameters<typeof awaitContextCallback>[0]} state
- * @param {import('estree').Node} node
- * @param {import('estree').Node} parent
- * @param {import('estree').Node[]} ancestry
- * @returns {void}
- */
-function awaitContextCallbackAtStart (state, node, parent, ancestry) {
-  const tryStatement = node.type === 'TryStatement'
-    ? node
-    : ancestry.find(ancestor => ancestor.type === 'TryStatement')
-  assert(tryStatement?.block?.type === 'BlockStatement',
-    'awaitContextCallbackAtStart: expected an enclosing try statement with a block body')
-
-  const callbackBranch = parse('async function wrapper () { if (true) {} }').body[0].body.body[0]
-  awaitContextCallback(state, callbackBranch, parent, ancestry)
-  tryStatement.block.body.unshift(callbackBranch)
+  return {
+    callbackBranch: callbackStatements[1],
+    callbackStatements,
+  }
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -19,6 +19,7 @@ const identifierPattern = /^[$A-Z_a-z][$\w]*$/
 
 module.exports = {
   awaitContextCallback,
+  awaitContextCallbackAtStart,
   configureGraphqlJitCompileObject,
   configureGraphqlJitDeferredField,
   configureGraphqlJitExecute,
@@ -104,6 +105,27 @@ function awaitContextCallback (state, node, _parent, ancestry) {
   recheckedBranch.alternate = clone(node.alternate)
   callbackBranch.alternate.body.push(...originalStatements)
   node.consequent.body = callbackStatements
+}
+
+/**
+ * Awaits an optional context callback before entering the matched node's enclosing try block.
+ *
+ * @param {Parameters<typeof awaitContextCallback>[0]} state
+ * @param {import('estree').Node} node
+ * @param {import('estree').Node} parent
+ * @param {import('estree').Node[]} ancestry
+ * @returns {void}
+ */
+function awaitContextCallbackAtStart (state, node, parent, ancestry) {
+  const tryStatement = node.type === 'TryStatement'
+    ? node
+    : ancestry.find(ancestor => ancestor.type === 'TryStatement')
+  assert(tryStatement?.block?.type === 'BlockStatement',
+    'awaitContextCallbackAtStart: expected an enclosing try statement with a block body')
+
+  const callbackBranch = parse('async function wrapper () { if (true) {} }').body[0].body.body[0]
+  awaitContextCallback(state, callbackBranch, parent, ancestry)
+  tryStatement.block.body.unshift(callbackBranch)
 }
 
 /**

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -365,7 +365,7 @@ describe('check-require-cache', () => {
             functionName: 'runAfterSetup',
             kind: 'Async',
           },
-          channelName: 'trace_await_context_callback_at_start',
+          channelName: 'trace_await_context_callback_at_try_start',
         },
         {
           module: {
@@ -374,8 +374,8 @@ describe('check-require-cache', () => {
             filePath: 'trace-await-context-callback.js',
           },
           astQuery: 'FunctionDeclaration[id.name="runAfterSetup"] TryStatement',
-          channelName: 'trace_await_context_callback_at_start',
-          transform: 'awaitContextCallbackAtStart',
+          channelName: 'trace_await_context_callback_at_try_start',
+          transform: 'awaitContextCallbackAtTryStart',
           transformOptions: {
             callbackName: 'beforeStart',
           },
@@ -892,7 +892,7 @@ describe('check-require-cache', () => {
       },
     }
 
-    ch = tracingChannel('orchestrion:test:trace_await_context_callback_at_start')
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_at_try_start')
     ch.subscribe(subs)
 
     const resultPromise = runAfterSetup(() => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -934,6 +934,25 @@ describe('check-require-cache', () => {
     assert.deepStrictEqual(steps, ['setup', 'setup done', 'task'])
   })
 
+  it('should preserve a try block when context callback lookup throws', async () => {
+    const { runAfterSetup } = compileFile('trace-await-context-callback')
+
+    subs = {
+      start (ctx) {
+        Object.defineProperty(ctx, 'beforeStart', {
+          get () {
+            throw new Error('observability callback lookup failed')
+          },
+        })
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_at_try_start')
+    ch.subscribe(subs)
+
+    assert.equal(await runAfterSetup(() => 'passed'), 'passed')
+  })
+
   it('should not use a try block outside the traced function', async () => {
     const filename = resolve(__dirname, 'node_modules', 'test', 'trace-await-context-callback-outer-try.js')
     const source = readFileSync(filename, 'utf8')
@@ -994,6 +1013,33 @@ describe('check-require-cache', () => {
     subs = {
       start (ctx) {
         ctx.beforeContinue = () => Promise.reject(new Error('observability callback failed'))
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback')
+    ch.subscribe(subs)
+
+    const result = await runWithRetry(() => {
+      attempts++
+      if (attempts === 1) throw new Error('first attempt failed')
+      return 'passed'
+    }, { remaining: 1 })
+
+    assert.equal(result, 'passed')
+    assert.equal(attempts, 2)
+  })
+
+  it('should preserve the conditional branch when context callback lookup throws', async () => {
+    const { runWithRetry } = compileFile('trace-await-context-callback')
+    let attempts = 0
+
+    subs = {
+      start (ctx) {
+        Object.defineProperty(ctx, 'beforeContinue', {
+          get () {
+            throw new Error('observability callback lookup failed')
+          },
+        })
       },
     }
 

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -384,6 +384,31 @@ describe('check-require-cache', () => {
           module: {
             name: 'test',
             versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback-outer-try.js',
+          },
+          functionQuery: {
+            functionName: 'tracedNested',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback_outer_try',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback-outer-try.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="tracedNested"] CallExpression[callee.name="task"]',
+          channelName: 'trace_await_context_callback_outer_try',
+          transform: 'awaitContextCallbackAtTryStart',
+          transformOptions: {
+            callbackName: 'beforeStart',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
             filePath: 'trace-await-context-callback.js',
           },
           functionQuery: {
@@ -907,6 +932,15 @@ describe('check-require-cache', () => {
 
     assert.equal(await resultPromise, 'passed')
     assert.deepStrictEqual(steps, ['setup', 'setup done', 'task'])
+  })
+
+  it('should not use a try block outside the traced function', async () => {
+    const filename = resolve(__dirname, 'node_modules', 'test', 'trace-await-context-callback-outer-try.js')
+    const source = readFileSync(filename, 'utf8')
+    const { runNestedWithoutTry } = compileFile('trace-await-context-callback-outer-try')
+
+    assert.strictEqual(content, source)
+    assert.equal(await runNestedWithoutTry(() => 'passed'), 'passed')
   })
 
   it('should call a context callback with the instrumented receiver', async () => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -334,6 +334,31 @@ describe('check-require-cache', () => {
             filePath: 'trace-await-context-callback.js',
           },
           functionQuery: {
+            functionName: 'runAfterSetup',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback_at_start',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="runAfterSetup"] TryStatement',
+          channelName: 'trace_await_context_callback_at_start',
+          transform: 'awaitContextCallbackAtStart',
+          transformOptions: {
+            callbackName: 'beforeStart',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          functionQuery: {
             functionName: 'consumeFirst',
             kind: 'Async',
           },
@@ -814,6 +839,46 @@ describe('check-require-cache', () => {
 
     assert.equal(await resultPromise, 'passed')
     assert.equal(attempts, 2)
+  })
+
+  it('should await a context callback before entering a try block', async () => {
+    const { runAfterSetup } = compileFile('trace-await-context-callback')
+    const steps = []
+    let finishSetup
+    let startSetup
+    const setupStarted = new Promise(resolve => {
+      startSetup = resolve
+    })
+    const setupFinished = new Promise(resolve => {
+      finishSetup = resolve
+    })
+
+    subs = {
+      start (ctx) {
+        ctx.beforeStart = async function () {
+          steps.push('setup')
+          startSetup()
+          await setupFinished
+          steps.push('setup done')
+        }
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_at_start')
+    ch.subscribe(subs)
+
+    const resultPromise = runAfterSetup(() => {
+      steps.push('task')
+      return 'passed'
+    })
+
+    await setupStarted
+    assert.deepStrictEqual(steps, ['setup'])
+
+    finishSetup()
+
+    assert.equal(await resultPromise, 'passed')
+    assert.deepStrictEqual(steps, ['setup', 'setup done', 'task'])
   })
 
   it('should recheck the condition after the context callback settles', async () => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -334,6 +334,34 @@ describe('check-require-cache', () => {
             filePath: 'trace-await-context-callback.js',
           },
           functionQuery: {
+            className: 'ContextRunner',
+            methodName: 'run',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback_this',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          astQuery: 'ClassDeclaration[id.name="ContextRunner"] ' +
+            'MethodDefinition[key.name="run"] IfStatement',
+          channelName: 'trace_await_context_callback_this',
+          transform: 'awaitContextCallback',
+          transformOptions: {
+            callbackName: 'beforeContinue',
+            callbackThis: true,
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          functionQuery: {
             functionName: 'runAfterSetup',
             kind: 'Async',
           },
@@ -879,6 +907,24 @@ describe('check-require-cache', () => {
 
     assert.equal(await resultPromise, 'passed')
     assert.deepStrictEqual(steps, ['setup', 'setup done', 'task'])
+  })
+
+  it('should call a context callback with the instrumented receiver', async () => {
+    const { ContextRunner } = compileFile('trace-await-context-callback')
+    const runner = new ContextRunner()
+
+    subs = {
+      start (ctx) {
+        ctx.beforeContinue = async function () {
+          assert.strictEqual(this, runner)
+          await new Promise(resolve => setImmediate(resolve))
+        }
+      },
+    }
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_this')
+    ch.subscribe(subs)
+
+    assert.equal(await runner.run({ shouldContinue: true }), 'continued')
   })
 
   it('should recheck the condition after the context callback settles', async () => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback-outer-try.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback-outer-try.js
@@ -1,0 +1,15 @@
+'use strict'
+
+function runNestedWithoutTry (task) {
+  try {
+    async function tracedNested () {
+      return task()
+    }
+
+    return tracedNested()
+  } catch (error) {
+    return error.message
+  }
+}
+
+module.exports = { runNestedWithoutTry }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
@@ -35,4 +35,12 @@ async function runAfterSetup (task) {
   }
 }
 
-module.exports = { chooseBranch, consumeFirst, runAfterSetup, runWithRetry }
+class ContextRunner {
+  async run (state) {
+    if (state.shouldContinue) {
+      return 'continued'
+    }
+  }
+}
+
+module.exports = { chooseBranch, consumeFirst, ContextRunner, runAfterSetup, runWithRetry }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
@@ -27,4 +27,12 @@ async function chooseBranch (state) {
   }
 }
 
-module.exports = { chooseBranch, consumeFirst, runWithRetry }
+async function runAfterSetup (task) {
+  try {
+    return await task()
+  } catch (error) {
+    return error.message
+  }
+}
+
+module.exports = { chooseBranch, consumeFirst, runAfterSetup, runWithRetry }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds two generic rewriter transforms for awaiting a callback stored on the Orchestrion context.

`awaitContextCallback` targets an `if` branch. It awaits the callback and then checks the condition again because state may have changed while waiting.

~~~js
// Before
if (shouldRetry) {
  retry()
}

// Conceptually after
if (shouldRetry) {
  if (callback) {
    try { await callback() } catch {}
    if (shouldRetry) retry()
  } else {
    retry()
  }
}
~~~

`awaitContextCallbackAtTryStart` targets the nearest enclosing `try` within the current traced function. It inserts the callback before the first existing statement.

~~~js
// Before
try {
  return await runWork()
} catch (error) {
  handle(error)
}

// Conceptually after
try {
  try { await callback() } catch {}
  return await runWork()
} catch (error) {
  handle(error)
}
~~~

The transforms have different AST and placement rules, but share callback validation and generation. Both check the actual insertion target before adding code, so applying a transform again does not insert a duplicate callback.

`callbackThis` is an optional, separate behavior for callbacks that need the original method receiver:

~~~js
await callback.call(this, ...args)
~~~

Callback lookup and invocation failures are caught so Datadog instrumentation cannot fail customer code.

### Motivation
<!-- What inspired you to submit this pull request? -->

Stacked PR #10049 adds WebdriverIO RUM correlation. It needs to await RUM preparation inside WebdriverIO internal `@wdio/utils` function `executeAsync`. This is not the public `browser.executeAsync()` command.

`executeAsync` receives `fn`, the test or hook function. WebdriverIO already wraps it in a `try/catch` that handles timeouts, cleanup, retries, and rethrowing failures:

~~~js
async function executeAsync(fn, retries, args) {
  // The tracing start subscriber has populated the Datadog context.
  try {
    // Datadog must await RUM preparation here.
    return await fn.apply(this, args)
  } catch (error) {
    if (shouldRetry(retries)) {
      return executeAsync.call(this, fn, retries, args)
    }
    throw error
  }
}
~~~

Why the existing tools do not provide this insertion point:

- A tracing-channel `start` subscriber is synchronous. Returning a promise does not pause WebdriverIO.
- `waitForAsyncEnd` runs after `fn` settles, so it is too late.
- `awaitContextCallback` requires an `if` branch. The retry `if` is reached only after the initial attempt has failed.

`awaitContextCallbackAtTryStart` inserts the await immediately before `fn.apply(this, args)`. A recursive retry enters the same `try`, so the callback runs before the initial attempt and every retry.

The `callbackThis` option supports a different WebdriverIO case: URL/navigation callbacks need the original receiver to access the browser instance.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR contains generic rewriter functionality only. WebdriverIO configuration and RUM-specific behavior remain in stacked PR #10049. It does not add generator handling.

Verification:

~~~text
./node_modules/.bin/mocha packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
39 passing
~~~
