### PR TITLE
feat(agentless): export client-computed trace stats

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,8 +15,8 @@ Set the API key with `DD_API_KEY` or `DATADOG_API_KEY`.
 Agentless crash tracking requires this key and sends crash data directly to Datadog.
 
 Agentless mode uses the Datadog trace intake and ignores `OTEL_TRACES_EXPORTER`.
-Explicit `DD_TRACE_SAMPLE_RATE`, `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SPAN_METRICS_ENABLED`, and
-`DD_METRICS_OTEL_ENABLED` settings still apply.
+Explicit `DD_TRACE_SAMPLE_RATE`, `DD_TRACE_STATS_COMPUTATION_ENABLED`, `OTEL_TRACES_SAMPLER`,
+`OTEL_TRACES_SPAN_METRICS_ENABLED`, and `DD_METRICS_OTEL_ENABLED` settings still apply.
 
 Agentless mode submits Bunyan, Pino, and Winston logs directly by default. Set
 `DD_AGENTLESS_LOG_SUBMISSION_ENABLED=false` to disable this behavior. Set `DD_LOGS_OTEL_ENABLED=true` to use the

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -668,8 +668,6 @@ class Config extends ConfigBase {
 
     if (agentlessTracingEnabled && !this.isCiVisibility) {
       setAndTrack(this, 'experimental.exporter', 'agentless')
-      // Disable client-side stats computation
-      setAndTrack(this, 'stats.DD_TRACE_STATS_COMPUTATION_ENABLED', false)
       // Enable hostname reporting
       setAndTrack(this, 'reportHostname', true)
       // Disable rate limiting - server-side sampling will be used

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -6,7 +6,7 @@ const os = require('node:os')
 const log = require('../../log')
 const { containerId } = require('../common/docker')
 const Writer = require('./writer')
-const { computeIntakeUrl } = require('./intake')
+const { computeIntakeUrl, computeStatsIntakeUrl } = require('./intake')
 
 /**
  * Agentless exporter for APM trace intake.
@@ -22,19 +22,28 @@ class AgentlessExporter {
    * @param {string} [config.site] - The Datadog site. Defaults to 'datadoghq.com'.
    * @param {number} [config.flushInterval] - Batch flush interval in ms
    * @param {string} [config.env] - Environment name
+   * @param {{ DD_TRACE_STATS_COMPUTATION_ENABLED: boolean }} [config.stats] - Client stats configuration
+   * @param {boolean} [config.OTEL_TRACES_SPAN_METRICS_ENABLED] - Whether OTLP owns span stats export
    * @param {object} config.tags - Tags including runtime-id
    */
   constructor (config) {
     this.#config = config
     const site = config.site ?? 'datadoghq.com'
+    let statsEndpoint
 
     try {
       // Agentless traffic carries the Datadog API key, so the intake is always an https endpoint
       // derived from the site; never config.url (the agent's cleartext http) or the key leaks.
       this._url = new URL(computeIntakeUrl(site))
-    } catch (err) {
-      log.error('Invalid site for agentless exporter. site=%s. Error: %s', site, err.message)
-      this._url = null
+      if (
+        config.stats?.DD_TRACE_STATS_COMPUTATION_ENABLED &&
+        !config.OTEL_TRACES_SPAN_METRICS_ENABLED
+      ) {
+        statsEndpoint = computeStatsIntakeUrl(site)
+      }
+    } catch (error) {
+      log.error('Invalid site for agentless exporter. site=%s. Error: %s', site, error.message)
+      this._url = undefined
     }
 
     const metadata = {
@@ -49,6 +58,7 @@ class AgentlessExporter {
     this._writer = new Writer({
       url: this._url,
       site,
+      statsEndpoint,
       metadata,
     })
 
@@ -108,6 +118,14 @@ class AgentlessExporter {
       }, flushInterval)
       this.#timer.unref?.()
     }
+  }
+
+  /**
+   * @param {Buffer} payload - Client-computed span stats payload.
+   * @param {() => void} done - Callback invoked after delivery completes or fails.
+   */
+  sendStats (payload, done) {
+    this._writer.sendStats(payload, done)
   }
 
   /**

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -4,7 +4,7 @@ const { URL } = require('node:url')
 const os = require('node:os')
 
 const log = require('../../log')
-const { containerId } = require('../common/docker')
+const { containerId, entityId } = require('../common/docker')
 const Writer = require('./writer')
 const { computeIntakeUrl, computeStatsIntakeUrl } = require('./intake')
 
@@ -16,6 +16,9 @@ const { computeIntakeUrl, computeStatsIntakeUrl } = require('./intake')
 class AgentlessExporter {
   #timer
   #config
+
+  /** @type {true} */
+  requiresClientComputedTopLevel = true
 
   /**
    * @param {object} config - Configuration object
@@ -54,6 +57,7 @@ class AgentlessExporter {
       get runtimeID () { return config.tags['runtime-id'] },
     }
     if (containerId) metadata.containerId = containerId
+    if (entityId) metadata.entityId = entityId
 
     this._writer = new Writer({
       url: this._url,

--- a/packages/dd-trace/src/exporters/agentless/intake.js
+++ b/packages/dd-trace/src/exporters/agentless/intake.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { createSiteUrl } = require('../common/url')
+
 // Per-site hosts for the agentless JSON span intake. Regional data centers serve it from
 // browser-intake-* hosts rather than public-trace-http-intake.logs.<site>, so a single template
 // silently drops spans on us3/us5/ap1/ap2. Mirrors dd-trace-py's AgentlessTraceWriter.INTAKE_URLS
@@ -17,6 +19,7 @@ const INTAKE_URLS = {
 
 // Path of the JSON span intake on every intake host.
 const INTAKE_PATH = '/api/v2/spans'
+const STATS_INTAKE_PATH = '/api/v0.2/stats'
 
 /**
  * Resolves the agentless intake origin for a Datadog site.
@@ -28,7 +31,12 @@ const INTAKE_PATH = '/api/v2/spans'
  * @returns {string} The intake origin, without a path.
  */
 function computeIntakeUrl (site = 'datadoghq.com') {
-  const normalized = site.toLowerCase()
+  const siteUrl = createSiteUrl(site)
+  if (siteUrl === undefined) {
+    throw new TypeError(`Invalid Datadog site: ${site}`)
+  }
+
+  const normalized = siteUrl.hostname
   const known = INTAKE_URLS[normalized]
   if (known !== undefined) {
     return known
@@ -40,4 +48,18 @@ function computeIntakeUrl (site = 'datadoghq.com') {
   return `https://browser-intake-${prefix.replaceAll('.', '-')}.${tld}`
 }
 
-module.exports = { INTAKE_URLS, INTAKE_PATH, computeIntakeUrl }
+/**
+ * @param {string} [site] - The Datadog site. Defaults to 'datadoghq.com'.
+ * @returns {string} The client stats intake endpoint.
+ */
+function computeStatsIntakeUrl (site = 'datadoghq.com') {
+  const url = createSiteUrl(site, 'trace.agent')
+  if (url === undefined) {
+    throw new TypeError(`Invalid Datadog site: ${site}`)
+  }
+
+  url.pathname = STATS_INTAKE_PATH
+  return url.href
+}
+
+module.exports = { INTAKE_URLS, INTAKE_PATH, computeIntakeUrl, computeStatsIntakeUrl }

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -28,17 +28,20 @@ class AgentlessWriter extends BaseWriter {
   #exporterEnv
   #exporterRuntimeId
   #metadata
+  #statsEndpoint
   #urlMissing = false
 
   /**
    * @param {object} options - Writer options
    * @param {URL} [options.url] - The intake URL. If not provided, constructed from site.
    * @param {string} [options.site] - The Datadog site
+   * @param {string} [options.statsEndpoint] - The client stats intake endpoint.
    * @param {object} [options.metadata] - Metadata to pass to the data pipeline
    */
-  constructor ({ url, site = 'datadoghq.com', metadata = {} }) {
-    super({ url })
+  constructor ({ url, site = 'datadoghq.com', statsEndpoint, metadata = {} }) {
+    super({ url, beforeFirstFlush: undefined, deliveryTracker: undefined })
     this.#metadata = metadata
+    this.#statsEndpoint = statsEndpoint
     this._encoder = new AgentEncoder(this)
 
     if (!url) {
@@ -77,12 +80,31 @@ class AgentlessWriter extends BaseWriter {
    * @param {() => void} done - Callback invoked after delivery completes or fails.
    */
   _sendPayload (data, count, done) {
+    this.#send(data, count, done)
+  }
+
+  /**
+   * @param {Buffer} data - Client-computed span stats payload.
+   * @param {() => void} done - Callback invoked after delivery completes or fails.
+   */
+  sendStats (data, done) {
+    this.#send(data, undefined, done)
+  }
+
+  /**
+   * @param {Buffer} data - MessagePack payload.
+   * @param {number|undefined} count - Number of traces, or undefined for a stats payload.
+   * @param {() => void} done - Callback invoked after delivery completes or fails.
+   */
+  #send (data, count, done) {
+    const isStats = count === undefined
     if (!this._url) {
       if (!this.#urlMissing) {
         this.#urlMissing = true
         log.error('No valid URL configured for agentless trace intake. Traces will not be sent.')
       }
-      log.debug('Dropping %d trace(s) due to missing URL', count)
+      if (isStats) log.debug('Dropping span stats due to missing URL')
+      else log.debug('Dropping %d trace(s) due to missing URL', count)
       done()
       return
     }
@@ -93,7 +115,8 @@ class AgentlessWriter extends BaseWriter {
         this.#apiKeyMissing = true
         log.error('DD_API_KEY is required for agentless trace intake. Set DD_API_KEY. Traces will not be sent.')
       }
-      log.debug('Dropping %d trace(s) due to missing DD_API_KEY', count)
+      if (isStats) log.debug('Dropping span stats due to missing DD_API_KEY')
+      else log.debug('Dropping %d trace(s) due to missing DD_API_KEY', count)
       done()
       return
     }
@@ -105,14 +128,16 @@ class AgentlessWriter extends BaseWriter {
       legacyStorage.run({ noop: true }, () => {
         const exporter = this.#applyConfiguration(DD_API_KEY)
         if (exporter) {
-          exporter.sendV04(data, done, log)
+          if (isStats) exporter.sendStats(data, done, log)
+          else exporter.sendV04(data, done, log)
         } else {
           done()
         }
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      log.error('Failed to send %d trace(s) to the agentless intake: %s', count, message)
+      if (isStats) log.error('Failed to send span stats to the agentless intake: %s', message)
+      else log.error('Failed to send %d trace(s) to the agentless intake: %s', count, message)
       done()
     }
   }
@@ -157,6 +182,7 @@ class AgentlessWriter extends BaseWriter {
     const agent = this._url.protocol === 'https:' ? getHttpsProxyAgent(this._url) : undefined
     this.#exporter = createAgentlessExporter({
       endpoint: this.#endpoint(),
+      statsEndpoint: this.#statsEndpoint,
       apiKey,
       hostname: this.#metadata.hostname,
       env,

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -190,6 +190,8 @@ class AgentlessWriter extends BaseWriter {
       version: config.version,
       runtimeId: runtimeID,
       containerId: this.#metadata.containerId,
+      entityId: this.#metadata.entityId,
+      clientComputedTopLevel: true,
       tracerVersion,
       languageVersion: process.version,
       languageInterpreter: process.versions.bun ? 'JavaScriptCore' : 'v8',

--- a/packages/dd-trace/src/exporters/span-stats/index.js
+++ b/packages/dd-trace/src/exporters/span-stats/index.js
@@ -7,11 +7,17 @@ const { Writer } = require('./writer')
 class SpanStatsExporter {
   #serverlessDeliveryTracker
 
+  /**
+   * @param {object} config
+   * @param {string|URL} config.url
+   * @param {(payload: Buffer, done: () => void) => void} [config.sendStats]
+   */
   constructor (config) {
     this.#serverlessDeliveryTracker = createServerlessDeliveryTracker()
     this._url = config.url
     this._writer = new Writer({
       url: this._url,
+      sendStats: config.sendStats,
       deliveryTracker: this.#serverlessDeliveryTracker,
     })
   }

--- a/packages/dd-trace/src/exporters/span-stats/writer.js
+++ b/packages/dd-trace/src/exporters/span-stats/writer.js
@@ -9,16 +9,35 @@ const request = require('../common/request')
 const log = require('../../log')
 
 class Writer extends BaseWriter {
-  constructor ({ url }) {
-    super(...arguments)
+  #sendStats
+
+  /**
+   * @param {object} options
+   * @param {string|URL} options.url
+   * @param {(payload: Buffer, done: () => void) => void} [options.sendStats]
+   * @param {import('../../serverless/telemetry-delivery-tracker')} [options.deliveryTracker]
+   */
+  constructor ({ url, sendStats, deliveryTracker }) {
+    super({ url, deliveryTracker, beforeFirstFlush: undefined })
     this._url = url
+    this.#sendStats = sendStats
     this._encoder = new SpanStatsEncoder(this)
   }
 
+  /**
+   * @param {Buffer} data
+   * @param {number} _
+   * @param {() => void} done
+   */
   _sendPayload (data, _, done) {
-    makeRequest(data, this._url, (err, res) => {
-      if (err) {
-        log.error('Error sending span stats', err)
+    if (this.#sendStats) {
+      this.#sendStats(data, done)
+      return
+    }
+
+    makeRequest(data, this._url, (error, res) => {
+      if (error) {
+        log.error('Error sending span stats', error)
         done()
         return
       }
@@ -42,8 +61,8 @@ function makeRequest (data, url, cb) {
 
   log.debug('Request to the intake: %j', options)
 
-  request(data, options, (err, res) => {
-    cb(err, res)
+  request(data, options, (error, res) => {
+    cb(error, res)
   })
 }
 

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -7,10 +7,24 @@ const SpanSampler = require('./span_sampler')
 const GitMetadataTagger = require('./git_metadata_tagger')
 const processTags = require('./process-tags')
 const { applyHttpOtelSemantics } = require('./plugins/util/http-otel-semantics')
-const { APM_TRACING_ENABLED_KEY } = require('./constants')
+const { APM_TRACING_ENABLED_KEY, TOP_LEVEL_KEY } = require('./constants')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
+
+/** @param {Array<ReturnType<typeof spanFormat>>} spans */
+function computeTopLevel (spans) {
+  const services = new Map()
+  for (const span of spans) {
+    services.set(span.span_id.toBigInt(), span.service)
+  }
+  for (const span of spans) {
+    const parentId = span.parent_id.toBigInt()
+    if (!services.has(parentId) || services.get(parentId) !== span.service) {
+      span.metrics[TOP_LEVEL_KEY] = 1
+    }
+  }
+}
 
 /**
  * @typedef {import('./config/config-base') & {
@@ -19,8 +33,14 @@ const finishedSpans = new WeakSet()
  */
 
 class SpanProcessor {
+  #computeTopLevel
+
   /**
-   * @param {{ export: Function, sendStats?: (payload: Buffer, done: () => void) => void }} exporter
+   * @param {{
+   *   export: Function,
+   *   requiresClientComputedTopLevel?: boolean,
+   *   sendStats?: (payload: Buffer, done: () => void) => void
+   * }} exporter
    * @param {import('./priority_sampler')} prioritySampler
    * @param {SpanProcessorConfig} config
    * @param {import('./opentelemetry/metrics/otlp_span_stats_exporter').OtlpStatsExporter} [otlpStatsExporter]
@@ -30,6 +50,7 @@ class SpanProcessor {
     this._prioritySampler = prioritySampler
     this._config = config
     this._killAll = false
+    this.#computeTopLevel = exporter.requiresClientComputedTopLevel === true
 
     if (config.stats?.DD_TRACE_STATS_COMPUTATION_ENABLED) {
       const { SpanStatsProcessor } = require('./span_stats')
@@ -94,13 +115,20 @@ class SpanProcessor {
             formattedSpan.metrics[APM_TRACING_ENABLED_KEY] = 0
           }
           isFirstSpanInChunk = false
+          formatted.push(formattedSpan)
+        }
+      }
+
+      if (this.#computeTopLevel) computeTopLevel(formatted)
+
+      if (this._stats || this._config.DD_TRACE_OTEL_SEMANTICS_ENABLED) {
+        for (const formattedSpan of formatted) {
           // Span stats read Datadog HTTP tag names from the formatted span, so
           // record them before the OTel rename — an export-only transform.
           this._stats?.onSpanFinished(formattedSpan)
           if (this._config.DD_TRACE_OTEL_SEMANTICS_ENABLED) {
             applyHttpOtelSemantics(formattedSpan)
           }
-          formatted.push(formattedSpan)
         }
       }
 

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -12,16 +12,29 @@ const { APM_TRACING_ENABLED_KEY } = require('./constants')
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
 
+/**
+ * @typedef {import('./config/config-base') & {
+ *   sampler: ConstructorParameters<typeof SpanSampler>[0]
+ * }} SpanProcessorConfig
+ */
+
 class SpanProcessor {
+  /**
+   * @param {{ export: Function, sendStats?: (payload: Buffer, done: () => void) => void }} exporter
+   * @param {import('./priority_sampler')} prioritySampler
+   * @param {SpanProcessorConfig} config
+   * @param {import('./opentelemetry/metrics/otlp_span_stats_exporter').OtlpStatsExporter} [otlpStatsExporter]
+   */
   constructor (exporter, prioritySampler, config, otlpStatsExporter) {
     this._exporter = exporter
     this._prioritySampler = prioritySampler
     this._config = config
     this._killAll = false
 
-    if (config.stats?.DD_TRACE_STATS_COMPUTATION_ENABLED && !config.appsec?.standalone?.enabled) {
+    if (config.stats?.DD_TRACE_STATS_COMPUTATION_ENABLED) {
       const { SpanStatsProcessor } = require('./span_stats')
-      this._stats = new SpanStatsProcessor(config, otlpStatsExporter)
+      const sendStats = otlpStatsExporter ? undefined : exporter.sendStats?.bind(exporter)
+      this._stats = new SpanStatsProcessor(config, otlpStatsExporter, sendStats)
     }
 
     this._spanSampler = new SpanSampler(config.sampler)

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -193,25 +193,23 @@ class SpanStatsProcessor {
   #config
 
   /**
-   * @param {import('./config/config-base')} config
+   * @param {import('./config/config-base') & { stats: { interval?: number } }} config
    * @param {import('./opentelemetry/metrics/otlp_span_stats_exporter').OtlpStatsExporter} [otlpExporter]
+   * @param {(payload: Buffer, done: () => void) => void} [sendStats]
    */
-  constructor (config, otlpExporter) {
+  constructor (config, otlpExporter, sendStats) {
     const {
       stats: {
         DD_TRACE_STATS_COMPUTATION_ENABLED: enabled = false,
         interval = 10,
       } = {},
-      hostname,
-      port,
       url,
       env,
-      tags,
       version: appVersion,
       _DD_TRACE_METRICS_OTEL_FLUSH_INTERVAL: flushIntervalMs,
     } = config
     if (!otlpExporter) {
-      this.exporter = new SpanStatsExporter({ hostname, port, tags, url })
+      this.exporter = new SpanStatsExporter({ url, sendStats })
     }
     const intervalMs = otlpExporter ? (flushIntervalMs ?? 10_000) : interval * 1e3
     this.interval = intervalMs / 1e3

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -5517,11 +5517,17 @@ rules:
       assert.strictEqual(config.sampler.rateLimit, -1)
     })
 
-    it('should disable stats computation when agentless is enabled', () => {
+    it('should preserve default stats computation when agentless is enabled', () => {
+      process.env._DD_APM_TRACING_AGENTLESS_ENABLED = 'true'
+      const config = getConfig()
+      assert.strictEqual(config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED, false)
+    })
+
+    it('should preserve explicitly enabled stats computation when agentless is enabled', () => {
       process.env._DD_APM_TRACING_AGENTLESS_ENABLED = 'true'
       process.env.DD_TRACE_STATS_COMPUTATION_ENABLED = 'true'
       const config = getConfig()
-      assert.strictEqual(config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED, false)
+      assert.strictEqual(config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED, true)
     })
 
     it('should enable hostname reporting when agentless is enabled', () => {

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -173,7 +173,8 @@ describe('AgentlessExporter', () => {
         tags: { 'runtime-id': 'test-uuid' },
       })
 
-      assert.strictEqual(Object.hasOwn(writerOptions.metadata, 'containerID'), false)
+      assert.strictEqual(Object.hasOwn(writerOptions.metadata, 'containerId'), false)
+      assert.strictEqual(writerOptions.metadata.entityId, 'in-1234')
     })
 
     it('should reflect a runtime id updated on config after construction', () => {

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -18,6 +18,7 @@ describe('AgentlessExporter', () => {
   let writer
   let initialHandlersSize
   let clock
+  let writerOptions
 
   beforeEach(() => {
     clock = sinon.useFakeTimers()
@@ -25,10 +26,12 @@ describe('AgentlessExporter', () => {
     writer = {
       append: sinon.stub(),
       flush: sinon.stub().callsFake((cb) => cb && cb()),
+      sendStats: sinon.stub().callsFake((payload, done) => done()),
       setUrl: sinon.stub(),
     }
 
-    const Writer = function () {
+    const Writer = function (options) {
+      writerOptions = options
       return writer
     }
 
@@ -72,6 +75,33 @@ describe('AgentlessExporter', () => {
       assert.strictEqual(exporter._url.hostname, 'trace.browser-intake-us3-datadoghq.com')
     })
 
+    it('should configure direct client stats intake when local stats are enabled', () => {
+      exporter = new Exporter({
+        site: 'us3.datadoghq.com',
+        stats: { DD_TRACE_STATS_COMPUTATION_ENABLED: true },
+        tags: {},
+      })
+
+      assert.strictEqual(
+        writerOptions.statsEndpoint,
+        'https://trace.agent.us3.datadoghq.com/api/v0.2/stats'
+      )
+    })
+
+    for (const [name, config] of [
+      ['client stats are disabled', { stats: { DD_TRACE_STATS_COMPUTATION_ENABLED: false } }],
+      ['OTLP span metrics are enabled', {
+        stats: { DD_TRACE_STATS_COMPUTATION_ENABLED: true },
+        OTEL_TRACES_SPAN_METRICS_ENABLED: true,
+      }],
+    ]) {
+      it(`should leave direct client stats intake disabled when ${name}`, () => {
+        exporter = new Exporter({ site: 'datadoghq.com', tags: {}, ...config })
+
+        assert.strictEqual(writerOptions.statsEndpoint, undefined)
+      })
+    }
+
     it('should register beforeExit handler', () => {
       exporter = new Exporter({})
 
@@ -93,7 +123,7 @@ describe('AgentlessExporter', () => {
       exporter = new Exporter({ site: 'bad host' })
 
       sinon.assert.calledOnce(log.error)
-      assert.strictEqual(exporter._url, null)
+      assert.strictEqual(exporter._url, undefined)
     })
 
     it('should pass metadata from config to writer', () => {
@@ -251,6 +281,17 @@ describe('AgentlessExporter', () => {
 
       sinon.assert.calledWith(writer.append, spans)
       sinon.assert.calledOnce(writer.flush)
+    })
+  })
+
+  describe('sendStats', () => {
+    it('should delegate client stats to the writer', async () => {
+      exporter = new Exporter({})
+      const payload = Buffer.from('stats')
+
+      await new Promise(resolve => exporter.sendStats(payload, resolve))
+
+      sinon.assert.calledOnceWithExactly(writer.sendStats, payload, sinon.match.func)
     })
   })
 

--- a/packages/dd-trace/test/exporters/agentless/intake.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/intake.spec.js
@@ -4,7 +4,12 @@ const assert = require('node:assert/strict')
 
 const { describe, it } = require('mocha')
 
-const { computeIntakeUrl, INTAKE_URLS, INTAKE_PATH } = require('../../../src/exporters/agentless/intake')
+const {
+  computeIntakeUrl,
+  computeStatsIntakeUrl,
+  INTAKE_URLS,
+  INTAKE_PATH,
+} = require('../../../src/exporters/agentless/intake')
 
 require('../../setup/core')
 
@@ -33,6 +38,27 @@ describe('agentless intake', () => {
         assert.strictEqual(computeIntakeUrl(site), expected)
       })
     }
+
+    it('rejects sites with URL components', () => {
+      assert.throws(() => computeIntakeUrl('datadoghq.com@evil.example'), /Invalid Datadog site/)
+    })
+  })
+
+  describe('computeStatsIntakeUrl', () => {
+    it('targets the client stats intake for the configured site', () => {
+      assert.strictEqual(
+        computeStatsIntakeUrl('US3.DataDogHQ.com'),
+        'https://trace.agent.us3.datadoghq.com/api/v0.2/stats'
+      )
+    })
+
+    it('defaults to the datadoghq.com client stats intake', () => {
+      assert.strictEqual(computeStatsIntakeUrl(), 'https://trace.agent.datadoghq.com/api/v0.2/stats')
+    })
+
+    it('rejects sites with URL components', () => {
+      assert.throws(() => computeStatsIntakeUrl('datadoghq.com@evil.example'), /Invalid Datadog site/)
+    })
   })
 
   it('targets the JSON span intake path', () => {

--- a/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
@@ -79,6 +79,7 @@ describe('AgentlessWriter data pipeline', () => {
         env: 'test-env',
         hostname: 'test-host',
         runtimeID: 'test-runtime-id',
+        entityId: 'in-1234',
       },
     })
 
@@ -86,7 +87,7 @@ describe('AgentlessWriter data pipeline', () => {
       duration: 1,
       error: 0,
       meta: {},
-      metrics: {},
+      metrics: { [TOP_LEVEL_KEY]: 1 },
       name: 'operation',
       parent_id: id('0'),
       resource: 'resource',
@@ -103,6 +104,8 @@ describe('AgentlessWriter data pipeline', () => {
     assert.strictEqual(received.headers['dd-api-key'], 'test-api-key')
     assert.strictEqual(received.headers['content-type'], 'application/json')
     assert.strictEqual(received.headers['content-encoding'], 'zstd')
+    assert.strictEqual(received.headers['datadog-client-computed-top-level'], 'true')
+    assert.strictEqual(received.headers['datadog-entity-id'], 'in-1234')
     assert.deepStrictEqual(received.payload.subarray(0, ZSTD_MAGIC.length), ZSTD_MAGIC)
 
     if (zstdDecompressSync) {
@@ -142,6 +145,7 @@ describe('AgentlessWriter data pipeline', () => {
         env: 'test-env',
         hostname: 'test-host',
         runtimeID: 'test-runtime-id',
+        entityId: 'in-1234',
       },
     })
     const statsProcessor = new SpanStatsProcessor({
@@ -160,7 +164,7 @@ describe('AgentlessWriter data pipeline', () => {
         duration: 1,
         error: 0,
         meta: {},
-        metrics: {},
+        metrics: { [TOP_LEVEL_KEY]: 1 },
         name: 'operation',
         parent_id: id('0'),
         resource: 'resource',
@@ -191,9 +195,15 @@ describe('AgentlessWriter data pipeline', () => {
 
       assert.ok(traceRequest)
       assert.ok(statsRequest)
+      assert.strictEqual(traceRequest.headers['datadog-client-computed-stats'], 'true')
+      assert.strictEqual(traceRequest.headers['datadog-client-computed-top-level'], 'true')
+      assert.strictEqual(traceRequest.headers['datadog-entity-id'], 'in-1234')
       assert.strictEqual(statsRequest.headers['dd-api-key'], 'test-api-key')
       assert.strictEqual(statsRequest.headers['content-type'], 'application/msgpack')
       assert.strictEqual(statsRequest.headers['content-encoding'], 'zstd')
+      assert.strictEqual(statsRequest.headers['datadog-client-computed-stats'], 'true')
+      assert.strictEqual(statsRequest.headers['datadog-client-computed-top-level'], 'true')
+      assert.strictEqual(statsRequest.headers['datadog-entity-id'], 'in-1234')
       assert.deepStrictEqual(statsRequest.payload.subarray(0, ZSTD_MAGIC.length), ZSTD_MAGIC)
 
       if (zstdDecompressSync) {

--- a/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { once } = require('node:events')
 const http = require('node:http')
 const { URL } = require('node:url')
 const zlib = require('node:zlib')
@@ -27,6 +28,8 @@ const zstdDecompressSync = zstdSupported ? zlib.zstdDecompressSync : undefined
 describe('AgentlessWriter data pipeline', () => {
   let server
   let intakeUrl
+  let statsEndpoint
+  let statsAndMetadataSupported
   let resolveRequest
   let request
 
@@ -44,7 +47,7 @@ describe('AgentlessWriter data pipeline', () => {
     })
   }
 
-  before(done => {
+  before(async () => {
     process.env.DD_API_KEY = 'test-api-key'
     server = http.createServer((incoming, response) => {
       const chunks = []
@@ -58,11 +61,23 @@ describe('AgentlessWriter data pipeline', () => {
         response.end()
       })
     })
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address()
-      intakeUrl = new URL(`http://127.0.0.1:${port}`)
-      done()
+    const listening = once(server, 'listening')
+    server.listen(0, '127.0.0.1')
+    await listening
+
+    const { port } = server.address()
+    intakeUrl = new URL(`http://127.0.0.1:${port}`)
+    statsEndpoint = new URL('/api/v0.2/stats', intakeUrl).href
+    const exporter = createAgentlessExporter({
+      endpoint: new URL('/api/v2/spans', intakeUrl).href,
+      statsEndpoint,
+      apiKey: 'test-api-key',
+      tracerVersion: 'test',
+      languageVersion: process.version,
+      languageInterpreter: 'v8',
     })
+    statsAndMetadataSupported = typeof exporter.sendStats === 'function'
+    exporter.close()
   })
 
   after(async () => {
@@ -104,8 +119,11 @@ describe('AgentlessWriter data pipeline', () => {
     assert.strictEqual(received.headers['dd-api-key'], 'test-api-key')
     assert.strictEqual(received.headers['content-type'], 'application/json')
     assert.strictEqual(received.headers['content-encoding'], 'zstd')
-    assert.strictEqual(received.headers['datadog-client-computed-top-level'], 'true')
-    assert.strictEqual(received.headers['datadog-entity-id'], 'in-1234')
+    assert.strictEqual(
+      received.headers['datadog-client-computed-top-level'],
+      statsAndMetadataSupported ? 'true' : undefined
+    )
+    assert.strictEqual(received.headers['datadog-entity-id'], statsAndMetadataSupported ? 'in-1234' : undefined)
     assert.deepStrictEqual(received.payload.subarray(0, ZSTD_MAGIC.length), ZSTD_MAGIC)
 
     if (zstdDecompressSync) {
@@ -124,18 +142,7 @@ describe('AgentlessWriter data pipeline', () => {
   })
 
   it('exports traces and client stats through one data pipeline', async function () {
-    const statsEndpoint = new URL('/api/v0.2/stats', intakeUrl).href
-    const exporter = createAgentlessExporter({
-      endpoint: new URL('/api/v2/spans', intakeUrl).href,
-      statsEndpoint,
-      apiKey: 'test-api-key',
-      tracerVersion: 'test',
-      languageVersion: process.version,
-      languageInterpreter: 'v8',
-    })
-    const statsSupported = typeof exporter.sendStats === 'function'
-    exporter.close()
-    if (!statsSupported) this.skip()
+    if (!statsAndMetadataSupported) this.skip()
 
     request = receiveRequests(2)
     const writer = new AgentlessWriter({

--- a/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
@@ -12,7 +12,9 @@ require('../../setup/core')
 
 const agent = require('../../plugins/agent')
 const id = require('../../../src/id')
+const { TOP_LEVEL_KEY } = require('../../../src/constants')
 const AgentlessWriter = require('../../../src/exporters/agentless/writer')
+const { SpanStatsProcessor } = require('../../../src/span_stats')
 
 const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd])
 const zstdSupported = NODE_MAJOR >= 24 ||
@@ -26,6 +28,20 @@ describe('AgentlessWriter data pipeline', () => {
   let intakeUrl
   let resolveRequest
   let request
+
+  /**
+   * @param {number} count
+   * @returns {Promise<object[]>}
+   */
+  function receiveRequests (count) {
+    const requests = []
+    return new Promise(resolve => {
+      resolveRequest = received => {
+        requests.push(received)
+        if (requests.length === count) resolve(requests)
+      }
+    })
+  }
 
   before(done => {
     process.env.DD_API_KEY = 'test-api-key'
@@ -55,7 +71,7 @@ describe('AgentlessWriter data pipeline', () => {
   })
 
   it('encodes v0.4 and exports agentless JSON through the pipeline', async () => {
-    request = new Promise(resolve => { resolveRequest = resolve })
+    request = receiveRequests(1)
     const writer = new AgentlessWriter({
       url: intakeUrl,
       metadata: {
@@ -80,7 +96,7 @@ describe('AgentlessWriter data pipeline', () => {
     }])
 
     await new Promise(resolve => writer.flush(resolve))
-    const received = await request
+    const [received] = await request
 
     assert.strictEqual(received.path, '/api/v2/spans')
     assert.strictEqual(received.headers['dd-api-key'], 'test-api-key')
@@ -103,6 +119,79 @@ describe('AgentlessWriter data pipeline', () => {
     }
   })
 
+  it('exports traces and client stats through one data pipeline', async () => {
+    request = receiveRequests(2)
+    const statsEndpoint = new URL('/api/v0.2/stats', intakeUrl).href
+    const writer = new AgentlessWriter({
+      url: intakeUrl,
+      statsEndpoint,
+      metadata: {
+        env: 'test-env',
+        hostname: 'test-host',
+        runtimeID: 'test-runtime-id',
+      },
+    })
+    const statsProcessor = new SpanStatsProcessor({
+      stats: {
+        DD_TRACE_STATS_COMPUTATION_ENABLED: true,
+        interval: 10,
+      },
+      url: intakeUrl,
+      env: 'test-env',
+      tags: { 'runtime-id': 'test-runtime-id' },
+      version: '1.0.0',
+    }, undefined, writer.sendStats.bind(writer))
+
+    try {
+      writer.append([{
+        duration: 1,
+        error: 0,
+        meta: {},
+        metrics: {},
+        name: 'operation',
+        parent_id: id('0'),
+        resource: 'resource',
+        service: 'service',
+        span_id: id('2'),
+        start: 1,
+        trace_id: id('1'),
+      }])
+      statsProcessor.onSpanFinished({
+        duration: 1,
+        error: 0,
+        meta: {},
+        metrics: { [TOP_LEVEL_KEY]: 1 },
+        name: 'operation',
+        resource: 'resource',
+        service: 'service',
+        start: 1,
+        type: 'web',
+      })
+
+      await Promise.all([
+        new Promise(resolve => writer.flush(resolve)),
+        new Promise(resolve => statsProcessor.forceFlush(resolve)),
+      ])
+      const received = await request
+      const traceRequest = received.find(({ path }) => path === '/api/v2/spans')
+      const statsRequest = received.find(({ path }) => path === '/api/v0.2/stats')
+
+      assert.ok(traceRequest)
+      assert.ok(statsRequest)
+      assert.strictEqual(statsRequest.headers['dd-api-key'], 'test-api-key')
+      assert.strictEqual(statsRequest.headers['content-type'], 'application/msgpack')
+      assert.strictEqual(statsRequest.headers['content-encoding'], 'zstd')
+      assert.deepStrictEqual(statsRequest.payload.subarray(0, ZSTD_MAGIC.length), ZSTD_MAGIC)
+
+      if (zstdDecompressSync) {
+        const payload = JSON.parse(zstdDecompressSync(traceRequest.payload).toString())
+        assert.strictEqual(Object.hasOwn(payload.traces[0].spans[0].meta, '_dd.compute_stats'), false)
+      }
+    } finally {
+      clearInterval(statsProcessor.timer)
+    }
+  })
+
   it('does not trace the pipeline intake request', async () => {
     await agent.load('http', { server: false })
     const writer = new AgentlessWriter({ url: intakeUrl })
@@ -110,7 +199,7 @@ describe('AgentlessWriter data pipeline', () => {
       assert.fail('the pipeline intake request must not create an HTTP client trace')
     }, { timeoutMs: 100 })
 
-    request = new Promise(resolve => { resolveRequest = resolve })
+    request = receiveRequests(1)
     writer.append([{
       duration: 1,
       error: 0,

--- a/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/pipeline.spec.js
@@ -5,6 +5,7 @@ const http = require('node:http')
 const { URL } = require('node:url')
 const zlib = require('node:zlib')
 
+const { createAgentlessExporter } = require('@datadog/libdatadog')
 const { after, before, describe, it } = require('mocha')
 
 const { NODE_MAJOR, NODE_MINOR } = require('../../../../../version')
@@ -119,9 +120,21 @@ describe('AgentlessWriter data pipeline', () => {
     }
   })
 
-  it('exports traces and client stats through one data pipeline', async () => {
-    request = receiveRequests(2)
+  it('exports traces and client stats through one data pipeline', async function () {
     const statsEndpoint = new URL('/api/v0.2/stats', intakeUrl).href
+    const exporter = createAgentlessExporter({
+      endpoint: new URL('/api/v2/spans', intakeUrl).href,
+      statsEndpoint,
+      apiKey: 'test-api-key',
+      tracerVersion: 'test',
+      languageVersion: process.version,
+      languageInterpreter: 'v8',
+    })
+    const statsSupported = typeof exporter.sendStats === 'function'
+    exporter.close()
+    if (!statsSupported) this.skip()
+
+    request = receiveRequests(2)
     const writer = new AgentlessWriter({
       url: intakeUrl,
       statsEndpoint,

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -83,6 +83,7 @@ describe('AgentlessWriter', () => {
         hostname: 'test-host',
         runtimeID: 'runtime-id',
         containerId: 'container-id',
+        entityId: 'in-1234',
       },
     })
 
@@ -99,6 +100,8 @@ describe('AgentlessWriter', () => {
       version: 'test-version',
       runtimeId: 'runtime-id',
       containerId: 'container-id',
+      entityId: 'in-1234',
+      clientComputedTopLevel: true,
       tracerVersion: 'tracer-version',
       languageVersion: process.version,
       languageInterpreter: 'v8',

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -33,6 +33,7 @@ describe('AgentlessWriter', () => {
     }
     exporter = {
       close: sinon.stub(),
+      sendStats: sinon.stub().callsArg(1),
       sendV04: sinon.stub().callsArg(1),
     }
     createAgentlessExporter = sinon.stub().returns(exporter)
@@ -76,6 +77,7 @@ describe('AgentlessWriter', () => {
   it('sends the v0.4 payload through the data pipeline', async () => {
     writer = new AgentlessWriter({
       url: new URL('https://intake.example/custom-path'),
+      statsEndpoint: 'https://trace.agent.example/api/v0.2/stats',
       metadata: {
         env: 'test-env',
         hostname: 'test-host',
@@ -89,6 +91,7 @@ describe('AgentlessWriter', () => {
     sinon.assert.calledOnceWithExactly(exporter.sendV04, Buffer.from('v0.4 payload'), sinon.match.func, log)
     sinon.assert.calledOnceWithExactly(createAgentlessExporter, {
       endpoint: 'https://intake.example/api/v2/spans',
+      statsEndpoint: 'https://trace.agent.example/api/v0.2/stats',
       apiKey: 'test-api-key',
       hostname: 'test-host',
       env: 'test-env',
@@ -103,6 +106,50 @@ describe('AgentlessWriter', () => {
       agent: proxyAgent,
     })
     sinon.assert.calledOnceWithExactly(getHttpsProxyAgent, new URL('https://intake.example/custom-path'))
+  })
+
+  it('sends client stats through the same data pipeline', async () => {
+    writer = new AgentlessWriter({
+      url: new URL('https://intake.example'),
+      statsEndpoint: 'https://trace.agent.example/api/v0.2/stats',
+    })
+    const payload = Buffer.from('stats payload')
+
+    await Promise.all([
+      new Promise(resolve => writer.flush(resolve)),
+      new Promise(resolve => writer.sendStats(payload, resolve)),
+    ])
+
+    sinon.assert.calledOnce(createAgentlessExporter)
+    sinon.assert.calledOnceWithExactly(exporter.sendV04, Buffer.from('v0.4 payload'), sinon.match.func, log)
+    sinon.assert.calledOnceWithExactly(exporter.sendStats, payload, sinon.match.func, log)
+  })
+
+  it('suppresses instrumentation of the client stats intake request', async () => {
+    /**
+     * @param {Buffer} data
+     * @param {() => void} done
+     */
+    exporter.sendStats.callsFake((data, done) => {
+      assert.strictEqual(storage('legacy').getHandle()?.noop, true)
+      done()
+    })
+    writer = new AgentlessWriter({ url: new URL('https://intake.example') })
+
+    await new Promise(resolve => writer.sendStats(Buffer.from('stats'), resolve))
+  })
+
+  it('contains synchronous client stats send failures', async () => {
+    exporter.sendStats.throws(new Error('send failed'))
+    writer = new AgentlessWriter({ url: new URL('https://intake.example') })
+
+    await new Promise(resolve => writer.sendStats(Buffer.from('stats'), resolve))
+
+    sinon.assert.calledWithExactly(
+      log.error,
+      'Failed to send span stats to the agentless intake: %s',
+      'send failed'
+    )
   })
 
   it('suppresses instrumentation of the data-pipeline intake request', async () => {
@@ -183,11 +230,15 @@ describe('AgentlessWriter', () => {
   it('does not give the API key to a non-loopback HTTP receiver', async () => {
     writer = new AgentlessWriter({ url: new URL('http://intake.example') })
 
-    await new Promise(resolve => writer.flush(resolve))
+    await Promise.all([
+      new Promise(resolve => writer.flush(resolve)),
+      new Promise(resolve => writer.sendStats(Buffer.from('stats'), resolve)),
+    ])
 
     sinon.assert.notCalled(createAgentlessExporter)
     sinon.assert.notCalled(getHttpsProxyAgent)
     sinon.assert.notCalled(exporter.sendV04)
+    sinon.assert.notCalled(exporter.sendStats)
     sinon.assert.calledWithExactly(
       log.warn,
       'DD_API_KEY will not be sent because the configured receiver is neither HTTPS nor loopback.'
@@ -262,22 +313,30 @@ describe('AgentlessWriter', () => {
     })
   }
 
-  it('drops traces without constructing a pipeline exporter when the API key is unavailable', async () => {
+  it('drops traces and stats without constructing a pipeline exporter when the API key is unavailable', async () => {
     apiKey = undefined
     writer = new AgentlessWriter({ url: new URL('https://intake.example') })
 
-    await new Promise(resolve => writer.flush(resolve))
+    await Promise.all([
+      new Promise(resolve => writer.flush(resolve)),
+      new Promise(resolve => writer.sendStats(Buffer.from('stats'), resolve)),
+    ])
 
     sinon.assert.notCalled(createAgentlessExporter)
     sinon.assert.notCalled(exporter.sendV04)
+    sinon.assert.notCalled(exporter.sendStats)
   })
 
-  it('drops traces without constructing a pipeline exporter when the intake URL is unavailable', async () => {
+  it('drops traces and stats without constructing a pipeline exporter when the intake URL is unavailable', async () => {
     writer = new AgentlessWriter({ site: 'invalid site' })
 
-    await new Promise(resolve => writer.flush(resolve))
+    await Promise.all([
+      new Promise(resolve => writer.flush(resolve)),
+      new Promise(resolve => writer.sendStats(Buffer.from('stats'), resolve)),
+    ])
 
     sinon.assert.notCalled(createAgentlessExporter)
     sinon.assert.notCalled(exporter.sendV04)
+    sinon.assert.notCalled(exporter.sendStats)
   })
 })

--- a/packages/dd-trace/test/exporters/span-stats/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/span-stats/exporter.spec.js
@@ -157,4 +157,12 @@ describe('span-stats exporter', () => {
       url: exporter._url,
     })
   })
+
+  it('should pass the configured stats sender to the writer', () => {
+    const sendStats = sinon.stub()
+
+    exporter = new Exporter({ url, sendStats })
+
+    assert.strictEqual(writerOptions.sendStats, sendStats)
+  })
 })

--- a/packages/dd-trace/test/exporters/span-stats/writer.spec.js
+++ b/packages/dd-trace/test/exporters/span-stats/writer.spec.js
@@ -109,6 +109,19 @@ describe('span-stats writer', () => {
       })
     })
 
+    it('should use the configured stats sender instead of the agent', async () => {
+      const expectedData = Buffer.from('prefixed')
+      const sendStats = sinon.stub().callsArg(1)
+      writer = new Writer({ url, sendStats })
+      encoder.count.returns(1)
+      encoder.makePayload.returns(expectedData)
+
+      await new Promise(resolve => writer.flush(resolve))
+
+      sinon.assert.calledOnceWithExactly(sendStats, expectedData, sinon.match.func)
+      sinon.assert.notCalled(request)
+    })
+
     // The writer must hand the agent URL to request() rather than pre-setting
     // protocol/hostname/port itself. Only request() knows to map a `unix:` URL
     // onto options.socketPath; a forced `protocol: 'unix:'` reaches

--- a/packages/dd-trace/test/process-tags.spec.js
+++ b/packages/dd-trace/test/process-tags.spec.js
@@ -256,6 +256,7 @@ describe('process-tags', () => {
   })
 
   describe('DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED', () => {
+    const exporter = { export () {} }
     let env
     let SpanProcessor
 
@@ -280,7 +281,7 @@ describe('process-tags', () => {
       assert.strictEqual(config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, true)
 
       SpanProcessor = require('../src/span_processor')
-      const processor = new SpanProcessor(undefined, undefined, config)
+      const processor = new SpanProcessor(exporter, undefined, config)
 
       assert.strictEqual(typeof processor._processTags, 'string')
       assert.match(processor._processTags, /entrypoint/)
@@ -296,7 +297,7 @@ describe('process-tags', () => {
       assert.strictEqual(config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, false)
 
       SpanProcessor = require('../src/span_processor')
-      const processor = new SpanProcessor(undefined, undefined, config)
+      const processor = new SpanProcessor(exporter, undefined, config)
 
       assert.strictEqual(processor._processTags, false)
     })
@@ -311,7 +312,7 @@ describe('process-tags', () => {
       assert.strictEqual(config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, true)
 
       SpanProcessor = require('../src/span_processor')
-      const processor = new SpanProcessor(undefined, undefined, config)
+      const processor = new SpanProcessor(exporter, undefined, config)
 
       assert.strictEqual(typeof processor._processTags, 'string')
       assert.match(processor._processTags, /entrypoint/)

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -9,7 +9,8 @@ const proxyquire = require('proxyquire')
 
 require('./setup/core')
 
-const { APM_TRACING_ENABLED_KEY } = require('../src/constants')
+const { APM_TRACING_ENABLED_KEY, TOP_LEVEL_KEY } = require('../src/constants')
+const id = require('../src/id')
 const { AUTO_REJECT, USER_KEEP } = require('../../../ext/priority')
 
 describe('SpanProcessor', () => {
@@ -95,6 +96,35 @@ describe('SpanProcessor', () => {
     sendStats(payload, done)
 
     sinon.assert.calledOnceWithExactly(exporter.sendStats, payload, done)
+  })
+
+  it('should compute top-level spans before recording stats when required by the exporter', () => {
+    exporter.requiresClientComputedTopLevel = true
+    processor = new SpanProcessor(exporter, prioritySampler, config)
+    processor._stats = { onSpanFinished: sinon.stub() }
+
+    const formattedSpans = [
+      { span_id: id('1'), parent_id: id('0'), service: 'web', metrics: {} },
+      { span_id: id('2'), parent_id: id('1'), service: 'web', metrics: {} },
+      { span_id: id('3'), parent_id: id('2'), service: 'database', metrics: {} },
+      { span_id: id('4'), parent_id: id('5'), service: 'worker', metrics: {} },
+    ]
+    for (const [index, formattedSpan] of formattedSpans.entries()) {
+      spanFormat.onCall(index).returns(formattedSpan)
+    }
+
+    const finishedSpans = formattedSpans.map(() => ({ ...finishedSpan }))
+    trace.started = finishedSpans
+    trace.finished = finishedSpans
+
+    processor.process(finishedSpans[0])
+
+    assert.strictEqual(formattedSpans[0].metrics[TOP_LEVEL_KEY], 1)
+    assert.ok(!Object.hasOwn(formattedSpans[1].metrics, TOP_LEVEL_KEY))
+    assert.strictEqual(formattedSpans[2].metrics[TOP_LEVEL_KEY], 1)
+    assert.strictEqual(formattedSpans[3].metrics[TOP_LEVEL_KEY], 1)
+    sinon.assert.callCount(processor._stats.onSpanFinished, 4)
+    assert.strictEqual(processor._stats.onSpanFinished.getCall(2).args[0].metrics[TOP_LEVEL_KEY], 1)
   })
 
   it('should keep OTLP span stats on the OTLP exporter', () => {

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -24,6 +24,7 @@ describe('SpanProcessor', () => {
   let spanFormat
   let config
   let SpanSampler
+  let SpanStatsProcessor
   let sample
 
   before(() => {
@@ -73,12 +74,45 @@ describe('SpanProcessor', () => {
     SpanSampler = sinon.stub().returns({
       sample,
     })
+    SpanStatsProcessor = sinon.stub()
 
     SpanProcessor = proxyquire('../src/span_processor', {
       './span_format': spanFormat,
       './span_sampler': SpanSampler,
+      './span_stats': { SpanStatsProcessor },
     })
     processor = new SpanProcessor(exporter, prioritySampler, config)
+  })
+
+  it('should route local span stats through an exporter-provided sender', () => {
+    const payload = Buffer.from('stats')
+    const done = sinon.stub()
+    exporter.sendStats = sinon.stub()
+    config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED = true
+
+    processor = new SpanProcessor(exporter, prioritySampler, config)
+    const sendStats = SpanStatsProcessor.lastCall.args[2]
+    sendStats(payload, done)
+
+    sinon.assert.calledOnceWithExactly(exporter.sendStats, payload, done)
+  })
+
+  it('should keep OTLP span stats on the OTLP exporter', () => {
+    const otlpStatsExporter = {}
+    exporter.sendStats = sinon.stub()
+    config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED = true
+
+    processor = new SpanProcessor(exporter, prioritySampler, config, otlpStatsExporter)
+
+    sinon.assert.calledWithExactly(SpanStatsProcessor, config, otlpStatsExporter, undefined)
+  })
+
+  it('should keep local span stats on the agent exporter', () => {
+    config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED = true
+
+    processor = new SpanProcessor(exporter, prioritySampler, config)
+
+    sinon.assert.calledWithExactly(SpanStatsProcessor, config, undefined, undefined)
   })
 
   it('should generate sampling priority', () => {

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -439,10 +439,8 @@ describe('SpanStatsProcessor', () => {
     clearTimeout(processor.timer)
 
     assert.deepStrictEqual(SpanStatsExporter.lastCall.args[0], {
-      hostname: config.hostname,
-      port: config.port,
       url: config.url,
-      tags: config.tags,
+      sendStats: undefined,
     })
     assert.strictEqual(processor.interval, config.stats.interval)
     assert.ok(processor.buckets instanceof TimeBuckets)
@@ -450,6 +448,13 @@ describe('SpanStatsProcessor', () => {
     assert.strictEqual(processor.enabled, config.stats.DD_TRACE_STATS_COMPUTATION_ENABLED)
     assert.strictEqual(processor.env, config.env)
     assert.strictEqual(processor.version, config.version)
+  })
+
+  it('should pass an injected stats sender to the exporter', () => {
+    const sendStats = sinon.stub()
+    processor = new SpanStatsProcessor(config, undefined, sendStats)
+
+    assert.strictEqual(SpanStatsExporter.lastCall.args[0].sendStats, sendStats)
   })
 
   it('should construct a disabled instance', () => {


### PR DESCRIPTION
Agentless tracing currently disables client-computed stats because its transport cannot send the payload. This uses the existing stats processor and sends its output through libdatadog.

The normal stats configuration now also applies to agentless tracing. The stats endpoint is set only when client-computed stats are enabled because its presence suppresses intake-side computation.

This draft depends on an unreleased `@datadog/libdatadog` version that includes https://github.com/DataDog/libdatadog-nodejs/pull/265. The current transport API shares one borrowed HTTP agent between trace and stats requests, so exact-host `NO_PROXY` rules cannot differ.