### PR TITLE
fix(llmobs): prevent duplicate tags in x-datadog-tags on injection

### DIFF
--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -25,7 +25,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution, stripTagsetEntry } = require('./util')
+const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
 const LLMObsEvalMetricsWriter = require('./writers/evaluations')
@@ -161,6 +161,21 @@ function retireWriters (retiredSpanWriter, retiredEvalWriter) {
   for (const writer of retiredWriters) writer.destroy(onWriterDestroyed)
 }
 
+function isReplacedKey (
+  key, parentId, mlApp, sessionId, sampleRate, samplingDecision, propagatedTraceId, parentAgentSpanId
+) {
+  if (parentId && key === PROPAGATED_PARENT_ID_KEY) return true
+  if (mlApp && key === PROPAGATED_ML_APP_KEY) return true
+  if (sessionId && key === PROPAGATED_SESSION_ID_KEY) return true
+  if (sampleRate != null && key === PROPAGATED_SAMPLE_RATE_KEY) return true
+  if (samplingDecision != null && key === PROPAGATED_SAMPLING_DECISION_KEY) return true
+  if (propagatedTraceId != null && key === PROPAGATED_TRACE_ID_KEY) return true
+  if (parentAgentSpanId && (key === PROPAGATED_PARENT_AGENT_ID_KEY || key === PROPAGATED_PARENT_AGENT_NAME_KEY)) {
+    return true
+  }
+  return false
+}
+
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propagate the parent id, mlApp, session id, and sampling rate/decision.
 function handleLLMObsInjection ({ carrier }) {
@@ -204,21 +219,29 @@ function handleLLMObsInjection ({ carrier }) {
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.
   const existing = readDatadogTags(carrier)
-  let tags = existing || ''
+  let tags = ''
+
+  if (existing) {
+    const entries = existing.split(',')
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      const separatorIndex = entry.indexOf('=')
+      const key = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex)
+      if (!isReplacedKey(
+        key, parentId, mlApp, sessionId, sampleRate, samplingDecision, propagatedTraceId, parentAgentSpanId
+      )) {
+        tags += `${tags ? ',' : ''}${entry}`
+      }
+    }
+  }
+
   if (parentId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_ID_KEY}=${parentId}`
   if (mlApp) tags += `${tags ? ',' : ''}${PROPAGATED_ML_APP_KEY}=${mlApp}`
   if (sessionId) tags += `${tags ? ',' : ''}${PROPAGATED_SESSION_ID_KEY}=${sessionId}`
   if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
   if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
   if (propagatedTraceId != null) tags += `${tags ? ',' : ''}${PROPAGATED_TRACE_ID_KEY}=${propagatedTraceId}`
-  // When a local agent attribution is resolved, strip any stale upstream pagent entries that
-  // `_injectTags` may have already written into the carrier (it propagates all `_dd.p.*` from
-  // `_trace.tags`). This ensures the downstream sees a consistent id-only or id+name pair
-  // rather than a mix from different hops. The id is always digit-safe; an unsafe name is wiped.
-  if (parentAgentSpanId) {
-    tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_ID_KEY)
-    tags = stripTagsetEntry(tags, PROPAGATED_PARENT_AGENT_NAME_KEY)
-  }
+
   const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
   const tagsWithId = appendOptionalPropagatedTag(
     tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId, null, maxLength

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -165,15 +165,13 @@ function retireWriters (retiredSpanWriter, retiredEvalWriter) {
 
 /**
  * @param {Set<string> | undefined} replacementKeys
- * @param {string} replacementTags
  * @param {string} key
  * @param {string} value
  * @returns {string}
  */
-function addTagReplacement (replacementKeys, replacementTags, key, value) {
-  const replacement = `${key}=${value}`
+function addTagReplacement (replacementKeys, key, value) {
   replacementKeys?.add(key)
-  return `${replacementTags}${replacementTags ? ',' : ''}${replacement}`
+  return `${key}=${value},`
 }
 
 /**
@@ -206,7 +204,7 @@ function replacePropagatedTags (tags, firstKeyIndex, replacementKeys, replacemen
     entryStart = entryEnd + 1
   }
 
-  return `${replaced}${hasEntry ? ',' : ''}${replacementTags}`
+  return hasEntry ? `${replacementTags}${replaced}` : replacementTags.slice(0, -1)
 }
 
 // since LLMObs traces can extend between services and be the same trace,
@@ -256,33 +254,32 @@ function handleLLMObsInjection ({ carrier }) {
   const replacementKeys = firstKeyIndex === -1 ? undefined : new Set()
   let replacementTags = ''
   if (parentId) {
-    replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_PARENT_ID_KEY, parentId)
+    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_PARENT_ID_KEY, parentId)
   }
-  if (mlApp) replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_ML_APP_KEY, mlApp)
+  if (mlApp) replacementTags += addTagReplacement(replacementKeys, PROPAGATED_ML_APP_KEY, mlApp)
   if (sessionId) {
-    replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_SESSION_ID_KEY, sessionId)
+    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_SESSION_ID_KEY, sessionId)
   }
   if (sampleRate != null) {
-    replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_SAMPLE_RATE_KEY, sampleRate)
+    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_SAMPLE_RATE_KEY, sampleRate)
   }
   if (samplingDecision != null) {
-    replacementTags = addTagReplacement(
-      replacementKeys, replacementTags, PROPAGATED_SAMPLING_DECISION_KEY, samplingDecision
-    )
+    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_SAMPLING_DECISION_KEY, samplingDecision)
   }
   if (propagatedTraceId != null) {
-    replacementTags = addTagReplacement(
-      replacementKeys, replacementTags, PROPAGATED_TRACE_ID_KEY, propagatedTraceId
-    )
+    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_TRACE_ID_KEY, propagatedTraceId)
   }
   if (parentAgentSpanId && replacementKeys) {
     // These entries are appended below after their wire and size constraints are applied.
     replacementKeys.add(PROPAGATED_PARENT_AGENT_ID_KEY)
     replacementKeys.add(PROPAGATED_PARENT_AGENT_NAME_KEY)
   }
-  let tags = firstKeyIndex === -1
-    ? `${existing}${existing ? ',' : ''}${replacementTags}`
-    : replacePropagatedTags(existing, firstKeyIndex, replacementKeys, replacementTags)
+  let tags
+  if (firstKeyIndex === -1) {
+    tags = existing ? `${replacementTags}${existing}` : replacementTags.slice(0, -1)
+  } else {
+    tags = replacePropagatedTags(existing, firstKeyIndex, replacementKeys, replacementTags)
+  }
 
   const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
   const tagsWithId = appendOptionalPropagatedTag(

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -2,7 +2,6 @@
 
 const { channel } = require('dc-polyfill')
 
-const { readDatadogTags, writeDatadogTags } = require('../carrier')
 const { registerTelemetryFlusher } = require('../flush')
 const log = require('../log')
 const { createServerlessDeliveryTracker } = require('../serverless')
@@ -25,7 +24,7 @@ const {
   PROPAGATED_TRACE_ID_KEY,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { agentNameWireSafe, appendOptionalPropagatedTag, resolveAgentAttribution } = require('./util')
+const { agentNameWireSafe, resolveAgentAttribution } = require('./util')
 const telemetry = require('./telemetry')
 const LLMObsSpanProcessor = require('./span_processor')
 const LLMObsEvalMetricsWriter = require('./writers/evaluations')
@@ -34,8 +33,6 @@ const LLMObsSpanWriter = require('./writers/spans')
 const { setAgentStrategy } = require('./writers/util')
 const { INCOMPATIBLE_INITIALIZATION } = require('./constants/text')
 const { llmObsTraceIdToWire } = require('./util')
-
-const PROPAGATED_LLMOBS_PREFIX = '_dd.p.llmobs_'
 
 const spanFinishCh = channel('dd-trace:span:finish')
 const evalMetricAppendCh = channel('llmobs:eval-metric:append')
@@ -65,6 +62,13 @@ let unregisterTelemetryFlusher
 
 /** @type {import('../config/config-base')} */
 let globalTracerConfig
+
+/**
+ * @typedef {object} TraceTagInjection
+ * @property {import('../opentracing/span_context')} spanContext
+ * @property {Record<string, string | undefined>} [traceTagReplacements]
+ * @property {number} [optionalTraceTagCount]
+ */
 
 /**
  * @param {@type import('../config/config-base')} config
@@ -163,53 +167,10 @@ function retireWriters (retiredSpanWriter, retiredEvalWriter) {
   for (const writer of retiredWriters) writer.destroy(onWriterDestroyed)
 }
 
-/**
- * @param {Set<string> | undefined} replacementKeys
- * @param {string} key
- * @param {string} value
- * @returns {string}
- */
-function addTagReplacement (replacementKeys, key, value) {
-  replacementKeys?.add(key)
-  return `${key}=${value},`
-}
-
-/**
- * @param {string} tags
- * @param {number} firstKeyIndex
- * @param {Set<string>} replacementKeys
- * @param {string} replacementTags
- * @returns {string}
- */
-function replacePropagatedTags (tags, firstKeyIndex, replacementKeys, replacementTags) {
-  let entryStart = tags.lastIndexOf(',', firstKeyIndex) + 1
-  let replaced = tags.slice(0, entryStart === 0 ? 0 : entryStart - 1)
-  let hasEntry = entryStart !== 0
-
-  while (entryStart <= tags.length) {
-    let entryEnd = tags.indexOf(',', entryStart)
-    if (entryEnd === -1) entryEnd = tags.length
-
-    const separatorIndex = tags.indexOf('=', entryStart)
-    const key = separatorIndex !== -1 && separatorIndex < entryEnd
-      ? tags.slice(entryStart, separatorIndex)
-      : undefined
-
-    if (!replacementKeys.has(key)) {
-      replaced += `${hasEntry ? ',' : ''}${tags.slice(entryStart, entryEnd)}`
-      hasEntry = true
-    }
-
-    if (entryEnd === tags.length) break
-    entryStart = entryEnd + 1
-  }
-
-  return hasEntry ? `${replacementTags}${replaced}` : replacementTags.slice(0, -1)
-}
-
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propagate the parent id, mlApp, session id, and sampling rate/decision.
-function handleLLMObsInjection ({ carrier }) {
+/** @param {TraceTagInjection} injection */
+function handleLLMObsInjection (injection) {
   // Respect the standard propagator's gate: when trace tag propagation is
   // disabled, don't write `x-datadog-tags` for LLMObs either.
   if (globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH === 0) return
@@ -247,53 +208,30 @@ function handleLLMObsInjection ({ carrier }) {
     mlObsSpanTags, parent
   )
 
-  // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
-  // tags, so it may be undefined here — coalesce before appending.
-  const existing = readDatadogTags(carrier) || ''
-  const firstKeyIndex = existing.indexOf(PROPAGATED_LLMOBS_PREFIX)
-  const replacementKeys = firstKeyIndex === -1 ? undefined : new Set()
-  let replacementTags = ''
-  if (parentId) {
-    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_PARENT_ID_KEY, parentId)
-  }
-  if (mlApp) replacementTags += addTagReplacement(replacementKeys, PROPAGATED_ML_APP_KEY, mlApp)
-  if (sessionId) {
-    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_SESSION_ID_KEY, sessionId)
-  }
-  if (sampleRate != null) {
-    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_SAMPLE_RATE_KEY, sampleRate)
-  }
+  const traceTagReplacements = {}
+  if (parentId) traceTagReplacements[PROPAGATED_PARENT_ID_KEY] = parentId
+  if (mlApp) traceTagReplacements[PROPAGATED_ML_APP_KEY] = mlApp
+  if (sessionId) traceTagReplacements[PROPAGATED_SESSION_ID_KEY] = sessionId
+  if (sampleRate != null) traceTagReplacements[PROPAGATED_SAMPLE_RATE_KEY] = sampleRate.toString()
   if (samplingDecision != null) {
-    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_SAMPLING_DECISION_KEY, samplingDecision)
+    traceTagReplacements[PROPAGATED_SAMPLING_DECISION_KEY] = samplingDecision.toString()
   }
-  if (propagatedTraceId != null) {
-    replacementTags += addTagReplacement(replacementKeys, PROPAGATED_TRACE_ID_KEY, propagatedTraceId)
-  }
-  if (parentAgentSpanId && replacementKeys) {
-    // These entries are appended below after their wire and size constraints are applied.
-    replacementKeys.add(PROPAGATED_PARENT_AGENT_ID_KEY)
-    replacementKeys.add(PROPAGATED_PARENT_AGENT_NAME_KEY)
-  }
-  let tags
-  if (firstKeyIndex === -1) {
-    tags = existing ? `${replacementTags}${existing}` : replacementTags.slice(0, -1)
-  } else {
-    tags = replacePropagatedTags(existing, firstKeyIndex, replacementKeys, replacementTags)
+  if (propagatedTraceId != null) traceTagReplacements[PROPAGATED_TRACE_ID_KEY] = propagatedTraceId
+
+  let optionalTraceTagCount = 0
+  if (parentAgentSpanId) {
+    traceTagReplacements[PROPAGATED_PARENT_AGENT_ID_KEY] = parentAgentSpanId
+    optionalTraceTagCount++
+    if (parentAgentName && agentNameWireSafe(parentAgentName)) {
+      traceTagReplacements[PROPAGATED_PARENT_AGENT_NAME_KEY] = parentAgentName
+    } else {
+      traceTagReplacements[PROPAGATED_PARENT_AGENT_NAME_KEY] = undefined
+    }
+    optionalTraceTagCount++
   }
 
-  const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
-  const tagsWithId = appendOptionalPropagatedTag(
-    tags, PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId, null, maxLength
-  )
-  // Only append the name when the id fit: a name without an id is unresolvable by the backend.
-  if (tagsWithId === tags) {
-    tags = tagsWithId
-  } else {
-    tags = appendOptionalPropagatedTag(
-      tagsWithId, PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName, agentNameWireSafe, maxLength
-    )
-  }
-  if (tags !== existing) writeDatadogTags(carrier, tags)
+  injection.traceTagReplacements = traceTagReplacements
+  injection.optionalTraceTagCount = optionalTraceTagCount
 }
 
 /**

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -66,7 +66,7 @@ let globalTracerConfig
 /**
  * @typedef {object} TraceTagInjection
  * @property {import('../opentracing/span_context')} spanContext
- * @property {Record<string, string | undefined>} [traceTagReplacements]
+ * @property {Array<string | undefined>} [traceTagReplacements]
  * @property {number} [optionalTraceTagCount]
  */
 
@@ -208,24 +208,24 @@ function handleLLMObsInjection (injection) {
     mlObsSpanTags, parent
   )
 
-  const traceTagReplacements = {}
-  if (parentId) traceTagReplacements[PROPAGATED_PARENT_ID_KEY] = parentId
-  if (mlApp) traceTagReplacements[PROPAGATED_ML_APP_KEY] = mlApp
-  if (sessionId) traceTagReplacements[PROPAGATED_SESSION_ID_KEY] = sessionId
-  if (sampleRate != null) traceTagReplacements[PROPAGATED_SAMPLE_RATE_KEY] = sampleRate.toString()
+  const traceTagReplacements = []
+  if (parentId) traceTagReplacements.push(PROPAGATED_PARENT_ID_KEY, parentId)
+  if (mlApp) traceTagReplacements.push(PROPAGATED_ML_APP_KEY, mlApp)
+  if (sessionId) traceTagReplacements.push(PROPAGATED_SESSION_ID_KEY, sessionId)
+  if (sampleRate != null) traceTagReplacements.push(PROPAGATED_SAMPLE_RATE_KEY, sampleRate.toString())
   if (samplingDecision != null) {
-    traceTagReplacements[PROPAGATED_SAMPLING_DECISION_KEY] = samplingDecision.toString()
+    traceTagReplacements.push(PROPAGATED_SAMPLING_DECISION_KEY, samplingDecision.toString())
   }
-  if (propagatedTraceId != null) traceTagReplacements[PROPAGATED_TRACE_ID_KEY] = propagatedTraceId
+  if (propagatedTraceId != null) traceTagReplacements.push(PROPAGATED_TRACE_ID_KEY, propagatedTraceId)
 
   let optionalTraceTagCount = 0
   if (parentAgentSpanId) {
-    traceTagReplacements[PROPAGATED_PARENT_AGENT_ID_KEY] = parentAgentSpanId
+    traceTagReplacements.push(PROPAGATED_PARENT_AGENT_ID_KEY, parentAgentSpanId)
     optionalTraceTagCount++
     if (parentAgentName && agentNameWireSafe(parentAgentName)) {
-      traceTagReplacements[PROPAGATED_PARENT_AGENT_NAME_KEY] = parentAgentName
+      traceTagReplacements.push(PROPAGATED_PARENT_AGENT_NAME_KEY, parentAgentName)
     } else {
-      traceTagReplacements[PROPAGATED_PARENT_AGENT_NAME_KEY] = undefined
+      traceTagReplacements.push(PROPAGATED_PARENT_AGENT_NAME_KEY, undefined)
     }
     optionalTraceTagCount++
   }

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -35,6 +35,8 @@ const { setAgentStrategy } = require('./writers/util')
 const { INCOMPATIBLE_INITIALIZATION } = require('./constants/text')
 const { llmObsTraceIdToWire } = require('./util')
 
+const PROPAGATED_LLMOBS_PREFIX = '_dd.p.llmobs_'
+
 const spanFinishCh = channel('dd-trace:span:finish')
 const evalMetricAppendCh = channel('llmobs:eval-metric:append')
 const flushCh = channel('llmobs:writers:flush')
@@ -161,19 +163,50 @@ function retireWriters (retiredSpanWriter, retiredEvalWriter) {
   for (const writer of retiredWriters) writer.destroy(onWriterDestroyed)
 }
 
-function isReplacedKey (
-  key, parentId, mlApp, sessionId, sampleRate, samplingDecision, propagatedTraceId, parentAgentSpanId
-) {
-  if (parentId && key === PROPAGATED_PARENT_ID_KEY) return true
-  if (mlApp && key === PROPAGATED_ML_APP_KEY) return true
-  if (sessionId && key === PROPAGATED_SESSION_ID_KEY) return true
-  if (sampleRate != null && key === PROPAGATED_SAMPLE_RATE_KEY) return true
-  if (samplingDecision != null && key === PROPAGATED_SAMPLING_DECISION_KEY) return true
-  if (propagatedTraceId != null && key === PROPAGATED_TRACE_ID_KEY) return true
-  if (parentAgentSpanId && (key === PROPAGATED_PARENT_AGENT_ID_KEY || key === PROPAGATED_PARENT_AGENT_NAME_KEY)) {
-    return true
+/**
+ * @param {Set<string> | undefined} replacementKeys
+ * @param {string} replacementTags
+ * @param {string} key
+ * @param {string} value
+ * @returns {string}
+ */
+function addTagReplacement (replacementKeys, replacementTags, key, value) {
+  const replacement = `${key}=${value}`
+  replacementKeys?.add(key)
+  return `${replacementTags}${replacementTags ? ',' : ''}${replacement}`
+}
+
+/**
+ * @param {string} tags
+ * @param {number} firstKeyIndex
+ * @param {Set<string>} replacementKeys
+ * @param {string} replacementTags
+ * @returns {string}
+ */
+function replacePropagatedTags (tags, firstKeyIndex, replacementKeys, replacementTags) {
+  let entryStart = tags.lastIndexOf(',', firstKeyIndex) + 1
+  let replaced = tags.slice(0, entryStart === 0 ? 0 : entryStart - 1)
+  let hasEntry = entryStart !== 0
+
+  while (entryStart <= tags.length) {
+    let entryEnd = tags.indexOf(',', entryStart)
+    if (entryEnd === -1) entryEnd = tags.length
+
+    const separatorIndex = tags.indexOf('=', entryStart)
+    const key = separatorIndex !== -1 && separatorIndex < entryEnd
+      ? tags.slice(entryStart, separatorIndex)
+      : undefined
+
+    if (!replacementKeys.has(key)) {
+      replaced += `${hasEntry ? ',' : ''}${tags.slice(entryStart, entryEnd)}`
+      hasEntry = true
+    }
+
+    if (entryEnd === tags.length) break
+    entryStart = entryEnd + 1
   }
-  return false
+
+  return `${replaced}${hasEntry ? ',' : ''}${replacementTags}`
 }
 
 // since LLMObs traces can extend between services and be the same trace,
@@ -218,29 +251,38 @@ function handleLLMObsInjection ({ carrier }) {
 
   // `_injectTags` only writes `x-datadog-tags` when the trace has `_dd.p.*`
   // tags, so it may be undefined here — coalesce before appending.
-  const existing = readDatadogTags(carrier)
-  let tags = ''
-
-  if (existing) {
-    const entries = existing.split(',')
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i]
-      const separatorIndex = entry.indexOf('=')
-      const key = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex)
-      if (!isReplacedKey(
-        key, parentId, mlApp, sessionId, sampleRate, samplingDecision, propagatedTraceId, parentAgentSpanId
-      )) {
-        tags += `${tags ? ',' : ''}${entry}`
-      }
-    }
+  const existing = readDatadogTags(carrier) || ''
+  const firstKeyIndex = existing.indexOf(PROPAGATED_LLMOBS_PREFIX)
+  const replacementKeys = firstKeyIndex === -1 ? undefined : new Set()
+  let replacementTags = ''
+  if (parentId) {
+    replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_PARENT_ID_KEY, parentId)
   }
-
-  if (parentId) tags += `${tags ? ',' : ''}${PROPAGATED_PARENT_ID_KEY}=${parentId}`
-  if (mlApp) tags += `${tags ? ',' : ''}${PROPAGATED_ML_APP_KEY}=${mlApp}`
-  if (sessionId) tags += `${tags ? ',' : ''}${PROPAGATED_SESSION_ID_KEY}=${sessionId}`
-  if (sampleRate != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLE_RATE_KEY}=${sampleRate}`
-  if (samplingDecision != null) tags += `${tags ? ',' : ''}${PROPAGATED_SAMPLING_DECISION_KEY}=${samplingDecision}`
-  if (propagatedTraceId != null) tags += `${tags ? ',' : ''}${PROPAGATED_TRACE_ID_KEY}=${propagatedTraceId}`
+  if (mlApp) replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_ML_APP_KEY, mlApp)
+  if (sessionId) {
+    replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_SESSION_ID_KEY, sessionId)
+  }
+  if (sampleRate != null) {
+    replacementTags = addTagReplacement(replacementKeys, replacementTags, PROPAGATED_SAMPLE_RATE_KEY, sampleRate)
+  }
+  if (samplingDecision != null) {
+    replacementTags = addTagReplacement(
+      replacementKeys, replacementTags, PROPAGATED_SAMPLING_DECISION_KEY, samplingDecision
+    )
+  }
+  if (propagatedTraceId != null) {
+    replacementTags = addTagReplacement(
+      replacementKeys, replacementTags, PROPAGATED_TRACE_ID_KEY, propagatedTraceId
+    )
+  }
+  if (parentAgentSpanId && replacementKeys) {
+    // These entries are appended below after their wire and size constraints are applied.
+    replacementKeys.add(PROPAGATED_PARENT_AGENT_ID_KEY)
+    replacementKeys.add(PROPAGATED_PARENT_AGENT_NAME_KEY)
+  }
+  let tags = firstKeyIndex === -1
+    ? `${existing}${existing ? ',' : ''}${replacementTags}`
+    : replacePropagatedTags(existing, firstKeyIndex, replacementKeys, replacementTags)
 
   const maxLength = globalTracerConfig.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
   const tagsWithId = appendOptionalPropagatedTag(

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -337,25 +337,6 @@ function resolveAgentAttribution (tags, span) {
   return { name: tags[PARENT_AGENT_NAME], spanId: tags[PARENT_AGENT_SPAN_ID] }
 }
 
-/**
- * Appends `key=value` to the tagset string with a comma separator, but only when `value` is
- * truthy, passes the optional `safeguard` predicate, and fits within `maxTagSetLength`. Returns
- * the original `tags` unchanged when the value is absent, unsafe, or would overflow the budget.
- *
- * @param {string} tags - Existing tagset string (may be empty).
- * @param {string} key
- * @param {string | undefined} value
- * @param {((v: string) => boolean) | null} [safeguard]
- * @param {number} [maxTagSetLength]
- * @returns {string}
- */
-function appendOptionalPropagatedTag (tags, key, value, safeguard, maxTagSetLength) {
-  if (!value || (safeguard && !safeguard(value))) return tags
-  const entry = `${tags ? ',' : ''}${key}=${value}`
-  if (maxTagSetLength != null && tags.length + entry.length > maxTagSetLength) return tags
-  return `${tags}${entry}`
-}
-
 function spanHasError (span) {
   const spanContext = span.context()
   return !!(spanContext.getTag('error') || spanContext.getTag('error.type'))
@@ -506,7 +487,6 @@ function formatAudioPart (data, mimeType) {
 
 module.exports = {
   agentNameWireSafe,
-  appendOptionalPropagatedTag,
   audioMimeTypeFromFormat,
   encodeUnicode,
   findGenAIAncestorSpanId,

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -338,18 +338,6 @@ function resolveAgentAttribution (tags, span) {
 }
 
 /**
- * Removes all `key=value` entries for the given key from a comma-separated tagset string.
- *
- * @param {string} tags - Existing tagset string (may be empty).
- * @param {string} key
- * @returns {string}
- */
-function stripTagsetEntry (tags, key) {
-  if (!tags.includes(key)) return tags
-  return tags.split(',').filter(entry => !entry.startsWith(`${key}=`)).join(',')
-}
-
-/**
  * Appends `key=value` to the tagset string with a comma separator, but only when `value` is
  * truthy, passes the optional `safeguard` predicate, and fits within `maxTagSetLength`. Returns
  * the original `tags` unchanged when the value is absent, unsafe, or would overflow the budget.
@@ -527,7 +515,6 @@ module.exports = {
   normalizeLlmObsTraceId,
   formatAudioPart,
   resolveAgentAttribution,
-  stripTagsetEntry,
   validateCostTags,
   validateKind,
   getFunctionArguments,

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -314,18 +314,31 @@ class TextMapPropagator {
 
     const injectTraceContext = this.#config.apmTracingEnabled !== false ||
       hasTraceSourcePropagationTag(spanContext._trace.tags)
+    let traceTagReplacements
+    let optionalTraceTagCount = 0
+    if (injectTraceContext && injectCh.hasSubscribers && (
+      this.#hasPropagationStyle('inject', 'datadog') || this.#hasPropagationStyle('inject', 'tracecontext')
+    )) {
+      const injection = { spanContext }
+      injectCh.publish(injection)
+      traceTagReplacements = injection.traceTagReplacements
+      optionalTraceTagCount = injection.optionalTraceTagCount ?? 0
+    }
     if (injectTraceContext) {
-      injectedCarrier = this.#injectDatadog(spanContext, injectedCarrier ?? carrier) ?? injectedCarrier
+      injectedCarrier = this.#injectDatadog(
+        spanContext, injectedCarrier ?? carrier, traceTagReplacements, optionalTraceTagCount
+      ) ?? injectedCarrier
       injectedCarrier = this.#injectB3MultipleHeaders(spanContext, injectedCarrier ?? carrier) ?? injectedCarrier
       injectedCarrier = this.#injectB3SingleHeader(spanContext, injectedCarrier ?? carrier) ?? injectedCarrier
     }
     injectedCarrier = this
-      .#injectTraceparent(spanContext, injectedCarrier ?? carrier, injectTraceContext) ?? injectedCarrier
+      .#injectTraceparent(
+        spanContext, injectedCarrier ?? carrier, injectTraceContext, traceTagReplacements
+      ) ?? injectedCarrier
 
     if (injectedCarrier === undefined) return
 
     carrier = injectedCarrier
-    if (injectCh.hasSubscribers) injectCh.publish({ spanContext, carrier })
 
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Inject into carrier: ${JSON.stringify(pickTextMap(carrier))}.`)
@@ -359,9 +372,11 @@ class TextMapPropagator {
   /**
    * @param {DatadogSpanContext} spanContext
    * @param {Record<string, string>} [carrier]
+   * @param {Record<string, string | undefined>} [traceTagReplacements]
+   * @param {number} optionalTraceTagCount
    * @returns {Record<string, string> | undefined}
    */
-  #injectDatadog (spanContext, carrier) {
+  #injectDatadog (spanContext, carrier, traceTagReplacements, optionalTraceTagCount) {
     if (!this.#hasPropagationStyle('inject', 'datadog')) return
 
     carrier ??= {}
@@ -374,7 +389,7 @@ class TextMapPropagator {
     const priority = spanContext._sampling.priority
     if (Number.isInteger(priority)) writeDatadogSamplingPriority(carrier, priority.toString())
 
-    this.#injectTags(spanContext, carrier)
+    this.#injectTags(carrier, spanContext._trace.tags, traceTagReplacements, optionalTraceTagCount)
 
     return carrier
   }
@@ -449,23 +464,26 @@ class TextMapPropagator {
   }
 
   /**
-   * @param {DatadogSpanContext} spanContext
    * @param {Record<string, string>} carrier
+   * @param {Record<string, string>} traceTags
+   * @param {Record<string, string | undefined>} [traceTagReplacements]
+   * @param {number} optionalTraceTagCount
    * @returns {void}
    */
-  #injectTags (spanContext, carrier) {
-    const trace = spanContext._trace
-
+  #injectTags (carrier, traceTags, traceTagReplacements, optionalTraceTagCount) {
     if (this.#config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH === 0) {
       log.debug('Trace tag propagation is disabled, skipping injection.')
       return
     }
 
+    const maxLength = this.#config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
     let header = ''
 
-    for (const key of Object.keys(trace.tags)) {
-      const value = trace.tags[key]
-      if (!value || !key.startsWith('_dd.p.')) continue
+    for (const key of Object.keys(traceTags)) {
+      const value = traceTags[key]
+      if (!value || !key.startsWith('_dd.p.') || traceTagReplacements && Object.hasOwn(traceTagReplacements, key)) {
+        continue
+      }
       if (!tagKeyExpr.test(key) || !tagValueExpr.test(value)) {
         log.error('Trace tags from span are invalid, skipping injection.')
         return
@@ -475,7 +493,25 @@ class TextMapPropagator {
       header += `${key}=${value}`
     }
 
-    if (header.length > this.#config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH) {
+    if (traceTagReplacements) {
+      const keys = Object.keys(traceTagReplacements)
+      const requiredTagCount = keys.length - optionalTraceTagCount
+      for (let index = 0; index < keys.length; index++) {
+        const key = keys[index]
+        const value = traceTagReplacements[key]
+        if (!value || !key.startsWith('_dd.p.')) continue
+        if (!tagKeyExpr.test(key) || !tagValueExpr.test(value)) {
+          log.error('Trace tags from span are invalid, skipping injection.')
+          return
+        }
+
+        const entry = `${header ? ',' : ''}${key}=${value}`
+        if (index >= requiredTagCount && header.length + entry.length > maxLength) break
+        header += entry
+      }
+    }
+
+    if (header.length > maxLength) {
       log.error('Trace tags from span are too large, skipping injection.')
     } else if (header) {
       writeDatadogTags(carrier, header)
@@ -538,9 +574,10 @@ class TextMapPropagator {
    * @param {DatadogSpanContext} spanContext
    * @param {Record<string, string> | undefined} carrier
    * @param {boolean} injectTraceContext
+   * @param {Record<string, string | undefined>} [traceTagReplacements]
    * @returns {Record<string, string> | undefined}
    */
-  #injectTraceparent (spanContext, carrier, injectTraceContext) {
+  #injectTraceparent (spanContext, carrier, injectTraceContext, traceTagReplacements) {
     if (!this.#hasPropagationStyle('inject', 'tracecontext')) return
 
     if (!injectTraceContext) {
@@ -556,9 +593,12 @@ class TextMapPropagator {
     carrier ??= {}
     const {
       _sampling: { priority, mechanism },
-      _tracestate: ts = new TraceState(),
-      _trace: { origin, tags: traceTags },
+      _tracestate,
+      _trace: { origin },
     } = spanContext
+    const ts = traceTagReplacements
+      ? TraceState.fromString(_tracestate?.toString())
+      : _tracestate ?? new TraceState()
 
     writeTraceparent(carrier, spanContext.toTraceparent())
 
@@ -584,8 +624,9 @@ class TextMapPropagator {
         state.set('o', originValue)
       }
 
-      for (const key of Object.keys(traceTags)) {
-        const tagValueRaw = traceTags[key]
+      for (const key of Object.keys(spanContext._trace.tags)) {
+        if (traceTagReplacements && Object.hasOwn(traceTagReplacements, key)) continue
+        const tagValueRaw = spanContext._trace.tags[key]
         if (!tagValueRaw || !key.startsWith('_dd.p.')) continue
 
         const tagKey = 't.' + key.slice(6)
@@ -597,6 +638,27 @@ class TextMapPropagator {
           .replaceAll('=', '~')
 
         state.set(tagKey, tagValue)
+      }
+
+      if (traceTagReplacements) {
+        for (const key of Object.keys(traceTagReplacements)) {
+          if (!key.startsWith('_dd.p.')) continue
+
+          const tagKey = 't.' + key.slice(6)
+            .replaceAll(tracestateTagKeyFilter, '_')
+          const tagValueRaw = traceTagReplacements[key]
+          if (!tagValueRaw) {
+            state.delete(tagKey)
+            continue
+          }
+
+          const tagValue = tagValueRaw
+            .toString()
+            .replaceAll(tracestateTagValueFilter, '_')
+            .replaceAll('=', '~')
+
+          state.set(tagKey, tagValue)
+        }
       }
     })
 

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -86,6 +86,18 @@ const percentByte = /%([0-9A-Fa-f]{2})/g
  */
 
 /**
+ * @param {Array<string | undefined>} traceTagReplacements
+ * @param {string} key
+ * @returns {boolean}
+ */
+function hasTraceTagReplacement (traceTagReplacements, key) {
+  for (let index = 0; index < traceTagReplacements.length; index += 2) {
+    if (traceTagReplacements[index] === key) return true
+  }
+  return false
+}
+
+/**
  * @param {string | undefined} traceId
  * @param {string | undefined} spanId
  * @param {number} radix
@@ -372,7 +384,7 @@ class TextMapPropagator {
   /**
    * @param {DatadogSpanContext} spanContext
    * @param {Record<string, string>} [carrier]
-   * @param {Record<string, string | undefined>} [traceTagReplacements]
+   * @param {Array<string | undefined>} [traceTagReplacements]
    * @param {number} optionalTraceTagCount
    * @returns {Record<string, string> | undefined}
    */
@@ -466,7 +478,7 @@ class TextMapPropagator {
   /**
    * @param {Record<string, string>} carrier
    * @param {Record<string, string>} traceTags
-   * @param {Record<string, string | undefined>} [traceTagReplacements]
+   * @param {Array<string | undefined>} [traceTagReplacements]
    * @param {number} optionalTraceTagCount
    * @returns {void}
    */
@@ -481,7 +493,8 @@ class TextMapPropagator {
 
     for (const key of Object.keys(traceTags)) {
       const value = traceTags[key]
-      if (!value || !key.startsWith('_dd.p.') || traceTagReplacements && Object.hasOwn(traceTagReplacements, key)) {
+      if (!value || !key.startsWith('_dd.p.') ||
+        traceTagReplacements && hasTraceTagReplacement(traceTagReplacements, key)) {
         continue
       }
       if (!tagKeyExpr.test(key) || !tagValueExpr.test(value)) {
@@ -494,11 +507,10 @@ class TextMapPropagator {
     }
 
     if (traceTagReplacements) {
-      const keys = Object.keys(traceTagReplacements)
-      const requiredTagCount = keys.length - optionalTraceTagCount
-      for (let index = 0; index < keys.length; index++) {
-        const key = keys[index]
-        const value = traceTagReplacements[key]
+      const requiredEntryCount = traceTagReplacements.length - optionalTraceTagCount * 2
+      for (let index = 0; index < traceTagReplacements.length; index += 2) {
+        const key = traceTagReplacements[index]
+        const value = traceTagReplacements[index + 1]
         if (!value || !key.startsWith('_dd.p.')) continue
         if (!tagKeyExpr.test(key) || !tagValueExpr.test(value)) {
           log.error('Trace tags from span are invalid, skipping injection.')
@@ -506,7 +518,7 @@ class TextMapPropagator {
         }
 
         const entry = `${header ? ',' : ''}${key}=${value}`
-        if (index >= requiredTagCount && header.length + entry.length > maxLength) break
+        if (index >= requiredEntryCount && header.length + entry.length > maxLength) break
         header += entry
       }
     }
@@ -574,7 +586,7 @@ class TextMapPropagator {
    * @param {DatadogSpanContext} spanContext
    * @param {Record<string, string> | undefined} carrier
    * @param {boolean} injectTraceContext
-   * @param {Record<string, string | undefined>} [traceTagReplacements]
+   * @param {Array<string | undefined>} [traceTagReplacements]
    * @returns {Record<string, string> | undefined}
    */
   #injectTraceparent (spanContext, carrier, injectTraceContext, traceTagReplacements) {
@@ -625,7 +637,7 @@ class TextMapPropagator {
       }
 
       for (const key of Object.keys(spanContext._trace.tags)) {
-        if (traceTagReplacements && Object.hasOwn(traceTagReplacements, key)) continue
+        if (traceTagReplacements && hasTraceTagReplacement(traceTagReplacements, key)) continue
         const tagValueRaw = spanContext._trace.tags[key]
         if (!tagValueRaw || !key.startsWith('_dd.p.')) continue
 
@@ -641,12 +653,13 @@ class TextMapPropagator {
       }
 
       if (traceTagReplacements) {
-        for (const key of Object.keys(traceTagReplacements)) {
+        for (let index = 0; index < traceTagReplacements.length; index += 2) {
+          const key = traceTagReplacements[index]
           if (!key.startsWith('_dd.p.')) continue
 
           const tagKey = 't.' + key.slice(6)
             .replaceAll(tracestateTagKeyFilter, '_')
-          const tagValueRaw = traceTagReplacements[key]
+          const tagValueRaw = traceTagReplacements[index + 1]
           if (!tagValueRaw) {
             state.delete(tagKey)
             continue

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -309,6 +309,124 @@ describe('module', () => {
       )
     })
 
+    it('does not duplicate _dd.p.llmobs_ml_app when already present in x-datadog-tags', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+
+      const carrier = {
+        'x-datadog-tags': '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test',
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test'
+      )
+    })
+
+    it('preserves non-replaced LLMObs keys from upstream carrier', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+
+      const carrier = {
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_sid=retained-session',
+        ].join(','),
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_sid=retained-session',
+          '_dd.p.llmobs_ml_app=test',
+        ].join(',')
+      )
+    })
+
+    it('updates existing LLMObs tags in x-datadog-tags without duplicating keys', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+      store.span = {
+        context () {
+          return {
+            toSpanId () {
+              return 'new-parent-id'
+            },
+          }
+        },
+      }
+      LLMObsTagger.tagMap.set(store.span, {
+        [SESSION_ID]: 'new-session',
+        [SAMPLE_RATE]: '0.8',
+        [SAMPLING_DECISION]: '1',
+      })
+
+      const carrier = {
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.llmobs_parent_id=old-id',
+          '_dd.p.llmobs_ml_app=old-app',
+          '_dd.p.llmobs_sid=old-session',
+        ].join(','),
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.llmobs_parent_id=new-parent-id',
+          '_dd.p.llmobs_ml_app=test',
+          '_dd.p.llmobs_sid=new-session',
+          '_dd.p.llmobs_sr=0.8',
+          '_dd.p.llmobs_sd=1',
+        ].join(',')
+      )
+    })
+
+    it('prevents duplicate tags through the full extraction -> standard propagation -> injection path (#9714)', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'downstream-app', agentlessEnabled: false } })
+
+      const TextMapPropagator = require('../../src/opentracing/propagation/text_map')
+      const config = getConfigFresh({ llmobs: { mlApp: 'downstream-app', agentlessEnabled: false } })
+      const propagator = new TextMapPropagator(config)
+
+      const inboundCarrier = {
+        'x-datadog-trace-id': '1234567890',
+        'x-datadog-parent-id': '9876543210',
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_ml_app=upstream-app',
+          '_dd.p.llmobs_sid=upstream-session',
+        ].join(','),
+      }
+
+      const spanContext = propagator.extract(inboundCarrier)
+      assert.ok(spanContext)
+      assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_ml_app'], 'upstream-app')
+      assert.strictEqual(spanContext._trace.tags['_dd.p.llmobs_sid'], 'upstream-session')
+
+      const outboundCarrier = {}
+      propagator.inject(spanContext, outboundCarrier)
+
+      const tags = outboundCarrier['x-datadog-tags']
+      assert.ok(tags)
+
+      const mlAppEntries = tags.split(',').filter(entry => entry.startsWith('_dd.p.llmobs_ml_app='))
+      assert.strictEqual(mlAppEntries.length, 1, `Expected exactly one _dd.p.llmobs_ml_app entry in: ${tags}`)
+      assert.strictEqual(mlAppEntries[0], '_dd.p.llmobs_ml_app=downstream-app')
+
+      const sidEntries = tags.split(',').filter(entry => entry.startsWith('_dd.p.llmobs_sid='))
+      assert.strictEqual(sidEntries.length, 1, `Expected exactly one _dd.p.llmobs_sid entry in: ${tags}`)
+      assert.strictEqual(sidEntries[0], '_dd.p.llmobs_sid=upstream-session')
+
+      assert.ok(tags.includes('_dd.p.tid=69fe014200000000'))
+      assert.ok(tags.includes('_dd.p.dm=-0'))
+    })
+
     describe('with DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH=0', () => {
       let config
 

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -10,6 +10,7 @@ const sinon = require('sinon')
 const { DD_MAJOR } = require('../../../../version')
 const { INCOMPATIBLE_INITIALIZATION } = require('../../src/llmobs/constants/text')
 const LLMObsTagger = require('../../src/llmobs/tagger')
+const TextMapPropagator = require('../../src/opentracing/propagation/text_map')
 const {
   PARENT_AGENT_NAME,
   PARENT_AGENT_SPAN_ID,
@@ -57,6 +58,24 @@ describe('module', () => {
     )
     proxyquire.preserveCache()
     loadLlmobsModule()
+  }
+
+  /**
+   * @param {Record<string, string>} carrier
+   * @param {string} [propagatedTags]
+   * @param {import('../../src/config/config-base')} [config]
+   */
+  function inject (carrier, propagatedTags, config = getConfigFresh()) {
+    const propagator = new TextMapPropagator(config)
+    const inboundCarrier = {
+      'x-datadog-trace-id': '1234567890',
+      'x-datadog-parent-id': '9876543210',
+    }
+    if (propagatedTags !== undefined) inboundCarrier['x-datadog-tags'] = propagatedTags
+
+    const spanContext = propagator.extract(inboundCarrier)
+    assert.ok(spanContext)
+    propagator.inject(spanContext, carrier)
   }
 
   beforeEach(() => {
@@ -141,7 +160,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test')
     })
@@ -161,7 +180,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '_dd.p.llmobs_parent_id=old-parent-id',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_parent_id=new-parent-id')
     })
@@ -185,7 +204,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
@@ -211,7 +230,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
@@ -235,7 +254,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
@@ -258,7 +277,7 @@ describe('module', () => {
       })
 
       const carrier = { 'x-datadog-tags': '' }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
@@ -280,7 +299,7 @@ describe('module', () => {
       }
 
       const carrier = { 'x-datadog-tags': '' }
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
@@ -294,7 +313,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
       assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_ml_app=test')
     })
 
@@ -304,7 +323,7 @@ describe('module', () => {
       const carrier = {
         'x-datadog-tags': '',
       }
-      injectCh.publish({ carrier })
+      inject(carrier)
       assert.strictEqual(carrier['x-datadog-tags'], '')
     })
 
@@ -312,63 +331,59 @@ describe('module', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
       const carrier = {}
-      injectCh.publish({ carrier })
+      inject(carrier)
 
       assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_ml_app=test')
     })
 
-    it('appends existing non-empty x-datadog-tags with a single comma separator', () => {
+    it('merges LLMObs tags with propagated trace tags before serialization', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
-      const carrier = {
-        'x-datadog-tags': '_dd.p.tid=69fe014200000000,_dd.p.dm=-0',
-      }
-      injectCh.publish({ carrier })
+      const carrier = {}
+      inject(carrier, '_dd.p.tid=69fe014200000000,_dd.p.dm=-0')
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
-        '_dd.p.llmobs_ml_app=test,_dd.p.tid=69fe014200000000,_dd.p.dm=-0'
+        '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test'
       )
     })
 
     it('does not duplicate _dd.p.llmobs_ml_app when already present in x-datadog-tags', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
-      const carrier = {
-        'x-datadog-tags': [
-          '_dd.p.tid=69fe014200000000',
-          '_dd.p.dm=-0',
-          '_dd.p.llmobs_ml_app=old-app',
-          '_dd.p.llmobs_ml_app=older-app',
-        ].join(','),
-      }
-      injectCh.publish({ carrier })
+      const propagatedTags = [
+        '_dd.p.tid=69fe014200000000',
+        '_dd.p.dm=-0',
+        '_dd.p.llmobs_ml_app=old-app',
+        '_dd.p.llmobs_ml_app=older-app',
+      ].join(',')
+      const carrier = {}
+      inject(carrier, propagatedTags)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
-        '_dd.p.llmobs_ml_app=test,_dd.p.tid=69fe014200000000,_dd.p.dm=-0'
+        '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test'
       )
     })
 
     it('preserves non-replaced LLMObs keys from upstream carrier', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
-      const carrier = {
-        'x-datadog-tags': [
-          '_dd.p.llmobs_sid=retained-session',
-          '_dd.p.tid=69fe014200000000',
-          '_dd.p.dm=-0',
-        ].join(','),
-      }
-      injectCh.publish({ carrier })
+      const propagatedTags = [
+        '_dd.p.llmobs_sid=retained-session',
+        '_dd.p.tid=69fe014200000000',
+        '_dd.p.dm=-0',
+      ].join(',')
+      const carrier = {}
+      inject(carrier, propagatedTags)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
         [
-          '_dd.p.llmobs_ml_app=test',
           '_dd.p.llmobs_sid=retained-session',
           '_dd.p.tid=69fe014200000000',
           '_dd.p.dm=-0',
+          '_dd.p.llmobs_ml_app=test',
         ].join(',')
       )
     })
@@ -376,14 +391,13 @@ describe('module', () => {
     it('preserves an LLMObs prefix inside another tag value', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
-      const carrier = {
-        'x-datadog-tags': '_dd.p.other=value_dd.p.llmobs_inside,_dd.p.llmobs_ml_app=old-app',
-      }
-      injectCh.publish({ carrier })
+      const propagatedTags = '_dd.p.other=value_dd.p.llmobs_inside,_dd.p.llmobs_ml_app=old-app'
+      const carrier = {}
+      inject(carrier, propagatedTags)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
-        '_dd.p.llmobs_ml_app=test,_dd.p.other=value_dd.p.llmobs_inside'
+        '_dd.p.other=value_dd.p.llmobs_inside,_dd.p.llmobs_ml_app=test'
       )
     })
 
@@ -407,33 +421,30 @@ describe('module', () => {
         [SAMPLING_DECISION]: '1',
       })
 
-      const carrier = {
-        'x-datadog-tags': [
-          '_dd.p.llmobs_parent_id=old-id',
-          '_dd.p.tid=69fe014200000000',
-          '_dd.p.llmobs_ml_app=old-app',
-          '_dd.p.llmobs_sid=old-session',
-          '_dd.p.llmobs_sr=0.1',
-          '_dd.p.llmobs_sd=0',
-          '_dd.p.llmobs_trace_id=old-trace-id',
-          '_dd.p.llmobs_pagent_span_id=old-agent-id',
-          '_dd.p.llmobs_pagent_name=old-agent',
-          'malformed',
-        ].join(','),
-      }
-      injectCh.publish({ carrier })
+      const propagatedTags = [
+        '_dd.p.llmobs_parent_id=old-id',
+        '_dd.p.tid=69fe014200000000',
+        '_dd.p.llmobs_ml_app=old-app',
+        '_dd.p.llmobs_sid=old-session',
+        '_dd.p.llmobs_sr=0.1',
+        '_dd.p.llmobs_sd=0',
+        '_dd.p.llmobs_trace_id=old-trace-id',
+        '_dd.p.llmobs_pagent_span_id=old-agent-id',
+        '_dd.p.llmobs_pagent_name=old-agent',
+      ].join(',')
+      const carrier = {}
+      inject(carrier, propagatedTags)
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
         [
+          '_dd.p.tid=69fe014200000000',
           '_dd.p.llmobs_parent_id=new-parent-id',
           '_dd.p.llmobs_ml_app=test',
           '_dd.p.llmobs_sid=new-session',
           '_dd.p.llmobs_sr=0.8',
           '_dd.p.llmobs_sd=1',
           '_dd.p.llmobs_trace_id=12345678901234567890123456789012',
-          '_dd.p.tid=69fe014200000000',
-          'malformed',
           '_dd.p.llmobs_pagent_span_id=new-agent-id',
           '_dd.p.llmobs_pagent_name=new-agent',
         ].join(',')
@@ -494,7 +505,7 @@ describe('module', () => {
         llmobsModule.enable(config)
 
         const carrier = {}
-        injectCh.publish({ carrier })
+        inject(carrier, undefined, config)
 
         assert.ok(!('x-datadog-tags' in carrier))
       })

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -317,7 +317,7 @@ describe('module', () => {
       assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_ml_app=test')
     })
 
-    it('appends to an existing non-empty x-datadog-tags with a single comma separator', () => {
+    it('appends existing non-empty x-datadog-tags with a single comma separator', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
       const carrier = {
@@ -327,7 +327,7 @@ describe('module', () => {
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
-        '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test'
+        '_dd.p.llmobs_ml_app=test,_dd.p.tid=69fe014200000000,_dd.p.dm=-0'
       )
     })
 
@@ -346,7 +346,7 @@ describe('module', () => {
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
-        '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test'
+        '_dd.p.llmobs_ml_app=test,_dd.p.tid=69fe014200000000,_dd.p.dm=-0'
       )
     })
 
@@ -365,10 +365,10 @@ describe('module', () => {
       assert.strictEqual(
         carrier['x-datadog-tags'],
         [
+          '_dd.p.llmobs_ml_app=test',
           '_dd.p.llmobs_sid=retained-session',
           '_dd.p.tid=69fe014200000000',
           '_dd.p.dm=-0',
-          '_dd.p.llmobs_ml_app=test',
         ].join(',')
       )
     })
@@ -383,7 +383,7 @@ describe('module', () => {
 
       assert.strictEqual(
         carrier['x-datadog-tags'],
-        '_dd.p.other=value_dd.p.llmobs_inside,_dd.p.llmobs_ml_app=test'
+        '_dd.p.llmobs_ml_app=test,_dd.p.other=value_dd.p.llmobs_inside'
       )
     })
 
@@ -426,14 +426,14 @@ describe('module', () => {
       assert.strictEqual(
         carrier['x-datadog-tags'],
         [
-          '_dd.p.tid=69fe014200000000',
-          'malformed',
           '_dd.p.llmobs_parent_id=new-parent-id',
           '_dd.p.llmobs_ml_app=test',
           '_dd.p.llmobs_sid=new-session',
           '_dd.p.llmobs_sr=0.8',
           '_dd.p.llmobs_sd=1',
           '_dd.p.llmobs_trace_id=12345678901234567890123456789012',
+          '_dd.p.tid=69fe014200000000',
+          'malformed',
           '_dd.p.llmobs_pagent_span_id=new-agent-id',
           '_dd.p.llmobs_pagent_name=new-agent',
         ].join(',')

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -11,6 +11,8 @@ const { DD_MAJOR } = require('../../../../version')
 const { INCOMPATIBLE_INITIALIZATION } = require('../../src/llmobs/constants/text')
 const LLMObsTagger = require('../../src/llmobs/tagger')
 const {
+  PARENT_AGENT_NAME,
+  PARENT_AGENT_SPAN_ID,
   PROPAGATED_TRACE_ID_KEY,
   SAMPLE_RATE,
   SAMPLING_DECISION,
@@ -142,6 +144,26 @@ describe('module', () => {
       injectCh.publish({ carrier })
 
       assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test')
+    })
+
+    it('replaces the parent ID without an mlApp configured', () => {
+      llmobsModule.enable({ llmobs: { agentlessEnabled: false } })
+      store.span = {
+        context () {
+          return {
+            toSpanId () {
+              return 'new-parent-id'
+            },
+          }
+        },
+      }
+
+      const carrier = {
+        'x-datadog-tags': '_dd.p.llmobs_parent_id=old-parent-id',
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.llmobs_parent_id=new-parent-id')
     })
 
     it('injects the sampling rate and decision from the parent LLMObs span', () => {
@@ -313,7 +335,12 @@ describe('module', () => {
       llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
 
       const carrier = {
-        'x-datadog-tags': '_dd.p.tid=69fe014200000000,_dd.p.dm=-0,_dd.p.llmobs_ml_app=test',
+        'x-datadog-tags': [
+          '_dd.p.tid=69fe014200000000',
+          '_dd.p.dm=-0',
+          '_dd.p.llmobs_ml_app=old-app',
+          '_dd.p.llmobs_ml_app=older-app',
+        ].join(','),
       }
       injectCh.publish({ carrier })
 
@@ -328,9 +355,9 @@ describe('module', () => {
 
       const carrier = {
         'x-datadog-tags': [
+          '_dd.p.llmobs_sid=retained-session',
           '_dd.p.tid=69fe014200000000',
           '_dd.p.dm=-0',
-          '_dd.p.llmobs_sid=retained-session',
         ].join(','),
       }
       injectCh.publish({ carrier })
@@ -338,11 +365,25 @@ describe('module', () => {
       assert.strictEqual(
         carrier['x-datadog-tags'],
         [
+          '_dd.p.llmobs_sid=retained-session',
           '_dd.p.tid=69fe014200000000',
           '_dd.p.dm=-0',
-          '_dd.p.llmobs_sid=retained-session',
           '_dd.p.llmobs_ml_app=test',
         ].join(',')
+      )
+    })
+
+    it('preserves an LLMObs prefix inside another tag value', () => {
+      llmobsModule.enable({ llmobs: { mlApp: 'test', agentlessEnabled: false } })
+
+      const carrier = {
+        'x-datadog-tags': '_dd.p.other=value_dd.p.llmobs_inside,_dd.p.llmobs_ml_app=old-app',
+      }
+      injectCh.publish({ carrier })
+
+      assert.strictEqual(
+        carrier['x-datadog-tags'],
+        '_dd.p.other=value_dd.p.llmobs_inside,_dd.p.llmobs_ml_app=test'
       )
     })
 
@@ -351,6 +392,7 @@ describe('module', () => {
       store.span = {
         context () {
           return {
+            _trace: { tags: { [PROPAGATED_TRACE_ID_KEY]: '12345678901234567890123456789012' } },
             toSpanId () {
               return 'new-parent-id'
             },
@@ -358,6 +400,8 @@ describe('module', () => {
         },
       }
       LLMObsTagger.tagMap.set(store.span, {
+        [PARENT_AGENT_NAME]: 'new-agent',
+        [PARENT_AGENT_SPAN_ID]: 'new-agent-id',
         [SESSION_ID]: 'new-session',
         [SAMPLE_RATE]: '0.8',
         [SAMPLING_DECISION]: '1',
@@ -365,10 +409,16 @@ describe('module', () => {
 
       const carrier = {
         'x-datadog-tags': [
-          '_dd.p.tid=69fe014200000000',
           '_dd.p.llmobs_parent_id=old-id',
+          '_dd.p.tid=69fe014200000000',
           '_dd.p.llmobs_ml_app=old-app',
           '_dd.p.llmobs_sid=old-session',
+          '_dd.p.llmobs_sr=0.1',
+          '_dd.p.llmobs_sd=0',
+          '_dd.p.llmobs_trace_id=old-trace-id',
+          '_dd.p.llmobs_pagent_span_id=old-agent-id',
+          '_dd.p.llmobs_pagent_name=old-agent',
+          'malformed',
         ].join(','),
       }
       injectCh.publish({ carrier })
@@ -377,11 +427,15 @@ describe('module', () => {
         carrier['x-datadog-tags'],
         [
           '_dd.p.tid=69fe014200000000',
+          'malformed',
           '_dd.p.llmobs_parent_id=new-parent-id',
           '_dd.p.llmobs_ml_app=test',
           '_dd.p.llmobs_sid=new-session',
           '_dd.p.llmobs_sr=0.8',
           '_dd.p.llmobs_sd=1',
+          '_dd.p.llmobs_trace_id=12345678901234567890123456789012',
+          '_dd.p.llmobs_pagent_span_id=new-agent-id',
+          '_dd.p.llmobs_pagent_name=new-agent',
         ].join(',')
       )
     })

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -3,7 +3,6 @@
 const assert = require('node:assert')
 const { inspect } = require('node:util')
 
-const { channel } = require('dc-polyfill')
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
@@ -16,8 +15,6 @@ const { getConfigFresh } = require('../../helpers/config')
 const tracerVersion = require('../../../../../package.json').version
 const { removeDestroyHandler } = require('../util')
 const { assertObjectContains } = require('../../../../../integration-tests/helpers')
-
-const injectCh = channel('dd-trace:span:inject')
 
 describe('sdk', () => {
   let LLMObsSDK
@@ -2416,15 +2413,17 @@ describe('sdk', () => {
         parentId = span.context().toSpanId()
         traceId = LLMObsTagger.tagMap.get(span)['_ml_obs.trace_id']
 
-        // simulate injection from http integration or from tracer
-        // something that triggers the text_map injection
-        injectCh.publish({ carrier })
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const wireTraceId = BigInt(`0x${traceId}`).toString(10)
+      const propagatedLlmobsTags = []
+      for (const tag of carrier['x-datadog-tags'].split(',')) {
+        if (tag.startsWith('_dd.p.llmobs_')) propagatedLlmobsTags.push(tag)
+      }
 
       assert.strictEqual(
-        carrier['x-datadog-tags'],
+        propagatedLlmobsTags.join(','),
         // eslint-disable-next-line @stylistic/max-len
         `_dd.p.llmobs_parent_id=${parentId},_dd.p.llmobs_ml_app=mlApp,_dd.p.llmobs_sr=1,_dd.p.llmobs_sd=1,_dd.p.llmobs_trace_id=${wireTraceId}`
       )
@@ -2435,7 +2434,7 @@ describe('sdk', () => {
       let agentId
       llmobs.trace({ kind: 'agent', name: 'my_agent' }, span => {
         agentId = span.context().toSpanId()
-        injectCh.publish({ carrier })
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const tags = carrier['x-datadog-tags']
@@ -2448,8 +2447,8 @@ describe('sdk', () => {
       let agentId
       llmobs.trace({ kind: 'agent', name: 'my_agent' }, span => {
         agentId = span.context().toSpanId()
-        llmobs.trace({ kind: 'tool', name: 'my_tool' }, () => {
-          injectCh.publish({ carrier })
+        llmobs.trace({ kind: 'tool', name: 'my_tool' }, toolSpan => {
+          tracer.inject(toolSpan, 'text_map', carrier)
         })
       })
 
@@ -2460,8 +2459,8 @@ describe('sdk', () => {
 
     it('does not propagate agent attribution when there is no agent in the chain', () => {
       const carrier = { 'x-datadog-tags': '' }
-      llmobs.trace({ kind: 'workflow', name: 'my_workflow' }, () => {
-        injectCh.publish({ carrier })
+      llmobs.trace({ kind: 'workflow', name: 'my_workflow' }, span => {
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const tags = carrier['x-datadog-tags']
@@ -2474,7 +2473,7 @@ describe('sdk', () => {
       let agentId
       llmobs.trace({ kind: 'agent', name: 'Researcher, v2' }, span => {
         agentId = span.context().toSpanId()
-        injectCh.publish({ carrier })
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const tags = carrier['x-datadog-tags']
@@ -2484,8 +2483,8 @@ describe('sdk', () => {
 
     it('propagates an agent name containing "=" (legal in tagset values)', () => {
       const carrier = { 'x-datadog-tags': '' }
-      llmobs.trace({ kind: 'agent', name: 'model=gpt4' }, () => {
-        injectCh.publish({ carrier })
+      llmobs.trace({ kind: 'agent', name: 'model=gpt4' }, span => {
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const tags = carrier['x-datadog-tags']
@@ -2493,14 +2492,13 @@ describe('sdk', () => {
     })
 
     it('strips stale upstream pagent entries when a local agent overrides them', () => {
-      // Simulate `_injectTags` having already written upstream attribution into the carrier.
       let agentId
-      const carrier = {
-        'x-datadog-tags': '_dd.p.llmobs_pagent_span_id=upstream_id,_dd.p.llmobs_pagent_name=upstream_agent',
-      }
+      const carrier = {}
       llmobs.trace({ kind: 'agent', name: 'local_agent' }, span => {
         agentId = span.context().toSpanId()
-        injectCh.publish({ carrier })
+        span.context()._trace.tags['_dd.p.llmobs_pagent_span_id'] = 'upstream_id'
+        span.context()._trace.tags['_dd.p.llmobs_pagent_name'] = 'upstream_agent'
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const tags = carrier['x-datadog-tags']
@@ -2511,15 +2509,13 @@ describe('sdk', () => {
     })
 
     it('strips stale upstream pagent_name when local agent name is unsafe', () => {
-      // Even though the upstream name was safe, the downstream should see id-only when the
-      // local agent name is not wire-safe (decision: keep just the id, wipe the name).
       let agentId
-      const carrier = {
-        'x-datadog-tags': '_dd.p.llmobs_pagent_span_id=upstream_id,_dd.p.llmobs_pagent_name=upstream_agent',
-      }
+      const carrier = {}
       llmobs.trace({ kind: 'agent', name: 'Researcher, v2' }, span => {
         agentId = span.context().toSpanId()
-        injectCh.publish({ carrier })
+        span.context()._trace.tags['_dd.p.llmobs_pagent_span_id'] = 'upstream_id'
+        span.context()._trace.tags['_dd.p.llmobs_pagent_name'] = 'upstream_agent'
+        tracer.inject(span, 'text_map', carrier)
       })
 
       const tags = carrier['x-datadog-tags']
@@ -2531,16 +2527,16 @@ describe('sdk', () => {
       const originalMax = tracer._tracer._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
       const carrier = { 'x-datadog-tags': '' }
 
-      llmobs.trace({ kind: 'agent', name: 'my_agent' }, () => {
+      llmobs.trace({ kind: 'agent', name: 'my_agent' }, span => {
         // First injection: measure the tags string length WITHOUT pagent entries.
-        injectCh.publish({ carrier })
+        tracer.inject(span, 'text_map', carrier)
         const baseLength = carrier['x-datadog-tags']
           .split(',').filter(e => !e.startsWith('_dd.p.llmobs_pagent')).join(',').length
 
         // Second injection: budget allows the base tags but not the id entry (so name is also dropped).
         carrier['x-datadog-tags'] = ''
         tracer._tracer._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH = baseLength
-        injectCh.publish({ carrier })
+        tracer.inject(span, 'text_map', carrier)
       })
       tracer._tracer._config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH = originalMax
 

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -16,7 +16,6 @@ const {
   formatAudioPart,
   getFunctionArguments,
   normalizeLlmObsTraceId,
-  stripTagsetEntry,
   validateCostTags,
   safeJsonParse,
   validateKind,
@@ -131,32 +130,6 @@ describe('util', () => {
     it('appends when the entry fits exactly within maxTagSetLength', () => {
       // 'a=1' (3) + ',k=v' (4) = 7. Cap at 7 → fits.
       assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v', null, 7), 'a=1,k=v')
-    })
-  })
-
-  describe('stripTagsetEntry', () => {
-    it('removes a key=value entry from the middle of the tagset', () => {
-      assert.strictEqual(stripTagsetEntry('a=1,b=2,c=3', 'b'), 'a=1,c=3')
-    })
-
-    it('removes a key=value entry from the start of the tagset', () => {
-      assert.strictEqual(stripTagsetEntry('b=2,c=3', 'b'), 'c=3')
-    })
-
-    it('removes a key=value entry from the end of the tagset', () => {
-      assert.strictEqual(stripTagsetEntry('a=1,b=2', 'b'), 'a=1')
-    })
-
-    it('removes all occurrences of a duplicate key', () => {
-      assert.strictEqual(stripTagsetEntry('k=old,a=1,k=new', 'k'), 'a=1')
-    })
-
-    it('returns the original tagset unchanged when the key is absent', () => {
-      assert.strictEqual(stripTagsetEntry('a=1,c=3', 'b'), 'a=1,c=3')
-    })
-
-    it('returns empty string when stripping the only entry', () => {
-      assert.strictEqual(stripTagsetEntry('k=v', 'k'), '')
     })
   })
 

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -7,7 +7,6 @@ const { before, describe, it } = require('mocha')
 const getConfig = require('../../src/config')
 const {
   agentNameWireSafe,
-  appendOptionalPropagatedTag,
   audioMimeTypeFromFormat,
   encodeUnicode,
   findGenAIAncestorSpanId,
@@ -97,39 +96,6 @@ describe('util', () => {
     it('accepts a name at the 256 byte cap and rejects the first byte over', () => {
       assert.strictEqual(agentNameWireSafe('a'.repeat(256)), true)
       assert.strictEqual(agentNameWireSafe('a'.repeat(257)), false)
-    })
-  })
-
-  describe('appendOptionalPropagatedTag', () => {
-    it('appends key=value to an empty tagset', () => {
-      assert.strictEqual(appendOptionalPropagatedTag('', 'k', 'v'), 'k=v')
-    })
-
-    it('appends with a comma separator to a non-empty tagset', () => {
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v'), 'a=1,k=v')
-    })
-
-    it('returns the original tagset when value is falsy', () => {
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', undefined), 'a=1')
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', ''), 'a=1')
-    })
-
-    it('returns the original tagset when the safeguard rejects the value', () => {
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'bad', () => false), 'a=1')
-    })
-
-    it('appends when the safeguard accepts the value', () => {
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'good', () => true), 'a=1,k=good')
-    })
-
-    it('skips the entry when it would exceed maxTagSetLength', () => {
-      // 'a=1' is 3 chars; ',k=v' is 4 chars; total 7. Cap at 6 → skip.
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v', null, 6), 'a=1')
-    })
-
-    it('appends when the entry fits exactly within maxTagSetLength', () => {
-      // 'a=1' (3) + ',k=v' (4) = 7. Cap at 7 → fits.
-      assert.strictEqual(appendOptionalPropagatedTag('a=1', 'k', 'v', null, 7), 'a=1,k=v')
     })
   })
 

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -25,6 +25,13 @@ const B3_SINGLE_STYLE = DD_MAJOR >= 6 ? 'b3' : 'b3 single header'
 const injectCh = channel('dd-trace:span:inject')
 const extractCh = channel('dd-trace:span:extract')
 
+/**
+ * @typedef {object} TraceTagInjection
+ * @property {SpanContext} spanContext
+ * @property {Record<string, string | undefined>} [traceTagReplacements]
+ * @property {number} [optionalTraceTagCount]
+ */
+
 describe('TextMapPropagator', () => {
   let TextMapPropagator
   let propagator
@@ -617,21 +624,119 @@ describe('TextMapPropagator', () => {
       })
     })
 
-    it('should publish spanContext and carrier', () => {
+    it('should serialize injection-local trace tags without mutating the span context', () => {
       const carrier = {}
       const spanContext = createContext({
         traceId: id('0000000000000123'),
         spanId: id('0000000000000456'),
       })
 
-      const onSpanInject = sinon.stub()
+      /** @param {TraceTagInjection} injection */
+      function onSpanInject (injection) {
+        assert.strictEqual(injection.spanContext, spanContext)
+        injection.traceTagReplacements = { '_dd.p.test': 'value' }
+      }
       injectCh.subscribe(onSpanInject)
 
       propagator.inject(spanContext, carrier)
 
       try {
-        sinon.assert.calledOnce(onSpanInject)
-        assert.deepStrictEqual(onSpanInject.firstCall.args[0], { spanContext, carrier })
+        assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.test=value')
+        assert.strictEqual(spanContext._trace.tags['_dd.p.test'], undefined)
+      } finally {
+        injectCh.unsubscribe(onSpanInject)
+      }
+    })
+
+    it('should serialize injection-local trace tags to tracestate', () => {
+      config.tracePropagationStyle.inject = ['tracecontext']
+      const carrier = {}
+      const spanContext = createContext({ isRemote: false })
+
+      /** @param {TraceTagInjection} injection */
+      function onSpanInject (injection) {
+        injection.traceTagReplacements = { '_dd.p.test': 'value' }
+      }
+      injectCh.subscribe(onSpanInject)
+
+      try {
+        propagator.inject(spanContext, carrier)
+
+        assert.strictEqual(carrier['x-datadog-tags'], undefined)
+        assert.ok(carrier.tracestate.includes('t.test:value'))
+        assert.strictEqual(spanContext._trace.tags['_dd.p.test'], undefined)
+      } finally {
+        injectCh.unsubscribe(onSpanInject)
+      }
+    })
+
+    it('should remove injection-local trace tags from each configured format', () => {
+      const carrier = {}
+      const spanContext = createContext({
+        isRemote: false,
+        trace: { tags: { '_dd.p.remove': 'value' } },
+        tracestate: TraceState.fromString('dd=t.remove:value'),
+      })
+
+      /** @param {TraceTagInjection} injection */
+      function onSpanInject (injection) {
+        injection.traceTagReplacements = {
+          '_dd.p.remove': undefined,
+          'not.propagated': 'value',
+        }
+      }
+      injectCh.subscribe(onSpanInject)
+
+      try {
+        propagator.inject(spanContext, carrier)
+
+        assert.strictEqual(carrier['x-datadog-tags'], undefined)
+        assert.ok(!carrier.tracestate.includes('t.remove:'))
+        assert.ok(!carrier.tracestate.includes('not.propagated'))
+        assert.strictEqual(spanContext._tracestate.toString(), 'dd=t.remove:value')
+      } finally {
+        injectCh.unsubscribe(onSpanInject)
+      }
+    })
+
+    it('should reject an invalid injection-local trace tag', () => {
+      const carrier = {}
+
+      /** @param {TraceTagInjection} injection */
+      function onSpanInject (injection) {
+        injection.traceTagReplacements = { '_dd.p.test': 'hélicoptère' }
+      }
+      injectCh.subscribe(onSpanInject)
+
+      try {
+        propagator.inject(createContext(), carrier)
+
+        assert.strictEqual(carrier['x-datadog-tags'], undefined)
+      } finally {
+        injectCh.unsubscribe(onSpanInject)
+      }
+    })
+
+    it('should include only optional trace tags that fit the length limit', () => {
+      config.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 40
+      const carrier = {}
+
+      /** @param {TraceTagInjection} injection */
+      function onSpanInject (injection) {
+        injection.traceTagReplacements = {
+          '_dd.p.required': 'replacement',
+          '_dd.p.first': '1',
+          '_dd.p.second': '2',
+        }
+        injection.optionalTraceTagCount = 2
+      }
+      injectCh.subscribe(onSpanInject)
+
+      try {
+        const spanContext = createContext({ trace: { tags: { '_dd.p.required': 'original' } } })
+        propagator.inject(spanContext, carrier)
+
+        assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.required=replacement,_dd.p.first=1')
       } finally {
         injectCh.unsubscribe(onSpanInject)
       }

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -28,7 +28,7 @@ const extractCh = channel('dd-trace:span:extract')
 /**
  * @typedef {object} TraceTagInjection
  * @property {SpanContext} spanContext
- * @property {Record<string, string | undefined>} [traceTagReplacements]
+ * @property {Array<string | undefined>} [traceTagReplacements]
  * @property {number} [optionalTraceTagCount]
  */
 
@@ -634,7 +634,7 @@ describe('TextMapPropagator', () => {
       /** @param {TraceTagInjection} injection */
       function onSpanInject (injection) {
         assert.strictEqual(injection.spanContext, spanContext)
-        injection.traceTagReplacements = { '_dd.p.test': 'value' }
+        injection.traceTagReplacements = ['_dd.p.test', 'value']
       }
       injectCh.subscribe(onSpanInject)
 
@@ -648,6 +648,31 @@ describe('TextMapPropagator', () => {
       }
     })
 
+    it('should match replacement keys only at key positions', () => {
+      config.tracePropagationStyle.inject = ['datadog', 'tracecontext']
+      const carrier = {}
+      const spanContext = createContext({
+        isRemote: false,
+        trace: { tags: { '_dd.p.test': 'original' } },
+      })
+
+      /** @param {TraceTagInjection} injection */
+      function onSpanInject (injection) {
+        injection.traceTagReplacements = ['_dd.p.other', '_dd.p.test']
+      }
+      injectCh.subscribe(onSpanInject)
+
+      try {
+        propagator.inject(spanContext, carrier)
+
+        assert.strictEqual(carrier['x-datadog-tags'], '_dd.p.test=original,_dd.p.other=_dd.p.test')
+        assert.ok(carrier.tracestate.includes('t.test:original'))
+        assert.ok(carrier.tracestate.includes('t.other:_dd.p.test'))
+      } finally {
+        injectCh.unsubscribe(onSpanInject)
+      }
+    })
+
     it('should serialize injection-local trace tags to tracestate', () => {
       config.tracePropagationStyle.inject = ['tracecontext']
       const carrier = {}
@@ -655,7 +680,7 @@ describe('TextMapPropagator', () => {
 
       /** @param {TraceTagInjection} injection */
       function onSpanInject (injection) {
-        injection.traceTagReplacements = { '_dd.p.test': 'value' }
+        injection.traceTagReplacements = ['_dd.p.test', 'value']
       }
       injectCh.subscribe(onSpanInject)
 
@@ -680,10 +705,10 @@ describe('TextMapPropagator', () => {
 
       /** @param {TraceTagInjection} injection */
       function onSpanInject (injection) {
-        injection.traceTagReplacements = {
-          '_dd.p.remove': undefined,
-          'not.propagated': 'value',
-        }
+        injection.traceTagReplacements = [
+          '_dd.p.remove', undefined,
+          'not.propagated', 'value',
+        ]
       }
       injectCh.subscribe(onSpanInject)
 
@@ -704,7 +729,7 @@ describe('TextMapPropagator', () => {
 
       /** @param {TraceTagInjection} injection */
       function onSpanInject (injection) {
-        injection.traceTagReplacements = { '_dd.p.test': 'hélicoptère' }
+        injection.traceTagReplacements = ['_dd.p.test', 'hélicoptère']
       }
       injectCh.subscribe(onSpanInject)
 
@@ -723,11 +748,11 @@ describe('TextMapPropagator', () => {
 
       /** @param {TraceTagInjection} injection */
       function onSpanInject (injection) {
-        injection.traceTagReplacements = {
-          '_dd.p.required': 'replacement',
-          '_dd.p.first': '1',
-          '_dd.p.second': '2',
-        }
+        injection.traceTagReplacements = [
+          '_dd.p.required', 'replacement',
+          '_dd.p.first', '1',
+          '_dd.p.second', '2',
+        ]
         injection.optionalTraceTagCount = 2
       }
       injectCh.subscribe(onSpanInject)


### PR DESCRIPTION
LLMObs propagation can append local `_dd.p.llmobs_*` tags after standard trace propagation already emitted inherited values. This creates duplicate keys in `x-datadog-tags`. The change replaces managed entries in one scan and preserves unrelated or malformed entries.

Patrick Ribbsaeter authored the source commit. The maintainer layer simplifies the replacement path and extends regression coverage.

Fixes: https://github.com/DataDog/dd-trace-js/issues/9714
Refs: https://github.com/DataDog/dd-trace-js/pull/9832
