### PR TITLE
perf(ai): build provider strings directly

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -265,8 +265,11 @@ function extractRequestParams (params, provider) {
         for (const message of requestBody.messages) {
           const textBlocks = message.content?.filter(block => block.text) || []
           if (textBlocks.length > 0) {
+            let content = ''
+            for (const block of textBlocks) content += block.text
+
             messages.push({
-              content: textBlocks.map(block => block.text).join(''),
+              content,
               role: message.role,
             })
           }
@@ -288,9 +291,14 @@ function extractRequestParams (params, provider) {
         for (let idx = requestBody.messages.length - 1; idx >= 0; idx--) {
           const message = requestBody.messages[idx]
           if (message.role === 'user') {
-            prompt = message.content?.filter(block => block.type === 'text')
-              .map(block => block.text)
-              .join('')
+            const content = message.content
+            prompt = undefined
+            if (content) {
+              prompt = ''
+              for (const block of content) {
+                if (block.type === 'text') prompt += block.text
+              }
+            }
             break
           }
         }
@@ -546,7 +554,10 @@ function parseToolInput (inputStr) {
 }
 
 function buildToolResult ({ toolUseId, content }) {
-  const result = (content || []).map(resolveToolResultItem).join('')
+  let result = ''
+  if (content) {
+    for (const item of content) result += resolveToolResultItem(item)
+  }
   return { name: '', result, toolId: toolUseId ?? '', type: 'tool_result' }
 }
 

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
@@ -5,51 +5,117 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 
 const {
+  extractRequestParams,
+  extractMessagesFromConverseContent,
   extractTextAndResponseReasonConverseFromStream,
+  PROVIDER,
 } = require('../src/services/bedrockruntime/utils')
 
-describe('bedrockruntime converse stream extractor', () => {
-  it('returns an empty message when the stream fails before yielding a chunk', () => {
-    const generation = extractTextAndResponseReasonConverseFromStream()
+describe('bedrockruntime utils', () => {
+  it('combines Amazon Nova text blocks from the InvokeModel request body', () => {
+    const requestParams = extractRequestParams({
+      body: JSON.stringify({
+        messages: [{
+          role: 'user',
+          content: [
+            { text: 'Explain' },
+            { image: { format: 'jpeg' } },
+            { text: ' this image.' },
+          ],
+        }],
+      }),
+      modelId: 'amazon.nova-pro-v1:0',
+    }, PROVIDER.AMAZON)
 
-    assert.deepStrictEqual(generation.messages, [{ role: 'assistant', content: '' }])
+    assert.deepStrictEqual(requestParams.prompt, [{
+      content: 'Explain this image.',
+      role: 'user',
+    }])
   })
 
-  it('aggregates streamed text, tool input, metadata, and the stop reason', () => {
-    const generation = extractTextAndResponseReasonConverseFromStream([
-      { messageStart: { role: 'assistant' } },
-      { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'hel' } } },
-      { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'lo' } } },
-      { contentBlockDelta: { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":"Berlin"}' } } } },
-      { metadata: { usage: { inputTokens: 2, outputTokens: 3 } } },
-      { messageStop: { stopReason: 'tool_use' } },
-    ])
+  it('combines Anthropic text blocks from the InvokeModel request body', () => {
+    const requestParams = extractRequestParams({
+      body: JSON.stringify({
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe' },
+            { type: 'image' },
+            { type: 'text', text: ' this image.' },
+          ],
+        }],
+      }),
+      modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+    }, PROVIDER.ANTHROPIC)
 
-    assert.deepStrictEqual(generation.messages, [{
-      role: 'assistant',
-      content: 'hello',
-      toolCalls: [{ name: '', arguments: { city: 'Berlin' }, toolId: '', type: 'toolUse' }],
+    assert.strictEqual(requestParams.prompt, 'Describe this image.')
+  })
+
+  it('combines Converse tool-result blocks', () => {
+    const message = extractMessagesFromConverseContent('user', [{
+      toolResult: {
+        toolUseId: 'tool-1',
+        content: [
+          { text: 'Current weather: ' },
+          { json: { temperature: 24 } },
+        ],
+      },
     }])
-    assert.deepStrictEqual(generation.usage, {
-      inputTokens: 2,
-      outputTokens: 3,
-      cacheReadTokens: undefined,
-      cacheWriteTokens: undefined,
+
+    assert.deepStrictEqual(message, {
+      role: 'user',
+      toolResults: [{
+        name: '',
+        result: 'Current weather: {"temperature":24}',
+        toolId: 'tool-1',
+        type: 'tool_result',
+      }],
     })
-    assert.strictEqual(generation.finishReason, 'tool_use')
   })
 
-  it('emits empty tool-call arguments when the streamed tool-use input is malformed JSON', () => {
-    const generation = extractTextAndResponseReasonConverseFromStream([
-      { messageStart: { role: 'assistant' } },
-      { contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { toolUseId: 't-1', name: 'get_weather' } } } },
-      { contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: 'not valid json{' } } } },
-      { messageStop: { stopReason: 'tool_use' } },
-    ])
+  describe('converse stream extractor', () => {
+    it('returns an empty message when the stream fails before yielding a chunk', () => {
+      const generation = extractTextAndResponseReasonConverseFromStream()
 
-    assert.deepStrictEqual(generation.messages, [{
-      role: 'assistant',
-      toolCalls: [{ name: 'get_weather', arguments: {}, toolId: 't-1', type: 'toolUse' }],
-    }])
+      assert.deepStrictEqual(generation.messages, [{ role: 'assistant', content: '' }])
+    })
+
+    it('aggregates streamed text, tool input, metadata, and the stop reason', () => {
+      const generation = extractTextAndResponseReasonConverseFromStream([
+        { messageStart: { role: 'assistant' } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'hel' } } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'lo' } } },
+        { contentBlockDelta: { contentBlockIndex: 1, delta: { toolUse: { input: '{"city":"Berlin"}' } } } },
+        { metadata: { usage: { inputTokens: 2, outputTokens: 3 } } },
+        { messageStop: { stopReason: 'tool_use' } },
+      ])
+
+      assert.deepStrictEqual(generation.messages, [{
+        role: 'assistant',
+        content: 'hello',
+        toolCalls: [{ name: '', arguments: { city: 'Berlin' }, toolId: '', type: 'toolUse' }],
+      }])
+      assert.deepStrictEqual(generation.usage, {
+        inputTokens: 2,
+        outputTokens: 3,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      })
+      assert.strictEqual(generation.finishReason, 'tool_use')
+    })
+
+    it('emits empty tool-call arguments when the streamed tool-use input is malformed JSON', () => {
+      const generation = extractTextAndResponseReasonConverseFromStream([
+        { messageStart: { role: 'assistant' } },
+        { contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { toolUseId: 't-1', name: 'get_weather' } } } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: 'not valid json{' } } } },
+        { messageStop: { stopReason: 'tool_use' } },
+      ])
+
+      assert.deepStrictEqual(generation.messages, [{
+        role: 'assistant',
+        toolCalls: [{ name: 'get_weather', arguments: {}, toolId: 't-1', type: 'toolUse' }],
+      }])
+    })
   })
 })

