### PR TITLE
fix(graphql): load plugin for GraphQL Tools executor

### DIFF
--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -19,6 +19,7 @@ const plugins = {
   get '@google-cloud/pubsub' () { return require('../../../datadog-plugin-google-cloud-pubsub/src') },
   get '@google-cloud/vertexai' () { return require('../../../datadog-plugin-google-cloud-vertexai/src') },
   get '@google/genai' () { return require('../../../datadog-plugin-google-genai/src') },
+  get '@graphql-tools/executor' () { return require('../../../datadog-plugin-graphql/src') },
   get '@grpc/grpc-js' () { return require('../../../datadog-plugin-grpc/src') },
   get '@hapi/hapi' () { return require('../../../datadog-plugin-hapi/src') },
   get '@happy-dom/jest-environment' () { return require('../../../datadog-plugin-jest/src') },

--- a/packages/dd-trace/test/plugins/plugin-structure.spec.js
+++ b/packages/dd-trace/test/plugins/plugin-structure.spec.js
@@ -8,6 +8,7 @@ const { describe, it } = require('mocha')
 
 require('../setup/core')
 const hooks = require('../../../datadog-instrumentations/src/helpers/hooks')
+const plugins = require('../../src/plugins')
 
 const abstractPlugins = [
   'web', // web is an abstract plugin, and will not have an instrumentation file
@@ -173,6 +174,10 @@ describe('Plugin Structure Validation', () => {
     })
 
     assert.deepStrictEqual(missingHooks, missingInstrumentationHooks)
+  })
+
+  it('should map @graphql-tools/executor instrumentation to the graphql plugin', () => {
+    assert.strictEqual(plugins['@graphql-tools/executor'], plugins.graphql)
   })
 
   it('should include all canonical plugin ids used by the runtime plugin registry in index.d.ts', () => {


### PR DESCRIPTION
`@graphql-tools/executor` emitted its package name on the instrumentation load channel, but the plugin registry lacked that alias, so GraphQL spans stayed disabled.