### PR TITLE
fix(instrumentation): share bundler integration matching

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/bundler-register.js
+++ b/packages/datadog-instrumentations/src/helpers/bundler-register.js
@@ -4,13 +4,15 @@ const Module = require('module')
 const dc = require('dc-polyfill')
 
 const log = require('../../../dd-trace/src/log')
+const { loadChannel } = require('./register.js')
 const {
   filename,
-  loadChannel,
+  getDisabledInstrumentations,
   matchVersion,
-} = require('./register.js')
+} = require('./instrumentation-utils')
 const hooks = require('./hooks')
 const instrumentations = require('./instrumentations')
+const disabledInstrumentations = getDisabledInstrumentations()
 
 // register.js has now set up ritm (require-in-the-middle). In bundled
 // environments (webpack, esbuild), Node.js built-in modules required by
@@ -69,21 +71,22 @@ function doHook (name) {
 
   try {
     hookFn()
-  } catch {
-    log.error('esbuild-wrapped %s hook failed', name)
+  } catch (error) {
+    log.error('esbuild-wrapped %s hook failed: %s', name, String(error?.message ?? error), error)
   }
 }
+
+/** @typedef {{ package: string, module: unknown, version: string, path: string }} Payload */
 
 /** @type {Set<string>} */
 const instrumentedNodeModules = new Set()
 
