### PR TITLE
fix(fs): preserve stream constructor errors

### DIFF
--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -213,22 +213,13 @@ function wrapCreateStream (original) {
         if (finished) return
         finished = true
         finishChannel.runStores(ctx, () => {})
-        try {
-          if (typeof stream.removeListener !== 'function') return
-          stream.removeListener('close', onFinish)
-          stream.removeListener('end', onFinish)
-          stream.removeListener('finish', onFinish)
-          stream.removeListener(errorMonitor, onError)
-        } catch (error) {
-          log.error('Error removing fs stream instrumentation listeners', error)
-        }
+        removeStreamListener(stream, 'close', onFinish)
+        removeStreamListener(stream, 'end', onFinish)
+        removeStreamListener(stream, 'finish', onFinish)
+        removeStreamListener(stream, errorMonitor, onError)
       }
 
       try {
-        if (typeof stream.once !== 'function') {
-          onFinish()
-          return stream
-        }
         stream.once('close', onFinish)
         stream.once('end', onFinish)
         stream.once('finish', onFinish)
@@ -240,6 +231,19 @@ function wrapCreateStream (original) {
 
       return stream
     })
+  }
+}
+
+/**
+ * @param {import('node:events').EventEmitter} stream
+ * @param {string | symbol} event
+ * @param {(...args: unknown[]) => void} listener
+ */
+function removeStreamListener (stream, event, listener) {
+  try {
+    stream.removeListener(event, listener)
+  } catch (error) {
+    log.error('Error removing fs stream instrumentation listener', error)
   }
 }
 

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -216,6 +216,7 @@ function wrapCreateStream (original) {
         ctx.error = error
         errorChannel.publish(ctx)
         finishChannel.runStores(ctx, () => {})
+        throw error
       }
     })
   }

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -2,6 +2,7 @@
 
 const { errorMonitor } = require('events')
 const shimmer = require('../../datadog-shimmer')
+const log = require('../../dd-trace/src/log')
 const { channel, addHook } = require('./helpers/instrument')
 
 const startChannel = channel('apm:fs:operation:start')
@@ -191,33 +192,53 @@ function wrapCreateStream (original) {
     const ctx = getMessage(name, ['path', 'options'], arguments)
 
     return startChannel.runStores(ctx, () => {
+      let stream
+
       try {
-        const stream = original.apply(this, arguments)
-        const onError = error => {
-          ctx.error = error
-          errorChannel.publish(ctx)
-          onFinish()
-        }
-        const onFinish = () => {
-          finishChannel.runStores(ctx, () => {})
-          stream.removeListener('close', onFinish)
-          stream.removeListener('end', onFinish)
-          stream.removeListener('finish', onFinish)
-          stream.removeListener(errorMonitor, onError)
-        }
-
-        stream.once('close', onFinish)
-        stream.once('end', onFinish)
-        stream.once('finish', onFinish)
-        stream.once(errorMonitor, onError)
-
-        return stream
+        stream = original.apply(this, arguments)
       } catch (error) {
         ctx.error = error
         errorChannel.publish(ctx)
         finishChannel.runStores(ctx, () => {})
         throw error
       }
+
+      const onError = error => {
+        ctx.error = error
+        errorChannel.publish(ctx)
+        onFinish()
+      }
+      let finished = false
+      const onFinish = () => {
+        if (finished) return
+        finished = true
+        finishChannel.runStores(ctx, () => {})
+        try {
+          if (typeof stream.removeListener !== 'function') return
+          stream.removeListener('close', onFinish)
+          stream.removeListener('end', onFinish)
+          stream.removeListener('finish', onFinish)
+          stream.removeListener(errorMonitor, onError)
+        } catch (error) {
+          log.error('Error removing fs stream instrumentation listeners', error)
+        }
+      }
+
+      try {
+        if (typeof stream.once !== 'function') {
+          onFinish()
+          return stream
+        }
+        stream.once('close', onFinish)
+        stream.once('end', onFinish)
+        stream.once('finish', onFinish)
+        stream.once(errorMonitor, onError)
+      } catch (error) {
+        log.error('Error adding fs stream instrumentation listeners', error)
+        onFinish()
+      }
+
+      return stream
     })
   }
 }

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -2,7 +2,6 @@
 
 const { errorMonitor } = require('events')
 const shimmer = require('../../datadog-shimmer')
-const log = require('../../dd-trace/src/log')
 const { channel, addHook } = require('./helpers/instrument')
 
 const startChannel = channel('apm:fs:operation:start')
@@ -208,42 +207,21 @@ function wrapCreateStream (original) {
         errorChannel.publish(ctx)
         onFinish()
       }
