### PR TITLE
test(claude-agent-sdk): restore VCR CI

### DIFF
--- a/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
@@ -154,6 +154,8 @@ describe('Plugin', () => {
             env: {
               ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
               CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: true,
+              // Prevent server-controlled token-budget reminders from changing cassette request shapes.
+              CLAUDE_CODE_TOTAL_TOKENS_REMINDER: 'off',
               ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
             },
           },

--- a/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
@@ -153,8 +153,9 @@ describe('Plugin', () => {
             pathToClaudeCodeExecutable,
             env: {
               ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
+              // Keep cassette-backed tests independent of Claude Code's remote configuration.
+              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
               CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: true,
-              // Prevent server-controlled token-budget reminders from changing cassette request shapes.
               CLAUDE_CODE_TOTAL_TOKENS_REMINDER: 'off',
               ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
             },

--- a/packages/datadog-plugin-claude-agent-sdk/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-claude-agent-sdk/test/integration-test/server.mjs
@@ -52,6 +52,8 @@ const stream = query({
     env: {
       ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
       CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: true,
+      // Prevent server-controlled token-budget reminders from changing cassette request shapes.
+      CLAUDE_CODE_TOTAL_TOKENS_REMINDER: 'off',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     },
   },

--- a/packages/datadog-plugin-claude-agent-sdk/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-claude-agent-sdk/test/integration-test/server.mjs
@@ -51,8 +51,9 @@ const stream = query({
     pathToClaudeCodeExecutable,
     env: {
       ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
+      // Keep cassette-backed tests independent of Claude Code's remote configuration.
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
       CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: true,
-      // Prevent server-controlled token-budget reminders from changing cassette request shapes.
       CLAUDE_CODE_TOTAL_TOKENS_REMINDER: 'off',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     },

--- a/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
@@ -88,8 +88,9 @@ describe('Plugin', () => {
           pathToClaudeCodeExecutable,
           env: {
             ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
+            // Keep cassette-backed tests independent of Claude Code's remote configuration.
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
             CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: true,
-            // Prevent server-controlled token-budget reminders from changing cassette request shapes.
             CLAUDE_CODE_TOTAL_TOKENS_REMINDER: 'off',
             ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
           },

--- a/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
@@ -89,6 +89,8 @@ describe('Plugin', () => {
           env: {
             ANTHROPIC_BASE_URL: 'http://127.0.0.1:9126/vcr/claude-agent-sdk',
             CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: true,
+            // Prevent server-controlled token-budget reminders from changing cassette request shapes.
+            CLAUDE_CODE_TOTAL_TOKENS_REMINDER: 'off',
             ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
           },
         },


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"57145f83-7d43-47df-bef8-cf68aed6be41","workflowId":"a072bb7f-85cf-47c1-a124-ca378d0fc4b5","codeChangeId":"a072bb7f-85cf-47c1-a124-ca378d0fc4b5","sourceType":"chat"} -->
### What does this PR do?

- Disables Claude Code nonessential traffic and its server-controlled token reminders in all Claude Agent SDK cassette-backed tests.
- Keeps APM, ESM, and LLMObs requests stable so they continue matching the committed VCR cassettes.

### Motivation

The claude-agent-sdk CI job is failing on master and active branches because the pinned Claude Code executable still initializes Anthropic's remote feature configuration. Configuration changes can add content to provider requests, producing VCR cassette misses; the SDK then retries those HTTP 500 responses until the tests time out.

The original token-reminder override addressed one observed request change but did not isolate the executable from other remote configuration, so PR CI still failed. Disabling nonessential traffic removes that dynamic dependency while preserving the provider calls under test through Datadog's VCR proxy.

### Testing

- Node 24 APM plugin matrix: 2 passing.
- Node 24 ESM integration matrix: all 4 version/export variants passing.
- Node 24 LLMObs plugin matrix: 2 passing.
- Confirmed every provider request resolves to an existing committed cassette hash.
- Traced network system calls before and after the change: the test previously connected directly to api.anthropic.com; the final configuration makes no such connection.
- `npm run lint` passes.

### Additional Notes

CI installs Claude Agent SDK 0.3.259, not 0.3.266. The recent 0.3.266 release did not cause this failure; the pinned executable's behavior remained externally configurable.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/57145f83-7d43-47df-bef8-cf68aed6be41)

Comment @datadog to request changes