-/** @typedef {{ package: string, module: unknown, version: string, path: string }} Payload */
 dc.subscribe(CHANNEL, (message) => {
   const payload = /** @type {Payload} */ (message)
   const name = payload.package
+  if (disabledInstrumentations.has(name)) return
 
   const isPrefixedWithNode = name.startsWith('node:')
-
   const isNodeModule = isPrefixedWithNode || !hooks[name]
 
   if (isNodeModule) {
@@ -105,15 +108,13 @@ dc.subscribe(CHANNEL, (message) => {
   }
 
   for (const { file, versions, hook } of instrumentation) {
-    if (payload.path !== filename(name, file) || !matchVersion(payload.version, versions)) {
-      continue
-    }
+    if (payload.path !== filename(name, file) || !matchVersion(payload.version, versions)) continue
 
     try {
-      loadChannel.publish({ name, version: payload.version, file })
+      loadChannel.publish({ name })
       payload.module = hook(payload.module, payload.version) ?? payload.module
-    } catch (e) {
-      log.error('Error executing bundler hook', e)
+    } catch (error) {
+      log.error('Error executing bundler hook: %s', String(error?.message ?? error), error)
     }
   }
 })

--- a/packages/datadog-instrumentations/src/helpers/instrumentation-utils.js
+++ b/packages/datadog-instrumentations/src/helpers/instrumentation-utils.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const { builtinModules } = require('node:module')
+
+const satisfies = require('../../../../vendor/dist/semifies')
+const { getValueFromEnvSources } = require('../../../dd-trace/src/config/helper')
+const { isRelativeRequire } = require('./shared-utils')
+
+/**
+ * @param {string|undefined} version
+ * @param {string[]|undefined} ranges
+ * @returns {boolean}
+ */
+function matchVersion (version, ranges) {
+  return !version || !ranges || ranges.some(range => satisfies(version, range))
+}
+
+/**
+ * @param {string} name
+ * @param {string} [file]
+ * @returns {string}
+ */
+function filename (name, file) {
+  return file ? `${name}/${file}` : name
+}
+
+/**
+ * @param {string} name
+ * @param {string|undefined} version
+ * @param {string} moduleName
+ * @param {{ file?: string, filePattern?: string, versions?: string[] }} instrumentation
+ * @returns {boolean}
+ */
+function matchesInstrumentation (name, version, moduleName, instrumentation) {
+  const { file, filePattern, versions } = instrumentation
+  if (!matchVersion(version, versions)) return false
+  if (isRelativeRequire(name)) return true
+  if (moduleName === filename(name, file)) return true
+  return Boolean(filePattern) && new RegExp(filename(name, filePattern)).test(moduleName)
+}
+
+/**
+ * @returns {Set<string>}
+ */
+function getDisabledInstrumentations () {
+  const disabled = new Set(
+    getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS')?.split(',').filter(Boolean)
+  )
+  if (disabled.size === 0) return disabled
+
+  const expanded = new Set(disabled)
+  const builtins = new Set(builtinModules)
+
+  for (const name of disabled) {
+    const prefixed = name.startsWith('node:')
+    if (!prefixed && !builtins.has(name)) continue
+
+    const counterpart = prefixed ? name.slice(5) : `node:${name}`
+    expanded.add(counterpart)
+  }
+
+  return expanded
+}
+
+module.exports = {
+  filename,
+  getDisabledInstrumentations,
+  matchesInstrumentation,
+  matchVersion,
+}

--- a/packages/datadog-instrumentations/src/helpers/instrumentation-utils.js
+++ b/packages/datadog-instrumentations/src/helpers/instrumentation-utils.js
@@ -33,10 +33,12 @@ function filename (name, file) {
  */
 function matchesInstrumentation (name, version, moduleName, instrumentation) {
   const { file, filePattern, versions } = instrumentation
-  if (!matchVersion(version, versions)) return false
-  if (isRelativeRequire(name)) return true
-  if (moduleName === filename(name, file)) return true
-  return Boolean(filePattern) && new RegExp(filename(name, filePattern)).test(moduleName)
+  let matchesFile = moduleName === filename(name, file)
+  if (!matchesFile && isRelativeRequire(name)) matchesFile = true
+  if (!matchesFile && filePattern) {
+    matchesFile = new RegExp(filename(name, filePattern)).test(moduleName)
+  }
+  return matchesFile && matchVersion(version, versions)
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const { builtinModules } = require('module')
 const path = require('path')
 const { channel } = require('dc-polyfill')
-const satisfies = require('../../../../vendor/dist/semifies')
 const log = require('../../../dd-trace/src/log')
 const telemetry = require('../../../dd-trace/src/guardrails/telemetry')
 const { IS_SERVERLESS } = require('../../../dd-trace/src/serverless')
 const { getValueFromEnvSources } = require('../../../dd-trace/src/config/helper')
 const checkRequireCache = require('./check-require-cache')
 const Hook = require('./hook')
-const { isRelativeRequire } = require('./shared-utils')
+const {
+  filename,
+  getDisabledInstrumentations,
+  matchesInstrumentation,
+} = require('./instrumentation-utils')
 const rewriter = require('./rewriter')
 
-const DD_TRACE_DISABLED_INSTRUMENTATIONS =
-  getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS')
 const DD_TRACE_DEBUG = getValueFromEnvSources('DD_TRACE_DEBUG')
 
 const hooks = require('./hooks')
@@ -22,9 +22,7 @@ const instrumentations = require('./instrumentations')
 const names = Object.keys(hooks)
 const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
 
-const disabledInstrumentations = new Set(
-  DD_TRACE_DISABLED_INSTRUMENTATIONS?.split(',')
-)
+const disabledInstrumentations = getDisabledInstrumentations()
 
 const loadChannel = channel('dd-trace:instrumentation:load')
 
@@ -53,29 +51,6 @@ const instrumentedNodeModules = new Map()
 const instrumentedIntegrationsSuccess = new Map()
 /** @type {Set<string>} */
 const alreadyLoggedIncompatibleIntegrations = new Set()
-
-// Always disable prefixed and unprefixed node modules if one is disabled.
-if (disabledInstrumentations.size) {
-  const builtinsSet = new Set(builtinModules)
-  const disabledBuiltinCounterparts = []
-  for (const name of disabledInstrumentations) {
-    const hasPrefix = name.startsWith('node:')
-    if (hasPrefix || builtinsSet.has(name)) {
-      if (hasPrefix) {
-        const unprefixedName = name.slice(5)
-        if (!disabledInstrumentations.has(unprefixedName)) {
-          disabledBuiltinCounterparts.push(unprefixedName)
-        }
-      } else if (!disabledInstrumentations.has(`node:${name}`)) {
-        disabledBuiltinCounterparts.push(`node:${name}`)
-      }
-    }
-  }
-  for (const name of disabledBuiltinCounterparts) {
-    disabledInstrumentations.add(name)
-  }
-  builtinsSet.clear()
-}
 
 for (const name of names) {
   if (disabledInstrumentations.has(name)) continue
@@ -111,21 +86,9 @@ for (const name of names) {
       instrumentedNodeModules.set(name, moduleExports)
     }
 
-    for (const { file, versions, hook, filePattern, patchDefault } of instrumentations[name]) {
-      const fullFilename = filename(name, file)
-
-      let matchesFile = moduleName === fullFilename
-
-      if (!matchesFile && isRelativeRequire(name)) matchesFile = true
-
-      const fullFilePattern = filePattern && filename(name, filePattern)
-      if (fullFilePattern) {
-        // Some libraries include a hash in their filenames when installed,
-        // so our instrumentation has to include a '.*' to match them for more than a single version.
-        matchesFile ||= new RegExp(fullFilePattern).test(moduleName)
-      }
-
-      if (matchesFile && matchVersion(moduleVersion, versions)) {
+    for (const instrumentation of instrumentations[name]) {
+      if (matchesInstrumentation(name, moduleVersion, moduleName, instrumentation)) {
+        const { hook, patchDefault } = instrumentation
         // IITM invokes this callback for every module in the package. Only unwrap the namespace after its file and
         // version match, otherwise a default export from an unrelated internal module can replace that module.
         if (isIitm && patchDefault === !!moduleExports.default) {
@@ -188,26 +151,8 @@ function logAbortedIntegrations () {
   instrumentedIntegrationsSuccess.clear()
 }
 
-/**
- * @param {string|undefined} version
- * @param {string[]|undefined} ranges
- */
-function matchVersion (version, ranges) {
-  return !version || !ranges || ranges.some(range => satisfies(version, range))
-}
-
-/**
- * @param {string} name
- * @param {string} [file]
- * @returns {string}
- */
-function filename (name, file) {
-  return file ? `${name}/${file}` : name
-}
-
 module.exports = {
   filename,
   pathSepExpr,
   loadChannel,
-  matchVersion,
 }

--- a/packages/datadog-instrumentations/test/helpers/bundler-register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/bundler-register.spec.js
@@ -1,0 +1,172 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const Module = require('node:module')
+
+const sinon = require('sinon')
+
+const instrumentationUtils = require('../../src/helpers/instrumentation-utils')
+
+const CHANNEL = 'dd-trace:bundler:load'
+
+describe('bundler register', () => {
+  let originalRequire
+
+  beforeEach(() => {
+    originalRequire = Module.prototype.require
+  })
+
+  afterEach(() => {
+    Module.prototype.require = originalRequire
+    sinon.restore()
+  })
+
+  it('patches modules published by existing bundlers', () => {
+    const Original = class Original {}
+    const Patched = class Patched {}
+    const hook = sinon.stub().returns(Patched)
+    const { loadChannel, publish } = loadBundlerRegister({
+      hooks: { 'test-commonjs-export': sinon.stub() },
+      instrumentations: {
+        'test-commonjs-export': [{ file: 'index.js', hook }],
+      },
+    })
+    const payload = {
+      module: { Original },
+      package: 'test-commonjs-export',
+      path: 'test-commonjs-export/index.js',
+      version: '1.0.0',
+    }
+
+    publish(payload)
+
+    sinon.assert.calledOnceWithExactly(hook, { Original }, '1.0.0')
+    sinon.assert.calledOnceWithExactly(loadChannel.publish, { name: 'test-commonjs-export' })
+    assert.equal(payload.module, Patched)
+  })
+
+  it('does not activate explicitly disabled bundled integrations', () => {
+    const hook = sinon.stub()
+    const integrationHook = sinon.stub()
+    const { loadChannel, publish } = loadBundlerRegister({
+      disabled: new Set(['test-disabled-integration']),
+      hooks: { 'test-disabled-integration': hook },
+      instrumentations: {
+        'test-disabled-integration': [{ hook: integrationHook }],
+      },
+    })
+
+    publish({
+      module: {},
+      package: 'test-disabled-integration',
+      path: 'test-disabled-integration',
+      version: '1.0.0',
+    })
+
+    sinon.assert.notCalled(loadChannel.publish)
+    sinon.assert.notCalled(hook)
+    sinon.assert.notCalled(integrationHook)
+  })
+
+  it('rejects unmatched paths and incompatible versions', () => {
+    const integrationHook = sinon.stub()
+    const { publish } = loadBundlerRegister({
+      hooks: { 'test-stale-plan': sinon.stub() },
+      instrumentations: {
+        'test-stale-plan': [{ file: 'index.js', hook: integrationHook, versions: ['>=2'] }],
+      },
+    })
+
+    publish({
+      module: {},
+      package: 'test-stale-plan',
+      path: 'test-stale-plan/other.js',
+      version: '2.0.0',
+    })
+    publish({
+      module: {},
+      package: 'test-stale-plan',
+      path: 'test-stale-plan/index.js',
+      version: '1.0.0',
+    })
+
+    sinon.assert.notCalled(integrationHook)
+  })
+
+  it('contains non-Error loader and instrumentation failures', () => {
+    const loadHook = sinon.stub().callsFake(() => throwValue('load failed'))
+    const integrationHook = sinon.stub().callsFake(() => throwValue('patch failed'))
+    const { log, publish } = loadBundlerRegister({
+      hooks: { 'test-hook-errors': loadHook },
+      instrumentations: {
+        'test-hook-errors': [{ hook: integrationHook }],
+      },
+    })
+
+    publish({
+      module: {},
+      package: 'test-hook-errors',
+      path: 'test-hook-errors',
+      version: '1.0.0',
+    })
+
+    sinon.assert.calledWithMatch(log.error, 'esbuild-wrapped %s hook failed: %s', 'test-hook-errors', 'load failed')
+    sinon.assert.calledWithMatch(log.error, 'Error executing bundler hook: %s', 'patch failed')
+  })
+})
+
+/**
+ * @param {unknown} value
+ */
+function throwValue (value) {
+  throw value
+}
+
+/**
+ * @param {{
+ *   disabled?: Set<string>,
+ *   hooks: Record<string, Function|{ fn: Function }>,
+ *   instrumentations: Record<string, Array<object>>
+ * }} options
+ */
+function loadBundlerRegister ({ disabled = new Set(), hooks, instrumentations }) {
+  const bundlerRegisterPath = require.resolve('../../src/helpers/bundler-register')
+  const originalRequire = Module.prototype.require
+  const loadChannel = { publish: sinon.stub() }
+  const log = { error: sinon.stub() }
+  const dc = {
+    subscribe: (channel, callback) => {
+      if (channel === CHANNEL) bundledModuleSubscriber = callback
+    },
+  }
+  let bundledModuleSubscriber
+  const register = { loadChannel }
+
+  Module.prototype.require = function (request) {
+    if (this.filename === bundlerRegisterPath) {
+      const stubs = {
+        './hooks': hooks,
+        './instrumentation-utils': {
+          ...instrumentationUtils,
+          getDisabledInstrumentations: () => disabled,
+        },
+        './instrumentations': instrumentations,
+        './register.js': register,
+        '../../../dd-trace/src/log': log,
+        'dc-polyfill': dc,
+      }
+      return stubs[request] || originalRequire.call(this, request)
+    }
+    return originalRequire.call(this, request)
+  }
+  delete require.cache[bundlerRegisterPath]
+  require('../../src/helpers/bundler-register')
+  Module.prototype.require = originalRequire
+
+  return {
+    dc,
+    loadChannel,
+    log,
+    publish: message => bundledModuleSubscriber(message),
+  }
+}

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -6,16 +6,21 @@ const assert = require('node:assert/strict')
 const { channel } = require('dc-polyfill')
 const sinon = require('sinon')
 
+const satisfies = require('../../../../vendor/dist/semifies')
+
 describe('register', () => {
   let hooksMock
   let HookMock
   let instrumentationsMock
   let originalModuleProtoRequire
+  let satisfiesMock
   let telemetryMock
 
   const clearRegisterCache = () => {
     const registerPath = require.resolve('../../src/helpers/register')
+    const instrumentationUtilsPath = require.resolve('../../src/helpers/instrumentation-utils')
     delete require.cache[registerPath]
+    delete require.cache[instrumentationUtilsPath]
   }
 
   beforeEach(() => {
@@ -33,12 +38,17 @@ describe('register', () => {
 
     HookMock = sinon.stub()
     instrumentationsMock = {}
+    satisfiesMock = sinon.spy(satisfies)
     telemetryMock = sinon.stub()
 
     const registerPath = require.resolve('../../src/helpers/register')
+    const instrumentationUtilsPath = require.resolve('../../src/helpers/instrumentation-utils')
     originalModuleProtoRequire = Module.prototype.require
 
     Module.prototype.require = function (request) {
+      if (this.filename === instrumentationUtilsPath && request === '../../../../vendor/dist/semifies') {
+        return satisfiesMock
+      }
       if (this.filename === registerPath) {
         const stubs = {
           './hooks': hooksMock,
@@ -168,6 +178,25 @@ describe('register', () => {
       moduleBaseDir: '/path/to/mariadb',
       moduleName: 'mariadb/lib/cmd/query.js',
     })
+  })
+
+  it('should reject a nonmatching file before checking its version', () => {
+    const patch = sinon.stub()
+    hooksMock.example = { fn: sinon.stub() }
+    instrumentationsMock.example = [{
+      file: 'index.js',
+      versions: ['>=1'],
+      hook: patch,
+    }]
+    loadRegisterWithEnv()
+
+    const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === 'example')
+    const hook = hookCall.args[2]
+    const moduleExports = {}
+
+    assert.strictEqual(hook(moduleExports, 'example/internal.js', '/path/to/example', '1.0.0'), moduleExports)
+    sinon.assert.notCalled(satisfiesMock)
+    sinon.assert.notCalled(patch)
   })
 
   it('should patch a package root namespace without also patching its default callback', () => {

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -194,4 +194,56 @@ describe('register', () => {
     assert.strictEqual(hook(namespace, 'mocha', '/path/to/mocha', '12.0.0', true), namespace)
     sinon.assert.calledOnceWithExactly(patch, Mocha)
   })
+
+  it('should match file patterns', () => {
+    const patch = sinon.stub()
+    hooksMock.example = { fn: sinon.stub() }
+    instrumentationsMock.example = [{ filePattern: 'dist/cli.*', hook: patch }]
+    loadRegisterWithEnv()
+
+    const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === 'example')
+    const hook = hookCall.args[2]
+    const moduleExports = {}
+
+    assert.strictEqual(
+      hook(moduleExports, 'example/dist/cli-123.js', '/path/to/example', '1.0.0'),
+      moduleExports
+    )
+    sinon.assert.calledOnceWithExactly(patch, moduleExports, '1.0.0', undefined, {
+      moduleBaseDir: '/path/to/example',
+      moduleName: 'example/dist/cli-123.js',
+    })
+  })
+
+  it('should match relative instrumentation names', () => {
+    const name = './runtime/library.js'
+    const patch = sinon.stub()
+    hooksMock[name] = { fn: sinon.stub() }
+    instrumentationsMock[name] = [{ hook: patch }]
+    loadRegisterWithEnv()
+
+    const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === name)
+    const hook = hookCall.args[2]
+    const moduleExports = {}
+
+    assert.strictEqual(hook(moduleExports, 'different/path.js', '/path/to/package', '1.0.0'), moduleExports)
+    sinon.assert.calledOnceWithExactly(patch, moduleExports, '1.0.0', undefined, {
+      moduleBaseDir: '/path/to/package',
+      moduleName: 'different/path.js',
+    })
+  })
+
+  it('should not treat an empty file pattern as a wildcard', () => {
+    const patch = sinon.stub()
+    hooksMock.example = { fn: sinon.stub() }
+    instrumentationsMock.example = [{ filePattern: '', hook: patch }]
+    loadRegisterWithEnv()
+
+    const hookCall = HookMock.getCalls().find(({ args }) => args[0][0] === 'example')
+    const hook = hookCall.args[2]
+    const moduleExports = {}
+
+    assert.strictEqual(hook(moduleExports, 'example/internal.js', '/path/to/example', '1.0.0'), moduleExports)
+    sinon.assert.notCalled(patch)
+  })
 })


### PR DESCRIPTION
Runtime and bundler registration evaluated integration enablement separately, so disabled integrations could still load and patch bundled modules.