### PR TITLE
test(aws-sdk): register trace assertions before requests

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -10,7 +10,7 @@ const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withPeerService } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { rawExpectedSchema } = require('./s3-naming')
-const { setup, withAwsSdkVersions } = require('./spec_helpers')
+const { callViaCallback, setup, withAwsSdkVersions } = require('./spec_helpers')
 
 const bucketName = 's3-bucket-name-test'
 
@@ -81,135 +81,105 @@ describe('Plugin', () => {
         )
 
         describe('span pointers', () => {
-          it('should add span pointer for putObject operation', (done) => {
-            agent.assertSomeTraces(traces => {
-              try {
-                const span = traces[0].find(s => s.meta?.['aws.operation'] === 'putObject')
-                assert.ok(span)
-                const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
+          it('should add span pointer for putObject operation', async () => {
+            const tracePromise = agent.assertFirstTraceSpan(span => {
+              const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
 
-                assert.strictEqual(links.length, 1)
-                assert.deepStrictEqual(links[0].attributes, {
-                  'ptr.kind': S3_PTR_KIND,
-                  'ptr.dir': SPAN_POINTER_DIRECTION.DOWNSTREAM,
-                  'ptr.hash': '6d1a2fe194c6579187408f827f942be3',
-                  'link.kind': 'span-pointer',
-                })
-                done()
-              } catch (error) {
-                done(error)
-              }
-            }).catch(done)
+              assert.strictEqual(links.length, 1)
+              assert.deepStrictEqual(links[0].attributes, {
+                'ptr.kind': S3_PTR_KIND,
+                'ptr.dir': SPAN_POINTER_DIRECTION.DOWNSTREAM,
+                'ptr.hash': '6d1a2fe194c6579187408f827f942be3',
+                'link.kind': 'span-pointer',
+              })
+            }, { spanResourceMatch: /^putObject / })
 
-            s3.putObject({
-              Bucket: bucketName,
-              Key: 'test-key',
-              Body: 'test body',
-            }, (err) => {
-              if (err) {
-                done(err)
-              }
-            })
+            await Promise.all([
+              tracePromise,
+              callViaCallback(s3, 'putObject', {
+                Bucket: bucketName,
+                Key: 'test-key',
+                Body: 'test body',
+              }),
+            ])
           })
 
-          it('should add span pointer for copyObject operation', (done) => {
-            agent.assertSomeTraces(traces => {
-              try {
-                const span = traces[0].find(s => s.meta?.['aws.operation'] === 'copyObject')
-                assert.ok(span)
-                const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
+          it('should add span pointer for copyObject operation', async () => {
+            const tracePromise = agent.assertFirstTraceSpan(span => {
+              const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
 
-                assert.strictEqual(links.length, 1)
-                assert.deepStrictEqual(links[0].attributes, {
-                  'ptr.kind': S3_PTR_KIND,
-                  'ptr.dir': SPAN_POINTER_DIRECTION.DOWNSTREAM,
-                  'ptr.hash': '1542053ce6d393c424b1374bac1fc0c5',
-                  'link.kind': 'span-pointer',
-                })
-                done()
-              } catch (error) {
-                done(error)
-              }
-            }).catch(done)
+              assert.strictEqual(links.length, 1)
+              assert.deepStrictEqual(links[0].attributes, {
+                'ptr.kind': S3_PTR_KIND,
+                'ptr.dir': SPAN_POINTER_DIRECTION.DOWNSTREAM,
+                'ptr.hash': '1542053ce6d393c424b1374bac1fc0c5',
+                'link.kind': 'span-pointer',
+              })
+            }, { spanResourceMatch: /^copyObject / })
 
-            s3.copyObject({
-              Bucket: bucketName,
-              Key: 'new-key',
-              CopySource: `${bucketName}/test-key`,
-            }, (err) => {
-              if (err) {
-                done(err)
-              }
-            })
+            await Promise.all([
+              tracePromise,
+              callViaCallback(s3, 'copyObject', {
+                Bucket: bucketName,
+                Key: 'new-key',
+                CopySource: `${bucketName}/test-key`,
+              }),
+            ])
           })
 
-          it('should add span pointer for completeMultipartUpload operation', (done) => {
-            // Create 5MiB+ buffers for parts
+          it('should add span pointer for completeMultipartUpload operation', async () => {
             const partSize = 5 * 1024 * 1024
             const part1Data = Buffer.alloc(partSize, 'a')
             const part2Data = Buffer.alloc(partSize, 'b')
 
-            // Start the multipart upload process
-            s3.createMultipartUpload({
+            const multipartData = await callViaCallback(s3, 'createMultipartUpload', {
               Bucket: bucketName,
               Key: 'multipart-test',
-            }, (err, multipartData) => {
-              if (err) return done(err)
-
-              // Upload both parts in parallel
-              Promise.all([
-                new Promise((resolve, reject) => {
-                  s3.uploadPart({
-                    Bucket: bucketName,
-                    Key: 'multipart-test',
-                    PartNumber: 1,
-                    UploadId: multipartData.UploadId,
-                    Body: part1Data,
-                  }, (err, data) => err ? reject(err) : resolve({ PartNumber: 1, ETag: data.ETag }))
-                }),
-                new Promise((resolve, reject) => {
-                  s3.uploadPart({
-                    Bucket: bucketName,
-                    Key: 'multipart-test',
-                    PartNumber: 2,
-                    UploadId: multipartData.UploadId,
-                    Body: part2Data,
-                  }, (err, data) => err ? reject(err) : resolve({ PartNumber: 2, ETag: data.ETag }))
-                }),
-              ]).then(parts => {
-                // Now complete the multipart upload
-                const completeParams = {
-                  Bucket: bucketName,
-                  Key: 'multipart-test',
-                  UploadId: multipartData.UploadId,
-                  MultipartUpload: {
-                    Parts: parts,
-                  },
-                }
-
-                s3.completeMultipartUpload(completeParams, (err) => {
-                  if (err) done(err)
-                  agent.assertSomeTraces(traces => {
-                    const span = traces[0].find(s => s.meta?.['aws.operation'] === 'completeMultipartUpload')
-                    if (span) {
-                      try {
-                        const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
-                        assert.strictEqual(links.length, 1)
-                        assert.deepStrictEqual(links[0].attributes, {
-                          'ptr.kind': S3_PTR_KIND,
-                          'ptr.dir': SPAN_POINTER_DIRECTION.DOWNSTREAM,
-                          'ptr.hash': '422412aa6b472a7194f3e24f4b12b4a6',
-                          'link.kind': 'span-pointer',
-                        })
-                        done()
-                      } catch (error) {
-                        done(error)
-                      }
-                    }
-                  })
-                })
-              }).catch(done)
             })
+
+            const [part1, part2] = await Promise.all([
+              callViaCallback(s3, 'uploadPart', {
+                Bucket: bucketName,
+                Key: 'multipart-test',
+                PartNumber: 1,
+                UploadId: multipartData.UploadId,
+                Body: part1Data,
+              }),
+              callViaCallback(s3, 'uploadPart', {
+                Bucket: bucketName,
+                Key: 'multipart-test',
+                PartNumber: 2,
+                UploadId: multipartData.UploadId,
+                Body: part2Data,
+              }),
+            ])
+            const completeParams = {
+              Bucket: bucketName,
+              Key: 'multipart-test',
+              UploadId: multipartData.UploadId,
+              MultipartUpload: {
+                Parts: [
+                  { PartNumber: 1, ETag: part1.ETag },
+                  { PartNumber: 2, ETag: part2.ETag },
+                ],
+              },
+            }
+            const tracePromise = agent.assertFirstTraceSpan(span => {
+              const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
+
+              assert.strictEqual(links.length, 1)
+              assert.deepStrictEqual(links[0].attributes, {
+                'ptr.kind': S3_PTR_KIND,
+                'ptr.dir': SPAN_POINTER_DIRECTION.DOWNSTREAM,
+                'ptr.hash': '422412aa6b472a7194f3e24f4b12b4a6',
+                'link.kind': 'span-pointer',
+              })
+            }, { spanResourceMatch: /^completeMultipartUpload / })
+
+            await Promise.all([
+              tracePromise,
+              callViaCallback(s3, 'completeMultipartUpload', completeParams),
+            ])
           })
         })
 

--- a/packages/datadog-plugin-aws-sdk/test/sns.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.dsm.spec.js
@@ -11,7 +11,7 @@ const { ENTRY_PARENT_HASH } = require('../../dd-trace/src/datastreams/processor'
 const propagationHash = require('../../dd-trace/src/propagation-hash')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
-const { setup, withAwsSdkVersions } = require('./spec_helpers')
+const { callViaCallback, setup, withAwsSdkVersions } = require('./spec_helpers')
 
 describe('Sns', function () {
   setup()
@@ -132,60 +132,37 @@ describe('Sns', function () {
         agent.reload('aws-sdk', { sns: { dsmEnabled: true, batchPropagationEnabled: true } }, { dsmEnabled: true })
       })
 
-      it('injects DSM pathway hash to SNS publish span', done => {
-        sns.subscribe(subParams, (err, data) => {
-          if (err) return done(err)
+      it('injects DSM pathway hash to SNS publish span', async () => {
+        await callViaCallback(sns, 'subscribe', subParams)
 
-          sns.publish(
-            { TopicArn, Message: 'message DSM' },
-            (err) => {
-              if (err) return done(err)
+        const tracePromise = agent.assertFirstTraceSpan({
+          meta: {
+            'pathway.hash': expectedProducerHash,
+          },
+        }, { spanResourceMatch: /^publish / })
 
-              let publishSpanMeta = {}
-              agent.assertSomeTraces(traces => {
-                const span = traces[0][0]
-
-                if (span.resource.startsWith('publish')) {
-                  publishSpanMeta = span.meta
-                }
-
-                assertObjectContains(publishSpanMeta, {
-                  'pathway.hash': expectedProducerHash,
-                })
-              }).then(done, done)
-            })
-        })
+        await Promise.all([
+          tracePromise,
+          callViaCallback(sns, 'publish', { TopicArn, Message: 'message DSM' }),
+        ])
       })
 
-      it('injects DSM pathway hash to SQS receive span from SNS topic', done => {
-        sns.subscribe(subParams, (err, data) => {
-          if (err) return done(err)
+      it('injects DSM pathway hash to SQS receive span from SNS topic', async () => {
+        await callViaCallback(sns, 'subscribe', subParams)
+        await callViaCallback(sns, 'publish', { TopicArn, Message: 'message DSM' })
 
-          sns.publish(
-            { TopicArn, Message: 'message DSM' },
-            (err) => {
-              if (err) return done(err)
-            })
-
-          sqs.receiveMessage(
-            receiveParams,
-            (err, res) => {
-              if (err) return done(err)
-
-              let consumeSpanMeta = {}
-              agent.assertSomeTraces(traces => {
-                const span = traces[0][0]
-
-                if (span.name === 'aws.response') {
-                  consumeSpanMeta = span.meta
-                }
-
-                assertObjectContains(consumeSpanMeta, {
-                  'pathway.hash': expectedConsumerHash,
-                })
-              }).then(done, done)
-            })
+        const tracePromise = agent.assertSomeTraces(traces => {
+          const span = traces.flat().find(span => span.name === 'aws.response')
+          assert.ok(span)
+          assertObjectContains(span.meta, {
+            'pathway.hash': expectedConsumerHash,
+          })
         })
+
+        await Promise.all([
+          tracePromise,
+          callViaCallback(sqs, 'receiveMessage', receiveParams),
+        ])
       })
 
       it('outputs DSM stats to the agent when publishing a message', done => {

--- a/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
@@ -13,6 +13,25 @@ const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toStrin
  * @param {object} params Operation parameters.
  * @returns {Promise<object>} Resolves with the operation result.
  */
+function callViaCallback (client, method, params) {
+  return new Promise((resolve, reject) => {
+    const operation = client[method](params, (error, result) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(result)
+      }
+    })
+    Promise.resolve(operation).catch(reject)
+  })
+}
+
+/**
+ * @param {object} client AWS client (v2 service instance or v3 aggregated client).
+ * @param {string} method Operation name, e.g. `getRecords` or `sendMessage`.
+ * @param {object} params Operation parameters.
+ * @returns {Promise<object>} Resolves with the operation result.
+ */
 function callViaPromise (client, method, params) {
   const result = client[method](params)
   // v2 returns an AWS.Request exposing `.promise()`; v3's aggregated client returns a Promise directly.
@@ -79,6 +98,7 @@ function getAwsSdkV3Range (range) {
 }
 
 const helpers = {
+  callViaCallback,
   callViaPromise,
   sort,
   withAwsSdkV2Versions,

--- a/packages/datadog-plugin-aws-sdk/test/sqs.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.dsm.spec.js
@@ -12,7 +12,7 @@ const { ENTRY_PARENT_HASH } = require('../../dd-trace/src/datastreams/processor'
 const propagationHash = require('../../dd-trace/src/propagation-hash')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
-const { callViaPromise, setup, withAwsSdkVersions } = require('./spec_helpers')
+const { callViaCallback, callViaPromise, setup, withAwsSdkVersions } = require('./spec_helpers')
 
 const getQueueParams = (queueName) => {
   return {
@@ -127,55 +127,43 @@ describe('Plugin', () => {
           agent.reload('aws-sdk', { kinesis: { dsmEnabled: true } }, { dsmEnabled: true })
         })
 
-        it('Should set pathway hash tag on a span when producing', (done) => {
-          sqs.sendMessage({
-            MessageBody: 'test DSM',
-            QueueUrl: QueueUrlDsm,
-          }, (err) => {
-            if (err) return done(err)
+        it('Should set pathway hash tag on a span when producing', async () => {
+          const tracePromise = agent.assertFirstTraceSpan({
+            meta: {
+              'pathway.hash': expectedProducerHash,
+            },
+          }, { spanResourceMatch: /^sendMessage / })
 
-            let produceSpanMeta = {}
-            agent.assertSomeTraces(traces => {
-              const span = traces[0][0]
-
-              if (span.resource.startsWith('sendMessage')) {
-                produceSpanMeta = span.meta
-              }
-
-              assertObjectContains(produceSpanMeta, {
-                'pathway.hash': expectedProducerHash,
-              })
-            }).then(done, done)
-          })
+          await Promise.all([
+            tracePromise,
+            callViaCallback(sqs, 'sendMessage', {
+              MessageBody: 'test DSM',
+              QueueUrl: QueueUrlDsm,
+            }),
+          ])
         })
 
-        it('Should set pathway hash tag on a span when consuming', (done) => {
-          sqs.sendMessage({
+        it('Should set pathway hash tag on a span when consuming', async () => {
+          await callViaCallback(sqs, 'sendMessage', {
             MessageBody: 'test DSM',
             QueueUrl: QueueUrlDsm,
-          }, (err) => {
-            if (err) return done(err)
+          })
 
-            sqs.receiveMessage({
-              QueueUrl: QueueUrlDsm,
-              MessageAttributeNames: ['.*'],
-            }, (err) => {
-              if (err) return done(err)
-
-              let consumeSpanMeta = {}
-              agent.assertSomeTraces(traces => {
-                const span = traces[0][0]
-
-                if (span.name === 'aws.response') {
-                  consumeSpanMeta = span.meta
-                }
-
-                assertObjectContains(consumeSpanMeta, {
-                  'pathway.hash': expectedConsumerHash,
-                })
-              }).then(done, done)
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const span = traces.flat().find(span => span.name === 'aws.response')
+            assert.ok(span)
+            assertObjectContains(span.meta, {
+              'pathway.hash': expectedConsumerHash,
             })
           })
+
+          await Promise.all([
+            tracePromise,
+            callViaCallback(sqs, 'receiveMessage', {
+              QueueUrl: QueueUrlDsm,
+              MessageAttributeNames: ['.*'],
+            }),
+          ])
         })
 
         if (promisesSupported) {


### PR DESCRIPTION
An AWS request span can be exported before its callback runs, so assertions registered from that callback can miss the only matching payload and time out. Register the assertion before starting the request and await both completions across the affected S3 span-pointer and SNS/SQS DSM cases.