### PR TITLE
fix(config): preserve OTel metrics in agentless mode

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,7 +14,8 @@ Agentless mode disables features that require an Agent.
 Set the API key with `DD_API_KEY` or `DATADOG_API_KEY`.
 
 Agentless mode uses the Datadog trace intake and ignores `OTEL_TRACES_EXPORTER`.
-Explicit `DD_TRACE_SAMPLE_RATE`, `OTEL_TRACES_SAMPLER`, and `OTEL_TRACES_SPAN_METRICS_ENABLED` settings still apply.
+Explicit `DD_TRACE_SAMPLE_RATE`, `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SPAN_METRICS_ENABLED`, and
+`DD_METRICS_OTEL_ENABLED` settings still apply.
 
 Agentless mode submits Bunyan, Pino, and Winston logs directly by default. Set
 `DD_AGENTLESS_LOG_SUBMISSION_ENABLED=false` to disable this behavior. Set `DD_LOGS_OTEL_ENABLED=true` to use the

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -651,7 +651,6 @@ class Config extends ConfigBase {
         setAndTrack(this, 'dynamicInstrumentation.enabled', false)
       }
       setAndTrack(this, 'runtimeMetrics.enabled', false)
-      setAndTrack(this, 'DD_METRICS_OTEL_ENABLED', false)
       setAndTrack(this, 'dsmEnabled', false)
       setAndTrack(this, 'DD_CRASHTRACKING_ENABLED', false)
 

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -5266,7 +5266,7 @@ rules:
       assert.strictEqual(config.dynamicInstrumentation.enabled, true)
       assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, false)
       assert.strictEqual(config.DD_LOGS_OTEL_ENABLED, true)
-      assert.strictEqual(config.DD_METRICS_OTEL_ENABLED, false)
+      assert.strictEqual(config.DD_METRICS_OTEL_ENABLED, true)
       assert.strictEqual(config.OTEL_TRACES_EXPORTER, 'none')
       assert.strictEqual(config.OTEL_TRACES_SPAN_METRICS_ENABLED, true)
       assert.strictEqual(config.logInjection, false)


### PR DESCRIPTION
The global agentless calculation treated the independent OTLP metrics exporter as Agent-dependent and overwrote its explicit configuration.