### PR TITLE
test: fix v5 release proposal failures

### DIFF
--- a/integration-tests/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const assert = require('node:assert/strict')
+const assert = require('assert').strict
 
 let firstCounter = 0
 let secondCounter = 0

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2510,7 +2510,7 @@ describe('Plugin', () => {
           return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        v6DepthTest('should not record a depth-gated child error on its collapsed parent span', async () => {
+        it('should not record a depth-gated child error on its collapsed parent span', async () => {
           const Nested = new graphql.GraphQLObjectType({
             name: 'DepthGatedResolverErrorNested',
             fields: {
@@ -2545,11 +2545,12 @@ describe('Plugin', () => {
           })
           const operationName = 'DepthGatedResolverError'
           const localSource = `query ${operationName} { items { nested { failure } } }`
+          const expectedParentPath = DD_MAJOR >= 6 ? 'items.*.nested' : 'items'
 
           const [result] = await Promise.all([
             graphql.graphql({ schema: localSchema, source: localSource }),
             agent.assertSomeTraces(traces => {
-              const span = sort(traces[0]).find(span => span.meta?.['graphql.field.path'] === 'items.*.nested')
+              const span = sort(traces[0]).find(span => span.meta?.['graphql.field.path'] === expectedParentPath)
 
               assert.ok(span)
               assert.strictEqual(span.error, 0)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2510,7 +2510,7 @@ describe('Plugin', () => {
           return Promise.all([assertion, graphql.graphql({ schema, source })])
         })
 
-        it('should not record a depth-gated child error on its collapsed parent span', async () => {
+        v6DepthTest('should not record a depth-gated child error on its collapsed parent span', async () => {
           const Nested = new graphql.GraphQLObjectType({
             name: 'DepthGatedResolverErrorNested',
             fields: {


### PR DESCRIPTION
This branch collects test fixes for the v5 release proposal. It skips the GraphQL collapsed-depth assertion on v5 and restores the Jest 24 EFD fixture from [#10144](https://github.com/DataDog/dd-trace-js/pull/10144).