### PR TITLE
bench(sirun): keep variants under one minute

### DIFF
--- a/benchmark/sirun/appsec-iast/meta.json
+++ b/benchmark/sirun/appsec-iast/meta.json
@@ -6,7 +6,7 @@
   "variants": {
     "no-vulnerability-iast-enabled-default-config": {
       "cpus": 2,
-      "iterations": 5,
+      "iterations": 4,
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY_SECOND node client.js >/dev/null 2>&1 &\"",
       "run": "node --require ../startup-guard.js --require ../noop-request.js --require ../../../init.js server-without-vulnerability.js",
@@ -20,7 +20,7 @@
     },
     "with-vulnerability-iast-enabled-default-config": {
       "cpus": 2,
-      "iterations": 5,
+      "iterations": 3,
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY_SECOND node client.js >/dev/null 2>&1 &\"",
       "run": "node --require ../startup-guard.js --require ../noop-request.js --require ../../../init.js server-with-vulnerability.js",

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -16,6 +16,7 @@
       }
     },
     "line-probe-without-snapshot": {
+      "iterations": 4,
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
@@ -43,6 +44,7 @@
       }
     },
     "line-probe-with-snapshot-minimal": {
+      "iterations": 4,
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -14,7 +14,7 @@
       }
     },
     "0.4-immediate-flush": {
-      "iterations": 7,
+      "iterations": 4,
       "run": "node immediate-flush.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node immediate-flush.js\"",
       "env": {

--- a/benchmark/sirun/iast/meta.json
+++ b/benchmark/sirun/iast/meta.json
@@ -7,6 +7,7 @@
   "instructions": true,
   "variants": {
     "request-lifecycle": {
+      "iterations": 10,
       "env": { "VARIANT": "request-lifecycle", "OPERATIONS": "8000" }
     },
     "sink-check": {

--- a/benchmark/sirun/llmobs-span-processor/meta.json
+++ b/benchmark/sirun/llmobs-span-processor/meta.json
@@ -20,7 +20,7 @@
     "agent": {
       "run": "node --predictable-gc-schedule index.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node --predictable-gc-schedule index.js\"",
-      "iterations": 18,
+      "iterations": 10,
       "env": { "VARIANT": "agent", "OPERATIONS": "1600000" }
     }
   }

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -7,6 +7,7 @@
   "instructions": true,
   "variants": {
     "with-depth-off": {
+      "iterations": 7,
       "operations_by_node": {
         "20": "1280",
         "24": "2550"
@@ -22,6 +23,7 @@
       }
     },
     "with-depth-on-max": {
+      "iterations": 6,
       "operations_by_node": {
         "20": "840",
         "24": "1680"
@@ -38,6 +40,7 @@
       }
     },
     "with-depth-and-collapse-off": {
+      "iterations": 5,
       "run": "node --predictable-gc-schedule --require ../noop-request.js index.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node --predictable-gc-schedule --require ../noop-request.js index.js\"",
       "operations_by_node": {

--- a/benchmark/sirun/plugin-kafkajs/meta.json
+++ b/benchmark/sirun/plugin-kafkajs/meta.json
@@ -10,6 +10,7 @@
       "env": { "VARIANT": "small", "OPERATIONS": "8500000" }
     },
     "large": {
+      "iterations": 13,
       "env": { "VARIANT": "large", "OPERATIONS": "5500000" }
     },
     "mixed": {

--- a/benchmark/sirun/propagation/meta.json
+++ b/benchmark/sirun/propagation/meta.json
@@ -15,7 +15,7 @@
     "inject": {
       "run": "node --predictable-gc-schedule index.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node --predictable-gc-schedule index.js\"",
-      "iterations": 10,
+      "iterations": 6,
       "env": {
         "VARIANT": "inject",
         "OPERATIONS": "3000000"

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -30,6 +30,7 @@
       }
     },
     "finish-immediately-with-many-tags": {
+      "iterations": 10,
       "env": {
         "DD_TRACE_SCOPE": "noop",
         "FINISH": "now",

--- a/benchmark/sirun/startup/meta.json
+++ b/benchmark/sirun/startup/meta.json
@@ -12,12 +12,14 @@
       }
     },
     "with-tracer-everything": {
+      "iterations": 30,
       "env": {
         "USE_TRACER": "1",
         "EVERYTHING": "1"
       }
     },
     "with-tracer-everything-esm": {
+      "iterations": 25,
       "env": {
         "USE_TRACER": "1",
         "EVERYTHING": "1",


### PR DESCRIPTION
### What does this PR do?

Reduces the configured Sirun iteration counts for the 15 benchmark variants
whose measured end-to-end runtimes were at least one minute.

The per-sample workloads remain unchanged so startup-share guards and measured
hot paths keep the same behavior. Based on the supplied timings, the adjusted
variants project to run in 46.4 to 57.3 seconds.

### Motivation

Keep every Sirun benchmark variant within the one-minute runtime budget while
retaining a 10-sample floor where the current per-sample cost permits it.

### Additional Notes

- Parsed all 10 modified metadata files as JSON.
- Ran `git diff --check`.
- Sirun was not available locally, so projected runtimes are proportional to the
  supplied benchmark measurements.

*Generated by Codex.*
