### PR TITLE
fix(appsec): improve SQL and command evidence parsing

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/command-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/command-sensitive-analyzer.js
@@ -2,7 +2,9 @@
 
 const log = require('../../../../../log')
 
-const COMMAND_PATTERN = String.raw`^(?:\s*(?:sudo|doas)\s+)?\b\S+\b\s(.*)`
+// `\S+\s` accepts command tokens that end in punctuation. The optional prefix uses horizontal
+// whitespace so multiline matching cannot start inside a line-terminator run.
+const COMMAND_PATTERN = String.raw`^(?:[ \t]*(?:sudo|doas)[ \t]+)?\S+\s([\s\S]*)`
 const pattern = new RegExp(COMMAND_PATTERN, 'gmi')
 
 module.exports = function extractSensitiveRanges (evidence) {

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/sql-sensitive-analyzer.js
@@ -2,84 +2,545 @@
 
 const log = require('../../../../../log')
 
-const STRING_LITERAL = '\'(?:\'\'|[^\'])*\''
-const POSTGRESQL_ESCAPED_LITERAL = String.raw`\$([^$]*)\$.*?\$\1\$`
-const MYSQL_STRING_LITERAL = String.raw`"(?:\\"|[^"])*"|'(?:\\'|[^'])*'`
-const LINE_COMMENT = '--.*$'
-const BLOCK_COMMENT = String.raw`/\*[\s\S]*\*/`
-const EXPONENT = String.raw`(?:E[-+]?\d+[fd]?)?`
-const INTEGER_NUMBER = String.raw`\b\d+`
-const DECIMAL_NUMBER = String.raw`\d*\.\d+`
-const HEX_NUMBER = 'x\'[0-9a-f]+\'|0x[0-9a-f]+'
-const BIN_NUMBER = 'b\'[0-9a-f]+\'|0b[0-9a-f]+'
-const NUMERIC_LITERAL =
-  `[-+]?(?:${HEX_NUMBER}|${BIN_NUMBER}|${DECIMAL_NUMBER + EXPONENT}|${INTEGER_NUMBER + EXPONENT})`
-const ORACLE_ESCAPED_LITERAL = String.raw`q'<.*?>'|q'\(.*?\)'|q'\{.*?\}'|q'\[.*?\]'|q'(?<ESCAPE>.).*?\k<ESCAPE>'`
+// Single-pass scanner for sensitive literals and comments in SQL evidence.
+// Well-formed tokens keep their delimiters outside the masked range. Unterminated tokens mask the remaining evidence.
+// Multiline Postgres dollar quotes and Oracle alternative quotes include their delimiters in the masked range.
 
-const patterns = {
-  ANSI: new RegExp( // Default
-    `${NUMERIC_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
-    'gmi'
-  ),
-  MYSQL: new RegExp(
-    `${NUMERIC_LITERAL}|${MYSQL_STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
-    'gmi'
-  ),
-  POSTGRES: new RegExp(
-    `${NUMERIC_LITERAL}|${POSTGRESQL_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
-    'gmi'
-  ),
-  ORACLE: new RegExp(
-    // The capture owns the quote delimiter while the lazy quantifier owns the body.
-    // eslint-disable-next-line regexp/optimal-quantifier-concatenation
-    `${NUMERIC_LITERAL}|${ORACLE_ESCAPED_LITERAL}|${STRING_LITERAL}|${LINE_COMMENT}|${BLOCK_COMMENT}`,
-    'gmi'
-  ),
+const LINE_FEED = 0x0A
+const CARRIAGE_RETURN = 0x0D
+const DOUBLE_QUOTE = 0x22
+const HASH = 0x23
+const DOLLAR = 0x24
+const SINGLE_QUOTE = 0x27
+const ASTERISK = 0x2A
+const PLUS = 0x2B
+const MINUS = 0x2D
+const DOT = 0x2E
+const SLASH = 0x2F
+const DIGIT_0 = 0x30
+const DIGIT_9 = 0x39
+const UPPER_B = 0x42
+const UPPER_E = 0x45
+const UPPER_Q = 0x51
+const UPPER_X = 0x58
+const BACKSLASH = 0x5C
+const UNDERSCORE = 0x5F
+const LOWER_A = 0x61
+const LOWER_B = 0x62
+const LOWER_E = 0x65
+const LOWER_Q = 0x71
+const LOWER_X = 0x78
+const LOWER_Z = 0x7A
+const LINE_SEPARATOR = 0x20_28
+const PARAGRAPH_SEPARATOR = 0x20_29
+
+const ASCII_CASE_BIT = 0x20
+
+// Oracle alternative-quote bracket delimiters and their mirrors (by char code); any other char
+// closes on itself.
+const ORACLE_CLOSERS = new Map([[0x3C, 0x3E], [0x28, 0x29], [0x7B, 0x7D], [0x5B, 0x5D]])
+
+/**
+ * @param {number} code
+ */
+function isLineTerminator (code) {
+  return code === LINE_FEED || code === CARRIAGE_RETURN ||
+    code === LINE_SEPARATOR || code === PARAGRAPH_SEPARATOR
 }
-patterns.SQLITE = patterns.MYSQL
-patterns.MARIADB = patterns.MYSQL
+
+/**
+ * Scans a half-open range for SQL line terminators.
+ * @param {string} value
+ * @param {number} from
+ * @param {number} to
+ */
+function hasLineTerminator (value, from, to) {
+  for (let i = from; i < to; i++) {
+    if (isLineTerminator(value.charCodeAt(i))) {
+      return true
+    }
+  }
+  return false
+}
+
+// The sticky (`y`) regex checks only `lastIndex`. It handles signs, exponents, radix literals, and decimals embedded
+// in identifiers after `canStartNumber` and `scanPlainNumber` exclude the simpler forms.
+const NUMERIC = /[-+]?(?:x'[\da-f]+'|0x[\da-f]+|b'[\da-f]+'|0b[\da-f]+|\d*\.\d+(?:e[-+]?\d+[fd]?)?|\b\d+(?:e[-+]?\d+[fd]?)?)/iy
+
+/**
+ * Cheap gate for the numeric regex: a numeric literal can only begin with a sign, a digit, a `.`, or the
+ * `x`/`b` radix prefixes — and the latter only when immediately followed by `'` (`x'FF'` / `b'10'`).
+ * Everything else (letters, whitespace, punctuation) skips the regex entirely.
+ * @param {string} value
+ * @param {number} index
+ * @param {number} code
+ */
+function canStartNumber (value, index, code) {
+  if ((code >= DIGIT_0 && code <= DIGIT_9) || code === PLUS || code === MINUS || code === DOT) {
+    return true
+  }
+  if (code === LOWER_X || code === UPPER_X || code === LOWER_B || code === UPPER_B) {
+    return value.charCodeAt(index + 1) === SINGLE_QUOTE
+  }
+  return false
+}
+
+/**
+ * Treats code units outside the value as non-identifier characters.
+ * @param {number} code
+ */
+function isIdentifierChar (code) {
+  const folded = code | ASCII_CASE_BIT
+  return (code >= DIGIT_0 && code <= DIGIT_9) ||
+    (folded >= LOWER_A && folded <= LOWER_Z) ||
+    code === UNDERSCORE
+}
+
+/**
+ * @param {string} value
+ * @param {number} from
+ * @param {number} length
+ */
+function digitRunEnd (value, from, length) {
+  let end = from
+  while (end < length) {
+    const code = value.charCodeAt(end)
+    if (code < DIGIT_0 || code > DIGIT_9) {
+      break
+    }
+    end++
+  }
+  return end
+}
+
+/**
+ * Handles plain integer and decimal literals. Exponents and radix literals defer to `NUMERIC`.
+ * @param {string} value
+ * @param {number} intEnd Index after the integer digit run measured by the caller.
+ * @param {number} length
+ * @returns {number} Index after the literal, or `-1` to defer to the `NUMERIC` regex.
+ */
+function scanPlainNumber (value, intEnd, length) {
+  // A digit run touching `x`/`b` is a radix prefix (`0x`, `0b`) — let the regex own it.
+  const afterInt = value.charCodeAt(intEnd)
+  if (afterInt === LOWER_X || afterInt === UPPER_X || afterInt === LOWER_B || afterInt === UPPER_B) {
+    return -1
+  }
+  if (afterInt === DOT) {
+    const fracEnd = digitRunEnd(value, intEnd + 1, length)
+    // `\d*\.\d+`: a fractional literal needs at least one digit after the `.`. A trailing `.` with no
+    // fraction digits (`3.`) is not part of the number — fall through to the integer-only result below.
+    if (fracEnd > intEnd + 1) {
+      const afterFrac = value.charCodeAt(fracEnd)
+      return afterFrac === LOWER_E || afterFrac === UPPER_E ? -1 : fracEnd
+    }
+  }
+  // `\b\d+`: a pure integer. An `e`/`E` right after it is an exponent the regex must handle.
+  return afterInt === LOWER_E || afterInt === UPPER_E ? -1 : intEnd
+}
+
+// The next index that could begin a token: a numeric start (sign, digit, a `.` before a digit, or
+// `x`/`b`/`q` before a quote), a string/comment delimiter, or a dialect literal opener. Used to skip
+// non-token runs (identifiers, keywords, whitespace) in one native scan instead of a per-character loop.
+// `.` is gated by `(?=\d)` because the only literal it can begin is `.5`; this keeps `a.b` column access
+// — the most common false positive in SQL — out of the scan entirely.
+const CANDIDATE_ANSI = /[-+\d'/]|\.(?=\d)|[xXbB](?=')/g
+const CANDIDATE_MYSQL = /[-+\d'"/#]|\.(?=\d)|[xXbB](?=')/g
+const CANDIDATE_SQLITE = /[-+\d'"/]|\.(?=\d)|[xXbB](?=')/g
+const CANDIDATE_POSTGRES = /[-+\d'$/]|\.(?=\d)|[xXbB](?=')/g
+const CANDIDATE_ORACLE = /[-+\d'/]|\.(?=\d)|[xXbBqQ](?=')/g
+
+const BACKSLASH_QUOTES = 1 << 0
+const CONSERVATIVE_BACKSLASH_QUOTES = 1 << 1
+const HASH_COMMENTS = 1 << 2
+const POSTGRES_SYNTAX = 1 << 3
+const ORACLE_SYNTAX = 1 << 4
+
+const ANSI_POLICY = { candidates: CANDIDATE_ANSI, features: 0 }
+const MYSQL_POLICY = {
+  candidates: CANDIDATE_MYSQL,
+  features: BACKSLASH_QUOTES | HASH_COMMENTS,
+}
+const DIALECT_POLICIES = new Map([
+  ['MYSQL', MYSQL_POLICY],
+  ['MARIADB', MYSQL_POLICY],
+  ['SQLITE', { candidates: CANDIDATE_SQLITE, features: CONSERVATIVE_BACKSLASH_QUOTES }],
+  ['POSTGRES', { candidates: CANDIDATE_POSTGRES, features: POSTGRES_SYNTAX }],
+  ['ORACLE', { candidates: CANDIDATE_ORACLE, features: ORACLE_SYNTAX }],
+])
+
+// Scanner return sentinels (distinct from any real end index, which is always > start >= 0):
+const UNTERMINATED = -1 // literal opened but never closed -> mask raw to the end of the value
+const FALL_THROUGH = -2 // not a literal start -> advance one character and reconsider
+
+/**
+ * @param {string} value
+ * @param {number} from
+ * @param {number} length
+ * @returns {number} Index of the first line terminator at or after `from`, else `length`.
+ */
+function lineEnd (value, from, length) {
+  for (let i = from; i < length; i++) {
+    if (isLineTerminator(value.charCodeAt(i))) {
+      return i
+    }
+  }
+  return length
+}
+
+/**
+ * `'…'` or `"…"` with doubled-quote escaping. Strings may span lines.
+ * @param {string} value
+ * @param {number} start
+ * @param {number} length
+ * @param {number} quote Char code of the opening delimiter, `'` or `"`.
+ * @param {boolean} conservativeBackslash Whether an odd backslash before a closing quote makes the
+ *   remainder ambiguous and therefore unterminated.
+ * @returns {number} Index after the closing quote, or `UNTERMINATED`.
+ */
+function scanQuotedDoubled (value, start, length, quote, conservativeBackslash) {
+  let backslashCount = 0
+  for (let i = start + 1; i < length; i++) {
+    const code = value.charCodeAt(i)
+    if (code === BACKSLASH) {
+      backslashCount++
+      continue
+    }
+    if (code === quote) {
+      if (value.charCodeAt(i + 1) === quote) {
+        i++
+        backslashCount = 0
+        continue
+      }
+      if (conservativeBackslash && (backslashCount & 1) === 1) {
+        return UNTERMINATED
+      }
+      return i + 1
+    }
+    backslashCount = 0
+  }
+  return UNTERMINATED
+}
+
+/**
+ * `'…'` or `"…"` with backslash escaping (MySQL / MariaDB / Postgres escape strings).
+ * @param {string} value
+ * @param {number} start
+ * @param {number} length
+ * @param {number} quote Char code of the opening delimiter, `'` or `"`.
+ * @param {boolean} doubled Whether two adjacent quotes escape each other.
+ * @returns {number} Index after the closing quote, or `UNTERMINATED`.
+ */
+function scanQuotedBackslash (value, start, length, quote, doubled) {
+  for (let i = start + 1; i < length; i++) {
+    const code = value.charCodeAt(i)
+    if (code === BACKSLASH) {
+      let backslashCount = 1
+      while (value.charCodeAt(i + 1) === BACKSLASH) {
+        i++
+        backslashCount++
+      }
+      if ((backslashCount & 1) === 1 && value.charCodeAt(i + 1) === quote) {
+        i++
+      }
+      continue
+    }
+    if (code === quote) {
+      if (doubled && value.charCodeAt(i + 1) === quote) {
+        i++
+        continue
+      }
+      return i + 1
+    }
+  }
+  return UNTERMINATED
+}
+
+/**
+ * @param {string} value
+ * @param {number} quoteIndex
+ */
+function isPostgresEscapeString (value, quoteIndex) {
+  const prefix = value.charCodeAt(quoteIndex - 1)
+  return (prefix === LOWER_E || prefix === UPPER_E) &&
+    !isPostgresIdentifierContinuation(value.charCodeAt(quoteIndex - 2))
+}
+
+/**
+ * Oracle `q'X…X'`: `X` is one of `< ( { [` (closed by its mirror) or any other char (closed by
+ * itself). The body may span line terminators.
+ * @param {string} value
+ * @param {number} start
+ * @param {number} length
+ * @returns {number} Index after the closing `X'`; `FALL_THROUGH` when `q'` is at the end of the value
+ *   or followed by a line terminator — Oracle forbids whitespace as the delimiter, so that `'` is a
+ *   plain string, not a quote opener; or `UNTERMINATED`.
+ */
+function scanOracleQuote (value, start, length) {
+  const delimiter = value.charCodeAt(start + 2)
+  if (Number.isNaN(delimiter) || isLineTerminator(delimiter)) {
+    return FALL_THROUGH
+  }
+  const closer = ORACLE_CLOSERS.get(delimiter) ?? delimiter
+  for (let i = start + 3; i < length; i++) {
+    if (value.charCodeAt(i) === closer && value.charCodeAt(i + 1) === SINGLE_QUOTE) {
+      return i + 2
+    }
+  }
+  return UNTERMINATED
+}
+
+/**
+ * Postgres `$tag$ … $tag$`, where `tag` is empty or an identifier. The body may span line
+ * terminators — PL/pgSQL function bodies routinely do, and treating a newline as the end of the
+ * literal would leave the rest of a multi-line body unredacted.
+ * @param {string} value
+ * @param {number} start
+ * @param {number} length
+ * @returns {number} Index after the closing tag; `FALL_THROUGH` when no second `$` exists; or
+ *   `UNTERMINATED` when the opening tag is malformed or has no close.
+ */
+function scanDollarQuote (value, start, length) {
+  const tagEnd = value.indexOf('$', start + 1)
+  if (tagEnd === -1) {
+    return FALL_THROUGH
+  }
+  if (!isDollarQuoteTag(value, start + 1, tagEnd)) {
+    return UNTERMINATED
+  }
+  const tagLength = tagEnd - start + 1 // both bracket `$` included
+  // The closing tag must begin with `$`, so hop `$`-to-`$` and only compare a full tag at each one;
+  // the body characters between candidates are skipped natively by `indexOf`.
+  for (let i = value.indexOf('$', tagEnd + 1); i !== -1 && i <= length - tagLength;
+    i = value.indexOf('$', i + 1)) {
+    if (matchesTag(value, start, i, tagLength)) {
+      return i + tagLength
+    }
+  }
+  return UNTERMINATED
+}
+
+/**
+ * A dollar-quote tag is empty (`$$`) or an identifier. The caller has already consumed the
+ * `$`-then-digit form, so a leading digit cannot reach here.
+ * @see https://www.postgresql.org/docs/current/sql-syntax-lexical.html
+ * @param {string} value
+ * @param {number} from Index of the first character after the opening `$`.
+ * @param {number} to Index of the closing `$` of the tag.
+ */
+function isDollarQuoteTag (value, from, to) {
+  for (let i = from; i < to; i++) {
+    const code = value.charCodeAt(i)
+    if (!isIdentifierChar(code) && code <= 0x7F) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * @param {number} code
+ */
+function isPostgresIdentifierContinuation (code) {
+  return isIdentifierChar(code) || code === DOLLAR || code > 0x7F
+}
+
+/**
+ * @param {number} code
+ */
+function isPostgresIdentifierStart (code) {
+  const folded = code | ASCII_CASE_BIT
+  return (folded >= LOWER_A && folded <= LOWER_Z) || code === UNDERSCORE || code > 0x7F
+}
+
+/**
+ * @param {string} value
+ * @param {number} index Index of a dollar sign after an identifier continuation character.
+ * @param {number} from Earliest unconsumed index; a prior dollar quote cannot be part of this identifier.
+ */
+function isInsidePostgresIdentifier (value, index, from) {
+  let start = index
+  while (start > from && isPostgresIdentifierContinuation(value.charCodeAt(start - 1))) {
+    start--
+  }
+  return isPostgresIdentifierStart(value.charCodeAt(start))
+}
+
+/**
+ * @param {string} value
+ * @param {number} from
+ * @param {number} length
+ */
+function postgresIdentifierEnd (value, from, length) {
+  let end = from
+  while (end < length && isPostgresIdentifierContinuation(value.charCodeAt(end))) {
+    end++
+  }
+  return end
+}
+
+/**
+ * Compares the `tagLength` code units at `at` against the opening tag at `tagStart` in place, so the
+ * closing-tag check costs no `slice` allocation and skips re-reading the leading `$`.
+ * @param {string} value
+ * @param {number} tagStart
+ * @param {number} at
+ * @param {number} tagLength
+ */
+function matchesTag (value, tagStart, at, tagLength) {
+  for (let offset = 1; offset < tagLength - 1; offset++) {
+    if (value.charCodeAt(tagStart + offset) !== value.charCodeAt(at + offset)) {
+      return false
+    }
+  }
+  return value.charCodeAt(at + tagLength - 1) === DOLLAR
+}
 
 module.exports = function extractSensitiveRanges (evidence) {
   try {
-    let pattern = patterns[evidence.dialect]
-    if (!pattern) {
-      pattern = patterns.ANSI
-    }
-    pattern.lastIndex = 0
-    const tokens = []
+    const value = evidence.value
+    const length = value.length
+    // Select token candidates and syntax features together so dialect aliases cannot drift.
+    const { candidates, features } = DIALECT_POLICIES.get(evidence.dialect) ?? ANSI_POLICY
+    // The greedy block comment needs the last `*/`, but most evidence has none — find it lazily on the
+    // first `/*` rather than scanning the whole value up front on every call.
+    let lastBlockClose = -2
+    let postgresIdentifierFloor = 0
+    const ranges = []
 
-    let regexResult = pattern.exec(evidence.value)
-    while (regexResult != null) {
-      let start = regexResult.index
-      let end = regexResult.index + regexResult[0].length
-      const startChar = evidence.value.charAt(start)
-      if (startChar === '\'' || startChar === '"') {
-        start++
-        end--
-      } else if (end > start + 1) {
-        const nextChar = evidence.value.charAt(start + 1)
-        if (startChar === '/' && nextChar === '*') {
-          start += 2
-          end -= 2
-        } else if (startChar === '-' && startChar === nextChar) {
-          start += 2
-        } else if (startChar.toLowerCase() === 'q' && nextChar === '\'') {
-          start += 3
-          end -= 2
-        } else if (startChar === '$') {
-          const match = regexResult[0]
-          const size = match.indexOf('$', 1) + 1
-          if (size > 1) {
-            start += size
-            end -= size
+    let i = 0
+    while (i < length) {
+      // Jump to the next position that could start a token; skip the non-token run natively.
+      candidates.lastIndex = i
+      const candidate = candidates.exec(value)
+      if (candidate === null) {
+        break
+      }
+      i = candidate.index
+      const code = value.charCodeAt(i)
+
+      if (canStartNumber(value, i, code)) {
+        // Measure a digit run once. At a word boundary it is a plain number or a prefix that the regex
+        // owns. Inside an identifier only the boundary-free decimal form can match; skip every other
+        // run whole instead of retrying the remaining suffix from each digit.
+        if (code >= DIGIT_0 && code <= DIGIT_9) {
+          const intEnd = digitRunEnd(value, i, length)
+          if (isIdentifierChar(value.charCodeAt(i - 1))) {
+            const afterInt = value.charCodeAt(intEnd)
+            const firstFraction = value.charCodeAt(intEnd + 1)
+            if (afterInt !== DOT || firstFraction < DIGIT_0 || firstFraction > DIGIT_9) {
+              i = intEnd
+              continue
+            }
+          } else {
+            const plainEnd = scanPlainNumber(value, intEnd, length)
+            if (plainEnd !== -1) {
+              ranges.push({ start: i, end: plainEnd })
+              i = plainEnd
+              continue
+            }
           }
+        }
+        NUMERIC.lastIndex = i
+        if (NUMERIC.exec(value) !== null) {
+          // A sticky match starts at `i`, so `lastIndex` is the match end. Numbers are masked whole.
+          ranges.push({ start: i, end: NUMERIC.lastIndex })
+          i = NUMERIC.lastIndex
+          continue
         }
       }
 
-      tokens.push({ start, end })
-      regexResult = pattern.exec(evidence.value)
+      // Dispatch by first character and record how many delimiter characters to trim from the matched token.
+      let end = FALL_THROUGH
+      let trimStart = 0
+      let trimEnd = 0
+      if (code === SINGLE_QUOTE) {
+        if ((features & BACKSLASH_QUOTES) !== 0) {
+          end = scanQuotedBackslash(value, i, length, SINGLE_QUOTE, false)
+        } else if ((features & POSTGRES_SYNTAX) !== 0 && isPostgresEscapeString(value, i)) {
+          end = scanQuotedBackslash(value, i, length, SINGLE_QUOTE, true)
+        } else {
+          end = scanQuotedDoubled(
+            value,
+            i,
+            length,
+            SINGLE_QUOTE,
+            (features & CONSERVATIVE_BACKSLASH_QUOTES) !== 0
+          )
+        }
+        trimStart = 1
+        trimEnd = 1
+      } else if (code === DOUBLE_QUOTE) {
+        end = (features & BACKSLASH_QUOTES) === 0
+          ? scanQuotedDoubled(
+            value,
+            i,
+            length,
+            DOUBLE_QUOTE,
+            (features & CONSERVATIVE_BACKSLASH_QUOTES) !== 0
+          )
+          : scanQuotedBackslash(value, i, length, DOUBLE_QUOTE, false)
+        trimStart = 1
+        trimEnd = 1
+      } else if (code === DOLLAR && (features & POSTGRES_SYNTAX) !== 0) {
+        if (isPostgresIdentifierContinuation(value.charCodeAt(i - 1)) &&
+          isInsidePostgresIdentifier(value, i, postgresIdentifierFloor)) {
+          // PostgreSQL requires whitespace between an identifier and a dollar-quoted string because
+          // `$` is an identifier continuation character.
+          i = postgresIdentifierEnd(value, i, length)
+          postgresIdentifierFloor = i
+          continue
+        }
+        const parameterEnd = digitRunEnd(value, i + 1, length)
+        if (parameterEnd > i + 1) {
+          // `$1` is a parameter reference, so the index is syntax rather than data.
+          i = parameterEnd
+          postgresIdentifierFloor = i
+          continue
+        }
+        end = scanDollarQuote(value, i, length)
+        if (end >= 0 && !hasLineTerminator(value, i, end)) {
+          // `$tag$ … $tag$`: trim the opening and closing tags unless the body spans a line.
+          trimStart = value.indexOf('$', i + 1) - i + 1
+          trimEnd = trimStart
+        }
+      } else if ((code === LOWER_Q || code === UPPER_Q) && (features & ORACLE_SYNTAX) !== 0) {
+        end = scanOracleQuote(value, i, length)
+        if (end >= 0 && !hasLineTerminator(value, i, end)) {
+          trimStart = 3 // q'X
+          trimEnd = 2 // X'
+        }
+      } else if (code === MINUS && value.charCodeAt(i + 1) === MINUS) {
+        end = lineEnd(value, i + 2, length)
+        trimStart = 2 // --
+      } else if (code === HASH && (features & HASH_COMMENTS) !== 0) {
+        end = lineEnd(value, i + 1, length)
+        trimStart = 1 // #
+      } else if (code === SLASH && value.charCodeAt(i + 1) === ASTERISK) {
+        if (lastBlockClose === -2) {
+          lastBlockClose = value.lastIndexOf('*/')
+        }
+        end = lastBlockClose >= i + 2 ? lastBlockClose + 2 : UNTERMINATED
+        trimStart = 2 // /*
+        trimEnd = 2 // */
+      }
+
+      if (end === FALL_THROUGH) {
+        i++
+      } else if (end === UNTERMINATED) {
+        // Mask the unterminated literal/comment raw (delimiters included) to the end of the evidence.
+        ranges.push({ start: i, end: length })
+        break
+      } else {
+        ranges.push({ start: i + trimStart, end: end - trimEnd })
+        i = end
+        if (code === DOLLAR && (features & POSTGRES_SYNTAX) !== 0) {
+          postgresIdentifierFloor = i
+        }
+      }
     }
-    return tokens
+
+    return ranges
   } catch (e) {
     log.debug('[ASM] Error extracting sensitive ranges', e)
   }

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/evidence-redaction/sensitive-handler.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/evidence-redaction/sensitive-handler.spec.js
@@ -9,6 +9,8 @@ const sensitiveHandler =
   require('../../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler')
 const REDACTION_DIR = '../../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction'
 const ldapSensitiveAnalyzer = require(`${REDACTION_DIR}/sensitive-analyzers/ldap-sensitive-analyzer`)
+const commandSensitiveAnalyzer = require(`${REDACTION_DIR}/sensitive-analyzers/command-sensitive-analyzer`)
+const sqlSensitiveAnalyzer = require(`${REDACTION_DIR}/sensitive-analyzers/sql-sensitive-analyzer`)
 const vulnerabilities = require('../../../../../src/appsec/iast/vulnerabilities')
 const { defaults } = require('../../../../../src/config/defaults')
 const { suite } = require('../resources/evidence-redaction-suite.json')
@@ -170,13 +172,7 @@ describe('Sensitive handler', () => {
   })
 
   describe('Analyzer performance on irregular inputs', () => {
-    // These fixtures keep the analyzers honest about linear scanning. Assertion is
-    // "completes" — mocha's per-test timeout will fail if the work grows super-linearly
-    // with input length.
     it('LDAP scanner completes on 16KB of unmatched input', () => {
-      // Repeated "(=" pairs: each "(" is a viable match start with an operator immediately
-      // after, but there is no terminating ")", which is the shape that forces per-start
-      // backtracking in a regex implementation.
       const evidence = { value: '(='.repeat(8 * 1024) }
       sensitiveHandler.scrubEvidence(vulnerabilities.LDAP_INJECTION, evidence, [], [])
     })
@@ -189,6 +185,209 @@ describe('Sensitive handler', () => {
     it('SQL Oracle analyzer completes on unmatched q-quote input', () => {
       const evidence = { value: "q'<".repeat(2000), dialect: 'ORACLE' }
       sensitiveHandler.scrubEvidence(vulnerabilities.SQL_INJECTION, evidence, [], [])
+    })
+
+    it('SQL analyzer completes on unterminated block comments', () => {
+      const evidence = { value: '/*aaaaaaaa'.repeat(2000), dialect: 'ANSI' }
+      const result = sensitiveHandler.scrubEvidence(vulnerabilities.SQL_INJECTION, evidence, [], [])
+
+      assert.deepStrictEqual(result.redactedValueParts, [{ redacted: true }])
+    })
+
+    it('SQL Postgres analyzer completes on unterminated dollar quotes', () => {
+      const evidence = { value: '$a$body'.repeat(2000), dialect: 'POSTGRES' }
+      sensitiveHandler.scrubEvidence(vulnerabilities.SQL_INJECTION, evidence, [], [])
+    })
+  })
+
+  describe('SQL scanner', () => {
+    /**
+     * @param {string} value
+     * @param {string} dialect
+     */
+    function redacted (value, dialect) {
+      return sqlSensitiveAnalyzer({ value, dialect }).map(({ start, end }) => value.slice(start, end))
+    }
+
+    it('reports the inner range of string and numeric literals', () => {
+      assert.deepStrictEqual(redacted("select * from t where a = 'secret' and b = 123", 'ANSI'),
+        ['secret', '123'])
+    })
+
+    it('reports comment bodies without their delimiters', () => {
+      assert.deepStrictEqual(redacted('a /* note */ b -- trailing', 'ANSI'), [' note ', ' trailing'])
+    })
+
+    it('ends a line comment at the line terminator, not at the value end', () => {
+      assert.deepStrictEqual(redacted('a -- note\nb = 1', 'ANSI'), [' note', '1'])
+    })
+
+    it('keeps doubled-quote escapes inside one string token', () => {
+      assert.deepStrictEqual(redacted("'O''Brien'", 'ANSI'), ["O''Brien"])
+    })
+
+    it('uses backslash parity to close MySQL-style quoted strings', () => {
+      for (const dialect of ['MYSQL', 'MARIADB']) {
+        assert.deepStrictEqual(redacted("'plain', 42", dialect), ['plain', '42'])
+        assert.deepStrictEqual(redacted(String.raw`'a\'b', "c\"d"`, dialect),
+          [String.raw`a\'b`, String.raw`c\"d`])
+        assert.deepStrictEqual(redacted(String.raw`'a\\', "b\\", 42`, dialect),
+          [String.raw`a\\`, String.raw`b\\`, '42'])
+        assert.deepStrictEqual(redacted("'unterminated\\", dialect), ["'unterminated\\"])
+        assert.deepStrictEqual(redacted(String.raw`'unterminated\'`, dialect), [String.raw`'unterminated\'`])
+      }
+    })
+
+    it('uses SQLite doubled-quote semantics', () => {
+      const value = String.raw`SELECT * FROM tainted WHERE a = 'first\' || 'second-secret'`
+      const result = sensitiveHandler.scrubEvidence(
+        vulnerabilities.SQL_INJECTION,
+        { value, dialect: 'SQLITE' },
+        [],
+        []
+      )
+
+      assert.strictEqual(
+        result.redactedValueParts.some(({ value }) => value?.includes('second-secret')),
+        false
+      )
+      assert.deepStrictEqual(redacted(value, 'SQLITE'), [value.slice(value.indexOf("'"))])
+      assert.deepStrictEqual(redacted('"identifier""part"', 'SQLITE'), ['identifier""part'])
+      assert.deepStrictEqual(redacted(String.raw`SELECT "first\\", 42`, 'SQLITE'), [String.raw`first\\`, '42'])
+    })
+
+    it('does not expose SQLite literal contents after a backslash quote', () => {
+      for (const value of [
+        String.raw`SELECT "first\" trailing-value"`,
+        String.raw`SELECT 'first\' trailing-value'`,
+      ]) {
+        const result = sensitiveHandler.scrubEvidence(
+          vulnerabilities.SQL_INJECTION,
+          { value, dialect: 'SQLITE' },
+          [],
+          []
+        )
+
+        assert.strictEqual(
+          result.redactedValueParts.some(({ value }) => value?.includes('trailing-value')),
+          false
+        )
+        assert.deepStrictEqual(redacted(value, 'SQLITE'), [value.slice(7)])
+      }
+    })
+
+    it('masks an unterminated literal through the end of the evidence', () => {
+      assert.deepStrictEqual(redacted("ok = 'unterminated secret", 'ANSI'), ["'unterminated secret"])
+    })
+
+    it('closes an Oracle quote on its mirror or exact self delimiter', () => {
+      assert.deepStrictEqual(redacted("q'<secret>', q'!secret!', q'AsecretA'", 'ORACLE'),
+        ['secret', 'secret', 'secret'])
+    })
+
+    it('does not expose Oracle quote contents after a differently-cased delimiter', () => {
+      for (const value of ["q'Afirst a' trailing-value A'", "q'afirst A' trailing-value a'"]) {
+        const result = sensitiveHandler.scrubEvidence(
+          vulnerabilities.SQL_INJECTION,
+          { value, dialect: 'ORACLE' },
+          [],
+          []
+        )
+
+        assert.strictEqual(
+          result.redactedValueParts.some(({ value }) => value?.includes('trailing-value')),
+          false
+        )
+        assert.deepStrictEqual(redacted(value, 'ORACLE'), [value.slice(3, -2)])
+      }
+    })
+
+    it('matches a Postgres dollar quote only on its own tag', () => {
+      assert.deepStrictEqual(redacted('$$plain$$, $tag$secret$tag$', 'POSTGRES'), ['plain', 'secret'])
+      // A different inner tag does not close; the literal runs to its real terminator.
+      assert.deepStrictEqual(redacted('$a$one$b$two$a$', 'POSTGRES'), ['one$b$two'])
+    })
+
+    it('passes through a lone dollar with no closing tag delimiter', () => {
+      assert.deepStrictEqual(redacted('price $ 5', 'POSTGRES'), ['5'])
+    })
+
+    it('leaves positional parameters intact', () => {
+      // `$1` is syntax, not data: masking the index tells a reader nothing and masking from the
+      // first `$` onwards (reading it as a dollar-quote tag) hides the whole statement.
+      assert.deepStrictEqual(redacted('select * from users where id = $1 and email = $2', 'POSTGRES'), [])
+      assert.deepStrictEqual(redacted('insert into t values ($1,$2,$3)', 'POSTGRES'), [])
+      assert.deepStrictEqual(redacted('select * from t offset $10 limit $2', 'POSTGRES'), [])
+      assert.deepStrictEqual(redacted('a = $1 and b = $tag$secret$tag$', 'POSTGRES'), ['secret'])
+    })
+
+    it('still masks a number that only follows a dollar', () => {
+      // `$ 5` is not a parameter reference, so the bare number is data again.
+      assert.deepStrictEqual(redacted('price $ 5', 'POSTGRES'), ['5'])
+      assert.deepStrictEqual(redacted('total $-5', 'POSTGRES'), ['-5'])
+    })
+
+    it('accepts an empty or identifier tag and masks malformed tags conservatively', () => {
+      assert.deepStrictEqual(redacted('$$a$$ $_x1$b$_x1$', 'POSTGRES'), ['a', 'b'])
+      assert.deepStrictEqual(redacted('$é$secret$é$, 42', 'POSTGRES'), ['secret', '42'])
+      assert.deepStrictEqual(redacted('select $a-b$ from t', 'POSTGRES'), ['$a-b$ from t'])
+    })
+
+    it('does not treat dollar signs inside Postgres identifiers as quote openers', () => {
+      assert.deepStrictEqual(redacted('SELECT foo$bar$, foo1$bar$, é$bar$ FROM users', 'POSTGRES'), [])
+    })
+
+    it('still recognizes Postgres dollar quotes after non-identifier tokens', () => {
+      assert.deepStrictEqual(redacted('SELECT 1$tag$secret$tag$', 'POSTGRES'), ['1', 'secret'])
+      assert.deepStrictEqual(redacted('$1$tag$secret$tag$', 'POSTGRES'), ['secret'])
+      assert.deepStrictEqual(redacted('$a$one$a$$b$two$b$', 'POSTGRES'), ['one', 'two'])
+    })
+
+    it('treats a bare q-quote opener with no delimiter as a plain string', () => {
+      // No delimiter after `q'` (end of value), so it is not an alternative-quote opener; the `'`
+      // falls through and opens an unterminated string masked to the end.
+      assert.deepStrictEqual(redacted("q'", 'ORACLE'), ["'"])
+    })
+
+    it('masks an unterminated Oracle quote or dollar quote through the end', () => {
+      assert.deepStrictEqual(redacted("q'<no closer here", 'ORACLE'), ["q'<no closer here"])
+      assert.deepStrictEqual(redacted('$t$no closer here', 'POSTGRES'), ['$t$no closer here'])
+    })
+
+    it('masks an unterminated multi-line Oracle quote or dollar quote through the end', () => {
+      // No closer, so the literal is unterminated and the whole tail is masked regardless of newlines.
+      assert.deepStrictEqual(redacted("q'<body\nmore", 'ORACLE'), ["q'<body\nmore"])
+      assert.deepStrictEqual(redacted('$t$body\nstill secret', 'POSTGRES'), ['$t$body\nstill secret'])
+    })
+
+    it('masks a terminated multi-line dollar quote or q-quote whole, delimiters included', () => {
+      assert.deepStrictEqual(redacted('$f$line one\nline two$f$', 'POSTGRES'), ['$f$line one\nline two$f$'])
+      assert.deepStrictEqual(redacted("q'<line one\nline two>'", 'ORACLE'), ["q'<line one\nline two>'"])
+      // Single-line literals still trim their delimiters, unchanged.
+      assert.deepStrictEqual(redacted('$f$one line$f$', 'POSTGRES'), ['one line'])
+      assert.deepStrictEqual(redacted("q'<one line>'", 'ORACLE'), ['one line'])
+    })
+
+    it('masks plain integers and decimals', () => {
+      assert.deepStrictEqual(redacted('id IN (1, 42, 3501, 1000000)', 'ANSI'), ['1', '42', '3501', '1000000'])
+      assert.deepStrictEqual(redacted('price = 19.95 AND ratio = 0.5', 'ANSI'), ['19.95', '0.5'])
+    })
+
+    it('treats a trailing dot as not part of an integer', () => {
+      // `\d*\.\d+` needs digits after the dot; `3.` is the integer `3` followed by a bare `.`.
+      assert.deepStrictEqual(redacted('x = 3. y', 'ANSI'), ['3'])
+    })
+
+    it('does not mask digits inside an identifier', () => {
+      // No word boundary before the digits, so `\b\d+` does not match — `table_120` stays untouched.
+      assert.deepStrictEqual(redacted('SELECT table_120 FROM t', 'ANSI'), [])
+      assert.deepStrictEqual(redacted('SELECT table_120.5 FROM t', 'ANSI'), ['120.5'])
+    })
+
+    it('defers exponent and radix literals to the regex, unchanged', () => {
+      assert.deepStrictEqual(redacted('a = 1e10, b = 2.5e-3, c = 6.02E23', 'ANSI'), ['1e10', '2.5e-3', '6.02E23'])
+      assert.deepStrictEqual(redacted('m = 0xFF, n = 0b1010', 'ANSI'), ['0xFF', '0b1010'])
+      assert.deepStrictEqual(redacted("p = x'1a', q = b'10'", 'ANSI'), ["x'1a'", "b'10'"])
     })
   })
 
@@ -246,6 +445,29 @@ describe('Sensitive handler', () => {
     it('handles operator-like character not followed by =', () => {
       // `<` without `=` should not be picked up as an operator
       assert.deepStrictEqual(extract('(a<b)'), [])
+    })
+  })
+
+  describe('Command scanner', () => {
+    function redacted (value) {
+      return commandSensitiveAnalyzer({ value }).map(({ start, end }) => value.slice(start, end))
+    }
+
+    it('redacts the arguments after the command token', () => {
+      assert.deepStrictEqual(redacted('ls -la'), ['-la'])
+    })
+
+    it('redacts arguments for commands whose token ends in a non-word character', () => {
+      assert.deepStrictEqual(redacted('/bin/ls -la'), ['-la'])
+      assert.deepStrictEqual(redacted('cmd) arg'), ['arg'])
+    })
+
+    it('strips a leading sudo/doas prefix before the command token', () => {
+      assert.deepStrictEqual(redacted('sudo rm -rf /tmp/x'), ['-rf /tmp/x'])
+    })
+
+    it('returns no ranges when there are no arguments to redact', () => {
+      assert.deepStrictEqual(redacted('noargs'), [])
     })
   })
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
@@ -82,6 +82,33 @@ function extractTestParameters (testCase) {
   return testsParameters
 }
 
+/**
+ * @param {string} type
+ * @param {string} value
+ * @param {string} [dialect]
+ */
+function formatEvidence (type, value, dialect) {
+  const sourceValue = 'tainted'
+  const start = value.indexOf(sourceValue)
+  return vulnerabilityFormatter.toJson([{
+    type,
+    evidence: {
+      value,
+      dialect,
+      ranges: [{
+        start,
+        end: start + sourceValue.length,
+        iinfo: {
+          type: 'http.request.parameter',
+          parameterName: 'input',
+          parameterValue: sourceValue,
+        },
+      }],
+    },
+    location: {},
+  }])
+}
+
 describe('Vulnerability formatter', () => {
   describe('Vulnerability redaction', () => {
     suite.filter(testCase => testCase.type === 'VULNERABILITIES')
@@ -129,6 +156,55 @@ describe('Vulnerability formatter', () => {
           },
         }],
       })
+    })
+
+    it('redacts complete Postgres escape strings', () => {
+      for (const prefix of ['E', 'e']) {
+        const output = JSON.stringify(formatEvidence(
+          'SQL_INJECTION',
+          String.raw`SELECT ${prefix}'first-secret\'second-secret''third-secret' FROM tainted`,
+          'POSTGRES'
+        ))
+
+        assert.strictEqual(output.includes('first-secret'), false)
+        assert.strictEqual(output.includes('second-secret'), false)
+        assert.strictEqual(output.includes('third-secret'), false)
+      }
+    })
+
+    it('redacts malformed Postgres dollar-quoted strings conservatively', () => {
+      const output = JSON.stringify(formatEvidence(
+        'SQL_INJECTION',
+        'SELECT $a-b$secret-with-hyphen$a-b$ FROM tainted',
+        'POSTGRES'
+      ))
+
+      assert.strictEqual(output.includes('secret-with-hyphen'), false)
+    })
+
+    it('redacts MySQL and MariaDB hash comments', () => {
+      for (const dialect of ['MYSQL', 'MARIADB']) {
+        const output = JSON.stringify(formatEvidence(
+          'SQL_INJECTION',
+          'SELECT * FROM tainted # secret-comment',
+          dialect
+        ))
+
+        assert.strictEqual(output.includes('secret-comment'), false)
+      }
+    })
+
+    it('redacts command arguments across line terminators', () => {
+      for (const terminator of ['\n', '\r', '\u2028', '\u2029']) {
+        const output = JSON.stringify(formatEvidence(
+          'COMMAND_INJECTION',
+          `tainted -c first-secret${terminator}second-secret${terminator}third-secret`
+        ))
+
+        assert.strictEqual(output.includes('first-secret'), false)
+        assert.strictEqual(output.includes('second-secret'), false)
+        assert.strictEqual(output.includes('third-secret'), false)
+      }
     })
   })
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
@@ -493,8 +493,7 @@
       "parameters": {
         "$1": [
           "MYSQL",
-          "MARIADB",
-          "SQLITE"
+          "MARIADB"
         ]
       },
       "input": [


### PR DESCRIPTION
Incomplete and multiline SQL input produced inconsistent sensitive ranges across supported dialects. Command tokens ending in punctuation left their arguments unchanged.