### PR TITLE
test(vitest): cover webdriverio browser provider

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -547,7 +547,7 @@ jobs:
           flags: test-optimization-vitest-${{ matrix.version }}
 
   integration-vitest-browser:
-    needs: playwright-image
+    needs: [playwright-image, selenium-image]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -557,13 +557,18 @@ jobs:
         include:
           - version: oldest
             browser-provider: playwright
+            container-image: ${{ fromJson(needs.playwright-image.outputs.images).oldest.latest }}
           - version: latest
             browser-provider: playwright
+            container-image: ${{ fromJson(needs.playwright-image.outputs.images).latest.latest }}
           - version: latest
             browser-provider: webdriverio
+            container-image: ${{ needs.selenium-image.outputs.image }}
+            browser-binary: /usr/bin/google-chrome
+            browser-driver-binary: /usr/bin/chromedriver
     name: integration-vitest-browser (${{ matrix.browser-provider }}, node-${{ matrix.version }})
     container:
-      image: ${{ fromJson(needs.playwright-image.outputs.images)[matrix.version].latest }}
+      image: ${{ matrix.container-image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -595,6 +600,8 @@ jobs:
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
           SPEC: vitest.browser
           VITEST_BROWSER_PROVIDER: ${{ matrix.browser-provider }}
+          VITEST_BROWSER_BINARY: ${{ matrix.browser-binary }}
+          VITEST_BROWSER_DRIVER_BINARY: ${{ matrix.browser-driver-binary }}
       - uses: ./.github/actions/coverage
         with:
           flags: test-optimization-vitest-browser-${{ matrix.version }}

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -582,6 +582,13 @@ jobs:
       - uses: ./.github/actions/install
       - name: Configure Git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Configure Chromium for WebdriverIO
+        if: matrix.browser-provider == 'webdriverio'
+        run: |
+          webdriverio_executable_path=$(find "$PLAYWRIGHT_BROWSERS_PATH" \
+            -type f -path '*/chrome-linux*/chrome' -print -quit)
+          test -n "$webdriverio_executable_path"
+          echo "VITEST_WEBDRIVERIO_EXECUTABLE_PATH=$webdriverio_executable_path" >> "$GITHUB_ENV"
       - run: npm run test:instrumentations
         env:
           PLUGINS: vitest-main

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -554,8 +554,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [oldest, latest]
-    name: integration-vitest-browser (node-${{ matrix.version }})
+        include:
+          - version: oldest
+            browser-provider: playwright
+          - version: latest
+            browser-provider: playwright
+          - version: latest
+            browser-provider: webdriverio
+    name: integration-vitest-browser (${{ matrix.browser-provider }}, node-${{ matrix.version }})
     container:
       image: ${{ fromJson(needs.playwright-image.outputs.images)[matrix.version].latest }}
       credentials:
@@ -588,6 +594,7 @@ jobs:
           NODE_OPTIONS: "-r ./ci/init"
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
           SPEC: vitest.browser
+          VITEST_BROWSER_PROVIDER: ${{ matrix.browser-provider }}
       - uses: ./.github/actions/coverage
         with:
           flags: test-optimization-vitest-browser-${{ matrix.version }}

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -582,13 +582,6 @@ jobs:
       - uses: ./.github/actions/install
       - name: Configure Git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Configure Chromium for WebdriverIO
-        if: matrix.browser-provider == 'webdriverio'
-        run: |
-          webdriverio_executable_path=$(find "$PLAYWRIGHT_BROWSERS_PATH" \
-            -type f -path '*/chrome-linux*/chrome' -print -quit)
-          test -n "$webdriverio_executable_path"
-          echo "VITEST_WEBDRIVERIO_EXECUTABLE_PATH=$webdriverio_executable_path" >> "$GITHUB_ENV"
       - run: npm run test:instrumentations
         env:
           PLUGINS: vitest-main

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -91,9 +91,22 @@ const browserName = browserProvider === 'webdriverio' ? 'chrome' : 'chromium'
 async function getBrowserProvider () {
   if (!process.env.VITEST_BROWSER_PROVIDER_FACTORY) return browserProvider
 
-  return browserProvider === 'webdriverio'
-    ? (await import('@vitest/browser-webdriverio')).webdriverio()
-    : (await import('@vitest/browser-playwright')).playwright()
+  if (browserProvider === 'webdriverio') {
+    const { webdriverio } = await import('@vitest/browser-webdriverio')
+    const executablePath = process.env.VITEST_WEBDRIVERIO_EXECUTABLE_PATH
+    return webdriverio(executablePath
+      ? {
+          capabilities: {
+            'goog:chromeOptions': {
+              args: ['no-sandbox'],
+              binary: executablePath,
+            },
+          },
+        }
+      : undefined)
+  }
+
+  return (await import('@vitest/browser-playwright')).playwright()
 }
 
 if (process.env.VITEST_BROWSER_MODE) {

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -93,12 +93,21 @@ async function getBrowserProvider () {
 
   if (browserProvider === 'webdriverio') {
     const { webdriverio } = await import('@vitest/browser-webdriverio')
-    return webdriverio({
-      capabilities: {
-        'goog:chromeOptions': {
-          args: ['no-sandbox'],
-        },
+    const capabilities = {
+      'goog:chromeOptions': {
+        args: ['disable-dev-shm-usage', 'no-sandbox'],
       },
+    }
+    if (process.env.VITEST_BROWSER_BINARY) {
+      capabilities['goog:chromeOptions'].binary = process.env.VITEST_BROWSER_BINARY
+    }
+    if (process.env.VITEST_BROWSER_DRIVER_BINARY) {
+      capabilities['wdio:chromedriverOptions'] = {
+        binary: process.env.VITEST_BROWSER_DRIVER_BINARY,
+      }
+    }
+    return webdriverio({
+      capabilities,
     })
   }
 

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -85,30 +85,33 @@ if (process.env.VITEST_RUNNER) {
   config.test.runner = process.env.VITEST_RUNNER
 }
 
-if (process.env.VITEST_BROWSER_MODE) {
-  const provider = process.env.VITEST_BROWSER_PROVIDER_FACTORY
-    ? (await import('@vitest/browser-playwright')).playwright()
-    : 'playwright'
+const browserProvider = process.env.VITEST_BROWSER_PROVIDER || 'playwright'
+const browserName = browserProvider === 'webdriverio' ? 'chrome' : 'chromium'
 
+async function getBrowserProvider () {
+  if (!process.env.VITEST_BROWSER_PROVIDER_FACTORY) return browserProvider
+
+  return browserProvider === 'webdriverio'
+    ? (await import('@vitest/browser-webdriverio')).webdriverio()
+    : (await import('@vitest/browser-playwright')).playwright()
+}
+
+if (process.env.VITEST_BROWSER_MODE) {
   config.test.browser = {
     connectTimeout: process.env.VITEST_BROWSER_CONNECT_TIMEOUT
       ? Number(process.env.VITEST_BROWSER_CONNECT_TIMEOUT)
       : undefined,
     enabled: true,
     headless: true,
-    provider,
+    provider: await getBrowserProvider(),
     instances: [{
-      browser: 'chromium',
-      name: 'browser-chromium',
+      browser: browserName,
+      name: `browser-${browserName}`,
     }],
   }
 }
 
 if (process.env.VITEST_MIXED_BROWSER_MODE) {
-  const provider = process.env.VITEST_BROWSER_PROVIDER_FACTORY
-    ? (await import('@vitest/browser-playwright')).playwright()
-    : 'playwright'
-
   config.test.projects = [
     {
       test: {
@@ -122,10 +125,10 @@ if (process.env.VITEST_MIXED_BROWSER_MODE) {
         browser: {
           enabled: true,
           headless: true,
-          provider,
+          provider: await getBrowserProvider(),
           instances: [{
-            browser: 'chromium',
-            name: 'browser-chromium',
+            browser: browserName,
+            name: `browser-${browserName}`,
           }],
         },
         include: ['ci-visibility/vitest-browser-tests/browser-reporting.mjs'],

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -93,17 +93,13 @@ async function getBrowserProvider () {
 
   if (browserProvider === 'webdriverio') {
     const { webdriverio } = await import('@vitest/browser-webdriverio')
-    const executablePath = process.env.VITEST_WEBDRIVERIO_EXECUTABLE_PATH
-    return webdriverio(executablePath
-      ? {
-          capabilities: {
-            'goog:chromeOptions': {
-              args: ['no-sandbox'],
-              binary: executablePath,
-            },
-          },
-        }
-      : undefined)
+    return webdriverio({
+      capabilities: {
+        'goog:chromeOptions': {
+          args: ['no-sandbox'],
+        },
+      },
+    })
   }
 
   return (await import('@vitest/browser-playwright')).playwright()

--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -127,8 +127,6 @@ describe(`vitest@${vitestVersion} Browser Mode${browserProviderDescription}`, fu
         ...extraEnv,
       },
     })
-    childProcess.stdout.pipe(process.stdout)
-    childProcess.stderr.pipe(process.stderr)
     childProcess.stdout.on('data', data => { testOutput += data })
     childProcess.stderr.on('data', data => { testOutput += data })
 

--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -127,6 +127,8 @@ describe(`vitest@${vitestVersion} Browser Mode${browserProviderDescription}`, fu
         ...extraEnv,
       },
     })
+    childProcess.stdout.pipe(process.stdout)
+    childProcess.stderr.pipe(process.stderr)
     childProcess.stdout.on('data', data => { testOutput += data })
     childProcess.stderr.on('data', data => { testOutput += data })
 

--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -107,18 +107,24 @@ describe(`vitest@${vitestVersion} Browser Mode${browserProviderDescription}`, fu
         '--eval',
         `
           import { remote } from 'webdriverio'
-          const browser = await remote({
-            logLevel: 'silent',
-            capabilities: {
-              browserName: 'chrome',
-              'goog:chromeOptions': {
-                args: ['headless', 'disable-gpu', 'no-sandbox'],
+          // Node.js 26 exits if remote() is the only unsettled top-level await.
+          const keepAlive = setInterval(() => undefined, 1_000)
+          try {
+            const browser = await remote({
+              logLevel: 'silent',
+              capabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': {
+                  args: ['headless', 'disable-gpu', 'no-sandbox'],
+                },
               },
-            },
-          })
-          await browser.deleteSession()
+            })
+            await browser.deleteSession()
+          } finally {
+            clearInterval(keepAlive)
+          }
         `,
-      ], { cwd, env, stdio: 'inherit' })
+      ], { cwd, env, stdio: 'inherit', timeout: 240_000 })
     }
   })
 

--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { exec, execFileSync } = require('node:child_process')
+const { exec } = require('node:child_process')
 const { once } = require('node:events')
 const { inspect } = require('node:util')
 
@@ -95,36 +95,10 @@ describe(`vitest@${vitestVersion} Browser Mode${browserProviderDescription}`, fu
   useSandbox(sandboxDependencies, true)
 
   before(function () {
-    this.timeout(300_000)
+    this.timeout(120_000)
     cwd = sandboxCwd()
     if (browserProvider === 'playwright') {
       installPlaywrightChromium(cwd)
-    } else {
-      // Browser downloads can exceed the per-test intake timeout, so finish setup before the tests start.
-      const { NODE_OPTIONS, ...env } = process.env
-      execFileSync(process.execPath, [
-        '--input-type=module',
-        '--eval',
-        `
-          import { remote } from 'webdriverio'
-          // Node.js 26 exits if remote() is the only unsettled top-level await.
-          const keepAlive = setInterval(() => undefined, 1_000)
-          try {
-            const browser = await remote({
-              logLevel: 'silent',
-              capabilities: {
-                browserName: 'chrome',
-                'goog:chromeOptions': {
-                  args: ['headless', 'disable-gpu', 'no-sandbox'],
-                },
-              },
-            })
-            await browser.deleteSession()
-          } finally {
-            clearInterval(keepAlive)
-          }
-        `,
-      ], { cwd, env, stdio: 'inherit', timeout: 240_000 })
     }
   })
 

--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { exec } = require('node:child_process')
+const { exec, execFileSync } = require('node:child_process')
 const { once } = require('node:events')
 const { inspect } = require('node:util')
 
@@ -95,10 +95,30 @@ describe(`vitest@${vitestVersion} Browser Mode${browserProviderDescription}`, fu
   useSandbox(sandboxDependencies, true)
 
   before(function () {
-    this.timeout(120_000)
+    this.timeout(300_000)
     cwd = sandboxCwd()
     if (browserProvider === 'playwright') {
       installPlaywrightChromium(cwd)
+    } else {
+      // Browser downloads can exceed the per-test intake timeout, so finish setup before the tests start.
+      const { NODE_OPTIONS, ...env } = process.env
+      execFileSync(process.execPath, [
+        '--input-type=module',
+        '--eval',
+        `
+          import { remote } from 'webdriverio'
+          const browser = await remote({
+            logLevel: 'silent',
+            capabilities: {
+              browserName: 'chrome',
+              'goog:chromeOptions': {
+                args: ['headless', 'disable-gpu', 'no-sandbox'],
+              },
+            },
+          })
+          await browser.deleteSession()
+        `,
+      ], { cwd, env, stdio: 'inherit' })
     }
   })
 

--- a/integration-tests/vitest/vitest.browser.spec.js
+++ b/integration-tests/vitest/vitest.browser.spec.js
@@ -48,14 +48,21 @@ const { NODE_MAJOR } = require('../../version')
 const latestVersions = require('../../packages/dd-trace/test/plugins/versions/package.json').dependencies
 const isLegacyBrowserProvider = process.env.VITEST_BROWSER_LEGACY === '1' || NODE_MAJOR <= 18
 const vitestVersion = isLegacyBrowserProvider ? '3.2.6' : latestVersions.vitest
+const browserProvider = process.env.VITEST_BROWSER_PROVIDER || 'playwright'
+const browserName = browserProvider === 'webdriverio' ? 'chrome' : 'chromium'
+const browserProjectName = `browser-${browserName}`
+const browserProviderDescription = browserProvider === 'playwright' ? '' : ` with ${browserProvider}`
 const playwrightVersion = getLatestPlaywrightSpecifier()
 const browserProviderDependency = isLegacyBrowserProvider
   ? `@vitest/browser@${vitestVersion}`
-  : `@vitest/browser-playwright@${vitestVersion}`
+  : `@vitest/browser-${browserProvider}@${vitestVersion}`
+const browserRuntimeDependency = browserProvider === 'webdriverio'
+  ? `webdriverio@${latestVersions.webdriverio}`
+  : `playwright@${playwrightVersion}`
 const sandboxDependencies = [
   `vitest@${vitestVersion}`,
   browserProviderDependency,
-  `playwright@${playwrightVersion}`,
+  browserRuntimeDependency,
 ]
 if (isLegacyBrowserProvider) {
   sandboxDependencies.push('vite@6.1.0')
@@ -76,7 +83,7 @@ function getTestByName (tests, name) {
   return test
 }
 
-describe(`vitest@${vitestVersion} Browser Mode`, function () {
+describe(`vitest@${vitestVersion} Browser Mode${browserProviderDescription}`, function () {
   this.timeout(180_000)
 
   const runtimeEfdSuiteAdmissionIt = isLegacyBrowserProvider ? it.skip : it
@@ -90,7 +97,9 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
   before(function () {
     this.timeout(120_000)
     cwd = sandboxCwd()
-    installPlaywrightChromium(cwd)
+    if (browserProvider === 'playwright') {
+      installPlaywrightChromium(cwd)
+    }
   })
 
   beforeEach(async () => {
@@ -157,8 +166,8 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
       const passedTest = getTestByName(tests, 'vitest browser reporting runs the test body in the browser')
       assert.strictEqual(passedTest.meta[TEST_STATUS], 'pass')
       assert.strictEqual(passedTest.meta[TEST_TYPE], 'browser')
-      assert.strictEqual(passedTest.meta[TEST_BROWSER_NAME], 'chromium')
-      assert.strictEqual(passedTest.meta[TEST_BROWSER_DRIVER], 'playwright')
+      assert.strictEqual(passedTest.meta[TEST_BROWSER_NAME], browserName)
+      assert.strictEqual(passedTest.meta[TEST_BROWSER_DRIVER], browserProvider)
       assert.strictEqual(passedTest.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
       assert.strictEqual(passedTest.meta[TEST_FINAL_STATUS], 'pass')
       assert.strictEqual(passedTest.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
@@ -167,8 +176,8 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
       assert.ok(!(TEST_IS_RUM_ACTIVE in passedTest.meta))
       assert.deepStrictEqual(JSON.parse(passedTest.meta[TEST_PARAMETERS]), {
         arguments: {
-          browser: 'chromium',
-          project: 'browser-chromium',
+          browser: browserName,
+          project: browserProjectName,
         },
         metadata: {},
       })
@@ -176,7 +185,7 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
       const skippedTest = getTestByName(tests, 'vitest browser reporting reports skipped browser tests')
       assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
       assert.strictEqual(skippedTest.meta[TEST_TYPE], 'browser')
-      assert.strictEqual(skippedTest.meta[TEST_BROWSER_NAME], 'chromium')
+      assert.strictEqual(skippedTest.meta[TEST_BROWSER_NAME], browserName)
       assert.strictEqual(skippedTest.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
       assert.strictEqual(skippedTest.meta[TEST_FINAL_STATUS], 'skip')
       assert.strictEqual(skippedTest.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
@@ -584,7 +593,7 @@ describe(`vitest@${vitestVersion} Browser Mode`, function () {
         const browserTest = getTestByName(tests, 'vitest browser reporting runs the test body in the browser')
         assert.strictEqual(browserTest.meta[TEST_STATUS], 'pass')
         assert.strictEqual(browserTest.meta[TEST_TYPE], 'browser')
-        assert.strictEqual(browserTest.meta[TEST_BROWSER_NAME], 'chromium')
+        assert.strictEqual(browserTest.meta[TEST_BROWSER_NAME], browserName)
 
         const [testSession] = getEventContents(events, 'test_session_end')
         assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_ENABLED], 'false')

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -237,6 +237,7 @@
     "typescript": "7.0.2",
     "undici": "8.10.0",
     "vitest": "4.1.11",
+    "webdriverio": "9.31.5",
     "when": "3.7.8",
     "winston": "3.19.0",
     "workerpool": "10.0.3",


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Parameterizes the Vitest Browser Mode integration suite by browser provider and adds a latest-Vitest CI entry for
`@vitest/browser-webdriverio`. Playwright remains the default and retains its existing oldest/latest coverage.

The shared assertions now verify provider-specific browser and driver metadata, and the test dependency versions pin
the WebdriverIO runtime used by the sandbox.

The Test Optimization workflow uses the existing Playwright images for Playwright and the existing Selenium tools
image for WebdriverIO. The Selenium image already contains a compatible Google Chrome and ChromeDriver pair, so the
WebdriverIO matrix entry passes their paths through `VITEST_BROWSER_BINARY` and
`VITEST_BROWSER_DRIVER_BINARY`. The Vitest configuration maps those values to Chrome's `binary` capability and
WebdriverIO's `wdio:chromedriverOptions.binary`, avoiding WebdriverIO's runtime browser/driver discovery and downloads.
Those downloads exceeded the integration-test timeout in CI and could leave a partial browser installation.

This requires the workflow job to depend on both image-building jobs and select `container-image` per matrix entry:
Playwright needs its version-specific image, while WebdriverIO needs the Selenium image and its explicit binary paths.

### Motivation
<!-- What inspired you to submit this pull request? -->

Vitest Browser Mode reporting is implemented at the Vitest layer and is provider-neutral, but the integration suite
previously exercised only Playwright. Running the same coverage with WebdriverIO verifies that both supported Vitest
browser providers preserve reporting, retries, RUM correlation, Early Flake Detection, and Test Management behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Validated locally with:

- `VITEST_BROWSER_PROVIDER=webdriverio SPEC=vitest.browser npm run test:integration:vitest:coverage` (24 passing)
- `SPEC=vitest.browser npm run test:integration:vitest:coverage` (24 passing)
- `VITEST_BROWSER_LEGACY=1 SPEC=vitest.browser npm run test:integration:vitest:coverage` (21 passing, 3 expected pending)
- ESLint, workflow YAML parsing, `git diff --check`, and the coverage-artifact guard

The Test Optimization workflow passed with all 166 jobs successful, including the new WebdriverIO browser job.
