### PR TITLE
fix(opentelemetry): wait for trace delivery in forceFlush

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@
 /packages/dd-trace/src/azure_metadata.js @DataDog/dd-trace-js @DataDog/apm-serverless
 /packages/dd-trace/src/serverless.js @DataDog/dd-trace-js @DataDog/apm-serverless
 /packages/dd-trace/src/serverless/ @DataDog/dd-trace-js @DataDog/apm-serverless
+/packages/dd-trace/src/flush-error.js @DataDog/dd-trace-js @DataDog/apm-serverless @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/src/flush.js @DataDog/dd-trace-js @DataDog/apm-serverless @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/lambda/ @DataDog/dd-trace-js @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/azure_metadata.spec.js @DataDog/dd-trace-js @DataDog/apm-serverless

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -710,8 +710,27 @@ class CiVisibilityExporter extends BufferingExporter {
   }
 
   flush (done) {
-    const isFinalFlush = typeof done === 'function'
+    this.#flush(done, typeof done === 'function', false)
+  }
+
+  /**
+   * Flushes data owned by the current completion boundary without finalizing the test session.
+   * @param {(error?: Error) => void} [done]
+   */
+  forceFlush (done) {
+    this.#flush(done, false, true)
+  }
+
+  /**
+   * @param {((error?: Error) => void)|undefined} done
+   * @param {boolean} isFinalFlush
+   * @param {boolean} isForceFlush
+   */
+  #flush (done, isFinalFlush, isForceFlush) {
     const onDone = done || (() => {})