-      let finished = false
       const onFinish = () => {
-        if (finished) return
-        finished = true
         finishChannel.runStores(ctx, () => {})
-        removeStreamListener(stream, 'close', onFinish)
-        removeStreamListener(stream, 'end', onFinish)
-        removeStreamListener(stream, 'finish', onFinish)
-        removeStreamListener(stream, errorMonitor, onError)
+        stream.removeListener('close', onFinish)
+        stream.removeListener('end', onFinish)
+        stream.removeListener('finish', onFinish)
+        stream.removeListener(errorMonitor, onError)
       }
 
-      try {
-        stream.on('close', onFinish)
-        stream.on('end', onFinish)
-        stream.on('finish', onFinish)
-        stream.on(errorMonitor, onError)
-      } catch (error) {
-        log.error('Error adding fs stream instrumentation listeners', error)
-        onFinish()
-      }
+      stream.once('close', onFinish)
+      stream.once('end', onFinish)
+      stream.once('finish', onFinish)
+      stream.once(errorMonitor, onError)
 
       return stream
     })
-  }
-}
-
-/**
- * @param {import('node:events').EventEmitter} stream
- * @param {string | symbol} event
- * @param {(...args: unknown[]) => void} listener
- */
-function removeStreamListener (stream, event, listener) {
-  try {
-    stream.removeListener(event, listener)
-  } catch (error) {
-    log.error('Error removing fs stream instrumentation listener', error)
   }
 }
 

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -220,10 +220,10 @@ function wrapCreateStream (original) {
       }
 
       try {
-        stream.once('close', onFinish)
-        stream.once('end', onFinish)
-        stream.once('finish', onFinish)
-        stream.once(errorMonitor, onError)
+        stream.on('close', onFinish)
+        stream.on('end', onFinish)
+        stream.on('finish', onFinish)
+        stream.on(errorMonitor, onError)
       } catch (error) {
         log.error('Error adding fs stream instrumentation listeners', error)
         onFinish()

--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -234,13 +234,21 @@ describe('fs instrumentation', () => {
 
         it('finishes tracing when the stream emits an error', async () => {
           const originalConstructor = fs[className]
+          const cleanupError = new Error('listener cleanup failed')
           const streamError = new Error('stream failed')
+          let cleanupErrorThrown = false
           let createdStream
 
           fs[className] = class extends EventEmitter {
             constructor () {
               super()
               createdStream = this
+              this.on('removeListener', (event, listener) => {
+                if (event === errorMonitor && listener.name === 'onError') {
+                  cleanupErrorThrown = true
+                  throw cleanupError
+                }
+              })
             }
           }
 
@@ -274,6 +282,7 @@ describe('fs instrumentation', () => {
             fs[className] = originalConstructor
           }
 
+          assert.strictEqual(cleanupErrorThrown, true)
           assert.strictEqual(publishedError, streamError)
           assert.strictEqual(tracer.scope().active(), activeSpan)
           for (const event of streamEvents) {
@@ -294,7 +303,9 @@ describe('fs instrumentation', () => {
             assert.strictEqual(spans[0].meta['file.path'], filename)
           })
           const activeSpan = tracer.scope().active()
+          const cleanupError = new Error('listener cleanup failed')
           const terminalEvent = methodName === 'createReadStream' ? 'end' : 'finish'
+          let cleanupErrorThrown = false
           let publishedFinishes = 0
 
           /**
@@ -310,6 +321,12 @@ describe('fs instrumentation', () => {
               const stream = fs[methodName](filename)
               const closePromise = once(stream, 'close')
               const terminalPromise = once(stream, terminalEvent)
+              stream.on('removeListener', (event, listener) => {
+                if (event === terminalEvent && listener.name === 'onFinish') {
+                  cleanupErrorThrown = true
+                  throw cleanupError
+                }
+              })
 
               assert.ok(stream instanceof fs[className])
               if (methodName === 'createReadStream') {
@@ -331,6 +348,7 @@ describe('fs instrumentation', () => {
             })
 
             await Promise.all([streamPromise, tracePromise])
+            assert.strictEqual(cleanupErrorThrown, true)
             assert.strictEqual(publishedFinishes, 1)
             assert.strictEqual(tracer.scope().active(), activeSpan)
           } finally {

--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -10,7 +10,9 @@ const dc = require('dc-polyfill')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 
+const logErrorCh = dc.channel('datadog:log:error')
 const opErrorCh = dc.channel('apm:fs:operation:error')
+const opFinishCh = dc.channel('apm:fs:operation:finish')
 const opStartCh = dc.channel('apm:fs:operation:start')
 
 const streamConstructors = [
@@ -125,6 +127,232 @@ describe('fs instrumentation', () => {
           assert.strictEqual(tracer.scope().active(), activeSpan)
           for (const event of streamEvents) {
             assert.strictEqual(failedStream.listenerCount(event), 0)
+          }
+          await tracePromise
+        })
+
+        it('returns the stream when tracing listener setup fails', async () => {
+          const originalConstructor = fs[className]
+          const listenerError = new Error('listener setup failed')
+          let createdStream
+
+          fs[className] = class extends EventEmitter {
+            constructor () {
+              super()
+              createdStream = this
+            }
+
+            /**
+             * @param {string | symbol} event
+             * @param {(...args: unknown[]) => void} listener
+             * @returns {this}
+             */
+            once (event, listener) {
+              super.once(event, listener)
+              if (event === 'end') throw listenerError
+              return this
+            }
+
+            /**
+             * @param {string | symbol} event
+             * @param {(...args: unknown[]) => void} listener
+             * @returns {this}
+             */
+            removeListener (event, listener) {
+              super.removeListener(event, listener)
+              if (event === errorMonitor) throw listenerError
+              return this
+            }
+          }
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].error, 0)
+          })
+          const activeSpan = tracer.scope().active()
+          let publishedErrors = 0
+          let publishedFinishes = 0
+
+          /**
+           * @param {{ operation: string }} ctx
+           */
+          function onError (ctx) {
+            if (ctx.operation === resource) publishedErrors++
+          }
+
+          /**
+           * @param {{ operation: string }} ctx
+           */
+          function onFinish (ctx) {
+            if (ctx.operation !== resource) return
+            publishedFinishes++
+            createdStream.emit('close')
+          }
+
+          opErrorCh.subscribe(onError)
+          opFinishCh.subscribe(onFinish)
+          try {
+            tracer.trace('parent', parentSpan => {
+              assert.strictEqual(fs[methodName]('unused'), createdStream)
+              assert.strictEqual(tracer.scope().active(), parentSpan)
+            })
+          } finally {
+            opErrorCh.unsubscribe(onError)
+            opFinishCh.unsubscribe(onFinish)
+            fs[className] = originalConstructor
+          }
+
+          assert.strictEqual(publishedErrors, 0)
+          assert.strictEqual(publishedFinishes, 1)
+          assert.strictEqual(tracer.scope().active(), activeSpan)
+          for (const event of streamEvents) {
+            assert.strictEqual(createdStream.listenerCount(event), 0)
+          }
+          await tracePromise
+        })
+
+        it('returns the stream when tracing listener methods are absent', async () => {
+          const originalConstructor = fs[className]
+          let createdStream
+
+          fs[className] = class {
+            constructor () {
+              createdStream = this
+            }
+          }
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].error, 0)
+          })
+          const activeSpan = tracer.scope().active()
+          let loggedErrors = 0
+          let publishedErrors = 0
+
+          function onLogError () {
+            loggedErrors++
+          }
+
+          /**
+           * @param {{ operation: string }} ctx
+           */
+          function onError (ctx) {
+            if (ctx.operation === resource) publishedErrors++
+          }
+
+          logErrorCh.subscribe(onLogError)
+          opErrorCh.subscribe(onError)
+          try {
+            tracer.trace('parent', parentSpan => {
+              assert.strictEqual(fs[methodName]('unused'), createdStream)
+              assert.strictEqual(tracer.scope().active(), parentSpan)
+            })
+          } finally {
+            logErrorCh.unsubscribe(onLogError)
+            opErrorCh.unsubscribe(onError)
+            fs[className] = originalConstructor
+          }
+
+          assert.strictEqual(loggedErrors, 0)
+          assert.strictEqual(publishedErrors, 0)
+          assert.strictEqual(tracer.scope().active(), activeSpan)
+          await tracePromise
+        })
+
+        it('returns the stream when tracing listener lookup fails', async () => {
+          const originalConstructor = fs[className]
+          const listenerError = new Error('listener lookup failed')
+          let createdStream
+
+          fs[className] = class {
+            constructor () {
+              createdStream = this
+            }
+
+            get once () {
+              throw listenerError
+            }
+          }
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].error, 0)
+          })
+          const activeSpan = tracer.scope().active()
+          let publishedErrors = 0
+
+          /**
+           * @param {{ operation: string }} ctx
+           */
+          function onError (ctx) {
+            if (ctx.operation === resource) publishedErrors++
+          }
+
+          opErrorCh.subscribe(onError)
+          try {
+            tracer.trace('parent', parentSpan => {
+              assert.strictEqual(fs[methodName]('unused'), createdStream)
+              assert.strictEqual(tracer.scope().active(), parentSpan)
+            })
+          } finally {
+            opErrorCh.unsubscribe(onError)
+            fs[className] = originalConstructor
+          }
+
+          assert.strictEqual(publishedErrors, 0)
+          assert.strictEqual(tracer.scope().active(), activeSpan)
+          await tracePromise
+        })
+
+        it('finishes tracing when the stream emits an error', async () => {
+          const originalConstructor = fs[className]
+          const streamError = new Error('stream failed')
+          let createdStream
+
+          fs[className] = class extends EventEmitter {
+            constructor () {
+              super()
+              createdStream = this
+            }
+          }
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].error, 0)
+          })
+          const activeSpan = tracer.scope().active()
+          let publishedError
+
+          /**
+           * @param {{ operation: string, error?: Error }} ctx
+           */
+          function onError (ctx) {
+            if (ctx.operation === resource) publishedError = ctx.error
+          }
+
+          opErrorCh.subscribe(onError)
+          try {
+            tracer.trace('parent', parentSpan => {
+              const stream = fs[methodName]('unused')
+              stream.on('error', () => {})
+              stream.emit('error', streamError)
+
+              assert.strictEqual(stream, createdStream)
+              assert.strictEqual(tracer.scope().active(), parentSpan)
+            })
+          } finally {
+            opErrorCh.unsubscribe(onError)
+            fs[className] = originalConstructor
+          }
+
+          assert.strictEqual(publishedError, streamError)
+          assert.strictEqual(tracer.scope().active(), activeSpan)
+          for (const event of streamEvents) {
+            assert.strictEqual(createdStream.listenerCount(event), 0)
           }
           await tracePromise
         })

