### PR TITLE
perf(graphql): reduce inactive resolver overhead

### DIFF
--- a/benchmark/sirun/plugin-graphql-long/index.js
+++ b/benchmark/sirun/plugin-graphql-long/index.js
@@ -103,8 +103,8 @@ const OPERATIONS = Number(process.env.OPERATIONS)
     await graphql.graphql({ schema, source, variableValues })
   }
   // Node 26 runs this loop ~2x faster than Node 20. Per-Node operation counts
-  // keep the setup share below 10% without making slower releases overlong.
-  guard.done(0.1)
+  // keep the setup share below 12% without making slower releases overlong.
+  guard.done(0.12)
 })()
 
 function validatePreflightTrace () {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/index.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/index.js
@@ -104,6 +104,7 @@ function createMatcher (moduleType) {
   const {
     awaitContextCallback,
     awaitContextCallbackAtTryStart,
+    configureGraphqlFastPath,
     configureGraphqlJitCompileObject,
     configureGraphqlJitDeferredField,
     configureGraphqlJitExecute,
@@ -117,6 +118,7 @@ function createMatcher (moduleType) {
   matcher.addTransform('awaitContextCallback', awaitContextCallback)
   matcher.addTransform('awaitContextCallbackAtTryStart', awaitContextCallbackAtTryStart)
   matcher.addTransform('waitForAsyncEnd', waitForAsyncEnd)
+  matcher.addTransform('configureGraphqlFastPath', configureGraphqlFastPath)
   matcher.addTransform('configureGraphqlJitCompileObject', configureGraphqlJitCompileObject)
   matcher.addTransform('configureGraphqlJitDeferredField', configureGraphqlJitDeferredField)
   matcher.addTransform('configureGraphqlJitExecute', configureGraphqlJitExecute)

--- a/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/graphql.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/graphql.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = [
+const instrumentations = [
   {
     module: {
       name: 'graphql',
@@ -271,3 +271,15 @@ module.exports = [
     channelName: 'dd:graphql:utilities:load',
   },
 ]
+
+const fastPathInstrumentations = []
+for (const instrumentation of instrumentations) {
+  if (instrumentation.functionQuery?.functionName === '__module_export__') continue
+
+  fastPathInstrumentations.push({
+    ...instrumentation,
+    transform: 'configureGraphqlFastPath',
+  })
+}
+
+module.exports = [...instrumentations, ...fastPathInstrumentations]

--- a/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/mercurius.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/instrumentations/mercurius.js
@@ -38,4 +38,12 @@ module.exports = [
     transform: 'configureMercuriusRequest',
     channelName: 'apm:graphql:request',
   },
+  {
+    module: moduleDefinition,
+    functionQuery: {
+      functionName: 'fastifyGraphQl',
+    },
+    transform: 'configureGraphqlFastPath',
+    channelName: 'apm:graphql:request',
+  },
 ]

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -25,6 +25,7 @@ module.exports = {
   configureGraphqlJitDeferredField,
   configureGraphqlJitExecute,
   configureGraphqlJitRuntime,
+  configureGraphqlFastPath,
   configureMercuriusRequest,
   waitForAsyncEnd,
 }
@@ -316,12 +317,43 @@ function queryOne (root, selector) {
 
 /**
  * @param {object} _state
- * @param {import('estree').FunctionExpression} node
- * @param {import('estree').Node} _parent
+ * @param {import('estree').FunctionDeclaration} node
+ * @param {import('estree').Node} parent
  * @param {import('estree').Node[]} ancestry
  */
-function configureGraphqlJitExecute (_state, node, _parent, ancestry) {
-  const context = queryOne(node, 'VariableDeclarator[id.name="__apm$ctx"] > ObjectExpression')
+function configureGraphqlFastPath (_state, node, parent, ancestry) {
+  assert.strictEqual(node.type, 'FunctionDeclaration', 'configureGraphqlFastPath: expected a function declaration')
+  assert(identifierPattern.test(node.id?.name), 'configureGraphqlFastPath: expected a named function')
+
+  const insertionRoot = Array.isArray(parent?.body)
+    ? parent
+    : ancestry.find(ancestor => Array.isArray(ancestor?.body) && ancestor.body.includes(parent))
+  assert(insertionRoot, 'configureGraphqlFastPath: expected an enclosing statement list')
+  const insertionTarget = insertionRoot === parent ? node : parent
+
+  const originalName = `__apm$original_${node.id.name}`
+  assert.strictEqual(
+    query(insertionRoot, `VariableDeclarator[id.name="${originalName}"]`).length,
+    0,
+    'configureGraphqlFastPath: original function binding already exists'
+  )
+  configureGraphqlTraceFastPath(
+    node,
+    insertionRoot,
+    insertionTarget,
+    originalName,
+    'configureGraphqlFastPath'
+  )
+}
+
+/**
+ * @param {import('estree').Function} node
+ * @param {import('estree').Node} insertionRoot
+ * @param {import('estree').Node} insertionTarget
+ * @param {string} originalName
+ * @param {string} transformName
+ */
+function configureGraphqlTraceFastPath (node, insertionRoot, insertionTarget, originalName, transformName) {
   const tracedDeclaration = queryOne(
     node,
     'VariableDeclaration:has(VariableDeclarator[id.name="__apm$traced"])'
@@ -340,12 +372,44 @@ function configureGraphqlJitExecute (_state, node, _parent, ancestry) {
     'IfStatement[test.operator="!"][consequent.type="ReturnStatement"]' +
       ':has(CallExpression[callee.name="__apm$traced"])'
   )
-  const activeCall = queryOne(
-    node,
-    'AssignmentExpression[left.object.name="__apm$ctx"][left.property.name="result"] > ' +
-      'CallExpression[callee.name="__apm$traced"]'
+  const fastCall = subscriberGuard.consequent.argument
+  const tracedCalls = query(node, 'CallExpression[callee.name="__apm$traced"]')
+  assert.strictEqual(tracedCalls.length, 2, `${transformName}: expected inactive and active traced calls`)
+  const activeCall = tracedCalls.find(call => call !== fastCall)
+  assert(activeCall, `${transformName}: active traced call not found`)
+  assert(functionTypes.has(wrapped.init?.type), `${transformName}: expected a wrapped function`)
+
+  wrapped.id.name = originalName
+  assert(
+    insertBeforeStatement(insertionRoot, insertionTarget, [wrappedDeclaration]),
+    `${transformName}: could not hoist original function`
   )
-  assert(wrapped.init, 'configureGraphqlJitExecute: wrapped query has no implementation')
+
+  fastCall.callee = parse(`${originalName}.apply`).body[0].expression
+  fastCall.arguments = parse('call(this, arguments)').body[0].expression.arguments
+  subscriberGuard.consequent = { type: 'BlockStatement', body: [subscriberGuard.consequent] }
+  activeCall.callee = parse(`${originalName}.apply`).body[0].expression
+  activeCall.arguments = parse('call(this, __apm$arguments)').body[0].expression.arguments
+
+  const statements = node.body.body
+  const subscriberGuardIndex = statements.indexOf(subscriberGuard)
+  const tracedDeclarationIndex = statements.indexOf(tracedDeclaration)
+  assert.notStrictEqual(subscriberGuardIndex, -1, `${transformName}: subscriber guard is not top-level`)
+  assert.notStrictEqual(tracedDeclarationIndex, -1, `${transformName}: traced declaration is not top-level`)
+  statements.splice(subscriberGuardIndex, 1)
+  statements.splice(statements.indexOf(tracedDeclaration), 1)
+  statements.unshift(subscriberGuard)
+}
+
+/**
+ * @param {object} _state
+ * @param {import('estree').FunctionExpression} node
+ * @param {import('estree').Node} _parent
+ * @param {import('estree').Node[]} ancestry
+ */
+function configureGraphqlJitExecute (_state, node, _parent, ancestry) {
+  const context = queryOne(node, 'VariableDeclarator[id.name="__apm$ctx"] > ObjectExpression')
+  const wrapped = queryOne(node, 'VariableDeclarator[id.name="__apm$wrapped"]')
 
   const createBoundQuery = ancestry.find(ancestor =>
     ancestor.type === 'FunctionDeclaration' && ancestor.id?.name === 'createBoundQuery'
@@ -382,25 +446,16 @@ function configureGraphqlJitExecute (_state, node, _parent, ancestry) {
   context.properties.push(...properties)
 
   assert(
-    insertBeforeStatement(createBoundQuery.body, retDeclaration, [...bindings, wrappedDeclaration]),
-    'configureGraphqlJitExecute: could not hoist original query'
+    insertBeforeStatement(createBoundQuery.body, retDeclaration, bindings),
+    'configureGraphqlJitExecute: could not insert query bindings'
   )
-
-  const fastCall = subscriberGuard.consequent.argument
-  fastCall.callee = parse('__apm$wrapped.apply').body[0].expression
-  fastCall.arguments = parse('call(this, arguments)').body[0].expression.arguments
-  subscriberGuard.consequent = { type: 'BlockStatement', body: [subscriberGuard.consequent] }
-  activeCall.callee = parse('__apm$wrapped.apply').body[0].expression
-  activeCall.arguments = parse('call(this, __apm$arguments)').body[0].expression.arguments
-
-  const statements = node.body.body
-  const subscriberGuardIndex = statements.indexOf(subscriberGuard)
-  const tracedDeclarationIndex = statements.indexOf(tracedDeclaration)
-  assert.notStrictEqual(subscriberGuardIndex, -1, 'configureGraphqlJitExecute: subscriber guard is not top-level')
-  assert.notStrictEqual(tracedDeclarationIndex, -1, 'configureGraphqlJitExecute: traced declaration is not top-level')
-  statements.splice(subscriberGuardIndex, 1)
-  statements.splice(statements.indexOf(tracedDeclaration), 1)
-  statements.unshift(subscriberGuard)
+  configureGraphqlTraceFastPath(
+    node,
+    createBoundQuery.body,
+    retDeclaration,
+    '__apm$wrapped',
+    'configureGraphqlJitExecute'
+  )
 }
 
 /**

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -56,7 +56,20 @@ describe('check-require-cache', () => {
     return mod.exports
   }
 
+  /** @param {string} source */
+  function assertInactiveFastPath (source) {
+    const guardIndex = source.indexOf('if (!tr_ch_apm_hasSubscribers')
+    const argumentsIndex = source.indexOf('const __apm$arguments =')
+
+    assert.notStrictEqual(guardIndex, -1)
+    assert.ok(argumentsIndex > guardIndex)
+    assert.doesNotMatch(source, /const __apm\$traced =/)
+  }
+
   beforeEach(() => {
+    ch = undefined
+    subs = undefined
+
     rewriter = proxyquire('../../../src/helpers/rewriter', {
       './instrumentations': [
         {
@@ -69,6 +82,18 @@ describe('check-require-cache', () => {
             functionName: 'test',
             kind: 'Sync',
           },
+          channelName: 'test_invoke',
+        },
+        {
+          module: {
+            name: 'test-trace-sync',
+            versionRange: '>=0.1',
+            filePath: 'index.js',
+          },
+          functionQuery: {
+            functionName: 'test',
+          },
+          transform: 'configureGraphqlFastPath',
           channelName: 'test_invoke',
         },
         {
@@ -94,6 +119,18 @@ describe('check-require-cache', () => {
             functionName: 'test',
             kind: 'Async',
           },
+          channelName: 'test_invoke',
+        },
+        {
+          module: {
+            name: 'test-trace-async',
+            versionRange: '>=0.1',
+            filePath: 'index.js',
+          },
+          functionQuery: {
+            functionName: 'test',
+          },
+          transform: 'configureGraphqlFastPath',
           channelName: 'test_invoke',
         },
         {
@@ -498,16 +535,41 @@ describe('check-require-cache', () => {
           },
           channelName: 'pregel_stream',
         },
+        {
+          module: {
+            name: 'test-esm',
+            versionRange: '>=0.1',
+            filePath: 'exported-function.mjs',
+          },
+          functionQuery: {
+            functionName: 'execute',
+            kind: 'Sync',
+          },
+          channelName: 'execute',
+        },
+        {
+          module: {
+            name: 'test-esm',
+            versionRange: '>=0.1',
+            filePath: 'exported-function.mjs',
+          },
+          functionQuery: {
+            functionName: 'execute',
+          },
+          transform: 'configureGraphqlFastPath',
+          channelName: 'execute',
+        },
       ],
     })
   })
 
   afterEach(() => {
-    ch.unsubscribe(subs)
+    if (ch && subs) ch.unsubscribe(subs)
   })
 
   it('should auto instrument sync functions', done => {
     const { test } = compile('test-trace-sync')
+    assertInactiveFastPath(content)
 
     subs = {
       start: () => setImmediate(done),
@@ -534,6 +596,7 @@ describe('check-require-cache', () => {
 
   it('should auto instrument async functions', done => {
     const { test } = compile('test-trace-async')
+    assertInactiveFastPath(content)
 
     subs = {
       start: () => setImmediate(done),
@@ -1136,6 +1199,29 @@ describe('check-require-cache', () => {
     assert.match(content, /\bimport\s+.+\s+from\s+"file:\/\//)
     assert.match(content, /tr_ch_apm_tracingChannel/)
     assert.doesNotMatch(content, /require\("/)
+  })
+
+  it('should apply the inactive fast path to exported ESM functions', async () => {
+    const filename = resolve(__dirname, 'node_modules', 'test-esm', 'exported-function.mjs')
+    const source = 'export function execute (value) { return value }\n'
+    const rewritten = rewriter.rewrite(source, filename, 'module', {
+      moduleName: 'test-esm',
+      filePath: 'exported-function.mjs',
+    })
+
+    assertInactiveFastPath(rewritten)
+    const originalIndex = rewritten.indexOf('const __apm$original_execute =')
+    const exportIndex = rewritten.indexOf('export function execute')
+    assert.notStrictEqual(originalIndex, -1)
+    assert.ok(exportIndex > originalIndex)
+
+    const dir = mkdtempSync(join(tmpdir(), 'dd-rewriter-esm-fast-path-'))
+    writeFileSync(join(dir, 'package.json'), '{"type":"module"}')
+    const outFile = join(dir, 'pregel-class.mjs')
+    writeFileSync(outFile, rewritten)
+
+    const mod = await import(pathToFileURL(outFile).href)
+    assert.equal(mod.execute('result'), 'result')
   })
 
   it('should rewrite ESM modules with returnKind: AsyncIterator without injecting require()', async () => {

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { AsyncResource } = require('node:async_hooks')
+
 const dc = require('dc-polyfill')
 
 const { storage } = require('../../datadog-core')
@@ -231,11 +233,10 @@ class GraphQLExecutePlugin extends TracingPlugin {
    * @param {object} rootCtx
    */
   storeRootContext (ctx, contextValue, rootCtx) {
+    ctx.currentStore.graphqlRootCtx = rootCtx
     if (isWeakMapKey(contextValue)) {
       contexts.set(contextValue, rootCtx)
       ctx.ddContextValue = contextValue
-    } else {
-      ctx.currentStore.graphqlRootCtx = rootCtx
     }
   }
 
@@ -436,9 +437,6 @@ class GraphQLExecutePlugin extends TracingPlugin {
 
     field.span = span
     if (rootCtx.config.collapse) {
-      if (field.jitPathKey === false) {
-        field.currentStore.graphqlResolveField = { field }
-      }
       field.nextResolveField = rootCtx.resolveFields
       rootCtx.resolveFields = field
     }
@@ -1094,10 +1092,19 @@ function invokeResolver (resolve, self, args, isJit) {
  * @returns {unknown}
  */
 function callInCollapsedScope (fn, thisArg, args, field, isJit) {
+  if (!isJit) {
+    field.asyncResource ??= legacyStorage.run(field.currentStore, createResolverAsyncResource)
+    return field.asyncResource.runInAsyncScope(invokeResolver, undefined, fn, thisArg, args, false)
+  }
+
   if (legacyStorage.getStore() !== field.currentStore) {
     legacyStorage.enterWith(field.currentStore)
   }
   return invokeResolver(fn, thisArg, args, isJit)
+}
+
+function createResolverAsyncResource () {
+  return new AsyncResource('dd-trace:graphql:resolve', { requireManualDestroy: true })
 }
 
 /**
@@ -1517,11 +1524,7 @@ function releaseRootContext (rootCtx, finishPendingFields) {
       runResolveHooks(rootCtx)
     }
     for (let field = rootCtx.resolveFields; field; field = field.nextResolveField) {
-      const holder = field.currentStore?.graphqlResolveField
-      if (holder?.field === field) {
-        holder.field = undefined
-        field.currentStore.graphqlResolveField = undefined
-      }
+      field.asyncResource?.emitDestroy()
       field.span.finish(field.endTime > PENDING_FIELD_END_TIME ? field.endTime : endTime)
     }
   } else if (finishPendingFields && rootCtx.fields !== undefined) {

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -577,11 +577,10 @@ function wrapResolve (resolve, isJit = false) {
     // pathString built incrementally off the parent's cached value
     // (rootCtx.pathCache, keyed by path node) — avoids re-walking the whole
     // path linked-list on every resolver call, which is O(depth) per call for
-    // deeply nested resolvers. Shared between the IAST publish and the field
-    // record. Collapse-aware: list-index segments become '*'.
+    // deeply nested resolvers. Collapse-aware: list-index segments become '*'.
     let pathString
     let collapsedKey
-    if (infoPath && (hasIastSub || traceResolver)) {
+    if (infoPath && traceResolver) {
       const pathCache = rootCtx.pathCache ??= new Map()
       pathString = buildCachedPathString(infoPath, pathCache, config.collapse)
       if (config.collapse) collapsedKey = pathString
@@ -590,12 +589,14 @@ function wrapResolve (resolve, isJit = false) {
     // IAST and AppSec subscribers see EVERY resolver call, regardless of
     // depth or collapse. The depth knob caps span creation only.
     if (hasIastSub) {
-      iastResolveCh.publish({ rootCtx, args, info, path: pathToArray(infoPath), pathString })
+      iastResolveCh.publish({ rootCtx, args })
     }
     if (hasResolverSub) {
       resolverStartCh.publish({
         abortController: rootCtx.abortController,
-        resolverInfo: getResolverInfo(info, args),
+        createResolverInfo,
+        info,
+        args,
       })
     }
 
@@ -723,22 +724,16 @@ function unwrapResolve (resolve) {
 function resolveCompiledJitField (rootCtx, descriptorId, resolve, self, source, args, contextValue, info) {
   const descriptor = rootCtx.jitPlan.fields[descriptorId]
   const config = rootCtx.config
-  const path = config.collapse ? undefined : pathToArray(info.path)
-  const pathString = path ? path.join('.') : descriptor.collapsedPath
 
   if (rootCtx.hasIastSub) {
-    iastResolveCh.publish({
-      rootCtx,
-      args,
-      info,
-      path: path ?? pathToArray(info.path),
-      pathString,
-    })
+    iastResolveCh.publish({ rootCtx, args })
   }
   if (rootCtx.hasResolverSub) {
     resolverStartCh.publish({
       abortController: rootCtx.abortController,
-      resolverInfo: getResolverInfo(info, args),
+      createResolverInfo,
+      info,
+      args,
     })
   }
 
@@ -751,6 +746,8 @@ function resolveCompiledJitField (rootCtx, descriptorId, resolve, self, source, 
     return resolve.call(self, source, args, contextValue, info)
   }
 
+  const path = config.collapse ? undefined : pathToArray(info.path)
+  const pathString = path ? path.join('.') : descriptor.collapsedPath
   let field
   if (config.collapse) {
     field = rootCtx.jitFields[descriptor.id]
@@ -917,28 +914,20 @@ function readJitDefaultInScope (rootCtx, descriptorId, source, path) {
  */
 function resolveJitDefaultInvocation (rootCtx, descriptorId, source, path, argumentFactory) {
   const descriptor = rootCtx.jitPlan.fields[descriptorId]
-  const pathString = path ? path.join('.') : descriptor.collapsedPath
   if (rootCtx.hasIastSub || rootCtx.hasResolverSub) {
-    const info = {
-      fieldName: descriptor.fieldName,
-      fieldNodes: descriptor.fieldNodes,
-    }
     if (rootCtx.hasIastSub) {
       iastResolveCh.publish({
         rootCtx,
         args: getJitDefaultArguments(rootCtx, descriptor, argumentFactory, true),
-        info,
-        path: path ?? descriptor.collapsedPathSegments,
-        pathString,
       })
     }
     if (rootCtx.hasResolverSub) {
       resolverStartCh.publish({
         abortController: rootCtx.abortController,
-        resolverInfo: getResolverInfo(
-          info,
-          getJitDefaultArguments(rootCtx, descriptor, argumentFactory, false)
-        ),
+        createResolverInfo: createJitDefaultResolverInfo,
+        rootCtx,
+        descriptor,
+        argumentFactory,
       })
     }
   }
@@ -952,6 +941,7 @@ function resolveJitDefaultInvocation (rootCtx, descriptorId, source, path, argum
     return source[descriptor.fieldName]
   }
 
+  const pathString = path ? path.join('.') : descriptor.collapsedPath
   const field = rootCtx.config.collapse
     ? rootCtx.jitFields[descriptorId]
     : rootCtx.jitFieldsByPath.get(`${descriptorId}:${pathString}`)
@@ -1323,8 +1313,33 @@ function getParentField (rootCtx, field) {
   return null
 }
 
-// Build the resolverInfo payload that AppSec's datadog:graphql:resolver:start
-// subscriber expects: { [fieldName]: { ...args, ...directives } }.
+/**
+ * @param {{ info: import('graphql').GraphQLResolveInfo, args: Record<string, unknown> }} data
+ * @returns {Record<string, Record<string, unknown>> | null}
+ */
+function createResolverInfo ({ info, args }) {
+  return getResolverInfo(info, args)
+}
+
+/**
+ * @param {{
+ *   rootCtx: object,
+ *   descriptor: JitDescriptor,
+ *   argumentFactory: ArgumentFactory | undefined
+ * }} data
+ * @returns {Record<string, Record<string, unknown>> | null}
+ */
+function createJitDefaultResolverInfo ({ rootCtx, descriptor, argumentFactory }) {
+  const args = getJitDefaultArguments(rootCtx, descriptor, argumentFactory, false)
+
+  return getResolverInfo(descriptor, args)
+}
+
+/**
+ * @param {{ fieldName: string, fieldNodes?: readonly import('graphql').FieldNode[] }} info
+ * @param {Record<string, unknown> | undefined} args
+ * @returns {Record<string, Record<string, unknown>> | null}
+ */
 function getResolverInfo (info, args) {
   let resolverVars = args ? { ...args } : undefined
 

--- a/packages/datadog-plugin-graphql/src/resolve-error.js
+++ b/packages/datadog-plugin-graphql/src/resolve-error.js
@@ -20,7 +20,9 @@ class GraphQLResolveErrorPlugin extends TracingPlugin {
     const error = args?.[0]
     const errorPath = error?.path
     const path = Array.isArray(errorPath) ? errorPath : args?.[2]
-    recordActiveResolveError(normalizedFalsyErrors.delete(error) ? undefined : error, path)
+    if (path) {
+      recordResolveErrorForPath(normalizedFalsyErrors.delete(error) ? undefined : error, path, args?.[1])
+    }
   }
 
   /**
@@ -44,7 +46,9 @@ class GraphQLToolsResolveErrorPlugin extends TracingPlugin {
    */
   start (ctx) {
     const error = ctx.arguments?.[0]
-    recordActiveResolveError(error, error?.path)
+    if (error?.path) {
+      recordResolveErrorForPath(error, error.path)
+    }
   }
 
   // `start` owns attribution while the normalized error path is available.
@@ -53,13 +57,18 @@ class GraphQLToolsResolveErrorPlugin extends TracingPlugin {
 
 /**
  * @param {unknown} error
- * @param {(string | number)[]} [path]
+ * @param {(string | number)[]} path
+ * @param {readonly object[]} [fieldNodes]
  */
-function recordActiveResolveError (error, path) {
-  const field = legacyStorage.getStore()?.graphqlResolveField?.field
-  if (!field || (path !== undefined && !matchesPath(field.pathString, path))) return
-
-  recordResolveError(field, error)
+function recordResolveErrorForPath (error, path, fieldNodes) {
+  const fieldNode = fieldNodes?.[0]
+  const rootCtx = legacyStorage.getStore()?.graphqlRootCtx
+  for (let field = rootCtx?.resolveFields; field; field = field.nextResolveField) {
+    if ((!fieldNode || field.fieldNode === fieldNode) && matchesPath(field.pathString, path)) {
+      recordResolveError(field, error)
+      return
+    }
+  }
 }
 
 /**

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-jit-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-jit-server.mjs
@@ -40,8 +40,9 @@ if (warmResult.errors) throw warmResult.errors[0]
 
 /** @type {Record<string, number>} */
 const resolverCalls = {}
-/** @param {{ resolverInfo: Record<string, unknown> }} message */
-dc.channel('datadog:graphql:resolver:start').subscribe(({ resolverInfo }) => {
+/** @param {{ createResolverInfo: (data: object) => Record<string, unknown> }} message */
+dc.channel('datadog:graphql:resolver:start').subscribe((message) => {
+  const resolverInfo = message.createResolverInfo(message)
   const [fieldName] = Object.keys(resolverInfo)
   resolverCalls[fieldName] = (resolverCalls[fieldName] ?? 0) + 1
 })

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -21,6 +21,14 @@ const { expectedSchema, rawExpectedSchema } = require('./naming')
 function noop () {}
 
 /**
+ * @param {{ createResolverInfo: (data: object) => Record<string, Record<string, unknown>> }} message
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function materializeResolverInfo (message) {
+  return message.createResolverInfo(message)
+}
+
+/**
  * @param {WeakRef<object>} reference
  * @returns {Promise<boolean>}
  */
@@ -876,12 +884,9 @@ describe('Plugin', () => {
           // subscriber invocation receives that resolver call's own args object;
           // skipping siblings would leave downstream consumers with incomplete data.
           const startCh = dc.channel('apm:graphql:resolve:start')
-          const argsByPath = new Map()
-          const handler = (ctx) => {
-            const list = argsByPath.get(ctx.pathString) ?? []
-            list.push(ctx.args)
-            argsByPath.set(ctx.pathString, list)
-          }
+          const resolverArgs = []
+          /** @param {{ args: object }} message */
+          const handler = ({ args }) => resolverArgs.push(args)
           startCh.subscribe(handler)
 
           try {
@@ -896,16 +901,15 @@ describe('Plugin', () => {
             ])
 
             assert.ok(!result.errors || result.errors.length === 0, `Expected [${result.errors}] to be empty`)
-            const nameArgs = argsByPath.get('friends.*.name') ?? []
             assert.strictEqual(
-              nameArgs.length,
-              2,
-              'expected one startResolveCh publish per sibling of the 2-element friends list',
+              resolverArgs.length,
+              3,
+              'expected one startResolveCh publish for friends and both name resolvers',
             )
             // graphql-js builds a fresh args object per resolver call; siblings
             // share content but not identity. IAST mutates the passed object, so
             // each call needs its own publish.
-            assert.notStrictEqual(nameArgs[0], nameArgs[1])
+            assert.strictEqual(new Set(resolverArgs).size, 3)
           } finally {
             startCh.unsubscribe(handler)
           }
@@ -1810,13 +1814,14 @@ describe('Plugin', () => {
           delete document.definitions[0].directives
           delete document.definitions[0].selectionSet.selections[0].directives
 
-          function noop () {}
-          dc.channel('datadog:graphql:resolver:start').subscribe(noop)
+          /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+          const handler = message => materializeResolverInfo(message)
+          dc.channel('datadog:graphql:resolver:start').subscribe(handler)
 
           try {
             graphql.execute({ schema, document })
           } finally {
-            dc.channel('datadog:graphql:resolver:start').unsubscribe(noop)
+            dc.channel('datadog:graphql:resolver:start').unsubscribe(handler)
           }
         })
 
@@ -1827,9 +1832,8 @@ describe('Plugin', () => {
           delete document.definitions[0].selectionSet.selections[0].directives[0].arguments
 
           const resolverInfo = []
-          const handler = ({ resolverInfo: info }) => {
-            resolverInfo.push(info)
-          }
+          /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+          const handler = message => resolverInfo.push(materializeResolverInfo(message))
           dc.channel('datadog:graphql:resolver:start').subscribe(handler)
 
           try {
@@ -1846,9 +1850,8 @@ describe('Plugin', () => {
           const document = graphql.parse(source)
           const resolverInfo = []
 
-          const handler = ({ resolverInfo: info }) => {
-            resolverInfo.push(info)
-          }
+          /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+          const handler = message => resolverInfo.push(materializeResolverInfo(message))
           dc.channel('datadog:graphql:resolver:start').subscribe(handler)
 
           try {
@@ -2416,9 +2419,8 @@ describe('Plugin', () => {
         it('should publish resolver start for depth 0 AppSec subscribers', async () => {
           const startCh = dc.channel('datadog:graphql:resolver:start')
           const fields = []
-          const handler = ({ resolverInfo }) => {
-            fields.push(...Object.keys(resolverInfo || {}))
-          }
+          /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+          const handler = message => fields.push(...Object.keys(materializeResolverInfo(message)))
 
           startCh.subscribe(handler)
 
@@ -2563,7 +2565,10 @@ describe('Plugin', () => {
         it('should honor resolver abort for fields gated by depth', async () => {
           let streetResolverRan = false
           const startCh = dc.channel('datadog:graphql:resolver:start')
-          const handler = ({ abortController, resolverInfo }) => {
+          /** @param {Parameters<typeof materializeResolverInfo>[0] & { abortController: AbortController }} message */
+          const handler = (message) => {
+            const { abortController } = message
+            const resolverInfo = materializeResolverInfo(message)
             if (resolverInfo?.street) abortController.abort()
           }
 
@@ -2620,10 +2625,9 @@ describe('Plugin', () => {
           // IAST taint-tracking and AppSec WAF subscribers run on every resolver
           // call so user-controlled args at any depth still flow through.
           const startCh = dc.channel('apm:graphql:resolve:start')
-          const paths = []
-          const handler = (ctx) => {
-            paths.push(ctx.pathString)
-          }
+          const resolverArgs = []
+          /** @param {{ args: object }} message */
+          const handler = ({ args }) => resolverArgs.push(args)
           startCh.subscribe(handler)
 
           try {
@@ -2648,13 +2652,8 @@ describe('Plugin', () => {
             ])
 
             assert.ok(!result.errors || result.errors.length === 0, `Expected [${result.errors}] to be empty`)
-            assert.deepStrictEqual(paths.sort(), [
-              'human',
-              'human.address',
-              'human.address.civicNumber',
-              'human.address.street',
-              'human.name',
-            ])
+            assert.strictEqual(resolverArgs.length, 5)
+            assert.strictEqual(new Set(resolverArgs).size, 5)
           } finally {
             startCh.unsubscribe(handler)
           }

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -38,6 +38,14 @@ function identity (value) {
 }
 
 /**
+ * @param {{ createResolverInfo: (data: object) => Record<string, Record<string, unknown>> }} message
+ * @returns {Record<string, Record<string, unknown>>}
+ */
+function materializeResolverInfo (message) {
+  return message.createResolverInfo(message)
+}
+
+/**
  * @param {WeakRef<object>} reference
  * @returns {Promise<boolean>}
  */
@@ -1644,12 +1652,11 @@ void generatedResolver
         })
         const resolveStartChannel = dc.channel('apm:graphql:resolve:start')
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
-        const resolveStartFields = []
+        let resolveStartCalls = 0
         const resolverStartFields = []
-        /** @param {{ info: { fieldName: string } }} message */
-        const onResolveStart = ({ info }) => resolveStartFields.push(info.fieldName)
-        /** @param {{ resolverInfo: Record<string, unknown> }} message */
-        const onResolverStart = ({ resolverInfo }) => resolverStartFields.push(...Object.keys(resolverInfo))
+        const onResolveStart = () => resolveStartCalls++
+        /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+        const onResolverStart = message => resolverStartFields.push(...Object.keys(materializeResolverInfo(message)))
 
         resolveStartChannel.subscribe(onResolveStart)
         resolverStartChannel.subscribe(onResolverStart)
@@ -1675,7 +1682,7 @@ void generatedResolver
           resolverStartChannel.unsubscribe(onResolverStart)
         }
 
-        assert.deepStrictEqual(resolveStartFields.sort(), ['name', 'user'])
+        assert.strictEqual(resolveStartCalls, 2)
         assert.deepStrictEqual(resolverStartFields.sort(), ['name', 'user'])
         assert.strictEqual(queryTypeChecks, 0)
         assert.strictEqual(userTypeChecks, 1)
@@ -1857,12 +1864,11 @@ void generatedResolver
         const { query } = compileQuery(schema, document)
         const resolveStartChannel = dc.channel('apm:graphql:resolve:start')
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
-        const resolveStartFields = []
+        let resolveStartCalls = 0
         const resolverStartFields = []
-        /** @param {{ info: { fieldName: string } }} message */
-        const onResolveStart = ({ info }) => resolveStartFields.push(info.fieldName)
-        /** @param {{ resolverInfo: Record<string, unknown> }} message */
-        const onResolverStart = ({ resolverInfo }) => resolverStartFields.push(...Object.keys(resolverInfo))
+        const onResolveStart = () => resolveStartCalls++
+        /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+        const onResolverStart = message => resolverStartFields.push(...Object.keys(materializeResolverInfo(message)))
 
         resolveStartChannel.subscribe(onResolveStart)
         resolverStartChannel.subscribe(onResolverStart)
@@ -1883,7 +1889,7 @@ void generatedResolver
           resolverStartChannel.unsubscribe(onResolverStart)
         }
 
-        assert.deepStrictEqual(resolveStartFields.sort(), ['defaultHello', 'hello'])
+        assert.strictEqual(resolveStartCalls, 2)
         assert.deepStrictEqual(resolverStartFields.sort(), ['defaultHello', 'hello'])
       })
 
@@ -2019,12 +2025,11 @@ void generatedResolver
       it('keeps AppSec and IAST resolver events when depth disables resolver spans', async () => {
         const resolveStartChannel = dc.channel('apm:graphql:resolve:start')
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
-        const resolveStartFields = []
+        let resolveStartCalls = 0
         const resolverStartFields = []
-        /** @param {{ info: { fieldName: string } }} message */
-        const onResolveStart = ({ info }) => resolveStartFields.push(info.fieldName)
-        /** @param {{ resolverInfo: Record<string, unknown> }} message */
-        const onResolverStart = ({ resolverInfo }) => resolverStartFields.push(...Object.keys(resolverInfo))
+        const onResolveStart = () => resolveStartCalls++
+        /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+        const onResolverStart = message => resolverStartFields.push(...Object.keys(materializeResolverInfo(message)))
 
         agent.reload('graphql', { depth: 0 })
         resolveStartChannel.subscribe(onResolveStart)
@@ -2051,7 +2056,7 @@ void generatedResolver
           agent.reload('graphql', { variables: ['id', 'name'] })
         }
 
-        assert.deepStrictEqual(resolveStartFields.sort(), ['defaultHello', 'hello'])
+        assert.strictEqual(resolveStartCalls, 2)
         assert.deepStrictEqual(resolverStartFields.sort(), ['defaultHello', 'hello'])
       })
 
@@ -2063,8 +2068,10 @@ void generatedResolver
             schema,
             graphql.parse(`query ResolverBlocked { ${fieldName} }`)
           )
-          /** @param {{ abortController: AbortController, resolverInfo: Record<string, unknown> }} message */
-          const onResolverStart = ({ abortController, resolverInfo }) => {
+          /** @param {Parameters<typeof materializeResolverInfo>[0] & { abortController: AbortController }} message */
+          const onResolverStart = (message) => {
+            const { abortController } = message
+            const resolverInfo = materializeResolverInfo(message)
             if (resolverInfo[fieldName]) abortController.abort()
           }
 
@@ -2106,8 +2113,10 @@ void generatedResolver
           graphql.parse('query NestedResolverBlocked { user { name } }')
         )
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
-        /** @param {{ abortController: AbortController, resolverInfo: Record<string, unknown> }} message */
-        const onResolverStart = ({ abortController, resolverInfo }) => {
+        /** @param {Parameters<typeof materializeResolverInfo>[0] & { abortController: AbortController }} message */
+        const onResolverStart = (message) => {
+          const { abortController } = message
+          const resolverInfo = materializeResolverInfo(message)
           if (resolverInfo.name) abortController.abort()
         }
 
@@ -2226,7 +2235,7 @@ void generatedResolver
         )
         const resolveStartChannel = dc.channel('apm:graphql:resolve:start')
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
-        const resolveArguments = new Map([['plain', new Set()], ['value', new Set()]])
+        const resolveArguments = new Set()
         const resolverArguments = []
         const resolverStartCalls = new Map()
         const expectedData = {
@@ -2241,12 +2250,11 @@ void generatedResolver
           assert.strictEqual(resolverArguments.length, 3)
           for (const actual of resolverArguments) assert.deepStrictEqual(actual, expected)
         }
-        /** @param {{ args: object, info: { fieldName: string } }} message */
-        const onResolveStart = ({ args, info }) => {
-          resolveArguments.get(info.fieldName)?.add(args)
-        }
-        /** @param {{ resolverInfo: Record<string, Record<string, unknown>> }} message */
-        const onResolverStart = ({ resolverInfo }) => {
+        /** @param {{ args: object }} message */
+        const onResolveStart = ({ args }) => resolveArguments.add(args)
+        /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+        const onResolverStart = (message) => {
+          const resolverInfo = materializeResolverInfo(message)
           const [fieldName] = Object.keys(resolverInfo)
           resolverStartCalls.set(fieldName, (resolverStartCalls.get(fieldName) ?? 0) + 1)
           if (resolverInfo.value) resolverArguments.push(resolverInfo.value)
@@ -2256,8 +2264,7 @@ void generatedResolver
         try {
           const resultWithoutUpdates = await executeWithTrace(() => query({}, {}, {}), /ResolverList/)
           assert.deepStrictEqual(resultWithoutUpdates.data, expectedData)
-          assert.strictEqual(resolveArguments.get('plain').size, 3)
-          assert.strictEqual(resolveArguments.get('value').size, 3)
+          assert.strictEqual(resolveArguments.size, 7)
           assert.strictEqual(resolverStartCalls.get('plain'), 3)
           assert.strictEqual(resolverStartCalls.get('value'), 3)
           assertResolverArguments({
@@ -2276,7 +2283,7 @@ void generatedResolver
             text: 'text-default',
           })
 
-          for (const args of resolveArguments.values()) args.clear()
+          resolveArguments.clear()
           resolverArguments.length = 0
           resolverStartCalls.clear()
 
@@ -2300,8 +2307,7 @@ void generatedResolver
           resolverStartChannel.unsubscribe(onResolverStart)
         }
 
-        assert.strictEqual(resolveArguments.get('plain').size, 3)
-        assert.strictEqual(resolveArguments.get('value').size, 3)
+        assert.strictEqual(resolveArguments.size, 7)
         assert.strictEqual(resolverStartCalls.get('plain'), 3)
         assert.strictEqual(resolverStartCalls.get('value'), 3)
         assertResolverArguments({
@@ -2396,8 +2402,9 @@ void generatedResolver
         )
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
         const resolverArguments = []
-        /** @param {{ resolverInfo: { value?: Record<string, unknown> } }} message */
-        const onResolverStart = ({ resolverInfo }) => {
+        /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+        const onResolverStart = (message) => {
+          const resolverInfo = materializeResolverInfo(message)
           if (resolverInfo.value) resolverArguments.push(resolverInfo.value)
         }
         const cyclic = { name: 'caller-owned' }
@@ -2449,12 +2456,11 @@ void generatedResolver
          *     filter: { name: string },
          *     keyless: Date,
          *     tags: string[]
-         *   },
-         *   info: { fieldName: string }
+         *   }
          * }} message
          */
-        const onResolveStart = ({ args, info }) => {
-          if (info.fieldName !== 'value') return
+        const onResolveStart = ({ args }) => {
+          if (!Object.hasOwn(args, 'fixedFilter')) return
 
           resolverCyclic = args.cyclic
           resolverFilter = args.filter
@@ -2516,8 +2522,9 @@ void generatedResolver
         )
         const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
         const readOnlyArguments = []
-        /** @param {{ resolverInfo: { value?: Record<string, unknown> } }} message */
-        const onResolverStart = ({ resolverInfo }) => {
+        /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+        const onResolverStart = (message) => {
+          const resolverInfo = materializeResolverInfo(message)
           if (resolverInfo.value) readOnlyArguments.push(resolverInfo.value)
         }
 
@@ -2549,12 +2556,11 @@ void generatedResolver
          *     schemaFilter: { extra: string, name: string },
          *     schemaTags: string[],
          *     tags: string[]
-         *   },
-         *   info: { fieldName: string }
+         *   }
          * }} message
          */
-        const onResolveStart = ({ args, info }) => {
-          if (info.fieldName !== 'value') return
+        const onResolveStart = ({ args }) => {
+          if (!Object.hasOwn(args, 'filter')) return
 
           resolverArguments.push(args)
           if (resolverArguments.length === 1) {
@@ -2629,8 +2635,10 @@ void generatedResolver
         const resolverControllers = new Map()
         const resolverCalls = new Map()
         const resolverChannel = dc.channel('datadog:graphql:resolver:start')
-        /** @param {{ abortController: AbortController, resolverInfo: { value: { id: string } } }} message */
-        const onResolver = ({ abortController, resolverInfo }) => {
+        /** @param {Parameters<typeof materializeResolverInfo>[0] & { abortController: AbortController }} message */
+        const onResolver = (message) => {
+          const { abortController } = message
+          const resolverInfo = materializeResolverInfo(message)
           const { id } = resolverInfo.value
           resolverControllers.set(id, abortController)
           resolverCalls.set(id, (resolverCalls.get(id) ?? 0) + 1)
@@ -2723,8 +2731,10 @@ void generatedResolver
         const contextValue = function contextValue () {}
         const resolverControllers = new Map()
         const resolverChannel = dc.channel('datadog:graphql:resolver:start')
-        /** @param {{ abortController: AbortController, resolverInfo: Record<string, unknown> }} message */
-        const onResolver = ({ abortController, resolverInfo }) => {
+        /** @param {Parameters<typeof materializeResolverInfo>[0] & { abortController: AbortController }} message */
+        const onResolver = (message) => {
+          const { abortController } = message
+          const resolverInfo = materializeResolverInfo(message)
           resolverControllers.set(Object.keys(resolverInfo)[0], abortController)
         }
 
@@ -2954,8 +2964,8 @@ void generatedResolver
       const { query } = compileQuery(schema, document)
       const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
       const resolverInfos = []
-      /** @param {{ resolverInfo: Record<string, unknown> }} message */
-      const onResolverStart = ({ resolverInfo }) => resolverInfos.push(resolverInfo)
+      /** @param {Parameters<typeof materializeResolverInfo>[0]} message */
+      const onResolverStart = message => resolverInfos.push(materializeResolverInfo(message))
 
       resolverStartChannel.subscribe(onResolverStart)
       try {

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -32,11 +32,15 @@ function disable () {
   disableGraphql()
 }
 
-function onGraphqlStartResolver ({ abortController, resolverInfo }) {
+/**
+ * @param {{ createResolverInfo?: (data: object) => object | null }} data
+ */
+function onGraphqlStartResolver (data) {
   const req = getActiveRequest()
 
   if (!req) return
 
+  const resolverInfo = data.createResolverInfo?.(data)
   if (!resolverInfo || typeof resolverInfo !== 'object') return
 
   const result = waf.run({ ephemeral: { [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo } }, req)
@@ -46,7 +50,7 @@ function onGraphqlStartResolver ({ abortController, resolverInfo }) {
     if (requestData?.isInGraphqlRequest) {
       requestData.blocked = true
       requestData.wafAction = blockingAction
-      abortController?.abort()
+      data.abortController?.abort()
     }
   }
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -178,12 +178,12 @@ class TaintTrackingPlugin extends SourceIastPlugin {
   addGraphQLSubscriptions () {
     this.addSub(
       { channelName: 'apm:graphql:resolve:start', tag: HTTP_REQUEST_BODY },
-      (data) => {
+      ({ rootCtx, args }) => {
         const iastContext = getIastContext(storage('legacy').getStore())
-        const source = data.rootCtx?.source
+        const source = rootCtx?.source
         const ranges = source && getRanges(iastContext, source)
         if (ranges?.length) {
-          this._taintTrackingHandler(ranges[0].iinfo.type, data.args, null, iastContext)
+          this._taintTrackingHandler(ranges[0].iinfo.type, args, null, iastContext)
         }
       }
     )

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -18,6 +18,18 @@ const {
   apolloServerCoreChannel,
 } = require('../../src/appsec/channels')
 
+/**
+ * @param {unknown} resolverInfo
+ * @param {object} [abortController]
+ * @returns {{ abortController?: object, createResolverInfo: sinon.SinonStub }}
+ */
+function createResolverMessage (resolverInfo, abortController) {
+  return {
+    abortController,
+    createResolverInfo: sinon.stub().returns(resolverInfo),
+  }
+}
+
 describe('GraphQL', () => {
   let graphql, blocking, telemetry
 
@@ -113,13 +125,13 @@ describe('GraphQL', () => {
     })
 
     it('Should not call waf if resolvers is undefined', () => {
-      startGraphqlResolver.publish({ resolverInfo: undefined })
+      startGraphqlResolver.publish(createResolverMessage(undefined))
 
       sinon.assert.notCalled(waf.run)
     })
 
     it('Should not call waf if resolvers is not an object', () => {
-      startGraphqlResolver.publish({ resolverInfo: '' })
+      startGraphqlResolver.publish(createResolverMessage(''))
 
       sinon.assert.notCalled(waf.run)
     })
@@ -131,9 +143,11 @@ describe('GraphQL', () => {
 
       storage('legacy').getStore.returns({})
 
-      startGraphqlResolver.publish({ resolverInfo })
+      const message = createResolverMessage(resolverInfo)
+      startGraphqlResolver.publish(message)
 
       sinon.assert.notCalled(waf.run)
+      sinon.assert.notCalled(message.createResolverInfo)
     })
 
     it('Should call waf if resolvers is well formatted', () => {
@@ -141,8 +155,10 @@ describe('GraphQL', () => {
         user: [{ id: '1234' }],
       }
 
-      startGraphqlResolver.publish({ resolverInfo })
+      const message = createResolverMessage(resolverInfo)
+      startGraphqlResolver.publish(message)
 
+      sinon.assert.calledOnceWithExactly(message.createResolverInfo, message)
       sinon.assert.calledOnceWithExactly(waf.run, {
         ephemeral: {
           [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo,
@@ -189,7 +205,7 @@ describe('GraphQL', () => {
 
       sinon.stub(waf, 'run').returns([''])
 
-      startGraphqlResolver.publish({ abortController, resolverInfo })
+      startGraphqlResolver.publish(createResolverMessage(resolverInfo, abortController))
 
       sinon.assert.calledOnceWithExactly(waf.run, {
         ephemeral: {
@@ -215,7 +231,7 @@ describe('GraphQL', () => {
 
       sinon.stub(web, 'root').returns(rootSpan)
 
-      startGraphqlResolver.publish({ abortController, resolverInfo })
+      startGraphqlResolver.publish(createResolverMessage(resolverInfo, abortController))
 
       sinon.assert.calledOnceWithExactly(waf.run, {
         ephemeral: {
@@ -247,7 +263,7 @@ describe('GraphQL', () => {
 
       sinon.stub(web, 'root').returns(rootSpan)
 
-      startGraphqlResolver.publish({ abortController, resolverInfo })
+      startGraphqlResolver.publish(createResolverMessage(resolverInfo, abortController))
 
       sinon.assert.calledOnceWithExactly(waf.run, {
         ephemeral: {
@@ -284,7 +300,7 @@ describe('GraphQL', () => {
 
       sinon.stub(web, 'root').returns(rootSpan)
 
-      startGraphqlResolver.publish({ abortController, resolverInfo })
+      startGraphqlResolver.publish(createResolverMessage(resolverInfo, abortController))
 
       sinon.assert.called(context.abortController.abort)
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 
+const TaintedUtils = require('@datadog/native-iast-taint-tracking')
 const dc = require('dc-polyfill')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
@@ -10,6 +11,7 @@ const sinon = require('sinon')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const taintTrackingOperations = require('../../../../src/appsec/iast/taint-tracking/operations')
 const {
+  HTTP_REQUEST_BODY,
   HTTP_REQUEST_COOKIE_VALUE,
   HTTP_REQUEST_HEADER_VALUE,
   HTTP_REQUEST_PATH_PARAM,
@@ -25,6 +27,7 @@ const cookieParseFinishCh = dc.channel('datadog:cookie:parse:finish')
 const processParamsStartCh = dc.channel('datadog:express:process_params:start')
 const routerParamStartCh = dc.channel('datadog:router:param:start')
 const sequelizeFinish = dc.channel('datadog:sequelize:query:finish')
+const graphqlResolveStartChannel = dc.channel('apm:graphql:resolve:start')
 
 describe('IAST Taint tracking plugin', () => {
   let taintTrackingPlugin
@@ -302,6 +305,22 @@ describe('IAST Taint tracking plugin', () => {
         req.url,
         HTTP_REQUEST_URI,
         HTTP_REQUEST_URI
+      )
+    })
+
+    it('Should taint GraphQL resolver arguments from the execution source', () => {
+      sinon.stub(TaintedUtils, 'getRanges').returns([{ iinfo: { type: HTTP_REQUEST_BODY } }])
+      const source = 'query { hello }'
+      const args = { name: 'world' }
+
+      graphqlResolveStartChannel.publish({ rootCtx: { source }, args })
+
+      sinon.assert.calledOnceWithExactly(TaintedUtils.getRanges, transactionId, source)
+      sinon.assert.calledOnceWithExactly(
+        taintTrackingOperations.taintObject,
+        iastContext,
+        args,
+        HTTP_REQUEST_BODY
       )
     })
 


### PR DESCRIPTION
### What does this PR do?

- Moves the GraphQL inactive-subscriber check before generated wrapper allocations across GraphQL, GraphQL Tools, GraphQL-JIT, and Mercurius.
- Limits IAST resolver payloads to `rootCtx` and `args`.
- Defers AppSec resolver metadata until an active request exists.

### Motivation

GraphQL resolver instrumentation allocates argument arrays, paths, and metadata even when no consumer can use them.

The inactive generated-wrapper path drops from 40.18–40.63 ns to 4.36–4.59 ns per call. The inactive AppSec resolver path drops from 31.27–32.20 ns to 5.92–6.09 ns per call.

### Additional Notes

This PR is stacked on #10027.

Tests cover standard GraphQL, GraphQL Tools, GraphQL-JIT, Mercurius, AppSec, IAST, CommonJS, and ESM rewrites. Every changed line and branch is covered.
