### PR TITLE
chore(docs): require dc-polyfill channels

### DIFF
--- a/.agents/skills/apm-integrations/references/new-integration-guide.md
+++ b/.agents/skills/apm-integrations/references/new-integration-guide.md
@@ -63,7 +63,7 @@ See [Orchestrion Reference](orchestrion.md) for the full config schema, ESQuery 
 
 Create `packages/datadog-instrumentations/src/<name>.js`. Always add a comment explaining why orchestrion is not viable!!!
 
-**When using shimmer, prefer `tracingChannel` over manual channels.** `tracingChannel` (from `dc-polyfill` or `diagnostics_channel`) automatically provides `start`, `end`, `asyncStart`, `asyncEnd`, and `error` events — less boilerplate and consistent with how orchestrion works internally.
+**When using shimmer, prefer `tracingChannel` over manual channels.** `tracingChannel` from `dc-polyfill` automatically provides `start`, `end`, `asyncStart`, `asyncEnd`, and `error` events — less boilerplate and consistent with how orchestrion works internally.
 
 **Streaming example** (the main case where shimmer is needed — intercepting emitted events on returned stream objects):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,5 +174,7 @@ New instrumentations belong in `packages/datadog-instrumentations/` and communic
 channels. Validate new plugin structure with
 `./node_modules/.bin/mocha packages/dd-trace/test/plugins/plugin-structure.spec.js`.
 
+Use `dc-polyfill` for production diagnostic-channel imports. Do not import `node:diagnostics_channel` directly.
+
 For vendored rspack dependencies, run yarn from `vendor/`; generated bundles are written under
 `packages/node_modules/`.


### PR DESCRIPTION
Production instrumentation targets runtimes with different core tracing-channel behavior, so `dc-polyfill` must own channel compatibility.