### PR TITLE
fix(dd-trace-api): restore tracer compatibility

### DIFF
--- a/packages/datadog-instrumentations/src/dd-trace-api.js
+++ b/packages/datadog-instrumentations/src/dd-trace-api.js
@@ -3,5 +3,5 @@
 const { addHook } = require('./helpers/instrument')
 
 // Empty hook just to make the plugin load.
-// TODO: Add version range when the module is released on npm.
-addHook({ name: 'dd-trace-api' }, api => api)
+// Version 1.0.1 re-publishes tracer initialization after the plugin subscribes.
+addHook({ name: 'dd-trace-api', versions: ['>=1.0.1'] }, api => api)

--- a/packages/datadog-plugin-dd-trace-api/test/entrypoints.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/entrypoints.spec.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
+
+const { describe, it } = require('mocha')
+
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+
+const repoRoot = path.join(__dirname, '../../..')
+const fixture = path.join(__dirname, 'fixtures', 'entrypoint.js')
+const entrypoints = [
+  ['dd-trace', path.join(repoRoot, 'index.js')],
+  ['dd-trace-electron', path.join(repoRoot, 'index.electron.js')],
+]
+
+describe('dd-trace-api entrypoints', () => {
+  withVersions('dd-trace-api', 'dd-trace-api', version => {
+    const apiPath = path.join(repoRoot, 'versions', `dd-trace-api@${version}`)
+
+    for (const [name, entrypoint] of entrypoints) {
+      it(`should bridge through ${name}`, () => {
+        const result = spawnSync(process.execPath, [fixture], {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false',
+            DD_REMOTE_CONFIGURATION_ENABLED: 'false',
+            DD_TRACE_STARTUP_LOGS: 'false',
+            DD_TRACE_TEST_API_PATH: apiPath,
+            DD_TRACE_TEST_ENTRYPOINT: entrypoint,
+          },
+          timeout: 5_000,
+        })
+
+        assert.strictEqual(result.status, 0, result.stderr || result.error?.message)
+      })
+    }
+  })
+})

--- a/packages/datadog-plugin-dd-trace-api/test/fixtures/entrypoint.js
+++ b/packages/datadog-plugin-dd-trace-api/test/fixtures/entrypoint.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+require(process.env.DD_TRACE_TEST_ENTRYPOINT).init()
+
+const api = require(process.env.DD_TRACE_TEST_API_PATH).get()
+const span = api.startSpan('dd-trace-api.entrypoint')
+
+assert.doesNotMatch(span.context().toTraceId(), /^0+$/)

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -4,47 +4,9 @@ const assert = require('node:assert')
 
 const dc = require('dc-polyfill')
 const { after, before, describe, it } = require('mocha')
-const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-const {
-  supportedConfigurations,
-} = require('../../dd-trace/src/config/supported-configurations.json')
-
 const SELF = Symbol('self')
-
-// The dd-trace-api plugin is not released yet (the `before` hook fires its load event
-// manually below), so its DD_TRACE_DD_TRACE_API_ENABLED flag is intentionally absent from
-// the shipped supported-configurations.json and must never be added there. Register it in an
-// in-memory copy and reload both consumers of that file — config/helper and the config/defaults
-// table it reads — against the copy, so plugin_manager's getEnabled() resolves the flag through
-// real production code instead of throwing on an unknown DD_-prefixed name. Reloading helper
-// alone would leave the defaults table without the entry and only pass while getEnabled keeps
-// short-circuiting before the default lookup.
-const stubbedConfigurations = {
-  supportedConfigurations: {
-    ...supportedConfigurations,
-    DD_TRACE_DD_TRACE_API_ENABLED: [
-      {
-        implementation: 'A',
-        type: 'boolean',
-        default: 'true',
-      },
-    ],
-  },
-}
-
-const configHelperPath = require.resolve('../../dd-trace/src/config/helper')
-const loadDefaults = proxyquire.noPreserveCache()
-const reloadedDefaults = loadDefaults(require.resolve('../../dd-trace/src/config/defaults'), {
-  './supported-configurations.json': stubbedConfigurations,
-})
-const loadConfigHelper = proxyquire.noPreserveCache()
-const reloadedConfigHelper = loadConfigHelper(configHelperPath, {
-  './supported-configurations.json': stubbedConfigurations,
-  './defaults': reloadedDefaults,
-})
-Object.assign(require(configHelperPath), reloadedConfigHelper)
 
 const agent = require('../../dd-trace/test/plugins/agent')
 
