### PR TITLE
fix(azure-cosmos): finalize spans through plugin lifecycle

### DIFF
--- a/packages/datadog-plugin-azure-cosmos/src/index.js
+++ b/packages/datadog-plugin-azure-cosmos/src/index.js
@@ -26,7 +26,7 @@ class AzureCosmosPlugin extends DatabasePlugin {
       const result = ctx.result
       if (result?.code) span.setTag('db.response.status_code', (result.code).toString())
       if (result?.substatus) span.setTag('cosmosdb.response.sub_status_code', result.substatus)
-      span.finish()
+      this.finish(ctx)
     }
   }
 

--- a/packages/datadog-plugin-azure-cosmos/test/index.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/index.spec.js
@@ -14,7 +14,7 @@ describe('Plugin', () => {
 
       beforeEach(async () => {
         // Provision DB/container without emitting azure-cosmos spans (plugin subscriptions stay off).
-        await agent.load('azure-cosmos', { enabled: false })
+        await agent.load('azure-cosmos', { enabled: false }, { spanComputePeerService: true })
         ; ({ client, container } = await setup())
         agent.reload('azure-cosmos', { enabled: true })
       })
@@ -34,6 +34,8 @@ describe('Plugin', () => {
             component: 'azure_cosmos',
             'db.system': 'cosmosdb',
             'db.name': 'testDatabase',
+            'peer.service': 'testDatabase',
+            '_dd.peer.service.source': 'db.name',
             'cosmosdb.container': 'testContainer',
             'cosmosdb.connection.mode': 'gateway',
             'span.kind': 'client',


### PR DESCRIPTION
### What does this PR do?

Routes Azure Cosmos async span completion through the inherited outbound plugin lifecycle instead of finishing the span directly. This preserves outbound finalization, including peer-service computation and serverless peer-service handling.

Adds regression coverage that enables peer-service computation and verifies that Cosmos spans derive peer.service from db.name.

### Motivation

Azure Cosmos called span.finish() directly from asyncEnd, bypassing OutboundPlugin.finish(). As a result, finalization behavior owned by the outbound base class did not run.

### Additional Notes

Validation:
- node --check packages/datadog-plugin-azure-cosmos/src/index.js
- node --check packages/datadog-plugin-azure-cosmos/test/index.spec.js
- git diff --check

The focused Mocha test was not run because node_modules is not installed in this worktree.