### PR TITLE
chore(deps): pin import-in-the-middle to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.11",
-    "import-in-the-middle": "^3.3.2",
+    "import-in-the-middle": "3.4.0",
     "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2661,10 +2661,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz#af7dacd4f3c25826abfc8314ebc71b6dcf47e238"
-  integrity sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==
+import-in-the-middle@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.4.0.tgz#74d868189dddbc300c3a558743504884277038de"
+  integrity sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw==
   dependencies:
     cjs-module-lexer "^2.2.0"
     es-module-lexer "^2.2.0"


### PR DESCRIPTION
## What does this PR do?

Pins `import-in-the-middle` from `^3.3.2` to exactly `3.4.0` to fix the failing ESM/IITM tests on master.

## Why

`import-in-the-middle@3.5.0` was published on 2026-09-08 at 16:25 UTC. Master CI had been green all day, then the very next Instrumentation runs failed ([run 34265128529](https://github.com/DataDog/dd-trace-js/actions/runs/34265128529)) because the integration test sandboxes install dd-trace fresh, so `^3.3.2` started resolving to 3.5.0.

3.5.0 ([`support es-module-lexer v3` + reduced ESM wrapper allocations](https://github.com/nodejs/import-in-the-middle/compare/import-in-the-middle-v3.4.0...import-in-the-middle-v3.5.0)) breaks us in two ways, seen in the `integration-esbuild` jobs:

1. `TypeError: Invalid value used as weak map key` at `binders.set(namespace, binder)` in IITM's generated ESM wrapper runtime — crashes bundled ESM apps at runtime (`should build basic esm http server exporting esm and create web traces at runtime`).
2. `exportNames is not iterable` in `packages/datadog-esbuild/src/utils.js` — the esbuild plugin drives IITM's `get-exports` generator, whose output shape changed with the lexer v3 path (`should build basic hono server exporting esm...`).

`3.4.0` is the last known-good version: it had been resolving from the `^3.3.2` range since 2026-08-28 with green CI.

## Verification

- `npx mocha integration-tests/esbuild/esm.integration.spec.js` — 8 passing with 3.4.0, including the two tests that failed in CI
- `yarn.lock` updated with minimal churn (single entry; 3.4.0 still uses `es-module-lexer ^2.2.0`)

Once IITM's es-module-lexer v3 path is compatible with our generated-wrapper and datadog-esbuild expectations, the pin can be relaxed again.

- [ ] The proper type label is present (`bug`, `feature`, `maintenance`, `patch`)
- [x] If a specific component was changed, the proper team label was added