### PR TITLE
fix(test-optimization): preserve Jest logger module realms

### DIFF
--- a/integration-tests/ci-visibility/jest-mock-bypass-require/pino-error-serialization-test.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/pino-error-serialization-test.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { stdSerializers } = require('pino')
+
+describe('Pino error serialization', () => {
+  it('serializes errors created in the Jest realm', () => {
+    const serializedError = stdSerializers.err(new Error('test error'))
+
+    assert.strictEqual(serializedError.type, 'Error')
+  })
+})

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -1658,7 +1658,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       for (const resolutionType of ['moduleNameMapper', 'custom resolver']) {
         it(`respects Jest ${resolutionType} for ${loggerName}`, async () => {
           let testOutput = ''
-          // Ensure the native bypass still defers to Jest when its resolution is customized.
+          // Ensure instrumentation still defers to Jest when its resolution is customized.
           const resolutionConfig = resolutionType === 'moduleNameMapper'
             ? {
                 CONFIG_MODULE_NAME_MAPPER: JSON.stringify({
@@ -2440,5 +2440,54 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
     assert.strictEqual(exitCode, 0, outputWithTracer)
     assert.doesNotMatch(outputWithTracer, /testEnvironmentOptions prototype was lost/)
+  })
+})
+
+describe(`jest@${JEST_VERSION} with pino@7.6.4`, () => {
+  let receiver
+  let childProcess
+  let cwd
+
+  useSandbox([
+    `jest@${JEST_VERSION}`,
+    JEST_VERSION !== 'latest' ? `jest-circus@${JEST_VERSION}` : '',
+    // Pino 7 uses instanceof Error in its serializer, exposing errors loaded from a different realm.
+    'pino@7.6.4',
+  ].filter(Boolean), true)
+
+  before(function () {
+    cwd = sandboxCwd()
+  })
+
+  beforeEach(async function () {
+    receiver = await new FakeCiVisIntake().start()
+  })
+
+  afterEach(async () => {
+    childProcess.kill()
+    await receiver.stop()
+  })
+
+  it('keeps Pino in the Jest realm', async () => {
+    let testOutput = ''
+    childProcess = exec(
+      runTestsCommand,
+      {
+        cwd,
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          TESTS_TO_RUN: 'jest-mock-bypass-require/pino-error-serialization-test',
+        },
+      }
+    )
+    childProcess.stdout.on('data', chunk => {
+      testOutput += chunk.toString()
+    })
+    childProcess.stderr.on('data', chunk => {
+      testOutput += chunk.toString()
+    })
+
+    const [code] = await once(childProcess, 'exit')
+    assert.strictEqual(code, 0, `Jest should pass but failed with code ${code}: ${testOutput}`)
   })
 })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -11,7 +11,7 @@ const path = require('path')
 const satisfies = require('../../../vendor/dist/semifies')
 const { DD_MAJOR } = require('../../../version')
 const shimmer = require('../../datadog-shimmer')
-const { getEnvironmentVariable } = require('../../dd-trace/src/config/helper')
+const { getEnvironmentVariable, getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 const log = require('../../dd-trace/src/log')
 const {
   EMPTY_EFD_RETRY_POLICY,
@@ -64,6 +64,7 @@ const { addHook, channel } = require('./helpers/instrument')
 const testSessionStartCh = channel('ci:jest:session:start')
 const testSessionFinishCh = channel('ci:jest:session:finish')
 const codeCoverageReportCh = channel('ci:jest:coverage-report')
+const bundlerLoadCh = channel('dd-trace:bundler:load')
 
 const testSessionConfigurationCh = channel('ci:jest:session:configuration')
 
@@ -179,7 +180,9 @@ const wrappedJestEsmLoaders = new WeakSet()
 const wrappedJestObjects = new WeakSet()
 const wrappedWorkerInitializers = new WeakSet()
 const publishedRuntimeReferenceErrors = new WeakMap()
-const jestEsmBypassModulePathsByRuntime = new WeakMap()
+const jestEsmLoggingModulePathsByRuntime = new WeakMap()
+const jestLoggingPackagesByRuntime = new WeakMap()
+const instrumentedJestLoggingModules = new WeakMap()
 const wrappedCoverageReporters = new WeakSet()
 const coverageReporterRequires = new WeakMap()
 const handledJestEvents = new WeakSet()
@@ -3733,13 +3736,15 @@ if (DD_MAJOR < 6) {
   }, jestConfigSyncWrapper)
 }
 
-const LOGGING_LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE = new Set([
+const JEST_LOGGING_LIBRARIES = new Set([
   'bunyan',
   'pino',
   'winston',
 ])
+const disabledJestInstrumentations = new Set(
+  getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS')?.split(',')
+)
 const LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE = new Set([
-  ...LOGGING_LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE,
   'selenium-webdriver',
   'selenium-webdriver/chrome',
   'selenium-webdriver/edge',
@@ -3884,13 +3889,17 @@ function requireOutsideJestRequireEngine (runtime, moduleName) {
  * @param {string} moduleName
  * @returns {void}
  */
-function recordJestEsmBypassModulePath (runtime, from, moduleName) {
-  if (typeof from !== 'string' || !LOGGING_LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.has(moduleName)) return
+function recordJestEsmLoggingModulePath (runtime, from, moduleName) {
+  if (
+    typeof from !== 'string' ||
+    !JEST_LOGGING_LIBRARIES.has(moduleName) ||
+    disabledJestInstrumentations.has(moduleName)
+  ) return
 
-  let pathsByParent = jestEsmBypassModulePathsByRuntime.get(runtime)
+  let pathsByParent = jestEsmLoggingModulePathsByRuntime.get(runtime)
   if (!pathsByParent) {
     pathsByParent = new Map()
-    jestEsmBypassModulePathsByRuntime.set(runtime, pathsByParent)
+    jestEsmLoggingModulePathsByRuntime.set(runtime, pathsByParent)
   }
 
   let modulePaths = pathsByParent.get(from)
@@ -3911,16 +3920,15 @@ function recordJestEsmBypassModulePath (runtime, from, moduleName) {
  * @param {object} runtime
  * @param {string} from
  * @param {string} modulePath
- * @returns {boolean}
+ * @returns {string | undefined}
  */
-function hasJestEsmBypassModulePath (runtime, from, modulePath) {
-  const modulePaths = jestEsmBypassModulePathsByRuntime.get(runtime)?.get(from)
-  if (!modulePaths) return false
+function getJestEsmLoggingModuleName (runtime, from, modulePath) {
+  const modulePaths = jestEsmLoggingModulePathsByRuntime.get(runtime)?.get(from)
+  if (!modulePaths) return
 
-  for (const resolvedPath of modulePaths.values()) {
-    if (resolvedPath === modulePath) return true
+  for (const [moduleName, resolvedPath] of modulePaths) {
+    if (resolvedPath === modulePath) return moduleName
   }
-  return false
 }
 
 /**
@@ -3934,7 +3942,7 @@ function wrapJestEsmLoader (runtime) {
   wrappedJestEsmLoaders.add(esmLoader)
   if (typeof esmLoader.resolveModule === 'function') {
     shimmer.wrap(esmLoader, 'resolveModule', resolveModule => function (moduleName, from) {
-      recordJestEsmBypassModulePath(runtime, from, moduleName)
+      recordJestEsmLoggingModulePath(runtime, from, moduleName)
       return resolveModule.apply(this, arguments)
     })
   }
@@ -3943,7 +3951,7 @@ function wrapJestEsmLoader (runtime) {
       esmLoader,
       'resolveSpecifierForSyncGraph',
       resolveSpecifier => function (from, moduleName) {
-        recordJestEsmBypassModulePath(runtime, from, moduleName)
+        recordJestEsmLoggingModulePath(runtime, from, moduleName)
         return resolveSpecifier.apply(this, arguments)
       }
     )
@@ -3960,11 +3968,10 @@ function getJestBypassModulePath (runtime, from, moduleName) {
   if (typeof from !== 'string' || typeof moduleName !== 'string') return
 
   if (!LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.has(moduleName)) {
-    // Jest passes the resolved path when a CommonJS package is imported from an ESM test.
-    if (path.isAbsolute(moduleName) && hasJestEsmBypassModulePath(runtime, from, moduleName)) {
-      return moduleName
-    }
-    return
+    // Keep the native fallback for logging packages that cannot be instrumented in Jest's realm, such as a
+    // package-name-preserving symlink whose target is a user wrapper rather than the package itself.
+    if (path.isAbsolute(moduleName) && getJestEsmLoggingModuleName(runtime, from, moduleName)) return moduleName
+    if (!JEST_LOGGING_LIBRARIES.has(moduleName) || disabledJestInstrumentations.has(moduleName)) return
   }
 
   try {
@@ -3981,6 +3988,113 @@ function getJestBypassModulePath (runtime, from, moduleName) {
   } catch {
     // Let Jest produce its own resolution error or load a resolver-only module.
   }
+}
+
+/**
+ * @param {object} runtime
+ * @param {string} from
+ * @param {string} moduleName
+ * @returns {string}
+ */
+function resolveJestModulePath (runtime, from, moduleName) {
+  if (path.isAbsolute(moduleName)) return moduleName
+
+  if (typeof runtime._resolveCjsModule === 'function') {
+    return runtime._resolveCjsModule(from, moduleName)
+  } else if (typeof runtime.cjsLoader?.resolution?.resolveCjs === 'function') {
+    return runtime.cjsLoader.resolution.resolveCjs(from, moduleName)
+  }
+  return runtime._resolveModule(from, moduleName)
+}
+
+/**
+ * @param {object} runtime
+ * @param {string} from
+ * @param {string} moduleName
+ * @returns {{ name: string, path: string, version: string } | undefined}
+ */
+function getJestLoggingPackage (runtime, from, moduleName) {
+  if (typeof from !== 'string' || typeof moduleName !== 'string') return
+
+  const directModuleName = JEST_LOGGING_LIBRARIES.has(moduleName) && !disabledJestInstrumentations.has(moduleName)
+    ? moduleName
+    : getJestEsmLoggingModuleName(runtime, from, moduleName)
+  const packages = jestLoggingPackagesByRuntime.get(runtime)
+  let containingPackage
+  if (!directModuleName) {
+    if (!packages) return
+
+    const normalizedFrom = from.replaceAll(path.sep, '/')
+    for (const [packageRoot, loggingPackage] of packages) {
+      if (normalizedFrom.startsWith(`${packageRoot}/`)) {
+        containingPackage = { packageRoot, ...loggingPackage }
+        break
+      }
+    }
+    if (!containingPackage) return
+  }
+
+  try {
+    const modulePath = resolveJestModulePath(runtime, from, moduleName)
+    const normalizedModulePath = modulePath.replaceAll(path.sep, '/')
+
+    if (directModuleName) {
+      if (modulePath !== createRequire(from).resolve(directModuleName)) return
+
+      const nodeModulesPath = `/node_modules/${directModuleName}/`
+      const packagePathIndex = normalizedModulePath.lastIndexOf(nodeModulesPath)
+      if (packagePathIndex === -1) return
+
+      const packageRoot = normalizedModulePath.slice(0, packagePathIndex + nodeModulesPath.length - 1)
+      const { version } = JSON.parse(readFileSync(`${packageRoot}/package.json`, 'utf8'))
+      if (typeof version !== 'string') return
+
+      let runtimePackages = packages
+      if (!runtimePackages) {
+        runtimePackages = new Map()
+        jestLoggingPackagesByRuntime.set(runtime, runtimePackages)
+      }
+      runtimePackages.set(packageRoot, { name: directModuleName, version })
+      return { name: directModuleName, path: directModuleName, version }
+    }
+
+    const { packageRoot, name, version } = containingPackage
+    if (!normalizedModulePath.startsWith(`${packageRoot}/`)) return
+
+    const modulePathWithinPackage = normalizedModulePath.slice(packageRoot.length + 1)
+    return { name, path: `${name}/${modulePathWithinPackage}`, version }
+  } catch {
+    // Let Jest load unresolved, resolver-only, or virtual modules without instrumentation.
+  }
+}
+
+/**
+ * @param {unknown} moduleExports
+ * @param {{ name: string, path: string, version: string } | undefined} loggingPackage
+ * @returns {unknown}
+ */
+function instrumentJestLoggingModule (moduleExports, loggingPackage) {
+  if (!loggingPackage || (typeof moduleExports !== 'object' && typeof moduleExports !== 'function')) {
+    return moduleExports
+  }
+  if (moduleExports === null) return moduleExports
+
+  const instrumentedModule = instrumentedJestLoggingModules.get(moduleExports)
+  if (instrumentedModule) return instrumentedModule
+
+  const payload = {
+    module: moduleExports,
+    package: loggingPackage.name,
+    path: loggingPackage.path,
+    version: loggingPackage.version,
+  }
+  // Apply the regular instrumentation after Jest has evaluated the module so its built-ins stay in Jest's realm.
+  bundlerLoadCh.publish(payload)
+  instrumentedJestLoggingModules.set(moduleExports, payload.module)
+  if (payload.module && (typeof payload.module === 'object' || typeof payload.module === 'function')) {
+    instrumentedJestLoggingModules.set(payload.module, payload.module)
+  }
+  return payload.module
 }
 
 function formatDefaultStackTrace (error, structuredStackTrace) {
@@ -4009,7 +4123,7 @@ addHook({
   // Jest 28 through 30.3 keeps ESM dependency resolution on Runtime itself.
   if (typeof Runtime.prototype.resolveModule === 'function') {
     shimmer.wrap(Runtime.prototype, 'resolveModule', resolveModule => function (moduleName, from) {
-      recordJestEsmBypassModulePath(this, from, moduleName)
+      recordJestEsmLoggingModulePath(this, from, moduleName)
       return resolveModule.apply(this, arguments)
     })
   }
@@ -4024,11 +4138,13 @@ addHook({
   shimmer.wrap(Runtime.prototype, 'requireModule', requireModule => function (from, moduleName) {
     wrapJestGlobalsForRuntime(this)
     try {
+      const loggingPackage = getJestLoggingPackage(this, from, moduleName)
       // Jest calls requireModule only after deciding that the module should not be mocked.
-      const bypassModulePath = getJestBypassModulePath(this, from, moduleName)
-      const returnedValue = bypassModulePath
+      const bypassModulePath = loggingPackage ? undefined : getJestBypassModulePath(this, from, moduleName)
+      let returnedValue = bypassModulePath
         ? requireOutsideJestRequireEngine(this, bypassModulePath)
         : requireModule.apply(this, arguments)
+      returnedValue = instrumentJestLoggingModule(returnedValue, loggingPackage)
       if (moduleName === '@jest/globals') {
         wrapConcurrentJestGlobalsForRuntime(this, returnedValue)
       }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Keeps Pino, Bunyan, and Winston modules in Jest’s runtime realm, then applies the existing Datadog instrumentation through the internal loader channel. This avoids changing logger behavior for values such as Error objects created inside Jest while preserving log injection and automatic log submission.

Adds a regression test in a dedicated Pino 7.6.4 sandbox, whose serializer uses instanceof Error and exposes the cross-realm failure. The main Jest logger sandbox continues to test the latest Pino release.

### Motivation
<!-- What inspired you to submit this pull request? -->
dd-trace 6.13 introduced Jest support for Pino and Bunyan by loading logger modules outside Jest’s module runtime. In applications using Pino 7, errors created in Jest’s VM failed Pino’s instanceof Error check and were returned un-serialized.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Validation:
- Latest Jest with the latest-Pino logger tests and dedicated Pino 7.6.4 regression: 7 passing.
- Jest 28.0.0 with the latest-Pino logger tests and dedicated Pino 7.6.4 regression: 7 passing.
- The broader Winston, Pino, Bunyan, and ESM logger-loading selection: 15 passing.
- The Pino automatic-log-submission Jest cases for CommonJS and ESM: 2 passing.
- Node syntax checks and git diff --check passed.

Targeted ESLint could not run locally because this checkout is missing eslint-plugin-regexp.