+    const hasBufferedData = this._traceBuffer.length !== 0 || this._coverageBuffer.length !== 0
+    const hasPendingFinalData = hasBufferedData ||
+      this.#deferredTestSuiteSpans.size !== 0 || this.#deferredTestSessionTraces.length !== 0
     let finalFlush
 
     if (isFinalFlush && this.#finalFlush) {
@@ -720,10 +739,7 @@ class CiVisibilityExporter extends BufferingExporter {
       return
     }
 
-    if (isFinalFlush && !this._isInitialized &&
-      this._traceBuffer.length === 0 && this._coverageBuffer.length === 0 &&
-      this.#deferredTestSuiteSpans.size === 0 && this.#deferredTestSessionTraces.length === 0 &&
-      this.#pendingMediaUploads.size === 0) {
+    if (isFinalFlush && !this._isInitialized && !hasPendingFinalData && this.#pendingMediaUploads.size === 0) {
       this._initializationRequest?.controller.abort()
       onDone()
       return
@@ -738,7 +754,7 @@ class CiVisibilityExporter extends BufferingExporter {
       this.#finalFlush = finalFlush
     }
 
-    const deadline = isFinalFlush ? Date.now() + FINAL_FLUSH_TIMEOUT : undefined
+    const deadline = isFinalFlush || isForceFlush ? Date.now() + FINAL_FLUSH_TIMEOUT : undefined
     let hasCompleted = false
     let initializationTimeoutId
     let mediaTimeoutId
@@ -839,7 +855,7 @@ class CiVisibilityExporter extends BufferingExporter {
       }, Math.max(0, deadline - Date.now()))
     }
 
-    if (!isFinalFlush) {
+    if (!isFinalFlush && !isForceFlush) {
       if (this._isInitialized) flushWriters()
       else complete()
       return
@@ -847,6 +863,11 @@ class CiVisibilityExporter extends BufferingExporter {
 
     if (this._isInitialized) {
       flushWriters()
+      return
+    }
+
+    if (!hasBufferedData) {
+      complete()
       return
     }
 

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -1,16 +1,16 @@
 'use strict'
 
 const { URL } = require('url')
+const getFlushError = require('../../flush-error')
 const log = require('../../log')
-const { createServerlessDeliveryTracker } = require('../../serverless')
+const TelemetryDeliveryTracker = require('../../serverless/telemetry-delivery-tracker')
 const Writer = require('./writer')
 
 class AgentExporter {
+  #deliveryTracker = new TelemetryDeliveryTracker()
   #timer
-  #serverlessDeliveryTracker
 
   constructor (config, prioritySampler) {
-    this.#serverlessDeliveryTracker = createServerlessDeliveryTracker()
     this._config = config
     const { lookup, protocolVersion, stats = {}, apmTracingEnabled, flushInterval } = config
     this._url = config.url
@@ -27,7 +27,7 @@ class AgentExporter {
       protocolVersion,
       flushInterval,
       headers,
-      deliveryTracker: this.#serverlessDeliveryTracker,
+      deliveryTracker: this.#deliveryTracker,
     })
 
     globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(this.flush.bind(this))
@@ -59,26 +59,32 @@ class AgentExporter {
     }
   }
 
-  flush (done) {
+  /**
+   * @param {(error?: Error) => void} [done]
+   * @param {{ reportErrors?: boolean }} [options]
+   */
+  flush (done, options) {
     clearTimeout(this.#timer)
     this.#timer = undefined
 
-    if (!this.#serverlessDeliveryTracker) {
-      try {
-        return this._writer.flush(done)
-      } catch (error) {
-        log.error('Failed to flush traces: %s', error.message)
-        done?.()
-        return
-      }
+    let boundaryError
+    let waiting = false
+    const captureError = error => {
+      if (!waiting) boundaryError = error
     }
-
     try {
-      this._writer.flush()
+      this._writer.flush(captureError, options)
     } catch (error) {
       log.error('Failed to flush traces: %s', error.message)
+      boundaryError = error
     }
-    this.#serverlessDeliveryTracker.waitForIdle(done)
+    waiting = true
+    if (!done) return
+
+    this.#deliveryTracker.waitForIdle(error => {
+      if (!options?.reportErrors || !boundaryError) return done(error)
+      done(getFlushError(error ? [boundaryError, error] : [boundaryError]))
+    }, options)
   }
 }
 

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -3,14 +3,19 @@
 const { URL } = require('url')
 const getFlushError = require('../../flush-error')
 const log = require('../../log')
+const { createServerlessDeliveryTracker } = require('../../serverless')
 const TelemetryDeliveryTracker = require('../../serverless/telemetry-delivery-tracker')
 const Writer = require('./writer')
 
 class AgentExporter {
-  #deliveryTracker = new TelemetryDeliveryTracker()
+  #deliveryTracker
   #timer
 
   constructor (config, prioritySampler) {
+    this.#deliveryTracker = createServerlessDeliveryTracker()
+    if (!this.#deliveryTracker && TelemetryDeliveryTracker.isProcessTrackingEnabled()) {
+      this.#deliveryTracker = new TelemetryDeliveryTracker()
+    }
     this._config = config
     const { lookup, protocolVersion, stats = {}, apmTracingEnabled, flushInterval } = config
     this._url = config.url
@@ -31,6 +36,13 @@ class AgentExporter {
     })
 
     globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(this.flush.bind(this))
+  }
+
+  enableDeliveryTracking () {
+    if (this.#deliveryTracker) return
+
+    this.#deliveryTracker = new TelemetryDeliveryTracker()
+    this._writer.enableDeliveryTracking(this.#deliveryTracker)
   }
 
   setUrl (url) {
@@ -66,6 +78,16 @@ class AgentExporter {
   flush (done, options) {
     clearTimeout(this.#timer)
     this.#timer = undefined
+
+    if (!this.#deliveryTracker) {
+      try {
+        this._writer.flush(done, options)
+      } catch (error) {
+        log.error('Failed to flush traces: %s', error.message)
+        done?.(options?.reportErrors ? error : undefined)
+      }
+      return
+    }
 
     let boundaryError
     let waiting = false

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -43,7 +43,7 @@ class AgentWriter extends BaseWriter {
    * Performs the writer flush without registering a serverless delivery.
    * Test Optimization owns its own request lifecycle tracking.
    * @param {(error?: Error) => void} [done]
-   * @param {{ deadline?: number }} [options]
+   * @param {{ deadline?: number, reportErrors?: boolean }} [options]
    * @returns {void}
    */
   flushDirect (done, options) {
@@ -73,7 +73,7 @@ class AgentWriter extends BaseWriter {
 
       if (err) {
         log.errorWithoutTelemetry('Error sending payload to the agent (status code: %s)', err.status, err)
-        done(flushOptions?.deadline === undefined ? undefined : err)
+        done(err)
         return
       }
 

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -4,6 +4,7 @@ const { URL } = require('node:url')
 const os = require('node:os')
 
 const log = require('../../log')
+const { createServerlessDeliveryTracker } = require('../../serverless')
 const TelemetryDeliveryTracker = require('../../serverless/telemetry-delivery-tracker')
 const { containerId } = require('../common/docker')
 const Writer = require('./writer')
@@ -15,7 +16,7 @@ const { computeIntakeUrl } = require('./intake')
  * Batches multiple traces per request using timer-based flushing.
  */
 class AgentlessExporter {
-  #deliveryTracker = new TelemetryDeliveryTracker()
+  #deliveryTracker
   #timer
   #config
 
@@ -27,6 +28,10 @@ class AgentlessExporter {
    * @param {object} config.tags - Tags including runtime-id
    */
   constructor (config) {
+    this.#deliveryTracker = createServerlessDeliveryTracker()
+    if (!this.#deliveryTracker && TelemetryDeliveryTracker.isProcessTrackingEnabled()) {
+      this.#deliveryTracker = new TelemetryDeliveryTracker()
+    }
     this.#config = config
     const site = config.site ?? 'datadoghq.com'
 
@@ -61,6 +66,13 @@ class AgentlessExporter {
     } else {
       log.error('dd-trace global not properly initialized. beforeExit handler not registered for agentless exporter.')
     }
+  }
+
+  enableDeliveryTracking () {
+    if (this.#deliveryTracker) return
+
+    this.#deliveryTracker = new TelemetryDeliveryTracker()
+    this._writer.enableDeliveryTracking(this.#deliveryTracker)
   }
 
   /**
@@ -121,6 +133,17 @@ class AgentlessExporter {
   flush (done, options) {
     clearTimeout(this.#timer)
     this.#timer = undefined
+
+    if (!this.#deliveryTracker) {
+      try {
+        this._writer.flush(done, options)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.error('Failed to flush traces: %s', message)
+        done?.(options?.reportErrors ? (error instanceof Error ? error : new Error(message)) : undefined)
+      }
+      return
+    }
 
     let boundaryError
     let waiting = false

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -112,16 +112,19 @@ class AgentlessExporter {
 
   /**
    * Flushes any pending traces immediately. Clears the batch timer.
-   * @param {Function} [done] - Callback when flush is complete
+   * @param {(error?: Error) => void} [done] - Callback when flush is complete
+   * @param {{ reportErrors?: boolean }} [options]
    */
-  flush (done = () => {}) {
+  flush (done = () => {}, options) {
     clearTimeout(this.#timer)
     this.#timer = undefined
     try {
-      this._writer.flush(done)
-    } catch (err) {
-      log.error('Failed to flush traces: %s', err.message)
-      done()
+      this._writer.flush(done, options)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const flushError = error instanceof Error ? error : new Error(message)
+      log.error('Failed to flush traces: %s', message)
+      done(options?.reportErrors ? flushError : undefined)
     }
   }
 }

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -4,6 +4,7 @@ const { URL } = require('node:url')
 const os = require('node:os')
 
 const log = require('../../log')
+const TelemetryDeliveryTracker = require('../../serverless/telemetry-delivery-tracker')
 const { containerId } = require('../common/docker')
 const Writer = require('./writer')
 const { computeIntakeUrl } = require('./intake')
@@ -14,6 +15,7 @@ const { computeIntakeUrl } = require('./intake')
  * Batches multiple traces per request using timer-based flushing.
  */
 class AgentlessExporter {
+  #deliveryTracker = new TelemetryDeliveryTracker()
   #timer
   #config
 
@@ -50,6 +52,7 @@ class AgentlessExporter {
       url: this._url,
       site,
       metadata,
+      deliveryTracker: this.#deliveryTracker,
     })
 
     const ddTrace = globalThis[Symbol.for('dd-trace')]
@@ -115,17 +118,28 @@ class AgentlessExporter {
    * @param {(error?: Error) => void} [done] - Callback when flush is complete
    * @param {{ reportErrors?: boolean }} [options]
    */
-  flush (done = () => {}, options) {
+  flush (done, options) {
     clearTimeout(this.#timer)
     this.#timer = undefined
+
+    let boundaryError
+    let waiting = false
+    const captureError = error => {
+      if (!waiting) boundaryError = error
+    }
     try {
-      this._writer.flush(done, options)
+      this._writer.flush(captureError, options)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      const flushError = error instanceof Error ? error : new Error(message)
       log.error('Failed to flush traces: %s', message)
-      done(options?.reportErrors ? flushError : undefined)
+      boundaryError = error instanceof Error ? error : new Error(message)
     }
+    waiting = true
+    if (!done) return
+
+    this.#deliveryTracker.waitForIdle(() => {
+      done(options?.reportErrors ? boundaryError : undefined)
+    })
   }
 }
 

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -45,9 +45,10 @@ class AgentlessWriter extends BaseWriter {
    * @param {URL} [options.url] - The intake URL. If not provided, constructed from site.
    * @param {string} [options.site] - The Datadog site
    * @param {object} [options.metadata] - Metadata to pass to the data pipeline
+   * @param {import('../../serverless/telemetry-delivery-tracker')} [options.deliveryTracker]
    */
-  constructor ({ url, site = 'datadoghq.com', metadata = {} }) {
-    super({ url })
+  constructor ({ url, site = 'datadoghq.com', metadata = {}, deliveryTracker }) {
+    super({ url, deliveryTracker })
     this.#metadata = metadata
     this._encoder = new AgentEncoder(this)
 

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -16,6 +16,16 @@ const { computeIntakeUrl, INTAKE_PATH } = require('./intake')
 const legacyStorage = storage('legacy')
 
 /**
+ * @param {(error?: Error) => void} done
+ * @param {{ reportErrors?: boolean }|undefined} options
+ * @param {unknown} reason
+ */
+function completeFlush (done, options, reason) {
+  if (!options?.reportErrors) return done()
+  done(reason instanceof Error ? reason : new Error(String(reason)))
+}
+
+/**
  * Writer for agentless APM trace intake.
  * Encodes traces as v0.4 MessagePack and delegates transformation and delivery
  * to the APM data pipeline.
@@ -74,16 +84,17 @@ class AgentlessWriter extends BaseWriter {
   /**
    * @param {Buffer} data - v0.4 MessagePack payload.
    * @param {number} count - Number of traces in the payload.
-   * @param {() => void} done - Callback invoked after delivery completes or fails.
+   * @param {(error?: Error) => void} done - Callback invoked after delivery completes or fails.
+   * @param {{ reportErrors?: boolean }} [options]
    */
-  _sendPayload (data, count, done) {
+  _sendPayload (data, count, done, options) {
     if (!this._url) {
       if (!this.#urlMissing) {
         this.#urlMissing = true
         log.error('No valid URL configured for agentless trace intake. Traces will not be sent.')
       }
       log.debug('Dropping %d trace(s) due to missing URL', count)
-      done()
+      completeFlush(done, options, 'No valid URL configured for agentless trace intake')
       return
     }
 
@@ -94,7 +105,7 @@ class AgentlessWriter extends BaseWriter {
         log.error('DD_API_KEY is required for agentless trace intake. Set DD_API_KEY. Traces will not be sent.')
       }
       log.debug('Dropping %d trace(s) due to missing DD_API_KEY', count)
-      done()
+      completeFlush(done, options, 'DD_API_KEY is required for agentless trace intake')
       return
     }
     this.#apiKeyMissing = false
@@ -107,13 +118,13 @@ class AgentlessWriter extends BaseWriter {
         if (exporter) {
           exporter.sendV04(data, done, log)
         } else {
-          done()
+          completeFlush(done, options, 'DD_API_KEY cannot be sent to the configured agentless trace intake')
         }
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       log.error('Failed to send %d trace(s) to the agentless intake: %s', count, message)
-      done()
+      completeFlush(done, options, error)
     }
   }
 

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -26,12 +26,13 @@ class Writer {
   /**
    * Flushes queued telemetry, retaining delivery on supported serverless platforms.
    * @param {(error?: Error) => void} [done]
-   * @param {{ deadline?: number }} [options]
+   * @param {{ deadline?: number, reportErrors?: boolean }} [options]
    * @returns {void}
    */
   flush (done, options) {
     if (this.#deliveryTracker) {
-      return this.#deliveryTracker.track(callback => this.flushDirect(callback, options), done)
+      const callback = options?.reportErrors || options?.deadline !== undefined || !done ? done : () => done()
+      return this.#deliveryTracker.track(callback => this.flushDirect(callback, options), callback)
     }
     this.flushDirect(done, options)
   }
@@ -39,7 +40,7 @@ class Writer {
   /**
    * Flushes queued telemetry without registering serverless delivery retention.
    * @param {(error?: Error) => void} [done]
-   * @param {{ deadline?: number }} [options]
+   * @param {{ deadline?: number, reportErrors?: boolean }} [options]
    * @returns {void}
    */
   flushDirect (done = noop, options) {
@@ -47,7 +48,13 @@ class Writer {
 
     if (!request.writable && options?.deadline === undefined && !this.#retainOnBackpressure) {
       this._encoder.reset()
-      done()
+      if (options?.reportErrors) {
+        const error = new log.NoTransmitError('Maximum active request buffer size reached: payload is discarded.')
+        error.code = 'ERR_DD_REQUEST_BUFFER_FULL'
+        done(error)
+      } else {
+        done()
+      }
     } else if (count > 0) {
       if (this.#isFirstFlush && firstFlushChannel.hasSubscribers && this._beforeFirstFlush) {
         this.#isFirstFlush = false
@@ -66,7 +73,7 @@ class Writer {
         // the oversized payload at the network boundary anyway.
         this._encoder.reset()
         log.error('Writer dropped %d trace(s) that exceeded the %d byte chunk cap', count, MAX_CHUNK_SIZE)
-        done()
+        done(options?.reportErrors ? error : undefined)
         return
       }
       if (options === undefined) {

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -37,11 +37,11 @@ class Writer {
    * @returns {void}
    */
   flush (done, options) {
+    const callback = options?.reportErrors || options?.deadline !== undefined || !done ? done : () => done()
     if (this.#deliveryTracker) {
-      const callback = options?.reportErrors || options?.deadline !== undefined || !done ? done : () => done()
       return this.#deliveryTracker.track(callback => this.flushDirect(callback, options), callback)
     }
-    this.flushDirect(done, options)
+    this.flushDirect(callback, options)
   }
 
   /**

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -21,6 +21,13 @@ class Writer {
     this.#deliveryTracker = deliveryTracker
   }
 
+  /**
+   * @param {import('../../serverless/telemetry-delivery-tracker')} deliveryTracker
+   */
+  enableDeliveryTracking (deliveryTracker) {
+    this.#deliveryTracker = deliveryTracker
+  }
+
   #isFirstFlush = true
 
   /**

--- a/packages/dd-trace/src/flush-error.js
+++ b/packages/dd-trace/src/flush-error.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * @param {unknown} reason
+ * @param {unknown[]} reasons
+ */
+function collectReason (reason, reasons) {
+  if (reason instanceof AggregateError) {
+    for (const error of reason.errors) collectReason(error, reasons)
+    return
+  }
+
+  reasons.push(reason)
+}
+
+/**
+ * Preserves a single rejection reason and aggregates independent failures.
+ * @param {unknown[]} flushReasons
+ * @returns {unknown}
+ */
+function getFlushError (flushReasons) {
+  let flushError
+  if (flushReasons.length > 0) {
+    const reasons = []
+    for (const reason of flushReasons) collectReason(reason, reasons)
+
+    flushError = reasons.length === 1
+      ? reasons[0]
+      : new AggregateError(reasons, 'Multiple errors occurred while flushing')
+  }
+  return flushError
+}
+
+module.exports = getFlushError

--- a/packages/dd-trace/src/flush-error.js
+++ b/packages/dd-trace/src/flush-error.js
@@ -19,16 +19,12 @@ function collectReason (reason, reasons) {
  * @returns {unknown}
  */
 function getFlushError (flushReasons) {
-  let flushError
-  if (flushReasons.length > 0) {
-    const reasons = []
-    for (const reason of flushReasons) collectReason(reason, reasons)
+  if (flushReasons.length < 2) return flushReasons[0]
 
-    flushError = reasons.length === 1
-      ? reasons[0]
-      : new AggregateError(reasons, 'Multiple errors occurred while flushing')
-  }
-  return flushError
+  const reasons = []
+  for (const reason of flushReasons) collectReason(reason, reasons)
+
+  return new AggregateError(reasons, 'Multiple errors occurred while flushing')
 }
 
 module.exports = getFlushError

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -5,8 +5,8 @@ const https = require('node:https')
 const { URL } = require('node:url')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
-const { createServerlessDeliveryTracker } = require('../../serverless')
 const { getHttpsProxyAgent } = require('../../exporters/common/proxy')
+const TelemetryDeliveryTracker = require('../../serverless/telemetry-delivery-tracker')
 const telemetryMetrics = require('../../telemetry/metrics')
 const { version: tracerVersion } = require('../../../../../package.json')
 
@@ -22,8 +22,8 @@ const legacyStorage = storage('legacy')
  * @class OtlpHttpExporterBase
  */
 class OtlpHttpExporterBase {
+  #deliveryTracker = new TelemetryDeliveryTracker()
   #transport = https
-  #serverlessDeliveryTracker
 
   /**
    * Creates a new OtlpHttpExporterBase instance.
@@ -36,7 +36,6 @@ class OtlpHttpExporterBase {
    * @param {string} signalType - Signal type for error messages (e.g., 'logs', 'metrics')
    */
   constructor (url, headers, timeout, protocol, signalType) {
-    this.#serverlessDeliveryTracker = createServerlessDeliveryTracker()
     this.protocol = protocol
     this.signalType = signalType
 
@@ -87,10 +86,7 @@ class OtlpHttpExporterBase {
    * @protected
    */
   sendPayload (payload, resultCallback) {
-    if (this.#serverlessDeliveryTracker) {
-      return this.#serverlessDeliveryTracker.track(done => this.#sendPayload(payload, resultCallback, done))
-    }
-    this.#sendPayload(payload, resultCallback)
+    this.#deliveryTracker.track(done => this.#sendPayload(payload, resultCallback, done))
   }
 
   #sendPayload (payload, resultCallback, done) {
@@ -107,7 +103,7 @@ class OtlpHttpExporterBase {
       if (completed) return
       completed = true
       resultCallback(result)
-      done?.()
+      done?.(result.error)
     }
 
     try {
@@ -155,12 +151,12 @@ class OtlpHttpExporterBase {
   }
 
   /**
-   * Calls back once Vercel-tracked requests active at the flush boundary complete.
-   * @param {Function} [done]
+   * Calls back once requests active at the flush boundary complete.
+   * @param {(error?: Error) => void} [done]
+   * @param {{ reportErrors?: boolean }} [options]
    */
-  flush (done) {
-    if (this.#serverlessDeliveryTracker) return this.#serverlessDeliveryTracker.waitForIdle(done)
-    done?.()
+  flush (done, options) {
+    this.#deliveryTracker.waitForIdle(done, options)
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/span_processor.js
+++ b/packages/dd-trace/src/opentelemetry/span_processor.js
@@ -1,5 +1,33 @@
 'use strict'
 
+const getFlushError = require('../flush-error')
+
+/**
+ * @typedef {{ status: 'fulfilled', value: unknown } | { status: 'rejected', reason: unknown }} FlushResult
+ */
+
+/**
+ * @param {FlushResult[]} results
+ * @returns {Promise<void> | undefined}
+ */
+function collectFlushErrors (results) {
+  const reasons = []
+  for (const result of results) {
+    if (result.status !== 'rejected') continue
+    reasons.push(result.reason)
+  }
+
+  if (reasons.length > 0) return Promise.reject(getFlushError(reasons))
+}
+
+/**
+ * @param {Promise<unknown>[]} flushes
+ * @returns {Promise<void>}
+ */
+function settleAllFlushes (flushes) {
+  return Promise.allSettled(flushes).then(collectFlushErrors)
+}
+
 class NoopSpanProcessor {
   forceFlush () {
     return Promise.resolve()
@@ -22,9 +50,15 @@ class MultiSpanProcessor extends NoopSpanProcessor {
   }
 
   forceFlush () {
-    return Promise.all(
-      this.#processors.map(p => p.forceFlush())
-    )
+    const flushes = []
+    for (const processor of this.#processors) {
+      try {
+        flushes.push(processor.forceFlush())
+      } catch (error) {
+        flushes.push(Promise.reject(error))
+      }
+    }
+    return settleAllFlushes(flushes)
   }
 
   onStart (span, context) {
@@ -49,4 +83,5 @@ class MultiSpanProcessor extends NoopSpanProcessor {
 module.exports = {
   MultiSpanProcessor,
   NoopSpanProcessor,
+  settleAllFlushes,
 }

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -6,12 +6,45 @@ const { W3CTraceContextPropagator } = require('../../../../vendor/dist/@opentele
 const tracer = require('../../')
 
 const ContextManager = require('./context_manager')
-const { MultiSpanProcessor, NoopSpanProcessor } = require('./span_processor')
+const { MultiSpanProcessor, NoopSpanProcessor, settleAllFlushes } = require('./span_processor')
 const Tracer = require('./tracer')
+
+/**
+ * @typedef {{
+ *   flush?: (done?: (error?: Error) => void, options?: { reportErrors?: boolean }) => void
+ * }} TraceExporter
+ */
+
+/**
+ * @param {TraceExporter} exporter
+ * @returns {Promise<void>}
+ */
+function flushExporter (exporter) {
+  if (typeof exporter.flush !== 'function') return Promise.resolve()
+
+  /**
+   * @param {() => void} resolve
+   * @param {(reason?: unknown) => void} reject
+   */
+  function flush (resolve, reject) {
+    /**
+     * @param {Error} [error]
+     */
+    function done (error) {
+      if (error) reject(error)
+      else resolve()
+    }
+
+    exporter.flush(done, { reportErrors: true })
+  }
+
+  return new Promise(flush)
+}
 
 class TracerProvider {
   #activeProcessor = new NoopSpanProcessor()
   #contextManager = new ContextManager()
+  #flush
   #processors = []
   #tracers = new Map()
 
@@ -84,8 +117,19 @@ class TracerProvider {
       return Promise.reject(new Error('Not started'))
     }
 
-    exporter._writer?.flush()
-    return this.#activeProcessor.forceFlush()
+    const flush = () => settleAllFlushes([
+      flushExporter(exporter),
+      this.#activeProcessor.forceFlush(),
+    ])
+    const pending = this.#flush ? this.#flush.then(flush, flush) : flush()
+    this.#flush = pending
+
+    const clear = () => {
+      if (this.#flush === pending) this.#flush = undefined
+    }
+    pending.then(clear, clear)
+
+    return pending
   }
 
   shutdown () {

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -12,6 +12,7 @@ const Tracer = require('./tracer')
 /**
  * @typedef {{
  *   flush?: (done?: (error?: Error) => void, options?: { reportErrors?: boolean }) => void
+ *   forceFlush?: (done?: (error?: Error) => void) => void
  * }} TraceExporter
  */
 
@@ -20,7 +21,7 @@ const Tracer = require('./tracer')
  * @returns {Promise<void>}
  */
 function flushExporter (exporter) {
-  if (typeof exporter.flush !== 'function') return Promise.resolve()
+  if (typeof exporter.forceFlush !== 'function' && typeof exporter.flush !== 'function') return Promise.resolve()
 
   /**
    * @param {() => void} resolve
@@ -35,7 +36,11 @@ function flushExporter (exporter) {
       else resolve()
     }
 
-    exporter.flush(done, { reportErrors: true })
+    if (typeof exporter.forceFlush === 'function') {
+      exporter.forceFlush(done)
+    } else {
+      exporter.flush(done, { reportErrors: true })
+    }
   }
 
   return new Promise(flush)
@@ -44,7 +49,6 @@ function flushExporter (exporter) {
 class TracerProvider {
   #activeProcessor = new NoopSpanProcessor()
   #contextManager = new ContextManager()
-  #flush
   #processors = []
   #tracers = new Map()
 
@@ -117,19 +121,10 @@ class TracerProvider {
       return Promise.reject(new Error('Not started'))
     }
 
-    const flush = () => settleAllFlushes([
+    return settleAllFlushes([
       flushExporter(exporter),
       this.#activeProcessor.forceFlush(),
     ])
-    const pending = this.#flush ? this.#flush.then(flush, flush) : flush()
-    this.#flush = pending
-
-    const clear = () => {
-      if (this.#flush === pending) this.#flush = undefined
-    }
-    pending.then(clear, clear)
-
-    return pending
   }
 
   shutdown () {

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -4,6 +4,7 @@ const { trace, context, propagation } = require('@opentelemetry/api')
 const { W3CTraceContextPropagator } = require('../../../../vendor/dist/@opentelemetry/core')
 
 const tracer = require('../../')
+const TelemetryDeliveryTracker = require('../serverless/telemetry-delivery-tracker')
 
 const ContextManager = require('./context_manager')
 const { MultiSpanProcessor, NoopSpanProcessor, settleAllFlushes } = require('./span_processor')
@@ -11,6 +12,7 @@ const Tracer = require('./tracer')
 
 /**
  * @typedef {{
+ *   enableDeliveryTracking?: () => void
  *   flush?: (done?: (error?: Error) => void, options?: { reportErrors?: boolean }) => void
  *   forceFlush?: (done?: (error?: Error) => void) => void
  * }} TraceExporter
@@ -53,6 +55,8 @@ class TracerProvider {
   #tracers = new Map()
 
   constructor (config = {}) {
+    TelemetryDeliveryTracker.enableProcessTracking()
+    tracer._tracer?._exporter?.enableDeliveryTracking?.()
     this.config = config
     this.resource = config.resource
 

--- a/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
+++ b/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
@@ -1,48 +1,56 @@
 'use strict'
 
+const getFlushError = require('../flush-error')
+
 /**
- * Tracks transport deliveries that must outlive a serverless request.
+ * Tracks transport deliveries until a completion boundary.
  *
- * The tracker is created only for platforms with an invocation-retention
- * boundary. Exporters keep their normal callback path when it is absent.
+ * Serverless exporters use the boundary to retain an invocation. OTLP
+ * exporters use it to make explicit flushes wait for active HTTP requests.
  */
 class TelemetryDeliveryTracker {
   #deliveries = new Set()
 
   /**
    * Tracks one asynchronous transport delivery until its callback runs.
-   * @param {(done: () => void) => void} deliver
-   * @param {(() => void)|undefined} done
+   * @param {(done: (error?: Error) => void) => void} deliver
+   * @param {((error?: Error) => void)|undefined} done
    */
   track (deliver, done) {
     const delivery = { callbacks: done ? [done] : [] }
     this.#deliveries.add(delivery)
 
-    const complete = () => {
+    const complete = (error) => {
       if (!this.#deliveries.delete(delivery)) return
-      for (const callback of delivery.callbacks) callback()
+      for (const callback of delivery.callbacks) callback(error)
     }
 
     try {
       deliver(complete)
     } catch (error) {
-      complete()
+      complete(error)
       throw error
     }
   }
 
   /**
    * Calls back after every delivery active at this boundary has completed.
-   * @param {(() => void)|undefined} done
+   * @param {((error?: Error) => void)|undefined} done
+   * @param {{ reportErrors?: boolean }} [options]
    */
-  waitForIdle (done) {
+  waitForIdle (done, options) {
     if (!done) return
 
+    const errors = []
     let pending = this.#deliveries.size
-    if (pending === 0) return done()
+    const finish = () => {
+      done(options?.reportErrors ? getFlushError(errors) : undefined)
+    }
+    if (pending === 0) return finish()
 
-    const complete = () => {
-      if (--pending === 0) done()
+    const complete = (error) => {
+      if (error) errors.push(error)
+      if (--pending === 0) finish()
     }
     for (const delivery of this.#deliveries) delivery.callbacks.push(complete)
   }

--- a/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
+++ b/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
@@ -11,6 +11,14 @@ const getFlushError = require('../flush-error')
 class TelemetryDeliveryTracker {
   #deliveries = new Set()
 
+  static enableProcessTracking () {
+    globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
+  }
+
+  static isProcessTrackingEnabled () {
+    return globalThis[Symbol.for('dd-trace')]?.telemetryDeliveryTrackingEnabled === true
+  }
+
   /**
    * Tracks one asynchronous transport delivery until its callback runs.
    * @param {(done: (error?: Error) => void) => void} deliver

--- a/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
+++ b/packages/dd-trace/src/serverless/telemetry-delivery-tracker.js
@@ -17,12 +17,14 @@ class TelemetryDeliveryTracker {
    * @param {((error?: Error) => void)|undefined} done
    */
   track (deliver, done) {
-    const delivery = { callbacks: done ? [done] : [] }
+    const delivery = { callbacks: done ? [done] : undefined }
     this.#deliveries.add(delivery)
 
     const complete = (error) => {
       if (!this.#deliveries.delete(delivery)) return
-      for (const callback of delivery.callbacks) callback(error)
+      if (delivery.callbacks) {
+        for (const callback of delivery.callbacks) callback(error)
+      }
     }
 
     try {
@@ -52,7 +54,10 @@ class TelemetryDeliveryTracker {
       if (error) errors.push(error)
       if (--pending === 0) finish()
     }
-    for (const delivery of this.#deliveries) delivery.callbacks.push(complete)
+    for (const delivery of this.#deliveries) {
+      delivery.callbacks ??= []
+      delivery.callbacks.push(complete)
+    }
   }
 }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -121,6 +121,26 @@ describe('AgentProxyCiVisibilityExporter', () => {
     sinon.assert.calledOnceWithExactly(done)
   })
 
+  it('preserves pending agent info initialization when an empty force flush completes', () => {
+    const controlled = createControlledExporter()
+    const done = sinon.spy()
+    const { signal } = controlled.getRequestOptions()
+
+    controlled.exporter.forceFlush(done)
+
+    assert.strictEqual(signal.aborted, false)
+    sinon.assert.calledOnceWithExactly(done, undefined)
+  })
+
+  it('preserves pending agent info initialization during a callback-free flush', () => {
+    const controlled = createControlledExporter()
+    const { signal } = controlled.getRequestOptions()
+
+    controlled.exporter.flush()
+
+    assert.strictEqual(signal.aborted, false)
+  })
+
   it('exports buffered data and flushes it when initialization finishes within the final deadline', async () => {
     const clock = sinon.useFakeTimers()
     try {
@@ -135,6 +155,35 @@ describe('AgentProxyCiVisibilityExporter', () => {
       assert.strictEqual(requestOptions.keepProcessAlive, true)
       assert.strictEqual(requestOptions.signal.aborted, false)
       assert.strictEqual(requestOptions.deadline, Date.now() + agentInfoTimeoutMs)
+
+      controlled.finishAgentInfo(null, { endpoints: ['/evp_proxy/v2'] })
+      await Promise.resolve()
+
+      assert.strictEqual(controlled.writers.length, 2)
+      sinon.assert.calledOnceWithExactly(controlled.writers[0].append, trace)
+      for (const writer of controlled.writers) {
+        sinon.assert.calledOnce(writer.flush)
+        assert.strictEqual(writer.flush.firstCall.args[1].deadline, Date.now() + FINAL_FLUSH_TIMEOUT)
+      }
+      sinon.assert.calledOnceWithExactly(done, undefined)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('waits for initialization and flushes buffered data without finalizing', async () => {
+    const clock = sinon.useFakeTimers()
+    try {
+      const controlled = createControlledExporter()
+      const trace = [{ type: 'test' }]
+      const done = sinon.spy()
+
+      controlled.exporter.export(trace)
+      controlled.exporter.forceFlush(done)
+
+      const { signal } = controlled.getRequestOptions()
+      assert.strictEqual(signal.aborted, false)
+      sinon.assert.notCalled(done)
 
       controlled.finishAgentInfo(null, { endpoints: ['/evp_proxy/v2'] })
       await Promise.resolve()

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -8,7 +8,6 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
 require('../../setup/core')
-const TelemetryDeliveryTracker = require('../../../src/serverless/telemetry-delivery-tracker')
 
 describe('Exporter', () => {
   let url
@@ -20,7 +19,6 @@ describe('Exporter', () => {
   let prioritySampler
   let span
   let writerOptions
-  let createServerlessDeliveryTracker
 
   beforeEach(() => {
     url = 'http://www.example.com:8126'
@@ -36,11 +34,8 @@ describe('Exporter', () => {
       writerOptions = options
       return writer
     })
-    createServerlessDeliveryTracker = sinon.stub()
-
     Exporter = proxyquire('../../../src/exporters/agent', {
       './writer': Writer,
-      '../../serverless': { createServerlessDeliveryTracker },
     })
   })
 
@@ -129,10 +124,6 @@ describe('Exporter', () => {
   })
 
   describe('flush', () => {
-    beforeEach(() => {
-      createServerlessDeliveryTracker.returns(new TelemetryDeliveryTracker())
-    })
-
     it('waits for trace exports already in flight', () => {
       const callbacks = []
       writer.flush = sinon.spy(done => {
@@ -199,18 +190,83 @@ describe('Exporter', () => {
       sinon.assert.calledOnce(flushed)
     })
 
-    it('waits for the boundary export without serverless retention', () => {
-      createServerlessDeliveryTracker.resetBehavior()
-      let complete
-      writer.flush = sinon.stub().callsFake(done => { complete = done })
+    it('reports a delivery failure when requested', () => {
+      const error = new Error('agent failed')
+      writer.flush = sinon.spy(done => {
+        writerOptions.deliveryTracker.track(complete => complete(error), done)
+      })
+      exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
+      const flushed = sinon.spy()
+
+      exporter.flush(flushed, { reportErrors: true })
+
+      sinon.assert.calledOnceWithExactly(flushed, error)
+    })
+
+    it('does not report a delivery failure by default', () => {
+      writer.flush = sinon.spy(done => {
+        writerOptions.deliveryTracker.track(complete => complete(new Error('agent failed')), done)
+      })
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 
       exporter.flush(flushed)
 
+      sinon.assert.calledOnceWithExactly(flushed, undefined)
+    })
+
+    it('supports a flush without a completion callback', () => {
+      exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
+
+      exporter.flush()
+
+      sinon.assert.calledOnce(writer.flush)
+    })
+
+    it('aggregates a synchronous boundary failure with an in-flight failure', () => {
+      const inFlightError = new Error('in-flight request failed')
+      const boundaryError = new Error('boundary flush failed')
+      let completeInFlight
+      writer.flush = sinon.stub()
+      writer.flush.onFirstCall().callsFake(done => {
+        writerOptions.deliveryTracker.track(complete => { completeInFlight = complete }, done)
+      })
+      writer.flush.onSecondCall().callsFake(done => {
+        writerOptions.deliveryTracker.track(() => { throw boundaryError }, done)
+      })
+      exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
+      const flushed = sinon.spy()
+
+      exporter.export([span])
+      exporter.flush(flushed, { reportErrors: true })
       sinon.assert.notCalled(flushed)
-      complete()
+      completeInFlight(inFlightError)
+
       sinon.assert.calledOnce(flushed)
+      const error = flushed.firstCall.firstArg
+      assert.ok(error instanceof AggregateError)
+      assert.deepStrictEqual(error.errors, [boundaryError, inFlightError])
+    })
+
+    it('reports a boundary flush failure when requested', () => {
+      const error = new Error('encode failed')
+      writer.flush = sinon.stub().throws(error)
+      exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
+      const flushed = sinon.spy()
+
+      exporter.flush(flushed, { reportErrors: true })
+
+      sinon.assert.calledOnceWithExactly(flushed, error)
+    })
+
+    it('does not report a boundary flush failure by default', () => {
+      writer.flush = sinon.stub().throws(new Error('encode failed'))
+      exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
+      const flushed = sinon.spy()
+
+      exporter.flush(flushed)
+
+      sinon.assert.calledOnceWithExactly(flushed, undefined)
     })
   })
 

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -3,7 +3,7 @@
 const assert = require('node:assert/strict')
 const URL = require('url').URL
 
-const { describe, it, beforeEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -19,13 +19,18 @@ describe('Exporter', () => {
   let prioritySampler
   let span
   let writerOptions
+  let deliveryTrackingEnabled
 
   beforeEach(() => {
+    const ddTrace = globalThis[Symbol.for('dd-trace')]
+    deliveryTrackingEnabled = ddTrace.telemetryDeliveryTrackingEnabled
+    ddTrace.telemetryDeliveryTrackingEnabled = false
     url = 'http://www.example.com:8126'
     flushInterval = 1000
     span = {}
     writer = {
       append: sinon.spy(),
+      enableDeliveryTracking: sinon.spy(),
       flush: sinon.spy(),
       setUrl: sinon.spy(),
     }
@@ -37,6 +42,49 @@ describe('Exporter', () => {
     Exporter = proxyquire('../../../src/exporters/agent', {
       './writer': Writer,
     })
+  })
+
+  afterEach(() => {
+    const ddTrace = globalThis[Symbol.for('dd-trace')]
+    if (deliveryTrackingEnabled === undefined) {
+      delete ddTrace.telemetryDeliveryTrackingEnabled
+    } else {
+      ddTrace.telemetryDeliveryTrackingEnabled = deliveryTrackingEnabled
+    }
+  })
+
+  it('does not enable delivery tracking without an OTel TracerProvider', () => {
+    exporter = new Exporter({ url, flushInterval }, prioritySampler)
+
+    assert.strictEqual(writerOptions.deliveryTracker, undefined)
+  })
+
+  it('enables delivery tracking after construction', () => {
+    exporter = new Exporter({ url, flushInterval }, prioritySampler)
+
+    exporter.enableDeliveryTracking()
+    exporter.enableDeliveryTracking()
+
+    sinon.assert.calledOnceWithExactly(writer.enableDeliveryTracking, sinon.match.object)
+  })
+
+  it('enables delivery tracking when process tracking is already enabled', () => {
+    globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
+    exporter = new Exporter({ url, flushInterval }, prioritySampler)
+
+    assert.ok(writerOptions.deliveryTracker)
+  })
+
+  it('keeps serverless delivery tracking without an OTel TracerProvider', () => {
+    const deliveryTracker = {}
+    Exporter = proxyquire('../../../src/exporters/agent', {
+      '../../serverless': { createServerlessDeliveryTracker: () => deliveryTracker },
+      './writer': Writer,
+    })
+
+    exporter = new Exporter({ url, flushInterval }, prioritySampler)
+
+    assert.strictEqual(writerOptions.deliveryTracker, deliveryTracker)
   })
 
   it('should pass computed stats header through to writer', () => {
@@ -129,6 +177,7 @@ describe('Exporter', () => {
       writer.flush = sinon.spy(done => {
         writerOptions.deliveryTracker.track(callback => callbacks.push(callback), done)
       })
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 
@@ -146,6 +195,7 @@ describe('Exporter', () => {
       const flushDirect = sinon.spy(done => callbacks.push(done))
       writer.flushDirect = flushDirect
       writer.flush = sinon.spy(done => writerOptions.deliveryTracker.track(flushDirect, done))
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 
@@ -179,6 +229,7 @@ describe('Exporter', () => {
         writerOptions.deliveryTracker.track(callback => { inFlightDone = callback }, done)
       })
       writer.flush.onSecondCall().throws(new Error('encode failed'))
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 
@@ -195,6 +246,7 @@ describe('Exporter', () => {
       writer.flush = sinon.spy(done => {
         writerOptions.deliveryTracker.track(complete => complete(error), done)
       })
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 
@@ -207,6 +259,7 @@ describe('Exporter', () => {
       writer.flush = sinon.spy(done => {
         writerOptions.deliveryTracker.track(complete => complete(new Error('agent failed')), done)
       })
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 
@@ -234,6 +287,7 @@ describe('Exporter', () => {
       writer.flush.onSecondCall().callsFake(done => {
         writerOptions.deliveryTracker.track(() => { throw boundaryError }, done)
       })
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
       const flushed = sinon.spy()
 

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -276,6 +276,15 @@ describe('Exporter', () => {
       sinon.assert.calledOnce(writer.flush)
     })
 
+    it('supports a tracked flush without a completion callback', () => {
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
+      exporter = new Exporter({ url, flushInterval: 0 }, prioritySampler)
+
+      exporter.flush()
+
+      sinon.assert.calledOnce(writer.flush)
+    })
+
     it('aggregates a synchronous boundary failure with an in-flight failure', () => {
       const inFlightError = new Error('in-flight request failed')
       const boundaryError = new Error('boundary flush failed')

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -235,6 +235,17 @@ function describeWriter (protocolVersion) {
       })
     })
 
+    it('should report request errors when requested', (done) => {
+      const error = new Error('agent unavailable')
+      request.yieldsAsync(error)
+      encoder.count.returns(1)
+
+      writer.flush((flushError) => {
+        assert.strictEqual(flushError, error)
+        done()
+      }, { reportErrors: true })
+    })
+
     it('should propagate terminal errors during a bounded Test Optimization flush', (done) => {
       const error = new Error('agent unavailable')
       const deadline = Date.now() + 10_000

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -169,6 +169,21 @@ function describeWriter (protocolVersion) {
       })
     })
 
+    it('enables delivery tracking after construction', (done) => {
+      const deliveryTracker = { track: sinon.spy((flush, callback) => flush(callback)) }
+      writer = new Writer({ url, prioritySampler, protocolVersion })
+      writer.enableDeliveryTracking(deliveryTracker)
+
+      writer.flush(() => {
+        try {
+          sinon.assert.calledOnce(deliveryTracker.track)
+          done()
+        } catch (error) {
+          done(error)
+        }
+      })
+    })
+
     it('should flush its traces to the agent, and call callback', (done) => {
       const expectedData = Buffer.from('prefixed')
 

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -250,6 +250,15 @@ function describeWriter (protocolVersion) {
       })
     })
 
+    it('should suppress request errors by default', async () => {
+      request.yieldsAsync(new Error('agent unavailable'))
+      encoder.count.returns(1)
+
+      const flushError = await new Promise(resolve => writer.flush(resolve))
+
+      assert.strictEqual(flushError, undefined)
+    })
+
     it('should report request errors when requested', (done) => {
       const error = new Error('agent unavailable')
       request.yieldsAsync(error)

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -280,6 +280,48 @@ describe('AgentlessExporter', () => {
     it('should call callback when done', (done) => {
       exporter.flush(done)
     })
+
+    it('reports writer failures when requested', () => {
+      const error = new Error('writer failed')
+      writer.flush.callsFake(done => done(error))
+      const done = sinon.spy()
+
+      exporter.flush(done, { reportErrors: true })
+
+      sinon.assert.calledOnceWithExactly(writer.flush, done, { reportErrors: true })
+      sinon.assert.calledOnceWithExactly(done, error)
+    })
+
+    it('reports synchronous writer failures when requested', () => {
+      const error = new Error('writer failed')
+      writer.flush.throws(error)
+      const done = sinon.spy()
+
+      exporter.flush(done, { reportErrors: true })
+
+      sinon.assert.calledOnceWithExactly(done, error)
+    })
+
+    it('suppresses synchronous writer failures by default', () => {
+      writer.flush.throws(new Error('writer failed'))
+      const done = sinon.spy()
+
+      exporter.flush(done)
+
+      sinon.assert.calledOnceWithExactly(done, undefined)
+    })
+
+    it('normalizes non-error flush failures when requested', () => {
+      const error = { toString: () => 'writer failed' }
+      writer.flush.callsFake(() => { throw error })
+      const done = sinon.spy()
+
+      exporter.flush(done, { reportErrors: true })
+
+      sinon.assert.calledOnce(done)
+      assert.ok(done.firstCall.firstArg instanceof Error)
+      assert.strictEqual(done.firstCall.firstArg.message, 'writer failed')
+    })
   })
 
   describe('setUrl', () => {

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
 const { assertObjectContains } = require('../../../../../integration-tests/helpers')
+const BaseWriter = require('../../../src/exporters/common/writer')
 
 require('../../setup/core')
 
@@ -288,8 +289,56 @@ describe('AgentlessExporter', () => {
 
       exporter.flush(done, { reportErrors: true })
 
-      sinon.assert.calledOnceWithExactly(writer.flush, done, { reportErrors: true })
+      sinon.assert.calledOnceWithExactly(writer.flush, sinon.match.func, { reportErrors: true })
       sinon.assert.calledOnceWithExactly(done, error)
+    })
+
+    it('waits for an active delivery before reporting a boundary failure', () => {
+      let completeDelivery
+      let failPayload = false
+      const boundaryError = new Error('boundary failed')
+      class ControlledWriter extends BaseWriter {
+        /** @param {object} options */
+        constructor (options) {
+          super(options)
+          let count = 0
+          this._encoder = {
+            count: () => count,
+            encode: () => { count++ },
+            makePayload: () => {
+              if (failPayload) throw boundaryError
+              count = 0
+              return Buffer.from('payload')
+            },
+            reset: () => { count = 0 },
+          }
+        }
+
+        /**
+         * @param {Buffer} data
+         * @param {number} count
+         * @param {(error?: Error) => void} done
+         */
+        _sendPayload (data, count, done) {
+          completeDelivery = done
+        }
+      }
+      Exporter = proxyquire('../../../src/exporters/agentless', {
+        './writer': ControlledWriter,
+      })
+      exporter = new Exporter({ flushInterval: 1 })
+      const done = sinon.spy()
+
+      exporter.export([{ name: 'active' }])
+      clock.tick(1)
+      exporter.export([{ name: 'boundary' }])
+      failPayload = true
+      exporter.flush(done, { reportErrors: true })
+
+      sinon.assert.notCalled(done)
+      assert.strictEqual(typeof completeDelivery, 'function')
+      completeDelivery()
+      sinon.assert.calledOnceWithExactly(done, boundaryError)
     })
 
     it('reports synchronous writer failures when requested', () => {

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -424,6 +424,28 @@ describe('AgentlessExporter', () => {
       assert.ok(done.firstCall.firstArg instanceof Error)
       assert.strictEqual(done.firstCall.firstArg.message, 'writer failed')
     })
+
+    it('supports a tracked flush without a completion callback after a non-error failure', () => {
+      const error = { toString: () => 'writer failed' }
+      writer.flush.callsFake(() => { throw error })
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
+      exporter = new Exporter({ flushInterval: 1000 })
+
+      exporter.flush()
+
+      sinon.assert.calledOnce(writer.flush)
+    })
+
+    it('suppresses tracked synchronous writer failures by default', () => {
+      writer.flush.throws(new Error('writer failed'))
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
+      exporter = new Exporter({ flushInterval: 1000 })
+      const done = sinon.spy()
+
+      exporter.flush(done)
+
+      sinon.assert.calledOnceWithExactly(done, undefined)
+    })
   })
 
   describe('setUrl', () => {

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -19,12 +19,17 @@ describe('AgentlessExporter', () => {
   let writer
   let initialHandlersSize
   let clock
+  let deliveryTrackingEnabled
 
   beforeEach(() => {
+    const ddTrace = globalThis[Symbol.for('dd-trace')]
+    deliveryTrackingEnabled = ddTrace.telemetryDeliveryTrackingEnabled
+    ddTrace.telemetryDeliveryTrackingEnabled = false
     clock = sinon.useFakeTimers()
 
     writer = {
       append: sinon.stub(),
+      enableDeliveryTracking: sinon.stub(),
       flush: sinon.stub().callsFake((cb) => cb && cb()),
       setUrl: sinon.stub(),
     }
@@ -44,10 +49,57 @@ describe('AgentlessExporter', () => {
   afterEach(() => {
     clock.restore()
     sinon.restore()
-    globalThis[Symbol.for('dd-trace')].beforeExitHandlers.clear()
+    const ddTrace = globalThis[Symbol.for('dd-trace')]
+    ddTrace.beforeExitHandlers.clear()
+    if (deliveryTrackingEnabled === undefined) {
+      delete ddTrace.telemetryDeliveryTrackingEnabled
+    } else {
+      ddTrace.telemetryDeliveryTrackingEnabled = deliveryTrackingEnabled
+    }
   })
 
   describe('constructor', () => {
+    it('does not enable delivery tracking without an OTel TracerProvider', () => {
+      const writerOptions = {}
+      /** @param {object} options */
+      const Writer = function (options) {
+        Object.assign(writerOptions, options)
+        return writer
+      }
+      Exporter = proxyquire('../../../src/exporters/agentless', { './writer': Writer })
+
+      exporter = new Exporter({})
+
+      assert.strictEqual(writerOptions.deliveryTracker, undefined)
+    })
+
+    it('enables delivery tracking after construction', () => {
+      exporter = new Exporter({})
+
+      exporter.enableDeliveryTracking()
+      exporter.enableDeliveryTracking()
+
+      sinon.assert.calledOnceWithExactly(writer.enableDeliveryTracking, sinon.match.object)
+    })
+
+    it('keeps serverless delivery tracking without an OTel TracerProvider', () => {
+      const deliveryTracker = {}
+      const writerOptions = {}
+      /** @param {object} options */
+      const Writer = function (options) {
+        Object.assign(writerOptions, options)
+        return writer
+      }
+      Exporter = proxyquire('../../../src/exporters/agentless', {
+        '../../serverless': { createServerlessDeliveryTracker: () => deliveryTracker },
+        './writer': Writer,
+      })
+
+      exporter = new Exporter({})
+
+      assert.strictEqual(writerOptions.deliveryTracker, deliveryTracker)
+    })
+
     it('should construct intake URL from site', () => {
       exporter = new Exporter({ site: 'datadoghq.eu' })
 
@@ -326,6 +378,7 @@ describe('AgentlessExporter', () => {
       Exporter = proxyquire('../../../src/exporters/agentless', {
         './writer': ControlledWriter,
       })
+      globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled = true
       exporter = new Exporter({ flushInterval: 1 })
       const done = sinon.spy()
 

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -10,6 +10,7 @@ const proxyquire = require('proxyquire').noCallThru()
 require('../../setup/core')
 
 const { storage } = require('../../../../datadog-core')
+const TelemetryDeliveryTracker = require('../../../src/serverless/telemetry-delivery-tracker')
 
 describe('AgentlessWriter', () => {
   let AgentlessWriter
@@ -133,6 +134,23 @@ describe('AgentlessWriter', () => {
     done()
     await flush
     assert.strictEqual(flushed, true)
+  })
+
+  it('registers data-pipeline requests with the delivery tracker', () => {
+    const deliveryTracker = new TelemetryDeliveryTracker()
+    exporter.sendV04.resetBehavior()
+    writer = new AgentlessWriter({
+      url: new URL('https://intake.example'),
+      deliveryTracker,
+    })
+    const done = sinon.spy()
+
+    writer.flush()
+    deliveryTracker.waitForIdle(done)
+
+    sinon.assert.notCalled(done)
+    exporter.sendV04.firstCall.args[1]()
+    sinon.assert.calledOnceWithExactly(done, undefined)
   })
 
   it('does not report data-pipeline failures by default', async () => {

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -135,13 +135,24 @@ describe('AgentlessWriter', () => {
     assert.strictEqual(flushed, true)
   })
 
-  it('contains synchronous data-pipeline construction failures', async () => {
+  it('does not report data-pipeline failures by default', async () => {
+    const error = new Error('exporter unavailable')
+    createAgentlessExporter.throws(error)
+    writer = new AgentlessWriter({ url: new URL('https://intake.example') })
+
+    const flushError = await new Promise(resolve => writer.flush(resolve))
+
+    assert.strictEqual(flushError, undefined)
+  })
+
+  it('reports synchronous data-pipeline construction failures when requested', async () => {
     const error = { toString: () => 'exporter unavailable' }
     createAgentlessExporter.callsFake(() => { throw error })
     writer = new AgentlessWriter({ url: new URL('https://intake.example') })
 
-    await new Promise(resolve => writer.flush(resolve))
+    const flushError = await new Promise(resolve => writer.flush(resolve, { reportErrors: true }))
 
+    assert.strictEqual(flushError.message, 'exporter unavailable')
     sinon.assert.calledWithExactly(
       log.error,
       'Failed to send %d trace(s) to the agentless intake: %s',
@@ -150,13 +161,14 @@ describe('AgentlessWriter', () => {
     )
   })
 
-  it('contains proxy configuration failures before constructing the data pipeline', async () => {
+  it('reports proxy configuration failures before constructing the data pipeline when requested', async () => {
     const error = new Error('invalid proxy URL')
     getHttpsProxyAgent.throws(error)
     writer = new AgentlessWriter({ url: new URL('https://intake.example') })
 
-    await new Promise(resolve => writer.flush(resolve))
+    const flushError = await new Promise(resolve => writer.flush(resolve, { reportErrors: true }))
 
+    assert.strictEqual(flushError, error)
     sinon.assert.notCalled(createAgentlessExporter)
     sinon.assert.calledWithExactly(
       log.error,
@@ -166,12 +178,15 @@ describe('AgentlessWriter', () => {
     )
   })
 
-  it('contains synchronous data-pipeline send failures', async () => {
-    exporter.sendV04.throws(new Error('send failed'))
+  it('reports synchronous data-pipeline send failures when requested', async () => {
+    const error = new Error('send failed')
+    exporter.sendV04.resetBehavior()
+    exporter.sendV04.throws(error)
     writer = new AgentlessWriter({ url: new URL('https://intake.example') })
 
-    await new Promise(resolve => writer.flush(resolve))
+    const flushError = await new Promise(resolve => writer.flush(resolve, { reportErrors: true }))
 
+    assert.strictEqual(flushError, error)
     sinon.assert.calledWithExactly(
       log.error,
       'Failed to send %d trace(s) to the agentless intake: %s',
@@ -192,6 +207,31 @@ describe('AgentlessWriter', () => {
       log.warn,
       'DD_API_KEY will not be sent because the configured receiver is neither HTTPS nor loopback.'
     )
+  })
+
+  it('reports an unsafe receiver when requested', async () => {
+    writer = new AgentlessWriter({ url: new URL('http://intake.example') })
+
+    const flushError = await new Promise(resolve => writer.flush(resolve, { reportErrors: true }))
+
+    assert.strictEqual(flushError.message, 'DD_API_KEY cannot be sent to the configured agentless trace intake')
+  })
+
+  it('reports a missing API key when requested', async () => {
+    apiKey = undefined
+    writer = new AgentlessWriter({ url: new URL('https://intake.example') })
+
+    const flushError = await new Promise(resolve => writer.flush(resolve, { reportErrors: true }))
+
+    assert.strictEqual(flushError.message, 'DD_API_KEY is required for agentless trace intake')
+  })
+
+  it('reports a missing intake URL when requested', async () => {
+    writer = new AgentlessWriter({ site: 'bad host' })
+
+    const flushError = await new Promise(resolve => writer.flush(resolve, { reportErrors: true }))
+
+    assert.strictEqual(flushError.message, 'No valid URL configured for agentless trace intake')
   })
 
   it('keeps loopback HTTP receivers direct', async () => {

--- a/packages/dd-trace/test/exporters/common/writer.spec.js
+++ b/packages/dd-trace/test/exporters/common/writer.spec.js
@@ -57,6 +57,16 @@ describe('common Writer', () => {
     sinon.assert.calledOnce(done)
   })
 
+  it('reports a chunk overflow when requested', () => {
+    const error = new OverflowError(MAX_SIZE + 1)
+    encoder.makePayload.throws(error)
+    const done = sinon.stub()
+
+    writer.flush(done, { reportErrors: true })
+
+    sinon.assert.calledOnceWithExactly(done, error)
+  })
+
   it('rethrows non-overflow makePayload errors', () => {
     encoder.makePayload.throws(new Error('not an overflow'))
 
@@ -87,6 +97,18 @@ describe('common Writer', () => {
     sinon.assert.calledOnce(writer._sendPayload)
   })
 
+  it('preserves deadline errors through the configured delivery tracker', () => {
+    const error = new Error('deadline exceeded')
+    const deliveryTracker = { track: sinon.stub().callsFake((flush, done) => flush(done)) }
+    const done = sinon.stub()
+    writer = new Writer({ url: 'http://localhost:8126', deliveryTracker })
+    writer.flushDirect = sinon.stub().callsFake(callback => callback(error))
+
+    writer.flush(done, { deadline: Date.now() + 1000 })
+
+    sinon.assert.calledOnceWithExactly(done, error)
+  })
+
   it('passes final flush options to the payload sender', () => {
     const done = sinon.stub()
     const options = { deadline: Date.now() + 1000 }
@@ -110,6 +132,18 @@ describe('common Writer', () => {
 
     sinon.assert.calledOnce(encoder.reset)
     sinon.assert.calledOnceWithExactly(done)
+  })
+
+  it('reports a dropped payload when the request buffer is full and errors are requested', () => {
+    request.writable = false
+    const done = sinon.stub()
+
+    writer.flush(done, { reportErrors: true })
+
+    sinon.assert.calledOnceWithMatch(done, {
+      code: 'ERR_DD_REQUEST_BUFFER_FULL',
+      message: 'Maximum active request buffer size reached: payload is discarded.',
+    })
   })
 
   it('retains a non-final payload under backpressure when configured', () => {

--- a/packages/dd-trace/test/exporters/common/writer.spec.js
+++ b/packages/dd-trace/test/exporters/common/writer.spec.js
@@ -82,7 +82,7 @@ describe('common Writer', () => {
     writer.flush(done)
 
     sinon.assert.notCalled(encoder.reset)
-    sinon.assert.calledOnceWithExactly(writer._sendPayload, payload, 2, done)
+    sinon.assert.calledOnceWithExactly(writer._sendPayload, payload, 2, sinon.match.func)
   })
 
   it('routes automatic flushes through the configured delivery tracker', () => {
@@ -156,7 +156,7 @@ describe('common Writer', () => {
     writer.flush(done)
 
     sinon.assert.notCalled(encoder.reset)
-    sinon.assert.calledOnceWithExactly(writer._sendPayload, Buffer.from('payload'), 2, done)
+    sinon.assert.calledOnceWithExactly(writer._sendPayload, Buffer.from('payload'), 2, sinon.match.func)
   })
 
   it('sends a bounded final payload when the request buffer is full', () => {

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -232,29 +232,39 @@ describe('OTel TracerProvider', () => {
       assert.deepStrictEqual(events, ['agent-received', 'agent-responded', 'forceFlush-resolved'])
     })
 
-    it('serializes overlapping flush generations', async () => {
+    it('starts every overlapping flush boundary immediately', async () => {
+      const firstSignal = new EventEmitter()
+      const secondSignal = new EventEmitter()
+      const processor = new NoopSpanProcessor()
+      processor.forceFlush = sinon.stub()
+      processor.forceFlush.onFirstCall().returns(once(firstSignal, 'done'))
+      processor.forceFlush.onSecondCall().returns(once(secondSignal, 'done'))
+      const provider = new TracerProvider({ spanProcessors: [processor] })
+
+      const firstFlush = provider.forceFlush()
+      const secondFlush = provider.forceFlush()
+
+      sinon.assert.calledTwice(processor.forceFlush)
+      firstSignal.emit('done')
+      secondSignal.emit('done')
+      await Promise.all([firstFlush, secondFlush])
+    })
+
+    it('reports a delivery failure to every overlapping flush boundary', async () => {
       const provider = new TracerProvider()
-      const firstRequest = waitForTraceRequest()
-      provider.getTracer().startSpan('otel.force_flush.first_generation').end()
-      let firstSettled = false
-      const firstFlush = provider.forceFlush().finally(() => { firstSettled = true })
-      const firstResponse = await firstRequest
+      const requestReceived = waitForTraceRequest()
+      provider.getTracer().startSpan('otel.force_flush.overlapping_failure').end()
 
-      provider.getTracer().startSpan('otel.force_flush.second_generation').end()
-      let secondSettled = false
-      const secondFlush = provider.forceFlush().finally(() => { secondSettled = true })
-      assert.strictEqual(firstSettled, false)
-      assert.strictEqual(secondSettled, false)
+      const firstFlush = provider.forceFlush()
+      const response = await requestReceived
+      const secondFlush = provider.forceFlush()
+      const firstRejected = assert.rejects(firstFlush, isAgentFailure)
+      const secondRejected = assert.rejects(secondFlush, isAgentFailure)
 
-      const secondRequest = waitForTraceRequest()
-      firstResponse.end(agentResponse)
-      await firstFlush
-      const secondResponse = await secondRequest
-      assert.strictEqual(secondSettled, false)
+      response.statusCode = 500
+      response.end('agent failed')
 
-      secondResponse.end(agentResponse)
-      await secondFlush
-      assert.strictEqual(secondSettled, true)
+      await Promise.all([firstRejected, secondRejected])
     })
 
     it('resolves without sending when the Datadog buffer is empty', async () => {
@@ -365,6 +375,23 @@ describe('OTel TracerProvider', () => {
       await provider.forceFlush()
 
       sinon.assert.calledOnce(processor.forceFlush)
+    })
+
+    it('prefers an exporter-specific force flush boundary', async () => {
+      const datadogTracer = require('../../index')._tracer
+      const originalExporter = datadogTracer._exporter
+      const flush = sinon.stub()
+      const forceFlush = sinon.stub().callsArg(0)
+      datadogTracer._exporter = { export: sinon.stub(), flush, forceFlush }
+
+      try {
+        await new TracerProvider().forceFlush()
+      } finally {
+        datadogTracer._exporter = originalExporter
+      }
+
+      sinon.assert.calledOnce(forceFlush)
+      sinon.assert.notCalled(flush)
     })
 
     it('still flushes processors when the exporter has no flush method', async () => {

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -353,6 +353,18 @@ describe('OTel TracerProvider', () => {
       })
     })
 
+    it('preserves a single aggregate span processor failure', async () => {
+      const processorError = new AggregateError([new Error('processor failed')], 'processor aggregate')
+      const processor = new NoopSpanProcessor()
+      processor.forceFlush = sinon.stub().rejects(processorError)
+      const provider = new TracerProvider({ spanProcessors: [processor] })
+
+      await assert.rejects(provider.forceFlush(), error => {
+        assert.strictEqual(error, processorError)
+        return true
+      })
+    })
+
     it('rejects when Datadog delivery fails', async () => {
       const requestReceived = waitForTraceRequest()
       const provider = new TracerProvider()

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -70,6 +70,36 @@ function isAgentFailure (error) {
 }
 
 describe('OTel TracerProvider', () => {
+  let deliveryTrackingEnabled
+
+  before(() => {
+    deliveryTrackingEnabled = globalThis[Symbol.for('dd-trace')].telemetryDeliveryTrackingEnabled
+  })
+
+  after(() => {
+    const ddTrace = globalThis[Symbol.for('dd-trace')]
+    if (deliveryTrackingEnabled === undefined) {
+      delete ddTrace.telemetryDeliveryTrackingEnabled
+    } else {
+      ddTrace.telemetryDeliveryTrackingEnabled = deliveryTrackingEnabled
+    }
+  })
+
+  it('enables delivery tracking on the initialized exporter', () => {
+    const datadogTracer = require('../../index')._tracer
+    const originalExporter = datadogTracer._exporter
+    const exporter = { enableDeliveryTracking: sinon.spy() }
+    datadogTracer._exporter = exporter
+
+    try {
+      assert.ok(new TracerProvider())
+    } finally {
+      datadogTracer._exporter = originalExporter
+    }
+
+    sinon.assert.calledOnce(exporter.enableDeliveryTracking)
+  })
+
   it('should register with OTel API', () => {
     const provider = new TracerProvider()
     provider.register()
@@ -337,8 +367,9 @@ describe('OTel TracerProvider', () => {
       assert.strictEqual(settled, true)
     })
 
-    it('aggregates multiple span processor failures', async () => {
-      const firstError = new Error('first processor failed')
+    it('flattens aggregate span processor failures', async () => {
+      const firstCause = new Error('first processor failed')
+      const firstError = new AggregateError([firstCause], 'first processor aggregate')
       const secondError = new Error('second processor failed')
       const first = new NoopSpanProcessor()
       const second = new NoopSpanProcessor()
@@ -348,7 +379,7 @@ describe('OTel TracerProvider', () => {
 
       await assert.rejects(provider.forceFlush(), error => {
         assert.ok(error instanceof AggregateError)
-        assert.deepStrictEqual(error.errors, [firstError, secondError])
+        assert.deepStrictEqual(error.errors, [firstCause, secondError])
         return true
       })
     })

--- a/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer_provider.spec.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { EventEmitter, once } = require('node:events')
+const http = require('node:http')
 
-const { describe, it } = require('mocha')
+const { after, before, describe, it } = require('mocha')
 const sinon = require('sinon')
 const { trace } = require('@opentelemetry/api')
 
@@ -10,7 +12,62 @@ require('../setup/core')
 const TracerProvider = require('../../src/opentelemetry/tracer_provider')
 const Tracer = require('../../src/opentelemetry/tracer')
 const { MultiSpanProcessor, NoopSpanProcessor } = require('../../src/opentelemetry/span_processor')
-require('../../index').init()
+
+const agentResponse = JSON.stringify({ rate_by_service: {} })
+
+let traceRequestCount = 0
+let traceRequestEvents
+let traceRequestResolve
+
+/**
+ * @param {(response: import('node:http').ServerResponse) => void} resolve
+ */
+function captureTraceRequest (resolve) {
+  traceRequestResolve = resolve
+}
+
+/**
+ * @param {string[]} [events]
+ * @returns {Promise<import('node:http').ServerResponse>}
+ */
+function waitForTraceRequest (events) {
+  traceRequestEvents = events
+  return new Promise(captureTraceRequest)
+}
+
+/**
+ * @param {import('node:http').IncomingMessage} request
+ * @param {import('node:http').ServerResponse} response
+ */
+function handleAgentRequest (request, response) {
+  request.resume()
+
+  if (!request.url?.endsWith('/traces')) {
+    response.end('{}')
+    return
+  }
+
+  traceRequestCount++
+  if (!traceRequestResolve) {
+    response.end(agentResponse)
+    return
+  }
+
+  const resolve = traceRequestResolve
+  traceRequestResolve = undefined
+  traceRequestEvents?.push('agent-received')
+  traceRequestEvents = undefined
+  resolve(response)
+}
+
+/**
+ * @param {Error & { status?: number }} error
+ * @returns {boolean}
+ */
+function isAgentFailure (error) {
+  assert.strictEqual(error.status, 500)
+  return true
+}
 
 describe('OTel TracerProvider', () => {
   it('should register with OTel API', () => {
@@ -113,13 +170,218 @@ describe('OTel TracerProvider', () => {
     sinon.assert.calledOnce(processor.shutdown)
   })
 
-  it('should delegate forceFlush to active span processor', () => {
-    const provider = new TracerProvider()
-    const processor = new NoopSpanProcessor()
-    provider.addSpanProcessor(processor)
-    processor.forceFlush = sinon.stub()
+  describe('forceFlush without an initialized tracer', () => {
+    it('rejects', async () => {
+      const provider = new TracerProvider()
 
-    provider.forceFlush()
-    sinon.assert.calledOnce(processor.forceFlush)
+      await assert.rejects(provider.forceFlush(), { message: 'Not started' })
+    })
+  })
+
+  describe('forceFlush with an initialized tracer', () => {
+    let agent
+    let originalRemoteConfigEnabled
+
+    before(async () => {
+      originalRemoteConfigEnabled = process.env.DD_REMOTE_CONFIGURATION_ENABLED
+      process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
+
+      agent = http.createServer(handleAgentRequest)
+      agent.listen(0, '127.0.0.1')
+      await once(agent, 'listening')
+
+      const { port } = agent.address()
+      require('../../index').init({
+        flushInterval: 0,
+        plugins: false,
+        startupLogs: false,
+        url: `http://127.0.0.1:${port}`,
+      })
+    })
+
+    after(async () => {
+      if (originalRemoteConfigEnabled === undefined) {
+        delete process.env.DD_REMOTE_CONFIGURATION_ENABLED
+      } else {
+        process.env.DD_REMOTE_CONFIGURATION_ENABLED = originalRemoteConfigEnabled
+      }
+
+      const closed = once(agent, 'close')
+      agent.close()
+      agent.closeAllConnections?.()
+      await closed
+    })
+
+    it('waits for Datadog delivery to complete', async () => {
+      const events = []
+      const requestReceived = waitForTraceRequest(events)
+      const provider = new TracerProvider()
+      provider.getTracer().startSpan('otel.force_flush.delayed').end()
+
+      const forceFlush = provider.forceFlush().then(() => events.push('forceFlush-resolved'))
+      const response = await requestReceived
+
+      assert.deepStrictEqual(events, ['agent-received'])
+
+      const responseFinished = once(response, 'finish')
+      response.end(agentResponse)
+      await responseFinished
+      events.push('agent-responded')
+      await forceFlush
+
+      assert.deepStrictEqual(events, ['agent-received', 'agent-responded', 'forceFlush-resolved'])
+    })
+
+    it('serializes overlapping flush generations', async () => {
+      const provider = new TracerProvider()
+      const firstRequest = waitForTraceRequest()
+      provider.getTracer().startSpan('otel.force_flush.first_generation').end()
+      let firstSettled = false
+      const firstFlush = provider.forceFlush().finally(() => { firstSettled = true })
+      const firstResponse = await firstRequest
+
+      provider.getTracer().startSpan('otel.force_flush.second_generation').end()
+      let secondSettled = false
+      const secondFlush = provider.forceFlush().finally(() => { secondSettled = true })
+      assert.strictEqual(firstSettled, false)
+      assert.strictEqual(secondSettled, false)
+
+      const secondRequest = waitForTraceRequest()
+      firstResponse.end(agentResponse)
+      await firstFlush
+      const secondResponse = await secondRequest
+      assert.strictEqual(secondSettled, false)
+
+      secondResponse.end(agentResponse)
+      await secondFlush
+      assert.strictEqual(secondSettled, true)
+    })
+
+    it('resolves without sending when the Datadog buffer is empty', async () => {
+      const requestsBeforeFlush = traceRequestCount
+
+      await new TracerProvider().forceFlush()
+
+      assert.strictEqual(traceRequestCount, requestsBeforeFlush)
+    })
+
+    it('waits for every configured span processor', async () => {
+      const firstSignal = new EventEmitter()
+      const secondSignal = new EventEmitter()
+      const firstDone = once(firstSignal, 'done')
+      const secondDone = once(secondSignal, 'done')
+      const first = new NoopSpanProcessor()
+      const second = new NoopSpanProcessor()
+      first.forceFlush = sinon.stub().returns(firstDone)
+      second.forceFlush = sinon.stub().returns(secondDone)
+      const provider = new TracerProvider({ spanProcessors: [first, second] })
+      let settled = false
+
+      const forceFlush = provider.forceFlush().finally(() => { settled = true })
+
+      sinon.assert.calledOnce(first.forceFlush)
+      sinon.assert.calledOnce(second.forceFlush)
+      firstSignal.emit('done')
+      await firstDone
+      assert.strictEqual(settled, false)
+      secondSignal.emit('done')
+      await forceFlush
+      assert.strictEqual(settled, true)
+    })
+
+    it('flushes every processor when one throws synchronously', async () => {
+      const error = new Error('processor failed')
+      const first = new NoopSpanProcessor()
+      const second = new NoopSpanProcessor()
+      first.forceFlush = sinon.stub().throws(error)
+      second.forceFlush = sinon.stub().resolves()
+      const provider = new TracerProvider({ spanProcessors: [first, second] })
+
+      const forceFlush = provider.forceFlush()
+
+      sinon.assert.calledOnce(first.forceFlush)
+      sinon.assert.calledOnce(second.forceFlush)
+      await assert.rejects(forceFlush, error)
+    })
+
+    it('waits for delivery after a span processor fails, then rejects with the original error', async () => {
+      const processorError = new Error('processor failed')
+      const processor = new NoopSpanProcessor()
+      processor.forceFlush = sinon.stub().rejects(processorError)
+      const provider = new TracerProvider({ spanProcessors: [processor] })
+      const requestReceived = waitForTraceRequest()
+      provider.getTracer().startSpan('otel.force_flush.processor_error').end()
+      let settled = false
+
+      const forceFlush = provider.forceFlush().finally(() => { settled = true })
+      await assert.rejects(processor.forceFlush.firstCall.returnValue, processorError)
+      assert.strictEqual(settled, false)
+
+      const response = await requestReceived
+      response.end(agentResponse)
+
+      await assert.rejects(forceFlush, error => {
+        assert.strictEqual(error, processorError)
+        return true
+      })
+      assert.strictEqual(settled, true)
+    })
+
+    it('aggregates multiple span processor failures', async () => {
+      const firstError = new Error('first processor failed')
+      const secondError = new Error('second processor failed')
+      const first = new NoopSpanProcessor()
+      const second = new NoopSpanProcessor()
+      first.forceFlush = sinon.stub().rejects(firstError)
+      second.forceFlush = sinon.stub().rejects(secondError)
+      const provider = new TracerProvider({ spanProcessors: [first, second] })
+
+      await assert.rejects(provider.forceFlush(), error => {
+        assert.ok(error instanceof AggregateError)
+        assert.deepStrictEqual(error.errors, [firstError, secondError])
+        return true
+      })
+    })
+
+    it('rejects when Datadog delivery fails', async () => {
+      const requestReceived = waitForTraceRequest()
+      const provider = new TracerProvider()
+      provider.getTracer().startSpan('otel.force_flush.exporter_error').end()
+
+      const forceFlush = provider.forceFlush()
+      const response = await requestReceived
+      response.statusCode = 500
+      response.end('agent failed')
+
+      await assert.rejects(forceFlush, isAgentFailure)
+    })
+
+    it('delegates to the active span processor', async () => {
+      const provider = new TracerProvider()
+      const processor = new NoopSpanProcessor()
+      provider.addSpanProcessor(processor)
+      processor.forceFlush = sinon.stub().resolves()
+
+      await provider.forceFlush()
+
+      sinon.assert.calledOnce(processor.forceFlush)
+    })
+
+    it('still flushes processors when the exporter has no flush method', async () => {
+      const datadogTracer = require('../../index')._tracer
+      const originalExporter = datadogTracer._exporter
+      datadogTracer._exporter = { export: sinon.stub() }
+      const processor = new NoopSpanProcessor()
+      processor.forceFlush = sinon.stub().resolves()
+      const provider = new TracerProvider({ spanProcessors: [processor] })
+
+      try {
+        await provider.forceFlush()
+      } finally {
+        datadogTracer._exporter = originalExporter
+      }
+
+      sinon.assert.calledOnce(processor.forceFlush)
+    })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const { once } = require('node:events')
 const http = require('node:http')
 const https = require('node:https')
 
@@ -651,6 +652,38 @@ describe('OpenTelemetry Traces', () => {
 
       const span = createMockSpan({ name: 'http.request' })
       exporter.export([span])
+    })
+
+    it('waits for an OTLP HTTP response and reports its failure', async () => {
+      let resolveRequest
+      const requestReceived = new Promise(resolve => { resolveRequest = resolve })
+      const receiver = http.createServer((request, response) => {
+        request.resume()
+        resolveRequest(response)
+      })
+      receiver.listen(0, '127.0.0.1')
+      await once(receiver, 'listening')
+
+      try {
+        const { port } = receiver.address()
+        const exporter = new OtlpHttpTraceExporter(`http://127.0.0.1:${port}/v1/traces`, {}, 1000, {})
+        exporter.export([createMockSpan()])
+        let settled = false
+        const flush = new Promise((resolve, reject) => {
+          exporter.flush(error => error ? reject(error) : resolve(), { reportErrors: true })
+        }).finally(() => { settled = true })
+        const response = await requestReceived
+
+        assert.strictEqual(settled, false)
+        response.statusCode = 500
+        response.end('collector failed')
+
+        await assert.rejects(flush, /HTTP 500: collector failed/)
+        assert.strictEqual(settled, true)
+      } finally {
+        receiver.close()
+        await once(receiver, 'close')
+      }
     })
 
     it('sends JSON content-type header', () => {

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -111,6 +111,56 @@ describe('TelemetryDeliveryTracker', () => {
 
     assert.strictEqual(done, 1)
   })
+
+  it('reports a synchronous delivery failure before rethrowing it', () => {
+    const tracker = new TelemetryDeliveryTracker()
+    const deliveryError = new Error('delivery failed')
+    let reportedError
+
+    assert.throws(() => tracker.track(
+      () => { throw deliveryError },
+      error => { reportedError = error }
+    ), deliveryError)
+
+    assert.strictEqual(reportedError, deliveryError)
+  })
+
+  it('does not retain failures completed before the flush boundary', () => {
+    const tracker = new TelemetryDeliveryTracker()
+    let flushError
+
+    tracker.track(complete => complete(new Error('delivery failed')))
+    tracker.waitForIdle(error => { flushError = error }, { reportErrors: true })
+
+    assert.strictEqual(flushError, undefined)
+  })
+
+  it('aggregates failures from deliveries active at the flush boundary', () => {
+    const tracker = new TelemetryDeliveryTracker()
+    const firstError = new Error('first delivery failed')
+    const secondError = new Error('second delivery failed')
+    const complete = []
+    let flushError
+
+    tracker.track(callback => complete.push(callback))
+    tracker.track(callback => complete.push(callback))
+    tracker.waitForIdle(error => { flushError = error }, { reportErrors: true })
+    complete[0](firstError)
+    complete[1](secondError)
+
+    assert.ok(flushError instanceof AggregateError)
+    assert.deepStrictEqual(flushError.errors, [firstError, secondError])
+  })
+
+  it('keeps delivery failures private unless requested', () => {
+    const tracker = new TelemetryDeliveryTracker()
+
+    tracker.track(complete => complete(new Error('delivery failed')))
+
+    tracker.waitForIdle(error => {
+      assert.strictEqual(error, undefined)
+    })
+  })
 })
 
 describe('flushServerlessTelemetry', () => {


### PR DESCRIPTION
This fixes OpenTelemetry `TracerProvider.forceFlush()` resolving before Datadog trace delivery completes. The provider now waits for the exporter's completion-aware flush boundary and every configured span processor, including delayed HTTP responses and overlapping flush generations.

Exporter failures remain observable through the OpenTelemetry promise contract, while legacy background flushes keep swallowing errors; OTLP and serverless delivery paths use the same boundary without retaining completed failures.
