### PR TITLE
ci(pr-title): avoid file API calls during validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@ PR title guidance:
 - Reserve feat, fix, and perf for shipped production code.
 - A scope is optional, but omitting it does not change how the type is selected. For example,
   use test: cover retries, not fix: cover retries.
+- A production type is valid for multiple scopes when at least one scope represents shipped code,
+  such as fix(http, tests): handle retries.
 - For non-production changes, use the area as the type:
   - Tests: test(scope): description
   - Benchmarks: bench(scope): description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ PR title guidance:
   use test(http): cover retries, not fix(test): cover retries.
 - Apply the same rule to repository tooling. Examples include docs(agents), chore(codeowners),
   chore(eslint), chore(scripts), ci(release), ci(workflows), and test(integration-tests).
-- Product scopes such as test-optimization and ci-visibility may still describe shipped production changes.
+- Product scopes such as ci, test-optimization, and ci-visibility may still describe shipped production changes.
 - Add the appropriate semver-patch, semver-minor, or semver-major label.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@ PR title guidance:
 - Follow Conventional Commits format: type(scope): description.
 - Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert.
 - Reserve feat, fix, and perf for shipped production code.
+- A scope is optional, but omitting it does not change how the type is selected. For example,
+  use test: cover retries, not fix: cover retries.
 - For non-production changes, use the area as the type:
   - Tests: test(scope): description
   - Benchmarks: bench(scope): description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,8 @@ PR title guidance:
   - Maintenance: chore(scope): description
 - For example, use docs(api): update setup guide, not fix(docs): update setup guide;
   use test(http): cover retries, not fix(test): cover retries.
+- Apply the same rule to repository tooling. Examples include docs(agents), chore(codeowners),
+  chore(eslint), chore(scripts), ci(release), ci(workflows), and test(integration-tests).
 - Product scopes such as test-optimization and ci-visibility may still describe shipped production changes.
 - Add the appropriate semver-patch, semver-minor, or semver-major label.
 -->
@@ -28,4 +30,3 @@ PR title guidance:
 
 ### Additional Notes
 <!-- Anything else we should know when reviewing? -->
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,23 @@
 <!-- Please make sure your changes are properly tested -->
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 
-<!-- PR title must follow Conventional Commits format: type(scope): description -->
-<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->
+<!--
+PR title guidance:
+- Follow Conventional Commits format: type(scope): description.
+- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert.
+- Reserve feat, fix, and perf for shipped production code.
+- For non-production changes, use the area as the type:
+  - Tests: test(scope): description
+  - Benchmarks: bench(scope): description
+  - Documentation: docs(scope): description
+  - CI and workflows: ci(scope): description
+  - Build tooling: build(scope): description
+  - Maintenance: chore(scope): description
+- For example, use docs(api): update setup guide, not fix(docs): update setup guide;
+  use test(http): cover retries, not fix(test): cover retries.
+- Product scopes such as test-optimization and ci-visibility may still describe shipped production changes.
+- Add the appropriate semver-patch, semver-minor, or semver-major label.
+-->
 
 ### What does this PR do?
 <!-- A brief description of the change being made with this pull request. -->
@@ -13,5 +28,4 @@
 
 ### Additional Notes
 <!-- Anything else we should know when reviewing? -->
-
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Validate PR title
         if: >-
           steps.rename.outputs.renamed != 'true' &&
-          (github.event.action != 'edited' || github.event.changes.title != null)
+          (github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          (github.event.action == 'edited' && github.event.changes.title != null))
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -72,7 +74,6 @@ jobs:
               ['benchmarks', 'bench'],
               ['build', 'build'],
               ['chore', 'chore'],
-              ['ci', 'ci'],
               ['codeowners', 'chore'],
               ['dependabot', 'ci'],
               ['deps-dev', 'chore'],

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -87,12 +87,13 @@ jobs:
               ['testing', 'test'],
               ['workflows', 'ci'],
             ])
-            const invalidScope = scope.split(',').map(scope => scope.trim().toLowerCase())
-              .find(scope => nonProductionScopes.has(scope))
-            if (invalidScope) {
-              core.setFailed(`PR title type "${type}" is not valid for non-production scope "${invalidScope}". ` +
-                `Use "${nonProductionScopes.get(invalidScope)}" instead.`)
-            }
+            const scopes = scope.split(',').map(scope => scope.trim().toLowerCase())
+            const suggestedTypes = scopes.map(scope => nonProductionScopes.get(scope))
+            if (suggestedTypes.includes(undefined)) return
+
+            const suggestions = [...new Set(suggestedTypes)].map(type => `"${type}"`).join(' or ')
+            core.setFailed(`PR title type "${type}" is not valid when every scope is non-production ` +
+              `("${scopes.join(', ')}"). Use ${suggestions} instead.`)
 
       - name: Sync labels with PR title
         if: >-

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -58,21 +58,35 @@ jobs:
 
             const type = match[3]
             const scope = match[5]
