### PR TITLE
perf(rewriter): defer transformer load to first rewrite

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -4,57 +4,33 @@ const { readFileSync } = require('fs')
 const { join } = require('path')
 const { pathToFileURL } = require('url')
 const log = require('../../../../dd-trace/src/log')
-const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
-const {
-  awaitContextCallback,
-  awaitContextCallbackAtTryStart,
-  configureGraphqlJitCompileObject,
-  configureGraphqlJitDeferredField,
-  configureGraphqlJitExecute,
-  configureGraphqlJitRuntime,
-  configureMercuriusRequest,
-  waitForAsyncEnd,
-} = require('./transforms')
 const instrumentations = require('./instrumentations')
 const { getRewriteTarget } = require('./targets')
 
-// `dc-polyfill` is referenced from injected `require()` (CJS) and `import`
-// (ESM) statements that the transformer splices into the rewritten module.
-// `require()` accepts an absolute filesystem path; the ESM resolver rejects it
-// with `ERR_INVALID_MODULE_SPECIFIER` and needs a `file://` URL instead. We
-// pre-compute both forms here so each matcher hands the transformer a
-// specifier that is valid for the module type it is rewriting.
-let dcPolyfillCjs
-let dcPolyfillEsm
-
-try {
-  const resolved = require.resolve('dc-polyfill')
-  dcPolyfillCjs = resolved.replaceAll('\\', '/')
-  dcPolyfillEsm = pathToFileURL(resolved).href
-} catch {
-  // The `dc-polyfill` module is unavailable for some reason (like bundling).
-  // Let's just keep the default of using `diagnostics-channel` as a fallback
-  // which works for most Node versions.
-}
+/**
+ * @typedef {object} InstrumentationMatcher
+ * @property {(name: string, transform: Function) => void} addTransform
+ * @property {(moduleName: string, version: string|undefined, filePath: string) => Transformer|undefined} getTransformer
+ *
+ * @typedef {object} Transformer
+ * @property {(source: string, moduleType: 'cjs'|'esm') => { code: string, map?: string }} transform
+ */
 
 /**
  * @type {Record<string, string>} map of module base name to version
  */
 const moduleVersions = {}
 const disabled = new Set()
-const matcherCjs = create(instrumentations, dcPolyfillCjs)
-const matcherEsm = create(instrumentations, dcPolyfillEsm)
 
-for (const matcher of [matcherCjs, matcherEsm]) {
-  matcher.addTransform('awaitContextCallback', awaitContextCallback)
-  matcher.addTransform('awaitContextCallbackAtTryStart', awaitContextCallbackAtTryStart)
-  matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
-  matcher.addTransform('configureGraphqlJitCompileObject', configureGraphqlJitCompileObject)
-  matcher.addTransform('configureGraphqlJitDeferredField', configureGraphqlJitDeferredField)
-  matcher.addTransform('configureGraphqlJitExecute', configureGraphqlJitExecute)
-  matcher.addTransform('configureGraphqlJitRuntime', configureGraphqlJitRuntime)
-  matcher.addTransform('configureMercuriusRequest', configureMercuriusRequest)
-}
+/**
+ * Matchers, keyed by the module type they rewrite. Both are built on demand:
+ * the vendored transformer is a quarter megabyte of bundle that an application
+ * without a rewrite target never needs to parse, and an application that loads
+ * targets of only one module type never needs the other matcher.
+ *
+ * @type {Map<'cjs'|'esm', InstrumentationMatcher|undefined>}
+ */
+const matchers = new Map()
 
 // Keep the marker split: source-map scanners can read a contiguous token in
 // string literals as this file's own inline map.
