### PR TITLE
test(cypress): support Cypress 16

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,6 +240,7 @@
 /integration-tests/cypress-return-config.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /integration-tests/cypress-return-config.config.mjs @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /integration-tests/cypress-support-file-false.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
+/integration-tests/cypress-test-environment.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /integration-tests/cypress-typescript.config.ts @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /integration-tests/cypress.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries
 /integration-tests/my-nyc.config.js @DataDog/dd-trace-js @DataDog/ci-app-libraries

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -4,11 +4,14 @@
 // Cypress does not call setupNodeEvents from inline config objects.
 import cypress from 'cypress'
 
+import getCypressTestEnvironment from './cypress-test-environment.js'
+
 const retries = Number(process.env.CYPRESS_RETRIES || 0)
 
 async function runCypress () {
   const results = await cypress.run({
     config: {
+      ...getCypressTestEnvironment(),
       defaultCommandTimeout: 1000,
       retries: process.env.CYPRESS_RETRIES_AS_NUMBER === undefined
         ? { runMode: retries, openMode: 0 }

--- a/integration-tests/cypress-return-config.config.js
+++ b/integration-tests/cypress-return-config.config.js
@@ -2,15 +2,17 @@
 
 const { defineConfig } = require('cypress')
 
+const getCypressTestEnvironment = require('./cypress-test-environment')
+
 module.exports = defineConfig({
   defaultCommandTimeout: 1000,
   e2e: {
     async setupNodeEvents () {
       await new Promise((resolve) => setTimeout(resolve, 50))
       return {
-        env: {
+        ...getCypressTestEnvironment({
           RETURNED_CONFIG_FLAG: 'true',
-        },
+        }),
         specPattern: 'cypress/e2e/returned-config.cy.js',
       }
     },

--- a/integration-tests/cypress-return-config.config.mjs
+++ b/integration-tests/cypress-return-config.config.mjs
@@ -1,14 +1,16 @@
 import { defineConfig } from 'cypress'
 
+import getCypressTestEnvironment from './cypress-test-environment.js'
+
 export default defineConfig({
   defaultCommandTimeout: 1000,
   e2e: {
     async setupNodeEvents () {
       await new Promise((resolve) => setTimeout(resolve, 50))
       return {
-        env: {
+        ...getCypressTestEnvironment({
           RETURNED_CONFIG_FLAG: 'true',
-        },
+        }),
         specPattern: 'cypress/e2e/returned-config.cy.js',
       }
     },

--- a/integration-tests/cypress-test-environment.js
+++ b/integration-tests/cypress-test-environment.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const { version } = require('cypress/package.json')
+
+const exposedEnvironmentVariables = [
+  'BASE_URL_SECOND',
+  'ENABLE_INCOMPATIBLE_PLUGIN',
+  'EXPECTED_ATTEMPT',
+  'FLAKY_PASS_ATTEMPT',
+  'MISSING_CY_NOW',
+  'RUM_COOKIE_FAILURE',
+  'RUM_COOKIE_STALE_TEST',
+  'RUM_LOG_FAILURE',
+  'SHOULD_ALWAYS_PASS',
+  'SHOULD_FAIL_SOMETIMES',
+]
+
+const useExpose = Number(version.split('.')[0]) >= 16
+
+/**
+ * @param {Record<string, unknown>} [additionalValues] Additional public test values
+ * @returns {{ env: Record<string, unknown> }|{ expose: Record<string, unknown> }} Cypress configuration
+ */
+module.exports = function getCypressTestEnvironment (additionalValues = {}) {
+  const values = { ...additionalValues }
+
+  for (const name of exposedEnvironmentVariables) {
+    const value = process.env[`CYPRESS_${name}`]
+    if (value !== undefined) {
+      values[name] = value
+    }
+  }
+
+  return useExpose ? { expose: values } : { env: values }
+}

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -2,9 +2,12 @@
 
 const { defineConfig } = require('cypress')
 
+const getCypressTestEnvironment = require('./cypress-test-environment')
+
 const retries = Number(process.env.CYPRESS_RETRIES || 0)
 
 module.exports = defineConfig({
+  ...getCypressTestEnvironment(),
   defaultCommandTimeout: 1000,
   retries: process.env.CYPRESS_RETRIES_AS_NUMBER === undefined
     ? { runMode: retries, openMode: 0 }

--- a/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
+++ b/integration-tests/cypress/cypress-reporting-instrumentation.spec.js
@@ -206,10 +206,10 @@ moduleTypes.forEach(({
     if (type === 'commonJS' && version === 'latest') {
       // These dependencies are only needed by the component/Vite regression test below.
       sandboxDependencies.push(
-        '@vitejs/plugin-react@4.3.4',
+        '@vitejs/plugin-react@6.1.1',
         'react@18.3.1',
         'react-dom@18.3.1',
-        'vite@6.1.0'
+        'vite@8.2.2'
       )
     }
     useSandbox(sandboxDependencies, true)

--- a/integration-tests/cypress/e2e/attempt-to-fix.js
+++ b/integration-tests/cypress/e2e/attempt-to-fix.js
@@ -1,11 +1,13 @@
 /* eslint-disable */
 
+const { getTestEnvironment } = require('../support/test-environment')
+
 let numAttempt = 0
 
 function getTextToAssert () {
-  if (Cypress.env('SHOULD_ALWAYS_PASS')) {
+  if (getTestEnvironment('SHOULD_ALWAYS_PASS')) {
     return 'Hello World'
-  } else if (Cypress.env('SHOULD_FAIL_SOMETIMES')) {
+  } else if (getTestEnvironment('SHOULD_FAIL_SOMETIMES')) {
     return numAttempt++ % 2 === 0 ? 'Hello World' : 'Hello Warld'
   }
   return 'Hello Warld'

--- a/integration-tests/cypress/e2e/fails-first-then-passes.cy.js
+++ b/integration-tests/cypress/e2e/fails-first-then-passes.cy.js
@@ -1,10 +1,12 @@
 /* eslint-disable */
+const { getTestEnvironment } = require('../support/test-environment')
+
 let attempt = 0
 
 describe('efd with manual cypress retries', () => {
   it('fails first then passes', () => {
     cy.then(() => {
-      expect(attempt++).to.equal(Number(Cypress.env('EXPECTED_ATTEMPT') || 2))
+      expect(attempt++).to.equal(Number(getTestEnvironment('EXPECTED_ATTEMPT') || 2))
     })
   })
 })

--- a/integration-tests/cypress/e2e/flaky-test-retries.js
+++ b/integration-tests/cypress/e2e/flaky-test-retries.js
@@ -1,7 +1,9 @@
 /* eslint-disable */
+const { getTestEnvironment } = require('../support/test-environment')
+
 describe('flaky test retry', () => {
   let numAttempt = 0
-  const passAttempt = Number(Cypress.env('FLAKY_PASS_ATTEMPT') || 2)
+  const passAttempt = Number(getTestEnvironment('FLAKY_PASS_ATTEMPT') || 2)
 
   it('eventually passes', () => {
     cy.visit('/')

--- a/integration-tests/cypress/e2e/flaky-with-hooks.cy.js
+++ b/integration-tests/cypress/e2e/flaky-with-hooks.cy.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
+const { getTestEnvironment } = require('../support/test-environment')
+
 let numAttempt = 0
-const passAttempt = Number(Cypress.env('FLAKY_PASS_ATTEMPT') || 2)
+const passAttempt = Number(getTestEnvironment('FLAKY_PASS_ATTEMPT') || 2)
 describe('flaky with hooks', () => {
   beforeEach(() => {
     cy.visit('/')

--- a/integration-tests/cypress/e2e/multi-origin.js
+++ b/integration-tests/cypress/e2e/multi-origin.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+const { getTestEnvironment } = require('../support/test-environment')
 
 it('tests multiple origins', () => {
   // Visit first site
@@ -7,7 +8,7 @@ it('tests multiple origins', () => {
     .should('have.text', 'Hello World')
 
   // Visit second site
-  cy.origin(Cypress.env('BASE_URL_SECOND'), () => {
+  cy.origin(getTestEnvironment('BASE_URL_SECOND'), () => {
     cy.visit('/')
     cy.get('.hella-world').should('have.text', 'Hella World')
   });

--- a/integration-tests/cypress/e2e/returned-config.cy.js
+++ b/integration-tests/cypress/e2e/returned-config.cy.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
+const { getTestEnvironment } = require('../support/test-environment')
+
 describe('returned config', () => {
   it('uses env from setupNodeEvents return value', () => {
-    expect(Cypress.env('RETURNED_CONFIG_FLAG')).to.equal('true')
+    expect(getTestEnvironment('RETURNED_CONFIG_FLAG')).to.equal('true')
   })
 })

--- a/integration-tests/cypress/e2e/rum-cookie-failure.cy.js
+++ b/integration-tests/cypress/e2e/rum-cookie-failure.cy.js
@@ -1,10 +1,12 @@
 /* eslint-disable */
+const { getTestEnvironment } = require('../support/test-environment')
+
 describe('RUM correlation cookie failure', () => {
   it('continues running the test', () => {
-    if (Cypress.env('MISSING_CY_NOW')) {
-      expect(Cypress.env('DD_RUM_COOKIE_NOW_MISSING')).to.equal(true)
+    if (getTestEnvironment('MISSING_CY_NOW')) {
+      expect(getTestEnvironment('DD_RUM_COOKIE_NOW_MISSING')).to.equal(true)
     } else {
-      expect(Cypress.env('DD_RUM_COOKIE_ATTEMPTED')).to.equal(true)
+      expect(getTestEnvironment('DD_RUM_COOKIE_ATTEMPTED')).to.equal(true)
     }
   })
 })

--- a/integration-tests/cypress/e2e/rum-cookie-stale.cy.js
+++ b/integration-tests/cypress/e2e/rum-cookie-stale.cy.js
@@ -1,11 +1,13 @@
 /* eslint-disable */
+const { setTestEnvironment } = require('../support/test-environment')
+
 const rumCookieName = 'datadog-ci-visibility-test-execution-id'
 
 describe('RUM correlation cookie lifecycle', () => {
   it('sets the initial cookie', () => {
     cy.getCookie(rumCookieName).then((cookie) => {
       expect(cookie && cookie.value).to.match(/^\d+$/)
-      Cypress.env('RUM_COOKIE_FAILURE', 'reject')
+      setTestEnvironment('RUM_COOKIE_FAILURE', 'reject')
     })
   })
 

--- a/integration-tests/cypress/support/e2e.js
+++ b/integration-tests/cypress/support/e2e.js
@@ -1,10 +1,32 @@
 'use strict'
 
 /* global Cypress, cy */
-if (Cypress.env('ENABLE_INCOMPATIBLE_PLUGIN')) {
+const useExpose = Number(Cypress.version.split('.')[0]) >= 16
+
+/**
+ * @param {string} name Environment variable name
+ * @returns {unknown} Environment variable value
+ */
+function getTestEnvironment (name) {
+  return useExpose ? Cypress.expose(name) : Cypress.env(name)
+}
+
+/**
+ * @param {string} name Environment variable name
+ * @param {unknown} value Environment variable value
+ */
+function setTestEnvironment (name, value) {
+  if (useExpose) {
+    Cypress.expose(name, value)
+  } else {
+    Cypress.env(name, value)
+  }
+}
+
+if (getTestEnvironment('ENABLE_INCOMPATIBLE_PLUGIN')) {
   require('cypress-fail-fast')
 }
-if (Cypress.env('RUM_COOKIE_FAILURE') || Cypress.env('RUM_COOKIE_STALE_TEST')) {
+if (getTestEnvironment('RUM_COOKIE_FAILURE') || getTestEnvironment('RUM_COOKIE_STALE_TEST')) {
   const automation = Cypress.automation.bind(Cypress)
   /**
    * @param {string} event
@@ -14,9 +36,9 @@ if (Cypress.env('RUM_COOKIE_FAILURE') || Cypress.env('RUM_COOKIE_STALE_TEST')) {
     if (event === 'set:cookie' &&
         options.name === 'datadog-ci-visibility-test-execution-id' &&
         options.value &&
-        Cypress.env('RUM_COOKIE_FAILURE')) {
-      Cypress.env('DD_RUM_COOKIE_ATTEMPTED', true)
-      if (Cypress.env('RUM_COOKIE_FAILURE') === 'throw') {
+        getTestEnvironment('RUM_COOKIE_FAILURE')) {
+      setTestEnvironment('DD_RUM_COOKIE_ATTEMPTED', true)
+      if (getTestEnvironment('RUM_COOKIE_FAILURE') === 'throw') {
         throw new Error('RUM correlation cookie threw')
       }
       return Cypress.Promise.reject(new Error('RUM correlation cookie rejected'))
@@ -24,11 +46,11 @@ if (Cypress.env('RUM_COOKIE_FAILURE') || Cypress.env('RUM_COOKIE_STALE_TEST')) {
     return automation(event, options)
   }
 }
-if (Cypress.env('MISSING_CY_NOW')) {
+if (getTestEnvironment('MISSING_CY_NOW')) {
   cy.now = undefined
-  Cypress.env('DD_RUM_COOKIE_NOW_MISSING', true)
+  setTestEnvironment('DD_RUM_COOKIE_NOW_MISSING', true)
 }
-if (Cypress.env('RUM_LOG_FAILURE')) {
+if (getTestEnvironment('RUM_LOG_FAILURE')) {
   const log = Cypress.log.bind(Cypress)
   /**
    * @param {{ name?: string }} options

--- a/integration-tests/cypress/support/test-environment.js
+++ b/integration-tests/cypress/support/test-environment.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/* global Cypress */
+const useExpose = Number(Cypress.version.split('.')[0]) >= 16
+
+/**
+ * @param {string} name Environment variable name
+ * @returns {unknown} Environment variable value
+ */
+function getTestEnvironment (name) {
+  return useExpose ? Cypress.expose(name) : Cypress.env(name)
+}
+
+/**
+ * @param {string} name Environment variable name
+ * @param {unknown} value Environment variable value
+ */
+function setTestEnvironment (name, value) {
+  if (useExpose) {
+    Cypress.expose(name, value)
+  } else {
+    Cypress.env(name, value)
+  }
+}
+
+module.exports = { getTestEnvironment, setTestEnvironment }

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -124,7 +124,7 @@
     "cookie": "2.0.1",
     "cookie-parser": "1.4.7",
     "couchbase": "4.7.1",
-    "cypress": "15.21.1",
+    "cypress": "16.0.0",
     "cypress-fail-fast": "8.1.0",
     "dd-trace-api": "1.0.1",
     "durable-functions": "3.5.0",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Bumps the latest Cypress integration-test version to Cypress 16.
- Uses `Cypress.expose()` for public test values on Cypress 16 while retaining `Cypress.env()` for older versions.
- Updates the latest-only component test dependencies to the Vite versions required by Cypress 16.

### Motivation
<!-- What inspired you to submit this pull request? -->

Cypress 16 removed `Cypress.env()` and its Vite dev server now requires Vite 8. This keeps the integration suite compatible with Cypress 16 without dropping support for Cypress versions below 16 or weakening existing assertions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validation:

- `CYPRESS_VERSION=latest npm run test:integration:cypress` (Cypress 16.0.0): 282 passing, 15 pending
- `CYPRESS_VERSION=14.5.4 npm run test:integration:cypress`: 238 passing, 59 pending
- `./node_modules/.bin/mocha integration-tests/cypress/dependencies.spec.js packages/dd-trace/test/plugins/versions.spec.js`: 30 passing
- ESLint on all changed JavaScript files
- `git diff --check`

