### PR TITLE
chore(lint): enable eslint-plugin-regexp rules

### DIFF
--- a/ci/test-optimization-validation/ci-package-scripts.js
+++ b/ci/test-optimization-validation/ci-package-scripts.js
@@ -146,7 +146,7 @@ function getPackageScriptInvocation (command) {
   const literalPrefix = parseLiteralEnvironmentPrefix(command)
   const source = command.slice(literalPrefix.length).trim()
     .replace(/^(?:c8|nyc)(?:\.cmd)?\s+/, '')
-  const match = /^(bun|npm(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:pkg)?(?:\.cmd)?)\s+(?:(run|run-script)\s+)?([\w:-]+)(?:\s+(.+))?$/
+  const match = /^(bun|npm(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:pkg)?(?:\.cmd)?)\s+(?:(run|run-script)\s+)?([\w:-]+)(?:\s+(\S.*))?$/
     .exec(source)
   if (!match) return
 
@@ -155,7 +155,7 @@ function getPackageScriptInvocation (command) {
   if (manager === 'bun' && match[2] !== 'run') return
   if (!match[2] && RESERVED_PACKAGE_MANAGER_COMMANDS[manager]?.has(match[3])) return
   const args = match[4]?.trim()
-  const separatedArguments = args ? /^--(?:\s+(.+))?$/.exec(args) : undefined
+  const separatedArguments = args ? /^--(?:\s+(\S.*))?$/.exec(args) : undefined
   if (['npm', 'pnpm'].includes(manager) && args && !separatedArguments) return
   const scriptArguments = ['npm', 'pnpm'].includes(manager) ? separatedArguments?.[1]?.trim() : args
   if (scriptArguments && !splitLiteralAndChain(scriptArguments)) return

--- a/ci/test-optimization-validation/command-blocker.js
+++ b/ci/test-optimization-validation/command-blocker.js
@@ -16,13 +16,15 @@ const MODULE_OR_TRANSFORM_PATTERN =
   /\b(?:Cannot find (?:module|package)|ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|ERR_PACKAGE_PATH_NOT_EXPORTED|Package subpath\b[\s\S]+\bnot defined by "exports"|Could not resolve|transform failed)\b/i
 const BUILD_ARTIFACT_PATH_PATTERN = String.raw`(?:^|[\\/])(?:build|dist|generated)(?:[\\/]|['"])`
 const MISSING_ARTIFACT_MESSAGE_PATTERN =
-  '(?:Cannot find (?:module|package)|ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|ENOENT|no such file or directory|' +
-  'is not found|does not exist|could not be found)'
+  /Cannot find (?:module|package)|ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|ENOENT|no such file or directory|is not found|does not exist|could not be found/
+/* eslint-disable regexp/no-useless-non-capturing-group, regexp/prefer-character-class --
+ * The interpolated message fragment contains alternatives and must stay grouped on both sides of the path. */
 const BUILD_ARTIFACT_MISSING_PATTERN = new RegExp(
-  String.raw`(?:${MISSING_ARTIFACT_MESSAGE_PATTERN}[^\r\n]{0,500}${BUILD_ARTIFACT_PATH_PATTERN}|` +
-    String.raw`${BUILD_ARTIFACT_PATH_PATTERN}[^\r\n]{0,500}${MISSING_ARTIFACT_MESSAGE_PATTERN})`,
+  String.raw`(?:(?:${MISSING_ARTIFACT_MESSAGE_PATTERN.source})[^\r\n]{0,500}${BUILD_ARTIFACT_PATH_PATTERN}|` +
+    String.raw`${BUILD_ARTIFACT_PATH_PATTERN}[^\r\n]{0,500}(?:${MISSING_ARTIFACT_MESSAGE_PATTERN.source}))`,
   'im'
 )
+/* eslint-enable regexp/no-useless-non-capturing-group, regexp/prefer-character-class */
 const FILE_PATH_REFERENCE_PATTERN = /(?:^|[\s('"`])((?:\.{1,2}[\\/]|[\\/]|[A-Za-z]:[\\/])[^'"`\s),;]*)/g
 const CUCUMBER_CONFIG_OPTION_UNSUPPORTED_PATTERN = /unknown option ['"]--config['"]/i
 const CYPRESS_BINARY_PATTERN =
@@ -41,7 +43,7 @@ const PUPPETEER_BROWSER_PATTERN =
 const PUPPETEER_BROWSER_ABORT_PATTERN =
   /Failed to launch the browser process[\s\S]*?(?:signal=SIGABRT|Received signal 6|Abort trap: 6)/i
 const CUCUMBER_BROWSER_FAILURE_PATTERN =
-  /(?:(?:browser|puppeteer|playwright|webdriver)[^\r\n]{0,160}\b(?:aborted|closed|crashed|failed|terminated|unavailable)\b|(?:Failed|Unable) to (?:connect to|launch|start) (?:the )?browser)/i
+  /(?:browser|puppeteer|playwright|webdriver)[^\r\n]{1,160}\b(?:aborted|closed|crashed|failed|terminated|unavailable)\b|(?:Failed|Unable) to (?:connect to|launch|start) (?:the )?browser/i
 const VITEST_BROWSER_PROVIDER_PATTERN =
   /Cannot find (?:module|package).*@vitest\/browser|@vitest\/browser-[^\s'"].*(?:missing|not (?:found|installed))/i
 const RUNNER_COMMAND_NOT_FOUND_PATTERN =

--- a/ci/test-optimization-validation/framework-adapters/cucumber.js
+++ b/ci/test-optimization-validation/framework-adapters/cucumber.js
@@ -478,7 +478,7 @@ function getYamlStringProfileDefinitions (source) {
   const definitions = new Map()
   for (const line of source.split(/\r?\n/)) {
     if (!line.trim() || /^\s*#/.test(line)) continue
-    const match = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line)
+    const match = /^([A-Za-z0-9_-]+):(.*)$/.exec(line)
     const definition = match && !/^\s/.test(line) ? getYamlStringProfileDefinition(match[2]) : undefined
     if (definition === undefined) {
       throw new Error('YAML profiles must be literal one-line command strings')

--- a/ci/test-optimization-validation/framework-adapters/vitest.js
+++ b/ci/test-optimization-validation/framework-adapters/vitest.js
@@ -213,7 +213,7 @@ function getProjectObject (source, nameIndex, workspaceConfig) {
 function isStandaloneProjectObject (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, range.start))
   const after = maskJavaScriptNonCode(source.slice(range.end + 1))
-  return PROJECT_CALL_PATTERN.test(before) && /^\s*,?\s*\)[\s;]*$/.test(after)
+  return PROJECT_CALL_PATTERN.test(before) && /^\s*(?:,\s*)?\)[\s;]*$/.test(after)
 }
 
 /**
@@ -259,7 +259,7 @@ function isExportedConfigObject (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, range.start))
   const after = maskJavaScriptNonCode(source.slice(range.end + 1))
   return (DIRECT_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
-    (CONFIG_CALL_PATTERN.test(before) && /^\s*,?\s*\)[\s;]*$/.test(after))
+    (CONFIG_CALL_PATTERN.test(before) && /^\s*(?:,\s*)?\)[\s;]*$/.test(after))
 }
 
 /**
@@ -276,7 +276,7 @@ function isWorkspaceProjectEntry (source, range) {
   const before = maskJavaScriptNonCode(source.slice(0, workspaceArray.start))
   const after = maskJavaScriptNonCode(source.slice(workspaceArray.end + 1))
   return (DIRECT_EXPORT_PATTERN.test(before) && /^[\s;]*$/.test(after)) ||
-    (WORKSPACE_ARRAY_CALL_PATTERN.test(before) && /^\s*,?\s*\)[\s;]*$/.test(after))
+    (WORKSPACE_ARRAY_CALL_PATTERN.test(before) && /^\s*(?:,\s*)?\)[\s;]*$/.test(after))
 }
 
 /**

--- a/ci/test-optimization-validation/package-check.js
+++ b/ci/test-optimization-validation/package-check.js
@@ -88,7 +88,7 @@ function getFailureDetail (result) {
 }
 
 function sanitizeLine (value) {
-  return sanitizeString(String(value)).replaceAll(/\p{Cc}+/gu, ' ').trim().slice(0, 1000).replace(/[.]+$/, '')
+  return sanitizeString(String(value)).replaceAll(/\p{Cc}+/gu, ' ').trim().slice(0, 1000).replace(/\.+$/, '')
 }
 
 module.exports = { checkInstalledPackage, getInstalledPackageFailure }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import eslintPluginJSDoc from 'eslint-plugin-jsdoc'
 import eslintPluginMocha from 'eslint-plugin-mocha'
 import eslintPluginN from 'eslint-plugin-n'
 import eslintPluginPromise from 'eslint-plugin-promise'
+import eslintPluginRegexp from 'eslint-plugin-regexp'
 import eslintPluginSonar from 'eslint-plugin-sonarjs'
 import eslintPluginUnicorn from 'eslint-plugin-unicorn'
 import globals from 'globals'
@@ -668,6 +669,44 @@ export default [
       // (`assertPromise`, `prepareTestServerForIast`) instead of literal `it()` calls.
       'sonarjs/no-empty-test-file': 'off',
       'sonarjs/todo-tag': 'off', // 434 errors. We use TODO/FIXME as tracked markers by policy.
+    },
+  },
+  eslintPluginRegexp.configs['flat/recommended'],
+  {
+    name: 'dd-trace/regexp',
+    rules: {
+      'regexp/no-dupe-disjunctions': 'error',
+      'regexp/optimal-lookaround-quantifier': 'error',
+      'regexp/no-useless-flag': 'error',
+      'regexp/no-useless-lazy': 'error',
+      'regexp/prefer-predefined-assertion': 'error',
+      'regexp/strict': 'error',
+      'regexp/prefer-range': 'error',
+      'regexp/no-useless-non-capturing-group': 'error',
+      'regexp/prefer-character-class': 'error',
+      'regexp/optimal-quantifier-concatenation': 'error',
+      'regexp/no-misleading-capturing-group': 'error',
+      'regexp/no-super-linear-move': 'off',
+      'regexp/no-unused-capturing-group': 'off',
+      'regexp/negation': 'off',
+      'regexp/prefer-w': 'off',
+      'regexp/use-ignore-case': 'off',
+      'regexp/prefer-d': 'off',
+      'regexp/sort-flags': 'off',
+    },
+  },
+  {
+    name: 'dd-trace/regexp-generated',
+    files: [
+      'packages/dd-trace/src/appsec/iast/analyzers/hardcoded-secret-rules.js',
+      'packages/dd-trace/src/appsec/iast/analyzers/hardcoded-password-rules.js',
+    ],
+    rules: {
+      'regexp/no-dupe-disjunctions': 'off',
+      'regexp/prefer-range': 'off',
+      'regexp/optimal-quantifier-concatenation': 'off',
+      'regexp/prefer-character-class': 'off',
+      'regexp/no-useless-non-capturing-group': 'off',
     },
   },
   {

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -3406,7 +3406,7 @@ describe(`cucumber@${version} commonJS`, () => {
                 assert.match(stdout, /Attempt to fix passed/)
               } else {
                 assert.match(stdout, /Attempt to fix failed/)
-                assert.doesNotMatch(stdout, /execution(?:s)? [\d, -]+:/)
+                assert.doesNotMatch(stdout, /executions? [\d, -]+:/)
               }
               if (isQuarantined || isDisabled) {
                 assert.doesNotMatch(stdout, /Errors are suppressed because this test is/)

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -443,7 +443,7 @@ moduleTypes.forEach(({
               assert.match(stdout, /Attempt to fix passed/)
             } else {
               assert.match(stdout, /Attempt to fix failed/)
-              assert.doesNotMatch(stdout, /execution(?:s)? [\d, -]+:/)
+              assert.doesNotMatch(stdout, /executions? [\d, -]+:/)
             }
             if (isQuarantined || isDisabled) {
               assert.doesNotMatch(stdout, /Errors are suppressed because this test is/)

--- a/integration-tests/esbuild/build-and-test-koa.mjs
+++ b/integration-tests/esbuild/build-and-test-koa.mjs
@@ -29,7 +29,11 @@ try {
   if (NODE_MAJOR >= 22) {
     // it is resolved as ESM module only in node 22+, becaues the require.resolve accepts conditions in node 22+
     assert.match(data, /register.*koa.mjs".*"koa"\);$/m, 'Bundle should contain the koa ESM instrumentation')
-    assert.match(data, /register.*@koa\/router.*".*"@koa\/router"\);$/m, 'Bundle should contain the @koa/router instrumentation')
+    assert.match(
+      data,
+      /register.*@koa\/router[^\n\r"\u2028\u2029]*".*"@koa\/router"\);$/m,
+      'Bundle should contain the @koa/router instrumentation'
+    )
   } else {
     assert.match(data, /^ {8}package: "koa",$/m, 'Bundle should contain the koa CJS instrumentation')
     assert.match(data, /^ {8}package: "@koa\/router",$/m, 'Bundle should contain the @koa/router instrumentation')

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -342,9 +342,9 @@ describe('init.js', () => {
        */
       function checkGlobalPreload (out) {
         assert.match(out,
-          /^if \(getBuiltin\('module'\)\.createRequire\("file:.+\/initialize\.mjs"\)\('\.\/init\.js'\)\) {\n/)
+          /^if \(getBuiltin\('module'\)\.createRequire\("file:.+\/initialize\.mjs"\)\('\.\/init\.js'\)\) \{\n/)
         assert.match(out,
-          /\n {2}process\.emitWarning\('dd-trace cannot instrument ES modules on Node\.js 20\.0\.0\. Upgrade to Node\.js 20\.1\.0 or newer\.'\)\n}\n$/)
+          /\n {2}process\.emitWarning\('dd-trace cannot instrument ES modules on Node\.js 20\.0\.0\. Upgrade to Node\.js 20\.1\.0 or newer\.'\)\n\}\n$/)
       }
 
       it('provides application-realm preload source', () =>

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -481,7 +481,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
                     'across 1 of 1 test\\(s\\)\\.'
                   )
                 )
-                assert.doesNotMatch(stdout, /execution(?:s)? [\d, -]+:/)
+                assert.doesNotMatch(stdout, /executions? [\d, -]+:/)
               }
               if (isQuarantined || isDisabled) {
                 assert.doesNotMatch(stdout, /Errors are suppressed because this test is/)
@@ -1873,7 +1873,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           // Verify Datadog Test Optimization message is shown for suppressed quarantine failures
           assert.match(stdout, /Datadog Test Optimization/)
           assert.match(stdout, /Quarantined: 1 test run; 1 failure did not affect the test session\./)
-          assert.match(stdout, /test-quarantine-1.*›.*quarantine tests can quarantine a test/)
+          assert.match(stdout, /test-quarantine-1[^\n\r\u2028\u2029›]*›.*quarantine tests can quarantine a test/)
         } else {
           assert.strictEqual(exitCode, 1)
         }

--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -3098,8 +3098,8 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       assert.match(testOutput, /Datadog Test Optimization/)
       assert.match(testOutput, /\d+ test failure\(s\) were ignored\. Exit code set to 0\./)
       assert.match(testOutput, /Early Flake Detection/)
-      assert.match(testOutput, /two-occasionally-failing-tests.*›.*fail first occasionally fails/)
-      assert.match(testOutput, /two-occasionally-failing-tests.*›.*fail second occasionally fails/)
+      assert.match(testOutput, /two-occasionally-failing-tests[^\n\r\u2028\u2029›]*›.*fail first occasionally fails/)
+      assert.match(testOutput, /two-occasionally-failing-tests[^\n\r\u2028\u2029›]*›.*fail second occasionally fails/)
     })
 
     // resetting snapshot state logic only works in latest versions

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6605,7 +6605,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
                 assert.match(stdout, /Attempt to fix passed/)
               } else {
                 assert.match(stdout, /Attempt to fix failed/)
-                assert.doesNotMatch(stdout, /execution(?:s)? [\d, -]+:/)
+                assert.doesNotMatch(stdout, /executions? [\d, -]+:/)
               }
               if (isQuarantined || isDisabled) {
                 assert.doesNotMatch(stdout, /Errors are suppressed because this test is/)

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -483,7 +483,7 @@ versions.forEach((version) => {
                 assert.match(stdout, /Attempt to fix passed/)
               } else {
                 assert.match(stdout, /Attempt to fix failed/)
-                assert.doesNotMatch(stdout, /execution(?:s)? [\d, -]+:/)
+                assert.doesNotMatch(stdout, /executions? [\d, -]+:/)
               }
               if (isQuarantined || isDisabled) {
                 assert.doesNotMatch(stdout, /Errors are suppressed because this test is/)

--- a/integration-tests/vitest/vitest.test-management.spec.js
+++ b/integration-tests/vitest/vitest.test-management.spec.js
@@ -509,7 +509,7 @@ versions.forEach((version) => {
                     assert.match(stdout, /Attempt to fix passed/)
                   } else {
                     assert.match(stdout, /Attempt to fix failed/)
-                    assert.doesNotMatch(stdout, /execution(?:s)? [\d, -]+:/)
+                    assert.doesNotMatch(stdout, /executions? [\d, -]+:/)
                   }
                   if (isQuarantining || isDisabling) {
                     assert.doesNotMatch(stdout, /Errors are suppressed because this test is/)

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "eslint-plugin-mocha": "^12.0.2",
     "eslint-plugin-n": "^18.3.0",
     "eslint-plugin-promise": "^7.3.0",
+    "eslint-plugin-regexp": "^3.1.0",
     "eslint-plugin-sonarjs": "^4.2.0",
     "eslint-plugin-unicorn": "^74.0.0",
     "express": "^5.1.0",

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -1132,6 +1132,7 @@ describe('check-require-cache', () => {
       filePath: 'pregel-class.js',
     })
 
+    // eslint-disable-next-line regexp/no-super-linear-backtracking -- Generated fixture content is bounded.
     assert.match(content, /\bimport\s+.+\s+from\s+"file:\/\//)
     assert.match(content, /tr_ch_apm_tracingChannel/)
     assert.doesNotMatch(content, /require\("/)

--- a/packages/datadog-plugin-ws/test/index.spec.js
+++ b/packages/datadog-plugin-ws/test/index.spec.js
@@ -837,7 +837,7 @@ describe('Plugin', () => {
             const { attributes } = pointerLink
             assert.ok(Object.hasOwn(attributes, 'ptr.hash'), `Available keys: ${inspect(Object.keys(attributes))}`)
             // Hash format: <prefix><32 hex trace id><16 hex span id><8 hex counter>
-            assert.match(attributes['ptr.hash'], /^[SC][0-9a-f]{32}[0-9a-f]{16}[0-9a-f]{8}$/)
+            assert.match(attributes['ptr.hash'], /^[SC][0-9a-f]{56}$/)
             assert.strictEqual(attributes['ptr.hash'].length, 57)
           })
 
@@ -883,7 +883,7 @@ describe('Plugin', () => {
             const { attributes } = pointerLink
             assert.ok(Object.hasOwn(attributes, 'ptr.hash'), `Available keys: ${inspect(Object.keys(attributes))}`)
             // Hash format: <prefix><32 hex trace id><16 hex span id><8 hex counter>
-            assert.match(attributes['ptr.hash'], /^[SC][0-9a-f]{32}[0-9a-f]{16}[0-9a-f]{8}$/)
+            assert.match(attributes['ptr.hash'], /^[SC][0-9a-f]{56}$/)
             assert.strictEqual(attributes['ptr.hash'].length, 57)
           })
 

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
@@ -8,7 +8,7 @@ const MYSQL_STRING_LITERAL = String.raw`"(?:\\"|[^"])*"|'(?:\\'|[^'])*'`
 const LINE_COMMENT = '--.*$'
 const BLOCK_COMMENT = String.raw`/\*[\s\S]*\*/`
 const EXPONENT = String.raw`(?:E[-+]?\d+[fd]?)?`
-const INTEGER_NUMBER = String.raw`(?<!\w)\d+`
+const INTEGER_NUMBER = String.raw`\b\d+`
 const DECIMAL_NUMBER = String.raw`\d*\.\d+`
 const HEX_NUMBER = 'x\'[0-9a-f]+\'|0x[0-9a-f]+'
 const BIN_NUMBER = 'b\'[0-9a-f]+\'|0b[0-9a-f]+'
@@ -30,6 +30,8 @@ const patterns = {
     'gmi'
   ),
   ORACLE: new RegExp(
+    // The capture owns the quote delimiter while the lazy quantifier owns the body.
+    // eslint-disable-next-line regexp/optimal-quantifier-concatenation
     `${NUMERIC_LITERAL}|${ORACLE_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
     'gmi'
   ),

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/url-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/url-sensitive-analyzer.js
@@ -8,7 +8,7 @@ const AUTHORITY = '^(?:[^:]+:)?//([^@]+)@'
 // boundaries), so excluding them preserves match semantics for valid URLs while keeping
 // the regex linear on arbitrary input.
 const QUERY_FRAGMENT = '[?#&]([^=&;?#]+)=([^?#&]+)'
-const pattern = new RegExp(`${AUTHORITY}|${QUERY_FRAGMENT}`, 'gmi')
+const pattern = new RegExp(`${AUTHORITY}|${QUERY_FRAGMENT}`, 'gm')
 
 module.exports = function extractSensitiveRanges (evidence) {
   try {

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -45,7 +45,9 @@ function parseEmailAndName (emailAndName) {
   }
   let name = ''
   let email = ''
-  const matchNameAndEmail = emailAndName.match(/(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)/)
+  // Untrusted git author metadata (a fork PR controls it). The anchor fixes the start position, the
+  // email classes cannot overlap around `@`, and the slice bounds the optional name part.
+  const matchNameAndEmail = emailAndName.slice(0, 1024).match(/^(?:"?([^"]*)"?\s)?<?([^\s@]+@[^\s>]+)>?/)
   if (matchNameAndEmail) {
     name = matchNameAndEmail[1]
     email = matchNameAndEmail[2]

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1631,8 +1631,8 @@ function isAsciiDigit (code) {
 function parseStackFrameLocation (frame, expectedPath) {
   let pathStart = frame.lastIndexOf(expectedPath)
   while (frame.charCodeAt(pathStart - 1) !== 0x28 /* ( */ &&
-         !frame.startsWith('at ', pathStart - 3) &&
-         !frame.startsWith('file://', pathStart - 7)) {
+        !frame.startsWith('at ', pathStart - 3) &&
+        !frame.startsWith('file://', pathStart - 7)) {
     const previousPathStart = frame.lastIndexOf(expectedPath, pathStart - 1)
     if (previousPathStart === -1) break
     pathStart = previousPathStart

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1629,7 +1629,15 @@ function isAsciiDigit (code) {
  * @returns {{ file: string, line: number } | null}
  */
 function parseStackFrameLocation (frame, expectedPath) {
-  const scope = frame.slice(frame.lastIndexOf(expectedPath))
+  let pathStart = frame.lastIndexOf(expectedPath)
+  while (frame.charCodeAt(pathStart - 1) !== 0x28 /* ( */ &&
+         !frame.startsWith('at ', pathStart - 3) &&
+         !frame.startsWith('file://', pathStart - 7)) {
+    const previousPathStart = frame.lastIndexOf(expectedPath, pathStart - 1)
+    if (previousPathStart === -1) break
+    pathStart = previousPathStart
+  }
+  const scope = frame.slice(pathStart)
   let end = scope.length
   if (scope.charCodeAt(end - 1) === 0x29 /* ) */) end--
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1641,7 +1641,7 @@ function parseStackFrameLocation (frame, expectedPath) {
   let end = scope.length
   if (scope.charCodeAt(end - 1) === 0x29 /* ) */) end--
 
-  for (;;) {
+  while (true) {
     let lastNumberStart = end
     while (lastNumberStart > 0 && isAsciiDigit(scope.charCodeAt(lastNumberStart - 1))) {
       lastNumberStart--

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -130,7 +130,7 @@ const TEST_IS_MODIFIED = 'test.is_modified'
 const TEST_HAS_DYNAMIC_NAME = '_dd.has_dynamic_name'
 const CI_APP_ORIGIN = 'ciapp-test'
 // eslint-disable-next-line no-control-regex
-const TEST_OPTIMIZATION_NAME_CONTROL_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g
+const TEST_OPTIMIZATION_NAME_CONTROL_RE = /[\u0000-\u0008\v\f\u000E-\u001F\u007F-\u009F]/g
 const TEST_OPTIMIZATION_NAME_WHITESPACE_RE = /\s+/g
 
 // Matches patterns that are almost certainly runtime-generated values in test names:
@@ -1611,19 +1611,69 @@ function fromCoverageMapToCoverage (coverageMap) {
   }, {})
 }
 
+/**
+ * @param {number} code
+ * @returns {boolean}
+ */
+function isAsciiDigit (code) {
+  return code >= 0x30 && code <= 0x39
+}
+
+/**
+ * Parse a V8 stack frame into its file path and 1-based line number.
+ *
+ * Stack text includes caller-controlled function names and can be overwritten. Scan numeric suffixes
+ * right-to-left and discard V8's trailing anonymous location for eval frames.
+ * @param {string} frame
+ * @param {string} expectedPath A known path contained in the frame.
+ * @returns {{ file: string, line: number } | null}
+ */
+function parseStackFrameLocation (frame, expectedPath) {
+  const scope = frame.slice(frame.lastIndexOf(expectedPath))
+  let end = scope.length
+  if (scope.charCodeAt(end - 1) === 0x29 /* ) */) end--
+
+  for (;;) {
+    let lastNumberStart = end
+    while (lastNumberStart > 0 && isAsciiDigit(scope.charCodeAt(lastNumberStart - 1))) {
+      lastNumberStart--
+    }
+    if (lastNumberStart === end || scope.charCodeAt(lastNumberStart - 1) !== 0x3A /* : */) {
+      return null
+    }
+    const colonBeforeLast = lastNumberStart - 1
+    let lineStart = colonBeforeLast
+    while (lineStart > 0 && isAsciiDigit(scope.charCodeAt(lineStart - 1))) {
+      lineStart--
+    }
+    if (lineStart < colonBeforeLast && scope.charCodeAt(lineStart - 1) === 0x3A /* : */) {
+      const fileEnd = lineStart - 1
+      const anonymousStart = fileEnd - 11
+      if (scope.charCodeAt(fileEnd - 1) === 0x3E /* > */ && anonymousStart >= 3 &&
+          scope.startsWith('<anonymous>', anonymousStart) &&
+          scope.charCodeAt(anonymousStart - 1) === 0x20 /* space */ &&
+          scope.charCodeAt(anonymousStart - 2) === 0x2C /* , */ &&
+          scope.charCodeAt(anonymousStart - 3) === 0x29 /* ) */) {
+        end = anonymousStart - 3
+        while (scope.charCodeAt(end - 1) === 0x29 /* ) */) end--
+        continue
+      }
+      return { file: scope.slice(0, fileEnd), line: Number(scope.slice(lineStart, colonBeforeLast)) }
+    }
+    return { file: scope.slice(0, colonBeforeLast), line: Number(scope.slice(lastNumberStart, end)) }
+  }
+}
+
 // Get the start line of a test by inspecting a given error's stack trace
 function getTestLineStart (err, testSuitePath) {
   if (!err.stack) {
     return null
   }
-  // From https://github.com/felixge/node-stack-trace/blob/ba06dcdb50d465cd440d84a563836e293b360427/index.js#L40
   const testFileLine = err.stack.split('\n').find(line => line.includes(testSuitePath))
-  try {
-    const testFileLineMatch = testFileLine.match(/at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/)
-    return Number.parseInt(testFileLineMatch[3], 10) || null
-  } catch {
+  if (!testFileLine) {
     return null
   }
+  return parseStackFrameLocation(testFileLine, testSuitePath)?.line || null
 }
 
 // Get the end line of a test by inspecting a given function's source code
@@ -1646,7 +1696,7 @@ function parseAnnotations (annotations) {
     }
     const { type, description } = annotation
     if (type.startsWith('DD_TAGS')) {
-      const regex = /\[(.*?)\]/
+      const regex = /^DD_TAGS\[([^\]]*)\]/
       const match = regex.exec(type)
       let tagValue = ''
       if (match) {
@@ -1750,15 +1800,9 @@ function getFileAndLineNumberFromError (error, repositoryRoot) {
   }
 
   const topFrame = frames[topRelevantFrameIndex]
-  // Regular expression to match the file path, line number, and column number
-  const regex = /\s*at\s+(?:.*\()?(.+):(\d+):(\d+)\)?/
-  const match = topFrame.match(regex)
-
-  if (match) {
-    const filePath = match[1]
-    const lineNumber = Number(match[2])
-
-    return [filePath, lineNumber, topRelevantFrameIndex]
+  const location = parseStackFrameLocation(topFrame, repositoryRoot)
+  if (location) {
+    return [location.file, location.line, topRelevantFrameIndex]
   }
   return []
 }

--- a/packages/dd-trace/src/plugins/util/url.js
+++ b/packages/dd-trace/src/plugins/util/url.js
@@ -14,7 +14,7 @@ const INT_SEGMENT = /^[1-9][0-9]+$/ // Integer of size at least 2 (>=10)
 const INT_ID_SEGMENT = /^(?=.*[0-9])[0-9._-]{3,}$/ // Mixed string with digits and delimiters
 const HEX_SEGMENT = /^(?=.*[0-9])[A-Fa-f0-9]{6,}$/ // Hexadecimal digits of size at least 6 with at least one decimal digit
 const HEX_ID_SEGMENT = /^(?=.*[0-9])[A-Fa-f0-9._-]{6,}$/ // Mixed string with hex digits and delimiters
-const STRING_SEGMENT = /(?:^.{20,}|[%&'()*+,:=@])/ // Long string or a string containing special characters
+const SPECIAL_CHARACTER_SEGMENT = /[%&'()*+,:=@]/
 
 /**
  * Extract full URL from HTTP request
@@ -167,7 +167,7 @@ function calculateHttpEndpoint (url) {
 
     if (HEX_ID_SEGMENT.test(element)) return '{param:hex_id}'
 
-    if (STRING_SEGMENT.test(element)) return '{param:str}'
+    if (element.length >= 20 || SPECIAL_CHARACTER_SEGMENT.test(element)) return '{param:str}'
 
     // No match
     return element

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -658,6 +658,20 @@ describe('CiPlugin', () => {
     assert.deepStrictEqual(plugin.diBreakpointHitResolvers, [])
   })
 
+  it('adds a DI probe using the full path when the repository root repeats', () => {
+    const plugin = createPlugin('jest_worker')
+    const addLineProbe = sinon.stub().returns(['probe-1', Promise.resolve()])
+    const file = '/app/packages/app/index.js'
+    const line = 23
+    const error = { stack: `Error: test failed\n    at test (${file}:${line}:5)` }
+    plugin.di = { addLineProbe }
+    plugin._setRepositoryRoot('/app', [])
+
+    plugin.addDiProbe(error)
+
+    assert.deepStrictEqual(addLineProbe.firstCall.args[0], { file, line })
+  })
+
   it('adds a new DI probe after removing one from the same location', async () => {
     const plugin = createPlugin('jest_worker')
     const setProbePromise = Promise.resolve()

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -2225,6 +2225,31 @@ describe('getFileAndLineNumberFromError', () => {
     assert.deepStrictEqual(getFileAndLineNumberFromError(unwrappedError, '/repo'), ['/repo/src/a(b).js', 12, 0])
   })
 
+  it('preserves a repeated repository root in wrapped and unwrapped file paths', () => {
+    const wrappedError = { stack: 'Error\n    at handler (/app/packages/app/index.js:12:3)' }
+    const unwrappedError = { stack: 'Error\n    at /app/packages/app/index.js:12:3' }
+
+    assert.deepStrictEqual(
+      getFileAndLineNumberFromError(wrappedError, '/app'),
+      ['/app/packages/app/index.js', 12, 0]
+    )
+    assert.deepStrictEqual(
+      getFileAndLineNumberFromError(unwrappedError, '/app'),
+      ['/app/packages/app/index.js', 12, 0]
+    )
+  })
+
+  it('does not parse a repository root from the function name', () => {
+    const error = { stack: 'Error\n    at /app (/app/src/index.js:12:3)' }
+    const fileUrlError = { stack: 'Error\n    at /app (file:///app/packages/app/index.js:12:3)' }
+
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/app'), ['/app/src/index.js', 12, 0])
+    assert.deepStrictEqual(
+      getFileAndLineNumberFromError(fileUrlError, '/app'),
+      ['/app/packages/app/index.js', 12, 0]
+    )
+  })
+
   it('ignores parentheses in the function name', () => {
     const error = { stack: 'Error\n    at foo(bar) (/repo/src/run.js:12:3)' }
     assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), ['/repo/src/run.js', 12, 0])

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -54,6 +54,8 @@ const {
   TEST_BROWSER_VERSION,
   TEST_IS_RUM_ACTIVE,
   DD_CAPABILITIES_TEST_IMPACT_ANALYSIS,
+  getTestLineStart,
+  getFileAndLineNumberFromError,
 } = require('../../../src/plugins/util/test')
 
 const {
@@ -2138,5 +2140,115 @@ describe('checkShaDiscrepancies', () => {
     checkShaDiscrepancies(ciMetadata, userProvidedGitMetadata)
 
     sinon.assert.calledWith(incrementCountMetricStub, TELEMETRY_GIT_SHA_MATCH, { matched: true })
+  })
+})
+
+describe('getTestLineStart', () => {
+  it('returns the line of the first frame matching the suite path', () => {
+    const error = {
+      stack: [
+        'Error: boom',
+        '    at assert (/repo/node_modules/chai/lib.js:100:7)',
+        '    at Context.<anonymous> (/repo/test/foo.spec.js:42:13)',
+      ].join('\n'),
+    }
+    assert.strictEqual(getTestLineStart(error, '/repo/test/foo.spec.js'), 42)
+  })
+
+  it('ignores parentheses in the function name', () => {
+    const error = { stack: 'Error\n    at foo(bar) (/repo/test/foo.spec.js:42:13)' }
+    assert.strictEqual(getTestLineStart(error, '/repo/test/foo.spec.js'), 42)
+  })
+
+  it('parses frames without a parenthesized function name', () => {
+    const error = { stack: 'Error\n    at /repo/test/bar.spec.js:7:2' }
+    assert.strictEqual(getTestLineStart(error, '/repo/test/bar.spec.js'), 7)
+  })
+
+  it('parses a frame without a column number', () => {
+    const error = { stack: 'Error\n    at /repo/test/bar.spec.js:7' }
+    assert.strictEqual(getTestLineStart(error, '/repo/test/bar.spec.js'), 7)
+  })
+
+  it('uses the source location from an eval frame', () => {
+    const error = {
+      stack: 'Error\n    at eval (eval at run (/repo/test/foo.spec.js:42:13), <anonymous>:1:3)',
+    }
+    assert.strictEqual(getTestLineStart(error, '/repo/test/foo.spec.js'), 42)
+  })
+
+  it('uses the source location from a nested eval frame', () => {
+    const error = {
+      stack: 'Error\n    at eval (eval at outer (eval at run (/repo/test/foo.spec.js:42:13)), <anonymous>:1:3)',
+    }
+    assert.strictEqual(getTestLineStart(error, '/repo/test/foo.spec.js'), 42)
+  })
+
+  it('returns null without a stack or matching frame', () => {
+    assert.strictEqual(getTestLineStart({}, '/repo/test/foo.spec.js'), null)
+    assert.strictEqual(getTestLineStart({ stack: 'Error\n    at fn (/repo/x.js:1:1)' }, '/repo/miss.js'), null)
+    assert.strictEqual(
+      getTestLineStart({ stack: 'Error\n    at /repo/test/foo.spec.js' }, '/repo/test/foo.spec.js'),
+      null
+    )
+  })
+
+  it('stays linear on an attacker-shaped newline-free frame', () => {
+    const suite = '/repo/test/evil.spec.js'
+    const error = { stack: `at ${'('.repeat(200_000)}${suite}:5:1` }
+    assert.strictEqual(getTestLineStart(error, suite), 5)
+  })
+})
+
+describe('getFileAndLineNumberFromError', () => {
+  it('returns the file, line, and index of the first non-dependency frame under the repo root', () => {
+    const error = {
+      stack: [
+        'Error: boom',
+        '    at dep (/repo/node_modules/x/index.js:9:9)',
+        '    at handler (/repo/src/server.js:128:20)',
+      ].join('\n'),
+    }
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), ['/repo/src/server.js', 128, 1])
+  })
+
+  it('parses frames without a parenthesized function name', () => {
+    const error = { stack: 'Error\n    at /repo/src/run.js:3:7' }
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), ['/repo/src/run.js', 3, 0])
+  })
+
+  it('preserves parentheses in wrapped and unwrapped file paths', () => {
+    const wrappedError = { stack: 'Error\n    at handler (/repo/src/a(b).js:12:3)' }
+    const unwrappedError = { stack: 'Error\n    at /repo/src/a(b).js:12:3' }
+
+    assert.deepStrictEqual(getFileAndLineNumberFromError(wrappedError, '/repo'), ['/repo/src/a(b).js', 12, 0])
+    assert.deepStrictEqual(getFileAndLineNumberFromError(unwrappedError, '/repo'), ['/repo/src/a(b).js', 12, 0])
+  })
+
+  it('ignores parentheses in the function name', () => {
+    const error = { stack: 'Error\n    at foo(bar) (/repo/src/run.js:12:3)' }
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), ['/repo/src/run.js', 12, 0])
+  })
+
+  it('uses the source location from an eval frame', () => {
+    const error = { stack: 'Error\n    at eval (eval at run (/repo/src/run.js:42:13), <anonymous>:1:3)' }
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), ['/repo/src/run.js', 42, 0])
+  })
+
+  it('uses the source location from a nested eval frame', () => {
+    const error = {
+      stack: 'Error\n    at eval (eval at outer (eval at run (/repo/src/run.js:42:13)), <anonymous>:1:3)',
+    }
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), ['/repo/src/run.js', 42, 0])
+  })
+
+  it('returns an empty array when only dependency frames match', () => {
+    const error = { stack: 'Error\n    at dep (/repo/node_modules/x.js:1:1)' }
+    assert.deepStrictEqual(getFileAndLineNumberFromError(error, '/repo'), [])
+  })
+
+  it('stays linear on an attacker-shaped newline-free frame', () => {
+    const error = { stack: `at (${'a'.repeat(200_000)} /repo/src/x.js:5:1)` }
+    assert.strictEqual(getFileAndLineNumberFromError(error, '/repo')[1], 5)
   })
 })

--- a/scripts/check-docker-image-shas.js
+++ b/scripts/check-docker-image-shas.js
@@ -9,7 +9,7 @@ const path = require('node:path')
 const CHECKED_EXTENSIONS = new Set(['.yml', '.yaml'])
 
 // Matches `image: <value>` where the value is on the same line (not a bare `image:` key)
-const IMAGE_LINE_RE = /^\s*image:\s+(\S+)\s*(?:#.*)?$/
+const IMAGE_LINE_RE = /^\s*image:\s+([^\s#]+)\s*(?:#.*)?$/
 
 /**
  * @returns {string[]}

--- a/scripts/mocha-parallel-files.js
+++ b/scripts/mocha-parallel-files.js
@@ -212,7 +212,7 @@ function mergeXunitFilesToSingleTestsuite (inputFiles, outputFile) {
       continue
     }
 
-    const openTagMatch = xml.match(/<testsuite\s+[^>]*>/)
+    const openTagMatch = xml.match(/<testsuite\s[^>]*>/)
     if (!openTagMatch) continue
 
     const openTag = openTagMatch[0]

--- a/scripts/release/validate.js
+++ b/scripts/release/validate.js
@@ -40,8 +40,8 @@ try {
   const currentBranch = capture('git rev-parse --abbrev-ref HEAD')
   const proposalBranch = params[0] || currentBranch
   const tempBranch = randomUUID()
-  const newVersion = proposalBranch.match(/^v([0-9]+\.[0-9]+\.[0-9]+).+/)[1]
-  const releaseLine = newVersion.match(/^([0-9]+).+/)[1]
+  const newVersion = proposalBranch.match(/^v([0-9]+\.[0-9]+\.[0-9]+)[^0-9]/)[1]
+  const releaseLine = newVersion.match(/^([0-9]+)\./)[1]
 
   // Restore current branch on success.
   process.once('exit', code => {

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -127,6 +127,7 @@ function normalizeScriptGlob (raw, opts = {}) {
   // Convert bash extglob + command substitution patterns used in this repo into plain env vars.
   // Example: @($(echo $PLUGINS)) -> $PLUGINS
   // Example: @($(echo ${SPEC:-'*'})) -> ${SPEC:-*}
+  // eslint-disable-next-line regexp/no-super-linear-backtracking -- Parses bounded repository package scripts.
   p = p.replaceAll(/@\(\$\(\s*echo\s+([^)]+?)\s*\)\)/g, '$1')
 
   // For global analysis we treat env vars as wildcards, but when evaluating a specific CI run
@@ -311,7 +312,7 @@ function parseExportAssignments (run) {
   const out = {}
   const lines = String(run).split('\n')
   for (const line of lines) {
-    const m = line.match(/^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)\s*$/)
+    const m = line.match(/^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/)
     if (!m) continue
     out[m[1]] = stripOuterQuotes(m[2].trim())
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,7 +360,7 @@
   resolved "https://registry.yarnpkg.com/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz#fe541a68aa080255f798c8561714ac8fad72cdd5"
   integrity sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==
 
-"@eslint-community/eslint-utils@4.10.1", "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.10.1", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.0", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
+"@eslint-community/eslint-utils@4.10.1", "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.10.1", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.0", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz#8911bd72b2c3640a543609e0400b8c4d2e7e7cb6"
   integrity sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==
@@ -1686,7 +1686,7 @@ commander@^10.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
-comment-parser@1.4.8, comment-parser@^1.4.1:
+comment-parser@1.4.8, comment-parser@^1.4.0, comment-parser@^1.4.1:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.8.tgz#774074d2140b21ed59d4886a5576982e73b74c4b"
   integrity sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==
@@ -2058,6 +2058,19 @@ eslint-plugin-promise@^7.3.0:
   integrity sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
+
+eslint-plugin-regexp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.0.tgz#e6fede2919ae39cece0669e02259c0feb1718cd9"
+  integrity sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.11.0"
+    comment-parser "^1.4.0"
+    jsdoc-type-pratt-parser "^7.0.0"
+    refa "^0.12.1"
+    regexp-ast-analysis "^0.7.1"
+    scslre "^0.3.0"
 
 eslint-plugin-sonarjs@^4.2.0:
   version "4.2.0"
@@ -2875,6 +2888,11 @@ js-yaml@^4.1.0, js-yaml@^4.3.0, js-yaml@^4.3.1:
   integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
+
+jsdoc-type-pratt-parser@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz"
+  integrity sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==
 
 jsdoc-type-pratt-parser@~9.1.2:
   version "9.1.2"
@@ -3699,7 +3717,7 @@ refa@^0.12.0, refa@^0.12.1:
   dependencies:
     "@eslint-community/regexpp" "^4.8.0"
 
-regexp-ast-analysis@^0.7.0:
+regexp-ast-analysis@^0.7.0, regexp-ast-analysis@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz#c0e24cb2a90f6eadd4cbaaba129317e29d29c482"
   integrity sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==


### PR DESCRIPTION
On Node v22.23.2 and V8 12.4.254.21-node.56, common frames improve from 124.6 ns to 63.4 ns. Malformed 4 KB frames improve from 40.4 ms to 2.2 µs.