### PR TITLE
fix(instrumentations): dedupe rewriter hooks by version range and file

### DIFF
--- a/.agents/skills/apm-integrations/references/new-integration-guide.md
+++ b/.agents/skills/apm-integrations/references/new-integration-guide.md
@@ -41,7 +41,7 @@ To find `filePath`, inspect the installed package to locate where the target met
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('<npm-package>')) {
+for (const hook of getHooks('<npm-package>').values()) {
   addHook(hook, exports => exports)
 }
 ```

--- a/.agents/skills/apm-integrations/references/orchestrion.md
+++ b/.agents/skills/apm-integrations/references/orchestrion.md
@@ -60,7 +60,7 @@ Hooks file (`src/<name>.js`):
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('<npm-package>')) {
+for (const hook of getHooks('<npm-package>').values()) {
   addHook(hook, exports => exports)
 }
 ```

--- a/packages/datadog-instrumentations/src/ai.js
+++ b/packages/datadog-instrumentations/src/ai.js
@@ -147,7 +147,7 @@ function wrapTracer (tracer) {
 
 let orchestrionSubscribed = false
 
-for (const hook of getHooks('ai')) {
+for (const hook of getHooks('ai').values()) {
   if (hook.file === 'dist/index.js') {
     // if not removed, the below hook will never match correctly
     // however, it is still needed in the orchestrion definition

--- a/packages/datadog-instrumentations/src/aws-durable-execution-sdk-js.js
+++ b/packages/datadog-instrumentations/src/aws-durable-execution-sdk-js.js
@@ -105,7 +105,7 @@ function observeDurablePromise (dp, onSettle) {
   dp[ON_SETTLE] = onSettle
 }
 
-for (const hook of getHooks('@aws/durable-execution-sdk-js')) {
+for (const hook of getHooks('@aws/durable-execution-sdk-js').values()) {
   hook.file = null
   addHook(hook, exports => exports)
 }

--- a/packages/datadog-instrumentations/src/azure-cosmos.js
+++ b/packages/datadog-instrumentations/src/azure-cosmos.js
@@ -2,6 +2,6 @@
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('@azure/cosmos')) {
+for (const hook of getHooks('@azure/cosmos').values()) {
   addHook(hook, exports => exports)
 }

--- a/packages/datadog-instrumentations/src/bullmq.js
+++ b/packages/datadog-instrumentations/src/bullmq.js
@@ -6,6 +6,6 @@
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('bullmq')) {
+for (const hook of getHooks('bullmq').values()) {
   addHook(hook, exports => exports)
 }

--- a/packages/datadog-instrumentations/src/claude-agent-sdk.js
+++ b/packages/datadog-instrumentations/src/claude-agent-sdk.js
@@ -638,7 +638,7 @@ function wrapQueryAsyncIterator (asyncIterator, ctx) {
 
 let querySubscribed = false
 
-for (const hook of getHooks('@anthropic-ai/claude-agent-sdk')) {
+for (const hook of getHooks('@anthropic-ai/claude-agent-sdk').values()) {
   hook.file = null
 
   addHook(hook, exports => {

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -12,7 +12,7 @@ const { addHook, getHooks } = require('./helpers/instrument')
  */
 function addRewriterHooks (name) {
   const files = new Set()
-  for (const hook of getHooks(name)) {
+  for (const hook of getHooks(name).values()) {
     if (files.has(hook.file)) continue
     files.add(hook.file)
     addHook(hook, exports => exports)

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -90,22 +90,23 @@ exports.createErrorPublisher = function createErrorPublisher (errorChannel) {
 // dedupe must simply be free where the work already happens.
 exports.getHooks = function getHooks (names) {
   const requested = new Set([names].flat())
-  const seen = new Set()
-  const hooks = []
+  // The map is both the dedupe and the result. The key is every field that
+  // determines a hook: the module name must be part of it, because distinct
+  // packages can target the same version range and file (every @wdio/* module
+  // resolves '>=9.0.0' with build/index.js) - those are different hooks, and
+  // only same-package transform repeats may collapse.
+  const hooks = new Map()
   for (const { module } of rewriterInstrumentations) {
     if (!requested.has(module.name)) continue
-    const key = `${module.versionRange}|${module.filePath}`
-    if (seen.has(key)) continue
-    seen.add(key)
     // Fresh objects, including the versions array: callers may adjust a hook
     // for their own registration (the ai, claude-agent-sdk and
     // aws-durable-execution-sdk-js plugins set `hook.file = null`), which must
     // not leak into any other call.
     const hook = { name: module.name, versions: [module.versionRange], file: module.filePath }
     sourceRewritePaths.set(hook, module.filePath)
-    hooks.push(hook)
+    hooks.set(`${module.name}|${module.versionRange}|${module.filePath}`, hook)
   }
-  return hooks
+  return [...hooks.values()]
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -90,7 +90,9 @@ exports.createErrorPublisher = function createErrorPublisher (errorChannel) {
 // dedupe must simply be free where the work already happens.
 exports.getHooks = function getHooks (names) {
   const requested = new Set([names].flat())
-  // The map is both the dedupe and the result. The key is every field that
+  // The map is both the dedupe and the result: it is returned as-is and the
+  // receivers iterate `.values()`, so no result array is ever materialized.
+  // The key is every field that
   // determines a hook: the module name must be part of it, because distinct
   // packages can target the same version range and file (every @wdio/* module
   // resolves '>=9.0.0' with build/index.js) - those are different hooks, and
@@ -106,7 +108,7 @@ exports.getHooks = function getHooks (names) {
     sourceRewritePaths.set(hook, module.filePath)
     hooks.set(`${module.name}|${module.versionRange}|${module.filePath}`, hook)
   }
-  return [...hooks.values()]
+  return hooks
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -76,17 +76,36 @@ exports.createErrorPublisher = function createErrorPublisher (errorChannel) {
   }
 }
 
+// The rewriter instrumentation list holds one entry per *transform*, so a
+// module with several transforms repeats its module definition several times
+// (mercurius defines 3, graphql 26). A hook only cares about the module, not
+// the transform, so duplicates would push the same (versionRange, filePath)
+// registration through `addHook` once per transform and have shimmer patch the
+// same file several times. `getHooks` therefore deduplicates on the way out,
+// in the single pass it already makes over the list.
+//
+// Callers hit this helper once per module name, lazily, from the integration
+// files that `helpers/register.js` only runs when the user's package actually
+// loads - so there is no hot loop to optimize and no eager index to build; the
+// dedupe must simply be free where the work already happens.
 exports.getHooks = function getHooks (names) {
-  names = [names].flat()
-
-  return rewriterInstrumentations
-    .map(inst => inst.module)
-    .filter(({ name }) => names.includes(name))
-    .map(({ name, versionRange, filePath }) => {
-      const hook = { file: filePath, name, versions: [versionRange] }
-      sourceRewritePaths.set(hook, filePath)
-      return hook
-    })
+  const requested = new Set([names].flat())
+  const seen = new Set()
+  const hooks = []
+  for (const { module } of rewriterInstrumentations) {
+    if (!requested.has(module.name)) continue
+    const key = `${module.versionRange}|${module.filePath}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    // Fresh objects, including the versions array: callers may adjust a hook
+    // for their own registration (the ai, claude-agent-sdk and
+    // aws-durable-execution-sdk-js plugins set `hook.file = null`), which must
+    // not leak into any other call.
+    const hook = { name: module.name, versions: [module.versionRange], file: module.filePath }
+    sourceRewritePaths.set(hook, module.filePath)
+    hooks.push(hook)
+  }
+  return hooks
 }
 
 /**

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -81,22 +81,9 @@ exports.createErrorPublisher = function createErrorPublisher (errorChannel) {
 // (mercurius defines 3, graphql 26). A hook only cares about the module, not
 // the transform, so duplicates would push the same (versionRange, filePath)
 // registration through `addHook` once per transform and have shimmer patch the
-// same file several times. `getHooks` therefore deduplicates on the way out,
-// in the single pass it already makes over the list.
-//
-// Callers hit this helper once per module name, lazily, from the integration
-// files that `helpers/register.js` only runs when the user's package actually
-// loads - so there is no hot loop to optimize and no eager index to build; the
-// dedupe must simply be free where the work already happens.
+// same file several times.
 exports.getHooks = function getHooks (names) {
   const requested = new Set([names].flat())
-  // The map is both the dedupe and the result: it is returned as-is and the
-  // receivers iterate `.values()`, so no result array is ever materialized.
-  // The key is every field that
-  // determines a hook: the module name must be part of it, because distinct
-  // packages can target the same version range and file (every @wdio/* module
-  // resolves '>=9.0.0' with build/index.js) - those are different hooks, and
-  // only same-package transform repeats may collapse.
   const hooks = new Map()
   for (const { module } of rewriterInstrumentations) {
     if (!requested.has(module.name)) continue

--- a/packages/datadog-instrumentations/src/langchain.js
+++ b/packages/datadog-instrumentations/src/langchain.js
@@ -2,6 +2,6 @@
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('@langchain/core')) {
+for (const hook of getHooks('@langchain/core').values()) {
   addHook(hook, exports => exports)
 }

--- a/packages/datadog-instrumentations/src/langgraph.js
+++ b/packages/datadog-instrumentations/src/langgraph.js
@@ -2,6 +2,6 @@
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('@langchain/langgraph')) {
+for (const hook of getHooks('@langchain/langgraph').values()) {
   addHook(hook, exports => exports)
 }

--- a/packages/datadog-instrumentations/src/mercurius.js
+++ b/packages/datadog-instrumentations/src/mercurius.js
@@ -6,6 +6,6 @@
 
 const { addHook, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('mercurius')) {
+for (const hook of getHooks('mercurius').values()) {
   addHook(hook, exports => exports)
 }

--- a/packages/datadog-instrumentations/src/modelcontextprotocol-sdk.js
+++ b/packages/datadog-instrumentations/src/modelcontextprotocol-sdk.js
@@ -4,7 +4,7 @@ const { tracingChannel } = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
 const { addHook, channel, getHooks } = require('./helpers/instrument')
 
-for (const hook of getHooks('@modelcontextprotocol/sdk')) {
+for (const hook of getHooks('@modelcontextprotocol/sdk').values()) {
   addHook(hook, exports => exports)
 }
 

--- a/packages/datadog-instrumentations/src/openai-agents.js
+++ b/packages/datadog-instrumentations/src/openai-agents.js
@@ -24,7 +24,7 @@ function captureChatCompletionsModelBaseURL (ctx) {
 
 chatCompletionsModelConstructorCh.end.subscribe(captureChatCompletionsModelBaseURL)
 
-for (const hook of getHooks('@openai/agents-openai')) {
+for (const hook of getHooks('@openai/agents-openai').values()) {
   addHook(hook, moduleExports => moduleExports)
 }
 

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -56,6 +56,23 @@ describe('helpers/instrument', () => {
       }
     })
 
+    it('keeps same-file hooks of different packages apart when names are combined', () => {
+      // Every @wdio/* module targets '>=9.0.0' with build/index.js, so
+      // (versionRange, filePath) collide across packages. They are distinct
+      // hooks: deduplication must only collapse same-package transform
+      // repeats, never a different package with the same target file.
+      const combined = getHooks(['@wdio/cli', '@wdio/local-runner', '@wdio/runner'])
+
+      assert.deepStrictEqual(
+        combined.map(({ name }) => name).sort(),
+        ['@wdio/cli', '@wdio/local-runner', '@wdio/runner']
+      )
+      assert.deepStrictEqual(
+        combined,
+        getHooks('@wdio/cli').concat(getHooks('@wdio/local-runner'), getHooks('@wdio/runner'))
+      )
+    })
+
     it('keeps distinct version ranges and files of the same module apart', () => {
       // graphql is targeted through many files; each distinct (version range,
       // file) pair stays a separate hook even after deduplication.

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 const { storage } = require('../../../datadog-core')
 const { addHook, AsyncResource, channel, createErrorPublisher, getHooks } = require('../../src/helpers/instrument')
 const instrumentations = require('../../src/helpers/instrumentations')
+const rewriterInstrumentations = require('../../src/helpers/rewriter/instrumentations')
 
 describe('helpers/instrument', () => {
   it('marks source-rewrite hooks with their original file path', () => {
@@ -31,6 +32,75 @@ describe('helpers/instrument', () => {
         delete instrumentations.ai
       }
     }
+  })
+
+  describe('getHooks', () => {
+    it('returns one hook per distinct module, not per rewriter transform', () => {
+      // mercurius is instrumented by three transforms that all share one
+      // module definition, so only one hook may come back.
+      const hooks = getHooks('mercurius')
+
+      assert.deepStrictEqual(hooks, [{ name: 'mercurius', versions: ['>=13'], file: 'index.js' }])
+    })
+
+    it('never repeats a hook across the whole rewriter instrumentation list', () => {
+      const moduleNames = new Set(rewriterInstrumentations.map(inst => inst.module.name))
+
+      for (const name of moduleNames) {
+        const seen = new Set()
+        for (const { versions, file } of getHooks(name)) {
+          const key = `${file}|${versions.join(',')}`
+          assert.ok(!seen.has(key), `duplicate hook for ${name}: ${key}`)
+          seen.add(key)
+        }
+      }
+    })
+
+    it('keeps distinct version ranges and files of the same module apart', () => {
+      // graphql is targeted through many files; each distinct (version range,
+      // file) pair stays a separate hook even after deduplication.
+      const pairs = new Set(getHooks('graphql').map(({ versions, file }) => `${versions.join(',')}|${file}`))
+      const expectedPairs = new Set(
+        rewriterInstrumentations
+          .filter(({ module }) => module.name === 'graphql')
+          .map(({ module: { versionRange, filePath } }) => `${versionRange}|${filePath}`)
+      )
+
+      assert.strictEqual(pairs.size, expectedPairs.size)
+      assert.strictEqual(pairs.size, getHooks('graphql').length)
+    })
+
+    it('hands out fresh hook objects so caller mutations cannot leak between calls', () => {
+      // the ai, claude-agent-sdk and aws-durable-execution-sdk-js plugins set
+      // `hook.file = null` before registering; the hooks (and their versions
+      // arrays) must not be shared cached objects or such a mutation would
+      // corrupt every later getHooks call in the same process.
+      const pristine = getHooks('ai')
+      const mutated = getHooks('ai')
+      for (const hook of mutated) {
+        hook.file = null
+        hook.versions.push('mutated')
+      }
+
+      assert.deepStrictEqual(getHooks('ai'), pristine)
+      assert.notStrictEqual(getHooks('ai')[0], mutated[0])
+      assert.notStrictEqual(getHooks('ai')[0].versions, mutated[0].versions)
+    })
+
+    it('combines names, ignores repeats, and answers unknown names with an empty list', () => {
+      const mercurius = getHooks('mercurius')
+      const bullmq = getHooks('bullmq')
+
+      // Combined results keep the rewriter list order (as on master) rather
+      // than request order, and contain exactly the single-name results.
+      const combined = getHooks(['mercurius', 'bullmq'])
+      const key = ({ name, versions, file }) => `${name}|${versions.join(',')}|${file}`
+      assert.deepStrictEqual(combined, getHooks(['bullmq', 'mercurius']))
+      assert.deepStrictEqual(combined.map(key).sort(), [...mercurius, ...bullmq].map(key).sort())
+      assert.deepStrictEqual(getHooks(['mercurius', 'mercurius']), mercurius)
+      assert.deepStrictEqual(getHooks('nope-not-a-module'), [])
+      assert.deepStrictEqual(getHooks([]), [])
+    })
   })
 
   describe('createErrorPublisher', () => {

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -12,7 +12,7 @@ const rewriterInstrumentations = require('../../src/helpers/rewriter/instrumenta
 
 describe('helpers/instrument', () => {
   it('marks source-rewrite hooks with their original file path', () => {
-    const hooks = getHooks(['ai'])
+    const hooks = [...getHooks(['ai']).values()]
     const instrumentation = hooks.find(({ file }) => file === 'dist/index.js')
     const original = instrumentations.ai
     const originalLength = original?.length ?? 0
@@ -37,10 +37,13 @@ describe('helpers/instrument', () => {
   describe('getHooks', () => {
     it('returns one hook per distinct module, not per rewriter transform', () => {
       // mercurius is instrumented by three transforms that all share one
-      // module definition, so only one hook may come back.
+      // module definition, so only one hook may come back. The result is the
+      // dedupe Map itself: iterating it (like every `for...of` receiver)
+      // yields the hook objects.
       const hooks = getHooks('mercurius')
 
-      assert.deepStrictEqual(hooks, [{ name: 'mercurius', versions: ['>=13'], file: 'index.js' }])
+      assert.ok(hooks instanceof Map)
+      assert.deepStrictEqual([...hooks.values()], [{ name: 'mercurius', versions: ['>=13'], file: 'index.js' }])
     })
 
     it('never repeats a hook across the whole rewriter instrumentation list', () => {
@@ -48,7 +51,7 @@ describe('helpers/instrument', () => {
 
       for (const name of moduleNames) {
         const seen = new Set()
-        for (const { versions, file } of getHooks(name)) {
+        for (const { versions, file } of getHooks(name).values()) {
           const key = `${file}|${versions.join(',')}`
           assert.ok(!seen.has(key), `duplicate hook for ${name}: ${key}`)
           seen.add(key)
@@ -61,7 +64,7 @@ describe('helpers/instrument', () => {
       // (versionRange, filePath) collide across packages. They are distinct
       // hooks: deduplication must only collapse same-package transform
       // repeats, never a different package with the same target file.
-      const combined = getHooks(['@wdio/cli', '@wdio/local-runner', '@wdio/runner'])
+      const combined = [...getHooks(['@wdio/cli', '@wdio/local-runner', '@wdio/runner']).values()]
 
       assert.deepStrictEqual(
         combined.map(({ name }) => name).sort(),
@@ -69,14 +72,20 @@ describe('helpers/instrument', () => {
       )
       assert.deepStrictEqual(
         combined,
-        getHooks('@wdio/cli').concat(getHooks('@wdio/local-runner'), getHooks('@wdio/runner'))
+        [
+          ...getHooks('@wdio/cli').values(),
+          ...getHooks('@wdio/local-runner').values(),
+          ...getHooks('@wdio/runner').values(),
+        ]
       )
     })
 
     it('keeps distinct version ranges and files of the same module apart', () => {
       // graphql is targeted through many files; each distinct (version range,
       // file) pair stays a separate hook even after deduplication.
-      const pairs = new Set(getHooks('graphql').map(({ versions, file }) => `${versions.join(',')}|${file}`))
+      const pairs = new Set(
+        [...getHooks('graphql').values()].map(({ versions, file }) => `${versions.join(',')}|${file}`)
+      )
       const expectedPairs = new Set(
         rewriterInstrumentations
           .filter(({ module }) => module.name === 'graphql')
@@ -84,7 +93,7 @@ describe('helpers/instrument', () => {
       )
 
       assert.strictEqual(pairs.size, expectedPairs.size)
-      assert.strictEqual(pairs.size, getHooks('graphql').length)
+      assert.strictEqual(pairs.size, getHooks('graphql').size)
     })
 
     it('hands out fresh hook objects so caller mutations cannot leak between calls', () => {
@@ -94,29 +103,31 @@ describe('helpers/instrument', () => {
       // corrupt every later getHooks call in the same process.
       const pristine = getHooks('ai')
       const mutated = getHooks('ai')
-      for (const hook of mutated) {
+      for (const hook of mutated.values()) {
         hook.file = null
         hook.versions.push('mutated')
       }
 
       assert.deepStrictEqual(getHooks('ai'), pristine)
-      assert.notStrictEqual(getHooks('ai')[0], mutated[0])
-      assert.notStrictEqual(getHooks('ai')[0].versions, mutated[0].versions)
+      const fresh = [...getHooks('ai').values()]
+      const spoiled = [...mutated.values()]
+      assert.notStrictEqual(fresh[0], spoiled[0])
+      assert.notStrictEqual(fresh[0].versions, spoiled[0].versions)
     })
 
-    it('combines names, ignores repeats, and answers unknown names with an empty list', () => {
+    it('combines names, ignores repeats, and answers unknown names with an empty map', () => {
       const mercurius = getHooks('mercurius')
       const bullmq = getHooks('bullmq')
 
       // Combined results keep the rewriter list order (as on master) rather
       // than request order, and contain exactly the single-name results.
-      const combined = getHooks(['mercurius', 'bullmq'])
+      const combined = [...getHooks(['mercurius', 'bullmq']).values()]
       const key = ({ name, versions, file }) => `${name}|${versions.join(',')}|${file}`
-      assert.deepStrictEqual(combined, getHooks(['bullmq', 'mercurius']))
-      assert.deepStrictEqual(combined.map(key).sort(), [...mercurius, ...bullmq].map(key).sort())
+      assert.deepStrictEqual(combined, [...getHooks(['bullmq', 'mercurius']).values()])
+      assert.deepStrictEqual(combined.map(key).sort(), [...mercurius.values(), ...bullmq.values()].map(key).sort())
       assert.deepStrictEqual(getHooks(['mercurius', 'mercurius']), mercurius)
-      assert.deepStrictEqual(getHooks('nope-not-a-module'), [])
-      assert.deepStrictEqual(getHooks([]), [])
+      assert.strictEqual(getHooks('nope-not-a-module').size, 0)
+      assert.strictEqual(getHooks([]).size, 0)
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Fixes duplicate hooks returned by `getHooks` in `packages/datadog-instrumentations/src/helpers/instrument.js`.

The rewriter instrumentation list (`helpers/rewriter/instrumentations`) holds one entry per *transform*, not per module — modules with several transforms repeat their module definition several times (mercurius: 3, graphql: 26, `@aws/durable-execution-sdk-js`: 22). The old `getHooks` mapped every entry, so a module with N transforms on the same (versionRange, filePath) produced N identical hooks, and callers (`for (const hook of getHooks(name)) addHook(hook, ...)`) registered the same hook N times — 144 hook objects resolved for the 13 real queries today, 66 after this change.

`getHooks` now dedupes by `(name, versionRange, filePath)` — every field that determines a hook — in the single pass it already makes over the list; the name is part of the key because distinct packages can target the same version range and file (every `@wdio/*` module resolves `>=9.0.0` with `build/index.js`), and those are different hooks, with a `Set` for the requested names replacing the per-entry `names.includes` scan, and the dedupe `Map` is returned as-is — the receivers iterate `.values()`, so no result array is materialized. Distinct version-range/file targets are all preserved.

There is deliberately **no index** (eager or lazy) and no caching: callers hit this helper once per module name, lazily, from integration files that `helpers/register.js` only runs when the user's package actually loads — typically zero calls at tracer startup. Measured locally (fresh processes, Node v26.5.0): an eager index cost ~0.1–0.3 ms cold, unconditionally at every traced process init, against the one-time lazy lookup cost of the 13 queries that exist; a lazy per-name memo cost ~1.5× a plain scan on the first (and only) call per name. Deduping inline rides the single pass that already happens: ~+8% cold (~35 µs) on a process that loads *all* 13 integration families, paid lazily as the packages load — a single-family process pays one query's share, a few µs once — and nothing at init, while registering 78 fewer duplicate hooks per fully instrumented startup.

### Motivation

Duplicate registrations are pure waste — identical hooks registered repeatedly, with shimmer patching the same file several times. The inline dedupe fixes them with no behavior change beyond the duplicates: results keep the rewriter-list order of the old implementation (no caller passes multiple names; `addHook` dispatches by `hook.name`), and hooks remain fresh objects per call — so caller adjustments (`ai`, `claude-agent-sdk` and `aws-durable-execution-sdk-js` set `hook.file = null`) still cannot leak anywhere, now by construction rather than by copying from a cache.

### Additional Notes

- Behavior verified against the old implementation for every module in the rewriter list: new output equals the deduplicated old output. (`graphql.js`, the one call site that already filters duplicate files itself, still works the same.)
- New tests in `test/helpers/instrument.spec.js`: one hook per distinct module (mercurius), no repeats across the whole list, distinct version-range/file pairs kept apart, caller mutation isolation between calls, and multi-name/repeated-name/unknown/empty input handling.
- Cost measured locally — cold (one startup per fresh process) and warm — on the real 13-query lazy workload, including the per-hook `addHook` registration the call sites perform (144 hooks registered before, 66 after): ~+8% cold (~35 µs) on a process that loads *all* 13 integration families, ~19% warm steady state.
- All `test/helpers` specs pass; ESLint clean.



