### PR TITLE
test(test-optimization): gate Pino isolation test on Jest 28

### DIFF
--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -67,8 +67,9 @@ const requestedJestVersion = process.env.JEST_VERSION || 'latest'
 const oldestJestVersion = DD_MAJOR >= 6 ? '28.0.0' : '24.8.0'
 const JEST_VERSION = requestedJestVersion === 'oldest' ? oldestJestVersion : requestedJestVersion
 const onlyLatestIt = JEST_VERSION === 'latest' ? it : it.skip
-const esmIt = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28 ? it : it.skip
-const shouldInstallJestEnvironmentJsdom = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
+const isJest28OrNewer = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
+const esmIt = isJest28OrNewer ? it : it.skip
+const shouldInstallJestEnvironmentJsdom = isJest28OrNewer
 
 describe(`jest@${JEST_VERSION} commonJS`, () => {
   let receiver
@@ -1695,7 +1696,9 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         })
       }
 
-      it(`instruments ${loggerName} after another suite mocks it`, async () => {
+      // Modern Pino releases use node: specifiers, which Jest <28 cannot resolve.
+      const mockIsolationIt = loggerName === 'pino' && !isJest28OrNewer ? it.skip : it
+      mockIsolationIt(`instruments ${loggerName} after another suite mocks it`, async () => {
         let testOutput = ''
         const logsPromise = receiver
           .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Skips the modern-Pino mock-isolation integration test on Jest versions older than 28. Bunyan coverage and the dedicated Pino 7.6.4 cross-realm regression remain unchanged.

### Motivation
<!-- What inspired you to submit this pull request? -->
The v5 release branch still exercises Jest 24.8.0. Modern Pino releases import Node.js built-ins using node: specifiers, which Jest 24 cannot resolve, so the test fails before it can exercise dd-trace instrumentation.

Failing jobs:
- https://github.com/DataDog/dd-trace-js/actions/runs/34128985735/job/101764283297?pr=10183
- https://github.com/DataDog/dd-trace-js/actions/runs/34128985735/job/101764283110?pr=10183

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Validation:
- Jest 24.8.0 reports the Pino mock-isolation test as pending.
- Jest 28.0.0 runs all targeted Pino, Bunyan, and Pino 7.6.4 regression tests: 7 passing.
- Node syntax validation and git diff --check passed.

Targeted ESLint could not run locally because this checkout is missing eslint-plugin-regexp.