### PR TITLE
refactor(eslint): detect guarded array joins

### DIFF
--- a/ci/test-optimization-validation/ci-remediation.js
+++ b/ci/test-optimization-validation/ci-remediation.js
@@ -54,12 +54,12 @@ function getConfiguredTransport (framework) {
 }
 
 function getCiLocation (ciWiring) {
-  const parts = []
-  if (ciWiring.configFile) parts.push(`configuration ${formatPath(ciWiring.configFile)}`)
-  if (ciWiring.workflow) parts.push(`workflow ${JSON.stringify(String(ciWiring.workflow))}`)
-  if (ciWiring.job) parts.push(`job ${JSON.stringify(String(ciWiring.job))}`)
-  if (ciWiring.step) parts.push(`step ${JSON.stringify(String(ciWiring.step))}`)
-  return parts.length > 0 ? parts.join(', ') : 'the selected CI test step'
+  let location = ''
+  if (ciWiring.configFile) location += `configuration ${formatPath(ciWiring.configFile)}`
+  if (ciWiring.workflow) location += `${location ? ', ' : ''}workflow ${JSON.stringify(String(ciWiring.workflow))}`
+  if (ciWiring.job) location += `${location ? ', ' : ''}job ${JSON.stringify(String(ciWiring.job))}`
+  if (ciWiring.step) location += `${location ? ', ' : ''}step ${JSON.stringify(String(ciWiring.step))}`
+  return location || 'the selected CI test step'
 }
 
 function formatPath (filename) {

--- a/ci/test-optimization-validation/report-writer.js
+++ b/ci/test-optimization-validation/report-writer.js
@@ -273,11 +273,13 @@ function getCiVerdict (results) {
   if (ci.evidence?.reasonCode === 'remote-ci-command-unavailable') {
     return 'INCOMPLETE — test execution is delegated to unavailable remote CI code'
   }
-  const facts = []
-  if (ci.evidence?.ciFacts?.initialization?.status === 'missing') facts.push('initialization not visible')
-  if (ci.evidence?.ciFacts?.transport?.status === 'missing') facts.push('transport not visible')
-  if (ci.evidence?.ciFacts?.runnerInvocation?.status === 'unresolved') facts.push('runner path unresolved')
-  return `INCOMPLETE${facts.length > 0 ? ` — ${facts.join('; ')}` : ''}`
+  let facts = ''
+  if (ci.evidence?.ciFacts?.initialization?.status === 'missing') facts = 'initialization not visible'
+  if (ci.evidence?.ciFacts?.transport?.status === 'missing') facts += `${facts ? '; ' : ''}transport not visible`
+  if (ci.evidence?.ciFacts?.runnerInvocation?.status === 'unresolved') {
+    facts += `${facts ? '; ' : ''}runner path unresolved`
+  }
+  return `INCOMPLETE${facts ? ` — ${facts}` : ''}`
 }
 
 function getPrerequisiteVerdict (results) {

--- a/eslint-rules/eslint-no-unnecessary-array-join.mjs
+++ b/eslint-rules/eslint-no-unnecessary-array-join.mjs
@@ -124,6 +124,8 @@ function reportUnnecessaryArrayJoin (node, sourceCode, arrayAppenders, context) 
       return
     }
 
+    if (member.property.name === 'length' && isNonEmptyCheck(member)) continue
+
     const call = member.parent
     if (call.type !== 'CallExpression' || call.callee !== member || call.optional) return
 
@@ -167,6 +169,26 @@ function reportUnnecessaryArrayJoin (node, sourceCode, arrayAppenders, context) 
     messageId: 'buildStringDirectly',
     data: { name: node.id.name },
   })
