### PR TITLE
refactor(google-cloud-pubsub): share request context reconstruction

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
@@ -2,9 +2,8 @@
 
 const { getMessageSize } = require('../../dd-trace/src/datastreams')
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
-const SpanContext = require('../../dd-trace/src/opentracing/span_context')
-const id = require('../../dd-trace/src/id')
 const { storage } = require('../../datadog-core')
+const reconstructPubSubRequestContext = require('./pubsub-request-context')
 
 /**
  * PULL SUBSCRIPTION: Service explicitly pulls messages from Pub/Sub and processes them.
@@ -75,27 +74,6 @@ class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
     })
   }
 
-  #reconstructPubSubRequestContext (attrs) {
-    const traceIdLower = attrs['_dd.pubsub_request.trace_id']
-    const spanId = attrs['_dd.pubsub_request.span_id']
-    const traceIdUpper = attrs['_dd.pubsub_request.p.tid']
-
-    if (!traceIdLower || !spanId) return null
-
-    const traceId128 = traceIdUpper ? traceIdUpper + traceIdLower : traceIdLower.padStart(32, '0')
-    const traceId = id(traceId128, 16)
-    const parentId = id(spanId, 16)
-
-    const tags = {}
-    if (traceIdUpper) tags['_dd.p.tid'] = traceIdUpper
-
-    return new SpanContext({
-      traceId,
-      spanId: parentId,
-      tags,
-    })
-  }
-
   start (ctx) {
     if (!this.config.dsmEnabled) return
     const { message } = ctx
@@ -128,7 +106,7 @@ class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
 
     const isFirstMessage = batchIndex === 0
     if (isFirstMessage && batchRequestSpanId) {
-      const pubsubRequestContext = this.#reconstructPubSubRequestContext(message.attributes)
+      const pubsubRequestContext = reconstructPubSubRequestContext(message.attributes)
       if (pubsubRequestContext) {
         childOf = pubsubRequestContext
       }

--- a/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription.js
@@ -1,9 +1,8 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const SpanContext = require('../../dd-trace/src/opentracing/span_context')
-const id = require('../../dd-trace/src/id')
 const log = require('../../dd-trace/src/log')
+const reconstructPubSubRequestContext = require('./pubsub-request-context')
 
 // WeakMap to track push receive spans by request
 const pushReceiveSpans = new WeakMap()
@@ -69,7 +68,7 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
     }
 
     const originalContext = this.#extractContext(messageData)
-    const pubsubRequestContext = this.#reconstructPubSubContext(messageData.attrs) || originalContext
+    const pubsubRequestContext = reconstructPubSubRequestContext(messageData.attrs) || originalContext
     const isSameTrace = pubsubRequestContext &&
       originalContext?.toTraceId() === pubsubRequestContext.toTraceId()
 
@@ -107,39 +106,6 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
 
   #extractContext (messageData) {
     return this.tracer.extract('text_map', messageData.attrs)
-  }
-
-  #reconstructPubSubContext (attrs) {
-    /**
-     * Reconstruct the batch publish span context from message attributes.
-     *
-     * When a batch is published, the producer injects:
-     * - _dd.pubsub_request.trace_id: lower 64 bits of the batch span's trace ID (hex)
-     * - _dd.pubsub_request.span_id: the batch span's span ID (hex)
-     * - _dd.pubsub_request.p.tid: upper 64 bits of trace ID (hex, optional for 128-bit traces)
-     *
-     * This context represents the "pubsub.request" span on the producer side.
-     * We use it to create span links, connecting each pubsub.push.receive span back to the original batch.
-     */
-    const traceIdLower = attrs['_dd.pubsub_request.trace_id']
-    const spanId = attrs['_dd.pubsub_request.span_id']
-    const traceIdUpper = attrs['_dd.pubsub_request.p.tid']
-
-    if (!traceIdLower || !spanId) return null
-
-    // Reconstruct full 128-bit trace ID (or pad 64-bit to 128-bit)
-    const traceId128 = traceIdUpper ? traceIdUpper + traceIdLower : traceIdLower.padStart(32, '0')
-    const traceId = id(traceId128, 16)
-    const parentId = id(spanId, 16)
-
-    const tags = {}
-    if (traceIdUpper) tags['_dd.p.tid'] = traceIdUpper
-
-    return new SpanContext({
-      traceId,
-      spanId: parentId,
-      tags,
-    })
   }
 
   #createPushReceiveSpan (messageData, parentContext, linkContext) {

--- a/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-request-context.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-request-context.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const SpanContext = require('../../dd-trace/src/opentracing/span_context')
+const id = require('../../dd-trace/src/id')
+
+/**
+ * @param {Record<string, string>} attributes
+ * @returns {import('../../dd-trace/src/opentracing/span_context') | null}
+ */
+function reconstructPubSubRequestContext (attributes) {
+  const traceIdLower = attributes['_dd.pubsub_request.trace_id']
+  const spanId = attributes['_dd.pubsub_request.span_id']
+  const traceIdUpper = attributes['_dd.pubsub_request.p.tid']
+
+  if (!traceIdLower || !spanId) return null
+
+  const traceId128 = traceIdUpper ? traceIdUpper + traceIdLower : traceIdLower.padStart(32, '0')
+  const traceId = id(traceId128, 16)
+  const parentId = id(spanId, 16)
+
+  const tags = {}
+  if (traceIdUpper) tags['_dd.p.tid'] = traceIdUpper
+
+  return new SpanContext({
+    traceId,
+    spanId: parentId,
+    tags,
+  })
+}
+
+module.exports = reconstructPubSubRequestContext

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { inspect } = require('node:util')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const semver = require('semver')
@@ -220,7 +219,7 @@ describe('Plugin', () => {
             return expectedSpanPromise
           })
 
