### PR TITLE
fix(esbuild): resolve imports in built-in subpath wrappers

### DIFF
--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -121,6 +121,45 @@ esbuildVersions.forEach((version) => {
         })
       })
 
+      it('bundles instrumented Node.js subpaths', async () => {
+        delete require.cache[require.resolve('esbuild')]
+        const esbuild = require('esbuild')
+        const ddPlugin = require('../../esbuild')
+
+        assert.strictEqual(esbuild.version, version)
+
+        const result = await esbuild.build({
+          absWorkingDir: pathModule.dirname(process.cwd()),
+          stdin: {
+            contents: `
+              import dns from 'node:dns/promises'
+              import http from 'node:http'
+              console.log(typeof dns.lookup, typeof http.createServer)
+            `,
+            loader: 'js',
+            resolveDir: process.cwd(),
+            sourcefile: 'builtin-subpath.mjs',
+          },
+          bundle: true,
+          format: 'esm',
+          platform: 'node',
+          plugins: [ddPlugin],
+          write: false,
+        })
+
+        const output = result.outputFiles[0].text
+        assert.match(
+          output,
+          /register.*"node:dns\/promises".*"node:dns\/promises"\);$/m,
+          'Bundle should contain the node:dns/promises instrumentation'
+        )
+        assert.match(
+          output,
+          /register.*"node:http".*"node:http"\);$/m,
+          'Bundle should contain the node:http instrumentation'
+        )
+      })
+
       it('runs minified ESM bundles without ReferenceError on arguments', () => {
         execSync('node ./build-and-test-esm-minify.mjs', {
           timeout,

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -125,8 +125,11 @@ esbuildVersions.forEach((version) => {
         delete require.cache[require.resolve('esbuild')]
         const esbuild = require('esbuild')
         const ddPlugin = require('../../esbuild')
+        const { version: installedVersion } = JSON.parse(
+          fs.readFileSync(require.resolve('esbuild/package.json'), 'utf8')
+        )
 
-        assert.strictEqual(esbuild.version, version)
+        assert.strictEqual(esbuild.version, installedVersion)
 
         const result = await esbuild.build({
           absWorkingDir: pathModule.dirname(process.cwd()),

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -370,7 +370,9 @@ register(${JSON.stringify(toRegister)}, _, set, get, ${JSON.stringify(data.raw)}
       return {
         contents,
         loader: 'js',
-        resolveDir: path.dirname(args.path),
+        resolveDir: data.internal
+          ? build.initialOptions.absWorkingDir ?? process.cwd()
+          : path.dirname(args.path),
       }
     }
     if (DD_IAST_ENABLED && args.pluginData?.applicationFile) {

--- a/packages/datadog-esbuild/test/plugin.spec.js
+++ b/packages/datadog-esbuild/test/plugin.spec.js
@@ -1,9 +1,45 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const path = require('node:path')
 const { describe, it } = require('mocha')
 
 const ddPlugin = require('../index')
+
+/**
+ * @param {object} [initialOptions]
+ */
+function captureOnLoad (initialOptions = {}) {
+  let onLoad
+  ddPlugin.setup({
+    initialOptions,
+    onResolve () {},
+    /**
+     * @param {object} options
+     * @param {Function} callback
+     */
+    onLoad (options, callback) {
+      onLoad = callback
+    },
+  })
+  return onLoad
+}
+
+/**
+ * @param {object} [initialOptions]
+ */
+function loadBuiltinWrapper (initialOptions) {
+  const onLoad = captureOnLoad(initialOptions)
+  return onLoad({
+    path: '/_dd_esm_internal_/node:dns/promises._dd_esbuild_intercepted',
+    pluginData: {
+      internal: true,
+      isESM: true,
+      pkgOfInterest: true,
+      raw: 'node:dns/promises',
+    },
+  })
+}
 
 function captureOnResolve () {
   let onResolve
@@ -34,5 +70,38 @@ describe('datadog-esbuild plugin', () => {
     })
 
     assert.strictEqual(result, undefined)
+  })
+
+  describe('ESM wrappers', () => {
+    it('uses the build directory to resolve imports in built-in module wrappers', async () => {
+      const absWorkingDir = path.dirname(process.cwd())
+      const result = await loadBuiltinWrapper({ absWorkingDir })
+
+      assert.strictEqual(result.resolveDir, absWorkingDir)
+    })
+
+    it('defaults the build directory to the current working directory', async () => {
+      const result = await loadBuiltinWrapper()
+
+      assert.strictEqual(result.resolveDir, process.cwd())
+    })
+
+    it('uses the module directory to resolve imports in package wrappers', async () => {
+      const onLoad = captureOnLoad()
+      const modulePath = path.join(__dirname, 'resources/export-method.mjs')
+
+      const result = await onLoad({
+        path: `${modulePath}._dd_esbuild_intercepted`,
+        pluginData: {
+          internal: false,
+          isESM: true,
+          pkg: 'fixture',
+          pkgOfInterest: true,
+          raw: 'fixture',
+        },
+      })
+
+      assert.strictEqual(result.resolveDir, path.dirname(modulePath))
+    })
   })
 })


### PR DESCRIPTION
Built-in Node.js subpath wrappers derived their resolve directory from the module specifier. Esbuild then searched a nonexistent directory and rejected ESM bundles.

This keeps the existing instrumentation and gives generated imports a valid build directory.

Fixes: https://github.com/DataDog/dd-trace-js/issues/9383