### PR TITLE
test(exporters): cover default HTTPS agent pool settings

### DIFF
--- a/packages/dd-trace/test/exporters/common/proxy.spec.js
+++ b/packages/dd-trace/test/exporters/common/proxy.spec.js
@@ -147,6 +147,25 @@ describe('HTTPS proxy agent selection', () => {
     }
   })
 
+  it('preserves the global HTTPS agent pool settings by default', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example:8202'
+    const originalGlobalAgent = https.globalAgent
+    const globalAgent = new https.Agent({ keepAlive: true, maxSockets: 4 })
+    let agent
+
+    try {
+      https.globalAgent = globalAgent
+      agent = getHttpsProxyAgent('https://intake.example/path')
+
+      assert.strictEqual(agent.keepAlive, true)
+      assert.strictEqual(agent.maxSockets, 4)
+    } finally {
+      https.globalAgent = originalGlobalAgent
+      globalAgent.destroy()
+      agent?.destroy()
+    }
+  })
+
   it('rejects an invalid proxy URL', () => {
     process.env.HTTPS_PROXY = '://invalid'
 


### PR DESCRIPTION
Pin the proxy agent's keep-alive and socket-limit settings when no direct agent is supplied, so a regression in global-agent propagation fails in the shared helper spec.