### PR TITLE
fix(agentless): pass raw container ID to trace intake

### DIFF
--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -4,7 +4,7 @@ const { URL } = require('node:url')
 const os = require('node:os')
 
 const log = require('../../log')
-const { entityId } = require('../common/docker')
+const { containerId } = require('../common/docker')
 const tracerVersion = require('../../../../../package.json').version
 const Writer = require('./writer')
 const { computeIntakeUrl } = require('./intake')
@@ -48,7 +48,7 @@ class AgentlessExporter {
       get env () { return config.env },
       get runtimeID () { return config.tags['runtime-id'] },
     }
-    if (entityId) metadata.containerID = entityId
+    if (containerId) metadata.containerID = containerId
 
     this._writer = new Writer({
       url: this._url,

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -105,7 +105,10 @@ describe('AgentlessExporter', () => {
 
       Exporter = proxyquire('../../../src/exporters/agentless', {
         './writer': Writer,
-        '../common/docker': { entityId: 'container-id' },
+        '../common/docker': {
+          containerId: 'container-id',
+          entityId: 'ci-container-id',
+        },
       })
 
       exporter = new Exporter({
@@ -121,6 +124,30 @@ describe('AgentlessExporter', () => {
         languageName: 'nodejs',
         containerID: 'container-id',
       })
+    })
+
+    it('should omit container metadata when only an entity ID is available', () => {
+      const writerOptions = {}
+      /** @param {object} options */
+      const Writer = function (options) {
+        Object.assign(writerOptions, options)
+        return writer
+      }
+
+      Exporter = proxyquire('../../../src/exporters/agentless', {
+        './writer': Writer,
+        '../common/docker': {
+          containerId: undefined,
+          entityId: 'in-1234',
+        },
+      })
+
+      exporter = new Exporter({
+        site: 'datadoghq.com',
+        tags: { 'runtime-id': 'test-uuid' },
+      })
+
+      assert.strictEqual(Object.hasOwn(writerOptions.metadata, 'containerID'), false)
     })
 
     it('should reflect a runtime id updated on config after construction', () => {


### PR DESCRIPTION
The agentless exporter passes the origin-detection entity ID as the trace payload container ID. ci- prefixes and cgroup inode entity IDs cannot identify the raw container, which prevents container correlation.