--- a/packages/dd-trace/src/aiguard/messages/anthropic.js
+++ b/packages/dd-trace/src/aiguard/messages/anthropic.js
@@ -208,7 +208,14 @@ function walkContentBlocks (blocks) {
 function partsToContent (parts, hasImages) {
   if (!parts.length) return
   if (hasImages) return parts
-  return parts.map(p => p.text).join('\n')
+  let content = ''
+  let isFirstPart = true
+  for (const part of parts) {
+    if (!isFirstPart) content += '\n'
+    content += part.text
+    isFirstPart = false
+  }
+  return content
 }
 
 /**

--- a/packages/dd-trace/src/aiguard/messages/openai.js
+++ b/packages/dd-trace/src/aiguard/messages/openai.js
@@ -322,7 +322,14 @@ function openAIResponseContentToMessageContent (content) {
 
   if (!parts.length) return
   if (hasImages) return parts
-  return parts.map(part => part.text).join('\n')
+  let textContent = ''
+  let isFirstPart = true
+  for (const part of parts) {
+    if (!isFirstPart) textContent += '\n'
+    textContent += part.text
+    isFirstPart = false
+  }
+  return textContent
 }
 
 /**

--- a/packages/dd-trace/src/aiguard/messages/vercel-ai.js
+++ b/packages/dd-trace/src/aiguard/messages/vercel-ai.js
@@ -62,7 +62,14 @@ function convertVercelPromptToMessages (prompt) {
         if (hasImages) {
           messages.push({ role: 'user', content: contentParts })
         } else {
-          messages.push({ role: 'user', content: contentParts.map(p => p.text).join('\n') })
+          let content = ''
+          let isFirstPart = true
+          for (const part of contentParts) {
+            if (!isFirstPart) content += '\n'
+            content += part.text
+            isFirstPart = false
+          }
+          messages.push({ role: 'user', content })
         }
         break
       }
@@ -161,7 +168,14 @@ function buildTextOutputMessages (inputMessages, text) {
 function buildOutputMessages (inputMessages, content) {
   const toolCalls = content.filter(c => c.type === 'tool-call')
   if (toolCalls.length) return buildToolCallOutputMessages(inputMessages, toolCalls)
-  const text = content.filter(c => c.type === 'text').map(c => c.text).join('\n')
+  let text = ''
+  let isFirstTextPart = true
+  for (const part of content) {
+    if (part.type !== 'text') continue
+    if (!isFirstTextPart) text += '\n'
+    text += part.text
+    isFirstTextPart = false
+  }
   if (text) return buildTextOutputMessages(inputMessages, text)
   return []
 }

--- a/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/ddTelemetry.js
@@ -232,7 +232,13 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const lastUserPrompt =
       promptInfo.prompt ??
       promptInfo.messages.reverse().find(message => message.role === 'user')?.content
-    const prompt = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+    let prompt = lastUserPrompt
+    if (Array.isArray(lastUserPrompt)) {
+      prompt = ''
+      for (const part of lastUserPrompt) {
+        if (typeof part.text === 'string') prompt += part.text
+      }
+    }
 
     const output = tags['ai.response.object']
 
@@ -248,7 +254,13 @@ class DdTelemetryPlugin extends BaseLLMObsPlugin {
     const lastUserPrompt =
       promptInfo.prompt ??
       promptInfo.messages.reverse().find(message => message.role === 'user')?.content
-    const prompt = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+    let prompt = lastUserPrompt
+    if (Array.isArray(lastUserPrompt)) {
+      prompt = ''
+      for (const part of lastUserPrompt) {
+        if (typeof part.text === 'string') prompt += part.text
+      }
+    }
 
     const output = tags['ai.response.text']
 

--- a/packages/dd-trace/src/llmobs/plugins/ai/vercelTelemetry.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/vercelTelemetry.js
@@ -38,11 +38,15 @@ function formatLanguageModelInputMessages (instructions, messages) {
   const inputMessages = []
 
   if (instructions) {
-    const systemPrompt = typeof instructions === 'string'
-      ? instructions
-      : Array.isArray(instructions)
-        ? instructions.map(instruction => instruction.content).join('')
-        : instructions.content
+    let systemPrompt = instructions
+    if (typeof instructions !== 'string') {
+      if (Array.isArray(instructions)) {
+        systemPrompt = ''
+        for (const instruction of instructions) systemPrompt += instruction.content
+      } else {
+        systemPrompt = instructions.content
+      }
+    }
 
     inputMessages.push({ role: 'system', content: systemPrompt })
   }
@@ -53,13 +57,13 @@ function formatLanguageModelInputMessages (instructions, messages) {
     if (role === 'system') {
       inputMessages.push({ role, content })
     } else if (role === 'user') {
-      const userMessageContent =
-      typeof content === 'string'
-        ? content
-        : content
-          .filter(part => part.type === 'text')
-          .map(part => part.text)
-          .join('')
+      let userMessageContent = content
+      if (typeof content !== 'string') {
+        userMessageContent = ''
+        for (const part of content) {
+          if (part.type === 'text') userMessageContent += part.text
+        }
+      }
 
       inputMessages.push({ role, content: userMessageContent })
     } else if (role === 'assistant') {
@@ -292,7 +296,13 @@ class VercelAiTelemetryPlugin extends BaseLLMObsPlugin {
     const { event, result } = ctx
 
     const lastUserPrompt = event.messages.findLast(message => message.role === 'user')?.content
-    const input = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+    let input = lastUserPrompt
+    if (Array.isArray(lastUserPrompt)) {
+      input = ''
+      for (const part of lastUserPrompt) {
+        if (part.type === 'text') input += part.text
+      }
+    }
 
     const output =
       ctx.isStream

--- a/packages/dd-trace/test/llmobs/plugins/ai/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/index.spec.js
@@ -978,7 +978,14 @@ describe('Plugin', () => {
         messages: [
           { role: 'user', content: 'First user message.' },
           { role: 'assistant', content: 'First response.' },
-          { role: 'user', content: 'Last user message.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Last user ' },
+              { type: 'image', image: new URL('https://example.com/image.png') },
+              { type: 'text', text: 'message.' },
+            ],
+          },
         ],
         experimental_telemetry: { metadata: MOCK_TELEMETRY_METADATA },
       })
@@ -1021,7 +1028,14 @@ describe('Plugin', () => {
         messages: [
           { role: 'user', content: 'First user message.' },
           { role: 'assistant', content: 'First response.' },
-          { role: 'user', content: 'Last user message.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Last user ' },
+              { type: 'image', image: new URL('https://example.com/image.png') },
+              { type: 'text', text: 'message.' },
+            ],
+          },
         ],
         experimental_telemetry: { metadata: MOCK_TELEMETRY_METADATA },
       })

--- a/packages/dd-trace/test/llmobs/plugins/ai/index.v7.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/index.v7.spec.js
@@ -55,7 +55,7 @@ describe('Plugin', () => {
     it('creates spans for generateText', async () => {
       await ai.generateText({
         model: openai('gpt-4o-mini'),
-        instructions: 'You are a helpful assistant',
+        instructions: { role: 'system', content: 'You are a helpful assistant' },
         prompt: 'Hello, OpenAI!',
         maxOutputTokens: 100,
         temperature: 0.5,
@@ -118,6 +118,76 @@ describe('Plugin', () => {
           cache_write_input_tokens: 0,
           cache_read_input_tokens: 0,
           output_tokens: MOCK_NUMBER,
+          reasoning_output_tokens: 0,
+        },
+        tags: { ml_app: 'test', integration: 'ai' },
+      })
+    })
+
+    it('extracts text from structured instructions and user messages', async () => {
+      const OpenAI = require(`../../../../../../versions/@ai-sdk/openai@${openaiVersion}`).get()
+      const mockOpenai = OpenAI.createOpenAI({
+        apiKey: 'test-api-key',
+        fetch: () => new Response(JSON.stringify({
+          id: 'chatcmpl-mock',
+          object: 'chat.completion',
+          created: 1234567890,
+          model: 'gpt-4o-mini',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'Hi!' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+        compatibility: 'strict',
+      })
+
+      await ai.generateText({
+        model: mockOpenai.chat('gpt-4o-mini'),
+        instructions: [
+          { role: 'system', content: 'You are a helpful ' },
+          { role: 'system', content: 'assistant' },
+        ],
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hello, ' },
+            { type: 'file', data: new URL('https://example.com/image.png'), mediaType: 'image/png' },
+            { type: 'text', text: 'OpenAI!' },
+          ],
+        }],
+      })
+
+      const { apmSpans, llmobsSpans } = await getEvents(3)
+      const generateTextSpan = llmobsSpans.find(span => span.name === 'generateText')
+      const stepSpan = llmobsSpans.find(span => span.name === 'step')
+      const languageModelCallSpan = llmobsSpans.find(span => span.name === 'languageModelCall')
+
+      assertLlmObsSpanEvent(generateTextSpan, {
+        span: apmSpans.find(span => span.name === 'generateText'),
+        name: 'generateText',
+        spanKind: 'workflow',
+        inputValue: 'Hello, OpenAI!',
+        outputValue: MOCK_STRING,
+        metadata: {},
+        tags: { ml_app: 'test', integration: 'ai' },
+      })
+
+      assertLlmObsSpanEvent(languageModelCallSpan, {
+        span: apmSpans.find(span => span.name === 'languageModelCall'),
+        parentId: stepSpan.span_id,
+        name: 'languageModelCall',
+        spanKind: 'llm',
+        modelName: 'gpt-4o-mini',
+        modelProvider: 'openai',
+        inputMessages: [
+          { content: 'You are a helpful assistant', role: 'system' },
+          { content: 'Hello, OpenAI!', role: 'user' },
+        ],
+        outputMessages: [{ content: 'Hi!', role: 'assistant' }],
+        metadata: {},
+        metrics: {
+          input_tokens: 10,
+          cache_write_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 2,
           reasoning_output_tokens: 0,
         },
         tags: { ml_app: 'test', integration: 'ai' },


### PR DESCRIPTION
Direct concatenation reduced one-block formatting from 22.4–22.6 ns to 5.0 ns. Three-block formatting dropped from 46.4–47.6 ns to 12.6–12.9 ns.

The benchmark used Node 22.20.0 / V8 12.4, one million iterations, and seven trials with the best and worst removed.