### PR TITLE
feat(test-optimization): report Jest suites pre-skipped by ddtest

### DIFF
--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -751,6 +751,77 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       })
     })
 
+    it('reports suites pre-skipped by ddtest without loading them in Jest', (done) => {
+      const skippedSuite = 'ci-visibility/test/ci-visibility-test.js'
+      const runnableSuite = 'ci-visibility/test/ci-visibility-test-2.js'
+      const itrCorrelationId = 'ddtest-correlation-id'
+      const artifactPath = path.join(
+        cwd,
+        '.testoptimization',
+        'runner',
+        'tia-skipped-test-suites',
+        'runner-0.json'
+      )
+      fs.mkdirSync(path.dirname(artifactPath), { recursive: true })
+      fs.writeFileSync(artifactPath, JSON.stringify({
+        version: 1,
+        test_suites: [skippedSuite],
+      }))
+
+      receiver.setSettings({
+        itr_enabled: true,
+        code_coverage: false,
+        tests_skipping: true,
+      })
+      receiver.setItrCorrelationId(itrCorrelationId)
+      receiver.setSuitesToSkip([{
+        type: 'suite',
+        attributes: { suite: skippedSuite },
+      }])
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSuites = events
+            .filter(event => event.type === 'test_suite_end')
+            .map(event => event.content)
+          const skippedTestSuite = testSuites.find(
+            testSuite => testSuite.resource === `test_suite.${skippedSuite}`
+          )
+          const runnableTestSuite = testSuites.find(
+            testSuite => testSuite.resource === `test_suite.${runnableSuite}`
+          )
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          const testsFromPreSkippedSuite = events
+            .filter(event => event.type === 'test')
+            .filter(event => event.content.meta[TEST_SUITE] === skippedSuite)
+
+          assert.ok(skippedTestSuite)
+          assert.ok(runnableTestSuite)
+          assert.strictEqual(skippedTestSuite.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(skippedTestSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
+          assert.strictEqual(skippedTestSuite.itr_correlation_id, itrCorrelationId)
+          assert.strictEqual(testsFromPreSkippedSuite.length, 0)
+          assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'true')
+          assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 1)
+        }, 25000)
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE: artifactPath,
+            TESTS_TO_RUN: 'ci-visibility/test/ci-visibility-test-2.js',
+          },
+        }
+      )
+      childProcess.on('exit', () => {
+        eventsPromise.then(() => done()).catch(done)
+      })
+    })
+
     it('works with multi project setup and test skipping', async () => {
       const projects = ['standard', 'node'].map(displayName => ({
         displayName,

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -114,6 +114,7 @@ const jestSessionState = (globalThis[JEST_SESSION_STATE] ||= {})
 const RETRY_TIMES = Symbol.for('RETRY_TIMES')
 
 let skippableSuites = []
+let preSkippedSuites = []
 let skippableSuitesCoverage
 let skippedSuitesCoverage = {}
 let knownTests = {}
@@ -2587,6 +2588,7 @@ function getCoverageBackfillContexts (contexts) {
 function resetSuiteSkippingRunState () {
   isSuitesSkipped = false
   numSkippedSuites = 0
+  preSkippedSuites = []
   hasUnskippableSuites = false
   hasForcedToRunSuites = false
   hasFilteredSkippableSuites = false
@@ -3026,12 +3028,16 @@ function getCliWrapper (isNewJestVersion) {
             err,
             skippableSuites: receivedSkippableSuites,
             skippableSuitesCoverage: receivedSkippableSuitesCoverage,
+            preSkippedSuites: receivedPreSkippedSuites,
           } = skippableSuitesResponse || await getChannelPromise(skippableSuitesCh)
           if (err) {
             skippableSuitesCoverage = undefined
           } else {
             skippableSuites = receivedSkippableSuites
             skippableSuitesCoverage = receivedSkippableSuitesCoverage
+            const skippableSuiteSet = new Set(skippableSuites)
+            preSkippedSuites = [...new Set(receivedPreSkippedSuites || [])]
+              .filter(testSuite => skippableSuiteSet.has(testSuite))
           }
           skippedSuitesCoverage = {}
         } catch (err) {
@@ -3071,6 +3077,13 @@ function getCliWrapper (isNewJestVersion) {
         command: `jest ${processArgv}`,
         frameworkVersion: jestVersion,
       })
+
+      if (preSkippedSuites.length > 0) {
+        isSuitesSkipped = true
+        numSkippedSuites += preSkippedSuites.length
+        skippedSuitesCoverage = skippableSuitesCoverage || {}
+        itrSkippedSuitesCh.publish({ skippedSuites: preSkippedSuites, frameworkVersion: jestVersion })
+      }
 
       let result
       try {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -302,6 +302,10 @@ class CiVisibilityExporter extends BufferingExporter {
       return callback(null, [])
     }
     const requestConfiguration = this.getRequestConfiguration(testConfiguration)
+    const cachedPreSkippedSuites = this._testOptimizationHttpCache.readPreSkippedSuites?.()
+    const preSkippedSuites = cachedPreSkippedSuites === CACHE_MISS || cachedPreSkippedSuites === undefined
+      ? []
+      : cachedPreSkippedSuites
     const cachedSkippableSuites = this._testOptimizationHttpCache.readSkippableSuites({
       testLevel: requestConfiguration.testLevel,
       isCoverageReportUploadEnabled: requestConfiguration.isCoverageReportUploadEnabled,
@@ -309,7 +313,7 @@ class CiVisibilityExporter extends BufferingExporter {
     })
     if (cachedSkippableSuites !== CACHE_MISS) {
       const { skippableSuites, correlationId, coverage } = cachedSkippableSuites
-      return callback(null, skippableSuites, correlationId, coverage)
+      return callback(null, skippableSuites, correlationId, coverage, preSkippedSuites)
     }
     if (this._isTestOptimizationCacheOnly) {
       return callback(this._getCacheOnlyError('skippable tests'), [])
@@ -319,7 +323,9 @@ class CiVisibilityExporter extends BufferingExporter {
       if (gitUploadError) {
         return callback(gitUploadError, [])
       }
-      getSkippableSuitesRequest(requestConfiguration, callback)
+      getSkippableSuitesRequest(requestConfiguration, (err, skippableSuites, correlationId, coverage) => {
+        callback(err, skippableSuites, correlationId, coverage, preSkippedSuites)
+      })
     })
   }
 

--- a/packages/dd-trace/src/ci-visibility/test-optimization-http-cache.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-http-cache.js
@@ -41,11 +41,13 @@ const ENV_MANIFEST_FILE_ALIAS = 'DD_TEST_OPTIMIZATION_MANIFEST_FILE'
 const ENV_RUNFILES_DIR = 'RUNFILES_DIR'
 const ENV_RUNFILES_MANIFEST_FILE = 'RUNFILES_MANIFEST_FILE'
 const ENV_TEST_SRCDIR = 'TEST_SRCDIR'
+const ENV_TIA_SKIPPED_TEST_SUITES_FILE = 'DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE'
 
 const SETTINGS_FILE_NAME = 'settings.json'
 const KNOWN_TESTS_FILE_NAME = 'known_tests.json'
 const SKIPPABLE_TESTS_FILE_NAME = 'skippable_tests.json'
 const TEST_MANAGEMENT_FILE_NAME = 'test_management.json'
+const TIA_SKIPPED_TEST_SUITES_ARTIFACT_VERSION = 1
 
 const RUNFILES_MANIFEST_SEPARATOR = ' '
 const DEFAULT_VALIDATION_MAX_FILE_BYTES = 1024 * 1024
@@ -162,6 +164,41 @@ class TestOptimizationHttpCache {
       return result
     } catch (err) {
       this._logInvalidCacheFile(SKIPPABLE_TESTS_FILE_NAME, err)
+      return CACHE_MISS
+    }
+  }
+
+  readPreSkippedSuites () {
+    const configuredPath = this._env[ENV_TIA_SKIPPED_TEST_SUITES_FILE]
+    if (!configuredPath) return CACHE_MISS
+
+    const artifactPath = path.resolve(this._cwd, this._resolveRunfilePath(configuredPath))
+    try {
+      this._assertValidationFixtureFile(artifactPath)
+      const stat = fs.statSync(artifactPath)
+      if (!stat.isFile() || stat.size > this._maxFileBytes) {
+        throw new Error('artifact must be a bounded regular file')
+      }
+
+      const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'))
+      if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact) ||
+        artifact.version !== TIA_SKIPPED_TEST_SUITES_ARTIFACT_VERSION ||
+        !Array.isArray(artifact.test_suites) ||
+        artifact.test_suites.length > DEFAULT_VALIDATION_MAX_ENTRIES) {
+        throw new Error('artifact has an invalid schema')
+      }
+
+      const uniqueSuites = new Set()
+      for (const testSuite of artifact.test_suites) {
+        if (typeof testSuite !== 'string' || testSuite.length === 0 ||
+          Buffer.byteLength(testSuite) > DEFAULT_VALIDATION_MAX_STRING_BYTES) {
+          throw new Error('artifact contains an invalid test suite')
+        }
+        uniqueSuites.add(testSuite)
+      }
+      return [...uniqueSuites]
+    } catch (err) {
+      log.debug('TIA-skipped test suites artifact %s could not be read: %s', artifactPath, err.message)
       return CACHE_MISS
     }
   }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -261,7 +261,7 @@ module.exports = class CiPlugin extends Plugin {
           isCoverageReportUploadEnabled: this.libraryConfig?.isCoverageReportUploadEnabled,
           isLineCoverageSupported: this.constructor.id !== 'vitest',
         },
-        (err, skippableSuites, itrCorrelationId, skippableSuitesCoverage) => {
+        (err, skippableSuites, itrCorrelationId, skippableSuitesCoverage, preSkippedSuites) => {
           if (err) {
             log.error('Skippable suites could not be fetched. %s', err.message)
             this._addRequestErrorTag(DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS, err)
@@ -269,7 +269,7 @@ module.exports = class CiPlugin extends Plugin {
             this.itrCorrelationId = itrCorrelationId
             this.skippableSuitesCoverage = skippableSuitesCoverage
           }
-          onDone({ err, skippableSuites, itrCorrelationId, skippableSuitesCoverage })
+          onDone({ err, skippableSuites, itrCorrelationId, skippableSuitesCoverage, preSkippedSuites })
         }
       )
     })

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -164,6 +164,31 @@ describe('CiPlugin', () => {
     sinon.assert.calledOnce(onDone)
   })
 
+  it('passes pre-skipped suites from the exporter to the instrumentation', () => {
+    const getSkippableSuites = sinon.stub().callsArgWith(
+      1,
+      null,
+      ['suite.js'],
+      'correlation-id',
+      undefined,
+      ['pre-skipped.js']
+    )
+    const onDone = sinon.stub()
+    const plugin = createPlugin('vitest_worker', true)
+    plugin.tracer._exporter.getSkippableSuites = getSkippableSuites
+
+    dc.channel('ci:vitest:test-suite:skippable').publish({ onDone })
+    plugin.configure(false)
+
+    sinon.assert.calledWith(onDone, {
+      err: null,
+      skippableSuites: ['suite.js'],
+      itrCorrelationId: 'correlation-id',
+      skippableSuitesCoverage: undefined,
+      preSkippedSuites: ['pre-skipped.js'],
+    })
+  })
+
   it('replaces frozen policy snapshots when dependent requests fail', () => {
     const plugin = createPlugin('vitest_worker', true)
     plugin.libraryConfig = Object.freeze({

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-http-cache.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-http-cache.spec.js
@@ -135,6 +135,13 @@ function writeCacheLayout (root, options = {}) {
   }
 }
 
+function writePreSkippedSuitesArtifact (root, testSuites) {
+  const filePath = path.join(root, '.testoptimization', 'runner', 'tia-skipped-test-suites', 'runner-0.json')
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify({ version: 1, test_suites: testSuites }))
+  process.env.DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE = filePath
+}
+
 function loadCiVisibilityExporterWithGitUpload (sendGitMetadata) {
   const Exporter = proxyquire('../../../src/ci-visibility/exporters/ci-visibility-exporter', {
     './git/git_metadata': {
@@ -149,16 +156,19 @@ describe('CI Visibility Exporter Test Optimization HTTP cache', () => {
 
   let previousCwd
   let previousSettingsCachePath
+  let previousPreSkippedSuitesFile
   let tmpRoot
 
   beforeEach(() => {
     previousCwd = process.cwd()
     previousSettingsCachePath = process.env.DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE
+    previousPreSkippedSuitesFile = process.env.DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-js-exporter-http-cache-'))
     writeCacheLayout(tmpRoot)
     process.chdir(tmpRoot)
     delete process.env.DD_API_KEY
     delete process.env.DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE
+    delete process.env.DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE
     getConfig().DD_API_KEY = undefined
     nock.cleanAll()
   })
@@ -171,6 +181,11 @@ describe('CI Visibility Exporter Test Optimization HTTP cache', () => {
       delete process.env.DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE
     } else {
       process.env.DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE = previousSettingsCachePath
+    }
+    if (previousPreSkippedSuitesFile === undefined) {
+      delete process.env.DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE
+    } else {
+      process.env.DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE = previousPreSkippedSuitesFile
     }
     getConfig().DD_API_KEY = '1'
     nock.cleanAll()
@@ -434,6 +449,7 @@ describe('CI Visibility Exporter Test Optimization HTTP cache', () => {
   })
 
   it('uses cached skippable tests without waiting on git upload', (done) => {
+    writePreSkippedSuitesArtifact(tmpRoot, ['suite1.spec.js'])
     const skippableScope = nock(url)
       .post('/api/v2/ci/tests/skippable')
       .reply(200, {})
@@ -442,11 +458,12 @@ describe('CI Visibility Exporter Test Optimization HTTP cache', () => {
     ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
     ciVisibilityExporter._libraryConfig = { isSuitesSkippingEnabled: true }
 
-    ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites, correlationId, coverage) => {
+    ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites, correlationId, coverage, preSkippedSuites) => {
       assert.strictEqual(err, null)
       assert.deepStrictEqual(skippableSuites, ['suite1.spec.js'])
       assert.strictEqual(correlationId, 'corr-123')
       assert.deepStrictEqual(coverage, { 'src/file.js': 'gA==' })
+      assert.deepStrictEqual(preSkippedSuites, ['suite1.spec.js'])
       assert.strictEqual(skippableScope.isDone(), false)
       done()
     })

--- a/packages/dd-trace/test/ci-visibility/test-optimization-http-cache.spec.js
+++ b/packages/dd-trace/test/ci-visibility/test-optimization-http-cache.spec.js
@@ -110,6 +110,7 @@ const ENV_NAMES = [
   'RUNFILES_DIR',
   'RUNFILES_MANIFEST_FILE',
   'TEST_SRCDIR',
+  'DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE',
 ]
 
 function writeCacheLayout (root, options = {}) {
@@ -134,6 +135,14 @@ function writeHttpCacheFile (root, fileName, payload) {
   const filePath = path.join(root, '.testoptimization', 'cache', 'http', fileName)
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
   fs.writeFileSync(filePath, typeof payload === 'string' ? payload : JSON.stringify(payload))
+  return filePath
+}
+
+function writePreSkippedSuitesArtifact (root, payload) {
+  const filePath = path.join(root, '.testoptimization', 'runner', 'tia-skipped-test-suites', 'runner-0.json')
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, typeof payload === 'string' ? payload : JSON.stringify(payload))
+  process.env.DD_TEST_OPTIMIZATION_TIA_SKIPPED_TEST_SUITES_FILE = filePath
   return filePath
 }
 
@@ -306,6 +315,30 @@ describe('test-optimization-http-cache', () => {
     assert.strictEqual(cache.readKnownTests(), CACHE_MISS)
     assert.strictEqual(cache.readSkippableSuites(), CACHE_MISS)
     assert.strictEqual(cache.readTestManagementTests(), CACHE_MISS)
+  })
+
+  it('reads and deduplicates pre-skipped suites without requiring an HTTP cache', () => {
+    writePreSkippedSuitesArtifact(tmpRoot, {
+      version: 1,
+      test_suites: ['suite1.spec.js', 'suite2.spec.js', 'suite1.spec.js'],
+    })
+
+    const cache = new TestOptimizationHttpCache()
+
+    assert.deepStrictEqual(cache.readPreSkippedSuites(), ['suite1.spec.js', 'suite2.spec.js'])
+  })
+
+  it('returns cache miss for missing or malformed pre-skipped suite artifacts', () => {
+    const cacheWithoutArtifact = new TestOptimizationHttpCache()
+    assert.strictEqual(cacheWithoutArtifact.readPreSkippedSuites(), CACHE_MISS)
+
+    writePreSkippedSuitesArtifact(tmpRoot, { version: 2, test_suites: ['suite1.spec.js'] })
+    const cacheWithWrongVersion = new TestOptimizationHttpCache()
+    assert.strictEqual(cacheWithWrongVersion.readPreSkippedSuites(), CACHE_MISS)
+
+    writePreSkippedSuitesArtifact(tmpRoot, { version: 1, test_suites: [42] })
+    const cacheWithInvalidSuite = new TestOptimizationHttpCache()
+    assert.strictEqual(cacheWithInvalidSuite.readPreSkippedSuites(), CACHE_MISS)
   })
 
   it('returns cache miss for invalid cache files', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Reads the optional per-runner TIA-skipped Jest suite artifact produced by DDTest and reports those suites through the existing synthetic skipped-suite event path. Artifact entries are bounded, deduplicated, and cross-checked against the current backend skippable suite response before reporting.

The resulting suite events carry the existing TIA skipped tags and correlation ID, while Jest continues to receive only runnable files.

### Motivation
<!-- What inspired you to submit this pull request? -->

DDTest can remove fully skippable suites before Jest starts. Without an explicit handoff, the tracer never observes those suites, so they disappear from the Test Optimization session and make shards appear lighter than the original workload.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Companion DDTest PR: https://github.com/DataDog/ddtest/pull/127
- The callback field and artifact are optional, so existing Jest integrations and plans remain compatible.
- Malformed or missing artifacts are ignored without affecting the test run.
- Scope is intentionally limited to Jest.
- Unit verification: 71 focused tests passed.
- Targeted ESLint passed.
- The focused Jest integration test verifies the skipped suite event, correlation ID, session skip count, and absence of test events for the pre-skipped suite.