+}
+
+/**
+ * @param {import('estree').MemberExpression} member
+ * @returns {boolean}
+ */
+function isNonEmptyCheck (member) {
+  const comparison = member.parent
+  if (comparison.type !== 'BinaryExpression') return false
+
+  return (comparison.operator === '>' && comparison.left === member && isZero(comparison.right)) ||
+    (comparison.operator === '<' && comparison.right === member && isZero(comparison.left))
+}
+
+/**
+ * @param {import('estree').Expression | import('estree').PrivateIdentifier} node
+ * @returns {boolean}
+ */
+function isZero (node) {
+  return node.type === 'Literal' && node.value === 0
 }
 
 /**

--- a/eslint-rules/eslint-no-unnecessary-array-join.test.mjs
+++ b/eslint-rules/eslint-no-unnecessary-array-join.test.mjs
@@ -33,6 +33,9 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
       options: [{ reportLiteralArrayJoins: true }],
     },
     "const parts = []; parts.push('a'); consume(parts); parts.join('')",
+    "const parts = []; parts.push('a'); consume(parts.length); parts.join('')",
+    "const parts = []; parts.push('a'); if (parts.length > 1) consume(parts.join(', '))",
+    "const parts = []; parts.push('a'); parts.length = 0; parts.join('')",
     "const parts = []; parts.push('a'); parts.join(separator)",
     "const parts = []; parts.push('a'); parts.join(`$" + '{separator}`)',
     "const parts = []; parts.push('a'); parts.join(''); parts.join('')",
@@ -257,6 +260,24 @@ ruleTester.run('eslint-no-unnecessary-array-join', /** @type {import('eslint').R
         }
       `,
       errors: [{ messageId: 'buildStringDirectly', data: { name: 'parts' } }],
+    },
+    {
+      code: `
+        function build (values) {
+          const aliases = []
+          for (const value of values) {
+            aliases.push(\`\${value} = source\`)
+          }
+          if (aliases.length > 0) {
+            consume(aliases.join(', '))
+          }
+        }
+      `,
+      errors: [{ messageId: 'buildStringDirectly', data: { name: 'aliases' } }],
+    },
+    {
+      code: "const aliases = []; aliases.push('value'); if (0 < aliases.length) consume(aliases.join(', '))",
+      errors: [{ messageId: 'buildStringDirectly', data: { name: 'aliases' } }],
     },
     {
       code: `

--- a/packages/dd-trace/src/aiguard/messages/vercel-ai.js
+++ b/packages/dd-trace/src/aiguard/messages/vercel-ai.js
@@ -75,13 +75,13 @@ function convertVercelPromptToMessages (prompt) {
       }
 
       case 'assistant': {
-        const textParts = []
+        let text
         const toolCalls = []
         if (!Array.isArray(msg.content)) break
 
         for (const part of msg.content) {
           if (part.type === 'text') {
-            textParts.push(part.text)
+            text = text === undefined ? part.text : `${text}\n${part.text}`
           } else if (part.type === 'tool-call') {
             toolCalls.push({
               id: part.toolCallId,
@@ -95,8 +95,8 @@ function convertVercelPromptToMessages (prompt) {
 
         if (toolCalls.length > 0) {
           messages.push({ role: 'assistant', tool_calls: toolCalls })
-        } else if (textParts.length > 0) {
-          messages.push({ role: 'assistant', content: textParts.join('\n') })
+        } else if (text !== undefined) {
+          messages.push({ role: 'assistant', content: text })
         }
         break
       }

--- a/packages/dd-trace/test/aiguard/messages/vercel-ai.spec.js
+++ b/packages/dd-trace/test/aiguard/messages/vercel-ai.spec.js
@@ -180,6 +180,11 @@ describe('aiguard/messages/vercel-ai', () => {
       ])
     })
 
+    it('should preserve an empty assistant text part', () => {
+      const prompt = [{ role: 'assistant', content: [{ type: 'text', text: '' }] }]
+      assert.deepStrictEqual(convertVercelPromptToMessages(prompt), [{ role: 'assistant', content: '' }])
+    })
+
     it('should ignore assistant messages with non-array content', () => {
       const prompt = [{
         role: 'assistant',

--- a/packages/dd-trace/test/ci-visibility/ci-remediation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-remediation.spec.js
@@ -70,6 +70,16 @@ describe('test optimization CI remediation', () => {
     )
   })
 
+  it('formats sparse CI locations without a leading separator', () => {
+    const workflow = buildCiRemediation({ framework: 'jest', ciWiring: { workflow: 'CI' } })
+    const step = buildCiRemediation({ framework: 'jest', ciWiring: { step: 'Run tests' } })
+    const fallback = buildCiRemediation({ framework: 'jest' })
+
+    assert.strictEqual(workflow.location, 'workflow "CI"')
+    assert.strictEqual(step.location, 'step "Run tests"')
+    assert.strictEqual(fallback.location, 'the selected CI test step')
+  })
+
   it('does not recommend agentless variables when CI records Agent transport evidence', () => {
     const remediation = buildCiRemediation({
       framework: 'jest',

--- a/packages/dd-trace/test/ci-visibility/report-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/report-writer.spec.js
@@ -150,6 +150,21 @@ describe('test optimization validation report', () => {
     assert.doesNotMatch(report, /^Coverage:/m)
   })
 
+  it('formats individual and absent CI facts', () => {
+    write([result('ci-wiring', 'error', 'Transport is missing.', {
+      ciFacts: { transport: { status: 'missing' } },
+    })])
+    assert.match(readReport(), /INCOMPLETE — transport not visible/)
+
+    write([result('ci-wiring', 'error', 'The runner path is unresolved.', {
+      ciFacts: { runnerInvocation: { status: 'unresolved' } },
+    })])
+    assert.match(readReport(), /INCOMPLETE — runner path unresolved/)
+
+    write([result('ci-wiring', 'error', 'No static fact is available.')])
+    assert.doesNotMatch(readReport(), /INCOMPLETE —/)
+  })
+
   it('reports a confirmed CI problem when no local check ran', () => {
     write([
       result('ci-wiring', 'fail', 'Test Optimization is not initialized in the selected CI job.', {

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -410,17 +410,17 @@ function selectProduct (scopes) {
  */
 function selectLabeledProduct (labels) {
   const labelSet = new Set(labels)
-  const selected = []
+  let selected
   for (const [product, , productLabels = []] of PRODUCTS) {
     for (const label of productLabels) {
       if (labelSet.has(label)) {
-        selected.push(product)
+        selected = selected === undefined ? product : `${selected} / ${product}`
         break
       }
     }
   }
 
-  return selected.length > 0 ? selected.join(' / ') : undefined
+  return selected
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Teach `eslint-no-unnecessary-array-join` to continue through exact non-empty checks (`array.length > 0` and `0 < array.length`). Convert the newly exposed cases to direct string accumulation.

### Motivation

A non-empty guard made the rule stop before seeing a later static `join()`, so `aliases` in the Undici rewriter configuration was missed.

### Additional Notes

Arbitrary length reads, writes, and thresholds above zero still stop analysis to avoid false positives. Tests preserve empty assistant text parts and sparse CI output.