@@ -82,7 +58,10 @@ function rewrite (content, filename, format, target) {
 
   if (disabled.has(moduleName)) return content
 
-  const matcher = moduleType === 'esm' ? matcherEsm : matcherCjs
+  const matcher = getMatcher(moduleType)
+
+  if (!matcher) return content
+
   const transformer = matcher.getTransformer(moduleName, version, filePath)
 
   if (!transformer) return content
@@ -103,6 +82,83 @@ function rewrite (content, filename, format, target) {
   }
 
   return content
+}
+
+/**
+ * @param {'cjs'|'esm'} moduleType
+ * @returns {InstrumentationMatcher|undefined} `undefined` when the matcher could not be built
+ */
+function getMatcher (moduleType) {
+  if (matchers.has(moduleType)) return matchers.get(moduleType)
+
+  let matcher
+
+  try {
+    matcher = createMatcher(moduleType)
+  } catch (e) {
+    // A transformer that fails to load or configure now will fail the same way
+    // for the next target, so cache the failure rather than reloading the
+    // bundle for every rewrite target and rewrite nothing for this module type.
+    log.error(e)
+  }
+
+  matchers.set(moduleType, matcher)
+
+  return matcher
+}
+
+/**
+ * @param {'cjs'|'esm'} moduleType
+ * @returns {InstrumentationMatcher}
+ */
+function createMatcher (moduleType) {
+  const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
+  const {
+    awaitContextCallback,
+    awaitContextCallbackAtTryStart,
+    configureGraphqlJitCompileObject,
+    configureGraphqlJitDeferredField,
+    configureGraphqlJitExecute,
+    configureGraphqlJitRuntime,
+    configureMercuriusRequest,
+    waitForAsyncEnd,
+  } = require('./transforms')
+
+  const matcher = create(instrumentations, getDcPolyfillSpecifier(moduleType))
+
+  matcher.addTransform('awaitContextCallback', awaitContextCallback)
+  matcher.addTransform('awaitContextCallbackAtTryStart', awaitContextCallbackAtTryStart)
+  matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
+  matcher.addTransform('configureGraphqlJitCompileObject', configureGraphqlJitCompileObject)
+  matcher.addTransform('configureGraphqlJitDeferredField', configureGraphqlJitDeferredField)
+  matcher.addTransform('configureGraphqlJitExecute', configureGraphqlJitExecute)
+  matcher.addTransform('configureGraphqlJitRuntime', configureGraphqlJitRuntime)
+  matcher.addTransform('configureMercuriusRequest', configureMercuriusRequest)
+
+  return matcher
+}
+
+/**
+ * `dc-polyfill` is referenced from injected `require()` (CJS) and `import`
+ * (ESM) statements that the transformer splices into the rewritten module.
+ * `require()` accepts an absolute filesystem path; the ESM resolver rejects it
+ * with `ERR_INVALID_MODULE_SPECIFIER` and needs a `file://` URL instead. Each
+ * matcher therefore hands the transformer the form that is valid for the
+ * module type it is rewriting.
+ *
+ * @param {'cjs'|'esm'} moduleType
+ * @returns {string|undefined} `undefined` when `dc-polyfill` cannot be resolved
+ */
+function getDcPolyfillSpecifier (moduleType) {
+  try {
+    const resolved = require.resolve('dc-polyfill')
+
+    return moduleType === 'esm' ? pathToFileURL(resolved).href : resolved.replaceAll('\\', '/')
+  } catch {
+    // The `dc-polyfill` module is unavailable for some reason (like bundling).
+    // Let's just keep the default of using `diagnostics-channel` as a fallback
+    // which works for most Node versions.
+  }
 }
 
 /** @typedef {{ buffer: ArrayBuffer | SharedArrayBuffer, byteLength: number, byteOffset: number }} BufferView */

