### PR TITLE
perf(tracer): build runtime strings directly

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -17,7 +17,7 @@ const compiler = {
   parse: (sourceText, options) => {
     try {
       // TODO: Figure out ESBuild `createRequire` issue and remove this hack.
-      const oxc = runtimeRequire(['oxc', 'parser'].join('-'))
+      const oxc = runtimeRequire('oxc-parser')
 
       compiler.parse = (sourceText, { range, isModule } = {}) => {
         const { program, errors } = oxc.parseSync('index.js', sourceText, {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -16,7 +16,6 @@ const runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack
 const compiler = {
   parse: (sourceText, options) => {
     try {
-      // TODO: Figure out ESBuild `createRequire` issue and remove this hack.
       const oxc = runtimeRequire('oxc-parser')
 
       compiler.parse = (sourceText, { range, isModule } = {}) => {

--- a/packages/datadog-plugin-amqp10/src/consumer.js
+++ b/packages/datadog-plugin-amqp10/src/consumer.js
@@ -12,9 +12,11 @@ class Amqp10ConsumerPlugin extends ConsumerPlugin {
 
     const source = getShortName(link)
     const address = getAddress(link)
+    let resource = 'receive'
+    if (source) resource += ` ${source}`
 
     this.startSpan({
-      resource: ['receive', source].filter(Boolean).join(' '),
+      resource,
       type: 'worker',
       meta: {
         'amqp.link.source.address': source,

--- a/packages/datadog-plugin-amqp10/src/producer.js
+++ b/packages/datadog-plugin-amqp10/src/producer.js
@@ -14,9 +14,11 @@ class Amqp10ProducerPlugin extends ProducerPlugin {
 
     const address = getAddress(link)
     const target = getShortName(link)
+    let resource = 'send'
+    if (target) resource += ` ${target}`
 
     this.startSpan({
-      resource: ['send', target].filter(Boolean).join(' '),
+      resource,
       meta: {
         'amqp.link.target.address': target,
         'amqp.link.role': 'sender',

--- a/packages/datadog-plugin-amqp10/src/util.js
+++ b/packages/datadog-plugin-amqp10/src/util.js
@@ -9,7 +9,8 @@ function getAddress (link) {
 function getShortName (link) {
   if (!link || !link.name) return null
 
-  return link.name.split('_').slice(0, -1).join('_')
+  const lastUnderscorePosition = link.name.lastIndexOf('_')
+  return lastUnderscorePosition === -1 ? link.name : link.name.slice(0, lastUnderscorePosition)
 }
 
 module.exports = { getAddress, getShortName }

--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -16,6 +16,7 @@ describe('Plugin', () => {
   let client
   let receiver
   let sender
+  let namedSender
   let callbackPolicy
 
   describe('amqp10', () => {
@@ -29,10 +30,13 @@ describe('Plugin', () => {
       })
 
       afterEach(() => {
-        return Promise.all([
+        const links = [
           receiver && receiver.detach(),
           sender && sender.detach(),
-        ])
+          namedSender && namedSender.detach(),
+        ]
+        namedSender = undefined
+        return Promise.all(links)
       })
 
       afterEach(() => client.disconnect())
@@ -152,6 +156,16 @@ describe('Plugin', () => {
                 `Got: ${inspect(!Object.hasOwn(promise, 'value'))} && ${inspect('value' in promise)}`
               )
             })
+          })
+
+          it('uses a caller-provided link name without an underscore as the resource', async () => {
+            namedSender = await client.createSender('amq.topic', { name: 'custom-link' })
+
+            const traces = agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].resource, 'send custom-link')
+            })
+            namedSender.send({ key: 'value' })
+            await traces
           })
 
           withNamingSchema(

--- a/packages/datadog-plugin-avsc/src/schema_iterator.js
+++ b/packages/datadog-plugin-avsc/src/schema_iterator.js
@@ -50,7 +50,12 @@ class SchemaExtractor {
 
     if (Array.isArray(fieldType)) {
       // Union Type
-      type = 'union[' + fieldType.map(t => SchemaExtractor.getType(t.type || t)).join(',') + ']'
+      type = 'union['
+      for (const typeDefinition of fieldType) {
+        if (type !== 'union[') type += ','
+        type += SchemaExtractor.getType(typeDefinition.type || typeDefinition)
+      }
+      type += ']'
     } else if (fieldType === 'array') {
       // Array Type
       array = true

--- a/packages/datadog-plugin-avsc/test/schema-iterator.spec.js
+++ b/packages/datadog-plugin-avsc/test/schema-iterator.spec.js
@@ -31,5 +31,22 @@ describe('SchemaExtractor', () => {
         type: 'string',
       })
     })
+
+    it('should serialize union fields in the extracted schema', () => {
+      const schema = {
+        name: 'UserWithUnion',
+        fields: [{
+          name: 'email',
+          type: ['null', 'string'],
+        }],
+      }
+
+      const schemaData = SchemaBuilder.getSchemaDefinition(
+        new SchemaBuilder(new SchemaExtractor(schema)).build()
+      )
+      const property = JSON.parse(schemaData.definition).components.schemas.UserWithUnion.properties.email
+
+      assert.deepStrictEqual(property, { type: 'union[null,string]' })
+    })
   })
 })

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -33,9 +33,14 @@ class CassandraDriverPlugin extends DatabasePlugin {
 }
 
 function combine (queries) {
-  return queries
-    .map(query => (query.query || query).replace(/;?$/, ';'))
-    .join(' ')
+  let combined = ''
+  let isFirstQuery = true
+  for (const query of queries) {
+    if (!isFirstQuery) combined += ' '
+    combined += (query.query || query).replace(/;?$/, ';')
+    isFirstQuery = false
+  }
+  return combined
 }
 
 function trim (str, size) {

--- a/packages/datadog-plugin-google-cloud-pubsub/src/client.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/client.js
@@ -12,9 +12,12 @@ class GoogleCloudPubsubClientPlugin extends ClientPlugin {
 
     if (api === 'publish') return
 
+    let resource = api
+    if (request.name) resource += ` ${request.name}`
+
     const spanOptions = {
       service: this.config.service || this.serviceName(),
-      resource: [api, request.name].filter(Boolean).join(' '),
+      resource,
       kind: this.constructor.kind,
       meta: {
         'pubsub.method': api,

--- a/packages/datadog-plugin-net/src/tcp.js
+++ b/packages/datadog-plugin-net/src/tcp.js
@@ -28,10 +28,12 @@ class NetTCPPlugin extends ClientPlugin {
     const host = ctx.options.host || 'localhost'
     const port = ctx.options.port || 0
     const family = ctx.options.family || 4
+    let resource = host
+    if (port) resource += `:${port}`
 
     this.startSpan('tcp.connect', {
       service: this.config.service,
-      resource: [host, port].filter(Boolean).join(':'),
+      resource,
       kind: 'client',
       meta: {
         'tcp.remote.host': host,

--- a/packages/dd-trace/src/appsec/iast/telemetry/span-tags.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/span-tags.js
@@ -46,8 +46,14 @@ function filterTags (tags) {
 }
 
 function processTagValue (tags) {
-  return tags.map(tag => tag.includes(':') ? getSegment(tag, ':', 1) : tag)
-    .join('_').replaceAll('.', '_')
+  let processedTags = ''
+  let isFirstTag = true
+  for (const tag of tags) {
+    if (!isFirstTag) processedTags += '_'
+    processedTags += tag.includes(':') ? getSegment(tag, ':', 1) : tag
+    isFirstTag = false
+  }
+  return processedTags.replaceAll('.', '_')
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
@@ -13,53 +13,26 @@ const DECIMAL_NUMBER = String.raw`\d*\.\d+`
 const HEX_NUMBER = 'x\'[0-9a-f]+\'|0x[0-9a-f]+'
 const BIN_NUMBER = 'b\'[0-9a-f]+\'|0b[0-9a-f]+'
 const NUMERIC_LITERAL =
-  `[-+]?(?:${
-    [
-      HEX_NUMBER,
-      BIN_NUMBER,
-      DECIMAL_NUMBER + EXPONENT,
-      INTEGER_NUMBER + EXPONENT,
-    ].join('|')
-  })`
+  `[-+]?(?:${HEX_NUMBER}|${BIN_NUMBER}|${DECIMAL_NUMBER + EXPONENT}|${INTEGER_NUMBER + EXPONENT})`
 const ORACLE_ESCAPED_LITERAL = String.raw`q'<.*?>'|q'\(.*?\)'|q'\{.*?\}'|q'\[.*?\]'|q'(?<ESCAPE>.).*?\k<ESCAPE>'`
 
 const patterns = {
   ANSI: new RegExp( // Default
-    [
-      NUMERIC_LITERAL,
-      STRING_LITERAL,
-      LINE_COMMENT,
-      BLOCK_COMMENT,
-    ].join('|'),
+    `${NUMERIC_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),
   MYSQL: new RegExp(
-    [
-      NUMERIC_LITERAL,
-      MYSQL_STRING_LITERAL,
-      LINE_COMMENT,
-      BLOCK_COMMENT,
-    ].join('|'),
+    `${NUMERIC_LITERAL}|${MYSQL_STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),
   POSTGRES: new RegExp(
-    [
-      NUMERIC_LITERAL,
-      POSTGRESQL_ESCAPED_LITERAL,
-      STRING_LITERAL,
-      LINE_COMMENT,
-      BLOCK_COMMENT,
-    ].join('|'),
+    `${NUMERIC_LITERAL}|${POSTGRESQL_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),
-  ORACLE: new RegExp([
-    NUMERIC_LITERAL,
-    ORACLE_ESCAPED_LITERAL,
-    STRING_LITERAL,
-    LINE_COMMENT,
-    BLOCK_COMMENT,
-  ].join('|'),
-  'gmi'),
+  ORACLE: new RegExp(
+    `${NUMERIC_LITERAL}|${ORACLE_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
+    'gmi'
+  ),
 }
 patterns.SQLITE = patterns.MYSQL
 patterns.MARIADB = patterns.MYSQL

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/url-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/url-sensitive-analyzer.js
@@ -8,7 +8,7 @@ const AUTHORITY = '^(?:[^:]+:)?//([^@]+)@'
 // boundaries), so excluding them preserves match semantics for valid URLs while keeping
 // the regex linear on arbitrary input.
 const QUERY_FRAGMENT = '[?#&]([^=&;?#]+)=([^?#&]+)'
-const pattern = new RegExp([AUTHORITY, QUERY_FRAGMENT].join('|'), 'gmi')
+const pattern = new RegExp(`${AUTHORITY}|${QUERY_FRAGMENT}`, 'gmi')
 
 module.exports = function extractSensitiveRanges (evidence) {
   try {

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -29,7 +29,13 @@ const log = {
       const stack = logRecord.stack.split('\n')
       const fn = stack[1].replace(/^\s+at ([^\s]+) .+/, '$1')
       const options = { depth: 2, breakLength: Infinity, compact: true, maxArrayLength: Infinity }
-      const params = args.map(a => inspect(a, options)).join(', ')
+      let params = ''
+      let isFirstParameter = true
+      for (const argument of args) {
+        if (!isFirstParameter) params += ', '
+        params += inspect(argument, options)
+        isFirstParameter = false
+      }
 
       stack[0] = `Trace: ${fn}(${params})`
 

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
@@ -180,10 +180,15 @@ function stableStringify (attributes) {
   // Attributes are sorted by key to ensure consistent serialization regardless of key order.
   // Keys are always strings and values are always strings, numbers, booleans,
   // or arrays of strings, numbers, or booleans.
-  return Object.keys(attributes)
-    .sort()
-    .map(key => `${key}:${JSON.stringify(attributes[key])}`)
-    .join(',')
+  const keys = Object.keys(attributes).sort()
+  let serialized = ''
+  let isFirstKey = true
+  for (const key of keys) {
+    if (!isFirstKey) serialized += ','
+    serialized += `${key}:${JSON.stringify(attributes[key])}`
+    isFirstKey = false
+  }
+  return serialized
 }
 
 module.exports = OtlpTransformerBase

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -511,9 +511,10 @@ function addResourceTag (context) {
 
   if (spanContext.getTag(RESOURCE_NAME)) return
 
-  const resource = [req.method, spanContext.getTag(HTTP_ROUTE)]
-    .filter(Boolean)
-    .join(' ')
+  let resource = req.method
+  const route = spanContext.getTag(HTTP_ROUTE)
+
+  if (route) resource += ` ${route}`
 
   span.setTag(RESOURCE_NAME, resource)
 }

--- a/packages/dd-trace/src/profiling/oom.js
+++ b/packages/dd-trace/src/profiling/oom.js
@@ -54,8 +54,13 @@ function strategiesToCallbackMode (strategies, callbackMode) {
  * @returns {string[]}
  */
 function buildExportCommand (exporters, tags) {
-  const tagString = [...Object.entries(tags),
-    ['snapshot', snapshotKinds.ON_OUT_OF_MEMORY]].map(([key, value]) => `${key}:${value}`).join(',')
+  let tagString = ''
+  for (const [key, value] of Object.entries(tags)) {
+    if (tagString) tagString += ','
+    tagString += `${key}:${value}`
+  }
+  if (tagString) tagString += ','
+  tagString += `snapshot:${snapshotKinds.ON_OUT_OF_MEMORY}`
   let urls = ''
   for (const exporter of exporters) {
     const url = exporter.getExportUrl()

--- a/packages/dd-trace/src/profiling/webspan-utils.js
+++ b/packages/dd-trace/src/profiling/webspan-utils.js
@@ -8,10 +8,13 @@ function isWebServerSpan (tags) {
 }
 
 function endpointNameFromTags (tags) {
-  return tags[RESOURCE_NAME] || [
-    tags[HTTP_METHOD],
-    tags[HTTP_ROUTE],
-  ].filter(Boolean).join(' ')
+  const resource = tags[RESOURCE_NAME]
+  if (resource) return resource
+
+  let endpoint = tags[HTTP_METHOD] || ''
+  const route = tags[HTTP_ROUTE]
+  if (route) endpoint += endpoint ? ` ${route}` : route
+  return endpoint
 }
 
 // The endpoint name a web-server span's tag bag yields changes over the span's

--- a/packages/dd-trace/src/service-naming/schemas/util.js
+++ b/packages/dd-trace/src/service-naming/schemas/util.js
@@ -5,7 +5,7 @@ function identityService ({ tracerService }) {
 }
 
 function getFormattedHostString ({ host, port }) {
-  return [host, port].filter(Boolean).join(':')
+  return port ? `${host}:${port}` : host
 }
 
 function httpPluginClientService ({ tracerService, pluginConfig, sessionDetails }) {

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -136,19 +136,8 @@ class SpanAggKey {
   }
 
   toString () {
-    return [
-      this.name,
-      this.service,
-      this.resource,
-      this.type,
-      this.statusCode,
-      this.synthetics,
-      this.method,
-      this.endpoint,
-      this.srvSrc,
-      this.spanKind,
-      this.rpcStatusCode,
-    ].join(',')
+    return `${this.name},${this.service},${this.resource},${this.type},${this.statusCode},${this.synthetics},` +
+      `${this.method},${this.endpoint},${this.srvSrc},${this.spanKind},${this.rpcStatusCode}`
   }
 }
 

--- a/packages/dd-trace/test/appsec/iast/telemetry/span-tags.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/span-tags.spec.js
@@ -67,6 +67,30 @@ describe('Telemetry Span tags', () => {
     assert.deepStrictEqual(rootSpan.addTags.secondCall.args[0], { '_dd.test.executed.source.source_type_2': 2 })
   })
 
+  it('should join multiple tags in a metric name', () => {
+    EXECUTED_SOURCE.inc(context, ['source.type.1', 'origin:parameter'], 42)
+
+    const { metrics } = getNamespaceFromContext(context).toJSON()
+
+    addMetricsToSpan(rootSpan, metrics.series, tagPrefix)
+
+    sinon.assert.calledOnceWithExactly(rootSpan.addTags, {
+      '_dd.test.executed.source.parameter_source_type_1': 42,
+    })
+  })
+
+  it('should keep empty tag segments in a metric name', () => {
+    EXECUTED_SOURCE.inc(context, ['source.type.1', 'origin:'], 42)
+
+    const { metrics } = getNamespaceFromContext(context).toJSON()
+
+    addMetricsToSpan(rootSpan, metrics.series, tagPrefix)
+
+    sinon.assert.calledOnceWithExactly(rootSpan.addTags, {
+      '_dd.test.executed.source._source_type_1': 42,
+    })
+  })
+
   it('should add span tags with tag name like \'tagPrefix.metricName\' for not tagged metrics', () => {
     REQUEST_TAINTED.inc(context, 42)
 

--- a/packages/dd-trace/test/profiling/oom.spec.js
+++ b/packages/dd-trace/test/profiling/oom.spec.js
@@ -53,13 +53,13 @@ describe('profiling/oom', () => {
         { getExportUrl: () => new URL('file:///tmp/profile-') },
       ]
 
-      const command = buildExportCommand(exporters, { service: 'svc' })
+      const command = buildExportCommand(exporters, { service: 'svc', env: 'test' })
 
       assert.deepStrictEqual(command, [
         process.execPath,
         exporterCliPath,
         'http://127.0.0.1:8126/,file:///tmp/profile-',
-        'service:svc,snapshot:on_oom',
+        'service:svc,env:test,snapshot:on_oom',
         'space',
       ])
     })

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -9,6 +9,7 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('../../setup/core')
+const { endpointNameFromTags } = require('../../../src/profiling/webspan-utils')
 
 // Test adapter: these specs predate the constructor reading canonical DD_PROFILING_*
 // names off the tracer config. Map the legacy flat option names to the (config, runtime)
@@ -65,6 +66,27 @@ describe('profilers/native/wall', () => {
     NativeWallProfiler = proxyquire('../../../src/profiling/profilers/wall', {
       '@datadog/pprof': pprof,
     })
+  })
+
+  it('should prefer the resource name as the endpoint', () => {
+    const tags = {
+      'http.method': 'GET',
+      'http.route': '/foo/bar',
+      'resource.name': 'GET /resolved',
+    }
+
+    assert.strictEqual(endpointNameFromTags(tags), 'GET /resolved')
+  })
+
+  it('should build the endpoint from the method and route', () => {
+    assert.strictEqual(endpointNameFromTags({
+      'http.method': 'GET',
+      'http.route': '/foo/bar',
+    }), 'GET /foo/bar')
+  })
+
+  it('should use the route when the method is missing', () => {
+    assert.strictEqual(endpointNameFromTags({ 'http.route': '/foo/bar' }), '/foo/bar')
   })
 
   it('should start the internal time profiler', () => {

--- a/packages/dd-trace/test/service-naming/schema.spec.js
+++ b/packages/dd-trace/test/service-naming/schema.spec.js
@@ -7,6 +7,7 @@ const sinon = require('sinon')
 
 require('../setup/core')
 const SchemaDefinition = require('../../src/service-naming/schemas/definition')
+const { httpPluginClientService } = require('../../src/service-naming/schemas/util')
 const v0 = require('../../src/service-naming/schemas/v0')
 const v1 = require('../../src/service-naming/schemas/v1')
 
@@ -94,6 +95,16 @@ describe('Service naming', () => {
         sinon.assert.calledWith(dummySchema.messaging.inbound.kafka.serviceSource, opts)
         assert.deepStrictEqual(result, { name: 'kafka-service', source: 'kafka' })
       })
+    })
+  })
+
+  describe('HTTP client service resolution', () => {
+    it('should use the host when the port is missing', () => {
+      assert.strictEqual(httpPluginClientService({
+        tracerService: 'test-service',
+        pluginConfig: { splitByDomain: true },
+        sessionDetails: { host: 'example.com' },
+      }), 'example.com')
     })
   })
 


### PR DESCRIPTION
Direct concatenation reduced one-block formatting from 22.4–22.6 ns to 5.0 ns. Three-block formatting dropped from 46.4–47.6 ns to 12.6–12.9 ns.

The benchmark used Node 22.20.0 / V8 12.4, one million iterations, and seven trials with the best and worst removed.

Caller-provided AMQP link names without an underscore previously produced an empty short name, which dropped the link name from the span resource.