### PR TITLE
feat(instrumentation): await callbacks at function start

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -7,6 +7,7 @@ const log = require('../../../../dd-trace/src/log')
 const { create } = require('../../../../../vendor/dist/@apm-js-collab/code-transformer')
 const {
   awaitContextCallback,
+  awaitContextCallbackAtFunctionStart,
   awaitContextCallbackAtTryStart,
   configureGraphqlJitCompileObject,
   configureGraphqlJitDeferredField,
@@ -47,6 +48,7 @@ const matcherEsm = create(instrumentations, dcPolyfillEsm)
 
 for (const matcher of [matcherCjs, matcherEsm]) {
   matcher.addTransform('awaitContextCallback', awaitContextCallback)
+  matcher.addTransform('awaitContextCallbackAtFunctionStart', awaitContextCallbackAtFunctionStart)
   matcher.addTransform('awaitContextCallbackAtTryStart', awaitContextCallbackAtTryStart)
   matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
   matcher.addTransform('configureGraphqlJitCompileObject', configureGraphqlJitCompileObject)

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -34,25 +34,45 @@ module.exports = {
  * Awaits an optional context callback at the start of the matched node's enclosing async function.
  *
  * @param {Parameters<typeof awaitContextCallback>[0]} state
- * @param {import('estree').Node} _node
+ * @param {import('estree').Node} node
  * @param {import('estree').Node} _parent
  * @param {import('estree').Node[]} ancestry
  * @returns {void}
  */
-function awaitContextCallbackAtFunctionStart (state, _node, _parent, ancestry) {
-  const enclosingFunction = ancestry.find(ancestor => functionTypes.has(ancestor.type))
+function awaitContextCallbackAtFunctionStart (state, node, _parent, ancestry) {
+  let enclosingFunction = functionTypes.has(node.type)
+    ? node
+    : ancestry.find(ancestor => functionTypes.has(ancestor.type))
+  let callbackAncestry = ancestry
+
+  if (enclosingFunction === node) {
+    callbackAncestry = [node, ...ancestry]
+    if (!node.async) {
+      // Function queries create a synchronous trace wrapper before custom transforms run.
+      const [wrappedFunction] = query(node,
+        'VariableDeclarator[id.name="__apm$traced"] > ArrowFunctionExpression > BlockStatement > ' +
+        'VariableDeclaration > VariableDeclarator[id.name="__apm$wrapped"] > ' +
+        ':matches(FunctionDeclaration, FunctionExpression)[async=true]')
+      if (wrappedFunction) {
+        enclosingFunction = wrappedFunction
+        callbackAncestry.unshift(wrappedFunction)
+      }
+    }
+  }
   assert(enclosingFunction?.async && enclosingFunction.body?.type === 'BlockStatement',
     'awaitContextCallbackAtFunctionStart: expected an enclosing async function with a block body')
 
   const generatedCallback = createAwaitedContextCallback(
     state,
     enclosingFunction.body,
-    ancestry,
+    callbackAncestry,
     'awaitContextCallbackAtFunctionStart'
   )
   if (!generatedCallback) return
 
-  enclosingFunction.body.body.unshift(...generatedCallback.callbackStatements)
+  let insertionIndex = 0
+  while (typeof enclosingFunction.body.body[insertionIndex]?.directive === 'string') insertionIndex++
+  enclosingFunction.body.body.splice(insertionIndex, 0, ...generatedCallback.callbackStatements)
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -20,6 +20,7 @@ const identifierPattern = /^[$A-Z_a-z][$\w]*$/
 
 module.exports = {
   awaitContextCallback,
+  awaitContextCallbackAtFunctionStart,
   awaitContextCallbackAtTryStart,
   configureGraphqlJitCompileObject,
   configureGraphqlJitDeferredField,
@@ -27,6 +28,31 @@ module.exports = {
   configureGraphqlJitRuntime,
   configureMercuriusRequest,
   waitForAsyncEnd,
+}
+
+/**
+ * Awaits an optional context callback at the start of the matched node's enclosing async function.
+ *
+ * @param {Parameters<typeof awaitContextCallback>[0]} state
+ * @param {import('estree').Node} _node
+ * @param {import('estree').Node} _parent
+ * @param {import('estree').Node[]} ancestry
+ * @returns {void}
+ */
+function awaitContextCallbackAtFunctionStart (state, _node, _parent, ancestry) {
+  const enclosingFunction = ancestry.find(ancestor => functionTypes.has(ancestor.type))
+  assert(enclosingFunction?.async && enclosingFunction.body?.type === 'BlockStatement',
+    'awaitContextCallbackAtFunctionStart: expected an enclosing async function with a block body')
+
+  const generatedCallback = createAwaitedContextCallback(
+    state,
+    enclosingFunction.body,
+    ancestry,
+    'awaitContextCallbackAtFunctionStart'
+  )
+  if (!generatedCallback) return
+
+  enclosingFunction.body.body.unshift(...generatedCallback.callbackStatements)
 }
 
 /**

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -12,6 +12,7 @@ const { beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { tracingChannel } = require('dc-polyfill')
+const { parse, query } = require('../../../src/helpers/rewriter/compiler')
 
 // TODO: Test actual functionality and not just the start channel.
 describe('check-require-cache', () => {
@@ -399,7 +400,7 @@ describe('check-require-cache', () => {
             versionRange: '>=0.1',
             filePath: 'trace-await-context-callback.js',
           },
-          astQuery: 'FunctionDeclaration[id.name="runFromStart"] ReturnStatement',
+          astQuery: 'FunctionDeclaration[id.name="runFromStart"]',
           channelName: 'trace_await_context_callback_at_function_start',
           transform: 'awaitContextCallbackAtFunctionStart',
           transformOptions: {
@@ -963,6 +964,10 @@ describe('check-require-cache', () => {
   it('should await a context callback before starting an async function body', async () => {
     const { runFromStart } = compileFile('trace-await-context-callback')
     const steps = []
+
+    const [rewrittenFunction] = query(parse(content), 'FunctionDeclaration[id.name="runFromStart"] ' +
+      'VariableDeclarator[id.name="__apm$wrapped"] > FunctionExpression[async=true]')
+    assert.equal(rewrittenFunction.body.body[0].directive, 'use strict')
 
     subs = {
       start (ctx) {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -384,6 +384,31 @@ describe('check-require-cache', () => {
           module: {
             name: 'test',
             versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          functionQuery: {
+            functionName: 'runFromStart',
+            kind: 'Async',
+          },
+          channelName: 'trace_await_context_callback_at_function_start',
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
+            filePath: 'trace-await-context-callback.js',
+          },
+          astQuery: 'FunctionDeclaration[id.name="runFromStart"] ReturnStatement',
+          channelName: 'trace_await_context_callback_at_function_start',
+          transform: 'awaitContextCallbackAtFunctionStart',
+          transformOptions: {
+            callbackName: 'beforeStart',
+          },
+        },
+        {
+          module: {
+            name: 'test',
+            versionRange: '>=0.1',
             filePath: 'trace-await-context-callback-outer-try.js',
           },
           functionQuery: {
@@ -932,6 +957,30 @@ describe('check-require-cache', () => {
 
     assert.equal(await resultPromise, 'passed')
     assert.deepStrictEqual(steps, ['setup', 'setup done', 'task'])
+  })
+
+  it('should await a context callback before starting an async function body', async () => {
+    const { runFromStart } = compileFile('trace-await-context-callback')
+    const steps = []
+
+    subs = {
+      start (ctx) {
+        ctx.beforeStart = async function () {
+          steps.push('callback')
+          await new Promise(resolve => setImmediate(resolve))
+          steps.push('callback done')
+        }
+      },
+    }
+
+    ch = tracingChannel('orchestrion:test:trace_await_context_callback_at_function_start')
+    ch.subscribe(subs)
+
+    assert.equal(await runFromStart((value) => {
+      steps.push('task')
+      return value
+    }), 'passed')
+    assert.deepStrictEqual(steps, ['callback', 'callback done', 'task'])
   })
 
   it('should preserve a try block when context callback lookup throws', async () => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
@@ -35,6 +35,11 @@ async function runAfterSetup (task) {
   }
 }
 
+async function runFromStart (task) {
+  const value = 'passed'
+  return task(value)
+}
+
 class ContextRunner {
   async run (state) {
     if (state.shouldContinue) {
@@ -43,4 +48,4 @@ class ContextRunner {
   }
 }
 
-module.exports = { chooseBranch, consumeFirst, ContextRunner, runAfterSetup, runWithRetry }
+module.exports = { chooseBranch, consumeFirst, ContextRunner, runAfterSetup, runFromStart, runWithRetry }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test/trace-await-context-callback.js
@@ -36,6 +36,8 @@ async function runAfterSetup (task) {
 }
 
 async function runFromStart (task) {
+  'use strict'
+
   const value = 'passed'
   return task(value)
 }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds `awaitContextCallbackAtFunctionStart`, a rewriter transform that awaits a tracing-context callback at the start of an instrumented async function.

It uses the same callback validation, tracing-wrapper validation, `callbackThis` handling, idempotency check, and failure-isolated invocation as the existing callback transforms.

### Motivation
<!-- What inspired you to submit this pull request? -->

The existing transforms only support conditional branches and the start of a `try` block. They cannot insert a callback before statements that appear before that `try`.

For example:

```js
await runBeforeHooks()
try {
  await runTest()
} catch (error) {
  // existing error handling
}
```

`awaitContextCallbackAtTryStart` runs after `runBeforeHooks()`. The new transform can run before `runBeforeHooks()` while keeping the generated callback isolated from application failures:

```js
try {
  await contextCallback()
} catch {}

await runBeforeHooks()
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR contains generic rewriter functionality only. The WebdriverIO and RUM use case remains in stacked draft PR #10049.

Validation:

- `./node_modules/.bin/mocha packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js` (40 passing)
- Focused ESLint for the changed rewriter files
