### PR TITLE
ci(artifacts): verify failed upload retries

### DIFF
--- a/.github/actions/upload-coverage-artifact/action.yml
+++ b/.github/actions/upload-coverage-artifact/action.yml
@@ -37,9 +37,21 @@ runs:
       shell: bash
       run: sleep 10
     - if: github.actor != 'dependabot[bot]' && steps.check.outputs.has_coverage == 'true' && steps.upload.outcome == 'failure'
+      id: retry
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-${{ inputs.flags }}__${{ github.job }}-${{ strategy.job-index }}
         path: ${{ inputs.report-dir }}/**/lcov.info
         retention-days: 1
         overwrite: true
+    # Finalization can fail after GitHub stores the artifact. Only recover when the existing artifact
+    # is downloadable and passes download-artifact's digest validation.
+    - if: >-
+        github.actor != 'dependabot[bot]' &&
+        steps.check.outputs.has_coverage == 'true' &&
+        steps.retry.outcome == 'failure'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: coverage-${{ inputs.flags }}__${{ github.job }}-${{ strategy.job-index }}
+        path: ${{ runner.temp }}/artifact-verification/coverage-${{ github.job }}-${{ strategy.job-index }}

--- a/.github/actions/upload-junit-artifacts/action.yml
+++ b/.github/actions/upload-junit-artifacts/action.yml
@@ -27,9 +27,18 @@ runs:
       shell: bash
       run: sleep 10
     - if: github.actor != 'dependabot[bot]' && steps.check.outputs.has_xml == 'true' && steps.upload.outcome == 'failure'
+      id: retry
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: junit-${{ inputs.id }}
         path: "*.xml"
         overwrite: true
         retention-days: 1
+    # Finalization can fail after GitHub stores the artifact. Only recover when the existing artifact
+    # is downloadable and passes download-artifact's digest validation.
+    - if: github.actor != 'dependabot[bot]' && steps.check.outputs.has_xml == 'true' && steps.retry.outcome == 'failure'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: junit-${{ inputs.id }}
+        path: ${{ runner.temp }}/artifact-verification/junit-${{ inputs.id }}

--- a/scripts/upload-artifacts.spec.mjs
+++ b/scripts/upload-artifacts.spec.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+import { describe, it } from 'mocha'
+import YAML from 'yaml'
+
+const actions = new Map([
+  ['coverage', '../.github/actions/upload-coverage-artifact/action.yml'],
+  ['JUnit', '../.github/actions/upload-junit-artifacts/action.yml'],
+])
+
+for (const [name, path] of actions) {
+  describe(`${name} artifact upload`, () => {
+    const action = YAML.parse(fs.readFileSync(new URL(path, import.meta.url), 'utf8'))
+
+    it('recovers a failed retry only when the artifact can be downloaded', () => {
+      const uploads = action.runs.steps.filter(step => step.uses?.startsWith('actions/upload-artifact@'))
+      const downloads = action.runs.steps.filter(step => step.uses?.startsWith('actions/download-artifact@'))
+
+      assert.strictEqual(uploads.length, 2)
+      assert.strictEqual(uploads[0].id, 'upload')
+      assert.strictEqual(uploads[0]['continue-on-error'], true)
+      assert.match(uploads[1].if, /steps\.upload\.outcome == 'failure'/)
+      assert.strictEqual(uploads[1].id, 'retry')
+      assert.strictEqual(uploads[1]['continue-on-error'], true)
+      assert.strictEqual(uploads[1].with.overwrite, true)
+
+      assert.strictEqual(downloads.length, 1)
+      assert.match(downloads[0].if, /steps\.retry\.outcome == 'failure'/)
+      assert.strictEqual(downloads[0].with.name, uploads[0].with.name)
+      assert.strictEqual(downloads[0].with.name, uploads[1].with.name)
+      assert.match(downloads[0].with.path, /\$\{\{ runner\.temp \}\}/)
+      assert.strictEqual(downloads[0]['continue-on-error'], undefined)
+    })
+  })
+}


### PR DESCRIPTION
### What does this PR do?

Keeps the existing retry for coverage and JUnit artifact uploads. If the retry
also reports a failure, the composite action downloads the artifact by its exact
name with `actions/download-artifact`. The job only recovers when that download
succeeds, including the action's built-in artifact digest validation.

Adds focused tests for both composite action configurations.

### Motivation

In the linked incident, `upload-artifact` sent the artifact bytes before
finalization returned 403. The retry then returned 409 because the artifact name
already existed. Rerunning the full workflow in that case is expensive, but
unconditionally ignoring both errors could hide an artifact that is missing or
unusable.

This recovery distinguishes a successfully stored but unacknowledged artifact
from a genuine upload failure:
https://github.com/DataDog/dd-trace-js/actions/runs/34251270594/job/102146018552

### Additional Notes

Validated with:

- `npm run test:scripts` (200 passing)
- `npm run lint`
- `git diff --check`

*Generated by Codex.*
