### PR TITLE
test(appsec): await requests and assertions together

### DIFF
--- a/integration-tests/appsec/graphql.spec.js
+++ b/integration-tests/appsec/graphql.spec.js
@@ -54,7 +54,7 @@ describe('graphql', () => {
       assert.ok(!('_dd.appsec.json' in payload[1][0].meta))
     })
 
-    await axios({
+    const requestPromise = axios({
       url: `${proc.url}/graphql`,
       method: 'post',
       headers: {
@@ -69,7 +69,7 @@ describe('graphql', () => {
       },
     })
 
-    return agentPromise
+    await Promise.all([agentPromise, requestPromise])
   })
 
   it('should report an attack', async () => {
@@ -123,7 +123,7 @@ describe('graphql', () => {
       assert.deepStrictEqual(JSON.parse(payload[1][0].meta['_dd.appsec.json']), result)
     })
 
-    await axios({
+    const requestPromise = axios({
       url: `${proc.url}/graphql`,
       method: 'post',
       headers: {
@@ -138,7 +138,7 @@ describe('graphql', () => {
       },
     })
 
-    return agentPromise
+    await Promise.all([agentPromise, requestPromise])
   })
 
   it('should block an attack', async () => {
@@ -153,7 +153,7 @@ describe('graphql', () => {
       assert.strictEqual(payload[1][0].meta['appsec.event'], 'true')
     })
 
-    await assert.rejects(
+    const requestPromise = assert.rejects(
       axios({
         url: `${proc.url}/graphql`,
         method: 'post',
@@ -174,7 +174,7 @@ describe('graphql', () => {
       }
     )
 
-    return agentPromise
+    await Promise.all([agentPromise, requestPromise])
   })
 
   it('should block an attack in a batched request', async () => {
@@ -189,7 +189,7 @@ describe('graphql', () => {
       assert.strictEqual(payload[1][0].meta['appsec.event'], 'true')
     })
 
-    await assert.rejects(
+    const requestPromise = assert.rejects(
       axios({
         url: `${proc.url}/graphql`,
         method: 'post',
@@ -215,6 +215,6 @@ describe('graphql', () => {
       }
     )
 
-    return agentPromise
+    await Promise.all([agentPromise, requestPromise])
   })
 })

--- a/integration-tests/appsec/multer.spec.js
+++ b/integration-tests/appsec/multer.spec.js
@@ -117,9 +117,10 @@ describe('multer', () => {
 
             const formData = new FormData()
             formData.append('command', 'echo 1')
-            await axios.post(`${proc.url}/cmd`, formData)
-
-            return resultPromise
+            await Promise.all([
+              resultPromise,
+              axios.post(`${proc.url}/cmd`, formData),
+            ])
           })
         })
 
@@ -129,9 +130,10 @@ describe('multer', () => {
 
             const formData = new FormData()
             formData.append('command', 'echo 1')
-            await axios.post(`${proc.url}/cmd-no-middleware`, formData)
-
-            return resultPromise
+            await Promise.all([
+              resultPromise,
+              axios.post(`${proc.url}/cmd-no-middleware`, formData),
+            ])
           })
         })
       })

--- a/packages/dd-trace/test/appsec/downstream_requests.integration.spec.js
+++ b/packages/dd-trace/test/appsec/downstream_requests.integration.spec.js
@@ -125,10 +125,8 @@ describe('RASP - downstream request integration', () => {
       timeout: 4_000,
       expectedMessageCount: 3,
       resolveAtFirstSuccess: true,
-    }).then(
-      () => {
-        assert.strictEqual(appsecTelemetryReceived, true)
-      })
+    })
+    assert.strictEqual(appsecTelemetryReceived, true)
   }
 
   describe('Downstream configuration', () => {
@@ -151,45 +149,51 @@ describe('RASP - downstream request integration', () => {
       })
 
       it('should set all tags', async function () {
-        const resultPromise = Promise.all([assertMessage(agent), assertTelemetry(agent)])
-        await axios.post('/with-body')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent),
+          assertTelemetry(agent),
+          axios.post('/with-body'),
+        ])
       })
 
       it('collects response body when stream is consumed via readable', async function () {
-        const resultPromise = Promise.all([assertMessage(agent), assertTelemetry(agent)])
-        await axios.post('/with-readable')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent),
+          assertTelemetry(agent),
+          axios.post('/with-readable'),
+        ])
       })
 
       it('collects response body when stream is consumed via async iterator', async function () {
-        const resultPromise = Promise.all([assertMessage(agent), assertTelemetry(agent)])
-        await axios.post('/with-async-iterator')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent),
+          assertTelemetry(agent),
+          axios.post('/with-async-iterator'),
+        ])
       })
 
       it('collects response body for form-urlencoded content-type', async function () {
-        const resultPromise = Promise.all([assertMessage(agent), assertTelemetry(agent)])
-        await axios.post('/with-body-form')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent),
+          assertTelemetry(agent),
+          axios.post('/with-body-form'),
+        ])
       })
 
       it('does not collect response body for unsupported content-type', async function () {
-        const resultPromise = Promise.all([assertMessage(agent, true, false), assertTelemetry(agent)])
-        await axios.post('/with-body-text')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent, true, false),
+          assertTelemetry(agent),
+          axios.post('/with-body-text'),
+        ])
       })
 
       it('Handles redirection correctly', async function () {
-        const resultPromise = Promise.all([assertMessage(agent, true, true, 2), assertTelemetry(agent)])
-        await axios.post('/with-redirect')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent, true, true, 2),
+          assertTelemetry(agent),
+          axios.post('/with-redirect'),
+        ])
       })
     })
 
@@ -213,10 +217,11 @@ describe('RASP - downstream request integration', () => {
 
       it('still sets metric even when body sampling is disabled', async function () {
         this.timeout(31_000)
-        const resultPromise = Promise.all([assertMessage(agent, true, false), assertTelemetry(agent)])
-        await axios.post('/with-body')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent, true, false),
+          assertTelemetry(agent),
+          axios.post('/with-body'),
+        ])
       })
     })
 
@@ -240,10 +245,11 @@ describe('RASP - downstream request integration', () => {
 
       it('skips downstream analysis when limit is zero', async function () {
         this.timeout(31_000)
-        const resultPromise = Promise.all([assertMessage(agent, true, false), assertTelemetry(agent)])
-        await axios.post('/with-body')
-
-        return resultPromise
+        await Promise.all([
+          assertMessage(agent, true, false),
+          assertTelemetry(agent),
+          axios.post('/with-body'),
+        ])
       })
     })
   })


### PR DESCRIPTION
Detached assertion promises can reject while a request is pending, so Mocha teardown resets the socket and hides the original failure.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/34222482762/job/102048634063?pr=10205