### PR TITLE
ci: build OTel operator images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,9 @@ variables:
   AGENT_REPO_PRODUCT_NAME: auto_inject-node
   SYSTEM_TESTS_LIBRARY: nodejs
   REPO_NOTIFICATION_CHANNEL: "#notifications-apm-js"
+  # Test the OpenTelemetry Operator-compatible Node.js image jobs from one-pipeline.
+  OTEL_OPERATOR_IMAGES_ENABLED: "true"
+  OTEL_OPERATOR_LANGUAGE: nodejs
   # One pipeline injection package size ratchet
   OCI_PACKAGE_MAX_SIZE_BYTES: 30_000_000
   LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 50_000_000


### PR DESCRIPTION
### What does this PR do?

Enables the libdatadogbuild OpenTelemetry Operator-compatible image jobs for Node.js. The repository already pins one-pipeline 1.5.0, so this adds only the feature flag and the `nodejs` language profile.

### Motivation

Build dd-trace-js images that can be used directly with the OpenTelemetry Operator, matching the rollout in the Java and Python tracers.

### Testing

- `git diff --check`
- The PR pipeline validates the generated one-pipeline image jobs.

No runtime tests are needed because this changes only GitLab CI variables.

### Additional Notes

Equivalent to DataDog/dd-trace-java#12255 and DataDog/dd-trace-py#20239.
