### PR TITLE
test(webdriverio): speed up integration test suite

### DIFF
--- a/integration-tests/webdriverio/fixtures/automatic-log-submission-logger.js
+++ b/integration-tests/webdriverio/fixtures/automatic-log-submission-logger.js
@@ -1,22 +1,17 @@
 'use strict'
 
-let logger
+const createPino = require('pino')
+const { createLogger, format, transports } = require('winston')
 
-if (process.env.TEST_LOGGER === 'bunyan') {
-  logger = require('bunyan').createLogger({ name: 'test-logger' })
-} else if (process.env.TEST_LOGGER === 'pino') {
-  const createPino = require('pino')
-  logger = createPino({ level: 'info' })
-} else {
-  const { createLogger, format, transports } = require('winston')
-  logger = createLogger({
+module.exports = {
+  bunyan: require('bunyan').createLogger({ name: 'test-logger' }),
+  pino: createPino({ level: 'info' }),
+  winston: createLogger({
     level: 'info',
     exitOnError: false,
     format: format.json(),
     transports: [
       new transports.Console(),
     ],
-  })
+  }),
 }
-
-module.exports = logger

--- a/integration-tests/webdriverio/fixtures/automatic-log-submission.e2e.js
+++ b/integration-tests/webdriverio/fixtures/automatic-log-submission.e2e.js
@@ -2,13 +2,15 @@
 
 const assert = require('node:assert/strict')
 
-const logger = require('./automatic-log-submission-logger')
+const loggers = require('./automatic-log-submission-logger')
 
 describe('WebdriverIO automatic log submission', () => {
   it('logs from an active Test Optimization span', () => {
     const activeSpan = require('dd-trace').scope().active()
 
     assert.ok(activeSpan)
-    logger.info('Hello from WebdriverIO!')
+    for (const [loggerName, logger] of Object.entries(loggers)) {
+      logger.info(`Hello from WebdriverIO ${loggerName}!`)
+    }
   })
 })

--- a/integration-tests/webdriverio/fixtures/wdio.conf.js
+++ b/integration-tests/webdriverio/fixtures/wdio.conf.js
@@ -154,6 +154,10 @@ const scenarioConfig = {
     maxInstances: 1,
     specs: ['./jasmine-statuses.e2e.js'],
   },
+  jasmineAfterAllFailure: {
+    maxInstances: 1,
+    specs: ['./jasmine-after-all-fail.e2e.js'],
+  },
   jasmineAttemptToFixSkipped: {
     maxInstances: 1,
     specs: ['./jasmine-attempt-to-fix-skipped.e2e.js'],
@@ -180,7 +184,6 @@ const scenarioConfig = {
   jasmineGlobalAfterAllFailure: {
     maxInstances: 1,
     specs: [[
-      './jasmine-after-all-fail.e2e.js',
       './jasmine-global-after-all-fail.e2e.js',
       './first.e2e.js',
     ]],

--- a/integration-tests/webdriverio/fixtures/wdio.conf.js
+++ b/integration-tests/webdriverio/fixtures/wdio.conf.js
@@ -34,7 +34,10 @@ const baseConfig = {
 const scenarioConfig = {
   automaticLogSubmission: {
     after () {
-      require('./automatic-log-submission-logger').info('Hello from WebdriverIO after hook!')
+      const loggers = require('./automatic-log-submission-logger')
+      for (const [loggerName, logger] of Object.entries(loggers)) {
+        logger.info(`Hello from WebdriverIO ${loggerName} after hook!`)
+      }
     },
     maxInstances: 1,
     specs: ['./automatic-log-submission.e2e.js'],
@@ -129,6 +132,7 @@ const scenarioConfig = {
     specs: [[
       './empty.e2e.js',
       './first.e2e.js',
+      './second.e2e.js',
     ]],
   },
   hookFailure: {
@@ -149,10 +153,6 @@ const scenarioConfig = {
     injectGlobals: false,
     maxInstances: 1,
     specs: ['./jasmine-statuses.e2e.js'],
-  },
-  jasmineAfterAllFailure: {
-    maxInstances: 1,
-    specs: ['./jasmine-after-all-fail.e2e.js'],
   },
   jasmineAttemptToFixSkipped: {
     maxInstances: 1,
@@ -180,6 +180,7 @@ const scenarioConfig = {
   jasmineGlobalAfterAllFailure: {
     maxInstances: 1,
     specs: [[
+      './jasmine-after-all-fail.e2e.js',
       './jasmine-global-after-all-fail.e2e.js',
       './first.e2e.js',
     ]],
@@ -224,11 +225,10 @@ const scenarioConfig = {
   },
   rum: {
     maxInstances: 1,
-    specs: ['./rum.e2e.js'],
-  },
-  rumNoAfterEach: {
-    maxInstances: 1,
-    specs: ['./rum-no-after-each.e2e.js'],
+    specs: [[
+      './rum.e2e.js',
+      './rum-no-after-each.e2e.js',
+    ]],
   },
   runnerEnvNodeOptions: {
     maxInstances: 1,

--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -468,6 +468,8 @@ for (const version of versions) {
         )
         assert.strictEqual(tests.length, 2)
         assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'pass'))
+        const nonEmptySuites = suites.filter(suite => suite.meta[TEST_STATUS] !== 'skip')
+        assertOneTestPerSuiteExecution(nonEmptySuites, tests)
         assert.strictEqual(new Set(tests.map(test => test.metrics.process_id)).size, 1)
         assert.deepStrictEqual(
           tests.map(test => test.meta['test.webdriverio.worker']).sort(),

--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -342,7 +342,8 @@ for (const version of versions) {
         childProcess,
         undefined,
         payloads => assertEvents(getReportingEvents(payloads, version, framework)),
-        { hardTimeout: 45_000 }
+        // WebdriverIO coordinator shutdown waits for the final Test Optimization export.
+        { gracePeriod: 0, hardTimeout: 45_000 }
       )
 
       let exitCode
@@ -453,28 +454,25 @@ for (const version of versions) {
       }, 0, { framework: 'jasmine' })
     })
 
-    it('reports grouped Jasmine specs from one worker', async () => {
-      await runScenario('grouped', 1, ({ suites, tests }) => {
-        assert.strictEqual(suites.length, 2)
-        assert.strictEqual(tests.length, 2)
-        assert.strictEqual(new Set(tests.map(test => test.metrics.process_id)).size, 1)
-        assertOneTestPerSuiteExecution(suites, tests)
-      }, 0, { framework: 'jasmine' })
-    })
-
-    it('reports an empty grouped Jasmine spec as skipped', async () => {
+    it('reports grouped Jasmine specs, including an empty spec, from one worker', async () => {
       await runScenario('groupedEmpty', 1, ({ session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'pass')
-        assert.strictEqual(suites.length, 2)
+        assert.strictEqual(suites.length, 3)
         assert.deepStrictEqual(
           suites.map(suite => [suite.meta[TEST_SUITE], suite.meta[TEST_STATUS]]).sort(),
           [
             ['empty.e2e.js', 'skip'],
             ['first.e2e.js', 'pass'],
+            ['second.e2e.js', 'pass'],
           ]
         )
-        assert.strictEqual(tests.length, 1)
-        assert.strictEqual(tests[0].meta[TEST_STATUS], 'pass')
+        assert.strictEqual(tests.length, 2)
+        assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'pass'))
+        assert.strictEqual(new Set(tests.map(test => test.metrics.process_id)).size, 1)
+        assert.deepStrictEqual(
+          tests.map(test => test.meta['test.webdriverio.worker']).sort(),
+          ['first', 'second']
+        )
       }, 0, { framework: 'jasmine' })
     })
 
@@ -493,33 +491,24 @@ for (const version of versions) {
       }, 1, { framework: 'jasmine' })
     })
 
-    it('reports a Jasmine afterAll failure on its suite', async () => {
-      await runScenario('jasmineAfterAllFailure', 1, ({ session, suites, tests }) => {
-        assert.strictEqual(session.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(suites.length, 1)
-        assert.strictEqual(suites[0].meta[TEST_STATUS], 'fail')
-        assert.strictEqual(suites[0].meta[TEST_SUITE], 'jasmine-after-all-fail.e2e.js')
-        assert.match(suites[0].meta['error.message'], /expected WebdriverIO Jasmine afterAll failure/)
-        assert.strictEqual(tests.length, 1)
-        assert.strictEqual(tests[0].meta[TEST_STATUS], 'pass')
-      }, 0, { framework: 'jasmine' })
-    })
-
-    it('reports a Jasmine global afterAll failure on its suite', async () => {
+    it('reports Jasmine suite and global afterAll failures on their suites', async () => {
       await runScenario('jasmineGlobalAfterAllFailure', 1, ({ session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(suites.length, 2)
+        assert.strictEqual(suites.length, 3)
         assert.deepStrictEqual(
           suites.map(suite => [suite.meta[TEST_SUITE], suite.meta[TEST_STATUS]]).sort(),
           [
             ['first.e2e.js', 'pass'],
+            ['jasmine-after-all-fail.e2e.js', 'fail'],
             ['jasmine-global-after-all-fail.e2e.js', 'fail'],
           ]
         )
-        const failedSuite = suites.find(suite => suite.meta[TEST_STATUS] === 'fail')
-        assert.match(failedSuite.meta['error.message'], /expected WebdriverIO Jasmine global afterAll failure/)
-        assert.strictEqual(tests.length, 2)
-        assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['pass', 'pass'])
+        const suiteAfterAll = suites.find(suite => suite.meta[TEST_SUITE] === 'jasmine-after-all-fail.e2e.js')
+        const globalAfterAll = suites.find(suite => suite.meta[TEST_SUITE] === 'jasmine-global-after-all-fail.e2e.js')
+        assert.match(suiteAfterAll.meta['error.message'], /expected WebdriverIO Jasmine afterAll failure/)
+        assert.match(globalAfterAll.meta['error.message'], /expected WebdriverIO Jasmine global afterAll failure/)
+        assert.strictEqual(tests.length, 3)
+        assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'pass'))
       }, 0, { framework: 'jasmine' })
     })
 

--- a/integration-tests/webdriverio/webdriverio.spec.js
+++ b/integration-tests/webdriverio/webdriverio.spec.js
@@ -331,6 +331,7 @@ for (const version of versions) {
           ...env,
         },
       })
+      const childClosed = once(childProcess, 'close')
       childProcess.stdout?.on('data', chunk => {
         testOutput += chunk.toString()
       })
@@ -349,10 +350,13 @@ for (const version of versions) {
       let exitCode
       try {
         [[exitCode]] = await Promise.all([
-          once(childProcess, 'exit'),
+          childClosed,
           payloadsPromise,
         ])
       } catch (error) {
+        if (childProcess.exitCode !== null || childProcess.signalCode != null) {
+          await childClosed.catch(() => {})
+        }
         error.message += `\n${testOutput}`
         throw error
       }
@@ -493,24 +497,33 @@ for (const version of versions) {
       }, 1, { framework: 'jasmine' })
     })
 
-    it('reports Jasmine suite and global afterAll failures on their suites', async () => {
+    it('reports a Jasmine afterAll failure on its suite', async () => {
+      await runScenario('jasmineAfterAllFailure', 1, ({ session, suites, tests }) => {
+        assert.strictEqual(session.meta[TEST_STATUS], 'fail')
+        assert.strictEqual(suites.length, 1)
+        assert.strictEqual(suites[0].meta[TEST_STATUS], 'fail')
+        assert.strictEqual(suites[0].meta[TEST_SUITE], 'jasmine-after-all-fail.e2e.js')
+        assert.match(suites[0].meta['error.message'], /expected WebdriverIO Jasmine afterAll failure/)
+        assert.strictEqual(tests.length, 1)
+        assert.strictEqual(tests[0].meta[TEST_STATUS], 'pass')
+      }, 0, { framework: 'jasmine' })
+    })
+
+    it('reports a Jasmine global afterAll failure on its suite', async () => {
       await runScenario('jasmineGlobalAfterAllFailure', 1, ({ session, suites, tests }) => {
         assert.strictEqual(session.meta[TEST_STATUS], 'fail')
-        assert.strictEqual(suites.length, 3)
+        assert.strictEqual(suites.length, 2)
         assert.deepStrictEqual(
           suites.map(suite => [suite.meta[TEST_SUITE], suite.meta[TEST_STATUS]]).sort(),
           [
             ['first.e2e.js', 'pass'],
-            ['jasmine-after-all-fail.e2e.js', 'fail'],
             ['jasmine-global-after-all-fail.e2e.js', 'fail'],
           ]
         )
-        const suiteAfterAll = suites.find(suite => suite.meta[TEST_SUITE] === 'jasmine-after-all-fail.e2e.js')
-        const globalAfterAll = suites.find(suite => suite.meta[TEST_SUITE] === 'jasmine-global-after-all-fail.e2e.js')
-        assert.match(suiteAfterAll.meta['error.message'], /expected WebdriverIO Jasmine afterAll failure/)
-        assert.match(globalAfterAll.meta['error.message'], /expected WebdriverIO Jasmine global afterAll failure/)
-        assert.strictEqual(tests.length, 3)
-        assert.ok(tests.every(test => test.meta[TEST_STATUS] === 'pass'))
+        const failedSuite = suites.find(suite => suite.meta[TEST_STATUS] === 'fail')
+        assert.match(failedSuite.meta['error.message'], /expected WebdriverIO Jasmine global afterAll failure/)
+        assert.strictEqual(tests.length, 2)
+        assert.deepStrictEqual(tests.map(test => test.meta[TEST_STATUS]), ['pass', 'pass'])
       }, 0, { framework: 'jasmine' })
     })
 

--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -295,6 +295,7 @@ for (const version of versions) {
           ...extraEnvironment,
         },
       })
+      const childClosed = once(childProcess, 'close')
       childProcess.stdout?.on('data', chunk => {
         testOutput += chunk.toString()
       })
@@ -316,10 +317,13 @@ for (const version of versions) {
       let exitCode
       try {
         [[exitCode]] = await Promise.all([
-          once(childProcess, 'exit'),
+          childClosed,
           payloadsPromise,
         ])
       } catch (error) {
+        if (childProcess.exitCode !== null || childProcess.signalCode != null) {
+          await childClosed.catch(() => {})
+        }
         error.message += `\n${testOutput}`
         throw error
       }

--- a/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
+++ b/integration-tests/webdriverio/webdriverio.test-optimization.spec.js
@@ -214,15 +214,17 @@ for (const version of versions) {
     let testOutput = ''
     let webDriver
 
-    useSandbox([
+    const dependencies = [
       `@wdio/cli@${version}`,
       `@wdio/jasmine-framework@${version}`,
       `@wdio/local-runner@${version}`,
       `@wdio/mocha-framework@${version}`,
-      'bunyan',
-      'pino',
-      'winston',
-    ], true, [
+    ]
+    if (version === 'latest') {
+      dependencies.push('bunyan', 'pino', 'winston')
+    }
+
+    useSandbox(dependencies, true, [
       './integration-tests/webdriverio/fixtures/*',
       './integration-tests/ci-visibility/dynamic-instrumentation/dependency.js',
     ])
@@ -307,7 +309,8 @@ for (const version of versions) {
           payloads,
           webDriver.getRequests().slice(initialWebDriverRequestCount)
         ),
-        { hardTimeout: 60_000 }
+        // WebdriverIO worker and coordinator shutdown wait for pending exports.
+        { gracePeriod: 0, hardTimeout: 60_000 }
       )
 
       let exitCode
@@ -368,107 +371,112 @@ for (const version of versions) {
               pino: { level: 30, messageKey: 'msg' },
               winston: { level: 'info', messageKey: 'message' },
             }
+            const loggerNames = Object.keys(loggers)
 
-            for (const [loggerName, { level: expectedLevel, messageKey }] of Object.entries(loggers)) {
-              describe(`with ${loggerName}`, () => {
-                it('submits correlated logs', async () => {
-                  await runScenario('automaticLogSubmission', 1, payloads => {
-                    const logRequests = getLogRequests(payloads)
-
-                    assert.ok(logRequests.length > 0)
-                    for (const logRequest of logRequests) {
-                      assert.strictEqual(logRequest.headers['dd-api-key'], '1')
-                      assert.strictEqual(logRequest.headers['content-type'], 'application/json')
-                      assert.strictEqual(
-                        logRequest.url,
-                        `/api/v2/logs?ddsource=${loggerName}&service=my-service`
-                      )
-                    }
-
-                    const logMessages = logRequests.flatMap(({ logMessage }) => logMessage)
-                    assert.strictEqual(logMessages.length, 2)
-
-                    const logMessage = logMessages.find(
-                      logMessage => logMessage[messageKey] === 'Hello from WebdriverIO!'
-                    )
-                    const afterHookLogMessage = logMessages.find(
-                      logMessage => logMessage[messageKey] === 'Hello from WebdriverIO after hook!'
-                    )
-                    const test = getEvents(payloads).find(event => event.type === 'test').content
-
-                    assert.ok(logMessage)
-                    assert.strictEqual(logMessage.level, expectedLevel)
-                    assert.deepStrictEqual(Object.keys(logMessage.dd).sort(), ['service', 'span_id', 'trace_id'])
-                    assert.strictEqual(logMessage.dd.service, 'my-service')
-                    assert.strictEqual(logMessage.dd.span_id, test.span_id.toString())
-                    assert.strictEqual(logMessage.dd.trace_id, test.trace_id.toString())
-                    assert.ok(afterHookLogMessage)
-                    assert.strictEqual(afterHookLogMessage.level, expectedLevel)
-                  }, {
-                    DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-                    DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
-                    DD_SERVICE: 'my-service',
-                    TEST_LOGGER: loggerName,
-                  })
-
-                  assert.match(testOutput, /Hello from WebdriverIO!/)
-                })
-
-                it('does not submit logs when automatic submission is disabled', async () => {
-                  await runScenario('automaticLogSubmission', 1, payloads => {
-                    assert.strictEqual(getLogRequests(payloads).length, 0)
-                  }, {
-                    DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
-                    DD_SERVICE: 'my-service',
-                    TEST_LOGGER: loggerName,
-                  })
-
-                  assert.match(testOutput, /Hello from WebdriverIO!/)
-                  assert.match(testOutput, /span_id/)
-                })
-
-                it('does not submit logs when the API key is missing', async () => {
-                  await runScenario('automaticLogSubmission', 1, payloads => {
-                    assert.strictEqual(getLogRequests(payloads).length, 0)
-                  }, {
-                    ...getCiVisEvpProxyConfig(receiver.port),
-                    DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-                    DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
-                    DD_API_KEY: '',
-                    DD_SERVICE: 'my-service',
-                    NODE_OPTIONS: '-r dd-trace/ci/init --import dd-trace/register.js',
-                    TEST_LOGGER: loggerName,
-                  })
-
-                  assert.match(testOutput, /Hello from WebdriverIO!/)
-                  assert.match(testOutput, /span_id/)
-                })
-              })
+            /**
+             * @param {boolean} [includesTraceIds]
+             * @returns {void}
+             */
+            function assertLoggerOutput (includesTraceIds = false) {
+              const lines = testOutput.split('\n')
+              for (const loggerName of loggerNames) {
+                const line = lines.find(line => line.includes(`Hello from WebdriverIO ${loggerName}!`))
+                assert.ok(line)
+                if (includesTraceIds) {
+                  assert.match(line, /span_id/)
+                }
+              }
             }
+
+            it('submits correlated logs from supported loggers', async () => {
+              await runScenario('automaticLogSubmission', 1, payloads => {
+                const logRequests = getLogRequests(payloads)
+                const test = getEvents(payloads).find(event => event.type === 'test').content
+                const expectedUrls = new Set(loggerNames.map(loggerName =>
+                  `/api/v2/logs?ddsource=${loggerName}&service=my-service`))
+
+                assert.ok(logRequests.length > 0)
+                for (const logRequest of logRequests) {
+                  assert.ok(expectedUrls.has(logRequest.url))
+                  assert.strictEqual(logRequest.headers['dd-api-key'], '1')
+                  assert.strictEqual(logRequest.headers['content-type'], 'application/json')
+                }
+                for (const [loggerName, { level: expectedLevel, messageKey }] of Object.entries(loggers)) {
+                  const loggerRequests = logRequests.filter(({ url }) =>
+                    url === `/api/v2/logs?ddsource=${loggerName}&service=my-service`)
+
+                  assert.ok(loggerRequests.length > 0)
+                  const logMessages = loggerRequests.flatMap(({ logMessage }) => logMessage)
+                  assert.strictEqual(logMessages.length, 2)
+
+                  const logMessage = logMessages.find(
+                    logMessage => logMessage[messageKey] === `Hello from WebdriverIO ${loggerName}!`
+                  )
+                  const afterHookLogMessage = logMessages.find(
+                    logMessage => logMessage[messageKey] === `Hello from WebdriverIO ${loggerName} after hook!`
+                  )
+
+                  assert.ok(logMessage)
+                  assert.strictEqual(logMessage.level, expectedLevel)
+                  assert.deepStrictEqual(Object.keys(logMessage.dd).sort(), ['service', 'span_id', 'trace_id'])
+                  assert.strictEqual(logMessage.dd.service, 'my-service')
+                  assert.strictEqual(logMessage.dd.span_id, test.span_id.toString())
+                  assert.strictEqual(logMessage.dd.trace_id, test.trace_id.toString())
+                  assert.ok(afterHookLogMessage)
+                  assert.strictEqual(afterHookLogMessage.level, expectedLevel)
+                }
+              }, {
+                DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
+                DD_SERVICE: 'my-service',
+              })
+
+              assertLoggerOutput()
+            })
+
+            it('does not submit logs when automatic submission is disabled', async () => {
+              await runScenario('automaticLogSubmission', 1, payloads => {
+                assert.strictEqual(getLogRequests(payloads).length, 0)
+              }, {
+                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
+                DD_SERVICE: 'my-service',
+              })
+
+              assertLoggerOutput(true)
+            })
+
+            it('does not submit logs when the API key is missing', async () => {
+              await runScenario('automaticLogSubmission', 1, payloads => {
+                assert.strictEqual(getLogRequests(payloads).length, 0)
+              }, {
+                ...getCiVisEvpProxyConfig(receiver.port),
+                DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+                DD_AGENTLESS_LOG_SUBMISSION_URL: `http://127.0.0.1:${receiver.port}`,
+                DD_API_KEY: '',
+                DD_SERVICE: 'my-service',
+                NODE_OPTIONS: '-r dd-trace/ci/init --import dd-trace/register.js',
+              })
+
+              assertLoggerOutput(true)
+            })
           })
         }
 
-        it('does not correlate classic WebDriver tests with RUM sessions', async () => {
+        it('does not correlate or retain classic WebDriver tests with RUM sessions', async () => {
           await runScenario('rum', 1, (payloads, requests) => {
-            const test = getEvents(payloads).find(event => event.type === 'test').content
-            assert.strictEqual(test.meta[TEST_IS_RUM_ACTIVE], undefined)
-            assert.strictEqual(test.meta[TEST_BROWSER_NAME], 'chrome')
-            assert.strictEqual(test.meta[TEST_BROWSER_VERSION], 'test')
-            assert.ok(requests.some(({ url }) => url?.endsWith('/refresh')))
-            assert.strictEqual(requests.some(({ url }) => url?.includes('/cookie')), false)
-            assert.strictEqual(requests.some(({ url }) => url?.endsWith('/chromium/send_command')), false)
-          })
-        })
-
-        it('does not retain classic RUM state between tests without afterEach hooks', async () => {
-          await runScenario('rumNoAfterEach', 1, (payloads, requests) => {
             const tests = getEvents(payloads)
               .filter(event => event.type === 'test')
               .map(event => event.content)
+            const navigatedTest = tests.find(test =>
+              test.meta[TEST_NAME].endsWith('correlates the RUM session with the test execution'))
 
-            assert.ok(tests.length > 0)
+            assert.strictEqual(tests.length, 3)
             assert.ok(tests.every(test => test.meta[TEST_IS_RUM_ACTIVE] === undefined))
+            assert.strictEqual(navigatedTest.meta[TEST_BROWSER_NAME], 'chrome')
+            assert.strictEqual(navigatedTest.meta[TEST_BROWSER_VERSION], 'test')
+            assert.ok(requests.some(({ url }) => url?.endsWith('/refresh')))
             assert.strictEqual(requests.some(({ url }) => url?.includes('/cookie')), false)
+            assert.strictEqual(requests.some(({ url }) => url?.endsWith('/chromium/send_command')), false)
           })
         })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Reduces the runtime of the WebdriverIO integration jobs without parallelizing them or dropping behavioral coverage.

- Combines equivalent automatic-log-submission, RUM, grouped-spec, and Jasmine `afterAll` scenarios into fewer WebdriverIO launches.
- Removes the redundant one-second post-exit payload grace period after WebdriverIO has already awaited its worker and coordinator exports.
- Avoids installing logger packages in the oldest-version job, where those tests do not run.

This removes 15 WebdriverIO launches from the latest-version suite and 3 from the oldest-version suite. Based on the referenced CI timings and the local measurements, the test step is projected to improve from approximately 12:18 to 9 minutes for latest and from 12:04 to 10 minutes for oldest.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `integration-webdriverio` jobs are among the slowest integration jobs. Most individual outer Mocha cases paid a fixed six-to-eight-second WebdriverIO process startup cost plus a one-second payload collection grace period. Grouping fixtures that exercise the same path retains their assertions while paying those fixed costs fewer times.

Example baseline jobs:

- https://github.com/DataDog/dd-trace-js/actions/runs/34132961596/job/101777239813?pr=10183
- https://github.com/DataDog/dd-trace-js/actions/runs/34132961596/job/101777240249?pr=10183

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Local validation:

- Before restoring the standalone `afterAll` confidence check, `WEBDRIVERIO_VERSION=latest OFFLINE=1 npm run test:integration:webdriverio:coverage`: 95 passing, 12 pending, approximately 4 minutes.
- Before restoring the standalone `afterAll` confidence check, `WEBDRIVERIO_VERSION=oldest OFFLINE=1 npm run test:integration:webdriverio:coverage`: 89 passing, 12 pending, approximately 4 minutes.
- A latest-version A/B run after scenario consolidation improved from approximately 6 minutes to 4 minutes when removing the grace period, with the same 95 passing tests, 12 pending tests, and 208 process profiles.
- After review follow-ups, all 6 automatic-log tests passed and both standalone/global `afterAll` tests passed on WebdriverIO latest and 9.0.0.
- Targeted high-risk scenarios passed across screenshots, logs, startup failures, RUM, faulty-session-threshold, and policy-failure behavior.
- Targeted ESLint, `npm run verify-exercised-tests`, `node scripts/check-no-coverage-artifacts.js`, and `git diff --check` passed.

The lower outer Mocha test count comes from combining scenarios; the underlying fixtures and behavioral assertions remain covered. The standalone suite-level `afterAll` run is intentionally retained because combining it with a global `afterAll` failure would mask its independent contribution to the session status.
