### PR TITLE
fix(test-optimization): support Mocha 12

### DIFF
--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -15,6 +15,7 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { NODE_MAJOR } = require('../../version')
+const { getLatestMochaSpecifier } = require('../mocha/versions')
 const { getLatestPlaywrightSpecifier } = require('../playwright/versions')
 const webAppServer = require('./web-app-server')
 
@@ -27,7 +28,7 @@ describe('test optimization automatic log submission', () => {
   let testOutput = ''
 
   useSandbox([
-    'mocha',
+    `mocha@${getLatestMochaSpecifier()}`,
     ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
     'bunyan',
     'jest',

--- a/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
+++ b/integration-tests/ci-visibility/run-mocha-reporter-rerun.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const Mocha = require('mocha')
+const MochaPackage = require('mocha')
+const Mocha = MochaPackage.default ?? MochaPackage
 
 const reporterEvent = process.env.MOCHA_REUSABLE_REPORTER_EVENT
 const runCallbackThrows = process.env.MOCHA_REUSABLE_RUN_CALLBACK_THROWS

--- a/integration-tests/ci-visibility/run-mocha.js
+++ b/integration-tests/ci-visibility/run-mocha.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const Mocha = require('mocha')
+const MochaPackage = require('mocha')
+const Mocha = MochaPackage.default ?? MochaPackage
 
 const mocha = new Mocha({
   parallel: !!process.env.RUN_IN_PARALLEL,

--- a/integration-tests/ci-visibility/test-optimization-wrong-init.spec.js
+++ b/integration-tests/ci-visibility/test-optimization-wrong-init.spec.js
@@ -8,6 +8,7 @@ const { exec } = require('child_process')
 const { sandboxCwd, useSandbox, getCiVisAgentlessConfig } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { NODE_MAJOR } = require('../../version')
+const { getLatestMochaSpecifier } = require('../mocha/versions')
 
 const isLatestCucumberSupported = NODE_MAJOR === 22 || NODE_MAJOR === 24 || NODE_MAJOR >= 26
 
@@ -54,7 +55,7 @@ testFrameworks.forEach(({ testFramework, command, expectedOutput, extraTestConte
     if (!isLatestCucumberSupported && testFramework === 'cucumber') return
     if (NODE_MAJOR <= 18 && testFramework === 'vitest') return
 
-    const testFrameworks = ['jest', 'mocha', 'vitest']
+    const testFrameworks = ['jest', `mocha@${getLatestMochaSpecifier()}`, 'vitest']
 
     if (isLatestCucumberSupported) {
       testFrameworks.push('@cucumber/cucumber')

--- a/integration-tests/ci-visibility/test-optimization-wrong-init/run-mocha.js
+++ b/integration-tests/ci-visibility/test-optimization-wrong-init/run-mocha.js
@@ -4,7 +4,8 @@ require('dd-trace').init({
   service: 'sum-service-tests',
 })
 
-const Mocha = require('mocha')
+const MochaPackage = require('mocha')
+const Mocha = MochaPackage.default ?? MochaPackage
 
 async function main () {
   const mocha = new Mocha()

--- a/integration-tests/ci-visibility/tia-code-coverage-mocha.spec.js
+++ b/integration-tests/ci-visibility/tia-code-coverage-mocha.spec.js
@@ -11,6 +11,7 @@ const {
   getCiVisAgentlessConfig,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
+const { getLatestMochaSpecifier } = require('../mocha/versions')
 const {
   TEST_CODE_COVERAGE_LINES_PCT,
   TEST_ITR_TESTS_SKIPPED,
@@ -36,7 +37,7 @@ const MINIMUM_SUPPORTED_MOCHA_VERSION = '8.0.0'
 const MOCHA_VERSION_CONFIGS = [
   {
     version: 'latest',
-    dependencies: ['mocha', 'nyc'],
+    dependencies: [`mocha@${getLatestMochaSpecifier()}`, 'nyc'],
   },
   {
     version: MINIMUM_SUPPORTED_MOCHA_VERSION,

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1436,6 +1436,29 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
     })
   }
 
+  onlyLatestIt('requests library configuration once with the programmatic API', async function () {
+    this.timeout(20_000)
+    childProcess = exec(runTestsCommand, {
+      cwd,
+      env: getCiVisAgentlessConfig(receiver.port),
+    })
+    childProcess.stdout?.on('data', chunk => { testOutput += chunk.toString() })
+    childProcess.stderr?.on('data', chunk => { testOutput += chunk.toString() })
+
+    const settingsPromise = receiver.gatherPayloadsUntilChildExit(
+      childProcess,
+      ({ url }) => url.endsWith('/api/v2/libraries/tests/services/setting'),
+      payloads => assert.strictEqual(payloads.length, 1),
+      { hardTimeout: 20_000 }
+    )
+
+    const [[exitCode]] = await Promise.all([
+      once(childProcess, 'exit'),
+      settingsPromise,
+    ])
+    assert.strictEqual(exitCode, 0, testOutput)
+  })
+
   const nonLegacyReportingOptions = ['evp proxy', 'agentless']
 
   nonLegacyReportingOptions.forEach((reportingOption) => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -94,6 +94,7 @@ const {
   ERROR_TYPE,
 } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR, VERSION: ddTraceVersion } = require('../../version')
+const { getLatestMochaSpecifier } = require('./versions')
 
 function assertItrSkippingEnabledTags (events, expected) {
   const testSuite = events.find(event => event.type === 'test_suite_end').content
@@ -119,6 +120,7 @@ const extraStdout = 'end event: can add event listeners to mocha'
 const requestedMochaVersion = process.env.MOCHA_VERSION || 'latest'
 const oldestMochaVersion = DD_MAJOR >= 6 ? '8.0.0' : '5.2.0'
 const MOCHA_VERSION = requestedMochaVersion === 'oldest' ? oldestMochaVersion : requestedMochaVersion
+const mochaDependencyVersion = MOCHA_VERSION === 'latest' ? getLatestMochaSpecifier() : MOCHA_VERSION
 const mochaMajor = MOCHA_VERSION === 'latest' ? Infinity : Number.parseInt(MOCHA_VERSION, 10)
 const supportsMochaRetryEvents = mochaMajor >= 6
 const onlyLatestIt = MOCHA_VERSION === 'latest' ? it : it.skip
@@ -211,7 +213,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
 
   useSandbox(
     [
-      `mocha@${MOCHA_VERSION}`,
+      `mocha@${mochaDependencyVersion}`,
       'nyc',
       'mocha-each',
       'workerpool',

--- a/integration-tests/mocha/versions.js
+++ b/integration-tests/mocha/versions.js
@@ -2,7 +2,10 @@
 
 const semver = require('semver')
 
+const latestBeforeMocha11 = '10'
 const latestBeforeMocha12 = '11'
+// Mocha 11 requires Node.js ^18.18.0, ^20.9.0, or >=21.1.0.
+const mocha11NodeRange = '^18.18.0 || ^20.9.0 || >=21.1.0'
 // Mocha 12 requires Node.js ^20.19.0 or >=22.12.0.
 const mocha12NodeRange = '^20.19.0 || >=22.12.0'
 
@@ -11,10 +14,13 @@ const mocha12NodeRange = '^20.19.0 || >=22.12.0'
  * @returns {string}
  */
 function getLatestMochaSpecifier (nodeVersion = process.version) {
-  return semver.satisfies(nodeVersion, mocha12NodeRange) ? 'latest' : latestBeforeMocha12
+  if (semver.satisfies(nodeVersion, mocha12NodeRange)) return 'latest'
+  if (semver.satisfies(nodeVersion, mocha11NodeRange)) return latestBeforeMocha12
+  return latestBeforeMocha11
 }
 
 module.exports = {
   getLatestMochaSpecifier,
+  latestBeforeMocha11,
   latestBeforeMocha12,
 }

--- a/integration-tests/mocha/versions.js
+++ b/integration-tests/mocha/versions.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const semver = require('semver')
+
+const latestBeforeMocha12 = '11'
+// Mocha 12 requires Node.js ^20.19.0 or >=22.12.0.
+const mocha12NodeRange = '^20.19.0 || >=22.12.0'
+
+/**
+ * @param {string} [nodeVersion]
+ * @returns {string}
+ */
+function getLatestMochaSpecifier (nodeVersion = process.version) {
+  return semver.satisfies(nodeVersion, mocha12NodeRange) ? 'latest' : latestBeforeMocha12
+}
+
+module.exports = {
+  getLatestMochaSpecifier,
+  latestBeforeMocha12,
+}

--- a/integration-tests/mocha/versions.spec.js
+++ b/integration-tests/mocha/versions.spec.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const {
+  getLatestMochaSpecifier,
+  latestBeforeMocha12,
+} = require('./versions')
+
+describe('getLatestMochaSpecifier', () => {
+  it('uses Mocha 11 when Mocha 12 does not support the Node.js runtime', () => {
+    assert.strictEqual(getLatestMochaSpecifier('18.20.8'), latestBeforeMocha12)
+    assert.strictEqual(getLatestMochaSpecifier('20.18.1'), latestBeforeMocha12)
+    assert.strictEqual(getLatestMochaSpecifier('22.11.0'), latestBeforeMocha12)
+  })
+
+  it('uses latest Mocha on supported Node.js versions', () => {
+    assert.strictEqual(getLatestMochaSpecifier('20.19.0'), 'latest')
+    assert.strictEqual(getLatestMochaSpecifier('22.12.0'), 'latest')
+  })
+})

--- a/integration-tests/mocha/versions.spec.js
+++ b/integration-tests/mocha/versions.spec.js
@@ -4,13 +4,23 @@ const assert = require('node:assert/strict')
 
 const {
   getLatestMochaSpecifier,
+  latestBeforeMocha11,
   latestBeforeMocha12,
 } = require('./versions')
 
 describe('getLatestMochaSpecifier', () => {
+  it('uses Mocha 10 when Mocha 11 does not support the Node.js runtime', () => {
+    assert.strictEqual(getLatestMochaSpecifier('18.17.1'), latestBeforeMocha11)
+    assert.strictEqual(getLatestMochaSpecifier('20.8.1'), latestBeforeMocha11)
+    assert.strictEqual(getLatestMochaSpecifier('21.0.0'), latestBeforeMocha11)
+  })
+
   it('uses Mocha 11 when Mocha 12 does not support the Node.js runtime', () => {
+    assert.strictEqual(getLatestMochaSpecifier('18.18.0'), latestBeforeMocha12)
     assert.strictEqual(getLatestMochaSpecifier('18.20.8'), latestBeforeMocha12)
+    assert.strictEqual(getLatestMochaSpecifier('20.9.0'), latestBeforeMocha12)
     assert.strictEqual(getLatestMochaSpecifier('20.18.1'), latestBeforeMocha12)
+    assert.strictEqual(getLatestMochaSpecifier('21.1.0'), latestBeforeMocha12)
     assert.strictEqual(getLatestMochaSpecifier('22.11.0'), latestBeforeMocha12)
   })
 

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -6,7 +6,6 @@ const { exec } = require('child_process')
 const { inspect } = require('node:util')
 
 const proxyquire = require('proxyquire').noPreserveCache()
-const semver = require('semver')
 const sinon = require('sinon')
 
 const {
@@ -28,11 +27,11 @@ const {
 const { NODE_MAJOR } = require('../../version')
 
 const webAppServer = require('../ci-visibility/web-app-server')
+const { getLatestMochaSpecifier } = require('../mocha/versions')
 
 const versionRange = ['4.11.0', 'latest']
 const isLatestCucumberSupported = NODE_MAJOR === 22 || NODE_MAJOR === 24 || NODE_MAJOR >= 26
-// Mocha 12 requires Node.js ^20.19.0 or >=22.12.0.
-const mochaDependency = semver.satisfies(process.version, '^20.19.0 || >=22.12.0') ? 'mocha' : 'mocha@11'
+const mochaDependency = `mocha@${getLatestMochaSpecifier()}`
 
 versionRange.forEach(version => {
   describe(`selenium ${version}`, () => {

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -6,6 +6,7 @@ const { exec } = require('child_process')
 const { inspect } = require('node:util')
 
 const proxyquire = require('proxyquire').noPreserveCache()
+const semver = require('semver')
 const sinon = require('sinon')
 
 const {
@@ -30,6 +31,8 @@ const webAppServer = require('../ci-visibility/web-app-server')
 
 const versionRange = ['4.11.0', 'latest']
 const isLatestCucumberSupported = NODE_MAJOR === 22 || NODE_MAJOR === 24 || NODE_MAJOR >= 26
+// Mocha 12 requires Node.js ^20.19.0 or >=22.12.0.
+const mochaDependency = semver.satisfies(process.version, '^20.19.0 || >=22.12.0') ? 'mocha' : 'mocha@11'
 
 versionRange.forEach(version => {
   describe(`selenium ${version}`, () => {
@@ -39,7 +42,7 @@ versionRange.forEach(version => {
     let webAppPort
 
     useSandbox([
-      'mocha',
+      mochaDependency,
       'jest',
       ...(isLatestCucumberSupported ? ['@cucumber/cucumber'] : []),
       `selenium-webdriver@${version}`,

--- a/packages/datadog-instrumentations/src/mocha/common.js
+++ b/packages/datadog-instrumentations/src/mocha/common.js
@@ -11,6 +11,60 @@ const MINIMUM_MOCHA_VERSION = DD_MAJOR >= 6 ? '>=8.0.0' : '>=5.2.0'
 const parameterizedTestCh = channel('ci:mocha:test:parameterize')
 const patched = new WeakSet()
 
+/**
+ * Registers every Mocha package view that can expose the constructor.
+ *
+ * @param {string[]} versions
+ * @param {(Mocha: Function, frameworkVersion: string) => Function} wrapMochaRun
+ * @returns {void}
+ */
+function addMochaRunHooks (versions, wrapMochaRun) {
+  const patchedMochaConstructors = new WeakSet()
+
+  /**
+   * @param {Function} Mocha
+   * @param {string} frameworkVersion
+   * @returns {Function}
+   */
+  function wrapMochaOnce (Mocha, frameworkVersion) {
+    if (patchedMochaConstructors.has(Mocha)) return Mocha
+    patchedMochaConstructors.add(Mocha)
+    return wrapMochaRun(Mocha, frameworkVersion)
+  }
+
+  /**
+   * @param {object|Function} MochaPackage
+   * @param {string} frameworkVersion
+   * @returns {object|Function}
+   */
+  function wrapMochaPackage (MochaPackage, frameworkVersion) {
+    wrapMochaOnce(MochaPackage.default ?? MochaPackage, frameworkVersion)
+    return MochaPackage
+  }
+
+  addHook({
+    name: 'mocha',
+    versions,
+    filePattern: String.raw`lib/mocha\.(?:c?js)$`,
+  }, wrapMochaOnce)
+
+  // Mocha 12's ESM package root can load lib/mocha.cjs before the CJS hook observes it. ESM imports report the
+  // package root while synchronous require reports index.js, so hook both views. Keeping the namespace intact makes
+  // the ESM hook skip its separate default-export callback, and wrapMochaOnce deduplicates loaders exposing both.
+  addHook({
+    name: 'mocha',
+    versions: ['>=12.0.0'],
+    patchDefault: false,
+  }, wrapMochaPackage)
+
+  addHook({
+    name: 'mocha',
+    versions: ['>=12.0.0'],
+    file: 'index.js',
+    patchDefault: false,
+  }, wrapMochaPackage)
+}
+
 // mocha-each support
 addHook({
   name: 'mocha-each',
@@ -50,3 +104,5 @@ addHook({
   })
   return SuitePackage
 })
+
+module.exports = { addMochaRunHooks }

--- a/packages/datadog-instrumentations/src/mocha/common.js
+++ b/packages/datadog-instrumentations/src/mocha/common.js
@@ -38,7 +38,8 @@ addHook({
   name: 'mocha',
   versions: [MINIMUM_MOCHA_VERSION],
   file: 'lib/suite.js',
-}, (Suite) => {
+}, (SuitePackage) => {
+  const Suite = SuitePackage.Suite ?? SuitePackage
   shimmer.wrap(Suite.prototype, 'addTest', addTest => function (test) {
     const callSites = getCallSites()
     const testCallSite = callSites.find(site => site.getFileName() === test.file)
@@ -47,5 +48,5 @@ addHook({
     }
     return addTest.apply(this, arguments)
   })
-  return Suite
+  return SuitePackage
 })

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -1131,13 +1131,17 @@ addHook({
   filePattern: String.raw`lib/mocha\.(?:c?js)$`,
 }, wrapMochaRun)
 
-// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it.
+// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it. Node.js 20 exposes the root
+// namespace to CJS hooks, while newer runtimes may expose its default constructor directly.
 addHook({
   name: 'mocha',
   versions: ['>=12.0.0'],
   file: 'index.js',
   patchDefault: true,
-}, wrapMochaRun)
+}, (MochaPackage, frameworkVersion) => {
+  wrapMochaRun(MochaPackage.default ?? MochaPackage, frameworkVersion)
+  return MochaPackage
+})
 
 addHook({
   name: 'mocha',

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -35,6 +35,7 @@ const {
   isMarkedAsUnskippable,
 } = require('../../../dd-trace/src/plugins/util/test')
 
+const { addMochaRunHooks } = require('./common')
 const {
   isNewTest,
   getTestProperties,
@@ -59,8 +60,6 @@ const {
   loggedAttemptToFixTests,
   adjustRunnerFailuresForTestOptimization,
 } = require('./utils')
-
-require('./common')
 
 const MINIMUM_MOCHA_VERSION = DD_MAJOR >= 6 ? '>=8.0.0' : '>=5.2.0'
 
@@ -1125,23 +1124,7 @@ function wrapMochaRun (Mocha, frameworkVersion) {
   return Mocha
 }
 
-addHook({
-  name: 'mocha',
-  versions: [MINIMUM_MOCHA_VERSION],
-  filePattern: String.raw`lib/mocha\.(?:c?js)$`,
-}, wrapMochaRun)
-
-// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it. Node.js 20 exposes the root
-// namespace to CJS hooks, while newer runtimes may expose its default constructor directly.
-addHook({
-  name: 'mocha',
-  versions: ['>=12.0.0'],
-  file: 'index.js',
-  patchDefault: true,
-}, (MochaPackage, frameworkVersion) => {
-  wrapMochaRun(MochaPackage.default ?? MochaPackage, frameworkVersion)
-  return MochaPackage
-})
+addMochaRunHooks([MINIMUM_MOCHA_VERSION], wrapMochaRun)
 
 addHook({
   name: 'mocha',

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -1063,13 +1063,15 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
 // In this hook we delay the execution with options.delay to grab library configuration,
 // skippable and known tests.
 // It is called but skipped in parallel mode.
-addHook({
-  name: 'mocha',
-  versions: [MINIMUM_MOCHA_VERSION],
-  file: 'lib/mocha.js',
-}, (Mocha, frameworkVersion) => {
+/**
+ * @param {Function} Mocha
+ * @param {string} frameworkVersion
+ * @returns {Function}
+ */
+function wrapMochaRun (Mocha, frameworkVersion) {
   warnDeprecatedMochaVersion(frameworkVersion)
 
+  // Shimmer is required because run must return its Runner while execution is paused and resumed after configuration.
   shimmer.wrap(Mocha.prototype, 'run', run => function (...args) {
     // Workers do not need to request any data, just run the tests
     if (!testFinishCh.hasSubscribers || getEnvironmentVariable('MOCHA_WORKER_ID') || this.options.parallel) {
@@ -1121,12 +1123,26 @@ addHook({
     return runner
   })
   return Mocha
-})
+}
 
 addHook({
   name: 'mocha',
   versions: [MINIMUM_MOCHA_VERSION],
-  file: 'lib/cli/run-helpers.js',
+  filePattern: String.raw`lib/mocha\.(?:c?js)$`,
+}, wrapMochaRun)
+
+// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it.
+addHook({
+  name: 'mocha',
+  versions: ['>=12.0.0'],
+  file: 'index.js',
+  patchDefault: true,
+}, wrapMochaRun)
+
+addHook({
+  name: 'mocha',
+  versions: [MINIMUM_MOCHA_VERSION],
+  filePattern: String.raw`lib/cli/run-helpers\.(?:c?js)$`,
 }, (run) => {
   // `runMocha` is an async function
   shimmer.wrap(run, 'runMocha', runMocha => function (...args) {
@@ -1157,7 +1173,7 @@ addHook({
 addHook({
   name: 'mocha',
   versions: [MINIMUM_MOCHA_VERSION],
-  file: 'lib/runner.js',
+  filePattern: String.raw`lib/runner\.(?:c?js)$`,
 }, function (Runner, frameworkVersion) {
   if (patched.has(Runner)) return Runner
 
@@ -1588,7 +1604,7 @@ addHook({
 addHook({
   name: 'mocha',
   versions: ['>=8.0.0'],
-  file: 'lib/nodejs/parallel-buffered-runner.js',
+  filePattern: String.raw`lib/nodejs/parallel-buffered-runner\.(?:c?js)$`,
 }, (ParallelBufferedRunner, frameworkVersion) => {
   shimmer.wrap(ParallelBufferedRunner.prototype, 'run', run => function (cb, { files, options = {} }) {
     if (!testFinishCh.hasSubscribers) {
@@ -1667,7 +1683,7 @@ addHook({
 addHook({
   name: 'mocha',
   versions: ['>=8.0.0'],
-  file: 'lib/nodejs/buffered-worker-pool.js',
+  filePattern: String.raw`lib/nodejs/buffered-worker-pool\.(?:c?js)$`,
 }, (BufferedWorkerPoolPackage, frameworkVersion) => {
   const { BufferedWorkerPool } = BufferedWorkerPoolPackage
 

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -507,7 +507,8 @@ function inheritDatadogPropertiesFromRetriedTest (test) {
 }
 
 function runnableWrapper (RunnablePackage, libraryConfig) {
-  shimmer.wrap(RunnablePackage.prototype, 'run', run => function (...args) {
+  const Runnable = RunnablePackage.Runnable ?? RunnablePackage
+  shimmer.wrap(Runnable.prototype, 'run', run => function (...args) {
     if (!testFinishCh.hasSubscribers) {
       return run.apply(this, args)
     }

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -448,13 +448,17 @@ addHook({
   filePattern: String.raw`lib/mocha\.(?:c?js)$`,
 }, wrapMochaRun)
 
-// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it.
+// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it. Node.js 20 exposes the root
+// namespace to CJS hooks, while newer runtimes may expose its default constructor directly.
 addHook({
   name: 'mocha',
   versions: ['>=12.0.0'],
   file: 'index.js',
   patchDefault: true,
-}, wrapMochaRun)
+}, (MochaPackage, frameworkVersion) => {
+  wrapMochaRun(MochaPackage.default ?? MochaPackage, frameworkVersion)
+  return MochaPackage
+})
 
 // Runner is also hooked in mocha/main.js, but in here we only generate test events.
 addHook({

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -7,6 +7,7 @@ const { getEnvironmentVariable } = require('../../../dd-trace/src/config/helper'
 const log = require('../../../dd-trace/src/log')
 const { DD_MAJOR } = require('../../../../version')
 
+const { addMochaRunHooks } = require('./common')
 const {
   runnableWrapper,
   getOnTestHandler,
@@ -29,7 +30,6 @@ const {
   WEBDRIVERIO_WORKER_ENV,
   WORKER_READY,
 } = require('./webdriverio-protocol')
-require('./common')
 
 const MINIMUM_MOCHA_VERSION = DD_MAJOR >= 6 ? '>=8.0.0' : '>=5.2.0'
 
@@ -442,23 +442,7 @@ function wrapMochaRun (Mocha, frameworkVersion) {
   return Mocha
 }
 
-addHook({
-  name: 'mocha',
-  versions: ['>=8.0.0'],
-  filePattern: String.raw`lib/mocha\.(?:c?js)$`,
-}, wrapMochaRun)
-
-// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it. Node.js 20 exposes the root
-// namespace to CJS hooks, while newer runtimes may expose its default constructor directly.
-addHook({
-  name: 'mocha',
-  versions: ['>=12.0.0'],
-  file: 'index.js',
-  patchDefault: true,
-}, (MochaPackage, frameworkVersion) => {
-  wrapMochaRun(MochaPackage.default ?? MochaPackage, frameworkVersion)
-  return MochaPackage
-})
+addMochaRunHooks(['>=8.0.0'], wrapMochaRun)
 
 // Runner is also hooked in mocha/main.js, but in here we only generate test events.
 addHook({

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -360,13 +360,15 @@ function isFailedTestReplayEnabled () {
   return config.isTestDynamicInstrumentationEnabled && config.isDiEnabled
 }
 
-addHook({
-  name: 'mocha',
-  versions: ['>=8.0.0'],
-  file: 'lib/mocha.js',
-}, (Mocha, frameworkVersion) => {
+/**
+ * @param {Function} Mocha
+ * @param {string} frameworkVersion
+ * @returns {Function}
+ */
+function wrapMochaRun (Mocha, frameworkVersion) {
   reportWebdriverioWorkerReady(frameworkVersion)
 
+  // Shimmer is required because run must return its Runner while execution is paused and resumed after configuration.
   shimmer.wrap(Mocha.prototype, 'run', run => function (...args) {
     applyMochaOptions(this.options)
     if (!isWebdriverioWorker || !workerFinishCh.hasSubscribers) {
@@ -438,13 +440,27 @@ addHook({
   })
 
   return Mocha
-})
+}
+
+addHook({
+  name: 'mocha',
+  versions: ['>=8.0.0'],
+  filePattern: String.raw`lib/mocha\.(?:c?js)$`,
+}, wrapMochaRun)
+
+// Mocha 12's ESM package root loads lib/mocha.cjs before the CJS hook can observe it.
+addHook({
+  name: 'mocha',
+  versions: ['>=12.0.0'],
+  file: 'index.js',
+  patchDefault: true,
+}, wrapMochaRun)
 
 // Runner is also hooked in mocha/main.js, but in here we only generate test events.
 addHook({
   name: 'mocha',
   versions: [MINIMUM_MOCHA_VERSION],
-  file: 'lib/runner.js',
+  filePattern: String.raw`lib/runner\.(?:c?js)$`,
 }, function (Runner) {
   shimmer.wrap(Runner.prototype, 'runTests', runTests => getRunTestsWrapper(runTests, config))
 

--- a/packages/datadog-instrumentations/test/fixtures/mocha-regular-worker.js
+++ b/packages/datadog-instrumentations/test/fixtures/mocha-regular-worker.js
@@ -14,7 +14,7 @@ require('../../src/mocha/worker')
 
 const runnerHook = instrumentations.mocha
   .slice(existingMochaHookCount)
-  .find(({ file }) => file === 'lib/runner.js')
+  .find(({ filePattern }) => filePattern === String.raw`lib/runner\.(?:c?js)$`)
 
 assert.ok(runnerHook)
 

--- a/packages/datadog-instrumentations/test/fixtures/webdriverio-delayed-worker.js
+++ b/packages/datadog-instrumentations/test/fixtures/webdriverio-delayed-worker.js
@@ -18,7 +18,7 @@ require('../../src/mocha/worker')
 
 const runnerHook = instrumentations.mocha
   .slice(existingMochaHookCount)
-  .find(({ file }) => file === 'lib/runner.js')
+  .find(({ filePattern }) => filePattern === String.raw`lib/runner\.(?:c?js)$`)
 
 assert.ok(runnerHook)
 

--- a/packages/datadog-instrumentations/test/fixtures/webdriverio-disconnected-worker.js
+++ b/packages/datadog-instrumentations/test/fixtures/webdriverio-disconnected-worker.js
@@ -18,8 +18,12 @@ const existingMochaHookCount = instrumentations.mocha?.length || 0
 require('../../src/mocha/worker')
 
 const webdriverioMochaHooks = instrumentations.mocha.slice(existingMochaHookCount)
-const mochaHook = webdriverioMochaHooks.find(({ file }) => file === 'lib/mocha.js')
-const runnerHook = webdriverioMochaHooks.find(({ file }) => file === 'lib/runner.js')
+const mochaHook = webdriverioMochaHooks.find(
+  ({ filePattern }) => filePattern === String.raw`lib/mocha\.(?:c?js)$`
+)
+const runnerHook = webdriverioMochaHooks.find(
+  ({ filePattern }) => filePattern === String.raw`lib/runner\.(?:c?js)$`
+)
 
 assert.ok(mochaHook)
 assert.ok(runnerHook)

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -169,4 +169,29 @@ describe('register', () => {
       moduleName: 'mariadb/lib/cmd/query.js',
     })
   })
+
+  it('should patch a package root namespace without also patching its default callback', () => {
+    const patch = sinon.stub()
+    hooksMock.mocha = { fn: sinon.stub() }
+    instrumentationsMock.mocha = [{
+      versions: ['>=12.0.0'],
+      patchDefault: false,
+      hook (moduleExports) {
+        patch(moduleExports.default ?? moduleExports)
+        return moduleExports
+      },
+    }]
+    loadRegisterWithEnv()
+
+    const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === 'mocha')
+    const hook = hookCall.args[2]
+    const Mocha = class Mocha {}
+    const namespace = { default: Mocha, Mocha }
+
+    assert.strictEqual(hook(Mocha, 'mocha', '/path/to/mocha', '12.0.0', true), Mocha)
+    sinon.assert.notCalled(patch)
+
+    assert.strictEqual(hook(namespace, 'mocha', '/path/to/mocha', '12.0.0', true), namespace)
+    sinon.assert.calledOnceWithExactly(patch, Mocha)
+  })
 })

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -174,7 +174,7 @@
     "mercurius": "16.10.0",
     "microgateway-core": "3.3.7",
     "middie": "7.1.0",
-    "mocha": "11.8.0",
+    "mocha": "12.0.0",
     "mocha-each": "2.0.1",
     "moleculer": "0.15.1",
     "mongodb": "7.5.0",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds compatibility with Mocha 12 by supporting its renamed CommonJS internals and ESM package entry point. It also updates the versions package to test against Mocha 12.0.0.

### Motivation
<!-- What inspired you to submit this pull request? -->

Mocha 12 publishes its package root as ESM and renames internal CommonJS files from `.js` to `.cjs`, preventing the existing instrumentation hooks from applying.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Verification:

- `MOCHA_VERSION=latest npm run test:integration:mocha` (228 passing)
- `MOCHA_VERSION=11.8.0 npm run test:integration:mocha -- --grep "can run tests and report tests with the APM protocol|retries new tests"` (2 passing, 2 expected pending)
- `PLUGINS=webdriverio npm run test:instrumentations` (44 passing)
- WebdriverIO 9.0.0 on Node.js 18.20.8 (89 passing, 12 expected pending)
- WebdriverIO latest on Node.js 26.2.0 (107 passing, 12 expected pending)
- Selenium on Node.js 18.20.8 (18 passing)
- `./node_modules/.bin/mocha packages/dd-trace/test/plugins/versions.spec.js` (28 passing)
- ESLint on the changed instrumentation files
