### PR TITLE
fix(graphql): record reused non-JIT resolver errors

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -3,24 +3,25 @@
 const { addHook, getHooks } = require('./helpers/instrument')
 
 // Orchestrion rewriter handles wrapping of:
-// - graphql: execute, parse, validate (CJS + ESM)
-// - @graphql-tools/executor: execute, normalizedExecutor (CJS + ESM)
+// - graphql: execute, locatedError, parse, validate (CJS + ESM)
+// - @graphql-tools/executor: execute, handleFieldError, normalizedExecutor (CJS + ESM)
 // See helpers/rewriter/instrumentations/graphql.js for the full config.
-for (const hook of getHooks('graphql')) {
-  addHook(hook, exports => exports)
+
+/**
+ * @param {string} name
+ */
+function addRewriterHooks (name) {
+  const files = new Set()
+  for (const hook of getHooks(name)) {
+    if (files.has(hook.file)) continue
+    files.add(hook.file)
+    addHook(hook, exports => exports)
+  }
 }
 
-for (const hook of getHooks('@graphql-tools/executor')) {
-  addHook(hook, exports => exports)
-}
-
-// Multiple graphql-jit rewrites share each build file; register one hook per file.
-const graphqlJitFiles = new Set()
-for (const hook of getHooks('graphql-jit')) {
-  if (graphqlJitFiles.has(hook.file)) continue
-  graphqlJitFiles.add(hook.file)
-  addHook(hook, exports => exports)
-}
+addRewriterHooks('graphql')
+addRewriterHooks('@graphql-tools/executor')
+addRewriterHooks('graphql-jit')
 
 // Module-load hooks: capture references on ddGlobal for cross-plugin access
 // (read lazily inside each callback so agent.load() between mocha suites can

--- a/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/graphql.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/graphql.js
@@ -28,6 +28,54 @@ module.exports = [
   {
     module: {
       name: 'graphql',
+      versionRange: '>=0.10 <16',
+      filePath: 'execution/execute.js',
+    },
+    functionQuery: {
+      functionName: 'asErrorInstance',
+      kind: 'Sync',
+    },
+    channelName: 'apm:graphql:resolve:error',
+  },
+  {
+    module: {
+      name: 'graphql',
+      versionRange: '>=0.10 <16',
+      filePath: 'execution/execute.mjs',
+    },
+    functionQuery: {
+      functionName: 'asErrorInstance',
+      kind: 'Sync',
+    },
+    channelName: 'apm:graphql:resolve:error',
+  },
+  {
+    module: {
+      name: 'graphql',
+      versionRange: '>=0.10',
+      filePath: 'error/locatedError.js',
+    },
+    functionQuery: {
+      functionName: 'locatedError',
+      kind: 'Sync',
+    },
+    channelName: 'apm:graphql:resolve:error',
+  },
+  {
+    module: {
+      name: 'graphql',
+      versionRange: '>=0.10',
+      filePath: 'error/locatedError.mjs',
+    },
+    functionQuery: {
+      functionName: 'locatedError',
+      kind: 'Sync',
+    },
+    channelName: 'apm:graphql:resolve:error',
+  },
+  {
+    module: {
+      name: 'graphql',
       versionRange: '>=0.10',
       filePath: 'language/parser.js',
     },
@@ -101,6 +149,30 @@ module.exports = [
       kind: 'Sync',
     },
     channelName: 'apm:graphql:execute',
+  },
+  {
+    module: {
+      name: '@graphql-tools/executor',
+      versionRange: '>=0.0.14',
+      filePath: 'cjs/execution/execute.js',
+    },
+    functionQuery: {
+      functionName: 'handleFieldError',
+      kind: 'Sync',
+    },
+    channelName: 'apm:graphql:resolve:error',
+  },
+  {
+    module: {
+      name: '@graphql-tools/executor',
+      versionRange: '>=0.0.14',
+      filePath: 'esm/execution/execute.js',
+    },
+    functionQuery: {
+      functionName: 'handleFieldError',
+      kind: 'Sync',
+    },
+    channelName: 'apm:graphql:resolve:error',
   },
   {
     module: {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/targets.json
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/targets.json
@@ -47,6 +47,8 @@
   "graphql-jit/dist/esm/execution.js": "graphql-jit",
   "graphql-jit/dist/execution.js": "graphql-jit",
   "graphql-jit/dist/execution.mjs": "graphql-jit",
+  "graphql/error/locatedError.js": "graphql",
+  "graphql/error/locatedError.mjs": "graphql",
   "graphql/execution/execute.js": "graphql",
   "graphql/execution/execute.mjs": "graphql",
   "graphql/language/parser.js": "graphql",

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -381,9 +381,8 @@ class GraphQLExecutePlugin extends TracingPlugin {
       instrumentedArgs.delete(ctx.ddInstrumentedArgs)
     }
 
-    this.config.hooks.execute(span, ctx.ddArgs, res)
-
     releaseRootContext(ctx.ddRootCtx, finishPendingFields)
+    this.config.hooks.execute(span, ctx.ddArgs, res)
     span.finish()
   }
 
@@ -472,11 +471,20 @@ class GraphQLExecutePlugin extends TracingPlugin {
    * @param {object} field
    * @param {unknown} error
    * @param {unknown} result
+   * @param {boolean} [failed]
+   * @param {boolean} [reused]
    */
-  completeResolveSpan (rootCtx, field, error, result) {
+  completeResolveSpan (rootCtx, field, error, result, failed = Boolean(error), reused = false) {
     if (rootCtx.resolveFields !== undefined) {
       if (field.endTime !== REUSED_FIELD_END_TIME) {
         field.endTime = rootCtx.executeSpan._getTime()
+      }
+      if (field.jitPathKey === false) {
+        if (failed) recordResolveError(field, error)
+        if (!reused && this.config.hooks.resolve) {
+          field.resolveHookContext = createResolveHookContext(field, field.error, result)
+        }
+        return
       }
       this.#completeResolveSpan(field, error, result)
       return
@@ -654,6 +662,17 @@ function wrapResolve (resolve, isJit = false) {
       }
     } else {
       field.endTime = REUSED_FIELD_END_TIME
+      if (!isJit) {
+        /**
+         * @param {unknown} error
+         * @param {unknown} result
+         * @param {boolean} failed
+         */
+        const finishField = (error, result, failed) => {
+          rootCtx.plugin?.completeResolveSpan(rootCtx, field, error, result, failed, true)
+        }
+        return callInAsyncScope(resolve, this, arguments, field.currentStore, finishField)
+      }
       return callInCollapsedScope(
         resolve,
         this,
@@ -667,9 +686,15 @@ function wrapResolve (resolve, isJit = false) {
     const startTime = executeSpan._getTime()
     rootCtx.plugin.startResolveSpan(field, rootCtx, executeSpan, startTime, info.variableValues)
 
-    return callInAsyncScope(resolve, this, arguments, field.currentStore, (error, res) => {
-      rootCtx.plugin?.completeResolveSpan(rootCtx, field, error, res)
-    }, isJit)
+    /**
+     * @param {unknown} error
+     * @param {unknown} res
+     * @param {boolean} failed
+     */
+    const finishField = (error, res, failed) => {
+      rootCtx.plugin?.completeResolveSpan(rootCtx, field, error, res, failed)
+    }
+    return callInAsyncScope(resolve, this, arguments, field.currentStore, finishField, isJit)
   }
 
   if (isJit) {
@@ -1070,7 +1095,7 @@ function callInCollapsedScope (fn, thisArg, args, field, isJit) {
  * @param {unknown} thisArg
  * @param {ArgumentsList} args
  * @param {object} store
- * @param {(error: unknown, result?: unknown) => void} callback
+ * @param {(error: unknown, result?: unknown, failed?: boolean) => void} callback
  * @param {boolean} isJit
  * @returns {unknown}
  */
@@ -1080,10 +1105,10 @@ function callInAsyncScope (fn, thisArg, args, store, callback, isJit) {
     if (typeof result?.then === 'function' && (!isJit || (result !== null && typeof result === 'object'))) {
       return observeThenable(result, callback)
     }
-    callback(null, result)
+    callback(null, result, false)
     return result
   } catch (error) {
-    callback(error)
+    callback(error, undefined, true)
     throw error
   }
 }
@@ -1104,7 +1129,7 @@ function callInAsyncScope (fn, thisArg, args, store, callback, isJit) {
  * get its real return value, while the settlement callbacks pass through us.
  *
  * @param {Thenable} thenable
- * @param {(error: unknown, result?: unknown) => void} callback
+ * @param {(error: unknown, result?: unknown, failed?: boolean) => void} callback
  * @returns {Thenable}
  */
 function observeThenable (thenable, callback) {
@@ -1120,14 +1145,14 @@ function observeThenable (thenable, callback) {
          * @param {unknown} result
          */
         result => {
-          callback(null, result)
+          callback(null, result, false)
           return onFulfilled ? onFulfilled(result) : result
         },
         /**
          * @param {unknown} error
          */
         error => {
-          callback(error)
+          callback(error, undefined, true)
           if (onRejected) return onRejected(error)
           throw error
         }
@@ -1404,6 +1429,9 @@ function releaseRootContext (rootCtx, finishPendingFields) {
   const endTime = rootCtx.executeSpan._getTime()
   if (rootCtx.resolveFields !== undefined) {
     for (let field = rootCtx.resolveFields; field; field = field.nextResolveField) {
+      if (field.resolveHookContext) {
+        rootCtx.config.hooks.resolve(field.span, field.resolveHookContext)
+      }
       field.span.finish(field.endTime > PENDING_FIELD_END_TIME ? field.endTime : endTime)
     }
   } else if (finishPendingFields && rootCtx.fields !== undefined) {
@@ -1415,6 +1443,38 @@ function releaseRootContext (rootCtx, finishPendingFields) {
   // Resolver-created async resources retain copied stores that all share this owner.
   for (const key of Object.keys(rootCtx)) {
     rootCtx[key] = undefined
+  }
+}
+
+/**
+ * @param {object} field
+ * @param {unknown} error
+ */
+function recordResolveError (field, error) {
+  if (field.error !== undefined) return
+
+  const recordedError = error || new Error('GraphQL resolver rejected without an error')
+  field.error = recordedError
+  field.span.setTag('error', recordedError)
+  if (field.resolveHookContext) {
+    field.resolveHookContext.error = recordedError
+    field.resolveHookContext.result = undefined
+  }
+}
+
+/**
+ * @param {object} field
+ * @param {unknown} error
+ * @param {unknown} result
+ * @returns {{ fieldName: string, path: string, error: unknown, result: unknown }}
+ */
+function createResolveHookContext (field, error, result) {
+  return {
+    fieldName: field.fieldName,
+    path: field.pathString,
+    error: error || null,
+    // Any thenable from any realm must stay undefined so the hook does not see an unresolved promise.
+    result: error || typeof result?.then === 'function' ? undefined : result,
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -5,6 +5,7 @@ const dc = require('dc-polyfill')
 const { storage } = require('../../datadog-core')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 const GraphQLParsePlugin = require('./parse')
+const { recordResolveError } = require('./resolve-error')
 const {
   extractErrorIntoSpanEvent,
   getBaseTypeName,
@@ -381,8 +382,10 @@ class GraphQLExecutePlugin extends TracingPlugin {
       instrumentedArgs.delete(ctx.ddInstrumentedArgs)
     }
 
-    releaseRootContext(ctx.ddRootCtx, finishPendingFields)
+    const releaseBeforeExecuteHook = ctx.ddRootCtx?.resolveHooksPending === true
+    if (releaseBeforeExecuteHook) releaseRootContext(ctx.ddRootCtx, finishPendingFields)
     this.config.hooks.execute(span, ctx.ddArgs, res)
+    if (!releaseBeforeExecuteHook) releaseRootContext(ctx.ddRootCtx, finishPendingFields)
     span.finish()
   }
 
@@ -428,6 +431,9 @@ class GraphQLExecutePlugin extends TracingPlugin {
 
     field.span = span
     if (rootCtx.config.collapse) {
+      if (field.jitPathKey === false) {
+        field.currentStore.graphqlResolveField = { field }
+      }
       field.nextResolveField = rootCtx.resolveFields
       rootCtx.resolveFields = field
     }
@@ -472,17 +478,17 @@ class GraphQLExecutePlugin extends TracingPlugin {
    * @param {unknown} error
    * @param {unknown} result
    * @param {boolean} [failed]
-   * @param {boolean} [reused]
    */
-  completeResolveSpan (rootCtx, field, error, result, failed = Boolean(error), reused = false) {
+  completeResolveSpan (rootCtx, field, error, result, failed = false) {
     if (rootCtx.resolveFields !== undefined) {
       if (field.endTime !== REUSED_FIELD_END_TIME) {
         field.endTime = rootCtx.executeSpan._getTime()
       }
       if (field.jitPathKey === false) {
         if (failed) recordResolveError(field, error)
-        if (!reused && this.config.hooks.resolve) {
+        if (this.config.hooks.resolve) {
           field.resolveHookContext = createResolveHookContext(field, field.error, result)
+          rootCtx.resolveHooksPending = true
         }
         return
       }
@@ -662,17 +668,6 @@ function wrapResolve (resolve, isJit = false) {
       }
     } else {
       field.endTime = REUSED_FIELD_END_TIME
-      if (!isJit) {
-        /**
-         * @param {unknown} error
-         * @param {unknown} result
-         * @param {boolean} failed
-         */
-        const finishField = (error, result, failed) => {
-          rootCtx.plugin?.completeResolveSpan(rootCtx, field, error, result, failed, true)
-        }
-        return callInAsyncScope(resolve, this, arguments, field.currentStore, finishField)
-      }
       return callInCollapsedScope(
         resolve,
         this,
@@ -1105,7 +1100,7 @@ function callInAsyncScope (fn, thisArg, args, store, callback, isJit) {
     if (typeof result?.then === 'function' && (!isJit || (result !== null && typeof result === 'object'))) {
       return observeThenable(result, callback)
     }
-    callback(null, result, false)
+    callback(null, result)
     return result
   } catch (error) {
     callback(error, undefined, true)
@@ -1145,7 +1140,7 @@ function observeThenable (thenable, callback) {
          * @param {unknown} result
          */
         result => {
-          callback(null, result, false)
+          callback(null, result)
           return onFulfilled ? onFulfilled(result) : result
         },
         /**
@@ -1429,6 +1424,11 @@ function releaseRootContext (rootCtx, finishPendingFields) {
   const endTime = rootCtx.executeSpan._getTime()
   if (rootCtx.resolveFields !== undefined) {
     for (let field = rootCtx.resolveFields; field; field = field.nextResolveField) {
+      const holder = field.currentStore?.graphqlResolveField
+      if (holder?.field === field) {
+        holder.field = undefined
+        field.currentStore.graphqlResolveField = undefined
+      }
       if (field.resolveHookContext) {
         rootCtx.config.hooks.resolve(field.span, field.resolveHookContext)
       }
@@ -1443,22 +1443,6 @@ function releaseRootContext (rootCtx, finishPendingFields) {
   // Resolver-created async resources retain copied stores that all share this owner.
   for (const key of Object.keys(rootCtx)) {
     rootCtx[key] = undefined
-  }
-}
-
-/**
- * @param {object} field
- * @param {unknown} error
- */
-function recordResolveError (field, error) {
-  if (field.error !== undefined) return
-
-  const recordedError = error || new Error('GraphQL resolver rejected without an error')
-  field.error = recordedError
-  field.span.setTag('error', recordedError)
-  if (field.resolveHookContext) {
-    field.resolveHookContext.error = recordedError
-    field.resolveHookContext.result = undefined
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -8,6 +8,7 @@ const GraphQLExecutePlugin = require('./execute')
 const GraphQLJitExecutePlugin = require('./jit')
 const GraphQLParsePlugin = require('./parse')
 const GraphQLRequestPlugin = require('./request')
+const { GraphQLResolveErrorPlugin, GraphQLToolsResolveErrorPlugin } = require('./resolve-error')
 const GraphQLValidatePlugin = require('./validate')
 
 class GraphQLPlugin extends CompositePlugin {
@@ -22,9 +23,9 @@ class GraphQLPlugin extends CompositePlugin {
       // and yoga produce no such channel, so the plugin simply never fires for
       // them.
       request: GraphQLRequestPlugin,
+      resolveError: GraphQLResolveErrorPlugin,
+      toolsResolveError: GraphQLToolsResolveErrorPlugin,
       validate: GraphQLValidatePlugin,
-      // Resolve handling is absorbed into execute. Spans start inline for
-      // correct parenting; collapsed spans finish when execute completes.
     }
   }
 

--- a/packages/datadog-plugin-graphql/src/resolve-error.js
+++ b/packages/datadog-plugin-graphql/src/resolve-error.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const { storage } = require('../../datadog-core')
+const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
+
+const legacyStorage = storage('legacy')
+const normalizedFalsyErrors = new WeakSet()
+
+class GraphQLResolveErrorPlugin extends TracingPlugin {
+  static id = 'graphql'
+  static prefix = 'tracing:orchestrion:graphql:apm:graphql:resolve:error'
+
+  /**
+   * @param {{ arguments?: unknown[], result?: unknown }} ctx
+   */
+  start (ctx) {
+    const args = ctx.arguments
+    if (args?.length === 1) return
+
+    const error = args?.[0]
+    const errorPath = error?.path
+    const path = Array.isArray(errorPath) ? errorPath : args?.[2]
+    recordActiveResolveError(normalizedFalsyErrors.delete(error) ? undefined : error, path)
+  }
+
+  /**
+   * @param {{ arguments?: unknown[], result?: unknown }} ctx
+   */
+  end (ctx) {
+    const args = ctx.arguments
+    if (args?.length !== 1 || args[0]) return
+
+    const error = ctx.result
+    if (error !== null && typeof error === 'object') normalizedFalsyErrors.add(error)
+  }
+}
+
+class GraphQLToolsResolveErrorPlugin extends TracingPlugin {
+  static id = 'graphql'
+  static prefix = 'tracing:orchestrion:@graphql-tools/executor:apm:graphql:resolve:error'
+
+  /**
+   * @param {{ arguments?: unknown[] }} ctx
+   */
+  start (ctx) {
+    const error = ctx.arguments?.[0]
+    recordActiveResolveError(error, error?.path)
+  }
+
+  // `start` owns attribution while the normalized error path is available.
+  error () {}
+}
+
+/**
+ * @param {unknown} error
+ * @param {(string | number)[]} [path]
+ */
+function recordActiveResolveError (error, path) {
+  const field = legacyStorage.getStore()?.graphqlResolveField?.field
+  if (!field || (path !== undefined && !matchesPath(field.pathString, path))) return
+
+  recordResolveError(field, error)
+}
+
+/**
+ * @param {string} fieldPath
+ * @param {(string | number)[]} path
+ * @returns {boolean}
+ */
+function matchesPath (fieldPath, path) {
+  let pathString = ''
+  for (let index = 0; index < path.length; index++) {
+    if (index !== 0) pathString += '.'
+    pathString += typeof path[index] === 'number' ? '*' : path[index]
+  }
+  return pathString === fieldPath
+}
+
+/**
+ * @param {object} field
+ * @param {unknown} error
+ */
+function recordResolveError (field, error) {
+  if (field.error !== undefined) return
+
+  const recordedError = error || new Error('GraphQL resolver rejected without an error')
+  field.error = recordedError
+  field.span.setTag('error', recordedError)
+  if (field.resolveHookContext) {
+    field.resolveHookContext.error = recordedError
+    field.resolveHookContext.result = undefined
+  }
+}
+
+module.exports = {
+  GraphQLResolveErrorPlugin,
+  GraphQLToolsResolveErrorPlugin,
+  recordResolveError,
+}

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
@@ -2,6 +2,20 @@ import 'dd-trace/init.js'
 import { createServer } from 'node:http'
 import graphql from 'graphql'
 
+const Item = new graphql.GraphQLObjectType({
+  name: 'Item',
+  fields: {
+    value: {
+      type: graphql.GraphQLString,
+      /** @param {{ error?: Error, value?: string }} source */
+      resolve (source) {
+        if (source.error) throw source.error
+        return source.value
+      },
+    },
+  },
+})
+
 const schema = new graphql.GraphQLSchema({
   query: new graphql.GraphQLObjectType({
     name: 'Query',
@@ -14,6 +28,10 @@ const schema = new graphql.GraphQLSchema({
         resolve (obj, args) {
           return `Hello, ${args.name || 'world'}!`
         },
+      },
+      items: {
+        type: new graphql.GraphQLList(Item),
+        resolve: () => [{ value: 'first' }, { error: new Error('ESM resolver failed') }],
       },
     },
   }),

--- a/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
@@ -38,6 +38,19 @@ describe('Plugin (ESM)', () => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
           assert.ok(Array.isArray(payload), `Expected array, got ${inspect(payload)}`)
           assert.strictEqual(checkSpansForServiceName(payload, 'graphql.execute'), true)
+
+          let resolveSpan
+          for (const trace of payload) {
+            for (const span of trace) {
+              if (span.meta?.['graphql.field.path'] === 'items.*.value') {
+                resolveSpan = span
+                break
+              }
+            }
+          }
+          assert.ok(resolveSpan)
+          assert.strictEqual(resolveSpan.error, 1)
+          assert.strictEqual(resolveSpan.meta['error.message'], 'ESM resolver failed')
         })
 
         proc = await spawnPluginIntegrationTestProc(
@@ -51,6 +64,9 @@ describe('Plugin (ESM)', () => {
         const query = `
           query MyQuery {
             hello(name: "world")
+            items {
+              value
+            }
           }
         `
 

--- a/packages/datadog-plugin-graphql/test/incremental.spec.js
+++ b/packages/datadog-plugin-graphql/test/incremental.spec.js
@@ -114,6 +114,105 @@ describe('GraphQL incremental execution', () => {
       await assertion
     })
 
+    it('records reused resolver errors from the GraphQL Tools executor', async () => {
+      const operationName = 'ReusedResolverError'
+      const error = new Error('GraphQL Tools resolver failed')
+      const Item = new graphql.GraphQLObjectType({
+        name: 'GraphQLToolsResolverErrorItem',
+        fields: {
+          value: {
+            type: graphql.GraphQLString,
+            /**
+             * @param {{ error?: Error, value?: string }} source
+             */
+            resolve (source) {
+              if (source.error) throw source.error
+              return source.value
+            },
+          },
+        },
+      })
+      const schema = new graphql.GraphQLSchema({
+        query: new graphql.GraphQLObjectType({
+          name: 'GraphQLToolsResolverErrorQuery',
+          fields: {
+            items: {
+              type: new graphql.GraphQLList(Item),
+              resolve: () => [{ value: 'first' }, { error }],
+            },
+          },
+        }),
+      })
+      const document = graphql.parse(`query ${operationName} { items { value } }`)
+
+      /** @param {Array<Array<object>>} traces */
+      const assertTrace = traces => {
+        let span
+        for (const candidate of traces[0]) {
+          if (candidate.meta?.['graphql.field.path'] === 'items.*.value') {
+            span = candidate
+            break
+          }
+        }
+
+        assert.ok(span)
+        assert.strictEqual(span.error, 1)
+        assert.strictEqual(span.meta[ERROR_MESSAGE], error.message)
+      }
+
+      const [result] = await Promise.all([
+        execute({ schema, document }),
+        agent.assertSomeTraces(assertTrace, { spanResourceMatch: new RegExp(operationName) }),
+      ])
+
+      assert.strictEqual(result.data.items[0].value, 'first')
+      assert.strictEqual(result.data.items[1].value, null)
+      assert.strictEqual(result.errors.length, 1)
+    })
+
+    it('does not record a pre-located non-null error on its reused collapsed span', async () => {
+      const operationName = 'PreLocatedNonNullResolverError'
+      const error = Object.assign(new Error('pre-located non-null failure'), { path: ['foreign'] })
+      const Item = new graphql.GraphQLObjectType({
+        name: 'PreLocatedNonNullResolverErrorItem',
+        fields: {
+          value: {
+            type: new graphql.GraphQLNonNull(graphql.GraphQLString),
+            /** @param {{ error?: Error, value?: string }} source */
+            resolve (source) {
+              if (source.error) throw source.error
+              return source.value
+            },
+          },
+        },
+      })
+      const schema = new graphql.GraphQLSchema({
+        query: new graphql.GraphQLObjectType({
+          name: 'PreLocatedNonNullResolverErrorQuery',
+          fields: {
+            items: {
+              type: new graphql.GraphQLList(Item),
+              resolve: () => [{ value: 'first' }, { error }],
+            },
+          },
+        }),
+      })
+      const document = graphql.parse(`query ${operationName} { items { value } }`)
+
+      const [result] = await Promise.all([
+        execute({ schema, document }),
+        agent.assertSomeTraces(traces => {
+          const span = traces[0].find(span => span.meta?.['graphql.field.path'] === 'items.*.value')
+
+          assert.ok(span)
+          assert.strictEqual(span.error, 0)
+          assert.strictEqual(span.meta[ERROR_MESSAGE], undefined)
+        }),
+      ])
+
+      assert.deepStrictEqual(result.errors[0].path, ['foreign'])
+    })
+
     it('finishes once when a deferred iterator is cancelled repeatedly', async () => {
       const operationName = 'CancelledDeferred'
       const deferred = createDeferredOperation(operationName)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -3196,6 +3196,100 @@ describe('Plugin', () => {
           ])
         })
 
+        for (const testCase of [
+          {
+            name: 'synchronous error',
+            item: { error: new Error('sync failure'), throws: true },
+            expectedError: 'sync failure',
+          },
+          {
+            name: 'asynchronous error',
+            item: { error: new Error('async failure'), rejects: true },
+            expectedError: 'async failure',
+          },
+          {
+            name: 'falsy asynchronous error',
+            item: { rejects: true },
+            expectedError: 'GraphQL resolver rejected without an error',
+          },
+        ]) {
+          it(`should record a reused resolver ${testCase.name} on its collapsed span and hook`, async () => {
+            const Item = new graphql.GraphQLObjectType({
+              name: 'ResolverErrorItem',
+              fields: {
+                value: {
+                  type: graphql.GraphQLString,
+                  /**
+                   * @param {{ error?: Error, rejects?: boolean, throws?: boolean, value?: string }} source
+                   * @returns {Promise<never> | string | undefined}
+                   */
+                  resolve (source) {
+                    if (source.rejects) return Promise.reject(source.error)
+                    if (source.throws) throw source.error
+                    return source.value
+                  },
+                },
+              },
+            })
+            const localSchema = new graphql.GraphQLSchema({
+              query: new graphql.GraphQLObjectType({
+                name: 'ResolverErrorQuery',
+                fields: {
+                  items: {
+                    type: new graphql.GraphQLList(Item),
+                    resolve: () => [
+                      { value: 'first' },
+                      testCase.item,
+                      {
+                        error: new Error('later failure'),
+                        rejects: testCase.item.rejects,
+                        throws: testCase.item.throws,
+                      },
+                      { value: 'last' },
+                    ],
+                  },
+                },
+              }),
+            })
+
+            /** @param {Array<Array<object>>} traces */
+            const assertTrace = traces => {
+              const spans = sort(traces[0])
+              let span
+              for (const candidate of spans) {
+                if (candidate.meta?.['graphql.field.path'] === 'items.*.value') {
+                  span = candidate
+                  break
+                }
+              }
+
+              assert.ok(span, 'expected one collapsed items.*.value span')
+              assert.strictEqual(span.error, 1)
+              assert.strictEqual(span.meta[ERROR_MESSAGE], testCase.expectedError)
+            }
+
+            const [result] = await Promise.all([
+              graphql.graphql({ schema: localSchema, source: '{ items { value } }' }),
+              agent.assertSomeTraces(assertTrace, { spanResourceMatch: /items:\[ResolverErrorItem\]/ }),
+            ])
+
+            assert.strictEqual(result.data.items[0].value, 'first')
+            assert.strictEqual(result.data.items[1].value, null)
+            assert.strictEqual(result.data.items[2].value, null)
+            assert.strictEqual(result.data.items[3].value, 'last')
+            assert.strictEqual(result.errors.length, 2)
+
+            const valueHookCalls = []
+            for (const call of config.hooks.resolve.getCalls()) {
+              if (call.args[1].path === 'items.*.value') valueHookCalls.push(call)
+            }
+            assert.strictEqual(valueHookCalls.length, 1)
+            assert.strictEqual(valueHookCalls[0].args[1].error.message, testCase.expectedError)
+            assert.strictEqual(valueHookCalls[0].args[1].result, undefined)
+            assert.strictEqual(valueHookCalls[0].calledBefore(config.hooks.execute.firstCall), true)
+          })
+        }
+
         it('should finish spans when hooks throw', async () => {
           const rejections = []
           /** @param {unknown} reason */

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -517,6 +517,45 @@ describe('Plugin', () => {
           }
         })
 
+        it('should release collapsed resolver fields retained through copied stores', async function () {
+          if (typeof global.gc !== 'function') this.skip()
+
+          let fieldNodeReference
+          let result
+          let timer
+
+          try {
+            await (async () => {
+              const localSchema = new graphql.GraphQLSchema({
+                query: new graphql.GraphQLObjectType({
+                  name: 'CopiedStoreRetentionQuery',
+                  fields: {
+                    retained: {
+                      type: graphql.GraphQLString,
+                      resolve: () => {
+                        tracer.trace('retention.child', () => {
+                          timer = setTimeout(noop, 60_000)
+                          timer.unref()
+                        })
+                        return 'ok'
+                      },
+                    },
+                  },
+                }),
+              })
+              const document = graphql.parse('query CopiedStoreRetention { retained }')
+              const fieldNode = document.definitions[0].selectionSet.selections[0]
+              fieldNodeReference = new WeakRef(fieldNode)
+              result = await graphql.execute({ schema: localSchema, document })
+            })()
+
+            assert.strictEqual(await waitForCollection(fieldNodeReference), true)
+            assert.strictEqual(result.data.retained, 'ok')
+          } finally {
+            clearTimeout(timer)
+          }
+        })
+
         it('should not overwrite the caller-supplied fieldResolver on the execute args object', async () => {
           const document = graphql.parse('query MyQuery { hello(name: "world") }')
           const callerFieldResolver = (source, args, contextValue, info) => 'caller-resolved'
@@ -2471,6 +2510,56 @@ describe('Plugin', () => {
           return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
+        it('should not record a depth-gated child error on its collapsed parent span', async () => {
+          const Nested = new graphql.GraphQLObjectType({
+            name: 'DepthGatedResolverErrorNested',
+            fields: {
+              failure: {
+                type: graphql.GraphQLString,
+                /** @param {{ error?: Error }} source */
+                resolve (source) {
+                  return Promise.reject(source.error)
+                },
+              },
+            },
+          })
+          const Item = new graphql.GraphQLObjectType({
+            name: 'DepthGatedResolverErrorItem',
+            fields: {
+              nested: {
+                type: Nested,
+                resolve: () => ({}),
+              },
+            },
+          })
+          const localSchema = new graphql.GraphQLSchema({
+            query: new graphql.GraphQLObjectType({
+              name: 'DepthGatedResolverErrorQuery',
+              fields: {
+                items: {
+                  type: new graphql.GraphQLList(Item),
+                  resolve: () => [{}],
+                },
+              },
+            }),
+          })
+          const operationName = 'DepthGatedResolverError'
+          const localSource = `query ${operationName} { items { nested { failure } } }`
+
+          const [result] = await Promise.all([
+            graphql.graphql({ schema: localSchema, source: localSource }),
+            agent.assertSomeTraces(traces => {
+              const span = sort(traces[0]).find(span => span.meta?.['graphql.field.path'] === 'items.*.nested')
+
+              assert.ok(span)
+              assert.strictEqual(span.error, 0)
+              assert.strictEqual(span.meta[ERROR_MESSAGE], undefined)
+            }, { spanResourceMatch: new RegExp(operationName) }),
+          ])
+
+          assert.strictEqual(result.errors.length, 1)
+        })
+
         it('should honor resolver abort for fields gated by depth', async () => {
           let streetResolverRan = false
           const startCh = dc.channel('datadog:graphql:resolver:start')
@@ -3289,6 +3378,47 @@ describe('Plugin', () => {
             assert.strictEqual(valueHookCalls[0].calledBefore(config.hooks.execute.firstCall), true)
           })
         }
+
+        it('should not record a pre-located foreign error on a reused resolver span', async () => {
+          const error = Object.assign(new Error('foreign failure'), { path: ['foreign'] })
+          const Item = new graphql.GraphQLObjectType({
+            name: 'PreLocatedResolverErrorItem',
+            fields: {
+              value: {
+                type: graphql.GraphQLString,
+                /** @param {{ error?: Error, value?: string }} source */
+                resolve (source) {
+                  if (source.error) throw source.error
+                  return source.value
+                },
+              },
+            },
+          })
+          const localSchema = new graphql.GraphQLSchema({
+            query: new graphql.GraphQLObjectType({
+              name: 'PreLocatedResolverErrorQuery',
+              fields: {
+                items: {
+                  type: new graphql.GraphQLList(Item),
+                  resolve: () => [{ value: 'first' }, { error }],
+                },
+              },
+            }),
+          })
+
+          const [result] = await Promise.all([
+            graphql.graphql({ schema: localSchema, source: '{ items { value } }' }),
+            agent.assertSomeTraces(traces => {
+              const span = sort(traces[0]).find(span => span.meta?.['graphql.field.path'] === 'items.*.value')
+
+              assert.ok(span)
+              assert.strictEqual(span.error, 0)
+              assert.strictEqual(span.meta[ERROR_MESSAGE], undefined)
+            }, { spanResourceMatch: /items:\[PreLocatedResolverErrorItem\]/ }),
+          ])
+
+          assert.deepStrictEqual(result.errors[0].path, ['foreign'])
+        })
 
         it('should finish spans when hooks throw', async () => {
           const rejections = []

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -805,6 +805,39 @@ describe('Plugin', () => {
         assert.deepStrictEqual(rejections.map(reason => reason?.message), [])
       })
 
+      it('runs the execute hook before collapsed JIT resolver spans finish', async () => {
+        const tracer = require('../../dd-trace')
+        let resolveSpan
+        let resolveFinishedAtExecute
+
+        /**
+         * @param {import('../../dd-trace/src/opentracing/span')} span
+         * @param {{ fieldName: string }} field
+         */
+        function resolveHook (span, field) {
+          if (field.fieldName === 'hello') resolveSpan = span
+        }
+
+        function executeHook () {
+          resolveFinishedAtExecute = resolveSpan?._duration !== undefined
+        }
+
+        try {
+          tracer.use('graphql', {
+            variables: ['id', 'name'],
+            hooks: { execute: executeHook, resolve: resolveHook },
+          })
+          const { query } = compileQuery(schema, graphql.parse('query HookOrder { hello }'))
+          const result = await executeWithTrace(() => query({}, {}, {}), /HookOrder/)
+
+          assert.strictEqual(resolveFinishedAtExecute, false)
+          assert.ok(resolveSpan, 'expected the resolve hook to receive the resolver span')
+          assert.deepStrictEqual(result.data, { hello: 'world' })
+        } finally {
+          tracer.use('graphql', { variables: ['id', 'name'] })
+        }
+      })
+
       it('preserves nested promise-valued default fields', async () => {
         const User = new graphql.GraphQLObjectType({
           name: 'NestedPromiseUser',


### PR DESCRIPTION
Collapsed non-JIT fields reuse one span, but a sibling rejection could leave that span and its resolve hook successful.

GraphQL normalizes resolver failures before execution completes. Recording the error at that boundary keeps successful reused calls on the existing collapsed fast path. The first error wins, and a falsy rejection receives a real Error. The resolve hook still runs once before the execute hook.