-            if (!/^(?:feat|fix)$/.test(type) || !scope) return
+            if (!/^(?:feat|fix|perf)$/.test(type) || !scope) return
 
             const nonProductionScopes = new Map([
+              ['agents', 'docs'],
               ['bench', 'bench'],
               ['benchmark', 'bench'],
               ['benchmarks', 'bench'],
               ['build', 'build'],
               ['chore', 'chore'],
               ['ci', 'ci'],
+              ['codeowners', 'chore'],
+              ['coverage', 'test'],
+              ['dependabot', 'ci'],
+              ['deps-dev', 'chore'],
               ['docs', 'docs'],
               ['documentation', 'docs'],
+              ['eslint', 'chore'],
+              ['github', 'ci'],
+              ['gitlab', 'ci'],
+              ['integration-test', 'test'],
+              ['integration-tests', 'test'],
+              ['lint', 'chore'],
+              ['release', 'ci'],
+              ['scripts', 'chore'],
               ['style', 'style'],
               ['test', 'test'],
               ['tests', 'test'],
               ['testing', 'test'],
+              ['workflows', 'ci'],
             ])
             const invalidScope = scope.split(',').map(scope => scope.trim().toLowerCase())
               .find(scope => nonProductionScopes.has(scope))

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,12 +22,6 @@ jobs:
       # Revert PRs always get semver-patch regardless of the original change's type.
       PR_TITLE_PATTERN: '^(revert(!)?: .+|(feat|fix|docs|style|refactor|perf|test|bench|build|ci|chore)(\(([^)]+)\))?(!)?: .+)'
     steps:
-      - name: Checkout base revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-
       - name: Auto-rename GitHub revert title to Conventional Commit
         id: rename
         if: startsWith(github.event.pull_request.title, 'Revert "')
@@ -46,7 +40,7 @@ jobs:
             })
             core.setOutput('renamed', 'true')
 
-      - name: Validate PR title and release-note context
+      - name: Validate PR title
         if: >-
           steps.rename.outputs.renamed != 'true' &&
           (github.event.action != 'edited' || github.event.changes.title != null)
@@ -63,19 +57,28 @@ jobs:
             core.info(`PR title OK: ${title}`)
 
             const type = match[3]
-            if (!/^(?:feat|fix|perf|docs)$/.test(type)) return
+            const scope = match[5]
+            if (!/^(?:feat|fix)$/.test(type) || !scope) return
 
-            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
-              ...context.repo,
-              pull_number: pullRequest.number,
-              per_page: 100,
-            })
-            const files = []
-            const { appendChangedPaths, isInternalOnly } = require('./scripts/release/changelog')
-            appendChangedPaths(files, changedFiles)
-            if (isInternalOnly(files)) {
-              core.setFailed(`PR title type "${type}" is public, but every changed file is internal. ` +
-                'Use test, bench, ci, or chore.')
+            const nonProductionScopes = new Map([
+              ['bench', 'bench'],
+              ['benchmark', 'bench'],
+              ['benchmarks', 'bench'],
+              ['build', 'build'],
+              ['chore', 'chore'],
+              ['ci', 'ci'],
+              ['docs', 'docs'],
+              ['documentation', 'docs'],
+              ['style', 'style'],
+              ['test', 'test'],
+              ['tests', 'test'],
+              ['testing', 'test'],
+            ])
+            const invalidScope = scope.split(',').map(scope => scope.trim().toLowerCase())
+              .find(scope => nonProductionScopes.has(scope))
+            if (invalidScope) {
+              core.setFailed(`PR title type "${type}" is not valid for non-production scope "${invalidScope}". ` +
+                `Use "${nonProductionScopes.get(invalidScope)}" instead.`)
             }
 
       - name: Sync labels with PR title

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -41,9 +41,7 @@ jobs:
             core.setOutput('renamed', 'true')
 
       - name: Checkout base revision
-        if: >-
-          steps.rename.outputs.renamed != 'true' &&
-          (github.event.action != 'edited' || github.event.changes.title != null)
+        if: steps.rename.outputs.renamed != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
@@ -53,9 +51,7 @@ jobs:
       # Fetch the PR head as Git objects only. The privileged pull_request_target
       # job must never check out or execute code from this ref.
       - name: Fetch pull request head
-        if: >-
-          steps.rename.outputs.renamed != 'true' &&
-          (github.event.action != 'edited' || github.event.changes.title != null)
+        if: steps.rename.outputs.renamed != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: >-
@@ -63,9 +59,7 @@ jobs:
           "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull-request/head"
 
       - name: Validate PR title and release-note context
-        if: >-
-          steps.rename.outputs.renamed != 'true' &&
-          (github.event.action != 'edited' || github.event.changes.title != null)
+        if: steps.rename.outputs.renamed != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -58,7 +58,12 @@ jobs:
 
             const type = match[3]
             const scope = match[5]
-            if (!/^(?:feat|fix|perf)$/.test(type) || !scope) return
+            const scopes = scope?.split(',').map(scope => scope.trim().toLowerCase())
+            if (scopes?.includes('')) {
+              core.setFailed('PR title scope list contains an empty scope.')
+              return
+            }
+            if (!/^(?:feat|fix|perf)$/.test(type) || !scopes) return
 
             const nonProductionScopes = new Map([
               ['agents', 'docs'],
@@ -87,7 +92,6 @@ jobs:
               ['testing', 'test'],
               ['workflows', 'ci'],
             ])
-            const scopes = scope.split(',').map(scope => scope.trim().toLowerCase())
             const suggestedTypes = scopes.map(scope => nonProductionScopes.get(scope))
             if (suggestedTypes.includes(undefined)) return
 
@@ -139,7 +143,12 @@ jobs:
               const labels = new Set()
               if (!parsed.type) return labels
               if (repoLabels.has(parsed.type)) labels.add(parsed.type)
-              if (parsed.scope && repoLabels.has(parsed.scope)) labels.add(parsed.scope)
+              if (parsed.scope) {
+                for (const scope of parsed.scope.split(',')) {
+                  const name = scope.trim()
+                  if (name && repoLabels.has(name)) labels.add(name)
+                }
+              }
               const semver = semverFor(parsed)
               if (semver) labels.add(semver)
               return labels

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -69,7 +69,6 @@ jobs:
               ['chore', 'chore'],
               ['ci', 'ci'],
               ['codeowners', 'chore'],
-              ['coverage', 'test'],
               ['dependabot', 'ci'],
               ['deps-dev', 'chore'],
               ['docs', 'docs'],

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -40,12 +40,32 @@ jobs:
             })
             core.setOutput('renamed', 'true')
 
