### PR TITLE
fix(llmobs): extract guarded Bedrock system text

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -613,7 +613,11 @@ function extractRequestParamsConverse (params) {
   const prompt = []
   if (params.system) {
     for (const block of params.system) {
-      if (typeof block?.text === 'string') prompt.push({ content: block.text, role: 'system' })
+      if (typeof block?.text === 'string') {
+        prompt.push({ content: block.text, role: 'system' })
+      } else if (typeof block?.guardContent?.text?.text === 'string') {
+        prompt.push({ content: block.guardContent.text.text, role: 'system' })
+      }
     }
   }
   if (params.messages) {

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.util.spec.js
@@ -6,6 +6,7 @@ const { describe, it } = require('mocha')
 
 const {
   extractRequestParams,
+  extractRequestParamsConverse,
   extractMessagesFromConverseContent,
   extractTextAndResponseReasonConverseFromStream,
   PROVIDER,
@@ -84,6 +85,23 @@ describe('bedrockruntime utils', () => {
       role: 'user',
       content: 'Context: What is the dose? Cite sources.',
     })
+  })
+
+  it('reads guarded text from Converse system blocks', () => {
+    const requestParams = extractRequestParamsConverse({
+      system: [
+        { text: 'Follow the policy. ' },
+        { guardContent: { text: { text: 'Do not expose secrets.', qualifiers: ['guard_content'] } } },
+        { guardContent: { image: { format: 'png', source: { bytes: Buffer.from('image') } } } },
+      ],
+      messages: [{ role: 'user', content: [{ text: 'Summarize the document.' }] }],
+    })
+
+    assert.deepStrictEqual(requestParams.prompt, [
+      { content: 'Follow the policy. ', role: 'system' },
+      { content: 'Do not expose secrets.', role: 'system' },
+      { content: 'Summarize the document.', role: 'user' },
+    ])
   })
 
   describe('converse stream extractor', () => {


### PR DESCRIPTION
Bedrock accepts `guardContent` blocks in the Converse system array. The LLMObs system extractor only reads plain text blocks, so guarded system instructions are omitted from recorded input.

This preserves one system message per text block and continues to ignore guarded image blocks.