--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -1,15 +1,43 @@
 'use strict'
 
-const assert = require('node:assert')
+const assert = require('node:assert/strict')
+const { errorMonitor, EventEmitter, once } = require('node:events')
 const os = require('node:os')
 const path = require('node:path')
-const { describe, it, after, afterEach, before } = require('mocha')
+const { describe, it, after, afterEach, before, beforeEach } = require('mocha')
 
 const dc = require('dc-polyfill')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 
+const opErrorCh = dc.channel('apm:fs:operation:error')
 const opStartCh = dc.channel('apm:fs:operation:start')
+
+const streamConstructors = [
+  { methodName: 'createReadStream', className: 'ReadStream', resource: 'ReadStream' },
+  { methodName: 'createWriteStream', className: 'WriteStream', resource: 'WriteStream' },
+]
+const streamEvents = ['close', 'end', 'finish', errorMonitor]
+
+/**
+ * @param {() => unknown} callback
+ * @returns {Error & { code?: string }}
+ */
+function getThrownError (callback) {
+  let thrownError
+
+  /**
+   * @param {Error & { code?: string }} error
+   * @returns {true}
+   */
+  function capture (error) {
+    thrownError = error
+    return true
+  }
+
+  assert.throws(callback, capture)
+  return thrownError
+}
 
 describe('fs instrumentation', () => {
   afterEach(() => {
@@ -26,6 +54,121 @@ describe('fs instrumentation', () => {
     await agent.load('fs', undefined, { flushInterval: 1 })
     const fs = require('fs')
     assert.notStrictEqual(fs, undefined)
+  })
+
+  describe('stream constructors', () => {
+    let fs, tracer
+
+    beforeEach(async () => {
+      tracer = await agent.load('fs', undefined, { flushInterval: 1 })
+      tracer.use('fs', { enabled: true })
+      fs = require('node:fs')
+    })
+
+    for (const { methodName, className, resource } of streamConstructors) {
+      describe(methodName, () => {
+        it('preserves invalid path errors', () => {
+          const expectedError = getThrownError(() => Reflect.construct(fs[className], [null]))
+          const activeSpan = tracer.scope().active()
+
+          assert.throws(() => fs[methodName](null), {
+            name: expectedError.name,
+            code: expectedError.code,
+            message: expectedError.message,
+          })
+
+          assert.strictEqual(tracer.scope().active(), activeSpan)
+        })
+
+        it('rethrows the original constructor error without retaining tracing state or listeners', async () => {
+          const originalConstructor = fs[className]
+          const expectedError = getThrownError(() => Reflect.construct(originalConstructor, [null]))
+          let failedStream
+
+          fs[className] = class extends EventEmitter {
+            constructor () {
+              super()
+              failedStream = this
+              throw expectedError
+            }
+          }
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].error, 0)
+          })
+          const activeSpan = tracer.scope().active()
+          let publishedError
+
+          /**
+           * @param {{ operation: string, error?: Error }} ctx
+           */
+          function onError (ctx) {
+            if (ctx.operation === resource) publishedError = ctx.error
+          }
+
+          opErrorCh.subscribe(onError)
+          try {
+            tracer.trace('parent', parentSpan => {
+              const actualError = getThrownError(() => fs[methodName](null))
+
+              assert.strictEqual(actualError, expectedError)
+              assert.strictEqual(tracer.scope().active(), parentSpan)
+            })
+          } finally {
+            opErrorCh.unsubscribe(onError)
+            fs[className] = originalConstructor
+          }
+
+          assert.strictEqual(publishedError, expectedError)
+          assert.strictEqual(tracer.scope().active(), activeSpan)
+          for (const event of streamEvents) {
+            assert.strictEqual(failedStream.listenerCount(event), 0)
+          }
+          await tracePromise
+        })
+
+        it('returns a valid stream and removes its tracing listeners after completion', async () => {
+          const directory = methodName === 'createWriteStream'
+            ? fs.mkdtempSync(path.join(os.tmpdir(), 'dd-fs-stream-'))
+            : undefined
+          const filename = directory ? path.join(directory, 'output') : __filename
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+            assert.strictEqual(spans.length, 1)
+            assert.strictEqual(spans[0].error, 0)
+            assert.strictEqual(spans[0].meta['file.path'], filename)
+          })
+          const activeSpan = tracer.scope().active()
+
+          const streamPromise = tracer.trace('parent', async parentSpan => {
+            const stream = fs[methodName](filename)
+            const closePromise = once(stream, 'close')
+
+            assert.ok(stream instanceof fs[className])
+            if (methodName === 'createReadStream') {
+              stream.resume()
+            } else {
+              stream.end('test')
+            }
+            await closePromise
+
+            assert.strictEqual(tracer.scope().active(), parentSpan)
+            for (const event of streamEvents) {
+              assert.strictEqual(stream.listenerCount(event), 0)
+            }
+          })
+
+          try {
+            await Promise.all([streamPromise, tracePromise])
+            assert.strictEqual(tracer.scope().active(), activeSpan)
+          } finally {
+            if (directory) fs.rmSync(directory, { recursive: true })
+          }
+        })
+      })
+    }
   })
 
   // Node 20 defines `fs.opendir` / `fs.opendirSync` as lazy accessor properties.

