### PR TITLE
test(claude-agent-sdk): stop streams at terminal result

### DIFF
--- a/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-claude-agent-sdk/test/index.spec.js
@@ -161,6 +161,7 @@ describe('Plugin', () => {
 
         for await (const message of stream) {
           assert.ok(message.type)
+          if (message.type === 'result') break
         }
 
         assert.deepEqual(userPromptSubmissions, [PROMPT])

--- a/packages/datadog-plugin-claude-agent-sdk/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-claude-agent-sdk/test/integration-test/server.mjs
@@ -59,4 +59,5 @@ const stream = query({
 
 for await (const message of stream) {
   if (!message.type) throw new Error('unexpected message')
+  if (message.type === 'result') break
 }

--- a/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/claude-agent-sdk/index.spec.js
@@ -96,6 +96,7 @@ describe('Plugin', () => {
 
       for await (const message of stream) {
         assert.ok(message.type)
+        if (message.type === 'result') break
       }
 
       const { apmSpans, llmobsSpans } = await getEvents(12)


### PR DESCRIPTION
Claude Code can emit the terminal `result` without closing stdout. The plugin tests then wait for transport EOF until Mocha times out.

Stop the in-process and ESM consumers at `result`, which invokes the async generator cleanup path. Future streaming integration tests should use the dependency's semantic terminal event instead of transport EOF.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/34489177535
Refs: https://github.com/anthropics/claude-code/issues/25629