@@ -62,9 +24,7 @@ describe('Plugin', () => {
       await agent.load('dd-trace-api')
 
       tracer = require('../../dd-trace')
-
-      // TODO: Use the real module when it's released.
-      dc.channel('dd-trace:instrumentation:load').publish({ name: 'dd-trace-api' })
+      require('../../../versions/dd-trace-api').get()
 
       sinon.spy(tracer)
       sinon.spy(tracer.appsec)

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -143,10 +143,17 @@ function getEnvNameFromSource (name, source) {
   }
 }
 
+/**
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isSupportedConfiguration (name) {
+  return supportedConfigurations[name] !== undefined || aliasToCanonical[name] !== undefined
+}
+
 function validateAccess (name) {
   if ((name.startsWith('DD_') || name.startsWith('OTEL_')) &&
-    !supportedConfigurations[name] &&
-    !aliasToCanonical[name]) {
+    !isSupportedConfiguration(name)) {
     throw new Error(`Missing ${name} env/configuration in "supported-configurations.json" file.`)
   }
 }
@@ -284,6 +291,7 @@ function getValueFromEnvSources (name, skipDefault) {
 
 module.exports = {
   getValueFromEnvSources,
+  isSupportedConfiguration,
 
   /**
    * Expose raw stable config maps and warnings for consumers that need

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -2,7 +2,11 @@
 
 const { channel } = require('dc-polyfill')
 
-const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
+const {
+  getEnvironmentVariable,
+  getValueFromEnvSources,
+  isSupportedConfiguration,
+} = require('./config/helper')
 const { isFalse, isTrue, normalizePluginEnvName } = require('./util')
 const plugins = require('./plugins')
 const log = require('./log')
@@ -59,12 +63,14 @@ function maybeEnable (Plugin) {
 }
 
 function getEnabled (Plugin) {
-  const envName = `DD_TRACE_${Plugin.id.toUpperCase()}_ENABLED`
+  const envName = normalizePluginEnvName(`DD_TRACE_${Plugin.id.toUpperCase()}_ENABLED`)
+  if (!isSupportedConfiguration(envName)) return
+
   // skipDefault: only an explicitly configured value should drive enablement here. A registered
   // default of `false` (e.g. an opt-in plugin like `nats`) must not be read as an explicit
   // "disabled via configuration option" — that path both logs a misleading line and nulls the
   // plugin class, bypassing the opt-in handled by `loadPlugin`.
-  return getValueFromEnvSources(normalizePluginEnvName(envName), true)
+  return getValueFromEnvSources(envName, true)
 }
 
 // TODO this must always be a singleton.

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -21,6 +21,7 @@ describe('Plugin Manager', () => {
   let Five
   let Six
   let Eight
+  let Nine
   let Graphql
   let pm
   let registeredDefaults
@@ -71,6 +72,9 @@ describe('Plugin Manager', () => {
         static optIn = true
         static id = 'eight'
       },
+      nine: class Nine extends FakePlugin {
+        static id = 'nine'
+      },
       graphql: class Graphql extends FakePlugin {
         static id = 'graphql'
       },
@@ -91,6 +95,8 @@ describe('Plugin Manager', () => {
 
     Eight = plugins.eight
     Eight.prototype.configure = sinon.spy()
+    Nine = plugins.nine
+    Nine.prototype.configure = sinon.spy()
 
     process.env.DD_TRACE_DISABLED_PLUGINS = 'five,six,seven'
 
@@ -107,10 +113,16 @@ describe('Plugin Manager', () => {
           return process.env[name]
         },
         getValueFromEnvSources (name, skipDefault) {
+          if (name === 'DD_TRACE_NINE_ENABLED') {
+            throw new Error(`${name} is not registered`)
+          }
           if (process.env[name] !== undefined) {
             return process.env[name]
           }
           return skipDefault ? undefined : registeredDefaults[name]
+        },
+        isSupportedConfiguration (name) {
+          return name !== 'DD_TRACE_NINE_ENABLED'
         },
       },
     })
@@ -345,6 +357,12 @@ describe('Plugin Manager', () => {
       loadChannel.publish({ name: 'two' })
       loadChannel.publish({ name: 'four' })
       assert.deepStrictEqual(instantiated, ['two', 'four'])
+    })
+
+    it('enables plugins without a registered per-plugin flag by default', () => {
+      pm.configure(makeTracerConfig())
+      loadChannel.publish({ name: 'nine' })
+      sinon.assert.calledWithMatch(Nine.prototype.configure, { enabled: true })
     })
 
     describe('service naming schema manager', () => {


### PR DESCRIPTION
### What does this PR do?

- Checks whether a generated per-plugin enablement key is registered before reading it.
- Leaves plugins without a dedicated key on the existing default or opt-in path.
- Declares support for the released `dd-trace-api` package starting at 1.0.1.
- Replaces the mocked plugin-load setup with the real package.
- Adds process-level regression coverage for both the `dd-trace` and `dd-trace-electron` entrypoints.

### Motivation

`DD_TRACE_DD_TRACE_API_ENABLED` was retired in dd-trace 5.88.0, but the plugin manager continued synthesizing and reading that key when `dd-trace-api` loaded. Strict supported-configuration validation rejected the retired key before the bridge could reach its normal default-enabled path.

The fix is generic: the plugin manager only reads a per-plugin override when the generated key is registered. Existing dedicated integration flags, opt-in behavior, `plugins: false`, and `DD_TRACE_DISABLED_PLUGINS` remain unchanged.

### Additional Notes

`dd-trace-api` 1.0.0 is excluded because it does not replay tracer initialization after the bridge subscribes; 1.0.1 introduced that behavior.

Validation:

- `PLUGINS=dd-trace-api npm run test:plugins` — 34 passing, including both package entrypoints
- `./node_modules/.bin/mocha packages/dd-trace/test/plugin_manager.spec.js packages/dd-trace/test/config/helper.spec.js` — 59 passing
- `npm run lint`

*Generated by Codex.*