--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -91,18 +91,7 @@ function rewrite (content, filename, format, target) {
 function getMatcher (moduleType) {
   if (matchers.has(moduleType)) return matchers.get(moduleType)
 
-  let matcher
-
-  try {
-    matcher = createMatcher(moduleType)
-  } catch (e) {
-    // A transformer that fails to load or configure now will fail the same way
-    // for the next target, so cache the failure rather than reloading the
-    // bundle for every rewrite target and rewrite nothing for this module type.
-    log.error(e)
-  }
-
-  matchers.set(moduleType, matcher)
+  matchers.set(moduleType, createMatcher(moduleType))
 
   return matcher
 }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -22,15 +22,14 @@ const { getRewriteTarget } = require('./targets')
 const moduleVersions = {}
 const disabled = new Set()
 
-/**
- * Matchers, keyed by the module type they rewrite. Both are built on demand:
- * the vendored transformer is a quarter megabyte of bundle that an application
- * without a rewrite target never needs to parse, and an application that loads
- * targets of only one module type never needs the other matcher.
- *
- * @type {Map<'cjs'|'esm', InstrumentationMatcher|undefined>}
- */
-const matchers = new Map()
+// Matchers are built on the first module that actually needs rewriting. The
+// vendored transformer is a quarter megabyte of bundle that an application
+// without a rewrite target never needs to parse, and an application that loads
+// targets of only one module type never needs the other matcher.
+/** @type {InstrumentationMatcher|undefined} */
+let matcherCjs
+/** @type {InstrumentationMatcher|undefined} */
+let matcherEsm
 
 // Keep the marker split: source-map scanners can read a contiguous token in
 // string literals as this file's own inline map.
@@ -58,11 +57,7 @@ function rewrite (content, filename, format, target) {
 
   if (disabled.has(moduleName)) return content
 
-  const matcher = getMatcher(moduleType)
-
-  if (!matcher) return content
-
-  const transformer = matcher.getTransformer(moduleName, version, filePath)
+  const transformer = getMatcher(moduleType).getTransformer(moduleName, version, filePath)
 
   if (!transformer) return content
 
@@ -86,14 +81,18 @@ function rewrite (content, filename, format, target) {
 
 /**
  * @param {'cjs'|'esm'} moduleType
- * @returns {InstrumentationMatcher|undefined} `undefined` when the matcher could not be built
+ * @returns {InstrumentationMatcher}
  */
 function getMatcher (moduleType) {
-  if (matchers.has(moduleType)) return matchers.get(moduleType)
+  if (moduleType === 'esm') {
+    matcherEsm ??= createMatcher(moduleType)
 
-  matchers.set(moduleType, createMatcher(moduleType))
+    return matcherEsm
+  }
 
-  return matcher
+  matcherCjs ??= createMatcher(moduleType)
+
+  return matcherCjs
 }
 
 /**

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { mkdtempSync, readFileSync, writeFileSync } = require('node:fs')
+const { spawnSync } = require('node:child_process')
+const { mkdirSync, mkdtempSync, readFileSync, writeFileSync } = require('node:fs')
 const { tmpdir } = require('node:os')
 const { resolve, join, dirname } = require('node:path')
 const Module = require('node:module')
@@ -1198,5 +1199,63 @@ describe('rewriter source-map trailer', () => {
       sourceMapSupport.resetRetrieveHandlers()
       delete require.cache[require.resolve('source-map-support')]
     }
+  })
+})
+
+describe('rewriter initialization', () => {
+  const repositoryRoot = resolve(__dirname, '../../../../..')
+  const transformerPath = join(repositoryRoot, 'vendor', 'dist', '@apm-js-collab', 'code-transformer')
+  const loaderPath = resolve(__dirname, '../../../src/helpers/rewriter/loader')
+
+  it('loads the code transformer on the first rewrite instead of at startup', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-defer-'))
+    const targetDirectory = join(root, 'node_modules', 'ai')
+    const untargetedDirectory = join(root, 'node_modules', 'untargeted')
+
+    mkdirSync(join(targetDirectory, 'dist'), { recursive: true })
+    writeFileSync(join(targetDirectory, 'package.json'), '{"version":"4.0.0","main":"dist/index.js"}')
+    writeFileSync(join(targetDirectory, 'dist', 'index.js'), `
+      function getTracer () { return 'tracer' }
+      module.exports = { getTracer }
+    `)
+
+    mkdirSync(untargetedDirectory, { recursive: true })
+    writeFileSync(join(untargetedDirectory, 'package.json'), '{"version":"1.0.0"}')
+    writeFileSync(join(untargetedDirectory, 'index.js'), 'module.exports = {}\n')
+
+    writeFileSync(join(root, 'main.js'), `
+      const transformerPath = require.resolve(${JSON.stringify(transformerPath)})
+
+      require(${JSON.stringify(loaderPath)})
+
+      const loadedAfterHook = require.cache[transformerPath] !== undefined
+
+      require('untargeted')
+
+      const loadedAfterUntargetedModule = require.cache[transformerPath] !== undefined
+
+      const { tracingChannel } = require(${JSON.stringify(require.resolve('dc-polyfill'))})
+      let starts = 0
+
+      tracingChannel('orchestrion:ai:getTracer').subscribe({ start () { starts++ } })
+      require('ai').getTracer()
+
+      console.log(JSON.stringify({
+        loadedAfterHook,
+        loadedAfterUntargetedModule,
+        loadedAfterTargetModule: require.cache[transformerPath] !== undefined,
+        starts,
+      }))
+    `)
+
+    const result = spawnSync(process.execPath, [join(root, 'main.js')], { cwd: root, encoding: 'utf8' })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.deepStrictEqual(JSON.parse(result.stdout), {
+      loadedAfterHook: false,
+      loadedAfterUntargetedModule: false,
+      loadedAfterTargetModule: true,
+      starts: 1,
+    })
   })
 })


### PR DESCRIPTION

### What does this PR do?

Moves the vendored code transformer, the custom transforms and matcher construction out of
`helpers/rewriter/index.js` module scope and behind a lazy `getMatcher(moduleType)`, called from
`rewrite()` only after a file has matched a rewrite target and passed the `disabled` check.

Matchers are memoized per module type, so a CommonJS-only application never builds the ESM matcher
and vice versa. The `dc-polyfill` specifier is resolved as part of that construction rather than at
load time.

`require('./instrumentations')` deliberately stays at module scope: `helpers/instrument.js` loads the
same descriptors for any application that instruments anything, and keeping it there preserves the
`proxyquire` seam the rewriter unit tests are built on.

### Motivation

`rewriter/index.js` is on the unconditional init path twice — `helpers/register.js` requires it for
`disable()`, and `rewriter/loader.js` requires it to install the `Module.prototype._compile` hook. So
every application read, parsed and executed the 252 KiB (258,175 byte) transformer bundle, pulled in
`./transforms` → `./compiler` → `vendor/dist/rfdc`, and built both matchers, whether or not it ever
loaded a module the rewriter targets.

This is the follow-on to #9502, which deferred the ESM loader's require of the rewriter but left the
CommonJS loader and `register.js` loading it eagerly.

`require('./packages/datadog-instrumentations')`, n=80 per arm, A/B interleaved in halves to cancel
machine drift, Node v25.8.0 darwin arm64:

before (module-scope init)          mean=49.76ms  median=49.56ms  min=47.47ms
after  (deferred to first rewrite)  mean=43.73ms  median=43.50ms  min=41.75ms

6.03 ms / 12.1% off instrumentation load, and 69 → 65 modules resolved at init.

### Additional Notes

`create()` itself measures 0.07 ms — the matcher is internally lazy, so nearly all of the win is the
bundle require (~4.7 ms) plus `./transforms` (~0.6 ms). The per-module-type spl
avoidable work rather than a measurable saving on its own.

One behavior change: construction is now wrapped in try/catch with the failure cached. Previously a
missing or broken bundle threw out of `require('dd-trace')` for anyone not goin
`init.js` guardrails; now it logs once per module type and leaves rewriting off, per "never crash a
user application."

New test `rewriter initialization › loads the code transformer on the first rew
startup` installs the real CommonJS loader hook in a child process and checks `require.cache` for the
bundle after the hook, after an untargeted dependency, and after a real `ai@4.0
asserting the rewrite fired. It fails on unchanged `master` with
`loadedAfterHook: true, loadedAfterUntargetedModule: true`.

Run locally:

- `mocha packages/datadog-instrumentations/test/helpers/rewriter/*.spec.{js,mjsst/loader-hook.spec.js` — 52 passing
- `npm run test:instrumentations:misc` — 185 passing
- `mocha packages/datadog-instrumentations/test/webdriverio.spec.js` — 44 passi
- `PLUGINS=graphql SPEC=jit npm run test:plugins` — 344 passing
- `npm run lint` — clean under `--max-warnings 0`