### PR TITLE
fix(net): clean up synchronous connection failures

### DIFF
--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -39,25 +39,24 @@ addHook({ name: 'net' }, (net) => {
     return startCh.runStores(ctx, () => {
       const cleanup = setupListeners(this, protocol, ctx, finishCh, errorCh)
 
-      const hadOwnEmit = Object.hasOwn(this, 'emit')
-      const emit = this.emit
+      const originalEmit = this.emit
       let pendingReadyEvents = 2
       // Named `emit`/arity-1 mirrors the socket method so the per-socket wrap
       // skips its name/length rewrite.
-      this.emit = shimmer.wrapFunction(emit, originalEmit => function emit (eventName) {
+      this.emit = shimmer.wrapFunction(originalEmit, wrappedEmit => function emit (eventName) {
         switch (eventName) {
           case 'ready':
           case 'connect':
-            if (--pendingReadyEvents === 0) restoreEmit(this, emit, hadOwnEmit)
+            if (--pendingReadyEvents === 0) this.emit = originalEmit
             return readyCh.runStores(ctx, () => {
-              return Reflect.apply(originalEmit, this, arguments)
+              return Reflect.apply(wrappedEmit, this, arguments)
             })
           case 'error':
           case 'close':
-            restoreEmit(this, emit, hadOwnEmit)
-            return Reflect.apply(originalEmit, this, arguments)
+            this.emit = originalEmit
+            return Reflect.apply(wrappedEmit, this, arguments)
           default:
-            return Reflect.apply(originalEmit, this, arguments)
+            return Reflect.apply(wrappedEmit, this, arguments)
         }
       })
 
@@ -65,7 +64,7 @@ addHook({ name: 'net' }, (net) => {
         return connect.apply(this, args)
       } catch (error) {
         cleanup()
-        restoreEmit(this, emit, hadOwnEmit)
+        this.emit = originalEmit
         errorCh.publish(error)
         finishCh.runStores(ctx, () => {})
 
@@ -76,19 +75,6 @@ addHook({ name: 'net' }, (net) => {
 
   return net
 })
-
-/**
- * @param {import('node:net').Socket} socket
- * @param {import('node:net').Socket['emit']} emit
- * @param {boolean} hadOwnEmit
- */
-function restoreEmit (socket, emit, hadOwnEmit) {
-  if (hadOwnEmit) {
-    socket.emit = emit
-  } else {
-    delete socket.emit
-  }
-}
 
 function getOptions (args) {
   if (!args[0]) return

--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -27,8 +27,6 @@ addHook({ name: 'net' }, (net) => {
     }
 
     const options = getOptions(args)
-    const lastIndex = args.length - 1
-    const callback = args[lastIndex]
 
     if (!options) return connect.apply(this, args)
 
@@ -38,15 +36,10 @@ addHook({ name: 'net' }, (net) => {
     const errorCh = protocol === 'ipc' ? errorICPCh : errorTCPCh
     const ctx = { options }
 
-    if (typeof callback === 'function') {
-      args[lastIndex] = function (...args) {
-        return finishCh.runStores(ctx, callback, this, ...args)
-      }
-    }
-
     return startCh.runStores(ctx, () => {
-      setupListeners(this, protocol, ctx, finishCh, errorCh)
+      const cleanup = setupListeners(this, protocol, ctx, finishCh, errorCh)
 
+      const hadOwnEmit = Object.hasOwn(this, 'emit')
       const emit = this.emit
       let pendingReadyEvents = 2
       // Named `emit`/arity-1 mirrors the socket method so the per-socket wrap
@@ -55,13 +48,13 @@ addHook({ name: 'net' }, (net) => {
         switch (eventName) {
           case 'ready':
           case 'connect':
-            if (--pendingReadyEvents === 0) this.emit = originalEmit
+            if (--pendingReadyEvents === 0) restoreEmit(this, emit, hadOwnEmit)
             return readyCh.runStores(ctx, () => {
               return Reflect.apply(originalEmit, this, arguments)
             })
           case 'error':
           case 'close':
-            this.emit = originalEmit
+            restoreEmit(this, emit, hadOwnEmit)
             return Reflect.apply(originalEmit, this, arguments)
           default:
             return Reflect.apply(originalEmit, this, arguments)
@@ -70,16 +63,32 @@ addHook({ name: 'net' }, (net) => {
 
       try {
         return connect.apply(this, args)
-      } catch (err) {
-        errorCh.publish(err)
+      } catch (error) {
+        cleanup()
+        restoreEmit(this, emit, hadOwnEmit)
+        errorCh.publish(error)
+        finishCh.runStores(ctx, () => {})
 
-        throw err
+        throw error
       }
     })
   })
 
   return net
 })
+
+/**
+ * @param {import('node:net').Socket} socket
+ * @param {import('node:net').Socket['emit']} emit
+ * @param {boolean} hadOwnEmit
+ */
+function restoreEmit (socket, emit, hadOwnEmit) {
+  if (hadOwnEmit) {
+    socket.emit = emit
+  } else {
+    delete socket.emit
+  }
+}
 
 function getOptions (args) {
   if (!args[0]) return
@@ -142,4 +151,6 @@ function setupListeners (socket, protocol, ctx, finishCh, errorCh) {
   for (const event of events) {
     socket.once(event, wrapListener)
   }
+
+  return cleanupOtherListeners
 }

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -326,7 +326,7 @@ describe('Plugin', () => {
             assert.deepStrictEqual(socket.listeners(event), listeners.get(event))
           }
           assert.strictEqual(socket.emit, emit)
-          assert.strictEqual(Object.hasOwn(socket, 'emit'), false)
+          assert.strictEqual(Object.hasOwn(socket, 'emit'), true)
         } finally {
           socket.destroy()
         }
@@ -343,14 +343,14 @@ describe('Plugin', () => {
             code: 'ERR_INVALID_ARG_TYPE',
           })
           assert.deepStrictEqual(socket.listeners('connect'), [callback])
+          assert.strictEqual(socket.emit, emit)
 
           const ready = once(socket, 'ready')
           socket.connect({ port, host: 'localhost' })
           await ready
 
           assert.strictEqual(callbackCalls, 1)
-          assert.strictEqual(socket.emit, emit)
-          assert.strictEqual(Object.hasOwn(socket, 'emit'), false)
+          assert.strictEqual(Object.hasOwn(socket, 'emit'), true)
         } finally {
           socket.destroy()
         }

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const dns = require('node:dns')
+const { errorMonitor, once } = require('node:events')
 
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
@@ -251,6 +252,108 @@ describe('Plugin', () => {
             })
           })
         })
+      })
+
+      it('should preserve synchronous TCP errors and cleanup repeated attempts', async () => {
+        const socket = new net.Socket()
+        const events = ['connect', 'close', 'timeout', errorMonitor]
+        const listeners = new Map()
+        const emit = socket.emit
+        const expectedError = new Error('lookup failed')
+        const span = expectSomeSpan(agent, {
+          name: 'tcp.connect',
+          resource: `localhost:${port}`,
+          meta: {
+            [ERROR_TYPE]: expectedError.name,
+            [ERROR_MESSAGE]: expectedError.message,
+            [ERROR_STACK]: expectedError.stack,
+          },
+        })
+
+        socket.emit = emit
+        socket.setMaxListeners(0)
+        for (const event of events) {
+          socket.on(event, () => {})
+          listeners.set(event, socket.listeners(event))
+        }
+
+        try {
+          assert.throws(() => socket.connect({
+            port,
+            host: 'localhost',
+            get lookup () {
+              throw expectedError
+            },
+          }), error => error === expectedError)
+          await span
+
+          for (let i = 0; i < 100; i++) {
+            assert.throws(() => socket.connect({ port, host: 'localhost', lookup: 42 }), {
+              code: 'ERR_INVALID_ARG_TYPE',
+            })
+          }
+
+          for (const event of events) {
+            assert.deepStrictEqual(socket.listeners(event), listeners.get(event))
+          }
+          assert.strictEqual(socket.emit, emit)
+          assert.strictEqual(Object.hasOwn(socket, 'emit'), true)
+        } finally {
+          socket.destroy()
+        }
+      })
+
+      it('should cleanup repeated synchronous IPC failures', () => {
+        const socket = new net.Socket()
+        const events = ['connect', 'close', 'timeout', errorMonitor]
+        const listeners = new Map()
+        const emit = socket.emit
+
+        socket.setMaxListeners(0)
+        for (const event of events) {
+          socket.on(event, () => {})
+          listeners.set(event, socket.listeners(event))
+        }
+
+        try {
+          for (let i = 0; i < 100; i++) {
+            assert.throws(() => socket.connect({ path: 42 }), {
+              code: 'ERR_INVALID_ARG_TYPE',
+            })
+          }
+
+          for (const event of events) {
+            assert.deepStrictEqual(socket.listeners(event), listeners.get(event))
+          }
+          assert.strictEqual(socket.emit, emit)
+          assert.strictEqual(Object.hasOwn(socket, 'emit'), false)
+        } finally {
+          socket.destroy()
+        }
+      })
+
+      it('should reuse a socket after a synchronous connect failure', async () => {
+        const socket = new net.Socket()
+        const emit = socket.emit
+        let callbackCalls = 0
+        const callback = () => callbackCalls++
+
+        try {
+          assert.throws(() => socket.connect({ port, host: 'localhost', lookup: 42 }, callback), {
+            code: 'ERR_INVALID_ARG_TYPE',
+          })
+          assert.deepStrictEqual(socket.listeners('connect'), [callback])
+
+          const ready = once(socket, 'ready')
+          socket.connect({ port, host: 'localhost' })
+          await ready
+
+          assert.strictEqual(callbackCalls, 1)
+          assert.strictEqual(socket.emit, emit)
+          assert.strictEqual(Object.hasOwn(socket, 'emit'), false)
+        } finally {
+          socket.destroy()
+        }
       })
 
       it('should run event listeners in the correct scope', () => {


### PR DESCRIPTION
Node.js validates some TCP and IPC connection options synchronously before a socket emits any lifecycle event. Those failures bypassed tracer cleanup and retained listeners plus a nested `emit` wrapper on every retry.

Clean up only the current attempt before rethrowing the original error, and leave caller-owned listeners, callback identity, and the previous `emit` implementation unchanged.