### PR TITLE
fix(tracing): preserve RegExp sampling rule matchers

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -8,7 +8,6 @@ const { channel } = require('dc-polyfill')
 
 const exporters = require('../../../../ext/exporters')
 const createRfdc = require('../../../../vendor/dist/rfdc')
-const rfdc = createRfdc({ proto: false, circles: false })
 const uuid = require('../../../../vendor/dist/crypto-randomuuid') // we need to keep the old uuid dep because of cypress
 const set = require('../../../datadog-core/src/utils/src/set')
 const { DD_MAJOR, NODE_MAJOR } = require('../../../../version')
@@ -44,6 +43,12 @@ const {
 } = require('./defaults')
 const { normalizeService } = require('./normalize-service')
 const { programmaticTypeCoercions, transformers } = require('./parsers')
+
+const rfdc = createRfdc({
+  proto: false,
+  circles: false,
+  constructorHandlers: [[RegExp, transformers.toCamelCase]],
+})
 
 const TEST_OPTIMIZATION_WORKER_EXPORTERS = new Set([
   exporters.CUCUMBER_WORKER,

--- a/packages/dd-trace/src/config/parsers.js
+++ b/packages/dd-trace/src/config/parsers.js
@@ -77,15 +77,16 @@ const transformers = {
    * @param {unknown} value
    */
   toCamelCase (value) {
-    if (isRegExp(value)) {
-      return new RegExp(value)
-    }
     if (Array.isArray(value)) {
       return value.map(item => {
         return transformers.toCamelCase(item)
       })
     }
     if (typeof value === 'object' && value !== null) {
+      // RegExp matchers are supported configuration leaves and need their own clone.
+      if (isRegExp(value)) {
+        return new RegExp(value)
+      }
       const result = {}
       for (const [key, innerValue] of Object.entries(value)) {
         const camelCaseKey = key.replaceAll(/_(\w)/g, (_, letter) => letter.toUpperCase())

--- a/packages/dd-trace/src/config/parsers.js
+++ b/packages/dd-trace/src/config/parsers.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs')
+const { isRegExp } = require('node:util').types
 
 const { DD_MAJOR, NODE_MAJOR } = require('../../../../version')
 const tagger = require('../tagger')
@@ -72,7 +73,13 @@ const transformers = {
   toUpperCase (value) {
     return toCase(value, 'toUpperCase')
   },
+  /**
+   * @param {unknown} value
+   */
   toCamelCase (value) {
+    if (isRegExp(value)) {
+      return new RegExp(value)
+    }
     if (Array.isArray(value)) {
       return value.map(item => {
         return transformers.toCamelCase(item)

--- a/packages/dd-trace/src/sampling_rule.js
+++ b/packages/dd-trace/src/sampling_rule.js
@@ -35,6 +35,21 @@ class AlwaysMatcher {
 }
 
 /**
+ * Matcher that always returns false for unsupported patterns.
+ * Implements the minimal `RuleMatcher` interface.
+ * @implements {RuleMatcher}
+ */
+class NeverMatcher {
+  /**
+   * @param {DatadogSpan} span
+   * @returns {boolean}
+   */
+  match (span) {
+    return false
+  }
+}
+
+/**
  * Matcher that evaluates a glob pattern against a derived subject.
  */
 class GlobMatcher {
@@ -62,6 +77,8 @@ class GlobMatcher {
  * Matcher that evaluates a regular expression against a derived subject.
  */
 class RegExpMatcher {
+  #resetLastIndex
+
   /**
    * @param {RegExp} pattern - Regular expression used to test the subject.
    * @param {Locator} locator - Function extracting the subject to test.
@@ -69,6 +86,7 @@ class RegExpMatcher {
   constructor (pattern, locator) {
     this.pattern = pattern
     this.locator = locator
+    this.#resetLastIndex = pattern.global || pattern.sticky
   }
 
   /**
@@ -77,17 +95,23 @@ class RegExpMatcher {
    */
   match (span) {
     const subject = this.locator(span)
-    if (!subject) return false
-    return this.pattern.test(subject)
+    if (subject === undefined) return false
+    if (!this.#resetLastIndex) return this.pattern.test(subject)
+
+    this.pattern.lastIndex = 0
+    const matched = this.pattern.test(subject)
+    this.pattern.lastIndex = 0
+    return matched
   }
 }
 
 /**
  * Creates a matcher for the provided pattern and locator.
  * Returns a glob matcher for non-trivial strings, a regexp matcher for RegExp,
- * or an always-true matcher for wildcard or missing patterns.
+ * an always-true matcher for wildcard patterns, or an always-false matcher for
+ * unsupported patterns.
  *
- * @param {string|RegExp|undefined} pattern
+ * @param {unknown} pattern
  * @param {Locator} locator
  * @returns {RuleMatcher}
  */
@@ -96,10 +120,13 @@ function matcher (pattern, locator) {
     return new RegExpMatcher(pattern, locator)
   }
 
-  if (typeof pattern === 'string' && pattern !== '*' && pattern !== '**' && pattern !== '***') {
+  if (typeof pattern === 'string') {
+    if (pattern === '*' || pattern === '**' || pattern === '***') {
+      return new AlwaysMatcher()
+    }
     return new GlobMatcher(pattern, locator)
   }
-  return new AlwaysMatcher()
+  return new NeverMatcher()
 }
 
 /**
@@ -171,13 +198,13 @@ class SamplingRule {
   constructor ({ name, service, resource, tags, sampleRate = 1, provenance, maxPerSecond } = {}) {
     this.matchers = []
 
-    if (name) {
+    if (name !== undefined) {
       this.matchers.push(matcher(name, nameLocator))
     }
-    if (service) {
+    if (service !== undefined) {
       this.matchers.push(matcher(service, serviceLocator))
     }
-    if (resource) {
+    if (resource !== undefined) {
       this.matchers.push(matcher(resource, resourceLocator))
     }
     if (tags) {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -357,6 +357,41 @@ describe('Config', () => {
     assert.strictEqual(config.lookup, lookup)
   })
 
+  it('should preserve RegExp sampling rules in the programmatic configuration snapshot', () => {
+    const name = /^health/
+    const service = /^web/
+    const resource = /^GET/
+    const tag = /^2/
+    const samplingRules = [{ name, service, resource, tags: { status: tag }, sampleRate: 0 }]
+    const config = getConfig({ samplingRules })
+
+    assert.ok(config.samplingRules[0].name instanceof RegExp)
+    assert.ok(config.samplingRules[0].service instanceof RegExp)
+    assert.ok(config.samplingRules[0].resource instanceof RegExp)
+    assert.ok(config.samplingRules[0].tags.status instanceof RegExp)
+    assert.notStrictEqual(config.samplingRules[0].name, name)
+    assert.notStrictEqual(config.samplingRules[0].service, service)
+    assert.notStrictEqual(config.samplingRules[0].resource, resource)
+    assert.notStrictEqual(config.samplingRules[0].tags.status, tag)
+
+    const activeName = config.samplingRules[0].name
+    activeName.lastIndex = 2
+
+    config.setRemoteConfig({ samplingRules: [{ name: 'remote', sampleRate: 1 }] })
+    config.setRemoteConfig(null)
+
+    assert.ok(config.samplingRules[0].name instanceof RegExp)
+    assert.ok(config.samplingRules[0].service instanceof RegExp)
+    assert.ok(config.samplingRules[0].resource instanceof RegExp)
+    assert.ok(config.samplingRules[0].tags.status instanceof RegExp)
+    assert.notStrictEqual(config.samplingRules[0].name, activeName)
+    assert.strictEqual(config.samplingRules[0].name.lastIndex, 0)
+    assert.strictEqual(samplingRules[0].name, name)
+    assert.strictEqual(samplingRules[0].service, service)
+    assert.strictEqual(samplingRules[0].resource, resource)
+    assert.strictEqual(samplingRules[0].tags.status, tag)
+  })
+
   it('should initialize from environment variables with DD env vars taking precedence OTEL env vars', () => {
     process.env.DD_SERVICE = 'service'
     process.env.OTEL_SERVICE_NAME = 'otel_service'

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -27,7 +27,7 @@ function runProgrammaticRegExpRules (ruleSampleRate) {
     const prefix = ruleSampleRate === 0 ? 'drop' : 'keep'
     const matchers = {
       name: vm.runInNewContext('new RegExp("^" + prefix + "[.]name$", "g")', { prefix }),
-      service: new RegExp('^' + prefix + '[.]service$', 'y'),
+      service: new RegExp(prefix + '[.]service', 'y'),
       resource: new RegExp('^' + prefix + '[.]resource$', 'g'),
       tag: new RegExp('^' + prefix + '[.]tag$', 'y'),
       emptyTag: /^$/,
@@ -73,7 +73,7 @@ function runProgrammaticRegExpRules (ruleSampleRate) {
     assert.strictEqual(matchers.service.lastIndex, 0)
     const serviceMatchingAgain = getPriority('service', { service: prefix + '.service' })
     assert.strictEqual(matchers.service.lastIndex, 0)
-    const serviceNonMatching = getPriority('service', { service: 'other.service' })
+    const serviceNonMatching = getPriority('service', { service: 'other.' + prefix + '.service' })
     const resourceMatching = getPriority('resource', { resource: prefix + '.resource' })
     assert.strictEqual(matchers.resource.lastIndex, 0)
     const resourceMatchingAgain = getPriority('resource', { resource: prefix + '.resource' })

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
@@ -8,6 +10,116 @@ const sinon = require('sinon')
 require('./setup/core')
 const id = require('../src/id')
 const SpanContext = require('../src/opentracing/span_context')
+
+/**
+ * @param {number} ruleSampleRate
+ * @returns {Record<string, string[]>}
+ */
+function runProgrammaticRegExpRules (ruleSampleRate) {
+  const tracerPath = path.resolve(__dirname, '../../..')
+  const script = `
+    'use strict'
+
+    const assert = require('node:assert/strict')
+    const vm = require('node:vm')
+
+    const ruleSampleRate = Number(process.env.DD_TEST_RULE_SAMPLE_RATE)
+    const prefix = ruleSampleRate === 0 ? 'drop' : 'keep'
+    const matchers = {
+      name: vm.runInNewContext('new RegExp("^" + prefix + "[.]name$", "g")', { prefix }),
+      service: new RegExp('^' + prefix + '[.]service$', 'y'),
+      resource: new RegExp('^' + prefix + '[.]resource$', 'g'),
+      tag: new RegExp('^' + prefix + '[.]tag$', 'y'),
+      emptyTag: /^$/,
+    }
+    const samplingRules = [
+      { name: matchers.name, sampleRate: ruleSampleRate },
+      { service: matchers.service, sampleRate: ruleSampleRate },
+      { resource: matchers.resource, sampleRate: ruleSampleRate },
+      { tags: { 'sampling.tag': matchers.tag }, sampleRate: ruleSampleRate },
+      { tags: { 'sampling.empty': matchers.emptyTag }, sampleRate: ruleSampleRate },
+    ]
+    const tracer = require(${JSON.stringify(tracerPath)}).init({
+      plugins: false,
+      remoteConfig: false,
+      startupLogs: false,
+      sampleRate: 1 - ruleSampleRate,
+      samplingRules,
+    })
+    const formats = require(${JSON.stringify(path.join(tracerPath, 'ext/formats'))})
+
+    /**
+     * @param {string} name
+     * @param {Record<string, string>} [tags]
+     * @returns {string}
+     */
+    function getPriority (name, tags = {}) {
+      const span = tracer.startSpan(name)
+      for (const [key, value] of Object.entries(tags)) {
+        span.setTag(key, value)
+      }
+      const carrier = {}
+      tracer.inject(span, formats.HTTP_HEADERS, carrier)
+      span.finish()
+      return carrier['x-datadog-sampling-priority']
+    }
+
+    const nameMatching = getPriority(prefix + '.name')
+    assert.strictEqual(matchers.name.lastIndex, 0)
+    const nameMatchingAgain = getPriority(prefix + '.name')
+    assert.strictEqual(matchers.name.lastIndex, 0)
+    const nameNonMatching = getPriority('other.name')
+    const serviceMatching = getPriority('service', { service: prefix + '.service' })
+    assert.strictEqual(matchers.service.lastIndex, 0)
+    const serviceMatchingAgain = getPriority('service', { service: prefix + '.service' })
+    assert.strictEqual(matchers.service.lastIndex, 0)
+    const serviceNonMatching = getPriority('service', { service: 'other.service' })
+    const resourceMatching = getPriority('resource', { resource: prefix + '.resource' })
+    assert.strictEqual(matchers.resource.lastIndex, 0)
+    const resourceMatchingAgain = getPriority('resource', { resource: prefix + '.resource' })
+    assert.strictEqual(matchers.resource.lastIndex, 0)
+    const resourceNonMatching = getPriority('resource', { resource: 'other.resource' })
+    const tagMatching = getPriority('tag', { 'sampling.tag': prefix + '.tag' })
+    assert.strictEqual(matchers.tag.lastIndex, 0)
+    const tagMatchingAgain = getPriority('tag', { 'sampling.tag': prefix + '.tag' })
+    assert.strictEqual(matchers.tag.lastIndex, 0)
+    const tagNonMatching = getPriority('tag', { 'sampling.tag': 'other.tag' })
+    const emptyTagMatching = getPriority('empty-tag', { 'sampling.empty': '' })
+    const emptyTagMissing = getPriority('empty-tag')
+
+    assert.strictEqual(samplingRules[0].name, matchers.name)
+    assert.strictEqual(samplingRules[1].service, matchers.service)
+    assert.strictEqual(samplingRules[2].resource, matchers.resource)
+    assert.strictEqual(samplingRules[3].tags['sampling.tag'], matchers.tag)
+    assert.strictEqual(samplingRules[4].tags['sampling.empty'], matchers.emptyTag)
+
+    process.stdout.write(JSON.stringify({
+      name: [nameMatching, nameMatchingAgain, nameNonMatching],
+      service: [serviceMatching, serviceMatchingAgain, serviceNonMatching],
+      resource: [resourceMatching, resourceMatchingAgain, resourceNonMatching],
+      tag: [tagMatching, tagMatchingAgain, tagNonMatching],
+      emptyTag: [emptyTagMatching, emptyTagMissing],
+    }), () => process.exit())
+  `
+  const env = {
+    ...process.env,
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false',
+    DD_REMOTE_CONFIGURATION_ENABLED: 'false',
+    DD_TEST_RULE_SAMPLE_RATE: String(ruleSampleRate),
+    DD_TRACE_STARTUP_LOGS: 'false',
+  }
+  delete env.OTEL_LOGS_EXPORTER
+  delete env.OTEL_METRICS_EXPORTER
+  delete env.OTEL_TRACES_EXPORTER
+  const result = spawnSync(process.execPath, ['--eval', script], {
+    encoding: 'utf8',
+    env,
+    timeout: 10_000,
+  })
+
+  assert.strictEqual(result.status, 0, result.stderr)
+  return JSON.parse(result.stdout)
+}
 
 function createDummySpans () {
   const operations = [
@@ -106,6 +218,26 @@ describe('sampling rule', () => {
   })
 
   describe('match', () => {
+    it('should not match unsupported matcher values', () => {
+      for (const pattern of [{}, null, false, 0, '']) {
+        rule = new SamplingRule({ name: pattern })
+
+        assert.strictEqual(rule.match(spans[0]), false)
+      }
+
+      rule = new SamplingRule({ tags: { tagged: {} } })
+
+      assert.strictEqual(rule.match(spans[9]), false)
+    })
+
+    it('should match wildcard strings', () => {
+      for (const pattern of ['*', '**', '***']) {
+        rule = new SamplingRule({ name: pattern })
+
+        assert.strictEqual(rule.match(spans[0]), true)
+      }
+    })
+
     it('should match with exact strings', () => {
       rule = new SamplingRule({
         service: 'test',
@@ -337,6 +469,44 @@ describe('sampling rule', () => {
       assert.strictEqual(rule.match(spans[8]), false)
       assert.strictEqual(rule.match(spans[9]), false)
       assert.strictEqual(rule.match(spans[10]), true)
+    })
+  })
+
+  describe('programmatic configuration', () => {
+    it('should apply RegExp matchers through tracer.init()', () => {
+      const drop = runProgrammaticRegExpRules(0)
+
+      assert.strictEqual(drop.name[0], '-1')
+      assert.strictEqual(drop.name[1], '-1')
+      assert.strictEqual(drop.name[2], '2')
+      assert.strictEqual(drop.service[0], '-1')
+      assert.strictEqual(drop.service[1], '-1')
+      assert.strictEqual(drop.service[2], '2')
+      assert.strictEqual(drop.resource[0], '-1')
+      assert.strictEqual(drop.resource[1], '-1')
+      assert.strictEqual(drop.resource[2], '2')
+      assert.strictEqual(drop.tag[0], '-1')
+      assert.strictEqual(drop.tag[1], '-1')
+      assert.strictEqual(drop.tag[2], '2')
+      assert.strictEqual(drop.emptyTag[0], '-1')
+      assert.strictEqual(drop.emptyTag[1], '2')
+
+      const keep = runProgrammaticRegExpRules(1)
+
+      assert.strictEqual(keep.name[0], '2')
+      assert.strictEqual(keep.name[1], '2')
+      assert.strictEqual(keep.name[2], '-1')
+      assert.strictEqual(keep.service[0], '2')
+      assert.strictEqual(keep.service[1], '2')
+      assert.strictEqual(keep.service[2], '-1')
+      assert.strictEqual(keep.resource[0], '2')
+      assert.strictEqual(keep.resource[1], '2')
+      assert.strictEqual(keep.resource[2], '-1')
+      assert.strictEqual(keep.tag[0], '2')
+      assert.strictEqual(keep.tag[1], '2')
+      assert.strictEqual(keep.tag[2], '-1')
+      assert.strictEqual(keep.emptyTag[0], '2')
+      assert.strictEqual(keep.emptyTag[1], '-1')
     })
   })
 


### PR DESCRIPTION
Programmatic sampling rules pass through recursive key normalization and snapshot cloning. Both treated RegExp values as plain objects, and unsupported matcher values then defaulted to match-all. A scoped RegExp rule therefore kept or dropped every span.