### PR TITLE
test(test-optimization): prevent backend telemetry

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false'
   # TODO: remove this once we have stable tests
   MOCHA_OPTIONS: --retries 2
 

--- a/integration-tests/ci-visibility/test-environment.spec.js
+++ b/integration-tests/ci-visibility/test-environment.spec.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const yaml = require('yaml')
+
+const { getCiVisAgentlessConfig, getCiVisEvpProxyConfig } = require('../helpers')
+
+describe('test environment', () => {
+  it('does not enable tracer telemetry in the Test Optimization workflow', () => {
+    const workflowPath = path.join(__dirname, '../../.github/workflows/test-optimization.yml')
+    const workflow = yaml.parse(fs.readFileSync(workflowPath, 'utf8'))
+
+    assert.strictEqual(workflow.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED, 'false')
+  })
+
+  it('does not pass backend API keys to fake Test Optimization endpoints', () => {
+    const originalApiKey = process.env.DD_API_KEY
+    const originalAliasApiKey = process.env.DATADOG_API_KEY
+
+    process.env.DD_API_KEY = 'real-api-key'
+    process.env.DATADOG_API_KEY = 'real-alias-api-key'
+
+    try {
+      const agentlessConfig = getCiVisAgentlessConfig(1234)
+      const evpProxyConfig = getCiVisEvpProxyConfig(1234)
+      const printApiKeys = `process.stdout.write(JSON.stringify({
+        DD_API_KEY: process.env.DD_API_KEY,
+        DATADOG_API_KEY: process.env.DATADOG_API_KEY,
+      }))`
+      const evpProxyApiKeys = JSON.parse(execFileSync(process.execPath, ['--eval', printApiKeys], {
+        encoding: 'utf8',
+        env: { ...evpProxyConfig, NODE_OPTIONS: '' },
+      }))
+      const agentlessApiKeys = JSON.parse(execFileSync(process.execPath, ['--eval', printApiKeys], {
+        encoding: 'utf8',
+        env: { ...agentlessConfig, NODE_OPTIONS: '' },
+      }))
+
+      assert.deepStrictEqual(evpProxyApiKeys, {})
+      assert.deepStrictEqual(agentlessApiKeys, { DD_API_KEY: '1' })
+      assert.strictEqual(agentlessConfig.DD_API_KEY, '1')
+      assert.strictEqual(agentlessConfig.DD_CIVISIBILITY_AGENTLESS_URL, 'http://127.0.0.1:1234')
+      assert.strictEqual(evpProxyConfig.DD_TRACE_AGENT_PORT, '1234')
+    } finally {
+      if (originalApiKey === undefined) {
+        delete process.env.DD_API_KEY
+      } else {
+        process.env.DD_API_KEY = originalApiKey
+      }
+      if (originalAliasApiKey === undefined) {
+        delete process.env.DATADOG_API_KEY
+      } else {
+        process.env.DATADOG_API_KEY = originalAliasApiKey
+      }
+    }
+  })
+})

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -952,6 +952,7 @@ function getCiVisAgentlessConfig (port) {
   const { GITHUB_ACTIONS, GITHUB_EVENT_PATH, GITHUB_RUN_ID, GITHUB_WORKSPACE, MOCHA_OPTIONS, ...rest } = process.env
   return {
     ...rest,
+    DATADOG_API_KEY: undefined,
     DD_API_KEY: '1',
     DD_CIVISIBILITY_AGENTLESS_ENABLED: '1',
     DD_CIVISIBILITY_AGENTLESS_URL: `http://127.0.0.1:${port}`,
@@ -972,6 +973,8 @@ function getCiVisEvpProxyConfig (port) {
   const { GITHUB_ACTIONS, GITHUB_EVENT_PATH, GITHUB_RUN_ID, GITHUB_WORKSPACE, MOCHA_OPTIONS, ...rest } = process.env
   return {
     ...rest,
+    DATADOG_API_KEY: undefined,
+    DD_API_KEY: undefined,
     DD_TRACE_AGENT_PORT: String(port),
     NODE_OPTIONS: '-r dd-trace/ci/init',
     DD_CIVISIBILITY_AGENTLESS_ENABLED: '0',


### PR DESCRIPTION
Repository CI preloads the Test Optimization tracer before Mocha disables instrumentation telemetry, so test runners send it with the real API key.

Fake endpoint environments also inherit that key, which enables direct intake fallback when their local receiver fails.

This keeps Test Optimization event reporting enabled while preventing instrumentation telemetry from leaving the test environment.