### PR TITLE
feat(test-optimization): upload WebdriverIO failure screenshots

### DIFF
--- a/integration-tests/webdriverio/fixtures/wdio.conf.js
+++ b/integration-tests/webdriverio/fixtures/wdio.conf.js
@@ -146,6 +146,7 @@ const scenarioConfig = {
     ]],
   },
   jasmineStatuses: {
+    injectGlobals: false,
     maxInstances: 1,
     specs: ['./jasmine-statuses.e2e.js'],
   },

--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -404,7 +404,7 @@ for (const version of versions) {
       }, 0, { framework: 'jasmine' })
     })
 
-    it('reports Jasmine pass, fail, and skip statuses with a failure screenshot', async () => {
+    it('reports Jasmine statuses and a failure screenshot without global injection', async () => {
       await runScenario('jasmineStatuses', 1, ({ media, session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'fail')
         assert.strictEqual(suites.length, 1)

--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -23,6 +23,8 @@ const {
   MOCHA_IS_PARALLEL,
   TEST_CODE_COVERAGE_ENABLED,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_FAILURE_SCREENSHOT_UPLOADED,
+  TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR,
   TEST_FRAMEWORK,
   TEST_FRAMEWORK_ADAPTER,
   TEST_FRAMEWORK_VERSION,
@@ -72,6 +74,7 @@ const advancedRequestPaths = [
  */
 function startWebDriverServer () {
   let sessionCount = 0
+  let screenshotCount = 0
   const server = http.createServer((request, response) => {
     request.resume()
     request.once('end', () => {
@@ -90,6 +93,9 @@ function startWebDriverServer () {
         }
       } else if (request.method === 'GET' && request.url === '/status') {
         value = { ready: true, message: '' }
+      } else if (request.method === 'GET' && /^\/session\/[^/]+\/screenshot$/.test(request.url)) {
+        screenshotCount++
+        value = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).toString('base64')
       }
 
       response.writeHead(200, { 'content-type': 'application/json' })
@@ -112,6 +118,7 @@ function startWebDriverServer () {
         port: address.port,
         server,
         getSessionCount: () => sessionCount,
+        getScreenshotCount: () => screenshotCount,
       })
     })
   })
@@ -168,6 +175,22 @@ function assertOneTestPerSuiteExecution (suites, tests) {
     tests.map(test => test.test_suite_id.toString(10)).sort(),
     suites.map(suite => suite.test_suite_id.toString(10)).sort()
   )
+}
+
+/**
+ * Asserts one failed test's screenshot media and success tags.
+ *
+ * @param {object} failedTest
+ * @param {object[]} media
+ * @returns {void}
+ */
+function assertFailureScreenshotUploaded (failedTest, media) {
+  assert.strictEqual(failedTest.meta[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
+  assert.strictEqual(failedTest.meta[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], undefined)
+  assert.strictEqual(media.length, 1)
+  assert.strictEqual(media[0].media.traceId, failedTest.trace_id.toString())
+  assert.strictEqual(media[0].media.contentType, 'image/png')
+  assert.deepStrictEqual([...media[0].media.content], [137, 80, 78, 71, 13, 10, 26, 10])
 }
 
 /**
@@ -234,6 +257,7 @@ function getReportingEvents (payloads, requestedVersion, frameworkAdapter) {
   assertEventHierarchy(sessions[0], modules[0], suites, tests)
 
   return {
+    media: payloads.filter(({ media }) => media),
     session: sessions[0],
     module: modules[0],
     suites,
@@ -286,12 +310,15 @@ for (const version of versions) {
      * @param {(events: ReturnType<typeof getReportingEvents>) => void} assertEvents
      * @param {number} [expectedExitCode]
      * @param {object} [options]
+     * @param {object} [options.env]
+     * @param {number} [options.expectedScreenshots]
      * @param {string} [options.framework]
      * @returns {Promise<void>}
      */
     async function runScenario (scenario, expectedWebDriverSessions, assertEvents, expectedExitCode = 0, options = {}) {
-      const { framework = 'mocha' } = options
+      const { env, expectedScreenshots, framework = 'mocha' } = options
       const initialWebDriverSessionCount = webDriver.getSessionCount()
+      const initialScreenshotCount = webDriver.getScreenshotCount()
       childProcess = exec('./node_modules/.bin/wdio run ./wdio.conf.js', {
         cwd,
         env: {
@@ -301,6 +328,7 @@ for (const version of versions) {
           WEBDRIVERIO_FRAMEWORK: framework,
           WEBDRIVERIO_SCENARIO: scenario,
           WEBDRIVER_PORT: String(webDriver.port),
+          ...env,
         },
       })
       childProcess.stdout?.on('data', chunk => {
@@ -335,6 +363,9 @@ for (const version of versions) {
         webDriver.getSessionCount() - initialWebDriverSessionCount,
         expectedWebDriverSessions
       )
+      if (expectedScreenshots !== undefined) {
+        assert.strictEqual(webDriver.getScreenshotCount() - initialScreenshotCount, expectedScreenshots)
+      }
     }
 
     it('reports parallel workers as one session', async () => {
@@ -373,8 +404,8 @@ for (const version of versions) {
       }, 0, { framework: 'jasmine' })
     })
 
-    it('reports Jasmine pass, fail, and skip statuses', async () => {
-      await runScenario('jasmineStatuses', 1, ({ session, suites, tests }) => {
+    it('reports Jasmine pass, fail, and skip statuses with a failure screenshot', async () => {
+      await runScenario('jasmineStatuses', 1, ({ media, session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'fail')
         assert.strictEqual(suites.length, 1)
         assert.strictEqual(suites[0].meta[TEST_STATUS], 'fail')
@@ -385,8 +416,14 @@ for (const version of versions) {
           tests.find(test => test.meta[TEST_STATUS] === 'pass').meta['test.webdriverio.worker'],
           'jasmine'
         )
-        assert.match(tests.find(test => test.meta[TEST_STATUS] === 'fail').meta['error.message'], /expected WebdriverIO/)
-      }, 1, { framework: 'jasmine' })
+        const failedTest = tests.find(test => test.meta[TEST_STATUS] === 'fail')
+        assert.match(failedTest.meta['error.message'], /expected WebdriverIO/)
+        assertFailureScreenshotUploaded(failedTest, media)
+      }, 1, {
+        env: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true' },
+        expectedScreenshots: 1,
+        framework: 'jasmine',
+      })
     })
 
     it('reports failures before Jasmine loads', async () => {
@@ -641,14 +678,18 @@ for (const version of versions) {
       })
     })
 
-    it('reports native Mocha retries', async () => {
-      await runScenario('retries', 1, ({ session, suites, tests }) => {
+    it('reports native Mocha retries and captures only the failed attempt', async () => {
+      await runScenario('retries', 1, ({ media, session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'pass')
         assert.strictEqual(suites.length, 1)
         assert.strictEqual(suites[0].meta[TEST_STATUS], 'pass')
         assert.strictEqual(tests.length, 2)
         assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]).sort(), ['fail', 'pass'])
         assert.strictEqual(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 1)
+        assertFailureScreenshotUploaded(tests.find(test => test.meta[TEST_STATUS] === 'fail'), media)
+      }, 0, {
+        env: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: 'true' },
+        expectedScreenshots: 1,
       })
     })
 

--- a/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
+++ b/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
@@ -36,6 +36,65 @@ function sendWebdriverioWorkerMessage (message, onError, onDone) {
 }
 
 let screenshotUploadRequestId = 0
+const screenshotUploadRequests = new Map()
+
+/**
+ * Removes shared screenshot response listeners when there are no pending requests.
+ *
+ * @returns {void}
+ */
+function removeScreenshotUploadListeners () {
+  if (screenshotUploadRequests.size !== 0) return
+
+  process.off('message', onScreenshotUploadResponse)
+  process.off('disconnect', onScreenshotUploadDisconnect)
+}
+
+/**
+ * Completes one pending screenshot upload request.
+ *
+ * @param {string} requestId
+ * @param {Error} [error]
+ * @returns {void}
+ */
+function finishScreenshotUploadRequest (requestId, error) {
+  const request = screenshotUploadRequests.get(requestId)
+  if (!request) return
+
+  screenshotUploadRequests.delete(requestId)
+  clearTimeout(request.timeout)
+  removeScreenshotUploadListeners()
+  request.onDone(error)
+}
+
+/**
+ * Dispatches one coordinator screenshot response to its pending request.
+ *
+ * @param {object} message
+ * @returns {void}
+ */
+function onScreenshotUploadResponse (message) {
+  if (message?.name !== SCREENSHOT_UPLOAD_RESPONSE) return
+
+  const { error: errorMessage, requestId } = message.content || {}
+  if (!requestId) return
+
+  finishScreenshotUploadRequest(requestId, errorMessage ? new Error(errorMessage) : undefined)
+}
+
+/**
+ * Fails every pending screenshot upload after coordinator disconnect.
+ *
+ * @returns {void}
+ */
+function onScreenshotUploadDisconnect () {
+  for (const requestId of screenshotUploadRequests.keys()) {
+    finishScreenshotUploadRequest(
+      requestId,
+      new Error('WebdriverIO coordinator disconnected during screenshot upload')
+    )
+  }
+}
 
 /**
  * Requests one screenshot upload from the WebdriverIO coordinator.
@@ -46,37 +105,23 @@ let screenshotUploadRequestId = 0
  */
 function requestWebdriverioScreenshotUpload (content, onDone) {
   const requestId = `${process.pid}-${++screenshotUploadRequestId}`
-  let finished = false
-  let timeout
-
-  const finish = (error) => {
-    if (finished) return
-    finished = true
-    clearTimeout(timeout)
-    timeout = undefined
-    process.off('message', onMessage)
-    process.off('disconnect', onDisconnect)
-    onDone(error)
-  }
-  const onDisconnect = () => finish(new Error('WebdriverIO coordinator disconnected during screenshot upload'))
-  const onMessage = (message) => {
-    if (message?.name !== SCREENSHOT_UPLOAD_RESPONSE || message.content?.requestId !== requestId) return
-
-    const errorMessage = message.content.error
-    finish(errorMessage ? new Error(errorMessage) : undefined)
-  }
-
-  process.on('message', onMessage)
-  process.once('disconnect', onDisconnect)
-  timeout = setTimeout(() => {
-    finish(new Error('WebdriverIO screenshot upload timed out'))
+  const timeout = setTimeout(() => {
+    finishScreenshotUploadRequest(requestId, new Error('WebdriverIO screenshot upload timed out'))
   }, SCREENSHOT_UPLOAD_TIMEOUT_MS)
   timeout.unref?.()
+  if (screenshotUploadRequests.size === 0) {
+    process.on('message', onScreenshotUploadResponse)
+    process.once('disconnect', onScreenshotUploadDisconnect)
+  }
+  screenshotUploadRequests.set(requestId, { onDone, timeout })
   sendWebdriverioWorkerMessage({
     origin: 'datadog',
     name: SCREENSHOT_UPLOAD,
     content: { ...content, requestId },
-  }, (error) => finish(error || new Error('WebdriverIO screenshot upload IPC failed')))
+  }, error => finishScreenshotUploadRequest(
+    requestId,
+    error || new Error('WebdriverIO screenshot upload IPC failed')
+  ))
 }
 
 module.exports = {

--- a/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
+++ b/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
@@ -6,10 +6,11 @@ const {
   WEBDRIVERIO_WORKER_EVENT,
   WEBDRIVERIO_WORKER_ORIGIN,
 } = require('../../../dd-trace/src/ci-visibility/exporters/test-worker/webdriverio')
+const { FINAL_FLUSH_TIMEOUT } = require('../../../dd-trace/src/ci-visibility/final-flush')
 
 const SCREENSHOT_UPLOAD = 'dd:test-optimization:webdriverio:screenshot:upload'
 const SCREENSHOT_UPLOAD_RESPONSE = 'dd:test-optimization:webdriverio:screenshot:upload:response'
-const SCREENSHOT_UPLOAD_TIMEOUT_MS = 30_000
+const SCREENSHOT_UPLOAD_TIMEOUT_MS = FINAL_FLUSH_TIMEOUT + 5000
 
 /**
  * Sends a message over WebdriverIO's worker IPC envelope.
@@ -85,6 +86,7 @@ module.exports = {
   requestWebdriverioScreenshotUpload,
   SCREENSHOT_UPLOAD,
   SCREENSHOT_UPLOAD_RESPONSE,
+  SCREENSHOT_UPLOAD_TIMEOUT_MS,
   sendWebdriverioWorkerMessage,
   SUITE_FINISH: 'dd:test-optimization:webdriverio:test-suite:finish',
   WORKER_READY: 'dd:test-optimization:webdriverio:worker:ready',

--- a/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
+++ b/packages/datadog-instrumentations/src/mocha/webdriverio-protocol.js
@@ -7,6 +7,10 @@ const {
   WEBDRIVERIO_WORKER_ORIGIN,
 } = require('../../../dd-trace/src/ci-visibility/exporters/test-worker/webdriverio')
 
+const SCREENSHOT_UPLOAD = 'dd:test-optimization:webdriverio:screenshot:upload'
+const SCREENSHOT_UPLOAD_RESPONSE = 'dd:test-optimization:webdriverio:screenshot:upload:response'
+const SCREENSHOT_UPLOAD_TIMEOUT_MS = 30_000
+
 /**
  * Sends a message over WebdriverIO's worker IPC envelope.
  *
@@ -30,10 +34,57 @@ function sendWebdriverioWorkerMessage (message, onError, onDone) {
   })
 }
 
+let screenshotUploadRequestId = 0
+
+/**
+ * Requests one screenshot upload from the WebdriverIO coordinator.
+ *
+ * @param {object} content - Screenshot upload metadata
+ * @param {(error?: Error) => void} onDone - Upload completion callback
+ * @returns {void}
+ */
+function requestWebdriverioScreenshotUpload (content, onDone) {
+  const requestId = `${process.pid}-${++screenshotUploadRequestId}`
+  let finished = false
+  let timeout
+
+  const finish = (error) => {
+    if (finished) return
+    finished = true
+    clearTimeout(timeout)
+    timeout = undefined
+    process.off('message', onMessage)
+    process.off('disconnect', onDisconnect)
+    onDone(error)
+  }
+  const onDisconnect = () => finish(new Error('WebdriverIO coordinator disconnected during screenshot upload'))
+  const onMessage = (message) => {
+    if (message?.name !== SCREENSHOT_UPLOAD_RESPONSE || message.content?.requestId !== requestId) return
+
+    const errorMessage = message.content.error
+    finish(errorMessage ? new Error(errorMessage) : undefined)
+  }
+
+  process.on('message', onMessage)
+  process.once('disconnect', onDisconnect)
+  timeout = setTimeout(() => {
+    finish(new Error('WebdriverIO screenshot upload timed out'))
+  }, SCREENSHOT_UPLOAD_TIMEOUT_MS)
+  timeout.unref?.()
+  sendWebdriverioWorkerMessage({
+    origin: 'datadog',
+    name: SCREENSHOT_UPLOAD,
+    content: { ...content, requestId },
+  }, (error) => finish(error || new Error('WebdriverIO screenshot upload IPC failed')))
+}
+
 module.exports = {
   CONFIGURATION_REQUEST: 'dd:test-optimization:webdriverio:configuration:request',
   CONFIGURATION_RESPONSE: 'dd:test-optimization:webdriverio:configuration:response',
   createWebdriverioWorkerMessage,
+  requestWebdriverioScreenshotUpload,
+  SCREENSHOT_UPLOAD,
+  SCREENSHOT_UPLOAD_RESPONSE,
   sendWebdriverioWorkerMessage,
   SUITE_FINISH: 'dd:test-optimization:webdriverio:test-suite:finish',
   WORKER_READY: 'dd:test-optimization:webdriverio:worker:ready',

--- a/packages/datadog-instrumentations/src/webdriverio.js
+++ b/packages/datadog-instrumentations/src/webdriverio.js
@@ -21,6 +21,8 @@ const { addHook, channel, tracingChannel } = require('./helpers/instrument')
 const {
   CONFIGURATION_REQUEST,
   CONFIGURATION_RESPONSE,
+  SCREENSHOT_UPLOAD,
+  SCREENSHOT_UPLOAD_RESPONSE,
   sendWebdriverioWorkerMessage,
   SUITE_FINISH,
   WEBDRIVERIO_WORKER_ENV,
@@ -41,6 +43,8 @@ const knownTestsCh = channel('ci:mocha:known-tests')
 const libraryConfigurationCh = channel('ci:mocha:library-configuration')
 const logSubmissionFlushCh = channel('ci:log-submission:flush')
 const modifiedFilesCh = channel('ci:mocha:modified-files')
+const screenshotCapabilitiesCh = channel('ci:webdriverio:screenshot:capabilities')
+const screenshotUploadCh = channel('ci:webdriverio:screenshot:upload')
 const testManagementTestsCh = channel('ci:mocha:test-management-tests')
 const workerConfigurationCh = channel('ci:mocha:worker:configuration')
 const workerReportLogsCh = channel('ci:mocha:worker-report:logs')
@@ -161,6 +165,7 @@ function createWorkerConfiguration () {
     isImpactedTestsEnabled: false,
     isItrEnabled: false,
     isKnownTestsEnabled: false,
+    isTestFailureScreenshotsEnabled: false,
     isSuitesSkippingEnabled: false,
     isTestDynamicInstrumentationEnabled: false,
     isTestManagementTestsEnabled: false,
@@ -478,6 +483,10 @@ function configureCoordinator (state, response) {
     libraryConfig,
     repositoryRoot,
   } = response || {}
+
+  const screenshotCapabilities = {}
+  screenshotCapabilitiesCh.publish(screenshotCapabilities)
+  configuration.isTestFailureScreenshotsEnabled = screenshotCapabilities.enabled === true
 
   configuration.repositoryRoot = repositoryRoot
   if (err || !libraryConfig) {
@@ -842,6 +851,28 @@ function handleWorkerMessage (state, workerRecord, message) {
   }
   if (message.name === CONFIGURATION_REQUEST) {
     handleConfigurationRequest(state, workerRecord, message)
+    return
+  }
+  if (message.name === SCREENSHOT_UPLOAD) {
+    const { requestId, ...content } = message.content || {}
+    const respond = (error) => sendWorkerMessage(workerRecord, {
+      origin: 'datadog',
+      name: SCREENSHOT_UPLOAD_RESPONSE,
+      content: {
+        error: error?.message,
+        requestId,
+      },
+    })
+    if (!requestId || !screenshotUploadCh.hasSubscribers) {
+      respond(new Error('WebdriverIO screenshot upload is not available'))
+    } else {
+      try {
+        screenshotUploadCh.publish({ ...content, onDone: respond })
+      } catch (error) {
+        log.error('WebdriverIO screenshot upload error: %s', error?.message || String(error))
+        respond(error)
+      }
+    }
     return
   }
   if (message.name === SUITE_FINISH) {

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -24,6 +24,8 @@ const {
   MOCHA_WORKER_LOGS_PAYLOAD_CODE,
   MOCHA_WORKER_TELEMETRY_PAYLOAD_CODE,
   MOCHA_WORKER_TRACE_PAYLOAD_CODE,
+  TEST_FAILURE_SCREENSHOT_UPLOADED,
+  TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR,
   TEST_HAS_DYNAMIC_NAME,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_IS_QUARANTINED,
@@ -514,6 +516,114 @@ describe('webdriverio instrumentation', () => {
       assert.strictEqual(plugin.testFrameworkAdapter, 'mocha')
     } finally {
       plugin.configure(false)
+    }
+  })
+
+  it('waits for every WebdriverIO screenshot upload before finishing a failed Jasmine test', async () => {
+    const originalBrowser = globalThis.browser
+    const screenshot = Buffer.from('webdriverio screenshot').toString('base64')
+    const uploadCallbacks = []
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: sinon.spy((options, callback) => uploadCallbacks.push(callback)),
+    }
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().resolves([screenshot, screenshot]),
+    }
+    const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'failure-screenshot.spec.js')
+    const result = {
+      ...createJasmineResult('failure screenshot', file, 'failed'),
+      failedExpectations: [{ message: 'expected failure' }],
+    }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish({
+        result: 'failed',
+        self: { id: result.id },
+      })
+      const finishContext = {
+        arguments: [result],
+        self: { _specs: [file] },
+      }
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish(finishContext)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      sinon.assert.calledOnce(globalThis.browser.takeScreenshot)
+      sinon.assert.calledTwice(exporter.uploadTestScreenshot)
+      assert.strictEqual(spans[0].context()._isFinished, false)
+      for (const call of exporter.uploadTestScreenshot.getCalls()) {
+        assert.deepStrictEqual(call.args[0].content, Buffer.from('webdriverio screenshot'))
+        assert.strictEqual(call.args[0].traceId, '123')
+      }
+
+      uploadCallbacks[0](null)
+      await Promise.resolve()
+      assert.strictEqual(spans[0].context()._isFinished, false)
+      uploadCallbacks[1](null)
+      await finishContext.result
+
+      assert.strictEqual(spans[0].context()._isFinished, true)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], undefined)
+    } finally {
+      plugin.configure(false)
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
+    }
+  })
+
+  it('tags a failed Jasmine test when its WebdriverIO screenshot upload fails', async () => {
+    const originalBrowser = globalThis.browser
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: sinon.spy((_options, callback) => callback(new Error('upload failed'))),
+    }
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().resolves(Buffer.from('webdriverio screenshot').toString('base64')),
+    }
+    const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'failure-screenshot-error.spec.js')
+    const result = {
+      ...createJasmineResult('failure screenshot error', file, 'failed'),
+      failedExpectations: [{ message: 'expected failure' }],
+    }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish({
+        result: 'failed',
+        self: { id: result.id },
+      })
+      const finishContext = {
+        arguments: [result],
+        self: { _specs: [file] },
+      }
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish(finishContext)
+      await finishContext.result
+
+      sinon.assert.calledOnce(exporter.uploadTestScreenshot)
+      assert.strictEqual(spans[0].context()._isFinished, true)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], undefined)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], 'true')
+    } finally {
+      plugin.configure(false)
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
     }
   })
 
@@ -1374,6 +1484,7 @@ describe('webdriverio instrumentation', () => {
         isKnownTestsEnabled: true,
         isSuitesSkippingEnabled: false,
         isTestDynamicInstrumentationEnabled: true,
+        isTestFailureScreenshotsEnabled: false,
         isTestManagementTestsEnabled: true,
         knownTests: {
           mocha: {
@@ -2053,10 +2164,14 @@ function createWorker () {
  * Creates a configured Jasmine worker plugin with observable test spans.
  *
  * @param {object} libraryConfig
+ * @param {object} [options]
+ * @param {object} [options.exporter]
+ * @param {object} [options.testOptimization]
  * @returns {{plugin: MochaPlugin, spans: object[]}}
  */
-function createJasminePlugin (libraryConfig) {
-  const plugin = new MochaPlugin({ _exporter: {} }, { testOptimization: {} })
+function createJasminePlugin (libraryConfig, options = {}) {
+  const { exporter = {}, testOptimization = {} } = options
+  const plugin = new MochaPlugin({ _exporter: exporter }, { testOptimization })
   const spans = []
   sinon.stub(plugin, 'startTestSpan').callsFake(() => {
     const tags = {}
@@ -2064,9 +2179,11 @@ function createJasminePlugin (libraryConfig) {
       _isFinished: false,
       _trace: { started: [] },
       getTags: () => tags,
+      toTraceId: () => '123',
     }
     const span = {
       context: () => context,
+      _getTime: () => Date.now(),
       finish: () => {
         context._isFinished = true
       },

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -108,6 +108,7 @@ const utilsFixtureModulePath = path.join(
   'index.js'
 )
 const execFileAsync = promisify(execFile)
+const PNG_SCREENSHOT = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).toString('base64')
 
 describe('webdriverio instrumentation', () => {
   it('rewrites the ESM launcher scheduler', () => {
@@ -525,9 +526,98 @@ describe('webdriverio instrumentation', () => {
     assert.strictEqual(SCREENSHOT_UPLOAD_TIMEOUT_MS, FINAL_FLUSH_TIMEOUT + 5000)
   })
 
+  it('rejects malformed coordinator screenshot payloads before upload', () => {
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: sinon.spy(),
+    }
+    const plugin = new MochaPlugin({ _exporter: exporter }, { testOptimization: {} })
+    const errors = []
+    plugin.configure({ enabled: true })
+
+    try {
+      for (const screenshot of [
+        `${PNG_SCREENSHOT}!!!`,
+        Buffer.from('not a PNG').toString('base64'),
+      ]) {
+        channel('ci:webdriverio:screenshot:upload').publish({
+          capturedAtMs: Date.now(),
+          idempotencyKey: '123:webdriverio-failure-0.png',
+          onDone: error => errors.push(error),
+          screenshot,
+          traceId: '123',
+        })
+      }
+
+      sinon.assert.notCalled(exporter.uploadTestScreenshot)
+      assert.strictEqual(errors.length, 2)
+      assert.match(errors[0].message, /invalid Base64 screenshot data/)
+      assert.match(errors[1].message, /invalid PNG screenshot data/)
+    } finally {
+      plugin.configure(false)
+    }
+  })
+
+  it('releases failed tests and worker shutdown when screenshot capture times out', () => {
+    const originalBrowser = globalThis.browser
+    const clock = sinon.useFakeTimers()
+    const workerFinished = sinon.spy()
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      flush: sinon.spy(callback => callback()),
+      uploadTestScreenshot: sinon.spy(),
+    }
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().returns({ then () {} }),
+    }
+    const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'failure-screenshot-timeout.spec.js')
+    const result = {
+      ...createJasmineResult('failure screenshot timeout', file, 'failed'),
+      failedExpectations: [{ message: 'expected failure' }],
+    }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish({
+        result: 'failed',
+        self: { id: result.id },
+      })
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+      channel('ci:mocha:worker:finish').publish({ onDone: workerFinished })
+
+      clock.tick(29_999)
+      assert.strictEqual(spans[0].context()._isFinished, false)
+      sinon.assert.notCalled(exporter.flush)
+      sinon.assert.notCalled(workerFinished)
+
+      clock.tick(1)
+      assert.strictEqual(spans[0].context()._isFinished, true)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], undefined)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], 'true')
+      sinon.assert.notCalled(exporter.uploadTestScreenshot)
+      sinon.assert.calledOnce(exporter.flush)
+      sinon.assert.calledOnce(workerFinished)
+    } finally {
+      plugin.configure(false)
+      clock.restore()
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
+    }
+  })
+
   it('waits for every WebdriverIO screenshot upload before finishing a failed Jasmine test', async () => {
     const originalBrowser = globalThis.browser
-    const screenshot = Buffer.from('webdriverio screenshot').toString('base64')
+    const screenshot = PNG_SCREENSHOT
     const uploadCallbacks = []
     const exporter = {
       canUploadTestScreenshots: () => true,
@@ -566,7 +656,7 @@ describe('webdriverio instrumentation', () => {
       sinon.assert.calledTwice(exporter.uploadTestScreenshot)
       assert.strictEqual(spans[0].context()._isFinished, false)
       for (const call of exporter.uploadTestScreenshot.getCalls()) {
-        assert.deepStrictEqual(call.args[0].content, Buffer.from('webdriverio screenshot'))
+        assert.deepStrictEqual(call.args[0].content, Buffer.from(PNG_SCREENSHOT, 'base64'))
         assert.strictEqual(call.args[0].traceId, '123')
       }
 
@@ -597,7 +687,7 @@ describe('webdriverio instrumentation', () => {
   it('captures failure screenshots when WebdriverIO global injection is disabled', async () => {
     const originalBrowser = globalThis.browser
     const originalWdioGlobals = globalThis._wdioGlobals
-    const screenshot = Buffer.from('webdriverio screenshot').toString('base64')
+    const screenshot = PNG_SCREENSHOT
     const browser = {
       takeScreenshot: sinon.stub().resolves(screenshot),
     }
@@ -649,7 +739,7 @@ describe('webdriverio instrumentation', () => {
     const originalBrowser = globalThis.browser
     const uploadCallbacks = []
     globalThis.browser = {
-      takeScreenshot: sinon.stub().resolves(Buffer.from('webdriverio screenshot').toString('base64')),
+      takeScreenshot: sinon.stub().resolves(PNG_SCREENSHOT),
     }
     const exporter = {
       canUploadTestScreenshots: () => true,
@@ -713,7 +803,7 @@ describe('webdriverio instrumentation', () => {
       uploadTestScreenshot: sinon.spy((_options, callback) => callback(new Error('upload failed'))),
     }
     globalThis.browser = {
-      takeScreenshot: sinon.stub().resolves(Buffer.from('webdriverio screenshot').toString('base64')),
+      takeScreenshot: sinon.stub().resolves(PNG_SCREENSHOT),
     }
     const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
       exporter,
@@ -739,6 +829,52 @@ describe('webdriverio instrumentation', () => {
       await finishContext.result
 
       sinon.assert.calledOnce(exporter.uploadTestScreenshot)
+      assert.strictEqual(spans[0].context()._isFinished, true)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], undefined)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], 'true')
+    } finally {
+      plugin.configure(false)
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
+    }
+  })
+
+  it('tags malformed WebdriverIO screenshot data as an upload error', async () => {
+    const originalBrowser = globalThis.browser
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: sinon.spy(),
+    }
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().resolves(`${PNG_SCREENSHOT}!!!`),
+    }
+    const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'failure-screenshot-invalid-data.spec.js')
+    const result = {
+      ...createJasmineResult('failure screenshot invalid data', file, 'failed'),
+      failedExpectations: [{ message: 'expected failure' }],
+    }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish({
+        result: 'failed',
+        self: { id: result.id },
+      })
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      sinon.assert.notCalled(exporter.uploadTestScreenshot)
       assert.strictEqual(spans[0].context()._isFinished, true)
       assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], undefined)
       assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], 'true')
@@ -863,7 +999,7 @@ describe('webdriverio instrumentation', () => {
     const originalBrowser = globalThis.browser
     const uploadCallbacks = []
     globalThis.browser = {
-      takeScreenshot: sinon.stub().resolves(Buffer.from('webdriverio screenshot').toString('base64')),
+      takeScreenshot: sinon.stub().resolves(PNG_SCREENSHOT),
     }
     const exporter = {
       canUploadTestScreenshots: () => true,

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -37,6 +37,8 @@ const {
 const {
   CONFIGURATION_REQUEST,
   CONFIGURATION_RESPONSE,
+  requestWebdriverioScreenshotUpload,
+  SCREENSHOT_UPLOAD_RESPONSE,
   SCREENSHOT_UPLOAD_TIMEOUT_MS,
   SUITE_FINISH,
   WEBDRIVERIO_WORKER_ENV,
@@ -524,6 +526,60 @@ describe('webdriverio instrumentation', () => {
 
   it('allows the WebdriverIO screenshot IPC response to outlive the exporter upload deadline', () => {
     assert.strictEqual(SCREENSHOT_UPLOAD_TIMEOUT_MS, FINAL_FLUSH_TIMEOUT + 5000)
+  })
+
+  it('shares one response dispatcher across concurrent screenshot upload requests', () => {
+    const originalConnected = process.connected
+    const originalSend = process.send
+    const initialDisconnectListeners = process.listenerCount('disconnect')
+    const initialMessageListeners = process.listenerCount('message')
+    const sentMessages = []
+    const uploadCallbacks = Array.from({ length: 11 }, () => sinon.spy())
+    process.connected = true
+    process.send = (message, onDone) => {
+      sentMessages.push(message)
+      onDone()
+    }
+
+    try {
+      for (const uploadCallback of uploadCallbacks) {
+        requestWebdriverioScreenshotUpload({ screenshot: PNG_SCREENSHOT }, uploadCallback)
+      }
+
+      assert.strictEqual(process.listenerCount('message'), initialMessageListeners + 1)
+      assert.strictEqual(process.listenerCount('disconnect'), initialDisconnectListeners + 1)
+      assert.strictEqual(sentMessages.length, 11)
+
+      for (const message of sentMessages) {
+        process.emit('message', {
+          name: SCREENSHOT_UPLOAD_RESPONSE,
+          content: { requestId: message.args.content.requestId },
+        })
+      }
+
+      for (const uploadCallback of uploadCallbacks) {
+        sinon.assert.calledOnceWithExactly(uploadCallback, undefined)
+      }
+      assert.strictEqual(process.listenerCount('message'), initialMessageListeners)
+      assert.strictEqual(process.listenerCount('disconnect'), initialDisconnectListeners)
+    } finally {
+      for (const message of sentMessages) {
+        process.emit('message', {
+          name: SCREENSHOT_UPLOAD_RESPONSE,
+          content: { requestId: message.args.content.requestId },
+        })
+      }
+      if (originalConnected === undefined) {
+        delete process.connected
+      } else {
+        process.connected = originalConnected
+      }
+      if (originalSend === undefined) {
+        delete process.send
+      } else {
+        process.send = originalSend
+      }
+    }
   })
 
   it('rejects malformed coordinator screenshot payloads before upload', () => {

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -37,10 +37,12 @@ const {
 const {
   CONFIGURATION_REQUEST,
   CONFIGURATION_RESPONSE,
+  SCREENSHOT_UPLOAD_TIMEOUT_MS,
   SUITE_FINISH,
   WEBDRIVERIO_WORKER_ENV,
   WORKER_READY,
 } = require('../src/mocha/webdriverio-protocol')
+const { FINAL_FLUSH_TIMEOUT } = require('../../dd-trace/src/ci-visibility/final-flush')
 
 const fixturePath = path.join(__dirname, 'fixtures', 'webdriverio-local-runner.mjs')
 const delayedWorkerFixturePath = path.join(__dirname, 'fixtures', 'webdriverio-delayed-worker.js')
@@ -519,12 +521,17 @@ describe('webdriverio instrumentation', () => {
     }
   })
 
+  it('allows the WebdriverIO screenshot IPC response to outlive the exporter upload deadline', () => {
+    assert.strictEqual(SCREENSHOT_UPLOAD_TIMEOUT_MS, FINAL_FLUSH_TIMEOUT + 5000)
+  })
+
   it('waits for every WebdriverIO screenshot upload before finishing a failed Jasmine test', async () => {
     const originalBrowser = globalThis.browser
     const screenshot = Buffer.from('webdriverio screenshot').toString('base64')
     const uploadCallbacks = []
     const exporter = {
       canUploadTestScreenshots: () => true,
+      flush: sinon.spy(callback => callback()),
       uploadTestScreenshot: sinon.spy((options, callback) => uploadCallbacks.push(callback)),
     }
     globalThis.browser = {
@@ -554,6 +561,7 @@ describe('webdriverio instrumentation', () => {
       await Promise.resolve()
       await Promise.resolve()
 
+      assert.strictEqual(finishContext.result, undefined)
       sinon.assert.calledOnce(globalThis.browser.takeScreenshot)
       sinon.assert.calledTwice(exporter.uploadTestScreenshot)
       assert.strictEqual(spans[0].context()._isFinished, false)
@@ -562,15 +570,132 @@ describe('webdriverio instrumentation', () => {
         assert.strictEqual(call.args[0].traceId, '123')
       }
 
+      const workerFinished = sinon.spy()
+      channel('ci:mocha:worker:finish').publish({ onDone: workerFinished })
+      sinon.assert.notCalled(exporter.flush)
+      sinon.assert.notCalled(workerFinished)
+
       uploadCallbacks[0](null)
-      await Promise.resolve()
       assert.strictEqual(spans[0].context()._isFinished, false)
       uploadCallbacks[1](null)
-      await finishContext.result
 
       assert.strictEqual(spans[0].context()._isFinished, true)
       assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
       assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOAD_ERROR], undefined)
+      sinon.assert.calledOnce(exporter.flush)
+      sinon.assert.calledOnce(workerFinished)
+    } finally {
+      plugin.configure(false)
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
+    }
+  })
+
+  it('captures failure screenshots when WebdriverIO global injection is disabled', async () => {
+    const originalBrowser = globalThis.browser
+    const originalWdioGlobals = globalThis._wdioGlobals
+    const screenshot = Buffer.from('webdriverio screenshot').toString('base64')
+    const browser = {
+      takeScreenshot: sinon.stub().resolves(screenshot),
+    }
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: sinon.spy((_options, callback) => callback()),
+    }
+    delete globalThis.browser
+    globalThis._wdioGlobals = new Map([['browser', browser]])
+    const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'failure-screenshot-no-globals.spec.js')
+    const result = {
+      ...createJasmineResult('failure screenshot without globals', file, 'failed'),
+      failedExpectations: [{ message: 'expected failure' }],
+    }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish({
+        result: 'failed',
+        self: { id: result.id },
+      })
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      sinon.assert.calledOnce(browser.takeScreenshot)
+      sinon.assert.calledOnce(exporter.uploadTestScreenshot)
+      assert.strictEqual(spans[0].context()._isFinished, true)
+      assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')
+    } finally {
+      plugin.configure(false)
+      globalThis._wdioGlobals = originalWdioGlobals
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
+    }
+  })
+
+  it('cleans up Failed Test Replay before a screenshot upload can overlap the next test', async () => {
+    const originalBrowser = globalThis.browser
+    const uploadCallbacks = []
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().resolves(Buffer.from('webdriverio screenshot').toString('base64')),
+    }
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: (_options, callback) => uploadCallbacks.push(callback),
+    }
+    const { plugin } = createJasminePlugin({
+      isDiEnabled: true,
+      isTestFailureScreenshotsEnabled: true,
+    }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'failure-screenshot-replay-cleanup.spec.js')
+    const result = {
+      ...createJasmineResult('failure screenshot replay cleanup', file, 'failed'),
+      failedExpectations: [{ message: 'expected failure' }],
+    }
+    const firstProbe = { file, line: 1 }
+    const secondProbe = { file, line: 2 }
+    plugin.di = {}
+    plugin.runningTestProbe = firstProbe
+    const cancelDiBreakpointHitWait = sinon.stub(plugin, 'cancelDiBreakpointHitWait')
+    const removeDiProbe = sinon.stub(plugin, 'removeDiProbe')
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish({
+        result: 'failed',
+        self: { id: result.id },
+      })
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [result],
+        self: { _specs: [file] },
+      })
+
+      sinon.assert.calledOnce(cancelDiBreakpointHitWait)
+      sinon.assert.calledOnceWithExactly(removeDiProbe, firstProbe)
+      assert.strictEqual(plugin.runningTestProbe, null)
+
+      plugin.runningTestProbe = secondProbe
+      await Promise.resolve()
+      uploadCallbacks[0]()
+
+      sinon.assert.calledOnce(cancelDiBreakpointHitWait)
+      sinon.assert.calledOnce(removeDiProbe)
+      assert.strictEqual(plugin.runningTestProbe, secondProbe)
     } finally {
       plugin.configure(false)
       if (originalBrowser === undefined) {
@@ -731,6 +856,74 @@ describe('webdriverio instrumentation', () => {
     } finally {
       retryCh.unsubscribe(onRetry)
       plugin.configure(false)
+    }
+  })
+
+  it('starts managed Jasmine retries while screenshot uploads are pending', async () => {
+    const originalBrowser = globalThis.browser
+    const uploadCallbacks = []
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().resolves(Buffer.from('webdriverio screenshot').toString('base64')),
+    }
+    const exporter = {
+      canUploadTestScreenshots: () => true,
+      uploadTestScreenshot: (_options, callback) => uploadCallbacks.push(callback),
+    }
+    const { plugin, spans } = createJasminePlugin({
+      flakyTestRetriesCount: 1,
+      isFlakyTestRetriesEnabled: true,
+      isTestFailureScreenshotsEnabled: true,
+    }, {
+      exporter,
+      testOptimization: { DD_TEST_FAILURE_SCREENSHOTS_ENABLED: true },
+    })
+    const file = path.join(process.cwd(), 'retry-with-screenshot-upload.spec.js')
+    const result = createJasmineResult('retry with screenshot upload', file, 'failed')
+    const onComplete = sinon.spy()
+    const spec = {
+      execute: sinon.spy(),
+      id: result.id,
+      queueableFn: { fn () {} },
+      reset: sinon.spy(),
+    }
+    const executeContext = {
+      arguments: [() => {}, onComplete, true, {}],
+      self: spec,
+    }
+
+    try {
+      reportJasmineSpecStarted(result, file)
+      channel('tracing:orchestrion:jasmine-core:Spec_execute:start').runStores(executeContext, () => {})
+
+      const attemptContext = { result: 'failed', self: spec }
+      channel('tracing:orchestrion:jasmine-core:Spec_attemptDone:end').publish(attemptContext)
+      channel('tracing:orchestrion:@wdio/jasmine-framework:JasmineReporter_specDone:end').publish({
+        arguments: [{
+          ...result,
+          failedExpectations: [{ message: 'managed retry failure' }],
+        }],
+        self: { _specs: [file] },
+      })
+      await Promise.resolve()
+      executeContext.arguments[1]()
+
+      assert.strictEqual(uploadCallbacks.length, 1)
+      assert.strictEqual(spans.length, 2)
+      assert.strictEqual(spec.execute.callCount, 1)
+      assert.strictEqual(spans[0].context()._isFinished, false)
+
+      uploadCallbacks[0]()
+
+      assert.strictEqual(spans[0].context()._isFinished, true)
+      assert.strictEqual(plugin.activeTestSpan, spans[1])
+      sinon.assert.notCalled(onComplete)
+    } finally {
+      plugin.configure(false)
+      if (originalBrowser === undefined) {
+        delete globalThis.browser
+      } else {
+        globalThis.browser = originalBrowser
+      }
     }
   })
 

--- a/packages/datadog-instrumentations/test/webdriverio.spec.js
+++ b/packages/datadog-instrumentations/test/webdriverio.spec.js
@@ -740,7 +740,7 @@ describe('webdriverio instrumentation', () => {
     }
   })
 
-  it('captures failure screenshots when WebdriverIO global injection is disabled', async () => {
+  it('prefers the registered WebdriverIO browser when global injection is disabled', async () => {
     const originalBrowser = globalThis.browser
     const originalWdioGlobals = globalThis._wdioGlobals
     const screenshot = PNG_SCREENSHOT
@@ -751,7 +751,9 @@ describe('webdriverio instrumentation', () => {
       canUploadTestScreenshots: () => true,
       uploadTestScreenshot: sinon.spy((_options, callback) => callback()),
     }
-    delete globalThis.browser
+    globalThis.browser = {
+      takeScreenshot: sinon.stub().rejects(new Error('not the WebdriverIO browser')),
+    }
     globalThis._wdioGlobals = new Map([['browser', browser]])
     const { plugin, spans } = createJasminePlugin({ isTestFailureScreenshotsEnabled: true }, {
       exporter,
@@ -777,6 +779,7 @@ describe('webdriverio instrumentation', () => {
       await Promise.resolve()
 
       sinon.assert.calledOnce(browser.takeScreenshot)
+      sinon.assert.notCalled(globalThis.browser.takeScreenshot)
       sinon.assert.calledOnce(exporter.uploadTestScreenshot)
       assert.strictEqual(spans[0].context()._isFinished, true)
       assert.strictEqual(spans[0].context().getTags()[TEST_FAILURE_SCREENSHOT_UPLOADED], 'true')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -15,7 +15,6 @@ const {
 const {
   SCREENSHOT_UPLOAD_RESULT_ERROR,
   SCREENSHOT_UPLOAD_RESULT_UPLOADED,
-  getScreenshotUploadResult,
   setScreenshotUploadTags,
 } = require('../../dd-trace/src/ci-visibility/test-screenshot')
 const log = require('../../dd-trace/src/log')
@@ -196,7 +195,8 @@ class MochaPlugin extends CiPlugin {
     this._testTitleToParams = {}
     this.sourceRoot = process.cwd()
     this._webdriverioScreenshotUploads = new WeakMap()
-    this._pendingWebdriverioScreenshotUploads = new Set()
+    this._pendingWebdriverioScreenshotUploads = 0
+    this._webdriverioScreenshotUploadCallbacks = []
 
     this.addSub('ci:webdriverio:screenshot:capabilities', (ctx) => {
       ctx.enabled = Boolean(
@@ -595,12 +595,11 @@ class MochaPlugin extends CiPlugin {
 
     this.addSub('ci:mocha:worker:finish', ({ onDone } = {}) => {
       const flush = () => this.tracer._exporter.flush(onDone)
-      if (this._pendingWebdriverioScreenshotUploads.size === 0) {
+      if (this._pendingWebdriverioScreenshotUploads === 0) {
         flush()
         return
       }
-      const uploads = [...this._pendingWebdriverioScreenshotUploads]
-      Promise.all(uploads.map(upload => upload.then(() => {}, () => {}))).then(flush)
+      this._webdriverioScreenshotUploadCallbacks.push(flush)
     })
 
     this.addSub('ci:mocha:test:finish', ({
@@ -615,7 +614,6 @@ class MochaPlugin extends CiPlugin {
       isAtrRetry,
       finalStatus,
       earlyFlakeAbortReason,
-      promises,
     }) => {
       if (span) {
         const finishTime = span._getTime()
@@ -647,6 +645,12 @@ class MochaPlugin extends CiPlugin {
           span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
         }
 
+        this.cancelDiBreakpointHitWait()
+        if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbe && isLastRetry) {
+          this.removeDiProbe(this.runningTestProbe)
+          this.runningTestProbe = null
+        }
+
         const finishSpan = () => {
           this.telemetry.ciVisEvent(
             TELEMETRY_EVENT_FINISHED,
@@ -658,19 +662,8 @@ class MochaPlugin extends CiPlugin {
           if (this.activeTestSpan === span) {
             this.activeTestSpan = null
           }
-          this.cancelDiBreakpointHitWait()
-          if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbe && isLastRetry) {
-            this.removeDiProbe(this.runningTestProbe)
-            this.runningTestProbe = null
-          }
         }
-        const screenshotUpload = status === 'fail' && this.#startWebdriverioScreenshotUpload(span)
-        if (screenshotUpload) {
-          const finishTestPromise = screenshotUpload.then(finishSpan, finishSpan)
-          if (promises) {
-            promises.finishTestPromise = finishTestPromise
-          }
-        } else {
+        if (status !== 'fail' || !this.#startWebdriverioScreenshotUpload(span, finishSpan)) {
           finishSpan()
         }
       }
@@ -780,21 +773,34 @@ class MochaPlugin extends CiPlugin {
           this.runningTestProbe) {
           finishWait = this.waitForInFlightDiBreakpointHits()
         }
-        const screenshotUpload = this.#startWebdriverioScreenshotUpload(span)
-        if (finishWait && screenshotUpload) {
-          finishWait = Promise.all([finishWait, screenshotUpload])
-        } else {
-          finishWait ||= screenshotUpload
+        let screenshotFinished = false
+        let canFinishScreenshot = false
+        let replayFinished = !finishWait
+        let spanFinished = false
+        const finishWhenReady = () => {
+          if (!spanFinished && replayFinished && (screenshotStarted === false || screenshotFinished)) {
+            spanFinished = true
+            finishSpan()
+          }
         }
+        const screenshotStarted = this.#startWebdriverioScreenshotUpload(span, () => {
+          screenshotFinished = true
+          if (canFinishScreenshot) {
+            finishWhenReady()
+          }
+        })
+        canFinishScreenshot = true
         if (finishWait) {
-          const finishTestPromise = finishWait.then(finishSpan, finishSpan)
+          const finishReplay = () => {
+            replayFinished = true
+            finishWhenReady()
+          }
+          const finishTestPromise = finishWait.then(finishReplay, finishReplay)
           if (promises) {
             promises.finishTestPromise = finishTestPromise
           }
-          return
         }
-
-        finishSpan()
+        finishWhenReady()
       }
     })
 
@@ -1325,7 +1331,7 @@ class MochaPlugin extends CiPlugin {
    *
    * @param {object} test
    * @param {WebdriverioJasmineResult} result
-   * @returns {Promise<void>|undefined}
+   * @returns {void}
    */
   #completeWebdriverioJasmineTest (test, result) {
     const state = this._webdriverioJasmineState
@@ -1353,7 +1359,6 @@ class MochaPlugin extends CiPlugin {
     } else if (test.isEarlyFlakeDetection && status !== 'skip' && !test.hasFinalHookFailure) {
       finalStatus = test.statuses.includes('pass') ? 'pass' : 'fail'
     }
-    const promises = {}
     testFinishCh.publish({
       attemptToFixFailed,
       attemptToFixPassed,
@@ -1364,7 +1369,6 @@ class MochaPlugin extends CiPlugin {
       isAttemptToFixRetry: test.isAttemptToFix && test.attempt > 0,
       isAtrRetry: test.isAtr && test.attempt > 0,
       isLastRetry: true,
-      promises,
       status,
       ...test.currentStore,
     })
@@ -1376,27 +1380,34 @@ class MochaPlugin extends CiPlugin {
     if (suiteStatus === 'fail' || !previousStatus || previousStatus === 'skip') {
       state.suiteStatuses.set(test.testSuiteAbsolutePath, suiteStatus)
     }
-    return promises.finishTestPromise
   }
 
   /**
    * Captures and uploads the current WebdriverIO browser state once for a failed test attempt.
    *
    * @param {object} span - Failed test span
-   * @returns {Promise<string>|undefined} Screenshot upload result
+   * @param {() => void} [onDone] - Called after the screenshot upload finishes
+   * @returns {boolean} Whether a screenshot upload exists for the span
    */
-  #startWebdriverioScreenshotUpload (span) {
+  #startWebdriverioScreenshotUpload (span, onDone) {
     if (
       !span ||
       this.testFramework !== WEBDRIVERIO_FRAMEWORK ||
       !this._tracerConfig.testOptimization?.DD_TEST_FAILURE_SCREENSHOTS_ENABLED
     ) {
-      return
+      return false
     }
 
     const previousUpload = this._webdriverioScreenshotUploads.get(span)
     if (previousUpload) {
-      return previousUpload
+      if (onDone) {
+        if (previousUpload.finished) {
+          onDone()
+        } else {
+          previousUpload.callbacks.push(onDone)
+        }
+      }
+      return true
     }
 
     const exporter = this.tracer?._exporter
@@ -1404,34 +1415,71 @@ class MochaPlugin extends CiPlugin {
       ? this.libraryConfig?.isTestFailureScreenshotsEnabled
       : exporter?.canUploadTestScreenshots?.() && exporter.uploadTestScreenshot
     if (!canUpload) {
-      return
+      return false
     }
 
-    const browser = globalThis.browser
-    let upload
+    const browser = globalThis.browser || globalThis._wdioGlobals?.get?.('browser')
+    const upload = {
+      callbacks: onDone ? [onDone] : [],
+      finished: false,
+    }
+    this._webdriverioScreenshotUploads.set(span, upload)
+    this._pendingWebdriverioScreenshotUploads++
+    const finishUpload = (result) => this.#finishWebdriverioScreenshotUpload(span, upload, result)
+    const uploadScreenshots = (content) => {
+      try {
+        this.#uploadWebdriverioScreenshots(span, content, finishUpload)
+      } catch (error) {
+        finishUpload(handleWebdriverioScreenshotError(error))
+      }
+    }
     try {
       if (typeof browser?.takeScreenshot !== 'function') {
         throw new TypeError('browser.takeScreenshot is not available')
       }
-      upload = Promise.resolve(browser.takeScreenshot()).then(
-        content => this.#uploadWebdriverioScreenshots(span, content),
-        handleWebdriverioScreenshotError
-      )
+      const screenshot = browser.takeScreenshot()
+      if (typeof screenshot?.then === 'function') {
+        screenshot.then(
+          uploadScreenshots,
+          error => finishUpload(handleWebdriverioScreenshotError(error))
+        )
+      } else {
+        uploadScreenshots(screenshot)
+      }
     } catch (error) {
-      handleWebdriverioScreenshotError(error)
-      upload = Promise.resolve(SCREENSHOT_UPLOAD_RESULT_ERROR)
+      finishUpload(handleWebdriverioScreenshotError(error))
     }
+    return true
+  }
 
-    const uploadPromise = upload.then(result => result, handleWebdriverioScreenshotError).then((result) => {
-      setScreenshotUploadTags(span, result)
-      return result
-    })
+  /**
+   * Completes one WebdriverIO screenshot upload and its waiters.
+   *
+   * @param {object} span - Failed test span
+   * @param {{callbacks: Array<() => void>, finished: boolean}} upload - Upload state
+   * @param {string} result - Aggregate screenshot upload result
+   * @returns {void}
+   */
+  #finishWebdriverioScreenshotUpload (span, upload, result) {
+    if (upload.finished) return
 
-    this._webdriverioScreenshotUploads.set(span, uploadPromise)
-    this._pendingWebdriverioScreenshotUploads.add(uploadPromise)
-    const clearPendingUpload = () => this._pendingWebdriverioScreenshotUploads.delete(uploadPromise)
-    uploadPromise.then(clearPendingUpload, clearPendingUpload)
-    return uploadPromise
+    upload.finished = true
+    setScreenshotUploadTags(span, result)
+    const uploadCallbacks = upload.callbacks
+    upload.callbacks = []
+
+    this._pendingWebdriverioScreenshotUploads--
+    let workerCallbacks = []
+    if (this._pendingWebdriverioScreenshotUploads === 0) {
+      workerCallbacks = this._webdriverioScreenshotUploadCallbacks
+      this._webdriverioScreenshotUploadCallbacks = []
+    }
+    for (const callback of uploadCallbacks) {
+      callback()
+    }
+    for (const callback of workerCallbacks) {
+      callback()
+    }
   }
 
   /**
@@ -1439,22 +1487,35 @@ class MochaPlugin extends CiPlugin {
    *
    * @param {object} span - Failed test span
    * @param {string|string[]} screenshots - Base64-encoded PNG data
-   * @returns {Promise<string>} Aggregate screenshot upload result
+   * @param {(result: string) => void} onDone - Aggregate upload completion callback
+   * @returns {void}
    */
-  #uploadWebdriverioScreenshots (span, screenshots) {
+  #uploadWebdriverioScreenshots (span, screenshots, onDone) {
     const screenshotList = Array.isArray(screenshots) ? screenshots : [screenshots]
     if (screenshotList.length === 0) {
       log.error('Error capturing WebdriverIO failure screenshot: WebdriverIO returned no screenshot data')
-      return Promise.resolve(SCREENSHOT_UPLOAD_RESULT_ERROR)
+      onDone(SCREENSHOT_UPLOAD_RESULT_ERROR)
+      return
     }
     const exporter = this.tracer?._exporter
     const traceId = span.context().toTraceId()
     const capturedAtMs = Date.now()
-    const uploads = screenshotList.map((screenshot, index) => new Promise((resolve) => {
+    let pendingUploads = screenshotList.length
+    let hasUploadError = false
+    const finishOne = (error) => {
+      if (error) {
+        hasUploadError = true
+        log.error('Error uploading WebdriverIO failure screenshot: %s', error?.message || String(error))
+      }
+      if (--pendingUploads === 0) {
+        onDone(hasUploadError ? SCREENSHOT_UPLOAD_RESULT_ERROR : SCREENSHOT_UPLOAD_RESULT_UPLOADED)
+      }
+    }
+    for (let index = 0; index < screenshotList.length; index++) {
+      const screenshot = screenshotList[index]
       if (typeof screenshot !== 'string' || !screenshot) {
-        log.error('Error capturing WebdriverIO failure screenshot: WebdriverIO returned invalid screenshot data')
-        resolve(SCREENSHOT_UPLOAD_RESULT_ERROR)
-        return
+        finishOne(new TypeError('WebdriverIO returned invalid screenshot data'))
+        continue
       }
       const options = {
         screenshot,
@@ -1462,36 +1523,36 @@ class MochaPlugin extends CiPlugin {
         idempotencyKey: `${traceId}:webdriverio-failure-${index}.png`,
         capturedAtMs,
       }
-      const onDone = (error) => {
-        if (error) {
-          log.error('Error uploading WebdriverIO failure screenshot: %s', error?.message || String(error))
-        }
-        resolve(error ? SCREENSHOT_UPLOAD_RESULT_ERROR : SCREENSHOT_UPLOAD_RESULT_UPLOADED)
-      }
       if (isWebdriverioWorker) {
-        requestWebdriverioScreenshotUpload(options, onDone)
+        try {
+          requestWebdriverioScreenshotUpload(options, finishOne)
+        } catch (error) {
+          finishOne(error)
+        }
       } else {
         let content
         try {
           content = Buffer.from(screenshot, 'base64')
         } catch (error) {
-          onDone(error)
-          return
+          finishOne(error)
+          continue
         }
         if (content.length === 0) {
-          onDone(new Error('WebdriverIO returned an empty screenshot'))
-          return
+          finishOne(new Error('WebdriverIO returned an empty screenshot'))
+          continue
         }
-        exporter.uploadTestScreenshot({
-          content,
-          traceId,
-          idempotencyKey: options.idempotencyKey,
-          capturedAtMs,
-        }, onDone)
+        try {
+          exporter.uploadTestScreenshot({
+            content,
+            traceId,
+            idempotencyKey: options.idempotencyKey,
+            capturedAtMs,
+          }, finishOne)
+        } catch (error) {
+          finishOne(error)
+        }
       }
-    }))
-
-    return Promise.all(uploads).then(getScreenshotUploadResult)
+    }
   }
 
   /**

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -92,11 +92,14 @@ const testFinishCh = channel('ci:mocha:test:finish')
 const testRetryCh = channel('ci:mocha:test:retry')
 const WEBDRIVERIO_FRAMEWORK = 'webdriverio'
 const WEBDRIVERIO_JASMINE_ADAPTER = 'jasmine'
+const WEBDRIVERIO_SCREENSHOT_CAPTURE_TIMEOUT_MS = 30_000
 const workerFinishCh = channel('ci:mocha:worker:finish')
 const WEBDRIVERIO_JASMINE_FAILED_EXPECTATION_COUNT = Symbol('webdriverioJasmineFailedExpectationCount')
 const WEBDRIVERIO_JASMINE_FUNCTION_TYPE = Symbol('webdriverioJasmineFunctionType')
 const WEBDRIVERIO_JASMINE_TEST = Symbol('webdriverioJasmineTest')
 const isWebdriverioWorker = !!getEnvironmentVariable(WEBDRIVERIO_WORKER_ENV)
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
+const BASE64_RE = /^(?:[A-Za-z\d+/]{4})*(?:[A-Za-z\d+/]{2}==|[A-Za-z\d+/]{3}=)?$/
 
 /**
  * @typedef {object} WebdriverioJasmineResult
@@ -161,6 +164,28 @@ function handleWebdriverioScreenshotError (error) {
 }
 
 /**
+ * Decodes and validates PNG screenshot data returned by WebdriverIO.
+ *
+ * @param {unknown} screenshot - Base64-encoded PNG data
+ * @returns {Buffer} Decoded PNG data
+ */
+function decodeWebdriverioScreenshot (screenshot) {
+  if (typeof screenshot !== 'string' || !BASE64_RE.test(screenshot)) {
+    throw new TypeError('WebdriverIO returned invalid Base64 screenshot data')
+  }
+
+  const content = Buffer.from(screenshot, 'base64')
+  if (
+    content.toString('base64') !== screenshot ||
+    content.length < PNG_SIGNATURE.length ||
+    !content.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)
+  ) {
+    throw new TypeError('WebdriverIO returned invalid PNG screenshot data')
+  }
+  return content
+}
+
+/**
  * Resolves the spec file responsible for a run-level Jasmine failure.
  *
  * @param {WebdriverioJasmineResult|undefined} result
@@ -219,16 +244,9 @@ class MochaPlugin extends CiPlugin {
       }
       let content
       try {
-        if (typeof screenshot !== 'string' || !screenshot) {
-          throw new TypeError('WebdriverIO returned invalid screenshot data')
-        }
-        content = Buffer.from(screenshot, 'base64')
+        content = decodeWebdriverioScreenshot(screenshot)
       } catch (error) {
         onDone(error)
-        return
-      }
-      if (content.length === 0) {
-        onDone(new Error('WebdriverIO returned an empty screenshot'))
         return
       }
       exporter.uploadTestScreenshot({ content, traceId, idempotencyKey, capturedAtMs }, onDone)
@@ -1426,13 +1444,29 @@ class MochaPlugin extends CiPlugin {
     this._webdriverioScreenshotUploads.set(span, upload)
     this._pendingWebdriverioScreenshotUploads++
     const finishUpload = (result) => this.#finishWebdriverioScreenshotUpload(span, upload, result)
+    let captureTimeout
+    const failCapture = (error) => {
+      if (upload.finished) return
+      clearTimeout(captureTimeout)
+      captureTimeout = undefined
+      finishUpload(handleWebdriverioScreenshotError(error))
+    }
     const uploadScreenshots = (content) => {
+      if (upload.finished) return
+      clearTimeout(captureTimeout)
+      captureTimeout = undefined
       try {
         this.#uploadWebdriverioScreenshots(span, content, finishUpload)
       } catch (error) {
-        finishUpload(handleWebdriverioScreenshotError(error))
+        failCapture(error)
       }
     }
+    captureTimeout = setTimeout(() => {
+      failCapture(new Error(
+        `WebdriverIO screenshot capture timed out after ${WEBDRIVERIO_SCREENSHOT_CAPTURE_TIMEOUT_MS}ms`
+      ))
+    }, WEBDRIVERIO_SCREENSHOT_CAPTURE_TIMEOUT_MS)
+    captureTimeout.unref?.()
     try {
       if (typeof browser?.takeScreenshot !== 'function') {
         throw new TypeError('browser.takeScreenshot is not available')
@@ -1441,13 +1475,13 @@ class MochaPlugin extends CiPlugin {
       if (typeof screenshot?.then === 'function') {
         screenshot.then(
           uploadScreenshots,
-          error => finishUpload(handleWebdriverioScreenshotError(error))
+          failCapture
         )
       } else {
         uploadScreenshots(screenshot)
       }
     } catch (error) {
-      finishUpload(handleWebdriverioScreenshotError(error))
+      failCapture(error)
     }
     return true
   }
@@ -1532,13 +1566,9 @@ class MochaPlugin extends CiPlugin {
       } else {
         let content
         try {
-          content = Buffer.from(screenshot, 'base64')
+          content = decodeWebdriverioScreenshot(screenshot)
         } catch (error) {
           finishOne(error)
-          continue
-        }
-        if (content.length === 0) {
-          finishOne(new Error('WebdriverIO returned an empty screenshot'))
           continue
         }
         try {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -7,14 +7,23 @@ const { channel } = require('dc-polyfill')
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
+const { getEnvironmentVariable } = require('../../dd-trace/src/config/helper')
 const {
   getEfdRetryCountForDuration,
   hasEfdRetries,
 } = require('../../dd-trace/src/ci-visibility/efd-retry-policy')
+const {
+  SCREENSHOT_UPLOAD_RESULT_ERROR,
+  SCREENSHOT_UPLOAD_RESULT_UPLOADED,
+  getScreenshotUploadResult,
+  setScreenshotUploadTags,
+} = require('../../dd-trace/src/ci-visibility/test-screenshot')
 const log = require('../../dd-trace/src/log')
 const {
+  requestWebdriverioScreenshotUpload,
   sendWebdriverioWorkerMessage,
   SUITE_FINISH,
+  WEBDRIVERIO_WORKER_ENV,
 } = require('../../datadog-instrumentations/src/mocha/webdriverio-protocol')
 
 const {
@@ -82,11 +91,13 @@ const jasmineSpecExecuteStartCh = 'tracing:orchestrion:jasmine-core:Spec_execute
 const jasmineTestFunctionStartCh = 'tracing:orchestrion:@wdio/utils:testFrameworkFnWrapper:start'
 const testFinishCh = channel('ci:mocha:test:finish')
 const testRetryCh = channel('ci:mocha:test:retry')
+const WEBDRIVERIO_FRAMEWORK = 'webdriverio'
 const WEBDRIVERIO_JASMINE_ADAPTER = 'jasmine'
 const workerFinishCh = channel('ci:mocha:worker:finish')
 const WEBDRIVERIO_JASMINE_FAILED_EXPECTATION_COUNT = Symbol('webdriverioJasmineFailedExpectationCount')
 const WEBDRIVERIO_JASMINE_FUNCTION_TYPE = Symbol('webdriverioJasmineFunctionType')
 const WEBDRIVERIO_JASMINE_TEST = Symbol('webdriverioJasmineTest')
+const isWebdriverioWorker = !!getEnvironmentVariable(WEBDRIVERIO_WORKER_ENV)
 
 /**
  * @typedef {object} WebdriverioJasmineResult
@@ -140,6 +151,17 @@ function getJasmineError (result) {
 }
 
 /**
+ * Converts a screenshot capture failure into its upload result.
+ *
+ * @param {unknown} error
+ * @returns {string}
+ */
+function handleWebdriverioScreenshotError (error) {
+  log.error('Error capturing WebdriverIO failure screenshot: %s', error?.message || String(error))
+  return SCREENSHOT_UPLOAD_RESULT_ERROR
+}
+
+/**
  * Resolves the spec file responsible for a run-level Jasmine failure.
  *
  * @param {WebdriverioJasmineResult|undefined} result
@@ -173,6 +195,44 @@ class MochaPlugin extends CiPlugin {
 
     this._testTitleToParams = {}
     this.sourceRoot = process.cwd()
+    this._webdriverioScreenshotUploads = new WeakMap()
+    this._pendingWebdriverioScreenshotUploads = new Set()
+
+    this.addSub('ci:webdriverio:screenshot:capabilities', (ctx) => {
+      ctx.enabled = Boolean(
+        this._tracerConfig.testOptimization?.DD_TEST_FAILURE_SCREENSHOTS_ENABLED &&
+        this.tracer._exporter?.canUploadTestScreenshots?.()
+      )
+    })
+
+    this.addSub('ci:webdriverio:screenshot:upload', ({
+      capturedAtMs,
+      idempotencyKey,
+      onDone,
+      screenshot,
+      traceId,
+    }) => {
+      const exporter = this.tracer?._exporter
+      if (!exporter?.canUploadTestScreenshots?.() || !exporter.uploadTestScreenshot) {
+        onDone(new Error('WebdriverIO screenshot upload is not supported by the active Test Optimization transport'))
+        return
+      }
+      let content
+      try {
+        if (typeof screenshot !== 'string' || !screenshot) {
+          throw new TypeError('WebdriverIO returned invalid screenshot data')
+        }
+        content = Buffer.from(screenshot, 'base64')
+      } catch (error) {
+        onDone(error)
+        return
+      }
+      if (content.length === 0) {
+        onDone(new Error('WebdriverIO returned an empty screenshot'))
+        return
+      }
+      exporter.uploadTestScreenshot({ content, traceId, idempotencyKey, capturedAtMs }, onDone)
+    })
 
     this.addSub('ci:mocha:worker:configuration', ({
       libraryConfig,
@@ -185,6 +245,18 @@ class MochaPlugin extends CiPlugin {
       this.testFramework = testFramework
       this.testFrameworkAdapter = testFrameworkAdapter
       this._setRepositoryRoot(repositoryRoot)
+      if (
+        testFramework === WEBDRIVERIO_FRAMEWORK &&
+        this._tracerConfig.testOptimization.DD_TEST_FAILURE_SCREENSHOTS_ENABLED &&
+        !(isWebdriverioWorker
+          ? libraryConfig.isTestFailureScreenshotsEnabled
+          : this.tracer._exporter?.canUploadTestScreenshots?.())
+      ) {
+        log.warn(
+          'DD_TEST_FAILURE_SCREENSHOTS_ENABLED is true, but WebdriverIO screenshot upload is not supported by the %s',
+          'active Test Optimization transport.'
+        )
+      }
       if (testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER) {
         this._webdriverioJasmineState = {
           completedTestStatuses: new Map(),
@@ -261,12 +333,11 @@ class MochaPlugin extends CiPlugin {
     this.addSub(jasmineExecuteAsyncErrorCh, (ctx) => {
       const currentStore = ctx.currentStore || storage('legacy').getStore()
       const test = currentStore?.[WEBDRIVERIO_JASMINE_TEST]
-      if (
-        this.testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER &&
-        test &&
-        currentStore[WEBDRIVERIO_JASMINE_FUNCTION_TYPE] === 'Hook'
-      ) {
-        test.hasFinalHookFailure = true
+      if (this.testFrameworkAdapter === WEBDRIVERIO_JASMINE_ADAPTER && test) {
+        this.#startWebdriverioScreenshotUpload(test.span)
+        if (currentStore[WEBDRIVERIO_JASMINE_FUNCTION_TYPE] === 'Hook') {
+          test.hasFinalHookFailure = true
+        }
       }
     })
 
@@ -281,6 +352,7 @@ class MochaPlugin extends CiPlugin {
         this._webdriverioJasmineState.currentResult?.failedExpectations?.length > failedExpectationCount
       ) {
         test.hasFinalHookFailure = true
+        this.#startWebdriverioScreenshotUpload(test.span)
       }
     })
 
@@ -522,7 +594,13 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:worker:finish', ({ onDone } = {}) => {
-      this.tracer._exporter.flush(onDone)
+      const flush = () => this.tracer._exporter.flush(onDone)
+      if (this._pendingWebdriverioScreenshotUploads.size === 0) {
+        flush()
+        return
+      }
+      const uploads = [...this._pendingWebdriverioScreenshotUploads]
+      Promise.all(uploads.map(upload => upload.then(() => {}, () => {}))).then(flush)
     })
 
     this.addSub('ci:mocha:test:finish', ({
@@ -537,8 +615,10 @@ class MochaPlugin extends CiPlugin {
       isAtrRetry,
       finalStatus,
       earlyFlakeAbortReason,
+      promises,
     }) => {
       if (span) {
+        const finishTime = span._getTime()
         span.setTag(TEST_STATUS, status)
         if (finalStatus) {
           span.setTag(TEST_FINAL_STATUS, finalStatus)
@@ -567,19 +647,31 @@ class MochaPlugin extends CiPlugin {
           span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
         }
 
-        this.telemetry.ciVisEvent(
-          TELEMETRY_EVENT_FINISHED,
-          'test',
-          this.getTestTelemetryTags(span)
-        )
-
-        span.finish()
-        finishAllTraceSpans(span)
-        this.activeTestSpan = null
-        this.cancelDiBreakpointHitWait()
-        if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbe && isLastRetry) {
-          this.removeDiProbe(this.runningTestProbe)
-          this.runningTestProbe = null
+        const finishSpan = () => {
+          this.telemetry.ciVisEvent(
+            TELEMETRY_EVENT_FINISHED,
+            'test',
+            this.getTestTelemetryTags(span)
+          )
+          span.finish(finishTime)
+          finishAllTraceSpans(span)
+          if (this.activeTestSpan === span) {
+            this.activeTestSpan = null
+          }
+          this.cancelDiBreakpointHitWait()
+          if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbe && isLastRetry) {
+            this.removeDiProbe(this.runningTestProbe)
+            this.runningTestProbe = null
+          }
+        }
+        const screenshotUpload = status === 'fail' && this.#startWebdriverioScreenshotUpload(span)
+        if (screenshotUpload) {
+          const finishTestPromise = screenshotUpload.then(finishSpan, finishSpan)
+          if (promises) {
+            promises.finishTestPromise = finishTestPromise
+          }
+        } else {
+          finishSpan()
         }
       }
     })
@@ -610,6 +702,7 @@ class MochaPlugin extends CiPlugin {
         } else {
           span.setTag(TEST_STATUS, 'fail')
           span.setTag('error', err)
+          this.#startWebdriverioScreenshotUpload(span)
         }
 
         ctx.parentStore = ctx.currentStore
@@ -634,8 +727,9 @@ class MochaPlugin extends CiPlugin {
       promises,
     }) => {
       if (span) {
+        const finishTime = span._getTime()
         const finishSpan = () => {
-          span.finish()
+          span.finish(finishTime)
           finishAllTraceSpans(span)
           if (this.activeTestSpan === span) {
             this.activeTestSpan = null
@@ -678,13 +772,25 @@ class MochaPlugin extends CiPlugin {
           }
         }
 
+        let finishWait
         if (!isFirstFailure &&
           willBeRetried &&
           this.di &&
           this.libraryConfig?.isDiEnabled &&
-          this.runningTestProbe &&
-          promises) {
-          promises.finishTestPromise = this.waitForInFlightDiBreakpointHits().then(finishSpan, finishSpan)
+          this.runningTestProbe) {
+          finishWait = this.waitForInFlightDiBreakpointHits()
+        }
+        const screenshotUpload = this.#startWebdriverioScreenshotUpload(span)
+        if (finishWait && screenshotUpload) {
+          finishWait = Promise.all([finishWait, screenshotUpload])
+        } else {
+          finishWait ||= screenshotUpload
+        }
+        if (finishWait) {
+          const finishTestPromise = finishWait.then(finishSpan, finishSpan)
+          if (promises) {
+            promises.finishTestPromise = finishTestPromise
+          }
           return
         }
 
@@ -1032,6 +1138,9 @@ class MochaPlugin extends CiPlugin {
     }
 
     const testStatus = getJasmineStatus(status)
+    if (testStatus === 'fail') {
+      this.#startWebdriverioScreenshotUpload(test.span)
+    }
     if (
       testStatus !== 'skip' &&
       test.isEarlyFlakeDetection &&
@@ -1191,8 +1300,7 @@ class MochaPlugin extends CiPlugin {
     if (test._ddShouldWaitForHitProbe) {
       delete test._ddShouldWaitForHitProbe
       state.pendingTestFinishes++
-      const finishTest = () => {
-        this.#completeWebdriverioJasmineTest(test, result)
+      const onTestFinished = () => {
         state.pendingTestFinishes--
         if (state.pendingTestFinishes === 0) {
           const callbacks = state.pendingTestFinishCallbacks
@@ -1202,10 +1310,14 @@ class MochaPlugin extends CiPlugin {
           }
         }
       }
+      const finishTest = () => {
+        const finishPromise = this.#completeWebdriverioJasmineTest(test, result)
+        return finishPromise?.then(onTestFinished, onTestFinished) || onTestFinished()
+      }
       return this.waitForDiBreakpointHits().then(finishTest, finishTest)
     }
 
-    this.#completeWebdriverioJasmineTest(test, result)
+    return this.#completeWebdriverioJasmineTest(test, result)
   }
 
   /**
@@ -1213,7 +1325,7 @@ class MochaPlugin extends CiPlugin {
    *
    * @param {object} test
    * @param {WebdriverioJasmineResult} result
-   * @returns {void}
+   * @returns {Promise<void>|undefined}
    */
   #completeWebdriverioJasmineTest (test, result) {
     const state = this._webdriverioJasmineState
@@ -1241,6 +1353,7 @@ class MochaPlugin extends CiPlugin {
     } else if (test.isEarlyFlakeDetection && status !== 'skip' && !test.hasFinalHookFailure) {
       finalStatus = test.statuses.includes('pass') ? 'pass' : 'fail'
     }
+    const promises = {}
     testFinishCh.publish({
       attemptToFixFailed,
       attemptToFixPassed,
@@ -1251,6 +1364,7 @@ class MochaPlugin extends CiPlugin {
       isAttemptToFixRetry: test.isAttemptToFix && test.attempt > 0,
       isAtrRetry: test.isAtr && test.attempt > 0,
       isLastRetry: true,
+      promises,
       status,
       ...test.currentStore,
     })
@@ -1262,6 +1376,122 @@ class MochaPlugin extends CiPlugin {
     if (suiteStatus === 'fail' || !previousStatus || previousStatus === 'skip') {
       state.suiteStatuses.set(test.testSuiteAbsolutePath, suiteStatus)
     }
+    return promises.finishTestPromise
+  }
+
+  /**
+   * Captures and uploads the current WebdriverIO browser state once for a failed test attempt.
+   *
+   * @param {object} span - Failed test span
+   * @returns {Promise<string>|undefined} Screenshot upload result
+   */
+  #startWebdriverioScreenshotUpload (span) {
+    if (
+      !span ||
+      this.testFramework !== WEBDRIVERIO_FRAMEWORK ||
+      !this._tracerConfig.testOptimization?.DD_TEST_FAILURE_SCREENSHOTS_ENABLED
+    ) {
+      return
+    }
+
+    const previousUpload = this._webdriverioScreenshotUploads.get(span)
+    if (previousUpload) {
+      return previousUpload
+    }
+
+    const exporter = this.tracer?._exporter
+    const canUpload = isWebdriverioWorker
+      ? this.libraryConfig?.isTestFailureScreenshotsEnabled
+      : exporter?.canUploadTestScreenshots?.() && exporter.uploadTestScreenshot
+    if (!canUpload) {
+      return
+    }
+
+    const browser = globalThis.browser
+    let upload
+    try {
+      if (typeof browser?.takeScreenshot !== 'function') {
+        throw new TypeError('browser.takeScreenshot is not available')
+      }
+      upload = Promise.resolve(browser.takeScreenshot()).then(
+        content => this.#uploadWebdriverioScreenshots(span, content),
+        handleWebdriverioScreenshotError
+      )
+    } catch (error) {
+      handleWebdriverioScreenshotError(error)
+      upload = Promise.resolve(SCREENSHOT_UPLOAD_RESULT_ERROR)
+    }
+
+    const uploadPromise = upload.then(result => result, handleWebdriverioScreenshotError).then((result) => {
+      setScreenshotUploadTags(span, result)
+      return result
+    })
+
+    this._webdriverioScreenshotUploads.set(span, uploadPromise)
+    this._pendingWebdriverioScreenshotUploads.add(uploadPromise)
+    const clearPendingUpload = () => this._pendingWebdriverioScreenshotUploads.delete(uploadPromise)
+    uploadPromise.then(clearPendingUpload, clearPendingUpload)
+    return uploadPromise
+  }
+
+  /**
+   * Uploads the PNG data returned by WebdriverIO for one or more browser sessions.
+   *
+   * @param {object} span - Failed test span
+   * @param {string|string[]} screenshots - Base64-encoded PNG data
+   * @returns {Promise<string>} Aggregate screenshot upload result
+   */
+  #uploadWebdriverioScreenshots (span, screenshots) {
+    const screenshotList = Array.isArray(screenshots) ? screenshots : [screenshots]
+    if (screenshotList.length === 0) {
+      log.error('Error capturing WebdriverIO failure screenshot: WebdriverIO returned no screenshot data')
+      return Promise.resolve(SCREENSHOT_UPLOAD_RESULT_ERROR)
+    }
+    const exporter = this.tracer?._exporter
+    const traceId = span.context().toTraceId()
+    const capturedAtMs = Date.now()
+    const uploads = screenshotList.map((screenshot, index) => new Promise((resolve) => {
+      if (typeof screenshot !== 'string' || !screenshot) {
+        log.error('Error capturing WebdriverIO failure screenshot: WebdriverIO returned invalid screenshot data')
+        resolve(SCREENSHOT_UPLOAD_RESULT_ERROR)
+        return
+      }
+      const options = {
+        screenshot,
+        traceId,
+        idempotencyKey: `${traceId}:webdriverio-failure-${index}.png`,
+        capturedAtMs,
+      }
+      const onDone = (error) => {
+        if (error) {
+          log.error('Error uploading WebdriverIO failure screenshot: %s', error?.message || String(error))
+        }
+        resolve(error ? SCREENSHOT_UPLOAD_RESULT_ERROR : SCREENSHOT_UPLOAD_RESULT_UPLOADED)
+      }
+      if (isWebdriverioWorker) {
+        requestWebdriverioScreenshotUpload(options, onDone)
+      } else {
+        let content
+        try {
+          content = Buffer.from(screenshot, 'base64')
+        } catch (error) {
+          onDone(error)
+          return
+        }
+        if (content.length === 0) {
+          onDone(new Error('WebdriverIO returned an empty screenshot'))
+          return
+        }
+        exporter.uploadTestScreenshot({
+          content,
+          traceId,
+          idempotencyKey: options.idempotencyKey,
+          capturedAtMs,
+        }, onDone)
+      }
+    }))
+
+    return Promise.all(uploads).then(getScreenshotUploadResult)
   }
 
   /**

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1436,7 +1436,7 @@ class MochaPlugin extends CiPlugin {
       return false
     }
 
-    const browser = globalThis.browser || globalThis._wdioGlobals?.get?.('browser')
+    const browser = globalThis._wdioGlobals?.get?.('browser') || globalThis.browser
     const upload = {
       callbacks: onDone ? [onDone] : [],
       finished: false,

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -945,20 +945,22 @@ class CiVisibilityExporter extends BufferingExporter {
    * Uploads a single test screenshot to the Test Optimization media intake.
    *
    * @param {object} options - Upload options
-   * @param {string} options.filePath - Path to the screenshot file
+   * @param {string} [options.filePath] - Path to the screenshot file
+   * @param {Buffer} [options.content] - In-memory screenshot content
    * @param {string} options.traceId - Test trace id used as the screenshot key
    * @param {string} options.idempotencyKey - Stable per-artifact key, reused on retry
    * @param {number} options.capturedAtMs - Capture time in epoch milliseconds
    * @param {AbortSignal} [options.signal] - Additional signal used to cancel the upload
    * @param {Function} callback - Callback function (err)
    */
-  uploadTestScreenshot ({ filePath, traceId, idempotencyKey, capturedAtMs, signal }, callback) {
+  uploadTestScreenshot ({ filePath, content, traceId, idempotencyKey, capturedAtMs, signal }, callback) {
     if (!this._testScreenshotUploadUrl) {
       return callback(new Error('Test screenshot upload URL not configured'))
     }
 
     this.#uploadTestMedia(uploadTestScreenshotRequest, {
       filePath,
+      content,
       traceId,
       idempotencyKey,
       capturedAtMs,

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -19,7 +19,7 @@ const MAX_VIDEO_SIZE_BYTES = 200 * 1024 * 1024
 const UINT64_MAX = 18_446_744_073_709_551_615n
 
 function getContentType (filePath, kind) {
-  const extension = extname(filePath).toLowerCase()
+  const extension = filePath ? extname(filePath).toLowerCase() : ''
   if (kind === 'video') {
     return extension === '.mp4' ? 'video/mp4' : 'video/webm'
   }
@@ -62,7 +62,8 @@ function toIdempotencyQueryValue (idempotencyKey) {
  * Uploads one screenshot or video to the Test Optimization media intake.
  *
  * @param {object} options - Upload options
- * @param {string} options.filePath - Path to the media file
+ * @param {string} [options.filePath] - Path to the media file
+ * @param {Buffer} [options.content] - In-memory screenshot content
  * @param {'screenshot'|'video'} options.kind - Media kind
  * @param {string} [options.traceId] - Test trace id for test-scoped media
  * @param {string} [options.testSessionId] - Test session id for suite-scoped media
@@ -80,6 +81,7 @@ function toIdempotencyQueryValue (idempotencyKey) {
 function uploadTestMedia (options, callback) {
   const {
     filePath,
+    content,
     kind,
     traceId,
     testSessionId,
@@ -127,9 +129,15 @@ function uploadTestMedia (options, callback) {
   try {
     if (kind === 'video') {
       fileSize = statSync(filePath).size
-    } else {
+    } else if (content === undefined) {
       screenshotContent = readFileSync(filePath)
       fileSize = screenshotContent.length
+    } else {
+      if (!Buffer.isBuffer(content)) {
+        return callback(new Error('In-memory screenshot content must be a Buffer'))
+      }
+      screenshotContent = content
+      fileSize = content.length
     }
   } catch (error) {
     const action = kind === 'video' ? 'inspect video' : 'read screenshot'
@@ -174,7 +182,12 @@ function uploadTestMedia (options, callback) {
     requestOptions.headers['DD-API-KEY'] = DD_API_KEY
   }
 
-  log.debug('Uploading test %s %s to %s', kind, filePath, new URL(requestOptions.path, url).href)
+  log.debug(
+    'Uploading test %s %s to %s',
+    kind,
+    filePath || 'from memory',
+    new URL(requestOptions.path, url).href
+  )
 
   const onResponse = (error, response, statusCode) => {
     if (error) {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -2066,6 +2066,17 @@ describe('CI Visibility Exporter', () => {
       sinon.assert.calledOnceWithExactly(flushCallback, undefined)
     })
 
+    it('forwards in-memory screenshot content', () => {
+      uploadTestScreenshotRequest = sinon.stub()
+      const exporter = createScreenshotExporter()
+      const content = Buffer.from('webdriverio screenshot')
+
+      exporter.uploadTestScreenshot({ ...screenshotOptions, filePath: undefined, content }, sinon.spy())
+
+      assert.strictEqual(uploadTestScreenshotRequest.firstCall.args[0].content, content)
+      assert.strictEqual(uploadTestScreenshotRequest.firstCall.args[0].filePath, undefined)
+    })
+
     it('forwards caller cancellation and completes once', () => {
       uploadTestScreenshotRequest = sinon.stub()
       const exporter = createScreenshotExporter()

--- a/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js
@@ -115,6 +115,24 @@ describe('ci-visibility/requests/upload-test-screenshot', () => {
       sinon.assert.notCalled(videoRequestStub)
     })
 
+    it('uploads an in-memory PNG without reading a file', () => {
+      const content = Buffer.from('in-memory-screenshot')
+
+      uploadTestScreenshot({
+        content,
+        traceId,
+        idempotencyKey: `${traceId}:webdriverio-failure-0.png`,
+        capturedAtMs: 1_700_000_000_000,
+        url: new URL('http://localhost:8126'),
+      }, () => {})
+
+      sinon.assert.calledOnce(requestStub)
+      const [payload, requestOptions] = requestStub.firstCall.args
+      assert.strictEqual(payload, content)
+      assert.strictEqual(requestOptions.headers['Content-Length'], content.length)
+      assert.strictEqual(requestOptions.headers['Content-Type'], 'image/png')
+    })
+
     it('reports an error when the request helper drops the upload', () => {
       const basename = 'screenshot.png'
       const filePath = join(tmpDir, basename)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds automatic failure screenshot capture and upload for WebdriverIO tests when `DD_TEST_FAILURE_SCREENSHOTS_ENABLED=true`.

Failed Mocha and Jasmine attempts call `browser.takeScreenshot()`, upload the PNG through the WebdriverIO coordinator, and receive the existing `test.failure_screenshot.uploaded` or `test.failure_screenshot.upload_error` tag. Passing attempts do not capture screenshots. Multiremote screenshot results are uploaded individually.

### Motivation
<!-- What inspired you to submit this pull request? -->

WebdriverIO does not provide an automatic failed-test screenshot setting, so Test Optimization must invoke the public screenshot API after determining that an attempt failed. This brings WebdriverIO failure artifacts in line with the existing Playwright and Cypress behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The worker sends screenshot data over the existing WebdriverIO request/response IPC boundary and waits for the coordinator upload result before finalizing the test span. The coordinator retains ownership of agentless and EVP proxy transport selection.

This does not modify the common rewriter files or `packages/dd-trace/src/exporters/common/request.js`.

Validation:

- `./node_modules/.bin/mocha packages/datadog-instrumentations/test/webdriverio.spec.js packages/dd-trace/test/ci-visibility/requests/upload-test-screenshot.spec.js packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js` — 139 passing
- Focused real WebdriverIO integrations passed with latest WebdriverIO for Jasmine failures and native Mocha retries
- Focused real WebdriverIO integrations passed with WebdriverIO 9.0.0 for both adapters
- Targeted ESLint passed
- `git diff --check` passed