### PR TITLE
perf(appsec): consolidate duration telemetry

### DIFF
--- a/packages/dd-trace/src/appsec/telemetry/api_security.js
+++ b/packages/dd-trace/src/appsec/telemetry/api_security.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const telemetryMetrics = require('../../telemetry/metrics')
-
-const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
+const { appsecMetrics } = require('./common')
 
 const normalizedFrameworkCache = new Map()
 

--- a/packages/dd-trace/src/appsec/telemetry/common.js
+++ b/packages/dd-trace/src/appsec/telemetry/common.js
@@ -1,6 +1,9 @@
 'use strict'
 
+const telemetryMetrics = require('../../telemetry/metrics')
+
 const DD_TELEMETRY_REQUEST_METRICS = Symbol('_dd.appsec.telemetry.request.metrics')
+const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
 
 const tags = {
   BLOCK_FAILURE: 'block_failure',
@@ -22,6 +25,7 @@ function getVersionsTags (wafVersion, rulesVersion) {
 }
 
 module.exports = {
+  appsecMetrics,
   tags,
   getVersionsTags,
   DD_TELEMETRY_REQUEST_METRICS,

--- a/packages/dd-trace/src/appsec/telemetry/index.js
+++ b/packages/dd-trace/src/appsec/telemetry/index.js
@@ -5,14 +5,13 @@ const {
   incrementApiSecRequestNoSchema,
   incrementApiSecRequestSchema,
 } = require('./api_security')
-const { DD_TELEMETRY_REQUEST_METRICS } = require('./common')
+const { appsecMetrics, DD_TELEMETRY_REQUEST_METRICS, getVersionsTags } = require('./common')
 const { incrementMissingUserId, incrementMissingUserLogin, incrementSdkEvent } = require('./user')
 const {
   addRaspRequestMetrics,
   trackRaspMetrics,
   trackRaspRuleMatch,
   trackRaspRuleSkipped,
-  incrementRaspDurationMetrics,
 } = require('./rasp')
 const {
   addWafRequestMetrics,
@@ -21,7 +20,6 @@ const {
   incrementWafUpdates,
   incrementWafConfigErrors,
   incrementWafRequests,
-  incrementWafDurationMetrics,
 } = require('./waf')
 
 const metricsStoreMap = new WeakMap()
@@ -150,8 +148,28 @@ function incrementRequestDurationMetrics (req) {
   const store = getStore(req)
   const requestMetrics = store[DD_TELEMETRY_REQUEST_METRICS]
 
-  incrementWafDurationMetrics(requestMetrics)
-  incrementRaspDurationMetrics(requestMetrics)
+  if (!requestMetrics.duration && !requestMetrics.durationExt &&
+      !requestMetrics.raspDuration && !requestMetrics.raspDurationExt) return
+
+  const { duration, durationExt, raspDuration, raspDurationExt, wafVersion, rulesVersion } = requestMetrics
+
+  const versionsTags = getVersionsTags(wafVersion, rulesVersion)
+
+  if (duration) {
+    appsecMetrics.distribution('waf.duration', versionsTags).track(duration)
+  }
+
+  if (durationExt) {
+    appsecMetrics.distribution('waf.duration_ext', versionsTags).track(durationExt)
+  }
+
+  if (raspDuration) {
+    appsecMetrics.distribution('rasp.duration', versionsTags).track(raspDuration)
+  }
+
+  if (raspDurationExt) {
+    appsecMetrics.distribution('rasp.duration_ext', versionsTags).track(raspDurationExt)
+  }
 }
 
 function incrementMissingUserLoginMetric (framework, eventType) {

--- a/packages/dd-trace/src/appsec/telemetry/rasp.js
+++ b/packages/dd-trace/src/appsec/telemetry/rasp.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const telemetryMetrics = require('../../telemetry/metrics')
-const { DD_TELEMETRY_REQUEST_METRICS, getVersionsTags } = require('./common')
-
-const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
+const { appsecMetrics, DD_TELEMETRY_REQUEST_METRICS, getVersionsTags } = require('./common')
 
 const BLOCKING_STATUS = {
   FAILURE: 'failure',
@@ -77,21 +74,6 @@ function trackRaspRuleMatch (store, raspRule, blockTriggered, blocked) {
   appsecMetrics.count('rasp.rule.match', tags).inc(1)
 }
 
-function incrementRaspDurationMetrics (requestMetrics) {
-  const { raspDuration, raspDurationExt, wafVersion, rulesVersion } = requestMetrics
-  if (!raspDuration && !raspDurationExt) return
-
-  const versionsTags = getVersionsTags(wafVersion, rulesVersion)
-
-  if (raspDuration) {
-    appsecMetrics.distribution('rasp.duration', versionsTags).track(raspDuration)
-  }
-
-  if (raspDurationExt) {
-    appsecMetrics.distribution('rasp.duration_ext', versionsTags).track(raspDurationExt)
-  }
-}
-
 function trackRaspRuleSkipped (raspRule, reason) {
   const tags = { reason, rule_type: raspRule.type }
 
@@ -115,5 +97,4 @@ module.exports = {
   trackRaspMetrics,
   trackRaspRuleMatch,
   trackRaspRuleSkipped,
-  incrementRaspDurationMetrics,
 }

--- a/packages/dd-trace/src/appsec/telemetry/user.js
+++ b/packages/dd-trace/src/appsec/telemetry/user.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const telemetryMetrics = require('../../telemetry/metrics')
-
-const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
+const { appsecMetrics } = require('./common')
 
 function incrementMissingUserLogin (framework, eventType) {
   appsecMetrics.count('instrum.user_auth.missing_user_login', {

--- a/packages/dd-trace/src/appsec/telemetry/waf.js
+++ b/packages/dd-trace/src/appsec/telemetry/waf.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const telemetryMetrics = require('../../telemetry/metrics')
-const { tags, getVersionsTags, DD_TELEMETRY_REQUEST_METRICS } = require('./common')
-
-const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
+const { appsecMetrics, tags, getVersionsTags, DD_TELEMETRY_REQUEST_METRICS } = require('./common')
 
 const DD_TELEMETRY_WAF_RESULT_TAGS = Symbol('_dd.appsec.telemetry.waf.result.tags')
 
@@ -126,21 +123,6 @@ function incrementWafRequests (store) {
   }
 }
 
-function incrementWafDurationMetrics (requestMetrics) {
-  const { duration, durationExt, wafVersion, rulesVersion } = requestMetrics
-  if (!duration && !durationExt) return
-
-  const versionsTags = getVersionsTags(wafVersion, rulesVersion)
-
-  if (duration) {
-    appsecMetrics.distribution('waf.duration', versionsTags).track(duration)
-  }
-
-  if (durationExt) {
-    appsecMetrics.distribution('waf.duration_ext', versionsTags).track(durationExt)
-  }
-}
-
 function incrementTruncatedMetrics (metrics, truncationReason) {
   const truncationTags = { truncation_reason: truncationReason }
   appsecMetrics.count('waf.input_truncated', truncationTags).inc(1)
@@ -163,5 +145,4 @@ module.exports = {
   incrementWafUpdates,
   incrementWafConfigErrors,
   incrementWafRequests,
-  incrementWafDurationMetrics,
 }

--- a/packages/dd-trace/test/appsec/telemetry/waf.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/waf.spec.js
@@ -370,6 +370,32 @@ describe('Appsec Waf Telemetry metrics', () => {
         sinon.assert.calledWith(track, 77)
       })
 
+      it('should report accumulated WAF and RASP durations with the same version tags', () => {
+        appsecTelemetry.updateWafRequestsMetricTags({ duration: 10, durationExt: 20, wafVersion, rulesVersion }, req)
+        appsecTelemetry.updateRaspRequestsMetricTags(
+          { duration: 30, durationExt: 40, wafVersion, rulesVersion },
+          req,
+          { type: 'rule-type' }
+        )
+
+        appsecTelemetry.incrementRequestDurationMetrics(req)
+
+        const versionsTags = {
+          waf_version: wafVersion,
+          event_rules_version: rulesVersion,
+        }
+        sinon.assert.callCount(distribution, 4)
+        sinon.assert.calledWithExactly(distribution, 'waf.duration', versionsTags)
+        sinon.assert.calledWithExactly(distribution, 'waf.duration_ext', versionsTags)
+        sinon.assert.calledWithExactly(distribution, 'rasp.duration', versionsTags)
+        sinon.assert.calledWithExactly(distribution, 'rasp.duration_ext', versionsTags)
+        sinon.assert.callCount(track, 4)
+        sinon.assert.calledWith(track, 10)
+        sinon.assert.calledWith(track, 20)
+        sinon.assert.calledWith(track, 30)
+        sinon.assert.calledWith(track, 40)
+      })
+
       it('should not report waf.duration/waf.duration_ext when there is no accumulated duration', () => {
         appsecTelemetry.incrementRequestDurationMetrics(req)
 


### PR DESCRIPTION
Combined WAF and RASP flushes take 82.81-88.40 ns, down from 107.58-107.73 ns, on Node.js 22.23.2 and V8 12.4.