### PR TITLE
feat(exporters): honor proxy environment variables

### DIFF
--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -13,6 +13,7 @@ const {
   singleJitteredDelay,
 } = require('../../exporters/common/retry')
 const { parseUrl } = require('../../exporters/common/url')
+const { getHttpsProxyAgent } = require('../../exporters/common/proxy')
 const { getRateLimitResetDelay } = require('./rate-limit')
 
 const legacyStorage = storage('legacy')
@@ -56,6 +57,16 @@ function request (data, options, callback) {
 
   if (!opts.socketPath) {
     opts.agent = isSecure ? httpsAgent : httpAgent
+  }
+
+  const hasApiKey = headers['dd-api-key'] !== undefined || headers['DD-API-KEY'] !== undefined
+  if (hasApiKey && isSecure) {
+    try {
+      opts.agent = getHttpsProxyAgent(opts, opts.agent)
+    } catch (error) {
+      callback(error)
+      return
+    }
   }
 
   let hasRetried = false

--- a/packages/dd-trace/src/ci-visibility/requests/video-request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/video-request.js
@@ -6,6 +6,7 @@ const https = require('node:https')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 const { markEndpointReached } = require('../../exporters/common/retry')
+const { getHttpsProxyAgent } = require('../../exporters/common/proxy')
 const { isLoopbackHost, parseUrl } = require('../../exporters/common/url')
 
 const legacyStorage = storage('legacy')
@@ -128,6 +129,9 @@ function getRequestOptions (options) {
     )
     delete requestOptions.headers['dd-api-key']
     delete requestOptions.headers['DD-API-KEY']
+  }
+  if (hasApiKey && requestOptions.protocol === 'https:') {
+    requestOptions.agent = getHttpsProxyAgent(requestOptions, requestOptions.agent)
   }
 
   delete requestOptions.deadline

--- a/packages/dd-trace/src/debugger/devtools_client/request-options.js
+++ b/packages/dd-trace/src/debugger/devtools_client/request-options.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { getHttpsProxyAgent } = require('../../evp_proxy/direct')
-
 /**
  * @param {ReturnType<import('../config')>} config - Debugger configuration
  * @param {string} path - Request path
@@ -10,8 +8,7 @@ const { getHttpsProxyAgent } = require('../../evp_proxy/direct')
  *   method: 'POST',
  *   url: string | URL,
  *   path: string,
- *   headers: Record<string, string>,
- *   agent?: import('node:https').Agent
+ *   headers: Record<string, string>
  * }}
  */
 module.exports = function getRequestOptions (config, path, headers) {
@@ -25,8 +22,6 @@ module.exports = function getRequestOptions (config, path, headers) {
   if (config.agentless) {
     if (config.apiKey !== undefined) headers['DD-API-KEY'] = config.apiKey
     headers['DD-EVP-ORIGIN'] = 'agent-debugger'
-    const agent = getHttpsProxyAgent(config.url.href)
-    if (agent !== undefined) options.agent = agent
   }
 
   return options

--- a/packages/dd-trace/src/evp_proxy/direct.js
+++ b/packages/dd-trace/src/evp_proxy/direct.js
@@ -1,19 +1,13 @@
 'use strict'
 
-const { HttpsProxyAgent } = require('../../../../vendor/dist/https-proxy-agent')
-const { getProxyForUrl } = require('../../../../vendor/dist/proxy-from-env')
 const { createSiteUrl } = require('../exporters/common/url')
 const log = require('../log')
-
-/** @type {Map<string, import('node:https').Agent>} */
-const proxyAgents = new Map()
 
 /**
  * @typedef {object} DirectEVPRoute
  * @property {URL} url - Direct intake URL
  * @property {string} basePath - Direct intake base path
  * @property {object} headers - Direct intake authentication headers
- * @property {import('node:https').Agent} [agent] - Optional HTTPS proxy agent
  */
 
 /**
@@ -33,36 +27,16 @@ function createDirectEVPRoute (config, intake) {
     const url = createSiteUrl(config.site, intake)
     if (url === undefined) throw new Error('Invalid direct EVP intake URL')
 
-    const agent = getHttpsProxyAgent(url.href)
-
-    const route = {
+    return {
       url,
       basePath: '',
       headers: {
         'DD-API-KEY': apiKey,
       },
     }
-    if (agent) route.agent = agent
-    return route
   } catch (error) {
     log.debug('Unable to configure direct EVP intake: %s', error.message)
   }
 }
 
-/**
- * @param {string} url
- * @returns {import('node:https').Agent|undefined}
- */
-function getHttpsProxyAgent (url) {
-  const proxyUrl = getProxyForUrl(url)
-  if (!proxyUrl) return
-
-  let agent = proxyAgents.get(proxyUrl)
-  if (agent === undefined) {
-    agent = new HttpsProxyAgent(proxyUrl)
-    proxyAgents.set(proxyUrl, agent)
-  }
-  return agent
-}
-
-module.exports = { createDirectEVPRoute, getHttpsProxyAgent }
+module.exports = { createDirectEVPRoute }

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -8,6 +8,7 @@ const log = require('../../log')
 const tracerVersion = require('../../../../../package.json').version
 
 const { canSendApiKey } = require('../common/url')
+const { getHttpsProxyAgent } = require('../common/proxy')
 const BaseWriter = require('../common/writer')
 const { AgentEncoder } = require('../../encode/0.4')
 const { computeIntakeUrl, INTAKE_PATH } = require('./intake')
@@ -153,6 +154,7 @@ class AgentlessWriter extends BaseWriter {
 
     this.#closeExporter()
     const config = getConfig()
+    const agent = this._url.protocol === 'https:' ? getHttpsProxyAgent(this._url) : undefined
     this.#exporter = createAgentlessExporter({
       endpoint: this.#endpoint(),
       apiKey,
@@ -165,7 +167,7 @@ class AgentlessWriter extends BaseWriter {
       tracerVersion,
       languageVersion: process.version,
       languageInterpreter: process.versions.bun ? 'JavaScriptCore' : 'v8',
-    })
+    }, { agent })
     this.#exporterApiKey = apiKey
     this.#exporterEnv = env
     this.#exporterRuntimeId = runtimeID

