### PR TITLE
test(graphql): cover graphql-jit 0.8.9 with GraphQL 17

### DIFF
--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-jit-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-jit-server.mjs
@@ -1,9 +1,12 @@
 import 'dd-trace/init.js'
+import tracer from 'dd-trace'
 import { createServer } from 'node:http'
 
 import dc from 'dc-polyfill'
 import * as graphql from 'graphql'
 import { compileQuery } from 'graphql-jit'
+
+tracer.use('graphql', { source: true })
 
 const User = new graphql.GraphQLObjectType({
   name: 'User',

--- a/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
@@ -162,7 +162,7 @@ describe('Plugin (ESM)', () => {
     let agent
     let proc
 
-    withVersions('graphql', 'graphql-jit', '0.8.5 || 0.8.7 || 0.8.8', (version, moduleName, resolvedVersion) => {
+    withVersions('graphql', 'graphql-jit', '0.8.5 || >=0.8.7 <0.9.0', (version, moduleName, resolvedVersion) => {
       useSandbox([`'graphql-jit@${resolvedVersion}'`, "'graphql@17.0.2'"], false, [
         './packages/datadog-plugin-graphql/test/esm-test/*'])
 
@@ -183,7 +183,9 @@ describe('Plugin (ESM)', () => {
           assert.ok(jitTrace, 'expected the JIT execution trace')
           assert.strictEqual(checkSpansForServiceName([jitTrace], 'graphql.execute'), true)
           assert.strictEqual(checkSpansForServiceName([jitTrace], 'graphql.resolve'), true)
-          assert.strictEqual(jitTrace.some(span => span.resource === 'name:String'), true)
+          const nameSpan = jitTrace.find(span => span.resource === 'name:String')
+          assert.ok(nameSpan)
+          assert.strictEqual(nameSpan.meta['graphql.source'], 'name')
         })
 
         proc = await spawnPluginIntegrationTestProc(

--- a/packages/datadog-plugin-graphql/test/jit.spec.js
+++ b/packages/datadog-plugin-graphql/test/jit.spec.js
@@ -333,14 +333,16 @@ void generatedResolver
     })
 
     withVersions('graphql', 'graphql-jit', '>=0.7.0', version => {
+      const graphqlJit = require(`../../../versions/graphql-jit@${version}`)
       const packageRoot = join(__dirname, '../../../versions', `graphql-jit@${version}`, 'node_modules/graphql-jit')
+      // This CommonJS matrix has no ESM loader. GraphQL 17's module-sync export is covered by the ESM matrix.
+      const cjsGraphqlIt = graphqlJit.getPath('graphql').endsWith('.mjs') ? it.skip : it
 
       before(() => {
         return agent.load('graphql', { variables: ['id', 'name'] })
       })
 
       before(() => {
-        const graphqlJit = require(`../../../versions/graphql-jit@${version}`)
         graphql = graphqlJit.get('graphql')
         compileQuery = graphqlJit.get().compileQuery
         schema = buildSchema()
@@ -478,7 +480,7 @@ void generatedResolver
         assert.deepStrictEqual(result.data, { hello: 'Ada' })
       })
 
-      it('does not nest schema and compiled resolver instrumentation', async () => {
+      cjsGraphqlIt('does not nest schema and compiled resolver instrumentation', async () => {
         const localSchema = buildSchema()
         const document = graphql.parse('query ReusedSchema { hello }')
 
@@ -536,7 +538,7 @@ void generatedResolver
         }
       })
 
-      it('derives anonymous operation metadata', async () => {
+      cjsGraphqlIt('derives anonymous operation metadata', async () => {
         const { query } = compileQuery(schema, graphql.parse('{ hello }'))
 
         /** @param {import('../../dd-trace/src/opentracing/span')[][]} traces */
@@ -1916,7 +1918,7 @@ void generatedResolver
         }
       })
 
-      it('tags the field source on collapsed JIT resolvers', async () => {
+      cjsGraphqlIt('tags the field source on collapsed JIT resolvers', async () => {
         agent.reload('graphql', { source: true, variables: ['id', 'name'] })
         try {
           const { query } = compileQuery(schema, graphql.parse('query SourceTagged { hello }'))
@@ -2921,11 +2923,11 @@ void generatedResolver
     })
   })
 
-  describe('graphql-jit with GraphQL 17', () => {
+  describe('repository-pinned graphql-jit and GraphQL', () => {
     let compileQuery
     let graphql
 
-    useSandbox(["'graphql-jit@0.8.8'", "'graphql@17.0.2'"], false, [])
+    useSandbox(["'graphql-jit'", "'graphql'"], false, [])
 
     before(() => {
       return agent.load('graphql')
@@ -2941,7 +2943,7 @@ void generatedResolver
       return agent.close()
     })
 
-    it('traces and publishes a default resolver without an argument list', async () => {
+    it('traces and publishes a default resolver', async () => {
       const User = new graphql.GraphQLObjectType({
         name: 'User',
         fields: {
@@ -2959,8 +2961,7 @@ void generatedResolver
           },
         }),
       })
-      const document = graphql.parse('query GraphQL17Default { user { name } }')
-      const fieldNode = document.definitions[0].selectionSet.selections[0].selectionSet.selections[0]
+      const document = graphql.parse('query DefaultResolver { user { name } }')
       const { query } = compileQuery(schema, document)
       const resolverStartChannel = dc.channel('datadog:graphql:resolver:start')
       const resolverInfos = []
@@ -2969,8 +2970,7 @@ void generatedResolver
 
       resolverStartChannel.subscribe(onResolverStart)
       try {
-        assert.strictEqual(fieldNode.arguments, undefined)
-        const result = await executeWithTrace(() => query({}, {}, {}), /GraphQL17Default/, traces => {
+        const result = await executeWithTrace(() => query({}, {}, {}), /DefaultResolver/, traces => {
           const span = traces[0].find(span => span.resource === 'name:String')
           assert.ok(span)
         })


### PR DESCRIPTION
The module-sync export in GraphQL 17 resolves to ESM on current Node.js. The CommonJS matrix cannot observe these ESM hooks, so dependent assertions must not run there.

Refs: https://github.com/DataDog/dd-trace-js/pull/10182