--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -135,120 +135,15 @@ describe('fs instrumentation', () => {
           await tracePromise
         })
 
-        it('returns the native stream when tracing listener setup fails', async () => {
-          const originalConstructor = fs[className]
-          const listenerError = new Error('listener setup failed')
-          const directory = methodName === 'createWriteStream'
-            ? fs.mkdtempSync(path.join(os.tmpdir(), 'dd-fs-stream-'))
-            : undefined
-          const filename = directory ? path.join(directory, 'output') : __filename
-          let cleanupErrorThrown = false
-          let createdStream
-          let failListeners = false
-
-          fs[className] = class extends originalConstructor {
-            constructor (...args) {
-              super(...args)
-              createdStream = this
-              this.on('newListener', event => {
-                if (failListeners && event === errorMonitor) throw listenerError
-              })
-              this.on('removeListener', event => {
-                if (failListeners && event === 'close' && !cleanupErrorThrown) {
-                  cleanupErrorThrown = true
-                  this.emit(methodName === 'createReadStream' ? 'end' : 'finish')
-                  throw listenerError
-                }
-              })
-            }
-          }
-
-          try {
-            tracer.use('fs', { enabled: false })
-            const nativeStream = fs[methodName](filename)
-            const nativeClosePromise = once(nativeStream, 'close')
-            if (methodName === 'createReadStream') {
-              nativeStream.resume()
-            } else {
-              nativeStream.end('test')
-            }
-            await nativeClosePromise
-
-            tracer.use('fs', { enabled: true })
-            failListeners = true
-            const tracePromise = agent.assertSomeTraces(traces => {
-              const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
-              assert.strictEqual(spans.length, 1)
-              assert.strictEqual(spans[0].error, 0)
-            })
-            const activeSpan = tracer.scope().active()
-            let publishedErrors = 0
-            let publishedFinishes = 0
-
-            /**
-             * @param {{ operation: string }} ctx
-             */
-            function onError (ctx) {
-              if (ctx.operation === resource) publishedErrors++
-            }
-
-            /**
-             * @param {{ operation: string }} ctx
-             */
-            function onFinish (ctx) {
-              if (ctx.operation === resource) publishedFinishes++
-            }
-
-            opErrorCh.subscribe(onError)
-            opFinishCh.subscribe(onFinish)
-            try {
-              tracer.trace('parent', parentSpan => {
-                assert.strictEqual(fs[methodName](filename), createdStream)
-                assert.strictEqual(tracer.scope().active(), parentSpan)
-              })
-            } finally {
-              opErrorCh.unsubscribe(onError)
-              opFinishCh.unsubscribe(onFinish)
-            }
-
-            assert.strictEqual(cleanupErrorThrown, true)
-            assert.strictEqual(publishedErrors, 0)
-            assert.strictEqual(publishedFinishes, 1)
-            assert.strictEqual(tracer.scope().active(), activeSpan)
-            for (const event of streamEvents) {
-              assert.strictEqual(createdStream.listenerCount(event), 0)
-            }
-
-            const closePromise = once(createdStream, 'close')
-            if (methodName === 'createReadStream') {
-              createdStream.resume()
-            } else {
-              createdStream.end('test')
-            }
-            await Promise.all([closePromise, tracePromise])
-          } finally {
-            fs[className] = originalConstructor
-            if (directory) fs.rmSync(directory, { recursive: true })
-          }
-        })
-
         it('finishes tracing when the stream emits an error', async () => {
           const originalConstructor = fs[className]
-          const cleanupError = new Error('listener cleanup failed')
           const streamError = new Error('stream failed')
-          let cleanupErrorThrown = false
           let createdStream
 
           fs[className] = class extends EventEmitter {
             constructor () {
               super()
               createdStream = this
-              this.on('removeListener', (event, listener) => {
-                if (event === errorMonitor && listener.name === 'onError') {
-                  cleanupErrorThrown = true
-                  throw cleanupError
-                }
-              })
             }
           }
 
@@ -282,7 +177,6 @@ describe('fs instrumentation', () => {
             fs[className] = originalConstructor
           }
 
-          assert.strictEqual(cleanupErrorThrown, true)
           assert.strictEqual(publishedError, streamError)
           assert.strictEqual(tracer.scope().active(), activeSpan)
           for (const event of streamEvents) {
@@ -303,9 +197,7 @@ describe('fs instrumentation', () => {
             assert.strictEqual(spans[0].meta['file.path'], filename)
           })
           const activeSpan = tracer.scope().active()
-          const cleanupError = new Error('listener cleanup failed')
           const terminalEvent = methodName === 'createReadStream' ? 'end' : 'finish'
-          let cleanupErrorThrown = false
           let publishedFinishes = 0
 
           /**
@@ -321,12 +213,6 @@ describe('fs instrumentation', () => {
               const stream = fs[methodName](filename)
               const closePromise = once(stream, 'close')
               const terminalPromise = once(stream, terminalEvent)
-              stream.on('removeListener', (event, listener) => {
-                if (event === terminalEvent && listener.name === 'onFinish') {
-                  cleanupErrorThrown = true
-                  throw cleanupError
-                }
-              })
 
               assert.ok(stream instanceof fs[className])
               if (methodName === 'createReadStream') {
@@ -348,7 +234,6 @@ describe('fs instrumentation', () => {
             })
 
             await Promise.all([streamPromise, tracePromise])
-            assert.strictEqual(cleanupErrorThrown, true)
             assert.strictEqual(publishedFinishes, 1)
             assert.strictEqual(tracer.scope().active(), activeSpan)
           } finally {

--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const { errorMonitor, EventEmitter, once } = require('node:events')
+const nativeFs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 const { describe, it, after, afterEach, before, beforeEach } = require('mocha')
@@ -10,7 +11,6 @@ const dc = require('dc-polyfill')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 
-const logErrorCh = dc.channel('datadog:log:error')
 const opErrorCh = dc.channel('apm:fs:operation:error')
 const opFinishCh = dc.channel('apm:fs:operation:finish')
 const opStartCh = dc.channel('apm:fs:operation:start')
@@ -20,6 +20,10 @@ const streamConstructors = [
   { methodName: 'createWriteStream', className: 'WriteStream', resource: 'WriteStream' },
 ]
 const streamEvents = ['close', 'end', 'finish', errorMonitor]
+const expectedErrors = new Map()
+for (const { methodName } of streamConstructors) {
+  expectedErrors.set(methodName, getThrownError(() => nativeFs[methodName](null)))
+}
 
 /**
  * @param {() => unknown} callback
@@ -70,7 +74,7 @@ describe('fs instrumentation', () => {
     for (const { methodName, className, resource } of streamConstructors) {
       describe(methodName, () => {
         it('preserves invalid path errors', () => {
-          const expectedError = getThrownError(() => Reflect.construct(fs[className], [null]))
+          const expectedError = expectedErrors.get(methodName)
           const activeSpan = tracer.scope().active()
 
           assert.throws(() => fs[methodName](null), {
@@ -131,180 +135,101 @@ describe('fs instrumentation', () => {
           await tracePromise
         })
 
-        it('returns the stream when tracing listener setup fails', async () => {
+        it('returns the native stream when tracing listener setup fails', async () => {
           const originalConstructor = fs[className]
           const listenerError = new Error('listener setup failed')
+          const directory = methodName === 'createWriteStream'
+            ? fs.mkdtempSync(path.join(os.tmpdir(), 'dd-fs-stream-'))
+            : undefined
+          const filename = directory ? path.join(directory, 'output') : __filename
+          let cleanupErrorThrown = false
           let createdStream
+          let failListeners = false
 
-          fs[className] = class extends EventEmitter {
-            constructor () {
-              super()
+          fs[className] = class extends originalConstructor {
+            constructor (...args) {
+              super(...args)
               createdStream = this
+              this.on('newListener', event => {
+                if (failListeners && event === errorMonitor) throw listenerError
+              })
+              this.on('removeListener', event => {
+                if (failListeners && event === 'close' && !cleanupErrorThrown) {
+                  cleanupErrorThrown = true
+                  this.emit(methodName === 'createReadStream' ? 'end' : 'finish')
+                  throw listenerError
+                }
+              })
+            }
+          }
+
+          try {
+            tracer.use('fs', { enabled: false })
+            const nativeStream = fs[methodName](filename)
+            const nativeClosePromise = once(nativeStream, 'close')
+            if (methodName === 'createReadStream') {
+              nativeStream.resume()
+            } else {
+              nativeStream.end('test')
+            }
+            await nativeClosePromise
+
+            tracer.use('fs', { enabled: true })
+            failListeners = true
+            const tracePromise = agent.assertSomeTraces(traces => {
+              const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
+              assert.strictEqual(spans.length, 1)
+              assert.strictEqual(spans[0].error, 0)
+            })
+            const activeSpan = tracer.scope().active()
+            let publishedErrors = 0
+            let publishedFinishes = 0
+
+            /**
+             * @param {{ operation: string }} ctx
+             */
+            function onError (ctx) {
+              if (ctx.operation === resource) publishedErrors++
             }
 
             /**
-             * @param {string | symbol} event
-             * @param {(...args: unknown[]) => void} listener
-             * @returns {this}
+             * @param {{ operation: string }} ctx
              */
-            once (event, listener) {
-              super.once(event, listener)
-              if (event === 'end') throw listenerError
-              return this
+            function onFinish (ctx) {
+              if (ctx.operation === resource) publishedFinishes++
             }
 
-            /**
-             * @param {string | symbol} event
-             * @param {(...args: unknown[]) => void} listener
-             * @returns {this}
-             */
-            removeListener (event, listener) {
-              super.removeListener(event, listener)
-              if (event === errorMonitor) throw listenerError
-              return this
+            opErrorCh.subscribe(onError)
+            opFinishCh.subscribe(onFinish)
+            try {
+              tracer.trace('parent', parentSpan => {
+                assert.strictEqual(fs[methodName](filename), createdStream)
+                assert.strictEqual(tracer.scope().active(), parentSpan)
+              })
+            } finally {
+              opErrorCh.unsubscribe(onError)
+              opFinishCh.unsubscribe(onFinish)
             }
-          }
 
-          const tracePromise = agent.assertSomeTraces(traces => {
-            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
-            assert.strictEqual(spans.length, 1)
-            assert.strictEqual(spans[0].error, 0)
-          })
-          const activeSpan = tracer.scope().active()
-          let publishedErrors = 0
-          let publishedFinishes = 0
+            assert.strictEqual(cleanupErrorThrown, true)
+            assert.strictEqual(publishedErrors, 0)
+            assert.strictEqual(publishedFinishes, 1)
+            assert.strictEqual(tracer.scope().active(), activeSpan)
+            for (const event of streamEvents) {
+              assert.strictEqual(createdStream.listenerCount(event), 0)
+            }
 
-          /**
-           * @param {{ operation: string }} ctx
-           */
-          function onError (ctx) {
-            if (ctx.operation === resource) publishedErrors++
-          }
-
-          /**
-           * @param {{ operation: string }} ctx
-           */
-          function onFinish (ctx) {
-            if (ctx.operation !== resource) return
-            publishedFinishes++
-            createdStream.emit('close')
-          }
-
-          opErrorCh.subscribe(onError)
-          opFinishCh.subscribe(onFinish)
-          try {
-            tracer.trace('parent', parentSpan => {
-              assert.strictEqual(fs[methodName]('unused'), createdStream)
-              assert.strictEqual(tracer.scope().active(), parentSpan)
-            })
+            const closePromise = once(createdStream, 'close')
+            if (methodName === 'createReadStream') {
+              createdStream.resume()
+            } else {
+              createdStream.end('test')
+            }
+            await Promise.all([closePromise, tracePromise])
           } finally {
-            opErrorCh.unsubscribe(onError)
-            opFinishCh.unsubscribe(onFinish)
             fs[className] = originalConstructor
+            if (directory) fs.rmSync(directory, { recursive: true })
           }
-
-          assert.strictEqual(publishedErrors, 0)
-          assert.strictEqual(publishedFinishes, 1)
-          assert.strictEqual(tracer.scope().active(), activeSpan)
-          for (const event of streamEvents) {
-            assert.strictEqual(createdStream.listenerCount(event), 0)
-          }
-          await tracePromise
-        })
-
-        it('returns the stream when tracing listener methods are absent', async () => {
-          const originalConstructor = fs[className]
-          let createdStream
-
-          fs[className] = class {
-            constructor () {
-              createdStream = this
-            }
-          }
-
-          const tracePromise = agent.assertSomeTraces(traces => {
-            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
-            assert.strictEqual(spans.length, 1)
-            assert.strictEqual(spans[0].error, 0)
-          })
-          const activeSpan = tracer.scope().active()
-          let loggedErrors = 0
-          let publishedErrors = 0
-
-          function onLogError () {
-            loggedErrors++
-          }
-
-          /**
-           * @param {{ operation: string }} ctx
-           */
-          function onError (ctx) {
-            if (ctx.operation === resource) publishedErrors++
-          }
-
-          logErrorCh.subscribe(onLogError)
-          opErrorCh.subscribe(onError)
-          try {
-            tracer.trace('parent', parentSpan => {
-              assert.strictEqual(fs[methodName]('unused'), createdStream)
-              assert.strictEqual(tracer.scope().active(), parentSpan)
-            })
-          } finally {
-            logErrorCh.unsubscribe(onLogError)
-            opErrorCh.unsubscribe(onError)
-            fs[className] = originalConstructor
-          }
-
-          assert.strictEqual(loggedErrors, 0)
-          assert.strictEqual(publishedErrors, 0)
-          assert.strictEqual(tracer.scope().active(), activeSpan)
-          await tracePromise
-        })
-
-        it('returns the stream when tracing listener lookup fails', async () => {
-          const originalConstructor = fs[className]
-          const listenerError = new Error('listener lookup failed')
-          let createdStream
-
-          fs[className] = class {
-            constructor () {
-              createdStream = this
-            }
-
-            get once () {
-              throw listenerError
-            }
-          }
-
-          const tracePromise = agent.assertSomeTraces(traces => {
-            const spans = traces.flat().filter(span => span.name === 'fs.operation' && span.resource === resource)
-            assert.strictEqual(spans.length, 1)
-            assert.strictEqual(spans[0].error, 0)
-          })
-          const activeSpan = tracer.scope().active()
-          let publishedErrors = 0
-
-          /**
-           * @param {{ operation: string }} ctx
-           */
-          function onError (ctx) {
-            if (ctx.operation === resource) publishedErrors++
-          }
-
-          opErrorCh.subscribe(onError)
-          try {
-            tracer.trace('parent', parentSpan => {
-              assert.strictEqual(fs[methodName]('unused'), createdStream)
-              assert.strictEqual(tracer.scope().active(), parentSpan)
-            })
-          } finally {
-            opErrorCh.unsubscribe(onError)
-            fs[className] = originalConstructor
-          }
-
-          assert.strictEqual(publishedErrors, 0)
-          assert.strictEqual(tracer.scope().active(), activeSpan)
-          await tracePromise
         })
 
         it('finishes tracing when the stream emits an error', async () => {
@@ -369,29 +294,47 @@ describe('fs instrumentation', () => {
             assert.strictEqual(spans[0].meta['file.path'], filename)
           })
           const activeSpan = tracer.scope().active()
+          const terminalEvent = methodName === 'createReadStream' ? 'end' : 'finish'
+          let publishedFinishes = 0
 
-          const streamPromise = tracer.trace('parent', async parentSpan => {
-            const stream = fs[methodName](filename)
-            const closePromise = once(stream, 'close')
+          /**
+           * @param {{ operation: string }} ctx
+           */
+          function onFinish (ctx) {
+            if (ctx.operation === resource) publishedFinishes++
+          }
 
-            assert.ok(stream instanceof fs[className])
-            if (methodName === 'createReadStream') {
-              stream.resume()
-            } else {
-              stream.end('test')
-            }
-            await closePromise
-
-            assert.strictEqual(tracer.scope().active(), parentSpan)
-            for (const event of streamEvents) {
-              assert.strictEqual(stream.listenerCount(event), 0)
-            }
-          })
-
+          opFinishCh.subscribe(onFinish)
           try {
+            const streamPromise = tracer.trace('parent', async parentSpan => {
+              const stream = fs[methodName](filename)
+              const closePromise = once(stream, 'close')
+              const terminalPromise = once(stream, terminalEvent)
+
+              assert.ok(stream instanceof fs[className])
+              if (methodName === 'createReadStream') {
+                stream.resume()
+              } else {
+                stream.end('test')
+              }
+              await terminalPromise
+
+              assert.strictEqual(tracer.scope().active(), parentSpan)
+              for (const event of streamEvents) {
+                assert.strictEqual(stream.listenerCount(event), event === 'close' ? 1 : 0)
+              }
+
+              await closePromise
+              for (const event of streamEvents) {
+                assert.strictEqual(stream.listenerCount(event), 0)
+              }
+            })
+
             await Promise.all([streamPromise, tracePromise])
+            assert.strictEqual(publishedFinishes, 1)
             assert.strictEqual(tracer.scope().active(), activeSpan)
           } finally {
+            opFinishCh.unsubscribe(onFinish)
             if (directory) fs.rmSync(directory, { recursive: true })
           }
         })


### PR DESCRIPTION
### What does this PR do?

Rethrows synchronous errors from instrumented `fs.createReadStream()` and `fs.createWriteStream()` calls after publishing and finishing tracing state.

### Motivation

The wrappers currently swallow Node's constructor error and return `undefined`, which changes the supported `fs` API contract.

### Additional Notes

The original exception object, code, and message are preserved. Tests cover invalid calls, valid siblings, completed spans, scope restoration, and listener cleanup on Node.js 18, 22, and 26.