### PR TITLE
fix(tracing): detach truncated string storage

### DIFF
--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [oldest, maintenance, 22, active, latest]
+        node-version: [oldest, maintenance, active, latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/node

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [oldest, maintenance, active, latest]
+        node-version: [oldest, maintenance, 22, active, latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/node

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -3,6 +3,7 @@
 const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const CachePlugin = require('../../dd-trace/src/plugins/cache')
 const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
+const { truncateString } = require('../../dd-trace/src/util')
 
 const MAX_ARG_LENGTH = 100
 const MAX_COMMAND_LENGTH = 1000
@@ -89,7 +90,7 @@ function formatCommand (command, args, argsStartIndex = 0) {
     if (typeof arg === 'function') continue
 
     result = `${result} ${formatArg(arg)}`
-    if (result.length > MAX_COMMAND_LENGTH) return result.slice(0, MAX_COMMAND_LENGTH - 3) + '...'
+    if (result.length > MAX_COMMAND_LENGTH) return truncateString(result, MAX_COMMAND_LENGTH, '...')
   }
 
   return result
@@ -97,7 +98,7 @@ function formatCommand (command, args, argsStartIndex = 0) {
 
 function formatArg (arg) {
   if (typeof arg === 'string') {
-    return arg.length > MAX_ARG_LENGTH ? arg.slice(0, MAX_ARG_LENGTH - 3) + '...' : arg
+    return truncateString(arg, MAX_ARG_LENGTH, '...')
   }
   // Number stringification is bounded (~23 chars max), so it never hits MAX_ARG_LENGTH.
   if (typeof arg === 'number') return String(arg)

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -6,6 +6,7 @@ const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
 const { truncateString } = require('../../dd-trace/src/util')
 
 const MAX_ARG_LENGTH = 100
+const MAX_ARG_LENGTH_WITHOUT_COPY = 256
 const MAX_COMMAND_LENGTH = 1000
 
 class RedisPlugin extends CachePlugin {
@@ -90,19 +91,31 @@ function formatCommand (command, args, argsStartIndex = 0) {
     if (typeof arg === 'function') continue
 
     result = `${result} ${formatArg(arg)}`
-    if (result.length > MAX_COMMAND_LENGTH) return truncateString(result, MAX_COMMAND_LENGTH, '...')
+    if (result.length > MAX_COMMAND_LENGTH) return result.slice(0, MAX_COMMAND_LENGTH - 3) + '...'
   }
 
   return result
 }
 
+/**
+ * @param {unknown} arg
+ */
 function formatArg (arg) {
   if (typeof arg === 'string') {
-    return arg.length > MAX_ARG_LENGTH ? truncateString(arg, MAX_ARG_LENGTH, '...') : arg
+    return arg.length > MAX_ARG_LENGTH ? truncateArg(arg) : arg
   }
   // Number stringification is bounded (~23 chars max), so it never hits MAX_ARG_LENGTH.
   if (typeof arg === 'number') return String(arg)
   return '?'
+}
+
+/**
+ * @param {string} arg
+ */
+function truncateArg (arg) {
+  return arg.length > MAX_ARG_LENGTH_WITHOUT_COPY
+    ? truncateString(arg, MAX_ARG_LENGTH, '...')
+    : arg.slice(0, MAX_ARG_LENGTH - 3) + '...'
 }
 
 function normalizeConfig (config) {

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -98,7 +98,7 @@ function formatCommand (command, args, argsStartIndex = 0) {
 
 function formatArg (arg) {
   if (typeof arg === 'string') {
-    return truncateString(arg, MAX_ARG_LENGTH, '...')
+    return arg.length > MAX_ARG_LENGTH ? truncateString(arg, MAX_ARG_LENGTH, '...') : arg
   }
   // Number stringification is bounded (~23 chars max), so it never hits MAX_ARG_LENGTH.
   if (typeof arg === 'number') return String(arg)

--- a/packages/datadog-plugin-redis/test/bindstart-cache.spec.js
+++ b/packages/datadog-plugin-redis/test/bindstart-cache.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
 
 const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
@@ -124,5 +125,61 @@ describe('RedisPlugin bindStart service caching', () => {
     assert.strictEqual(calls[1].args[1].tags['service.name'], 'custom-b')
     assert.strictEqual(calls[2].args[1].tags['service.name'], 'custom-a')
     assert.strictEqual(calls[3].args[1].tags['service.name'], 'custom-b')
+  })
+})
+
+describe('RedisPlugin bindStart retention', () => {
+  it('does not retain long command argument storage', () => {
+    const pluginPath = JSON.stringify(require.resolve('../src'))
+    const script = `
+      const RedisPlugin = require(${pluginPath})
+      const values = new Array(400)
+      let index = 0
+      const span = {
+        _spanContext: { _tags: {} },
+        setTag () {},
+        finish () {},
+        addLink () {},
+      }
+      const tracer = {
+        _service: 'test',
+        _nomenclature: {
+          config: {},
+          opName () { return 'redis.command' },
+          serviceName () { return { name: 'test-redis' } },
+        },
+        startSpan (name, options) {
+          values[index++] = options.tags['redis.raw_command']
+          return span
+        },
+      }
+      const plugin = new RedisPlugin(tracer, {
+        codeOriginForSpans: {
+          enabled: false,
+          experimental: { exit_spans: { enabled: false } },
+        },
+      })
+      plugin.configure({ enabled: false })
+
+      for (let i = 0; i < values.length; i++) {
+        const parent = JSON.parse(JSON.stringify(
+          String(i).padStart(6, '0') + 'x'.repeat(128 * 1024)
+        ))
+        plugin.bindStart({
+          command: 'set',
+          args: ['key', parent.slice(0, 257)],
+          connectionOptions: { host: 'localhost', port: 6379 },
+          currentStore: {},
+        })
+      }
+
+      let retainedLength = 0
+      for (const value of values) retainedLength += value.length
+      process.stdout.write(String(retainedLength))
+    `
+    const result = spawnSync(process.execPath, ['--max-old-space-size=32', '--eval', script], { encoding: 'utf8' })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout, '43200')
   })
 })

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -100,15 +100,28 @@ describe('Plugin', () => {
           await Promise.all([client.set('multi-arg-key', 'multi-arg-value'), promise])
         })
 
-        it('trims a string arg longer than 100 chars', async () => {
-          const longValue = 'x'.repeat(150)
+        it('trims string args at the retention threshold boundaries', async () => {
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
-            assert.strictEqual(rawCommand, `SET long-key ${'x'.repeat(97)}...`)
-            assert.strictEqual(rawCommand.length, 'SET long-key '.length + 100)
-          }, { spanResourceMatch: /^SET$/ })
+            assert.strictEqual(rawCommand, [
+              'MSET',
+              'at-limit', 'a'.repeat(100),
+              'first-truncated', `${'b'.repeat(97)}...`,
+              'last-sliced', `${'c'.repeat(97)}...`,
+              'first-copied', `${'d'.repeat(97)}...`,
+            ].join(' '))
+          }, { spanResourceMatch: /^MSET$/ })
 
-          await Promise.all([client.set('long-key', longValue), promise])
+          await Promise.all([
+            client.sendCommand([
+              'MSET',
+              'at-limit', 'a'.repeat(100),
+              'first-truncated', 'b'.repeat(101),
+              'last-sliced', 'c'.repeat(256),
+              'first-copied', 'd'.repeat(257),
+            ]),
+            promise,
+          ])
         })
 
         it('redacts the AUTH password from the raw command', async () => {

--- a/packages/dd-trace/src/aiguard/evaluation.js
+++ b/packages/dd-trace/src/aiguard/evaluation.js
@@ -9,6 +9,7 @@ const { keepTrace } = require('../priority_sampler')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const { AI_GUARD } = require('../standalone/product')
 const telemetryMetrics = require('../telemetry/metrics')
+const { truncateString } = require('../util')
 const { normalizeRedactionReplacements, redactMessages } = require('./redaction')
 const TAGS = require('./tags')
 
@@ -306,7 +307,7 @@ class EvaluationReporter {
     if (typeof content === 'string') {
       if (content.length <= this.#maxContentSize) return false
 
-      message.content = content.slice(0, this.#maxContentSize)
+      message.content = truncateString(content, this.#maxContentSize)
       return true
     }
 
@@ -319,7 +320,7 @@ class EvaluationReporter {
       if (typeof text !== 'string') continue
 
       if (text.length > remainingContentSize) {
-        part.text = text.slice(0, remainingContentSize)
+        part.text = truncateString(text, remainingContentSize)
         truncated = true
         remainingContentSize = 0
       } else {

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -8,7 +8,7 @@ const web = require('../plugins/util/web')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const { keepTrace } = require('../priority_sampler')
 const { ASM } = require('../standalone/product')
-const { isEmpty } = require('../util')
+const { isEmpty, truncateString } = require('../util')
 const { getActiveRequest } = require('./store')
 const {
   incrementWafInitMetric,
@@ -431,7 +431,7 @@ function truncateRequestBody (target, depth = 0) {
   switch (typeof target) {
     case 'string':
       if (target.length > COLLECTED_REQUEST_BODY_MAX_STRING_LENGTH) {
-        return { value: target.slice(0, COLLECTED_REQUEST_BODY_MAX_STRING_LENGTH), truncated: true }
+        return { value: truncateString(target, COLLECTED_REQUEST_BODY_MAX_STRING_LENGTH), truncated: true }
       }
       return { value: target, truncated: false }
     case 'object': {

--- a/packages/dd-trace/src/payload-tagging/tagging.js
+++ b/packages/dd-trace/src/payload-tagging/tagging.js
@@ -68,13 +68,14 @@ function tagsFromObject (object, opts) {
 
     if (['number', 'boolean'].includes(typeof object) || Buffer.isBuffer(object)) {
       tagCount += 1
-      result[prefix] = truncateString(object.toString(), 5000)
+      const value = object.toString()
+      result[prefix] = value.length > 5000 ? truncateString(value, 5000) : value
       return
     }
 
     if (typeof object === 'string') {
       tagCount += 1
-      result[prefix] = truncateString(object, 5000)
+      result[prefix] = object.length > 5000 ? truncateString(object, 5000) : object
     }
 
     if (typeof object === 'object') {

--- a/packages/dd-trace/src/payload-tagging/tagging.js
+++ b/packages/dd-trace/src/payload-tagging/tagging.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { PAYLOAD_TAGGING_MAX_TAGS } = require('../constants')
+const { truncateString } = require('../util')
 
 const redactedKeys = new Set([
   'authorization', 'x-authorization', 'password', 'token',
@@ -67,13 +68,13 @@ function tagsFromObject (object, opts) {
 
     if (['number', 'boolean'].includes(typeof object) || Buffer.isBuffer(object)) {
       tagCount += 1
-      result[prefix] = object.toString().slice(0, 5000)
+      result[prefix] = truncateString(object.toString(), 5000)
       return
     }
 
     if (typeof object === 'string') {
       tagCount += 1
-      result[prefix] = object.slice(0, 5000)
+      result[prefix] = truncateString(object, 5000)
     }
 
     if (typeof object === 'object') {

--- a/packages/dd-trace/src/payload-tagging/tagging.js
+++ b/packages/dd-trace/src/payload-tagging/tagging.js
@@ -8,6 +8,18 @@ const redactedKeys = new Set([
 ])
 const truncated = 'truncated'
 const redacted = 'redacted'
+const maxValueLength = 5000
+const maxRetainedValueLength = maxValueLength * 2
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function truncateValue (value) {
+  return value.length > maxRetainedValueLength
+    ? truncateString(value, maxValueLength)
+    : value.slice(0, maxValueLength)
+}
 
 /**
  * Escapes dots in keys to preserve hierarchy in flattened tag names.
@@ -69,13 +81,13 @@ function tagsFromObject (object, opts) {
     if (['number', 'boolean'].includes(typeof object) || Buffer.isBuffer(object)) {
       tagCount += 1
       const value = object.toString()
-      result[prefix] = value.length > 5000 ? truncateString(value, 5000) : value
+      result[prefix] = value.length > maxValueLength ? truncateValue(value) : value
       return
     }
 
     if (typeof object === 'string') {
       tagCount += 1
-      result[prefix] = object.length > 5000 ? truncateString(object, 5000) : object
+      result[prefix] = object.length > maxValueLength ? truncateValue(object) : object
     }
 
     if (typeof object === 'object') {

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -3,6 +3,7 @@
 const { LRUCache } = require('../../../../vendor/dist/lru-cache')
 const { PEER_SERVICE_KEY, PEER_SERVICE_SOURCE_KEY } = require('../constants')
 const propagationHash = require('../propagation-hash')
+const { truncateString } = require('../util')
 const StoragePlugin = require('./storage')
 
 // Unreserved RFC 3986 set that `encodeURIComponent` leaves untouched (a conservative subset:
@@ -147,7 +148,7 @@ class DatabasePlugin extends StoragePlugin {
       : 5000 // same as what the agent does
 
     if (this.config.truncate && query && query.length > maxLength) {
-      query = `${query.slice(0, maxLength - 3)}...`
+      query = truncateString(query, maxLength, '...')
     }
 
     return query

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -144,6 +144,21 @@ function formatKnuthRate (rate) {
   }
 }
 
+/**
+ * Truncates a string without retaining its original backing store.
+ *
+ * @param {string} value
+ * @param {number} maxLength
+ * @param {string} [suffix]
+ * @returns {string}
+ */
+function truncateString (value, maxLength, suffix = '') {
+  if (value.length <= maxLength) return value
+
+  const prefix = value.slice(0, maxLength - suffix.length)
+  return Buffer.from(prefix, 'utf16le').toString('utf16le') + suffix
+}
+
 module.exports = {
   isEmpty,
   isTrue,
@@ -155,4 +170,5 @@ module.exports = {
   ddBasePath: globalThis.__DD_ESBUILD_BASEPATH || calculateDDBasePath(__dirname),
   normalizePluginEnvName,
   formatKnuthRate,
+  truncateString,
 }

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -145,7 +145,7 @@ function formatKnuthRate (rate) {
 }
 
 /**
- * Truncates a string without retaining its original backing store.
+ * Truncates an oversized string without retaining its original backing store.
  *
  * @param {string} value
  * @param {number} maxLength
@@ -153,10 +153,8 @@ function formatKnuthRate (rate) {
  * @returns {string}
  */
 function truncateString (value, maxLength, suffix = '') {
-  if (value.length <= maxLength) return value
-
-  const prefix = value.slice(0, maxLength - suffix.length)
-  return Buffer.from(prefix, 'utf16le').toString('utf16le') + suffix
+  // V8 flattens this bounded concatenation before creating the slice.
+  return (' ' + value.slice(0, maxLength - suffix.length)).slice(1) + suffix
 }
 
 module.exports = {

--- a/packages/dd-trace/test/payload-tagging/index.spec.js
+++ b/packages/dd-trace/test/payload-tagging/index.spec.js
@@ -126,12 +126,14 @@ describe('Payload tagger', () => {
     })
 
     it('should truncate long strings and buffers', () => {
-      const value = 'x'.repeat(5001)
-      const tags = tagsFromObject({ string: value, buffer: Buffer.from(value) }, defaultOpts)
-      assert.deepStrictEqual(tags, {
-        'http.payload.string': 'x'.repeat(5000),
-        'http.payload.buffer': 'x'.repeat(5000),
-      })
+      for (const length of [5000, 5001, 10_000, 10_001]) {
+        const value = 'x'.repeat(length)
+        const tags = tagsFromObject({ string: value, buffer: Buffer.from(value) }, defaultOpts)
+        assert.deepStrictEqual(tags, {
+          'http.payload.string': 'x'.repeat(5000),
+          'http.payload.buffer': 'x'.repeat(5000),
+        })
+      }
     })
 
     it('should provide tags from simple JSON objects, casting to strings where necessary', () => {

--- a/packages/dd-trace/test/payload-tagging/index.spec.js
+++ b/packages/dd-trace/test/payload-tagging/index.spec.js
@@ -125,6 +125,15 @@ describe('Payload tagger', () => {
       assert.deepStrictEqual(tags, { 'http.payload.foo': 'bar' })
     })
 
+    it('should truncate long strings and buffers', () => {
+      const value = 'x'.repeat(5001)
+      const tags = tagsFromObject({ string: value, buffer: Buffer.from(value) }, defaultOpts)
+      assert.deepStrictEqual(tags, {
+        'http.payload.string': 'x'.repeat(5000),
+        'http.payload.buffer': 'x'.repeat(5000),
+      })
+    })
+
     it('should provide tags from simple JSON objects, casting to strings where necessary', () => {
       const input = {
         foo: { bar: { baz: 1, quux: 2 } },

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -62,24 +62,21 @@ describe('util', () => {
       const utilPath = JSON.stringify(require.resolve('../src/util'))
       const script = `
         const { truncateString } = require(${utilPath})
-        const count = 2000
-        const collect = () => {
-          for (let i = 0; i < 5; i++) global.gc()
-        }
-        collect()
-        const before = process.memoryUsage().heapUsed
+        const count = 400
         const values = new Array(count)
         for (let i = 0; i < count; i++) {
-          const value = String(i).padStart(6, '0') + 'x'.repeat(20 * 1024)
+          // Parsing creates independent flat strings instead of ropes that can share storage.
+          const value = JSON.parse(JSON.stringify(String(i).padStart(6, '0') + 'x'.repeat(128 * 1024)))
           values[i] = truncateString(value, 100, '...')
         }
-        collect()
-        process.stdout.write(String((process.memoryUsage().heapUsed - before) / count))
+        let retainedLength = 0
+        for (const value of values) retainedLength += value.length
+        process.stdout.write(String(retainedLength))
       `
-      const result = spawnSync(process.execPath, ['--expose-gc', '-e', script], { encoding: 'utf8' })
+      const result = spawnSync(process.execPath, ['--max-old-space-size=32', '-e', script], { encoding: 'utf8' })
 
       assert.strictEqual(result.status, 0, result.stderr)
-      assert.ok(Number(result.stdout) < 1024, `${result.stdout} bytes retained per value`)
+      assert.strictEqual(result.stdout, '40000')
     })
   })
 

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -62,7 +62,7 @@ describe('util', () => {
       const utilPath = JSON.stringify(require.resolve('../src/util'))
       const script = `
         const { truncateString } = require(${utilPath})
-        const count = 400
+        const count = 200
         const values = new Array(count)
         for (let i = 0; i < count; i++) {
           // Parsing creates independent flat strings instead of ropes that can share storage.
@@ -73,10 +73,10 @@ describe('util', () => {
         for (const value of values) retainedLength += value.length
         process.stdout.write(String(retainedLength))
       `
-      const result = spawnSync(process.execPath, ['--max-old-space-size=32', '-e', script], { encoding: 'utf8' })
+      const result = spawnSync(process.execPath, ['--max-old-space-size=16', '-e', script], { encoding: 'utf8' })
 
       assert.strictEqual(result.status, 0, result.stderr)
-      assert.strictEqual(result.stdout, '40000')
+      assert.strictEqual(result.stdout, '20000')
     })
   })
 

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -49,10 +49,6 @@ const NONMATCH_CASES = [
 
 describe('util', () => {
   describe('truncateString', () => {
-    it('returns the original value within the limit', () => {
-      assert.strictEqual(truncateString('value', 5, '...'), 'value')
-    })
-
     it('includes the suffix in the limit', () => {
       assert.strictEqual(truncateString('abcdef', 5, '...'), 'ab...')
     })

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -1,11 +1,20 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
 
 const { describe, it } = require('mocha')
 
 require('./setup/core')
-const { isEmpty, isTrue, isFalse, globMatch, getSegment, stripQueryAndFragment } = require('../src/util')
+const {
+  isEmpty,
+  isTrue,
+  isFalse,
+  globMatch,
+  getSegment,
+  stripQueryAndFragment,
+  truncateString,
+} = require('../src/util')
 
 const TRUES = [
   1,
@@ -39,6 +48,45 @@ const NONMATCH_CASES = [
 ]
 
 describe('util', () => {
+  describe('truncateString', () => {
+    it('returns the original value within the limit', () => {
+      assert.strictEqual(truncateString('value', 5, '...'), 'value')
+    })
+
+    it('includes the suffix in the limit', () => {
+      assert.strictEqual(truncateString('abcdef', 5, '...'), 'ab...')
+    })
+
+    it('preserves UTF-16 code units', () => {
+      const value = `ab\uD83D${'x'.repeat(100)}`
+      assert.strictEqual(truncateString(value, 3), value.slice(0, 3))
+    })
+
+    it('does not retain the full input through the truncated value', () => {
+      const utilPath = JSON.stringify(require.resolve('../src/util'))
+      const script = `
+        const { truncateString } = require(${utilPath})
+        const count = 2000
+        const collect = () => {
+          for (let i = 0; i < 5; i++) global.gc()
+        }
+        collect()
+        const before = process.memoryUsage().heapUsed
+        const values = new Array(count)
+        for (let i = 0; i < count; i++) {
+          const value = String(i).padStart(6, '0') + 'x'.repeat(20 * 1024)
+          values[i] = truncateString(value, 100, '...')
+        }
+        collect()
+        process.stdout.write(String((process.memoryUsage().heapUsed - before) / count))
+      `
+      const result = spawnSync(process.execPath, ['--expose-gc', '-e', script], { encoding: 'utf8' })
+
+      assert.strictEqual(result.status, 0, result.stderr)
+      assert.ok(Number(result.stdout) < 1024, `${result.stdout} bytes retained per value`)
+    })
+  })
+
   it('isTrue works', () => {
     TRUES.forEach((v) => {
       assert.strictEqual(isTrue(v), true)


### PR DESCRIPTION
String#slice can produce a V8 SlicedString that retains the complete source allocation. The tracer can then retain large caller inputs through truncated metadata.

Use a bounded concatenation for callers that require detached output. Keep ordinary slicing on bounded-retention fast paths. Redis arguments use String#slice through 256 code units for a 100-code-unit tag. Payload tags use it through 10,000 code units for a 5,000-code-unit tag.

At 5,001 code units, focused payload truncation fell from 373 ns to 12 ns on Node 22.23.2. Longer values still detach their backing storage.

Fixes: https://github.com/DataDog/dd-trace-js/issues/10242