### PR TITLE
docs(openfeature): describe configured exposure destinations

### DIFF
--- a/integration-tests/openfeature/openfeature-exposure-events.spec.js
+++ b/integration-tests/openfeature/openfeature-exposure-events.spec.js
@@ -61,7 +61,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
             DD_TRACE_AGENT_PORT: agent.port,
             DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
             DD_FEATURE_FLAGS_ENABLED: 'true',
-            // Preserve the existing RC exposure path until agentless emission is supported.
+            // Use Remote Config so this Agent-mode test can deliver the fixture.
             DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'remote_config',
           },
         })

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -140,7 +140,7 @@ class BaseFFEWriter {
   }
 
   /**
-   * Flushes all buffered events to the agent
+   * Flushes all buffered events to the configured destination
    */
   flush () {
     if (this._buffer.length === 0) {

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -188,7 +188,7 @@ class ExposuresWriter extends BaseFFEWriter {
   }
 
   /**
-   * Flushes buffered exposure events to the agent
+   * Flushes buffered exposure events to the configured destination
    */
   flush () {
     if (!this.#enabled) {


### PR DESCRIPTION
OpenFeature exposure writers can send batches to a local Agent or directly to intake. This updates the comments without weakening the direct-agentless assertion already on master.

This preserves the final two commits from Roch Devost's stacked contribution. Their behavior is already present on master.

Refs: https://github.com/DataDog/dd-trace-js/pull/9885