### PR TITLE
perf(profiling): load the dedicated zstd artifact

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -157,7 +157,7 @@ class Profiler extends EventEmitter {
                 }
               }
             } else {
-              const { zstd_compress: zstdCompress } = require('@datadog/libdatadog')
+              const { zstd_compress: zstdCompress } = require('@datadog/libdatadog/zstd')
               const level = clevel ?? 0 // 0 is zstd default compression level
               this.#compressionFn = (buffer) => Promise.resolve(Buffer.from(zstdCompress(buffer, level)))
             }

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -392,7 +392,7 @@ describe('profiler', function () {
       const compressed = Buffer.from([0x28, 0xb5, 0x2f, 0xfd])
       const zstdCompress = sinon.stub().returns(compressed)
       initProfiler({
-        '@datadog/libdatadog': { zstd_compress: zstdCompress },
+        '@datadog/libdatadog/zstd': { zstd_compress: zstdCompress },
         zlib: { zstdCompress: undefined },
       })
 


### PR DESCRIPTION
### What does this PR do?

Loads `@datadog/libdatadog/zstd` when Node.js does not provide native Zstandard compression.

### Motivation

The current fallback loads the regular libdatadog module, including exporter code the profiler never uses.

### Additional Notes

This draft depends on the companion libdatadog-nodejs release. Before it becomes ready, bump `@datadog/libdatadog` and refresh `yarn.lock`. The full profiler suite passes 42/42.