--- a/packages/dd-trace/src/exporters/common/proxy.js
+++ b/packages/dd-trace/src/exporters/common/proxy.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { isIPv6 } = require('node:net')
+
 let defaultAgentKey
 let getProxyForUrl
 let proxyAgents
@@ -14,9 +16,11 @@ let proxyAgents
 function getHttpsProxyAgent (url, directAgent) {
   getProxyForUrl ??= require('../../../../../vendor/dist/proxy-from-env').getProxyForUrl
 
+  const host = typeof url === 'string' ? undefined : url.host ?? url.hostname
+  const isUnbracketedIPv6 = typeof host === 'string' && host.includes(':') && isIPv6(host)
   const target = typeof url === 'string'
     ? url
-    : { protocol: url.protocol, host: url.host ?? url.hostname, port: url.port }
+    : { protocol: url.protocol, host: isUnbracketedIPv6 ? `[${host}]` : host, port: url.port }
   const proxyUrl = getProxyForUrl(target)
   if (!proxyUrl) return directAgent
 

--- a/packages/dd-trace/src/exporters/common/proxy.js
+++ b/packages/dd-trace/src/exporters/common/proxy.js
@@ -1,0 +1,46 @@
+'use strict'
+
+let defaultAgentKey
+let getProxyForUrl
+let proxyAgents
+
+/**
+ * Selects a proxy agent for an HTTPS target while preserving the direct agent's pool boundaries.
+ *
+ * @param {string|URL|object} url
+ * @param {import('node:http').Agent|false} [directAgent]
+ * @returns {import('node:http').Agent|false|undefined}
+ */
+function getHttpsProxyAgent (url, directAgent) {
+  getProxyForUrl ??= require('../../../../../vendor/dist/proxy-from-env').getProxyForUrl
+
+  const target = typeof url === 'string'
+    ? url
+    : { protocol: url.protocol, host: url.host ?? url.hostname, port: url.port }
+  const proxyUrl = getProxyForUrl(target)
+  if (!proxyUrl) return directAgent
+
+  if (proxyAgents === undefined) {
+    defaultAgentKey = {}
+    proxyAgents = new WeakMap()
+  }
+  const cacheKey = directAgent || defaultAgentKey
+  let agents = proxyAgents.get(cacheKey)
+  if (agents === undefined) {
+    agents = new Map()
+    proxyAgents.set(cacheKey, agents)
+  }
+
+  let agent = agents.get(proxyUrl)
+  if (agent === undefined) {
+    const { HttpsProxyAgent } = require('../../../../../vendor/dist/https-proxy-agent')
+    const options = directAgent
+      ? { keepAlive: directAgent.keepAlive, maxSockets: directAgent.maxSockets }
+      : undefined
+    agent = new HttpsProxyAgent(proxyUrl, options)
+    agents.set(proxyUrl, agent)
+  }
+  return agent
+}
+
+module.exports = { getHttpsProxyAgent }

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -13,6 +13,7 @@ const log = require('../../log')
 const { canSendApiKey, parseUrl } = require('./url')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
+const { getHttpsProxyAgent } = require('./proxy')
 const {
   getMaxAttempts,
   getRetryDelay,
@@ -94,10 +95,17 @@ function request (data, options, callback) {
 
   docker.inject(options.headers)
 
-  const connectionOptions = {
-    ...options,
-    agent: options.agent ?? (isSecure ? httpsAgent : httpAgent),
+  let agent = options.agent ?? (isSecure ? httpsAgent : httpAgent)
+  if (hasApiKey && isSecure) {
+    try {
+      agent = getHttpsProxyAgent(options, agent)
+    } catch (error) {
+      callback(error)
+      return
+    }
   }
+
+  const connectionOptions = { ...options, agent }
 
   /**
    * @param {import('node:http').IncomingMessage} res

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -76,9 +76,10 @@ let getTestOptimizationAgent
  * @param {import('../config/config-base')} config
  * @param {TelemetryApplication} application
  * @param {TelemetryRequestType} reqType
+ * @param {string} [apiKey]
  * @returns {Record<string, string>}
  */
-function getHeaders (config, application, reqType) {
+function getHeaders (config, application, reqType, apiKey) {
   const headers = {
     'DD-Client-Library-Language': application.language_name,
     'DD-Client-Library-Version': application.tracer_version,
@@ -94,8 +95,8 @@ function getHeaders (config, application, reqType) {
   if (debug) {
     headers['dd-telemetry-debug-enabled'] = 'true'
   }
-  if (config.DD_API_KEY) {
-    headers['dd-api-key'] = config.DD_API_KEY
+  if (apiKey) {
+    headers['dd-api-key'] = apiKey
   }
   return headers
 }
@@ -161,7 +162,7 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
     port,
     method: 'POST',
     path: isAgentlessMode ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
-    headers: getHeaders(config, application, reqType),
+    headers: getHeaders(config, application, reqType, isAgentlessMode ? config.DD_API_KEY : undefined),
   }
   if (isCiVisibility) options.agent = getTestOptimizationAgent(url)
 

--- a/packages/dd-trace/test/ci-visibility/requests/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/request.spec.js
@@ -2,20 +2,28 @@
 
 const assert = require('node:assert/strict')
 const http = require('node:http')
+const https = require('node:https')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const nock = require('nock')
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 require('../../setup/core')
 
-const request = require('../../../src/ci-visibility/requests/request')
+const { httpsAgent } = require('../../../src/exporters/common/agents')
 
 describe('ci-visibility/requests/request', () => {
   let clock
+  let getHttpsProxyAgent
+  let request
   let timeoutStub
 
   beforeEach(() => {
+    getHttpsProxyAgent = sinon.stub().callsFake((url, agent) => agent)
+    request = proxyquire('../../../src/ci-visibility/requests/request', {
+      '../../exporters/common/proxy': { getHttpsProxyAgent },
+    })
     clock = sinon.useFakeTimers({ now: 1_700_000_000_000, toFake: ['Date'] })
 
     // Collapse retry delays (5–7.5 s) to 0 ms so tests don't wait for real time,
@@ -24,6 +32,52 @@ describe('ci-visibility/requests/request', () => {
     timeoutStub = sinon.stub(global, 'setTimeout').callsFake((fn, delay, ...args) => {
       return realSetTimeout(fn, delay > 100 ? 0 : delay, ...args)
     })
+  })
+
+  it('selects an HTTPS proxy agent for authenticated requests', (done) => {
+    const url = new URL('https://intake.example/path')
+    const options = {
+      url,
+      headers: {
+        'DD-API-KEY': 'test-api-key',
+      },
+    }
+    nock('https://intake.example').post('/path').reply(200, 'ok')
+
+    request('{}', options, (error) => {
+      sinon.assert.calledOnceWithExactly(getHttpsProxyAgent, sinon.match({
+        ...options,
+        headers: sinon.match.object,
+      }), httpsAgent)
+      done(error)
+    })
+  })
+
+  it('keeps HTTPS requests without an API key direct', (done) => {
+    nock('https://intake.example').post('/path').reply(200, 'ok')
+
+    request('{}', { url: 'https://intake.example/path' }, (error) => {
+      sinon.assert.notCalled(getHttpsProxyAgent)
+      done(error)
+    })
+  })
+
+  it('reports proxy selection errors without starting a request', () => {
+    const error = new Error('invalid proxy URL')
+    const requestSpy = sinon.spy(https, 'request')
+    const callback = sinon.spy()
+    getHttpsProxyAgent.throws(error)
+
+    request('{}', {
+      url: 'https://intake.example/path',
+      headers: {
+        'DD-API-KEY': 'test-api-key',
+      },
+    }, callback)
+
+    requestSpy.restore()
+    sinon.assert.calledOnceWithExactly(callback, error)
+    sinon.assert.notCalled(requestSpy)
   })
 
   afterEach(() => {

--- a/packages/dd-trace/test/ci-visibility/requests/video-request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/video-request.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const http = require('node:http')
+const https = require('node:https')
 const { PassThrough, Readable } = require('node:stream')
 
 const { afterEach, describe, it } = require('mocha')
@@ -186,6 +187,94 @@ describe('ci-visibility/requests/video-request', () => {
 
     assert.strictEqual(requestOptions.headers['DD-API-KEY'], undefined)
     req.emit('error', new Error('stop'))
+  })
+
+  it('selects a proxy agent for authenticated HTTPS video uploads', () => {
+    const directAgent = new https.Agent({ keepAlive: true, maxSockets: 16 })
+    const proxyAgent = new https.Agent()
+    const getHttpsProxyAgent = sinon.stub().returns(proxyAgent)
+    const req = new PassThrough()
+    req.setTimeout = sinon.stub()
+    let requestOptions
+    const requestVideo = proxyquire('../../../src/ci-visibility/requests/video-request', {
+      'node:https': {
+        ...https,
+        request: (options) => {
+          requestOptions = options
+          return req
+        },
+      },
+      '../../exporters/common/proxy': { getHttpsProxyAgent },
+    })
+
+    requestVideo(Readable.from('video-content'), getOptions({
+      agent: directAgent,
+      headers: {
+        'Content-Length': 13,
+        'DD-API-KEY': 'test-api-key',
+      },
+      url: new URL('https://intake.example'),
+    }), sinon.spy())
+
+    sinon.assert.calledOnceWithExactly(
+      getHttpsProxyAgent,
+      requestOptions,
+      directAgent
+    )
+    assert.strictEqual(requestOptions.agent, proxyAgent)
+    req.emit('error', new Error('stop'))
+    directAgent.destroy()
+    proxyAgent.destroy()
+  })
+
+  it('keeps Agent video uploads direct', () => {
+    const directAgent = new http.Agent()
+    const getHttpsProxyAgent = sinon.stub()
+    const req = new PassThrough()
+    req.setTimeout = sinon.stub()
+    let requestOptions
+    const requestVideo = proxyquire('../../../src/ci-visibility/requests/video-request', {
+      'node:http': {
+        ...http,
+        request: (options) => {
+          requestOptions = options
+          return req
+        },
+      },
+      '../../exporters/common/proxy': { getHttpsProxyAgent },
+    })
+
+    requestVideo(Readable.from('video-content'), getOptions({
+      agent: directAgent,
+    }), sinon.spy())
+
+    sinon.assert.notCalled(getHttpsProxyAgent)
+    assert.strictEqual(requestOptions.agent, directAgent)
+    req.emit('error', new Error('stop'))
+    directAgent.destroy()
+  })
+
+  it('reports proxy selection errors without consuming video capacity', () => {
+    const error = new Error('invalid proxy URL')
+    const body = Readable.from('video-content')
+    const callback = sinon.spy()
+    const requestVideo = proxyquire('../../../src/ci-visibility/requests/video-request', {
+      '../../exporters/common/proxy': {
+        getHttpsProxyAgent: () => { throw error },
+      },
+    })
+
+    requestVideo(body, getOptions({
+      headers: {
+        'Content-Length': 13,
+        'DD-API-KEY': 'test-api-key',
+      },
+      url: new URL('https://intake.example'),
+    }), callback)
+
+    sinon.assert.calledOnceWithExactly(callback, error)
+    assert.strictEqual(body.destroyed, true)
+    assert.strictEqual(requestVideo.writable, true)
   })
 
   it('limits active video requests independently', () => {

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -184,12 +184,6 @@ describe('input message http requests', function () {
   })
 
   it('should send directly to the debugger intake in agentless mode', function () {
-    const proxyAgent = {}
-    const getHttpsProxyAgent = sinon.stub().returns(proxyAgent)
-    getHttpsProxyAgent['@noCallThru'] = true
-    const requestOptions = proxyquire('../../../src/debugger/devtools_client/request-options', {
-      '../../evp_proxy/direct': { getHttpsProxyAgent },
-    })
     const sendAgentless = proxyquire('../../../src/debugger/devtools_client/send', {
       './config': createConfigMock({
         agentless: true,
@@ -199,7 +193,6 @@ describe('input message http requests', function () {
       }),
       './json-buffer': JSONBuffer,
       '../../exporters/common/request': request,
-      './request-options': requestOptions,
       './snapshot-pruner': { pruneSnapshot: pruneSnapshotStub },
     })
 
@@ -213,8 +206,7 @@ describe('input message http requests', function () {
     assert.strictEqual(options.url.href, 'https://debugger-intake.us3.datadoghq.com/')
     assert.strictEqual(Object.hasOwn(options.headers, 'DD-API-KEY'), false)
     assert.strictEqual(options.headers['DD-EVP-ORIGIN'], 'agent-debugger')
-    assert.strictEqual(options.agent, proxyAgent)
-    sinon.assert.calledOnceWithExactly(getHttpsProxyAgent, 'https://debugger-intake.us3.datadoghq.com/')
+    assert.strictEqual(options.agent, undefined)
   })
 
   it('should fallback to /debugger/v1/diagnostics on 404 from v2 endpoint', function (done) {

--- a/packages/dd-trace/test/debugger/devtools_client/status.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/status.spec.js
@@ -152,12 +152,6 @@ describe('diagnostic message http requests', function () {
   it('should send directly to the debugger intake in agentless mode', function () {
     const requestAgentless = sinon.spy()
     requestAgentless['@noCallThru'] = true
-    const proxyAgent = {}
-    const getHttpsProxyAgent = sinon.stub().returns(proxyAgent)
-    getHttpsProxyAgent['@noCallThru'] = true
-    const requestOptions = proxyquire('../../../src/debugger/devtools_client/request-options', {
-      '../../evp_proxy/direct': { getHttpsProxyAgent },
-    })
     const statusAgentless = proxyquire('../../../src/debugger/devtools_client/status', {
       './config': {
         agentless: true,
@@ -173,7 +167,6 @@ describe('diagnostic message http requests', function () {
         '@noCallThru': true,
       },
       '../../exporters/common/request': requestAgentless,
-      './request-options': requestOptions,
     })
 
     statusAgentless.ackReceived({ id: 'agentless-probe', version: 0 })
@@ -186,8 +179,7 @@ describe('diagnostic message http requests', function () {
     assert.strictEqual(options.url.href, 'https://debugger-intake.us3.datadoghq.com/')
     assert.strictEqual(options.headers['DD-API-KEY'], 'test-api-key')
     assert.strictEqual(options.headers['DD-EVP-ORIGIN'], 'agent-debugger')
-    assert.strictEqual(options.agent, proxyAgent)
-    sinon.assert.calledOnceWithExactly(getHttpsProxyAgent, 'https://debugger-intake.us3.datadoghq.com/')
+    assert.strictEqual(options.agent, undefined)
   })
 })
 

--- a/packages/dd-trace/test/evp_proxy/direct.spec.js
+++ b/packages/dd-trace/test/evp_proxy/direct.spec.js
@@ -8,19 +8,12 @@ const sinon = require('sinon')
 
 describe('direct EVP route', () => {
   let createDirectEVPRoute
-  let getHttpsProxyAgent
-  let getProxyForUrl
-  let HttpsProxyAgent
   let log
 
   beforeEach(() => {
-    getProxyForUrl = sinon.stub().returns('')
-    HttpsProxyAgent = sinon.stub().callsFake(proxyUrl => ({ proxyUrl }))
     log = { debug: sinon.spy() }
 
-    ;({ createDirectEVPRoute, getHttpsProxyAgent } = proxyquire('../../src/evp_proxy/direct', {
-      '../../../../vendor/dist/https-proxy-agent': { HttpsProxyAgent },
-      '../../../../vendor/dist/proxy-from-env': { getProxyForUrl },
+    ;({ createDirectEVPRoute } = proxyquire('../../src/evp_proxy/direct', {
       '../log': log,
     }))
   })
@@ -53,33 +46,6 @@ describe('direct EVP route', () => {
         'DD-API-KEY': 'test-api-key',
       },
     })
-  })
-
-  it('uses the standard HTTPS proxy for direct intake', () => {
-    const proxyUrl = 'http://proxy:8202'
-    getProxyForUrl.returns(proxyUrl)
-
-    const route = createDirectEVPRoute({
-      DD_API_KEY: 'test-api-key',
-      site: 'datadoghq.com',
-    }, 'event-platform-intake')
-
-    assert.deepStrictEqual(route.agent, { proxyUrl })
-    sinon.assert.calledOnceWithExactly(
-      getProxyForUrl,
-      'https://event-platform-intake.datadoghq.com/'
-    )
-    sinon.assert.calledOnceWithExactly(HttpsProxyAgent, proxyUrl)
-  })
-
-  it('reuses the HTTPS agent for the same proxy', () => {
-    getProxyForUrl.returns('http://proxy:8202')
-
-    const first = getHttpsProxyAgent('https://debugger-intake.datadoghq.com/')
-    const second = getHttpsProxyAgent('https://event-platform-intake.datadoghq.com/')
-
-    assert.strictEqual(second, first)
-    sinon.assert.calledOnce(HttpsProxyAgent)
   })
 
   it('does not create a route without an API key', () => {

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -18,7 +18,9 @@ describe('AgentlessWriter', () => {
   let encoder
   let encoderArgs
   let exporter
+  let getHttpsProxyAgent
   let log
+  let proxyAgent
   let writer
 
   beforeEach(() => {
@@ -34,6 +36,8 @@ describe('AgentlessWriter', () => {
       sendV04: sinon.stub().callsArg(1),
     }
     createAgentlessExporter = sinon.stub().returns(exporter)
+    proxyAgent = {}
+    getHttpsProxyAgent = sinon.stub().returns(proxyAgent)
     log = {
       debug: sinon.stub(),
       error: sinon.stub(),
@@ -55,6 +59,7 @@ describe('AgentlessWriter', () => {
       }),
       '../../encode/0.4': { AgentEncoder },
       '../../log': log,
+      '../common/proxy': { getHttpsProxyAgent },
     })
   })
 
@@ -94,7 +99,10 @@ describe('AgentlessWriter', () => {
       tracerVersion: 'tracer-version',
       languageVersion: process.version,
       languageInterpreter: 'v8',
+    }, {
+      agent: proxyAgent,
     })
+    sinon.assert.calledOnceWithExactly(getHttpsProxyAgent, new URL('https://intake.example/custom-path'))
   })
 
   it('suppresses instrumentation of the data-pipeline intake request', async () => {
@@ -142,6 +150,22 @@ describe('AgentlessWriter', () => {
     )
   })
 
+  it('contains proxy configuration failures before constructing the data pipeline', async () => {
+    const error = new Error('invalid proxy URL')
+    getHttpsProxyAgent.throws(error)
+    writer = new AgentlessWriter({ url: new URL('https://intake.example') })
+
+    await new Promise(resolve => writer.flush(resolve))
+
+    sinon.assert.notCalled(createAgentlessExporter)
+    sinon.assert.calledWithExactly(
+      log.error,
+      'Failed to send %d trace(s) to the agentless intake: %s',
+      1,
+      'invalid proxy URL'
+    )
+  })
+
   it('contains synchronous data-pipeline send failures', async () => {
     exporter.sendV04.throws(new Error('send failed'))
     writer = new AgentlessWriter({ url: new URL('https://intake.example') })
@@ -162,11 +186,21 @@ describe('AgentlessWriter', () => {
     await new Promise(resolve => writer.flush(resolve))
 
     sinon.assert.notCalled(createAgentlessExporter)
+    sinon.assert.notCalled(getHttpsProxyAgent)
     sinon.assert.notCalled(exporter.sendV04)
     sinon.assert.calledWithExactly(
       log.warn,
       'DD_API_KEY will not be sent because the configured receiver is neither HTTPS nor loopback.'
     )
+  })
+
+  it('keeps loopback HTTP receivers direct', async () => {
+    writer = new AgentlessWriter({ url: new URL('http://127.0.0.1:8126') })
+
+    await new Promise(resolve => writer.flush(resolve))
+
+    sinon.assert.notCalled(getHttpsProxyAgent)
+    assert.strictEqual(createAgentlessExporter.firstCall.args[1].agent, undefined)
   })
 
   it('reuses the pipeline exporter while its endpoint and API key are unchanged', async () => {

--- a/packages/dd-trace/test/exporters/common/proxy.spec.js
+++ b/packages/dd-trace/test/exporters/common/proxy.spec.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const http = require('node:http')
+const https = require('node:https')
+const { once } = require('node:events')
+
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+require('../../setup/core')
+
+const { getHttpsProxyAgent } = require('../../../src/exporters/common/proxy')
+
+const httpsRequest = https.request
+const proxyEnvironmentNames = [
+  'ALL_PROXY',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NO_PROXY',
+  'all_proxy',
+  'https_proxy',
+  'http_proxy',
+  'no_proxy',
+]
+
+describe('HTTPS proxy agent selection', () => {
+  let originalEnvironment
+
+  beforeEach(() => {
+    originalEnvironment = new Map()
+    for (const name of proxyEnvironmentNames) {
+      originalEnvironment.set(name, process.env[name])
+      delete process.env[name]
+    }
+  })
+
+  afterEach(() => {
+    for (const [name, value] of originalEnvironment) {
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+  })
+
+  it('routes an HTTPS request through the standard proxy', async () => {
+    const proxy = http.createServer()
+    let resolveTarget
+    let proxySocket
+    const target = new Promise(resolve => {
+      resolveTarget = resolve
+    })
+    proxy.once('connect', (request, socket) => {
+      proxySocket = socket
+      resolveTarget(request.url)
+      socket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n')
+    })
+    proxy.listen(0, '127.0.0.1')
+    await once(proxy, 'listening')
+
+    const directAgent = new https.Agent({ keepAlive: true, maxSockets: 4 })
+    const { port } = proxy.address()
+    process.env.https_proxy = `http://127.0.0.1:${port}`
+    const agent = getHttpsProxyAgent('https://intake.example/path', directAgent)
+    const request = httpsRequest({
+      agent,
+      hostname: 'intake.example',
+      method: 'POST',
+      path: '/path',
+      port: 443,
+    })
+    request.on('error', () => {})
+    request.end()
+
+    try {
+      assert.strictEqual(await target, 'intake.example:443')
+    } finally {
+      request.destroy()
+      directAgent.destroy()
+      agent.destroy()
+      proxySocket?.destroy()
+      proxy.closeAllConnections()
+      await new Promise(resolve => proxy.close(resolve))
+    }
+  })
+
+  it('honors NO_PROXY', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example:8202'
+    process.env.NO_PROXY = 'intake.example'
+    const directAgent = new https.Agent()
+
+    try {
+      assert.strictEqual(
+        getHttpsProxyAgent({
+          protocol: 'https:',
+          hostname: 'intake.example',
+          port: 443,
+        }, directAgent),
+        directAgent
+      )
+    } finally {
+      directAgent.destroy()
+    }
+  })
+
+  it('reuses proxy agents without merging direct agent pools', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example:8202'
+    const payloadAgent = new https.Agent({ keepAlive: true, maxSockets: 16 })
+    const mediaAgent = new https.Agent({ keepAlive: true, maxSockets: 16 })
+
+    const firstPayloadProxy = getHttpsProxyAgent('https://intake.example/path', payloadAgent)
+    const secondPayloadProxy = getHttpsProxyAgent('https://other.example/path', payloadAgent)
+    const mediaProxy = getHttpsProxyAgent('https://intake.example/path', mediaAgent)
+
+    try {
+      assert.strictEqual(secondPayloadProxy, firstPayloadProxy)
+      assert.notStrictEqual(mediaProxy, firstPayloadProxy)
+      assert.strictEqual(firstPayloadProxy.keepAlive, true)
+      assert.strictEqual(firstPayloadProxy.maxSockets, 16)
+      assert.strictEqual(mediaProxy.keepAlive, true)
+      assert.strictEqual(mediaProxy.maxSockets, 16)
+    } finally {
+      payloadAgent.destroy()
+      mediaAgent.destroy()
+      firstPayloadProxy.destroy()
+      mediaProxy.destroy()
+    }
+  })
+
+  it('rejects an invalid proxy URL', () => {
+    process.env.HTTPS_PROXY = '://invalid'
+
+    assert.throws(
+      () => getHttpsProxyAgent('https://intake.example/path'),
+      { code: 'ERR_INVALID_URL' }
+    )
+  })
+})

--- a/packages/dd-trace/test/exporters/common/proxy.spec.js
+++ b/packages/dd-trace/test/exporters/common/proxy.spec.js
@@ -104,6 +104,25 @@ describe('HTTPS proxy agent selection', () => {
     }
   })
 
+  it('honors NO_PROXY for IPv6 targets', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example:8202'
+    process.env.NO_PROXY = '[::1]'
+    const directAgent = new https.Agent()
+    const targets = [
+      'https://[::1]:443/path',
+      new URL('https://[::1]:443/path'),
+      { protocol: 'https:', hostname: '::1', port: 443 },
+    ]
+
+    try {
+      for (const target of targets) {
+        assert.strictEqual(getHttpsProxyAgent(target, directAgent), directAgent)
+      }
+    } finally {
+      directAgent.destroy()
+    }
+  })
+
   it('reuses proxy agents without merging direct agent pools', () => {
     process.env.HTTPS_PROXY = 'http://proxy.example:8202'
     const payloadAgent = new https.Agent({ keepAlive: true, maxSockets: 16 })

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 const { EventEmitter, once } = require('node:events')
 const http = require('node:http')
+const https = require('node:https')
 const zlib = require('node:zlib')
 const stream = require('node:stream')
 
@@ -43,6 +44,7 @@ describe('request', function () {
   let request
   let log
   let docker
+  let getHttpsProxyAgent
   let maxAttempts
   let retryStubs
   let runInNoopContext
@@ -57,6 +59,7 @@ describe('request', function () {
         carrier['datadog-container-id'] = 'abcd'
       },
     }
+    getHttpsProxyAgent = sinon.stub().callsFake((url, agent) => agent)
     // The retry policy is exercised in retry.spec.js. Here we keep the integration
     // deterministic: zero backoff, no startup-phase mutation, attempt count
     // overridable per test.
@@ -72,6 +75,7 @@ describe('request', function () {
         storage: () => ({ run: runInNoopContext }),
       },
       './docker': docker,
+      './proxy': { getHttpsProxyAgent },
       '../../log': log,
       './retry': {
         ...require('../../../src/exporters/common/retry'),
@@ -133,6 +137,42 @@ describe('request', function () {
     })
   })
 
+  it('selects an HTTPS proxy agent for authenticated requests', (done) => {
+    const url = new URL('https://test:443/path')
+    const options = {
+      url,
+      method: 'POST',
+      headers: {
+        'DD-API-KEY': 'test-api-key',
+      },
+    }
+    nock('https://test:443').post('/path').reply(200, 'OK')
+
+    request(Buffer.from(''), options, (error) => {
+      sinon.assert.calledOnceWithExactly(getHttpsProxyAgent, options, sinon.match.instanceOf(https.Agent))
+      done(error)
+    })
+  })
+
+  it('reports proxy selection errors without starting a request', () => {
+    const error = new Error('invalid proxy URL')
+    const requestSpy = sinon.spy(https, 'request')
+    const callback = sinon.spy()
+    getHttpsProxyAgent.throws(error)
+
+    request(Buffer.from(''), {
+      url: new URL('https://test:443/path'),
+      method: 'POST',
+      headers: {
+        'DD-API-KEY': 'test-api-key',
+      },
+    }, callback)
+
+    requestSpy.restore()
+    sinon.assert.calledOnceWithExactly(callback, error)
+    sinon.assert.notCalled(requestSpy)
+  })
+
   it('selects a new default agent when callers reuse options with another protocol', (done) => {
     const options = {
       url: new URL('http://test:123'),
@@ -150,6 +190,7 @@ describe('request', function () {
 
       request(Buffer.from(''), options, (httpsError) => {
         assert.strictEqual(options.agent, undefined)
+        sinon.assert.notCalled(getHttpsProxyAgent)
         done(httpsError)
       })
     })

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -81,6 +81,19 @@ describe('sendData', () => {
     })
   })
 
+  it('does not send the API key to the Agent', () => {
+    sendDataModule.sendData({
+      DD_API_KEY: 'secret-key',
+      url: new URL('https://agent.example:8126'),
+      tags: { 'runtime-id': '123' },
+    }, application, host, 'req-type')
+
+    sinon.assert.calledOnce(request)
+    const options = request.getCall(0).args[1]
+
+    assert.strictEqual(options.headers['dd-api-key'], undefined)
+  })
+
   it('adds the debug header when telemetry debug mode is enabled', () => {
     sendDataModule.sendData({
       url: '/test',
@@ -162,6 +175,7 @@ describe('sendData', () => {
   it('uses the CI Visibility agentless intake when agentless mode is enabled', () => {
     sendDataModule.sendData(
       {
+        DD_API_KEY: 'secret-key',
         isCiVisibility: true,
         testOptimization: { DD_CIVISIBILITY_AGENTLESS_ENABLED: true },
         tags: { 'runtime-id': '123' },
@@ -181,6 +195,7 @@ describe('sendData', () => {
     const { url } = options
     assert.deepStrictEqual(url, new URL('https://instrumentation-telemetry-intake.datadoghq.eu'))
     assert.strictEqual(options.agent, getAgent(url))
+    assert.strictEqual(options.headers['dd-api-key'], 'secret-key')
   })
 
   it('uses DD_CIVISIBILITY_AGENTLESS_URL for telemetry when the agentless intake is overridden', () => {


### PR DESCRIPTION
Authenticated HTTPS intake requests now use the standard proxy environment variables and NO_PROXY. Agent and EVP-proxy routes remain direct. Invalid proxy configuration fails the request instead of bypassing the proxy. Agentless APM transport requires a libdatadog release that accepts a borrowed transport agent. The lockfile update remains blocked until that release is available.