-          it('should give the current span a parentId from the sender', async () => {
+          it('should parent the first batch message to the Pub/Sub request span', async () => {
             const expectedSpanPromise = expectSpanWithDefaults({
               name: expectedSchema.receive.opName,
               service: expectedSchema.receive.serviceName,
@@ -234,17 +233,27 @@ describe('Plugin', () => {
             const [topic] = await pubsub.createTopic(topicName)
             const [sub] = await topic.createSubscription('foo')
             sub.on('message', msg => {
-              const activeSpan = tracer.scope().active()
-              if (activeSpan) {
-                const receiverSpanContext = activeSpan.context()
-                assert.ok(
-                  typeof receiverSpanContext._parentId === 'object' && receiverSpanContext._parentId !== null,
-                  `Expected non-null object, got ${inspect(receiverSpanContext._parentId)}`
-                )
-              }
+              const receiverSpanContext = tracer.scope().active().context()
+              const traceIdLower = msg.attributes['_dd.pubsub_request.trace_id']
+              const traceIdUpper = msg.attributes['_dd.pubsub_request.p.tid']
+
+              assert.strictEqual(
+                receiverSpanContext.toTraceId(true),
+                traceIdUpper ? traceIdUpper + traceIdLower : traceIdLower.padStart(32, '0')
+              )
+              assert.strictEqual(
+                receiverSpanContext._parentId.toString(16).padStart(16, '0'),
+                msg.attributes['_dd.pubsub_request.span_id']
+              )
               msg.ack()
             })
-            await publish(topic, { data: Buffer.from('hello') })
+            await publish(topic, {
+              data: Buffer.from('hello'),
+              attributes: {
+                'x-datadog-trace-id': '42',
+                'x-datadog-parent-id': '43',
+              },
+            })
             return expectedSpanPromise
           })
 
@@ -596,6 +605,6 @@ function publish (topic, options) {
   if (topic.publishMessage) {
     return topic.publishMessage(options)
   } else {
-    return topic.publish(options.data)
+    return topic.publish(options.data, options.attributes)
   }
 }

--- a/packages/datadog-plugin-google-cloud-pubsub/test/pubsub-push-subscription.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/pubsub-push-subscription.spec.js
@@ -5,7 +5,6 @@ process.env.K_SERVICE = 'test-service'
 
 const assert = require('node:assert/strict')
 const { setTimeout: wait } = require('node:timers/promises')
-const { inspect } = require('node:util')
 
 const axios = require('axios')
 const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
@@ -130,12 +129,7 @@ describe('Push Subscription Plugin', () => {
           .assertSomeTraces(traces => {
             const pubsubSpan = findPubSubSpan(traces)
 
-            if (pubsubSpan.meta['_dd.span_links']) {
-              const spanLinks = JSON.parse(pubsubSpan.meta['_dd.span_links'])
-              assert.ok(Array.isArray(spanLinks), `Expected array, got ${inspect(spanLinks)}`)
-              const hasProducerLink = spanLinks.some(link => link.trace_id && link.span_id)
-              assert.strictEqual(hasProducerLink, true)
-            }
+            assert.strictEqual(pubsubSpan.meta['_dd.span_links'], undefined)
           })
           .then(done)
           .catch(done)
@@ -149,8 +143,9 @@ describe('Push Subscription Plugin', () => {
     })
 
     it('should add batch metadata to receive span', (done) => {
-      const batchTraceId = 'abc123def456'
-      const batchSpanId = '789012345678'
+      const batchTraceId = 'abc123def4567890'
+      const batchSpanId = '789012345678abcd'
+      const batchTraceIdUpper = 'abcdef1234567890'
 
       appListener = createServer().listen(0, 'localhost', () => {
         const port = appListener.address().port
@@ -167,6 +162,10 @@ describe('Push Subscription Plugin', () => {
               'pubsub.batch.message_count': 3,
               'pubsub.batch.message_index': 0,
             })
+            assert.deepStrictEqual(JSON.parse(pubsubSpan.meta['_dd.span_links']), [{
+              trace_id: batchTraceIdUpper + batchTraceId,
+              span_id: batchSpanId,
+            }])
           })
           .then(done)
           .catch(done)
@@ -176,6 +175,7 @@ describe('Push Subscription Plugin', () => {
           '_dd.batch.index': '0',
           '_dd.pubsub_request.trace_id': batchTraceId,
           '_dd.pubsub_request.span_id': batchSpanId,
+          '_dd.pubsub_request.p.tid': batchTraceIdUpper,
         }).catch(done)
       })
     })


### PR DESCRIPTION
Pull and push delivery reconstruct producer batch contexts from the same attributes and must apply identical 64-bit and 128-bit trace-ID rules.