### PR TITLE
fix(agentless): fix agentless crashtracking setup

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,7 +14,7 @@ Agentless mode disables features that require an Agent.
 Set the API key with `DD_API_KEY` or `DATADOG_API_KEY`.
 Agentless crash tracking requires this key and sends crash data directly to Datadog.
 
-Agentless mode uses the Datadog trace intake and ignores `OTEL_TRACES_EXPORTER`.
+Agentless mode uses the Datadog trace intake by default.
 Explicit `DD_TRACE_SAMPLE_RATE`, `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SPAN_METRICS_ENABLED`, and
 `DD_METRICS_OTEL_ENABLED` settings still apply.
 

--- a/integration-tests/crashtracking/crashtracking.spec.js
+++ b/integration-tests/crashtracking/crashtracking.spec.js
@@ -41,7 +41,9 @@ function spawnCrashFixture (fixture, agentPort, environment = {}, onStderr) {
 }
 
 /**
- * Collect the native receiver's agentless requests until both direct intakes receive crash data.
+ * Collect the native receiver's requests to the Errors Tracking intake (the ping and the full
+ * crash report) until both have arrived. Agentless mode does not configure a telemetry endpoint,
+ * so the receiver only ever submits directly to the errors intake.
  *
  * @param {http.Server} server
  * @param {string} expectedApiKey
@@ -50,8 +52,7 @@ function spawnCrashFixture (fixture, agentPort, environment = {}, onStderr) {
  */
 function collectAgentlessCrashRequests (server, expectedApiKey, timeout = 10_000) {
   const requestUrls = []
-  const telemetry = []
-  let receivedErrorTracking = false
+  const errorsIntake = []
 
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -73,28 +74,18 @@ function collectAgentlessCrashRequests (server, expectedApiKey, timeout = 10_000
 
         requestUrls.push(request.url)
 
-        if (request.url === '/api/v2/apmtelemetry') {
-          const payload = JSON.parse(Buffer.concat(chunks).toString())
-          if (payload.origin === 'Crashtracker') {
-            if (request.headers['dd-api-key'] !== expectedApiKey) {
-              cleanup()
-              reject(new Error('Crash telemetry request has an invalid API key'))
-              return
-            }
-            telemetry.push(payload)
-          }
-        } else if (request.url === '/api/v2/errorsintake') {
+        if (request.url === '/api/v2/errorsintake') {
           if (request.headers['dd-api-key'] !== expectedApiKey) {
             cleanup()
             reject(new Error('Errors Tracking request has an invalid API key'))
             return
           }
-          receivedErrorTracking = true
+          errorsIntake.push(JSON.parse(Buffer.concat(chunks).toString()))
         }
 
-        if (telemetry.length >= 2 && receivedErrorTracking) {
+        if (errorsIntake.length >= 2) {
           cleanup()
-          resolve(telemetry)
+          resolve(errorsIntake)
         }
       })
     }
@@ -201,7 +192,7 @@ describeNotWindows('crashtracking integration', () => {
       )
     })
 