-      - name: Validate PR title
+      - name: Checkout base revision
         if: >-
           steps.rename.outputs.renamed != 'true' &&
-          (github.event.action == 'opened' ||
-          github.event.action == 'reopened' ||
-          (github.event.action == 'edited' && github.event.changes.title != null))
+          (github.event.action != 'edited' || github.event.changes.title != null)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Fetch the PR head as Git objects only. The privileged pull_request_target
+      # job must never check out or execute code from this ref.
+      - name: Fetch pull request head
+        if: >-
+          steps.rename.outputs.renamed != 'true' &&
+          (github.event.action != 'edited' || github.event.changes.title != null)
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: >-
+          git fetch --no-tags origin
+          "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull-request/head"
+
+      - name: Validate PR title and release-note context
+        if: >-
+          steps.rename.outputs.renamed != 'true' &&
+          (github.event.action != 'edited' || github.event.changes.title != null)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -59,46 +79,24 @@ jobs:
             core.info(`PR title OK: ${title}`)
 
             const type = match[3]
-            const scope = match[5]
-            const scopes = scope?.split(',').map(scope => scope.trim().toLowerCase())
-            if (scopes?.includes('')) {
-              core.setFailed('PR title scope list contains an empty scope.')
-              return
+            if (!/^(?:feat|fix|perf|docs)$/.test(type)) return
+
+            const { execFileSync } = require('node:child_process')
+            const { isInternalOnly } = require('./scripts/release/changelog')
+            // Treat renames as delete/add pairs so both paths affect classification.
+            const output = execFileSync('git', [
+              'diff',
+              '--name-only',
+              '--no-renames',
+              '-z',
+              `${pullRequest.base.sha}...refs/remotes/pull-request/head`,
+            ], { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 })
+            const files = output.split('\0').filter(Boolean)
+
+            if (isInternalOnly(files)) {
+              core.setFailed(`PR title type "${type}" is public, but every changed file is internal. ` +
+                'Use test, bench, ci, or chore.')
             }
-            if (!/^(?:feat|fix|perf)$/.test(type) || !scopes) return
-
-            const nonProductionScopes = new Map([
-              ['agents', 'docs'],
-              ['bench', 'bench'],
-              ['benchmark', 'bench'],
-              ['benchmarks', 'bench'],
-              ['build', 'build'],
-              ['chore', 'chore'],
-              ['codeowners', 'chore'],
-              ['dependabot', 'ci'],
-              ['deps-dev', 'chore'],
-              ['docs', 'docs'],
-              ['documentation', 'docs'],
-              ['eslint', 'chore'],
-              ['github', 'ci'],
-              ['gitlab', 'ci'],
-              ['integration-test', 'test'],
-              ['integration-tests', 'test'],
-              ['lint', 'chore'],
-              ['release', 'ci'],
-              ['scripts', 'chore'],
-              ['style', 'style'],
-              ['test', 'test'],
-              ['tests', 'test'],
-              ['testing', 'test'],
-              ['workflows', 'ci'],
-            ])
-            const suggestedTypes = scopes.map(scope => nonProductionScopes.get(scope))
-            if (suggestedTypes.includes(undefined)) return
-
-            const suggestions = [...new Set(suggestedTypes)].map(type => `"${type}"`).join(' or ')
-            core.setFailed(`PR title type "${type}" is not valid when every scope is non-production ` +
-              `("${scopes.join(', ')}"). Use ${suggestions} instead.`)
 
       - name: Sync labels with PR title
         if: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,9 +153,7 @@ never weaken or delete assertions to make them pass.
 ## Pull Requests and CI
 
 - Commit format: `type(scope): description`.
-- Types: `feat`, `fix`, `perf`, `refactor`, `test`, `bench`, `docs`, `chore`, `ci`.
-- Reserve `feat`, `fix`, and `perf` for shipped production code; use the area type for tests, benchmarks, CI, or tools.
-- Use `.github/pull_request_template.md` and the appropriate `semver-patch`, `semver-minor`, or `semver-major` label.
+- Before opening or updating a PR, read and follow `.github/pull_request_template.md`.
 - All required tests must pass; the repository follows an all-green policy.
 
 ## Specialized Workflows

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -41,7 +41,6 @@ describe('PR title workflow', () => {
       ['benchmarks', 'bench'],
       ['build', 'build'],
       ['chore', 'chore'],
-      ['ci', 'ci'],
       ['codeowners', 'chore'],
       ['dependabot', 'ci'],
       ['deps-dev', 'chore'],
@@ -99,6 +98,7 @@ describe('PR title workflow', () => {
       'fix(ci-visibility): change',
       'fix(test-optimization): change',
       'fix(http, tests): change',
+      'feat(ci): change',
       'perf(http): change',
       'perf(agent): change',
       'feat(coverage): change',
@@ -149,11 +149,14 @@ describe('PR title workflow', () => {
     assert.deepStrictEqual([...request.labels], ['fix', 'http', 'tests', 'semver-patch'])
   })
 
-  it('syncs labels only for events that can require reconciliation', () => {
-    assert.strictEqual(labelSync.if.replaceAll(/\s+/g, ' '),
-      "steps.rename.outputs.renamed != 'true' && " +
+  it('runs title-dependent steps only for events that can require reconciliation', () => {
+    const expectedCondition = "steps.rename.outputs.renamed != 'true' && " +
       "(github.event.action == 'opened' || " +
       "github.event.action == 'reopened' || " +
-      "(github.event.action == 'edited' && github.event.changes.title != null))")
+      "(github.event.action == 'edited' && github.event.changes.title != null))"
+
+    for (const step of [validation, labelSync]) {
+      assert.strictEqual(step.if.replaceAll(/\s+/g, ' '), expectedCondition)
+    }
   })
 })

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -10,61 +10,76 @@ const job = workflow.jobs['conventional-commit']
 const steps = new Map()
 for (const step of job.steps) steps.set(step.name, step)
 
-const checkout = steps.get('Checkout base revision')
-const validation = steps.get('Validate PR title and release-note context')
+const validation = steps.get('Validate PR title')
 const labelSync = steps.get('Sync labels with PR title')
 const validateTitle = vm.runInNewContext(
-  `(async function validateTitle (context, core, github, process, require) {\n${validation.with.script}\n})`
+  `(async function validateTitle (context, core, process) {\n${validation.with.script}\n})`
 )
-const releaseHelpers = {
-  appendChangedPaths: Function.prototype,
-  isInternalOnly: () => false,
+const validate = async (title) => {
+  const failures = []
+  const context = { payload: { pull_request: { title } } }
+  const core = {
+    info: Function.prototype,
+    setFailed: message => failures.push(message),
+  }
+  const process = { env: { PR_TITLE_PATTERN: job.env.PR_TITLE_PATTERN } }
+
+  await validateTitle(context, core, process)
+
+  return failures
 }
-const loadReleaseHelpers = () => releaseHelpers
 
 describe('PR title workflow', () => {
-  it('lists changed files only for public title types', async () => {
-    const expectedCallsByType = new Map([
-      ['feat', 1],
-      ['fix', 1],
-      ['perf', 1],
-      ['docs', 1],
-      ['style', 0],
-      ['refactor', 0],
-      ['test', 0],
-      ['bench', 0],
-      ['build', 0],
-      ['ci', 0],
-      ['chore', 0],
-      ['revert', 0],
+  it('rejects production types for non-production scopes', async () => {
+    const expectedTypeByScope = new Map([
+      ['bench', 'bench'],
+      ['benchmark', 'bench'],
+      ['benchmarks', 'bench'],
+      ['build', 'build'],
+      ['chore', 'chore'],
+      ['ci', 'ci'],
+      ['docs', 'docs'],
+      ['documentation', 'docs'],
+      ['style', 'style'],
+      ['test', 'test'],
+      ['tests', 'test'],
+      ['testing', 'test'],
     ])
-    const validations = []
 
-    for (const [type, expectedCalls] of expectedCallsByType) {
-      let listFilesCalls = 0
-      const context = {
-        repo: { owner: 'DataDog', repo: 'dd-trace-js' },
-        payload: { pull_request: { number: 1, title: `${type}: change` } },
+    await Promise.all(['feat', 'fix'].flatMap(type => [...expectedTypeByScope].map(
+      async ([scope, expectedType]) => {
+        const failures = await validate(`${type}(${scope}): change`)
+        assert.deepStrictEqual(failures, [
+          `PR title type "${type}" is not valid for non-production scope "${scope}". ` +
+          `Use "${expectedType}" instead.`,
+        ])
       }
-      const core = {
-        info: Function.prototype,
-        setFailed: assert.fail,
-      }
-      const github = {
-        paginate: () => {
-          listFilesCalls++
-          return []
-        },
-        rest: { pulls: { listFiles: Function.prototype } },
-      }
-      const process = { env: { PR_TITLE_PATTERN: job.env.PR_TITLE_PATTERN } }
+    )))
+  })
 
-      validations.push(validateTitle(context, core, github, process, loadReleaseHelpers))
+  it('rejects a non-production scope in a scope list', async () => {
+    const failures = await validate('fix(http, tests): change')
+    assert.strictEqual(failures.length, 1)
+  })
 
-      assert.strictEqual(listFilesCalls, expectedCalls, type)
-    }
+  it('allows production and product scopes', async () => {
+    const titles = [
+      'feat(http): change',
+      'fix(ci-visibility): change',
+      'fix(test-optimization): change',
+      'perf(test): change',
+      'docs(test): change',
+      'test(http): change',
+    ]
 
-    await Promise.all(validations)
+    await Promise.all(titles.map(async (title) => {
+      const failures = await validate(title)
+      assert.deepStrictEqual(failures, [], title)
+    }))
+  })
+
+  it('does not call the GitHub API during validation', () => {
+    assert.doesNotMatch(validation.with.script, /\bgithub\b/)
   })
 
   it('syncs labels only for events that can require reconciliation', () => {
@@ -73,9 +88,5 @@ describe('PR title workflow', () => {
       "(github.event.action == 'opened' || " +
       "github.event.action == 'reopened' || " +
       "(github.event.action == 'edited' && github.event.changes.title != null))")
-  })
-
-  it('checks out the workflow revision', () => {
-    assert.strictEqual(checkout.with.ref, '$' + '{{ github.sha }}')
   })
 })

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -15,6 +15,9 @@ const labelSync = steps.get('Sync labels with PR title')
 const validateTitle = vm.runInNewContext(
   `(async function validateTitle (context, core, process) {\n${validation.with.script}\n})`
 )
+const syncLabels = vm.runInNewContext(
+  `(async function syncLabels (context, github, process) {\n${labelSync.with.script}\n})`
+)
 const validate = async (title) => {
   const failures = []
   const context = { payload: { pull_request: { title } } }
@@ -78,6 +81,18 @@ describe('PR title workflow', () => {
     ])
   })
 
+  it('rejects empty entries in a scope list', async () => {
+    const titles = [
+      'fix(docs,): change',
+      'fix(docs, ): change',
+    ]
+
+    await Promise.all(titles.map(async (title) => {
+      const failures = await validate(title)
+      assert.deepStrictEqual(failures, ['PR title scope list contains an empty scope.'], title)
+    }))
+  })
+
   it('allows production and product scopes', async () => {
     const titles = [
       'feat(http): change',
@@ -101,6 +116,37 @@ describe('PR title workflow', () => {
 
   it('does not call the GitHub API during validation', () => {
     assert.doesNotMatch(validation.with.script, /\bgithub\./)
+  })
+
+  it('syncs each label in a scope list', async () => {
+    let request
+    const context = {
+      repo: { owner: 'DataDog', repo: 'dd-trace-js' },
+      payload: {
+        action: 'opened',
+        pull_request: {
+          number: 1,
+          title: 'fix(http, tests): change',
+          labels: [],
+        },
+      },
+    }
+    const github = {
+      paginate: {
+        iterator: () => [{ data: ['fix', 'http', 'tests'].map(name => ({ name })) }],
+      },
+      rest: {
+        issues: {
+          listLabelsForRepo: Function.prototype,
+          setLabels: value => { request = value },
+        },
+      },
+    }
+    const process = { env: { PR_TITLE_PATTERN: job.env.PR_TITLE_PATTERN } }
+
+    await syncLabels(context, github, process)
+
+    assert.deepStrictEqual([...request.labels], ['fix', 'http', 'tests', 'semver-patch'])
   })
 
   it('syncs labels only for events that can require reconciliation', () => {

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import vm from 'node:vm'
 
 import { describe, it } from 'mocha'
@@ -10,111 +11,105 @@ const job = workflow.jobs['conventional-commit']
 const steps = new Map()
 for (const step of job.steps) steps.set(step.name, step)
 
-const validation = steps.get('Validate PR title')
+const checkout = steps.get('Checkout base revision')
+const fetchHead = steps.get('Fetch pull request head')
+const validation = steps.get('Validate PR title and release-note context')
 const labelSync = steps.get('Sync labels with PR title')
 const validateTitle = vm.runInNewContext(
-  `(async function validateTitle (context, core, process) {\n${validation.with.script}\n})`
+  `(async function validateTitle (context, core, process, require) {\n${validation.with.script}\n})`
 )
 const syncLabels = vm.runInNewContext(
   `(async function syncLabels (context, github, process) {\n${labelSync.with.script}\n})`
 )
-const validate = async (title) => {
+const require = createRequire(import.meta.url)
+const { isInternalOnly } = require('./release/changelog')
+const validate = async (title, files = []) => {
   const failures = []
-  const context = { payload: { pull_request: { title } } }
+  const commands = []
+  const context = {
+    payload: {
+      pull_request: {
+        title,
+        base: { sha: 'base-sha' },
+      },
+    },
+  }
   const core = {
     info: Function.prototype,
     setFailed: message => failures.push(message),
   }
   const process = { env: { PR_TITLE_PATTERN: job.env.PR_TITLE_PATTERN } }
+  const loadModule = (id) => {
+    if (id === 'node:child_process') {
+      return {
+        execFileSync: (command, args, options) => {
+          commands.push({ command, args: [...args], options: { ...options } })
+          return `${files.join('\0')}${files.length ? '\0' : ''}`
+        },
+      }
+    }
+    if (id === './scripts/release/changelog') return { isInternalOnly }
+    assert.fail(`Unexpected module: ${id}`)
+  }
 
-  await validateTitle(context, core, process)
+  await validateTitle(context, core, process, loadModule)
 
-  return failures
+  return { commands, failures }
 }
 
 describe('PR title workflow', () => {
-  it('rejects production types for non-production scopes', async () => {
-    const expectedTypeByScope = new Map([
-      ['agents', 'docs'],
-      ['bench', 'bench'],
-      ['benchmark', 'bench'],
-      ['benchmarks', 'bench'],
-      ['build', 'build'],
-      ['chore', 'chore'],
-      ['codeowners', 'chore'],
-      ['dependabot', 'ci'],
-      ['deps-dev', 'chore'],
-      ['docs', 'docs'],
-      ['documentation', 'docs'],
-      ['eslint', 'chore'],
-      ['github', 'ci'],
-      ['gitlab', 'ci'],
-      ['integration-test', 'test'],
-      ['integration-tests', 'test'],
-      ['lint', 'chore'],
-      ['release', 'ci'],
-      ['scripts', 'chore'],
-      ['style', 'style'],
-      ['test', 'test'],
-      ['tests', 'test'],
-      ['testing', 'test'],
-      ['workflows', 'ci'],
-    ])
-
-    await Promise.all(['feat', 'fix', 'perf'].flatMap(type => [...expectedTypeByScope].map(
-      async ([scope, expectedType]) => {
-        const failures = await validate(`${type}(${scope}): change`)
-        assert.deepStrictEqual(failures, [
-          `PR title type "${type}" is not valid when every scope is non-production ` +
-          `("${scope}"). Use "${expectedType}" instead.`,
-        ])
-      }
-    )))
-  })
-
-  it('rejects a scope list when every scope is non-production', async () => {
-    const failures = await validate('fix(docs, tests): change')
-    assert.deepStrictEqual(failures, [
-      'PR title type "fix" is not valid when every scope is non-production ' +
-      '("docs, tests"). Use "docs" or "test" instead.',
-    ])
-  })
-
-  it('rejects empty entries in a scope list', async () => {
-    const titles = [
-      'fix(docs,): change',
-      'fix(docs, ): change',
-    ]
-
-    await Promise.all(titles.map(async (title) => {
-      const failures = await validate(title)
-      assert.deepStrictEqual(failures, ['PR title scope list contains an empty scope.'], title)
+  it('rejects public release-note types for internal-only changes', async () => {
+    await Promise.all(['feat', 'fix', 'perf', 'docs'].map(async (type) => {
+      const { failures } = await validate(`${type}(http): change`, [
+        'scripts/pr-title.spec.mjs',
+        'packages/dd-trace/test/index.spec.js',
+      ])
+      assert.deepStrictEqual(failures, [
+        `PR title type "${type}" is public, but every changed file is internal. ` +
+        'Use test, bench, ci, or chore.',
+      ])
     }))
   })
 
-  it('allows production and product scopes', async () => {
+  it('allows public release-note types when any changed file is public', async () => {
     const titles = [
       'feat(http): change',
-      'fix(ci-visibility): change',
-      'fix(test-optimization): change',
-      'fix(http, tests): change',
-      'feat(ci): change',
+      'fix(http): change',
       'perf(http): change',
-      'perf(agent): change',
-      'feat(coverage): change',
-      'fix(integration): change',
-      'fix: change',
       'docs(test): change',
-      'test(http): change',
     ]
 
     await Promise.all(titles.map(async (title) => {
-      const failures = await validate(title)
+      const { failures } = await validate(title, [
+        'scripts/pr-title.spec.mjs',
+        'packages/dd-trace/src/index.js',
+      ])
       assert.deepStrictEqual(failures, [], title)
     }))
   })
 
-  it('does not call the GitHub API during validation', () => {
+  it('skips file inspection for internal title types', async () => {
+    await Promise.all(['test', 'bench', 'ci', 'chore'].map(async (type) => {
+      const { commands, failures } = await validate(`${type}(http): change`)
+      assert.deepStrictEqual(failures, [])
+      assert.deepStrictEqual(commands, [])
+    }))
+  })
+
+  it('derives changed paths from the fetched PR ref without a GitHub API call', async () => {
+    const { commands } = await validate('fix(http): change', ['packages/dd-trace/src/index.js'])
+
+    assert.deepStrictEqual(commands, [{
+      command: 'git',
+      args: [
+        'diff',
+        '--name-only',
+        '--no-renames',
+        '-z',
+        'base-sha...refs/remotes/pull-request/head',
+      ],
+      options: { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+    }])
     assert.doesNotMatch(validation.with.script, /\bgithub\./)
   })
 
@@ -149,14 +144,25 @@ describe('PR title workflow', () => {
     assert.deepStrictEqual([...request.labels], ['fix', 'http', 'tests', 'semver-patch'])
   })
 
-  it('runs title-dependent steps only for events that can require reconciliation', () => {
-    const expectedCondition = "steps.rename.outputs.renamed != 'true' && " +
+  it('inspects files whenever the title or changed files can differ', () => {
+    const inspectionCondition = "steps.rename.outputs.renamed != 'true' && " +
+      "(github.event.action != 'edited' || github.event.changes.title != null)"
+    const titleCondition = "steps.rename.outputs.renamed != 'true' && " +
       "(github.event.action == 'opened' || " +
       "github.event.action == 'reopened' || " +
       "(github.event.action == 'edited' && github.event.changes.title != null))"
 
-    for (const step of [validation, labelSync]) {
-      assert.strictEqual(step.if.replaceAll(/\s+/g, ' '), expectedCondition)
+    for (const step of [checkout, fetchHead, validation]) {
+      assert.strictEqual(step.if.replaceAll(/\s+/g, ' '), inspectionCondition)
     }
+    assert.strictEqual(labelSync.if.replaceAll(/\s+/g, ' '), titleCondition)
+  })
+
+  it('checks out only the trusted base and fetches the PR head without checking it out', () => {
+    assert.strictEqual(checkout.with.ref, '$' + '{{ github.sha }}')
+    assert.strictEqual(checkout.with['fetch-depth'], 0)
+    assert.strictEqual(checkout.with['persist-credentials'], false)
+    assert.match(fetchHead.run, /refs\/pull\/\$\{PR_NUMBER\}\/head/)
+    assert.match(fetchHead.run, /refs\/remotes\/pull-request\/head/)
   })
 })

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -144,9 +144,8 @@ describe('PR title workflow', () => {
     assert.deepStrictEqual([...request.labels], ['fix', 'http', 'tests', 'semver-patch'])
   })
 
-  it('inspects files whenever the title or changed files can differ', () => {
-    const inspectionCondition = "steps.rename.outputs.renamed != 'true' && " +
-      "(github.event.action != 'edited' || github.event.changes.title != null)"
+  it('inspects files for every event unless the title was auto-renamed', () => {
+    const inspectionCondition = "steps.rename.outputs.renamed != 'true'"
     const titleCondition = "steps.rename.outputs.renamed != 'true' && " +
       "(github.event.action == 'opened' || " +
       "github.event.action == 'reopened' || " +

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -32,21 +32,35 @@ const validate = async (title) => {
 describe('PR title workflow', () => {
   it('rejects production types for non-production scopes', async () => {
     const expectedTypeByScope = new Map([
+      ['agents', 'docs'],
       ['bench', 'bench'],
       ['benchmark', 'bench'],
       ['benchmarks', 'bench'],
       ['build', 'build'],
       ['chore', 'chore'],
       ['ci', 'ci'],
+      ['codeowners', 'chore'],
+      ['coverage', 'test'],
+      ['dependabot', 'ci'],
+      ['deps-dev', 'chore'],
       ['docs', 'docs'],
       ['documentation', 'docs'],
+      ['eslint', 'chore'],
+      ['github', 'ci'],
+      ['gitlab', 'ci'],
+      ['integration-test', 'test'],
+      ['integration-tests', 'test'],
+      ['lint', 'chore'],
+      ['release', 'ci'],
+      ['scripts', 'chore'],
       ['style', 'style'],
       ['test', 'test'],
       ['tests', 'test'],
       ['testing', 'test'],
+      ['workflows', 'ci'],
     ])
 
-    await Promise.all(['feat', 'fix'].flatMap(type => [...expectedTypeByScope].map(
+    await Promise.all(['feat', 'fix', 'perf'].flatMap(type => [...expectedTypeByScope].map(
       async ([scope, expectedType]) => {
         const failures = await validate(`${type}(${scope}): change`)
         assert.deepStrictEqual(failures, [
@@ -67,7 +81,9 @@ describe('PR title workflow', () => {
       'feat(http): change',
       'fix(ci-visibility): change',
       'fix(test-optimization): change',
-      'perf(test): change',
+      'perf(http): change',
+      'perf(agent): change',
+      'fix(integration): change',
       'docs(test): change',
       'test(http): change',
     ]
@@ -79,7 +95,7 @@ describe('PR title workflow', () => {
   })
 
   it('does not call the GitHub API during validation', () => {
-    assert.doesNotMatch(validation.with.script, /\bgithub\b/)
+    assert.doesNotMatch(validation.with.script, /\bgithub\./)
   })
 
   it('syncs labels only for events that can require reconciliation', () => {

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -63,16 +63,19 @@ describe('PR title workflow', () => {
       async ([scope, expectedType]) => {
         const failures = await validate(`${type}(${scope}): change`)
         assert.deepStrictEqual(failures, [
-          `PR title type "${type}" is not valid for non-production scope "${scope}". ` +
-          `Use "${expectedType}" instead.`,
+          `PR title type "${type}" is not valid when every scope is non-production ` +
+          `("${scope}"). Use "${expectedType}" instead.`,
         ])
       }
     )))
   })
 
-  it('rejects a non-production scope in a scope list', async () => {
-    const failures = await validate('fix(http, tests): change')
-    assert.strictEqual(failures.length, 1)
+  it('rejects a scope list when every scope is non-production', async () => {
+    const failures = await validate('fix(docs, tests): change')
+    assert.deepStrictEqual(failures, [
+      'PR title type "fix" is not valid when every scope is non-production ' +
+      '("docs, tests"). Use "docs" or "test" instead.',
+    ])
   })
 
   it('allows production and product scopes', async () => {
@@ -80,6 +83,7 @@ describe('PR title workflow', () => {
       'feat(http): change',
       'fix(ci-visibility): change',
       'fix(test-optimization): change',
+      'fix(http, tests): change',
       'perf(http): change',
       'perf(agent): change',
       'feat(coverage): change',

--- a/scripts/pr-title.spec.mjs
+++ b/scripts/pr-title.spec.mjs
@@ -40,7 +40,6 @@ describe('PR title workflow', () => {
       ['chore', 'chore'],
       ['ci', 'ci'],
       ['codeowners', 'chore'],
-      ['coverage', 'test'],
       ['dependabot', 'ci'],
       ['deps-dev', 'chore'],
       ['docs', 'docs'],
@@ -83,7 +82,9 @@ describe('PR title workflow', () => {
       'fix(test-optimization): change',
       'perf(http): change',
       'perf(agent): change',
+      'feat(coverage): change',
       'fix(integration): change',
+      'fix: change',
       'docs(test): change',
       'test(http): change',
     ]


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Removes the pull-request files REST API call from PR title validation without removing file-aware validation.

The workflow checks out the trusted base revision, fetches the PR head as Git objects, and obtains changed paths with a NUL-delimited `git diff`. It never checks out or executes the PR head in the privileged `pull_request_target` job. Disabling rename detection makes both the old and new paths participate in classification, matching the previous API-based behavior.

Validation continues to use the repository's existing `isInternalOnly` classifier, so `feat`, `fix`, `perf`, and `docs` are rejected when every changed file is internal. This avoids maintaining a second, necessarily incomplete list of title scopes.

File-aware validation runs for every configured PR event. This prevents a body-only edit from producing a successful check that supersedes a previous title-validation failure on the same commit. Label synchronization remains limited to title-relevant events.

The PR template documents how to select types for non-production changes, with concrete good and bad examples. `AGENTS.md` stays lean by directing agents to read that template before opening or updating a PR. Multi-scope titles also synchronize each matching repository label.

### Motivation

We keep hitting GitHub API rate limits. The webhook payload does not contain the changed filenames, but the validator should not need a rate-limited REST request to recover data already available through Git.

Using Git preserves the authoritative path-based check while removing API quota usage from validation. The trade-off is a trusted-base checkout and Git fetch on relevant events; that is preferable to both rate-limit failures and the correctness/maintenance gaps of a static scope list.

Putting the same guidance in the PR template should help AI agents choose the correct title before validation runs.

### Additional Notes

Validated with the focused PR title tests, ESLint, actionlint, the `AGENTS.md` size check, and `git diff --check`.

*Generated by Codex.*
