### PR TITLE
fix(llmobs): read the text of Bedrock Converse guardContent blocks

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -500,6 +500,8 @@ function extractMessagesFromConverseContent (role, contentBlocks) {
       if (block == null || typeof block !== 'object') continue
       if (typeof block.text === 'string') {
         content += block.text
+      } else if (typeof block.guardContent?.text?.text === 'string') {
+        content += block.guardContent.text.text
       } else if (block.toolUse) {
         toolCalls.push(buildToolCall(block.toolUse))
       } else if (block.toolResult) {

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
@@ -73,6 +73,19 @@ describe('bedrockruntime utils', () => {
     })
   })
 
+  it('reads the text of Converse guardContent blocks', () => {
+    const message = extractMessagesFromConverseContent('user', [
+      { text: 'Context: ' },
+      { guardContent: { text: { text: 'What is the dose?', qualifiers: ['guard_content'] } } },
+      { text: ' Cite sources.' },
+    ])
+
+    assert.deepStrictEqual(message, {
+      role: 'user',
+      content: 'Context: What is the dose? Cite sources.',
+    })
+  })
+
   describe('converse stream extractor', () => {
     it('returns an empty message when the stream fails before yielding a chunk', () => {
       const generation = extractTextAndResponseReasonConverseFromStream()


### PR DESCRIPTION
### What does this PR do?
Reads the text of Bedrock Converse `guardContent` blocks when building the LLM Observability input for `converse` and `converseStream` requests, instead of recording them as `[Unsupported content type: guardContent]`.

### Motivation
`guardContent` is how a Converse caller scopes a Bedrock guardrail to part of a turn, typically the user's question, with retrieved context left unscanned around it. With the current walker the recorded `llm` span keeps the context and loses the question, which is the one part of the prompt anyone reading the span needs. The block is input-only, so response and stream extraction are unchanged.

### Additional Notes
One unit test in `bedrockruntime.util.spec.js` covers a guarded text block between two plain text blocks. A guarded image block still falls through to the placeholder.

Fixes #10172