-    it('sends native crash data directly to both agentless intakes', async function () {
+    it('sends native crash data directly to the errors tracking intake', async function () {
       if (os.platform() !== 'linux') this.skip()
 
       const server = http.createServer()
@@ -225,7 +216,7 @@ describeNotWindows('crashtracking integration', () => {
           error.message += `\nFixture stderr: ${stderr}`
           throw error
         }
-        assert.ok(requests.every(payload => payload.request_type === 'logs'))
+        assert.strictEqual(requests.length, 2, 'expected a ping and a full crash report')
       } finally {
         await new Promise(resolve => server.close(resolve))
       }

--- a/integration-tests/crashtracking/fixtures/agentless-signal-crash.js
+++ b/integration-tests/crashtracking/fixtures/agentless-signal-crash.js
@@ -35,14 +35,8 @@ const testLibdatadogExtras = {
 }
 testLibdatadogExtras['@global'] = true
 
-function getAgentlessTelemetryUrl () {
-  return new URL(intakeUrl)
-}
-getAgentlessTelemetryUrl['@global'] = true
-
-// Initialize through the normal fixture while the global stubs are active. Runtime-global stubs
+// Initialize through the normal fixture while the global stub is active. Runtime-global stubs
 // bypass the module cache and split tracer singleton state across duplicate module instances.
 proxyquire('../signal-crash', {
   '@datadog/libdatadog-extras': testLibdatadogExtras,
-  '../../packages/dd-trace/src/telemetry/agentless-url': getAgentlessTelemetryUrl,
 })

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1837,7 +1837,8 @@
         "default": "datadoghq.com",
         "configurationNames": [
           "site"
-        ]
+        ],
+        "transform": "toLowerCase"
       }
     ],
     "DD_SPAN_SAMPLING_RULES": [

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -8,10 +8,10 @@ const binding = libdatadogExtras.load('crashtracker')
 
 const { channel } = require('dc-polyfill')
 const { getEnvironmentVariable } = require('../config/helper')
+const getAgentlessTelemetryUrl = require('../telemetry/agentless-url')
 const log = require('../log')
 const pkg = require('../../../../package.json')
 const processTags = require('../process-tags')
-const getAgentlessTelemetryUrl = require('../telemetry/agentless-url')
 
 const identityRefreshChannel = channel('datadog:identity:refresh')
 const INHERITED_RECEIVER_ENVIRONMENT_VARIABLES = [
@@ -38,16 +38,12 @@ function getAgentlessReceiverEnvironment (config) {
   }
 
   const site = config.site.toLowerCase()
-  const telemetryUrl = getAgentlessTelemetryUrl(site).origin
 
   const environment = /** @type {Array<[string, string]>} */ ([
     ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
     ['DD_API_KEY', config.DD_API_KEY],
     ['DD_SITE', site],
-    ['DD_APM_TELEMETRY_DD_URL', telemetryUrl],
-    // libdatadog v43 parses the dedicated URL above but does not use it when constructing the
-    // endpoint. Keep this compatibility fallback until its telemetry config honors that setting.
-    ['DD_TRACE_AGENT_URL', telemetryUrl],
+    ['DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED', 'true'],
   ])
 
   // The receiver environment does not inherit from this process.
@@ -117,8 +113,23 @@ class Crashtracker {
    * @param {import('../config/config-base')} config - Tracer configuration
    */
   #getConfig (config) {
-    let endpoint = null
-    if (!config.DD_AGENTLESS_ENABLED) {
+    let endpoint
+    if (config.DD_AGENTLESS_ENABLED) {
+      // Crash reports ride the telemetry intake, so agentless points at the same host the
+      // telemetry writer uses (matches dd-trace-py's _agentless_endpoint_url).
+      const url = getAgentlessTelemetryUrl(config.site.toLowerCase())
+      endpoint = {
+        url: {
+          scheme: url.protocol.slice(0, -1),
+          authority: url.host,
+          path_and_query: '',
+        },
+        // Direct submission is only selected when the endpoint carries an API key; without
+        // it, the receiver falls back to the agent's EvP proxy path.
+        api_key: config.DD_API_KEY,
+        timeout_ms: 3000,
+      }
+    } else {
       const url = config.url
       endpoint = {
         // TODO: Use the string directly when deserialization is fixed.

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -8,7 +8,6 @@ const binding = libdatadogExtras.load('crashtracker')
 
 const { channel } = require('dc-polyfill')
 const { getEnvironmentVariable } = require('../config/helper')
-const getAgentlessTelemetryUrl = require('../telemetry/agentless-url')
 const log = require('../log')
 const pkg = require('../../../../package.json')
 const processTags = require('../process-tags')
@@ -113,21 +112,19 @@ class Crashtracker {
    * @param {import('../config/config-base')} config - Tracer configuration
    */
   #getConfig (config) {
-    const url = config.DD_AGENTLESS_ENABLED ? getAgentlessTelemetryUrl(config.site) : config.url
-    const endpoint = {
-      // TODO: Use the string directly when deserialization is fixed.
-      url: {
-        scheme: url.protocol.slice(0, -1),
-        authority: url.protocol === 'unix:'
-          ? Buffer.from(url.pathname).toString('hex')
-          : url.host,
-        path_and_query: '',
-      },
-      timeout_ms: 3000,
-    }
-    if (config.DD_AGENTLESS_ENABLED) {
-      endpoint.api_key = config.DD_API_KEY
-    }
+    const endpoint = config.DD_AGENTLESS_ENABLED
+      ? undefined
+      : {
+        // TODO: Use the string directly when deserialization is fixed.
+        url: {
+          scheme: config.url.protocol.slice(0, -1),
+          authority: config.url.protocol === 'unix:'
+            ? Buffer.from(config.url.pathname).toString('hex')
+            : config.url.host,
+          path_and_query: '',
+        },
+        timeout_ms: 3000,
+      }
 
     // Out-of-process symbolication currently works on
     // Linux only, does not work on Mac.

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -113,35 +113,20 @@ class Crashtracker {
    * @param {import('../config/config-base')} config - Tracer configuration
    */
   #getConfig (config) {
-    let endpoint
+    const url = config.DD_AGENTLESS_ENABLED ? getAgentlessTelemetryUrl(config.site) : config.url
+    const endpoint = {
+      // TODO: Use the string directly when deserialization is fixed.
+      url: {
+        scheme: url.protocol.slice(0, -1),
+        authority: url.protocol === 'unix:'
+          ? Buffer.from(url.pathname).toString('hex')
+          : url.host,
+        path_and_query: '',
+      },
+      timeout_ms: 3000,
+    }
     if (config.DD_AGENTLESS_ENABLED) {
-      // Crash reports ride the telemetry intake, so agentless points at the same host the
-      // telemetry writer uses (matches dd-trace-py's _agentless_endpoint_url).
-      const url = getAgentlessTelemetryUrl(config.site.toLowerCase())
-      endpoint = {
-        url: {
-          scheme: url.protocol.slice(0, -1),
-          authority: url.host,
-          path_and_query: '',
-        },
-        // Direct submission is only selected when the endpoint carries an API key; without
-        // it, the receiver falls back to the agent's EvP proxy path.
-        api_key: config.DD_API_KEY,
-        timeout_ms: 3000,
-      }
-    } else {
-      const url = config.url
-      endpoint = {
-        // TODO: Use the string directly when deserialization is fixed.
-        url: {
-          scheme: url.protocol.slice(0, -1),
-          authority: url.protocol === 'unix:'
-            ? Buffer.from(url.pathname).toString('hex')
-            : url.host,
-          path_and_query: '',
-        },
-        timeout_ms: 3000,
-      }
+      endpoint.api_key = config.DD_API_KEY
     }
 
     // Out-of-process symbolication currently works on

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -115,16 +115,16 @@ class Crashtracker {
     const endpoint = config.DD_AGENTLESS_ENABLED
       ? undefined
       : {
-        // TODO: Use the string directly when deserialization is fixed.
-        url: {
-          scheme: config.url.protocol.slice(0, -1),
-          authority: config.url.protocol === 'unix:'
-            ? Buffer.from(config.url.pathname).toString('hex')
-            : config.url.host,
-          path_and_query: '',
-        },
-        timeout_ms: 3000,
-      }
+          // TODO: Use the string directly when deserialization is fixed.
+          url: {
+            scheme: config.url.protocol.slice(0, -1),
+            authority: config.url.protocol === 'unix:'
+              ? Buffer.from(config.url.pathname).toString('hex')
+              : config.url.host,
+            path_and_query: '',
+          },
+          timeout_ms: 3000,
+        }
 
     // Out-of-process symbolication currently works on
     // Linux only, does not work on Mac.

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -124,15 +124,7 @@ describeNotWindows('crashtracker', () => {
       crashtracker.start(config)
 
       sinon.assert.calledOnce(binding.init)
-      assert.deepStrictEqual(binding.init.firstCall.args[0].endpoint, {
-        url: {
-          scheme: 'https',
-          authority: 'instrumentation-telemetry-intake.us3.datadoghq.com',
-          path_and_query: '',
-        },
-        api_key: 'test-api-key',
-        timeout_ms: 3000,
-      })
+      assert.strictEqual(binding.init.firstCall.args[0].endpoint, undefined)
       assert.deepStrictEqual(binding.init.firstCall.args[1].env, [
         ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
         ['DD_API_KEY', 'test-api-key'],
@@ -200,19 +192,6 @@ describeNotWindows('crashtracker', () => {
       sinon.assert.notCalled(binding.init)
       sinon.assert.calledOnce(log.error)
       assert.match(log.error.firstCall.args[1].message, /DD_API_KEY is required/)
-      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
-    })
-
-    it('should reject an agentless site that could redirect the API key', () => {
-      config.DD_AGENTLESS_ENABLED = true
-      config.DD_API_KEY = 'test-api-key'
-      config.site = 'datadoghq.com@evil.example'
-
-      crashtracker.start(config)
-
-      sinon.assert.notCalled(binding.init)
-      sinon.assert.calledOnce(log.error)
-      assert.match(log.error.firstCall.args[1].message, /Invalid DD_SITE/)
       assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
     })
   })

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -7,7 +7,6 @@ const { inspect } = require('node:util')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-const actualGetAgentlessTelemetryUrl = require('../../src/telemetry/agentless-url')
 require('../setup/core')
 
 const describeNotWindows = os.platform() !== 'win32' ? describe : describe.skip
@@ -19,7 +18,6 @@ describeNotWindows('crashtracker', () => {
   let identityRefreshChannel
   let libdatadogExtras
   let log
-  let getAgentlessTelemetryUrl
 
   before(() => {
     require('../../src/process-tags').initialize()
@@ -44,7 +42,6 @@ describeNotWindows('crashtracker', () => {
     identityRefreshChannel = {
       subscribe: sinon.stub(),
     }
-    getAgentlessTelemetryUrl = sinon.stub().callsFake(actualGetAgentlessTelemetryUrl)
 
     sinon.stub(binding, 'init')
     sinon.stub(binding, 'updateConfig')
@@ -54,7 +51,6 @@ describeNotWindows('crashtracker', () => {
     crashtracker = proxyquire('../../src/crashtracking/crashtracker', {
       'dc-polyfill': { channel: sinon.stub().returns(identityRefreshChannel) },
       '../log': log,
-      '../telemetry/agentless-url': getAgentlessTelemetryUrl,
     })
   })
 
@@ -128,30 +124,20 @@ describeNotWindows('crashtracker', () => {
       crashtracker.start(config)
 
       sinon.assert.calledOnce(binding.init)
-      assert.strictEqual(binding.init.firstCall.args[0].endpoint, null)
+      assert.deepStrictEqual(binding.init.firstCall.args[0].endpoint, {
+        url: {
+          scheme: 'https',
+          authority: 'instrumentation-telemetry-intake.us3.datadoghq.com',
+          path_and_query: '',
+        },
+        api_key: 'test-api-key',
+        timeout_ms: 3000,
+      })
       assert.deepStrictEqual(binding.init.firstCall.args[1].env, [
         ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
         ['DD_API_KEY', 'test-api-key'],
         ['DD_SITE', 'us3.datadoghq.com'],
-        ['DD_APM_TELEMETRY_DD_URL', 'https://instrumentation-telemetry-intake.us3.datadoghq.com'],
-        ['DD_TRACE_AGENT_URL', 'https://instrumentation-telemetry-intake.us3.datadoghq.com'],
-      ])
-      sinon.assert.notCalled(log.error)
-    })
-
-    it('should use the staging telemetry intake in agentless mode', () => {
-      config.DD_AGENTLESS_ENABLED = true
-      config.DD_API_KEY = 'test-api-key'
-      config.site = 'datad0g.com'
-
-      crashtracker.start(config)
-
-      assert.deepStrictEqual(binding.init.firstCall.args[1].env, [
-        ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
-        ['DD_API_KEY', 'test-api-key'],
-        ['DD_SITE', 'datad0g.com'],
-        ['DD_APM_TELEMETRY_DD_URL', 'https://all-http-intake.logs.datad0g.com'],
-        ['DD_TRACE_AGENT_URL', 'https://all-http-intake.logs.datad0g.com'],
+        ['DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED', 'true'],
       ])
       sinon.assert.notCalled(log.error)
     })
@@ -160,7 +146,6 @@ describeNotWindows('crashtracker', () => {
       config.DD_AGENTLESS_ENABLED = true
       config.DD_API_KEY = 'test-api-key'
       config.site = 'datadoghq.com'
-      getAgentlessTelemetryUrl.returns(new URL('http://127.0.0.1:1234'))
       const environment = {
         HTTP_PROXY: 'http://uppercase-http-proxy',
         HTTPS_PROXY: 'http://uppercase-https-proxy',
@@ -193,8 +178,7 @@ describeNotWindows('crashtracker', () => {
         ['_DD_DIRECT_SUBMISSION_ENABLED', 'true'],
         ['DD_API_KEY', 'test-api-key'],
         ['DD_SITE', 'datadoghq.com'],
-        ['DD_APM_TELEMETRY_DD_URL', 'http://127.0.0.1:1234'],
-        ['DD_TRACE_AGENT_URL', 'http://127.0.0.1:1234'],
+        ['DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED', 'true'],
         ['HTTP_PROXY', 'http://uppercase-http-proxy'],
         ['HTTPS_PROXY', 'http://uppercase-https-proxy'],
         ['NO_PROXY', 'uppercase-no-proxy'],


### PR DESCRIPTION
Setting the correct env variables, and don't override the intake-settings of the crashtracker itself for no reason.