### PR TITLE
ci(npm): disable audit during installs

### DIFF
--- a/.github/actions/install/branch-diff/action.yml
+++ b/.github/actions/install/branch-diff/action.yml
@@ -11,7 +11,7 @@ runs:
       with:
         path: ~/.npm
         key: ${{ github.workflow }}-branch-diff-3.1.1
-    - run: npm i -g branch-diff@3.1.1
+    - run: npm i -g branch-diff@3.1.1 --no-audit
       shell: bash
     - run: |
         mkdir -p ~/.config/changelog-maker

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Playwright 1.18.x tries obsolete Ubuntu package names on Debian Bookworm
 # (`ttf-unifont`, `xfonts-cyrillic`, `ttf-ubuntu-font-family`) and exits 0
 # even though apt fails. Install Chromium's runtime dependencies directly.
-RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
+RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} --no-audit \
     && case "$PLAYWRIGHT_VERSION" in \
       1.18|1.18.*) \
         echo "Installing Playwright 1.18 Chromium dependencies for Debian Bookworm" \

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         manager:
           - name: npm
-            install: npm install
+            install: npm install --no-audit
           - name: pnpm
             install: >-
               pnpm
@@ -43,7 +43,7 @@ jobs:
             install: yarn add
           - name: yarn-berry
             install: >-
-              (command -v corepack >/dev/null 2>&1 || npm install -g corepack)
+              (command -v corepack >/dev/null 2>&1 || npm install -g corepack --no-audit)
               && yarn set version stable
               && yarn config set nodeLinker node-modules
               && yarn config set enableScripts true
@@ -58,7 +58,7 @@ jobs:
       - uses: ./.github/actions/install
       - run: FILENAME=$(npm pack --silent --pack-destination /tmp) && mv "/tmp/$FILENAME" /tmp/dd-trace.tgz
       - run: mkdir -p /tmp/app
-      - run: npm i -g pnpm
+      - run: npm i -g pnpm --no-audit
         if: matrix.manager.name == 'pnpm'
       - name: Install packed package
         shell: bash

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -84,7 +84,7 @@ jobs:
             .github
             scripts/verify-workflow-job-names.js
       - uses: ./.github/actions/node/latest
-      - run: npm install yaml
+      - run: npm install yaml --no-audit
       - run: node scripts/verify-workflow-job-names.js
 
   # The package size is especially useful in constrained environments, so the

--- a/.gitlab/benchmarks/container/Dockerfile
+++ b/.gitlab/benchmarks/container/Dockerfile
@@ -63,7 +63,7 @@ RUN git clone --depth 1 https://github.com/hdiv/insecure-bank-js.git /opt/insecu
 WORKDIR /opt/insecure-bank-js
 RUN git checkout 5755d091e6a5dc965a8e7c6d4fb79b2f0ea06d9a
 RUN . $NVM_DIR/nvm.sh \
-    && npm ci \
+    && npm ci --no-audit \
     && npm cache clean --force
 
 WORKDIR /app

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -8,7 +8,7 @@ npm pack
 
 mkdir -p packaging/sources
 
