### PR TITLE
test(test-optimization): restore Jest 24 EFD fixture execution

### DIFF
--- a/integration-tests/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/two-occasionally-failing-tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const assert = require('node:assert/strict')
+const assert = require('assert').strict
 
 let firstCounter = 0
 let secondCounter = 0


### PR DESCRIPTION
Jest 24 cannot resolve node:assert/strict, so the EFD fixture fails before it can exercise retry aggregation.