### PR TITLE
ci: add team freeze guard workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -385,6 +385,7 @@
 /.github/workflows/release-proposal.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
 /.github/workflows/release-validate.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
 /.github/workflows/stale.yml @DataDog/dd-trace-js @Datadog/lang-platform-js @dd-octo-sts
+/.github/workflows/team-freeze-guard.yml @Datadog/lang-platform-js
 /.github/workflows/update-3rdparty-licenses.yml @DataDog/dd-trace-js @DataDog/lang-platform-js @dd-octo-sts
 
 /.github/workflows/apm-capabilities.yml @DataDog/dd-trace-js @DataDog/apm-sdk-capabilities-js @dd-octo-sts

--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -37,7 +37,6 @@ jobs:
             dev/testing
             github_actions
           frozen-teams: |
-            @DataDog/dd-trace-js
             @DataDog/apm-idm-js
             @DataDog/ml-observability
             @DataDog/lang-platform-js

--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -1,0 +1,39 @@
+# How to configure:
+#
+# When no team is frozen, set `frozen-teams` to an empty string:
+# frozen-teams: ""
+#
+# When one or more teams are frozen, add them one per line with the @DataDog prefix:
+#
+# frozen-teams: |
+#   @DataDog/team-a
+#   @DataDog/team-b
+
+name: Team freeze guard
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  team-freeze-guard:
+    name: Team freeze guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: DataDog/team-freeze-guard@29e92069c40f38088e636f27df70d10c24e647b6  # v0.0.2
+        with:
+          bypass-labels: |
+            dev/testing
+            github_actions
+          frozen-teams: ""

--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -17,8 +17,7 @@ on:
       - opened
       - reopened
       - synchronize
-      - labeled
-      - unlabeled
+      - edited
       - ready_for_review
 
 permissions:
@@ -31,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: DataDog/team-freeze-guard@e4ff51a72cac229b238e5a302af0d3d955ae5b54 # v0.0.4
+      - uses: DataDog/team-freeze-guard@d28a2e357903b426122feaae225629bd63fcd2c5 # v0.0.5
         with:
-          bypass-labels: |
-            dev/testing
-            github_actions
+          # subset of pattern defined here:
+          # .github/workflows/pr-title.yml#L22C85-L23C128
+          bypass-title-pattern: '^(revert(!)?: .+|(fix|test|ci)(\(([^)]+)\))?(!)?: .+)'
           frozen-teams: |
             @DataDog/apm-idm-js
             @DataDog/ml-observability

--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -31,9 +31,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: DataDog/team-freeze-guard@29e92069c40f38088e636f27df70d10c24e647b6  # v0.0.2
+      - uses: DataDog/team-freeze-guard@e4ff51a72cac229b238e5a302af0d3d955ae5b54 # v0.0.4
         with:
           bypass-labels: |
             dev/testing
             github_actions
-          frozen-teams: ""
+          frozen-teams: |
+            @DataDog/dd-trace-js
+            @DataDog/apm-idm-js
+            @DataDog/ml-observability
+            @DataDog/lang-platform-js


### PR DESCRIPTION
### What does this PR do?
Adds a GitHub Action that will fail if the PR author or last committer is part of a frozen team. Please read https://github.com/DataDog/team-freeze-guard on how it works.

It also freeze those teams in the context of incident-57564 : 

@DataDog/apm-idm-js
@DataDog/ml-observability
@DataDog/lang-platform-js

The criteria is every team with a CI health lower than `95%` on the Green CI SLI message : 

<img width="462" height="412" alt="image" src="https://github.com/user-attachments/assets/76c5963f-a92e-4b0c-a2a4-e1fb41d0021d" />


### Motivation
RFC: https://docs.google.com/document/d/1qIhh1MHY08Vbn34MZXiGXwVaMvYSQkfgmBb9j2tqf-0/edit?tab=t.0#heading=h.o9e3y54cla5b

### Additional Notes

**Testing**
The workflow runs on `pull_request_target` (read DataDog/team-freeze-guard to understand why), so you can't test it on this PR. I've tested a lot on DataDog/team-freeze-guard itself, and system-tests, and I'll closely monitor actions once merged.

**Risks**
Freeze the entire repo if I mess up. But easy to revert. Already deployed on dd-trace-py with success.

**FAQ**
- The list of frozen teams should be in a central way to have better control on it.
  - This is a first iteration to have this code freeze available as soon as possible. I'll then start working on a place to store this list, with a restricted access on who can change it.
- Why in github action?
  - Most commonly used CI engine, already used by most small PR checks on almost all repos (labels, PR title, etc...) and easier to set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)