-npm install --prefix ./packaging/sources/ dd-trace-*.tgz
+npm install --prefix ./packaging/sources/ dd-trace-*.tgz --no-audit
 
 rm packaging/sources/*.json # package.json and package-lock.json are unneeded
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -42,7 +42,7 @@ fi
 
 (
   cd ../../ &&
-  npm install --global yarn || (sleep 60 && npm install --global yarn) \
+  npm install --global yarn --no-audit || (sleep 60 && npm install --global yarn --no-audit) \
     && yarn install --ignore-engines || (sleep 60 && yarn install --ignore-engines) \
     && PLUGINS="graphql|express" yarn services
 )

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -36,7 +36,7 @@ describe('esbuild support for IAST', () => {
     // Craft node_modules directory to ship native modules
     fs.mkdirSync(craftedNodeModulesDir)
     await exec('npm init -y', { cwd: craftedNodeModulesDir })
-    await retry(() => exec('npm install @datadog/wasm-js-rewriter @datadog/native-iast-taint-tracking', {
+    await retry(() => exec('npm install @datadog/wasm-js-rewriter @datadog/native-iast-taint-tracking --no-audit', {
       cwd: craftedNodeModulesDir,
       timeout: 60_000,
     }))
@@ -77,7 +77,7 @@ describe('esbuild support for IAST', () => {
     const applicationDir = path.join(cwd, 'appsec', appDirName)
 
     // Install app deps
-    await retry(() => exec('npm install', {
+    await retry(() => exec('npm install --no-audit', {
       cwd: applicationDir,
       timeout: 6e3,
     }))

--- a/integration-tests/electron/electron.spec.js
+++ b/integration-tests/electron/electron.spec.js
@@ -43,7 +43,7 @@ describe('Electron integration', function () {
     )
 
     // Install dd-trace and its transitive dependencies into the app directory.
-    execFileSync('npm', ['install'], { cwd: appDir, stdio: 'pipe' })
+    execFileSync('npm', ['install', '--no-audit'], { cwd: appDir, stdio: 'pipe' })
 
     // Use the electron version already installed in the sandbox so that
     // electron-packager finds the cached binary and does not re-download it.

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -35,17 +35,17 @@ esbuildVersions.forEach((version) => {
 
     before(() => {
       process.chdir(TEST_DIR)
-      execSync('npm install', {
+      execSync('npm install --no-audit', {
         timeout,
       })
-      execSync(`npm install esbuild@${version}`, {
+      execSync(`npm install esbuild@${version} --no-audit`, {
         timeout,
       })
     })
 
     after(() => {
       process.chdir(originalDir)
-      execSync('npm remove esbuild', {
+      execSync('npm remove esbuild --no-audit', {
         timeout,
       })
     })

--- a/integration-tests/esbuild/openfeature.spec.js
+++ b/integration-tests/esbuild/openfeature.spec.js
@@ -21,7 +21,7 @@ esbuildVersions.forEach((version) => {
       // TODO add this in createSandbox if it's need in more places
       execSync(`rm -rf ${path.join(cwd, 'node_modules')}`, { cwd })
       execSync(`rm -rf ${path.join(cwd, 'bun.lock')}`, { cwd })
-      execSync('npm install -g yarn', { cwd })
+      execSync('npm install -g yarn --no-audit', { cwd })
 
       execSync('yarn --ignore-engines', { cwd })
     })

--- a/integration-tests/webpack/index.spec.js
+++ b/integration-tests/webpack/index.spec.js
@@ -32,13 +32,13 @@ webpackVersions.forEach((version) => {
 
     before(() => {
       process.chdir(TEST_DIR)
-      execSync('npm install', { timeout })
-      execSync(`npm install webpack@${version}`, { timeout })
+      execSync('npm install --no-audit', { timeout })
+      execSync(`npm install webpack@${version} --no-audit`, { timeout })
     })
 
     after(() => {
       process.chdir(originalDir)
-      execSync('npm remove webpack', { timeout })
+      execSync('npm remove webpack --no-audit', { timeout })
     })
 
     it('works', () => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "env": "bash ./plugin-env",
-    "prepare": "node scripts/patch-istanbul-lib-coverage.js && node scripts/patch-v8-to-istanbul.js && cd vendor && npm ci --include=dev",
+    "prepare": "node scripts/patch-istanbul-lib-coverage.js && node scripts/patch-v8-to-istanbul.js && cd vendor && npm ci --include=dev --no-audit",
     "prepack": "node scripts/release/swap-v5-types.js",
     "bench": "node benchmark/index.js",
     "bench:e2e:test-optimization": "node benchmark/e2e-test-optimization/benchmark-run.js",

--- a/packages/dd-trace/test/plugins/suite.js
+++ b/packages/dd-trace/test/plugins/suite.js
@@ -73,10 +73,10 @@ async function setup (modName, repoName, commitish) {
   }
 
   try {
-    await execOrError('npm install --legacy-peer-deps', { cwd })
+    await execOrError('npm install --legacy-peer-deps --no-audit', { cwd })
   } catch (e) {
     console.error(e)
-    await execOrError('npm install --legacy-peer-deps', { cwd })
+    await execOrError('npm install --legacy-peer-deps --no-audit', { cwd })
   }
 }
 


### PR DESCRIPTION
An npm incident causes the audit endpoint to return HTTP 503 responses during dependency installation. This disables audit for repository-owned npm dependency-tree mutations as a stop gap. Dependabot remains enabled, but these commands will not report vulnerabilities during installation. The regression probe checks that every affected command forwards `--no-audit`.