### PR TITLE
feat(scope): Implements trace discarding via DD_TRACE_SAMPLING_RULES

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -72,7 +72,8 @@ tracer.init({
     { sampleRate: 0.5, service: 'foo', name: 'foo.request' },
     { sampleRate: 0.1, service: /foo/, name: /foo\.request/ },
     { sampleRate: 0, resource: 'GET /health', maxPerSecond: 5 },
-    { sampleRate: 0, tags: { 'http.url': '*/spam*', 'span.kind': /server/ } }
+    { sampleRate: 0, tags: { 'http.url': '*/spam*', 'span.kind': /server/ } },
+    { sampleRate: 0, resource: '/health', discard: true }
   ],
   spanSamplingRules: [
     { sampleRate: 1.0, service: 'foo', name: 'foo.request', maxPerSecond: 5 },

--- a/index.d.ts
+++ b/index.d.ts
@@ -466,6 +466,13 @@ declare namespace tracer {
      * Maximum number of traces matching this rule to sample per second.
      */
     maxPerSecond?: number
+
+    /**
+     * When `true`, a trace chunk rejected by this rule is fully dropped:
+     * it is excluded from client-side stats and never sent to the Agent.
+     * @default false
+     */
+    discard?: boolean
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -657,6 +657,7 @@ declare namespace tracer {
      * Sampling rules to apply to priority sampling. Each rule matches against a trace's
      * `service`, `name`, `resource`, and `tags`, and applies the rule's `sampleRate`. Use a
      * `sampleRate` of `0` to drop matching traces (for example to filter out unwanted resources).
+     * Specify `"discard": true` to fully drop it from stats as well.
      * If not specified, will defer to global sampling rate for all spans.
      * @default []
      * @env DD_TRACE_SAMPLING_RULES

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -479,6 +479,13 @@ declare namespace tracer {
      * Maximum number of traces matching this rule to sample per second.
      */
     maxPerSecond?: number
+
+    /**
+     * When `true`, a trace chunk rejected by this rule is fully dropped:
+     * it is excluded from client-side stats and never sent to the Agent.
+     * @default false
+     */
+    discard?: boolean
   }
 
   /**
@@ -663,6 +670,7 @@ declare namespace tracer {
      * Sampling rules to apply to priority sampling. Each rule matches against a trace's
      * `service`, `name`, `resource`, and `tags`, and applies the rule's `sampleRate`. Use a
      * `sampleRate` of `0` to drop matching traces (for example to filter out unwanted resources).
+     * Specify `"discard": true` to fully drop it from stats as well.
      * If not specified, will defer to global sampling rate for all spans.
      * @default []
      * @env DD_TRACE_SAMPLING_RULES

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -263,13 +263,13 @@ class PrioritySampler {
       context._sampling.mechanism = SAMPLING_MECHANISM_REMOTE_DYNAMIC
     }
 
-    const sampled = rule.sample(context) && this._isSampledByRateLimit(context)
-
-    if (!sampled && rule.discard) {
+    if (rule.discard) {
       context._sampling.discard = true
     }
 
-    return sampled ? USER_KEEP : USER_REJECT
+    return rule.sample(context) && this._isSampledByRateLimit(context)
+      ? USER_KEEP
+      : USER_REJECT
   }
 
   /**

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -263,9 +263,13 @@ class PrioritySampler {
       context._sampling.mechanism = SAMPLING_MECHANISM_REMOTE_DYNAMIC
     }
 
-    return rule.sample(context) && this._isSampledByRateLimit(context)
-      ? USER_KEEP
-      : USER_REJECT
+    const sampled = rule.sample(context) && this._isSampledByRateLimit(context)
+
+    if (!sampled && rule.discard) {
+      context._sampling.discard = true
+    }
+
+    return sampled ? USER_KEEP : USER_REJECT
   }
 
   /**

--- a/packages/dd-trace/src/sampling_rule.js
+++ b/packages/dd-trace/src/sampling_rule.js
@@ -185,6 +185,7 @@ function resourceLocator (span) {
  * @property {number} [sampleRate=1] - Deterministic sampling rate in [0, 1].
  * @property {string} [provenance] - Optional provenance/metadata for this rule.
  * @property {number} [maxPerSecond] - Maximum samples per second (rate limit).
+ * @property {boolean} [discard=false] - Whether to fully drop a trace if not kept.
  */
 
 /**
@@ -195,7 +196,7 @@ class SamplingRule {
   /**
    * @param {SamplingRuleConfig} [config]
    */
-  constructor ({ name, service, resource, tags, sampleRate = 1, provenance, maxPerSecond } = {}) {
+  constructor ({ name, service, resource, tags, sampleRate = 1, provenance, maxPerSecond, discard = false } = {}) {
     this.matchers = []
 
     if (name !== undefined) {
@@ -216,6 +217,7 @@ class SamplingRule {
     this._sampler = new Sampler(sampleRate)
     this._limiter = undefined
     this.provenance = provenance
+    this.discard = !!discard
 
     if (Number.isFinite(maxPerSecond)) {
       this._limiter = new RateLimiter(maxPerSecond)

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -7,6 +7,7 @@ const GitMetadataTagger = require('./git_metadata_tagger')
 const processTags = require('./process-tags')
 const { applyHttpOtelSemantics } = require('./plugins/util/http-otel-semantics')
 const { APM_TRACING_ENABLED_KEY } = require('./constants')
+const { AUTO_REJECT } = require('../../../ext/priority')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
@@ -34,9 +35,13 @@ class SpanProcessor {
   sample (span) {
     const spanContext = span.context()
     this._prioritySampler.sample(spanContext)
-    if (!spanContext._sampling.discard) {
+    if (!this.#isDiscarded(spanContext)) {
       this._spanSampler.sample(spanContext)
     }
+  }
+
+  #isDiscarded (spanContext) {
+    return spanContext._sampling.discard && spanContext._sampling.priority <= AUTO_REJECT
   }
 
   process (span) {
@@ -58,7 +63,7 @@ class SpanProcessor {
 
       let isFirstSpanInChunk = true
       const stampApmDisabled = this._config.apmTracingEnabled === false
-      const discard = spanContext._sampling.discard
+      const discard = this.#isDiscarded(spanContext)
 
       for (const span of started) {
         if (span._duration === undefined) {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -40,6 +40,13 @@ class SpanProcessor {
     }
   }
 
+  /**
+   * A rule's reject decision can later be overridden (e.g. a product force-keeping the trace via
+   * `PrioritySampler.keepTrace()`), so `discard` only applies while the priority is still a reject.
+   *
+   * @param {import('./opentracing/span_context')} spanContext
+   * @returns {boolean}
+   */
   #isDiscarded (spanContext) {
     return spanContext._sampling.discard && spanContext._sampling.priority <= AUTO_REJECT
   }

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -34,7 +34,9 @@ class SpanProcessor {
   sample (span) {
     const spanContext = span.context()
     this._prioritySampler.sample(spanContext)
-    this._spanSampler.sample(spanContext)
+    if (!spanContext._sampling.discard) {
+      this._spanSampler.sample(spanContext)
+    }
   }
 
   process (span) {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { AUTO_REJECT } = require('../../../ext/priority')
 const log = require('./log')
 const spanFormat = require('./span_format')
 const SpanSampler = require('./span_sampler')
@@ -7,7 +8,6 @@ const GitMetadataTagger = require('./git_metadata_tagger')
 const processTags = require('./process-tags')
 const { applyHttpOtelSemantics } = require('./plugins/util/http-otel-semantics')
 const { APM_TRACING_ENABLED_KEY } = require('./constants')
-const { AUTO_REJECT } = require('../../../ext/priority')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -56,11 +56,12 @@ class SpanProcessor {
 
       let isFirstSpanInChunk = true
       const stampApmDisabled = this._config.apmTracingEnabled === false
+      const discard = spanContext._sampling.discard
 
       for (const span of started) {
         if (span._duration === undefined) {
           active.push(span)
-        } else {
+        } else if (!discard) {
           const formattedSpan = spanFormat(span, isFirstSpanInChunk, this._processTags)
           if (stampApmDisabled) {
             formattedSpan.metrics[APM_TRACING_ENABLED_KEY] = 0
@@ -76,7 +77,7 @@ class SpanProcessor {
         }
       }
 
-      if (formatted.length !== 0 && trace.isRecording !== false) {
+      if (!discard && formatted.length !== 0 && trace.isRecording !== false) {
         this._exporter.export(formatted)
       }
 

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1545,7 +1545,7 @@ describe('Config', () => {
     process.env.DD_TRACE_REPORT_HOSTNAME = 'true'
     process.env.DD_TRACE_SAMPLE_RATE = '0.5'
     process.env.DD_TRACE_SAMPLING_RULES = `[
-      {"service":"usersvc","name":"healthcheck","sample_rate":0.0 },
+      {"service":"usersvc","name":"healthcheck","sample_rate":0.0,"discard":true },
       {"service":"usersvc","sample_rate":0.5},
       {"service":"authsvc","sample_rate":1.0},
       {"sample_rate":0.1}
@@ -1702,7 +1702,7 @@ describe('Config', () => {
       sampleRate: 0.5,
       rateLimit: -1,
       rules: [
-        { service: 'usersvc', name: 'healthcheck', sampleRate: 0.0 },
+        { service: 'usersvc', name: 'healthcheck', sampleRate: 0.0, discard: true },
         { service: 'usersvc', sampleRate: 0.5 },
         { service: 'authsvc', sampleRate: 1.0 },
         { sampleRate: 0.1 },

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -216,6 +216,43 @@ describe('PrioritySampler', () => {
       assert.strictEqual(context._sampling.mechanism, SAMPLING_MECHANISM_RULE)
     })
 
+    it('should mark the context for discard when a discard=true rule rejects the trace', () => {
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 0, service: 'test', resource: /res.*/, discard: true },
+        ],
+      })
+      prioritySampler.sample(context)
+
+      assert.strictEqual(context._sampling.priority, USER_REJECT)
+      assert.strictEqual(context._sampling.discard, true)
+    })
+
+    it('should not mark the context for discard when a discard=true rule keeps the trace', () => {
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 1, service: 'test', resource: /res.*/, discard: true },
+        ],
+      })
+      prioritySampler.sample(context)
+
+      assert.strictEqual(context._sampling.priority, USER_KEEP)
+      assert.strictEqual(context._sampling.discard, undefined)
+    })
+
+    it('should not mark the context for discard when the rejecting rule has discard=false', () => {
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 0, service: 'foo', resource: /res.*/ },
+          { sampleRate: 0, service: 'test', resource: /res.*/ },
+        ],
+      })
+      prioritySampler.sample(context)
+
+      assert.strictEqual(context._sampling.priority, USER_REJECT)
+      assert.strictEqual(context._sampling.discard, undefined)
+    })
+
     it('should support a customer-defined remote configuration sampling', () => {
       prioritySampler = new PrioritySampler('test', {
         rules: [

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -228,7 +228,7 @@ describe('PrioritySampler', () => {
       assert.strictEqual(context._sampling.discard, true)
     })
 
-    it('should not mark the context for discard when a discard=true rule keeps the trace', () => {
+    it('should mark the context for discard when a discard=true rule keeps the trace (but not actually drop)', () => {
       prioritySampler = new PrioritySampler('test', {
         rules: [
           { sampleRate: 1, service: 'test', resource: /res.*/, discard: true },
@@ -237,7 +237,7 @@ describe('PrioritySampler', () => {
       prioritySampler.sample(context)
 
       assert.strictEqual(context._sampling.priority, USER_KEEP)
-      assert.strictEqual(context._sampling.discard, undefined)
+      assert.strictEqual(context._sampling.discard, true)
     })
 
     it('should not mark the context for discard when the rejecting rule has discard=false', () => {

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -542,6 +542,20 @@ describe('sampling rule', () => {
     })
   })
 
+  describe('discard', () => {
+    it('should default to false', () => {
+      rule = new SamplingRule({ service: 'test' })
+
+      assert.strictEqual(rule.discard, false)
+    })
+
+    it('should coerce a truthy value to a boolean', () => {
+      rule = new SamplingRule({ service: 'test', discard: true })
+
+      assert.strictEqual(rule.discard, true)
+    })
+  })
+
   describe('maxPerSecond', () => {
     it('should not create limiter without finite maxPerSecond', () => {
       rule = new SamplingRule({

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -92,6 +92,23 @@ describe('SpanProcessor', () => {
     sinon.assert.calledWith(prioritySampler.sample, finishedSpan.context())
   })
 
+  it('should span sample when the trace is not marked for discard', () => {
+    processor.sample(finishedSpan)
+
+    sinon.assert.calledWith(sample, finishedSpan.context())
+  })
+
+  it('should skip span sampling when the priority sampler marks the trace for discard', () => {
+    prioritySampler.sample = sinon.stub().callsFake((context) => {
+      context._sampling.discard = true
+    })
+
+    processor.sample(finishedSpan)
+
+    sinon.assert.calledWith(prioritySampler.sample, finishedSpan.context())
+    sinon.assert.notCalled(sample)
+  })
+
   it('should erase the trace once finished', () => {
     trace.started = [finishedSpan]
     trace.finished = [finishedSpan]

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -143,6 +143,42 @@ describe('SpanProcessor', () => {
     assert.deepStrictEqual(trace.finished, [])
   })
 
+  it('should drop the chunk without exporting or formatting when marked for discard', () => {
+    trace.started = [finishedSpan]
+    trace.finished = [finishedSpan]
+    finishedSpan.context()._sampling.discard = true
+
+    processor.process(finishedSpan)
+
+    sinon.assert.notCalled(exporter.export)
+    sinon.assert.notCalled(spanFormat)
+    assert.deepStrictEqual(trace.started, [])
+    assert.deepStrictEqual(trace.finished, [])
+  })
+
+  it('should not record span stats for a chunk marked for discard', () => {
+    processor._stats = { onSpanFinished: sinon.stub() }
+    trace.started = [finishedSpan]
+    trace.finished = [finishedSpan]
+    finishedSpan.context()._sampling.discard = true
+
+    processor.process(finishedSpan)
+
+    sinon.assert.notCalled(processor._stats.onSpanFinished)
+  })
+
+  it('should keep not-yet-finished spans active when a chunk is discarded', () => {
+    trace.started = [activeSpan, finishedSpan, finishedSpan, finishedSpan]
+    trace.finished = [finishedSpan, finishedSpan, finishedSpan]
+    finishedSpan.context()._sampling.discard = true
+
+    processor.process(finishedSpan)
+
+    sinon.assert.notCalled(exporter.export)
+    assert.deepStrictEqual(trace.started, [activeSpan])
+    assert.deepStrictEqual(trace.finished, [])
+  })
+
   it('should configure span sampler correctly', () => {
     const config = {
       stats: { DD_TRACE_STATS_COMPUTATION_ENABLED: false },

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -10,6 +10,7 @@ const proxyquire = require('proxyquire')
 require('./setup/core')
 
 const { APM_TRACING_ENABLED_KEY } = require('../src/constants')
+const { AUTO_REJECT, USER_KEEP } = require('../../../ext/priority')
 
 describe('SpanProcessor', () => {
   let prioritySampler
@@ -101,12 +102,25 @@ describe('SpanProcessor', () => {
   it('should skip span sampling when the priority sampler marks the trace for discard', () => {
     prioritySampler.sample = sinon.stub().callsFake((context) => {
       context._sampling.discard = true
+      context._sampling.priority = AUTO_REJECT
     })
 
     processor.sample(finishedSpan)
 
     sinon.assert.calledWith(prioritySampler.sample, finishedSpan.context())
     sinon.assert.notCalled(sample)
+  })
+
+  it('should still span sample when discard was set but the priority was later force-kept', () => {
+    // e.g. a product forcing the trace to be kept via PrioritySampler.keepTrace() after a
+    // sampling rule already rejected it and flagged it for discard.
+    finishedSpan.context()._sampling.discard = true
+    finishedSpan.context()._sampling.priority = AUTO_REJECT
+    finishedSpan.context()._sampling.priority = USER_KEEP
+
+    processor.sample(finishedSpan)
+
+    sinon.assert.calledWith(sample, finishedSpan.context())
   })
 
   it('should erase the trace once finished', () => {
@@ -164,6 +178,7 @@ describe('SpanProcessor', () => {
     trace.started = [finishedSpan]
     trace.finished = [finishedSpan]
     finishedSpan.context()._sampling.discard = true
+    finishedSpan.context()._sampling.priority = AUTO_REJECT
 
     processor.process(finishedSpan)
 
@@ -178,6 +193,7 @@ describe('SpanProcessor', () => {
     trace.started = [finishedSpan]
     trace.finished = [finishedSpan]
     finishedSpan.context()._sampling.discard = true
+    finishedSpan.context()._sampling.priority = AUTO_REJECT
 
     processor.process(finishedSpan)
 
@@ -188,12 +204,24 @@ describe('SpanProcessor', () => {
     trace.started = [activeSpan, finishedSpan, finishedSpan, finishedSpan]
     trace.finished = [finishedSpan, finishedSpan, finishedSpan]
     finishedSpan.context()._sampling.discard = true
+    finishedSpan.context()._sampling.priority = AUTO_REJECT
 
     processor.process(finishedSpan)
 
     sinon.assert.notCalled(exporter.export)
     assert.deepStrictEqual(trace.started, [activeSpan])
     assert.deepStrictEqual(trace.finished, [])
+  })
+
+  it('should still export the chunk when discard was set but the priority was later force-kept', () => {
+    trace.started = [finishedSpan]
+    trace.finished = [finishedSpan]
+    finishedSpan.context()._sampling.discard = true
+    finishedSpan.context()._sampling.priority = USER_KEEP
+
+    processor.process(finishedSpan)
+
+    sinon.assert.calledWith(exporter.export, [{ formatted: true }])
   })
 
   it('should configure span sampler correctly', () => {

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -112,9 +112,9 @@ describe('startup logging', () => {
       debug: true,
       sample_rate: 1,
       sampling_rules: [
-        { matchers: [{ pattern: 'rule1' }], _sampler: { _rate: 0.4 } },
+        { matchers: [{ pattern: 'rule1' }], _sampler: { _rate: 0.4 }, discard: false },
         'rule2',
-        { matchers: [{ pattern: 'rule3' }], _sampler: { _rate: 1 } },
+        { matchers: [{ pattern: 'rule3' }], _sampler: { _rate: 1 }, discard: false },
       ],
       tags: { version: '1.2.3', invalid_but_listed_due_to_mocking: '42' },
       dd_version: '1.2.3',


### PR DESCRIPTION
This follows the same implementation in DataDog/dd-trace-py#19975.