### PR TITLE
bench(sirun): add instrument-get-hooks benchmark

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,6 +97,7 @@
 /benchmark/sirun/plugin-redis-traced/ @DataDog/dd-trace-js @DataDog/apm-idm-js
 /benchmark/sirun/plugin-ws/ @DataDog/dd-trace-js @DataDog/apm-idm-js
 /benchmark/sirun/url/ @DataDog/dd-trace-js @DataDog/apm-idm-js
+/benchmark/sirun/instrument-get-hooks/ @DataDog/dd-trace-js @DataDog/apm-idm-js
 
 /index.electron.js @DataDog/dd-trace-js @DataDog/apm-idm-js
 /integration-tests/electron/ @DataDog/dd-trace-js @DataDog/apm-idm-js

--- a/benchmark/sirun/instrument-get-hooks/README.md
+++ b/benchmark/sirun/instrument-get-hooks/README.md
@@ -1,53 +1,56 @@
 # instrument-get-hooks
 
-Measures the end-to-end hook-resolution cost of one tracer startup for
-`getHooks` in `packages/datadog-instrumentations/src/helpers/instrument.js`:
-every rewriter-based integration calls it once at require time, one call per
-rewriter-instrumented module (23 calls per traced process).
+Quantifies the cost of the dedupe fix in `getHooks`
+(`packages/datadog-instrumentations/src/helpers/instrument.js`). The rewriter
+instrumentation list holds one entry per transform, so `getHooks` returned one
+hook per transform and integrations registered the same (versionRange,
+filePath) several times (144 hooks for the real query set before the fix, 66
+after).
 
-Each loop iteration simulates one complete startup, inside the measured window:
-the `indexed` variant (re)builds the startup index and then resolves hooks for
-every rewriter-instrumented module once — matching the production lookup count
-— while the `scan` variant resolves the same names with the pre-index
-implementation, which has no startup cost of its own. Keeping the index
-construction in the measurement matters: production never calls `getHooks` in
-a hot loop, so a synthetic per-call loop would amortize the index build away
-and misrepresent the trade.
+The workload models what production actually does: `getHooks` is called once
+per module name, **lazily**, from integration files that
+`helpers/register.js` only runs when the user's package loads. A traced
+process performs **zero** of these calls at tracer init, and all 13 only when
+every instrumented package family is used. The 13 queries are the complete set
+of call sites in the repo (`ai.js`, `langchain.js`, `mercurius.js`,
+`bullmq.js`, `modelcontextprotocol-sdk.js`, `openai-agents.js`,
+`langgraph.js`, `aws-durable-execution-sdk-js.js`, `azure-cosmos.js`,
+`claude-agent-sdk.js`, and the three in `graphql.js`). There is no hot loop
+to optimize and no fixed startup cost to charge against lookup savings, so
+the bench measures one simulated lazy load pass per iteration.
 
-- `scan` — the pre-index implementation, kept verbatim as the baseline. Full
-  map → filter → map over the rewriter list per call, with a nested
-  `names.includes`.
-- `indexed` — the name-indexed implementation, also verbatim: one startup pass
-  dedupes the hooks by (versionRange, filePath) into a `Map`, then each call is
-  a lookup plus a defensive copy of the cached hooks.
+- `scan` — the pre-fix implementation, verbatim: map → filter → map, one
+  hook per transform (duplicates included).
+- `deduped` — the fixed implementation, verbatim: one pass, skipping
+  transforms whose (versionRange, filePath) was already emitted, with a Set
+  for the requested names.
 
-Both implementations are frozen references over the real rewriter
-instrumentation list: the setup assertions prove their outputs are equivalent
-(up to the dedupe the index introduces) before anything is measured.
+Variants (`meta.json`):
 
-Measured (Node v26.2.0, warm, 20 000 simulated startups):
+- `*-cold` — one simulated startup through the measured window per process.
+  Each sirun iteration is a fresh process, so the window is paid cold, where
+  production pays it. The startup-guard share ceiling is vacuous here by
+  design (load+setup legitimately dominates a single pass) — the guard's
+  rot protection is carried by the warm variants instead.
+- `*-warm` — 20 000 simulated startups per process, for steady-state signal
+  over the same workload.
 
-| | per startup |
-|---|---|
-| `scan` | ~65 µs (resolves 193 hook objects) |
-| `indexed` | ~13 µs (resolves 81 hook objects, index build included) |
+Measured (Node v26.2.0, median of fresh processes / warm loops):
 
-The one-time cold cost of the index build (paid once at require, before the
-JIT warms up) is on the order of ~0.1–0.3 ms; it is part of the measured
-per-startup figure above in its warm form.
+| variant | per startup (13 queries) | hooks resolved |
+|---|---|---|
+| `scan-cold` | ~175 µs | 144 |
+| `deduped-cold` | ~195 µs | 66 |
+| `scan-warm` | ~34 µs | 144 |
+| `deduped-warm` | ~29 µs | 66 |
 
-The optimization that ships the indexed implementation in
-`helpers/instrument.js` is stacked on this branch. The benchmark deliberately
-stays self-contained rather than requiring the shipped helper: the shipped
-implementation builds its index at require time, outside any in-process
-measured window, so requiring it would reintroduce exactly the
-measurement-boundary problem this design exists to avoid.
+Zero-lookup startups (the common case) run no `getHooks` code in either
+variant: the fix adds no fixed cost anywhere — nothing is built at require
+time.
 
-The `startup-guard` ceiling is relaxed to 30% for the `indexed` variant: its
-loop is shorter by the size of the win itself (~5× fewer instructions per
-startup), and the guard's purpose (catching a bench that rots into measuring
-startup) is still enforced by the setup assertions plus the identical
-`STARTUPS` per variant.
+Read: the correctness fix costs ~10% cold on a process that loads *all* 13
+integration families (~20 µs, only paid as the packages load), and wins
+~15% warm. A zero-lookup process pays nothing either way.
 
 Run with:
 

--- a/benchmark/sirun/instrument-get-hooks/README.md
+++ b/benchmark/sirun/instrument-get-hooks/README.md
@@ -44,7 +44,12 @@ Variants (`meta.json`):
   Each sirun iteration is a fresh process, so the window is paid cold, where
   production pays it. The startup-guard share ceiling is vacuous here by
   design (load+setup legitimately dominates a single pass) — the guard's
-  rot protection is carried by the warm variants instead.
+  rot protection is carried by the warm variants instead. Cold variants
+  deliberately set no `OPERATIONS`: the ops-gauge emission runs after the
+  loop but before process exit — inside sirun's measured window — and
+  requires the tracer's statsd client plus a UDP socket, a fixed cost that
+  would dwarf a single ~0.4 ms sample. Cold samples are read from sirun's
+  `wall.time`/`instructions`, which stay clean.
 - `*-warm` — 20 000 simulated startups per process, for steady-state signal
   over the same workload.
 

--- a/benchmark/sirun/instrument-get-hooks/README.md
+++ b/benchmark/sirun/instrument-get-hooks/README.md
@@ -1,0 +1,35 @@
+# instrument-get-hooks
+
+Measures the per-call cost of `getHooks` in
+`packages/datadog-instrumentations/src/helpers/instrument.js`, which every
+rewriter-based integration calls once at require time to look up its module
+hooks (15+ calls per traced process).
+
+Both implementations are kept in the bench so it runs standalone, over the real
+rewriter instrumentation list:
+
+- `scan` — the pre-index implementation, kept verbatim as the baseline. Full
+  map → filter → map over the list per call, with a nested `names.includes`.
+- `indexed` — the name-indexed implementation, also verbatim: one startup pass
+  dedupes the hooks by (versionRange, filePath) into a `Map`, then each call is
+  a lookup plus a defensive copy of the cached hooks.
+
+Measured (Node v26.2.0, warm, 1M calls across all 23 rewriter-instrumented
+module names): `scan` ~1.24µs/call, `indexed` ~0.14µs/call (~9×), one-time index
+build ~84µs. The optimization that ships the indexed implementation in
+`helpers/instrument.js` is stacked on this branch and repoints the `indexed`
+variant at the shipped helper, so the bench keeps tracking production code once
+it lands.
+
+The `startup-guard` ceiling is relaxed to 30% for the `indexed` variant: its
+loop is intentionally ~100× shorter than the scan baseline, which is precisely
+the win, and the guard's purpose (catching a bench that rots into measuring
+startup) is still enforced by the setup assertions plus the identical `CALLS`
+per variant.
+
+Run with:
+
+```sh
+cd benchmark/sirun/instrument-get-hooks
+node ../run-all-variants.js
+```

--- a/benchmark/sirun/instrument-get-hooks/README.md
+++ b/benchmark/sirun/instrument-get-hooks/README.md
@@ -7,23 +7,36 @@ hook per transform and integrations registered the same (versionRange,
 filePath) several times (144 hooks for the real query set before the fix, 66
 after).
 
-The workload models what production actually does: `getHooks` is called once
-per module name, **lazily**, from integration files that
-`helpers/register.js` only runs when the user's package loads. A traced
-process performs **zero** of these calls at tracer init, and all 13 only when
-every instrumented package family is used. The 13 queries are the complete set
-of call sites in the repo (`ai.js`, `langchain.js`, `mercurius.js`,
-`bullmq.js`, `modelcontextprotocol-sdk.js`, `openai-agents.js`,
-`langgraph.js`, `aws-durable-execution-sdk-js.js`, `azure-cosmos.js`,
-`claude-agent-sdk.js`, and the three in `graphql.js`). There is no hot loop
-to optimize and no fixed startup cost to charge against lookup savings, so
-the bench measures one simulated lazy load pass per iteration.
+The workload models what production actually does, end to end:
+
+- `getHooks` is called once per module name, **lazily**, from integration
+  files that `helpers/register.js` only runs when the user's package loads.
+  A traced process performs **zero** of these calls at tracer init, and all
+  13 only when every instrumented package family is used. The 13 queries
+  are the complete set of call sites in the repo (`ai.js`, `langchain.js`,
+  `mercurius.js`, `bullmq.js`, `modelcontextprotocol-sdk.js`,
+  `openai-agents.js`, `langgraph.js`, `aws-durable-execution-sdk-js.js`,
+  `azure-cosmos.js`, `claude-agent-sdk.js`, and the three in `graphql.js`).
+- Production call sites never stop at the hook count: each one registers
+  every returned hook through `addHook` (for example `azure-cosmos.js`:
+  `for (const hook of getHooks('@azure/cosmos')) addHook(hook, exports =>
+  exports)`). The bench models that pass too — one closure, one push into
+  the per-name list, per returned hook — because the number of returned
+  hooks (144 vs 66) is a real part of what the fix changes.
+
+There is no hot loop to optimize and no fixed startup cost to charge against
+lookup savings, so the bench measures one simulated lazy load pass per
+iteration.
 
 - `scan` — the pre-fix implementation, verbatim: map → filter → map, one
   hook per transform (duplicates included).
 - `deduped` — the fixed implementation, verbatim: one pass, skipping
   transforms whose (versionRange, filePath) was already emitted, with a Set
   for the requested names.
+
+Both live in `get-hooks.js`; `validate.js` runs as a sirun `setup` command
+before the measured process exists, so its equivalence gate can neither warm
+the measured process nor land inside the measured window.
 
 Variants (`meta.json`):
 
@@ -35,22 +48,28 @@ Variants (`meta.json`):
 - `*-warm` — 20 000 simulated startups per process, for steady-state signal
   over the same workload.
 
-Measured (Node v26.2.0, median of fresh processes / warm loops):
+Measured (Node v26.5.0, median of fresh processes / warm loops):
 
-| variant | per startup (13 queries) | hooks resolved |
+| variant | per startup (13 queries + registration) | hooks registered |
 |---|---|---|
-| `scan-cold` | ~175 µs | 144 |
-| `deduped-cold` | ~195 µs | 66 |
-| `scan-warm` | ~34 µs | 144 |
-| `deduped-warm` | ~29 µs | 66 |
+| `scan-cold` | ~435 µs | 144 |
+| `deduped-cold` | ~470 µs | 66 |
+| `scan-warm` | ~22.5 µs | 144 |
+| `deduped-warm` | ~27 µs | 66 |
 
 Zero-lookup startups (the common case) run no `getHooks` code in either
 variant: the fix adds no fixed cost anywhere — nothing is built at require
 time.
 
-Read: the correctness fix costs ~10% cold on a process that loads *all* 13
-integration families (~20 µs, only paid as the packages load), and wins
-~15% warm. A zero-lookup process pays nothing either way.
+Read: the correctness fix costs ~8% (~35 µs) on a *fully instrumented*
+startup, only as the packages load, and ~19% in steady state per startup.
+Warm is the pessimistic lens: production never calls `getHooks` twice for
+the same name in one process, so the cold number is the production cost.
+The warm gap is real and instructive — the dedupe pays a Set lookup per
+list entry plus a (versionRange, filePath) key string per match, which
+costs more after JIT than the scan's extra duplicate allocations, even
+while saving 78 registrations per startup. A process using a single
+integration family pays one query's share of the delta: a few µs, once.
 
 Run with:
 

--- a/benchmark/sirun/instrument-get-hooks/README.md
+++ b/benchmark/sirun/instrument-get-hooks/README.md
@@ -1,31 +1,53 @@
 # instrument-get-hooks
 
-Measures the per-call cost of `getHooks` in
-`packages/datadog-instrumentations/src/helpers/instrument.js`, which every
-rewriter-based integration calls once at require time to look up its module
-hooks (15+ calls per traced process).
+Measures the end-to-end hook-resolution cost of one tracer startup for
+`getHooks` in `packages/datadog-instrumentations/src/helpers/instrument.js`:
+every rewriter-based integration calls it once at require time, one call per
+rewriter-instrumented module (23 calls per traced process).
 
-Both implementations are kept in the bench so it runs standalone, over the real
-rewriter instrumentation list:
+Each loop iteration simulates one complete startup, inside the measured window:
+the `indexed` variant (re)builds the startup index and then resolves hooks for
+every rewriter-instrumented module once — matching the production lookup count
+— while the `scan` variant resolves the same names with the pre-index
+implementation, which has no startup cost of its own. Keeping the index
+construction in the measurement matters: production never calls `getHooks` in
+a hot loop, so a synthetic per-call loop would amortize the index build away
+and misrepresent the trade.
 
 - `scan` — the pre-index implementation, kept verbatim as the baseline. Full
-  map → filter → map over the list per call, with a nested `names.includes`.
+  map → filter → map over the rewriter list per call, with a nested
+  `names.includes`.
 - `indexed` — the name-indexed implementation, also verbatim: one startup pass
   dedupes the hooks by (versionRange, filePath) into a `Map`, then each call is
   a lookup plus a defensive copy of the cached hooks.
 
-Measured (Node v26.2.0, warm, 1M calls across all 23 rewriter-instrumented
-module names): `scan` ~1.24µs/call, `indexed` ~0.14µs/call (~9×), one-time index
-build ~84µs. The optimization that ships the indexed implementation in
-`helpers/instrument.js` is stacked on this branch and repoints the `indexed`
-variant at the shipped helper, so the bench keeps tracking production code once
-it lands.
+Both implementations are frozen references over the real rewriter
+instrumentation list: the setup assertions prove their outputs are equivalent
+(up to the dedupe the index introduces) before anything is measured.
+
+Measured (Node v26.2.0, warm, 20 000 simulated startups):
+
+| | per startup |
+|---|---|
+| `scan` | ~65 µs (resolves 193 hook objects) |
+| `indexed` | ~13 µs (resolves 81 hook objects, index build included) |
+
+The one-time cold cost of the index build (paid once at require, before the
+JIT warms up) is on the order of ~0.1–0.3 ms; it is part of the measured
+per-startup figure above in its warm form.
+
+The optimization that ships the indexed implementation in
+`helpers/instrument.js` is stacked on this branch. The benchmark deliberately
+stays self-contained rather than requiring the shipped helper: the shipped
+implementation builds its index at require time, outside any in-process
+measured window, so requiring it would reintroduce exactly the
+measurement-boundary problem this design exists to avoid.
 
 The `startup-guard` ceiling is relaxed to 30% for the `indexed` variant: its
-loop is intentionally ~100× shorter than the scan baseline, which is precisely
-the win, and the guard's purpose (catching a bench that rots into measuring
-startup) is still enforced by the setup assertions plus the identical `CALLS`
-per variant.
+loop is shorter by the size of the win itself (~5× fewer instructions per
+startup), and the guard's purpose (catching a bench that rots into measuring
+startup) is still enforced by the setup assertions plus the identical
+`STARTUPS` per variant.
 
 Run with:
 

--- a/benchmark/sirun/instrument-get-hooks/get-hooks.js
+++ b/benchmark/sirun/instrument-get-hooks/get-hooks.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// The two `getHooks` implementations under comparison, kept verbatim here so
+// the bench runs standalone on master (where the shipped helper is still the
+// scan variant), and so index.js and validate.js exercise the exact same
+// code. The functions below are copies of
+// packages/datadog-instrumentations/src/helpers/instrument.js:
+// - scan: the pre-fix implementation - map -> filter -> map over the rewriter
+//   list, returning one hook per transform (duplicates included).
+// - deduped: the fixed implementation - one pass over the list that skips
+//   transforms whose (versionRange, filePath) was already emitted and answers
+//   the requested names through a Set instead of a per-entry includes scan.
+
+const rewriterInstrumentations =
+  require('../../../packages/datadog-instrumentations/src/helpers/rewriter/instrumentations')
+
+// The 13 queries that exist in the repo, one per getHooks call site: ai.js,
+// langchain.js, mercurius.js, bullmq.js, modelcontextprotocol-sdk.js,
+// openai-agents.js, langgraph.js, aws-durable-execution-sdk-js.js,
+// azure-cosmos.js, claude-agent-sdk.js and the three from graphql.js.
+const QUERIES = [
+  'ai',
+  '@langchain/core',
+  'mercurius',
+  'bullmq',
+  '@modelcontextprotocol/sdk',
+  '@openai/agents-openai',
+  '@langchain/langgraph',
+  '@aws/durable-execution-sdk-js',
+  '@azure/cosmos',
+  '@anthropic-ai/claude-agent-sdk',
+  'graphql',
+  '@graphql-tools/executor',
+  'graphql-jit',
+]
+
+function scanGetHooks (names) {
+  names = [names].flat()
+
+  return rewriterInstrumentations
+    .map(inst => inst.module)
+    .filter(({ name }) => names.includes(name))
+    .map(({ name, versionRange, filePath }) => ({ name, versions: [versionRange], file: filePath }))
+}
+
+function dedupedGetHooks (names) {
+  const requested = new Set([names].flat())
+  const seen = new Set()
+  const hooks = []
+  for (const { module } of rewriterInstrumentations) {
+    if (!requested.has(module.name)) continue
+    const key = `${module.versionRange}|${module.filePath}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    hooks.push({ name: module.name, versions: [module.versionRange], file: module.filePath })
+  }
+  return hooks
+}
+
+module.exports = { rewriterInstrumentations, QUERIES, scanGetHooks, dedupedGetHooks }

--- a/benchmark/sirun/instrument-get-hooks/index.js
+++ b/benchmark/sirun/instrument-get-hooks/index.js
@@ -4,23 +4,32 @@ const assert = require('node:assert/strict')
 
 const guard = require('../startup-guard')
 
-// Self-contained algorithm comparison for `getHooks` in
-// packages/datadog-instrumentations/src/helpers/instrument.js, which every
-// rewriter-based integration calls once at require time to look up its module
-// hooks (23 calls per traced process, one per rewriter-instrumented module).
-// Both implementations are kept here verbatim so the bench runs standalone:
-// - scan: the pre-index implementation - a full map -> filter (with a nested
-//   `names.includes`) -> map over the rewriter list on every call.
-// - indexed: the name-indexed implementation - one pass dedupes the hooks by
-//   (versionRange, filePath) into a Map, then each call is a lookup plus a
-//   defensive copy of the cached hooks.
-// Each loop iteration simulates one complete tracer startup, end to end and
-// inside the measured window: the indexed variant (re)builds the startup
-// index and then resolves hooks for every rewriter-instrumented module once,
-// matching the production lookup count; the scan variant resolves the same
-// names with no startup cost of its own. That keeps the index construction in
-// the measurement instead of amortizing it away behind a synthetic lookup
-// loop, since production never calls `getHooks` in a hot loop.
+// Cost-of-correctness benchmark for `getHooks` in
+// packages/datadog-instrumentations/src/helpers/instrument.js, quantifying the
+// fix that dedupes rewriter hooks by (versionRange, filePath). Both
+// implementations are kept here verbatim so the bench runs standalone:
+// - scan: the pre-fix implementation - map -> filter -> map over the rewriter
+//   list, returning one hook per transform (duplicates included).
+// - deduped: the fixed implementation - one pass over the list that skips
+//   transforms whose (versionRange, filePath) was already emitted and answers
+//   the requested names through a Set instead of a per-entry includes scan.
+//
+// The workload models what production actually does. `getHooks` is called
+// once per module name, lazily, from integration files that
+// helpers/register.js only runs when the user's package loads; a traced
+// process performs zero of these calls at tracer init, and all 13 only when
+// every instrumented package family is used. So there is no hot loop to
+// optimize and no startup cost to charge against lookup savings: the
+// question this bench answers is how much the dedupe costs (or saves) per
+// startup, at the real query count.
+//
+// Variants (see meta.json):
+// - *-cold: one simulated startup through the measured window per process -
+//   each sirun iteration is a fresh process, so the window is paid cold,
+//   exactly where production pays it. The share guard is vacuous for these
+//   by design (load+setup legitimately dominates a single pass).
+// - *-warm: 20 000 simulated startups per process, for steady-state per-call
+//   signal over the same workload.
 
 const STARTUPS = Number(process.env.STARTUPS) || 20000
 const SCAN = Number(process.env.SCAN)
@@ -28,7 +37,25 @@ const SCAN = Number(process.env.SCAN)
 const rewriterInstrumentations =
   require('../../../packages/datadog-instrumentations/src/helpers/rewriter/instrumentations')
 
-const NAMES = [...new Set(rewriterInstrumentations.map(inst => inst.module.name))]
+// The 13 queries that exist in the repo, one per getHooks call site:
+// ai.js, langchain.js, mercurius.js, bullmq.js, modelcontextprotocol-sdk.js,
+// openai-agents.js, langgraph.js, aws-durable-execution-sdk-js.js,
+// azure-cosmos.js, claude-agent-sdk.js and the three from graphql.js.
+const QUERIES = [
+  'ai',
+  '@langchain/core',
+  'mercurius',
+  'bullmq',
+  '@modelcontextprotocol/sdk',
+  '@openai/agents-openai',
+  '@langchain/langgraph',
+  '@aws/durable-execution-sdk-js',
+  '@azure/cosmos',
+  '@anthropic-ai/claude-agent-sdk',
+  'graphql',
+  '@graphql-tools/executor',
+  'graphql-jit',
+]
 
 function scanGetHooks (names) {
   names = [names].flat()
@@ -39,67 +66,49 @@ function scanGetHooks (names) {
     .map(({ name, versionRange, filePath }) => ({ name, versions: [versionRange], file: filePath }))
 }
 
-let rewriterHooksByName = new Map()
-
-// Mirrors the eager startup index of the proposed helpers/instrument.js; it is
-// rebuilt per simulated startup so its construction cost lands inside the
-// measured window, exactly where production pays it (once, at require time).
-function buildRewriterHooksByName () {
-  rewriterHooksByName = new Map()
-  for (const { module: { name, versionRange, filePath } } of rewriterInstrumentations) {
-    const hooks = rewriterHooksByName.get(name) ?? []
-    if (!hooks.some(({ versions, file }) => file === filePath && versions[0] === versionRange)) {
-      hooks.push({ name, versions: [versionRange], file: filePath })
-    }
-    rewriterHooksByName.set(name, hooks)
-  }
-}
-
-function indexedGetHooks (names) {
+function dedupedGetHooks (names) {
+  const requested = new Set([names].flat())
+  const seen = new Set()
   const hooks = []
-  for (const name of new Set([names].flat())) {
-    const hooksByName = rewriterHooksByName.get(name)
-    if (!hooksByName) continue
-    for (const hook of hooksByName) hooks.push({ ...hook, versions: [...hook.versions] })
+  for (const { module } of rewriterInstrumentations) {
+    if (!requested.has(module.name)) continue
+    const key = `${module.versionRange}|${module.filePath}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    hooks.push({ name: module.name, versions: [module.versionRange], file: module.filePath })
   }
   return hooks
 }
 
-// One simulated tracer startup: resolve the hooks every rewriter-based
-// integration resolves at its require time.
-function resolveStartupScan () {
+// One simulated startup: resolve the hooks every lazy integration resolves
+// when its user package loads.
+function resolveStartup () {
+  const getHooks = SCAN ? scanGetHooks : dedupedGetHooks
   let hooks = 0
-  for (const name of NAMES) hooks += scanGetHooks(name).length
+  for (const name of QUERIES) hooks += getHooks(name).length
   return hooks
 }
 
-function resolveStartupIndexed () {
-  buildRewriterHooksByName()
-  let hooks = 0
-  for (const name of NAMES) hooks += indexedGetHooks(name).length
-  return hooks
-}
-
-// The two implementations must stay observationally equivalent up to the
-// deduplication the index itself introduces, or the variants are not
-// measuring the same workload. The counts differ on purpose: the scan variant
-// resolves 193 hook objects per startup (one per transform), the indexed
-// variant 81 (one per distinct versionRange/file pair).
-buildRewriterHooksByName()
-for (const name of NAMES) {
+// The deduped variant must answer exactly the distinct hooks of the scan
+// variant, or the two are not measuring the same workload. The counts differ
+// on purpose: the scan variant resolves 144 hook objects per startup (one
+// per transform), the deduped variant 66 (one per distinct
+// (versionRange, filePath) pair).
+for (const name of QUERIES) {
   const scanned = scanGetHooks(name)
-  const uniqueScanned = [...new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook])).values()]
-    .map(({ versions, file }) => ({ versions, file }))
-  const indexed = indexedGetHooks(name).map(({ versions, file }) => ({ versions, file }))
-  assert.deepStrictEqual(uniqueScanned, indexed)
+  const byKey = new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook]))
+  const uniqueScanned = [...byKey.values()].map(({ name, versions, file }) => ({ name, versions, file }))
+  assert.deepStrictEqual(uniqueScanned, dedupedGetHooks(name))
 }
 
 let sink = 0
 
 guard.loopStart()
 for (let i = 0; i < STARTUPS; i++) {
-  sink += SCAN ? resolveStartupScan() : resolveStartupIndexed()
+  sink += resolveStartup()
 }
-guard.done(0.3) // see README: the indexed loop is shorter by the size of the win itself
+// Cold variants run a single startup through the window, so load+setup
+// legitimately dominates; only the warm variants enforce a share ceiling.
+guard.done(STARTUPS > 1 ? 0.15 : 1)
 
 assert.ok(sink > 0, 'benchmark did no work')

--- a/benchmark/sirun/instrument-get-hooks/index.js
+++ b/benchmark/sirun/instrument-get-hooks/index.js
@@ -89,18 +89,6 @@ function resolveStartup () {
   return hooks
 }
 
-// The deduped variant must answer exactly the distinct hooks of the scan
-// variant, or the two are not measuring the same workload. The counts differ
-// on purpose: the scan variant resolves 144 hook objects per startup (one
-// per transform), the deduped variant 66 (one per distinct
-// (versionRange, filePath) pair).
-for (const name of QUERIES) {
-  const scanned = scanGetHooks(name)
-  const byKey = new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook]))
-  const uniqueScanned = [...byKey.values()].map(({ name, versions, file }) => ({ name, versions, file }))
-  assert.deepStrictEqual(uniqueScanned, dedupedGetHooks(name))
-}
-
 let sink = 0
 
 guard.loopStart()
@@ -112,3 +100,21 @@ for (let i = 0; i < STARTUPS; i++) {
 guard.done(STARTUPS > 1 ? 0.15 : 1)
 
 assert.ok(sink > 0, 'benchmark did no work')
+
+// The deduped variant must answer exactly the distinct hooks of the scan
+// variant, or the two are not measuring the same workload. The counts differ
+// on purpose: the scan variant resolves 144 hook objects per startup (one
+// per transform), the deduped variant 66 (one per distinct
+// (versionRange, filePath) pair).
+//
+// This validates AFTER the measured window, on purpose: the cold variants
+// must put a genuinely first execution of both implementations through the
+// window, and pre-flight assertions would warm the functions and the
+// instrumentation data in every fresh process - turning the "cold" pass into
+// each function's fourteenth invocation. A mismatch still fails the process.
+for (const name of QUERIES) {
+  const scanned = scanGetHooks(name)
+  const byKey = new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook]))
+  const uniqueScanned = [...byKey.values()].map(({ name, versions, file }) => ({ name, versions, file }))
+  assert.deepStrictEqual(uniqueScanned, dedupedGetHooks(name))
+}

--- a/benchmark/sirun/instrument-get-hooks/index.js
+++ b/benchmark/sirun/instrument-get-hooks/index.js
@@ -3,16 +3,14 @@
 const assert = require('node:assert/strict')
 
 const guard = require('../startup-guard')
+const { QUERIES, scanGetHooks, dedupedGetHooks } = require('./get-hooks')
 
 // Cost-of-correctness benchmark for `getHooks` in
 // packages/datadog-instrumentations/src/helpers/instrument.js, quantifying the
-// fix that dedupes rewriter hooks by (versionRange, filePath). Both
-// implementations are kept here verbatim so the bench runs standalone:
-// - scan: the pre-fix implementation - map -> filter -> map over the rewriter
-//   list, returning one hook per transform (duplicates included).
-// - deduped: the fixed implementation - one pass over the list that skips
-//   transforms whose (versionRange, filePath) was already emitted and answers
-//   the requested names through a Set instead of a per-entry includes scan.
+// fix that dedupes rewriter hooks by (versionRange, filePath). The two
+// implementations live in ./get-hooks.js (see its header), and ./validate.js
+// runs as a sirun `setup` command that gates their equivalence outside the
+// measured process.
 //
 // The workload models what production actually does. `getHooks` is called
 // once per module name, lazily, from integration files that
@@ -22,6 +20,15 @@ const guard = require('../startup-guard')
 // optimize and no startup cost to charge against lookup savings: the
 // question this bench answers is how much the dedupe costs (or saves) per
 // startup, at the real query count.
+//
+// Production call sites never stop at the hook count either - each one
+// registers every returned hook through `addHook` (for example
+// azure-cosmos.js: `for (const hook of getHooks('@azure/cosmos'))
+// addHook(hook, exports => exports)`). The registration pass is modeled
+// here on purpose: the scan variant resolves 144 hooks per startup where
+// the deduped variant resolves 66, so the per-hook registration work is a
+// real part of what the dedupe saves in production, and leaving it out would
+// bias the comparison toward the scan variant.
 //
 // Variants (see meta.json):
 // - *-cold: one simulated startup through the measured window per process -
@@ -34,58 +41,25 @@ const guard = require('../startup-guard')
 const STARTUPS = Number(process.env.STARTUPS) || 20000
 const SCAN = Number(process.env.SCAN)
 
-const rewriterInstrumentations =
-  require('../../../packages/datadog-instrumentations/src/helpers/rewriter/instrumentations')
-
-// The 13 queries that exist in the repo, one per getHooks call site:
-// ai.js, langchain.js, mercurius.js, bullmq.js, modelcontextprotocol-sdk.js,
-// openai-agents.js, langgraph.js, aws-durable-execution-sdk-js.js,
-// azure-cosmos.js, claude-agent-sdk.js and the three from graphql.js.
-const QUERIES = [
-  'ai',
-  '@langchain/core',
-  'mercurius',
-  'bullmq',
-  '@modelcontextprotocol/sdk',
-  '@openai/agents-openai',
-  '@langchain/langgraph',
-  '@aws/durable-execution-sdk-js',
-  '@azure/cosmos',
-  '@anthropic-ai/claude-agent-sdk',
-  'graphql',
-  '@graphql-tools/executor',
-  'graphql-jit',
-]
-
-function scanGetHooks (names) {
-  names = [names].flat()
-
-  return rewriterInstrumentations
-    .map(inst => inst.module)
-    .filter(({ name }) => names.includes(name))
-    .map(({ name, versionRange, filePath }) => ({ name, versions: [versionRange], file: filePath }))
-}
-
-function dedupedGetHooks (names) {
-  const requested = new Set([names].flat())
-  const seen = new Set()
-  const hooks = []
-  for (const { module } of rewriterInstrumentations) {
-    if (!requested.has(module.name)) continue
-    const key = `${module.versionRange}|${module.filePath}`
-    if (seen.has(key)) continue
-    seen.add(key)
-    hooks.push({ name: module.name, versions: [module.versionRange], file: module.filePath })
-  }
-  return hooks
-}
-
 // One simulated startup: resolve the hooks every lazy integration resolves
-// when its user package loads.
+// when its user package loads, and register each one - an addHook-style
+// push of { versions, file, hook } into a per-startup instrumentations map,
+// one closure per hook, as every integration file does.
 function resolveStartup () {
   const getHooks = SCAN ? scanGetHooks : dedupedGetHooks
+  const instrumentations = new Map()
   let hooks = 0
-  for (const name of QUERIES) hooks += getHooks(name).length
+  for (const name of QUERIES) {
+    for (const { versions, file } of getHooks(name)) {
+      hooks++
+      let byName = instrumentations.get(name)
+      if (!byName) {
+        byName = []
+        instrumentations.set(name, byName)
+      }
+      byName.push({ versions, file, hook: exports => exports })
+    }
+  }
   return hooks
 }
 
@@ -100,21 +74,3 @@ for (let i = 0; i < STARTUPS; i++) {
 guard.done(STARTUPS > 1 ? 0.15 : 1)
 
 assert.ok(sink > 0, 'benchmark did no work')
-
-// The deduped variant must answer exactly the distinct hooks of the scan
-// variant, or the two are not measuring the same workload. The counts differ
-// on purpose: the scan variant resolves 144 hook objects per startup (one
-// per transform), the deduped variant 66 (one per distinct
-// (versionRange, filePath) pair).
-//
-// This validates AFTER the measured window, on purpose: the cold variants
-// must put a genuinely first execution of both implementations through the
-// window, and pre-flight assertions would warm the functions and the
-// instrumentation data in every fresh process - turning the "cold" pass into
-// each function's fourteenth invocation. A mismatch still fails the process.
-for (const name of QUERIES) {
-  const scanned = scanGetHooks(name)
-  const byKey = new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook]))
-  const uniqueScanned = [...byKey.values()].map(({ name, versions, file }) => ({ name, versions, file }))
-  assert.deepStrictEqual(uniqueScanned, dedupedGetHooks(name))
-}

--- a/benchmark/sirun/instrument-get-hooks/index.js
+++ b/benchmark/sirun/instrument-get-hooks/index.js
@@ -7,22 +7,28 @@ const guard = require('../startup-guard')
 // Self-contained algorithm comparison for `getHooks` in
 // packages/datadog-instrumentations/src/helpers/instrument.js, which every
 // rewriter-based integration calls once at require time to look up its module
-// hooks (15+ calls per traced process). Both implementations are kept here
-// verbatim so the bench runs standalone:
+// hooks (23 calls per traced process, one per rewriter-instrumented module).
+// Both implementations are kept here verbatim so the bench runs standalone:
 // - scan: the pre-index implementation - a full map -> filter (with a nested
 //   `names.includes`) -> map over the rewriter list on every call.
-// - indexed: the name-indexed implementation - one startup pass dedupes the
-//   hooks by (versionRange, filePath) into a Map, then each call is a lookup
-//   plus a defensive copy of the cached hooks.
-// The optimization that ships the indexed implementation is stacked on this
-// branch; that PR repoints the indexed variant at the shipped helper so the
-// bench keeps tracking production code once it lands.
+// - indexed: the name-indexed implementation - one pass dedupes the hooks by
+//   (versionRange, filePath) into a Map, then each call is a lookup plus a
+//   defensive copy of the cached hooks.
+// Each loop iteration simulates one complete tracer startup, end to end and
+// inside the measured window: the indexed variant (re)builds the startup
+// index and then resolves hooks for every rewriter-instrumented module once,
+// matching the production lookup count; the scan variant resolves the same
+// names with no startup cost of its own. That keeps the index construction in
+// the measurement instead of amortizing it away behind a synthetic lookup
+// loop, since production never calls `getHooks` in a hot loop.
 
-const CALLS = Number(process.env.CALLS) || 100000
+const STARTUPS = Number(process.env.STARTUPS) || 20000
 const SCAN = Number(process.env.SCAN)
 
 const rewriterInstrumentations =
   require('../../../packages/datadog-instrumentations/src/helpers/rewriter/instrumentations')
+
+const NAMES = [...new Set(rewriterInstrumentations.map(inst => inst.module.name))]
 
 function scanGetHooks (names) {
   names = [names].flat()
@@ -33,13 +39,20 @@ function scanGetHooks (names) {
     .map(({ name, versionRange, filePath }) => ({ name, versions: [versionRange], file: filePath }))
 }
 
-const rewriterHooksByName = new Map()
-for (const { module: { name, versionRange, filePath } } of rewriterInstrumentations) {
-  const hooks = rewriterHooksByName.get(name) ?? []
-  if (!hooks.some(({ versions, file }) => file === filePath && versions[0] === versionRange)) {
-    hooks.push({ name, versions: [versionRange], file: filePath })
+let rewriterHooksByName = new Map()
+
+// Mirrors the eager startup index of the proposed helpers/instrument.js; it is
+// rebuilt per simulated startup so its construction cost lands inside the
+// measured window, exactly where production pays it (once, at require time).
+function buildRewriterHooksByName () {
+  rewriterHooksByName = new Map()
+  for (const { module: { name, versionRange, filePath } } of rewriterInstrumentations) {
+    const hooks = rewriterHooksByName.get(name) ?? []
+    if (!hooks.some(({ versions, file }) => file === filePath && versions[0] === versionRange)) {
+      hooks.push({ name, versions: [versionRange], file: filePath })
+    }
+    rewriterHooksByName.set(name, hooks)
   }
-  rewriterHooksByName.set(name, hooks)
 }
 
 function indexedGetHooks (names) {
@@ -52,11 +65,27 @@ function indexedGetHooks (names) {
   return hooks
 }
 
-const NAMES = [...new Set(rewriterInstrumentations.map(inst => inst.module.name))]
+// One simulated tracer startup: resolve the hooks every rewriter-based
+// integration resolves at its require time.
+function resolveStartupScan () {
+  let hooks = 0
+  for (const name of NAMES) hooks += scanGetHooks(name).length
+  return hooks
+}
+
+function resolveStartupIndexed () {
+  buildRewriterHooksByName()
+  let hooks = 0
+  for (const name of NAMES) hooks += indexedGetHooks(name).length
+  return hooks
+}
 
 // The two implementations must stay observationally equivalent up to the
 // deduplication the index itself introduces, or the variants are not
-// measuring the same workload.
+// measuring the same workload. The counts differ on purpose: the scan variant
+// resolves 193 hook objects per startup (one per transform), the indexed
+// variant 81 (one per distinct versionRange/file pair).
+buildRewriterHooksByName()
 for (const name of NAMES) {
   const scanned = scanGetHooks(name)
   const uniqueScanned = [...new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook])).values()]
@@ -68,10 +97,9 @@ for (const name of NAMES) {
 let sink = 0
 
 guard.loopStart()
-for (let i = 0; i < CALLS; i++) {
-  const hooks = SCAN ? scanGetHooks(NAMES[i % NAMES.length]) : indexedGetHooks(NAMES[i % NAMES.length])
-  sink += hooks.length
+for (let i = 0; i < STARTUPS; i++) {
+  sink += SCAN ? resolveStartupScan() : resolveStartupIndexed()
 }
-guard.done(0.3) // the indexed loop is intentionally ~100x shorter; see README
+guard.done(0.3) // see README: the indexed loop is shorter by the size of the win itself
 
 assert.ok(sink > 0, 'benchmark did no work')

--- a/benchmark/sirun/instrument-get-hooks/index.js
+++ b/benchmark/sirun/instrument-get-hooks/index.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const guard = require('../startup-guard')
+
+// Self-contained algorithm comparison for `getHooks` in
+// packages/datadog-instrumentations/src/helpers/instrument.js, which every
+// rewriter-based integration calls once at require time to look up its module
+// hooks (15+ calls per traced process). Both implementations are kept here
+// verbatim so the bench runs standalone:
+// - scan: the pre-index implementation - a full map -> filter (with a nested
+//   `names.includes`) -> map over the rewriter list on every call.
+// - indexed: the name-indexed implementation - one startup pass dedupes the
+//   hooks by (versionRange, filePath) into a Map, then each call is a lookup
+//   plus a defensive copy of the cached hooks.
+// The optimization that ships the indexed implementation is stacked on this
+// branch; that PR repoints the indexed variant at the shipped helper so the
+// bench keeps tracking production code once it lands.
+
+const CALLS = Number(process.env.CALLS) || 100000
+const SCAN = Number(process.env.SCAN)
+
+const rewriterInstrumentations =
+  require('../../../packages/datadog-instrumentations/src/helpers/rewriter/instrumentations')
+
+function scanGetHooks (names) {
+  names = [names].flat()
+
+  return rewriterInstrumentations
+    .map(inst => inst.module)
+    .filter(({ name }) => names.includes(name))
+    .map(({ name, versionRange, filePath }) => ({ name, versions: [versionRange], file: filePath }))
+}
+
+const rewriterHooksByName = new Map()
+for (const { module: { name, versionRange, filePath } } of rewriterInstrumentations) {
+  const hooks = rewriterHooksByName.get(name) ?? []
+  if (!hooks.some(({ versions, file }) => file === filePath && versions[0] === versionRange)) {
+    hooks.push({ name, versions: [versionRange], file: filePath })
+  }
+  rewriterHooksByName.set(name, hooks)
+}
+
+function indexedGetHooks (names) {
+  const hooks = []
+  for (const name of new Set([names].flat())) {
+    const hooksByName = rewriterHooksByName.get(name)
+    if (!hooksByName) continue
+    for (const hook of hooksByName) hooks.push({ ...hook, versions: [...hook.versions] })
+  }
+  return hooks
+}
+
+const NAMES = [...new Set(rewriterInstrumentations.map(inst => inst.module.name))]
+
+// The two implementations must stay observationally equivalent up to the
+// deduplication the index itself introduces, or the variants are not
+// measuring the same workload.
+for (const name of NAMES) {
+  const scanned = scanGetHooks(name)
+  const uniqueScanned = [...new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook])).values()]
+    .map(({ versions, file }) => ({ versions, file }))
+  const indexed = indexedGetHooks(name).map(({ versions, file }) => ({ versions, file }))
+  assert.deepStrictEqual(uniqueScanned, indexed)
+}
+
+let sink = 0
+
+guard.loopStart()
+for (let i = 0; i < CALLS; i++) {
+  const hooks = SCAN ? scanGetHooks(NAMES[i % NAMES.length]) : indexedGetHooks(NAMES[i % NAMES.length])
+  sink += hooks.length
+}
+guard.done(0.3) // the indexed loop is intentionally ~100x shorter; see README
+
+assert.ok(sink > 0, 'benchmark did no work')

--- a/benchmark/sirun/instrument-get-hooks/meta.json
+++ b/benchmark/sirun/instrument-get-hooks/meta.json
@@ -6,14 +6,27 @@
   "instructions": true,
   "iterations": 10,
   "variants": {
-    "scan": {
+    "scan-cold": {
+      "env": {
+        "SCAN": "1",
+        "STARTUPS": "1",
+        "OPERATIONS": "1"
+      }
+    },
+    "deduped-cold": {
+      "env": {
+        "STARTUPS": "1",
+        "OPERATIONS": "1"
+      }
+    },
+    "scan-warm": {
       "env": {
         "SCAN": "1",
         "STARTUPS": "20000",
         "OPERATIONS": "20000"
       }
     },
-    "indexed": {
+    "deduped-warm": {
       "env": {
         "STARTUPS": "20000",
         "OPERATIONS": "20000"

--- a/benchmark/sirun/instrument-get-hooks/meta.json
+++ b/benchmark/sirun/instrument-get-hooks/meta.json
@@ -9,14 +9,14 @@
     "scan": {
       "env": {
         "SCAN": "1",
-        "CALLS": "1000000",
-        "OPERATIONS": "1000000"
+        "STARTUPS": "20000",
+        "OPERATIONS": "20000"
       }
     },
     "indexed": {
       "env": {
-        "CALLS": "1000000",
-        "OPERATIONS": "1000000"
+        "STARTUPS": "20000",
+        "OPERATIONS": "20000"
       }
     }
   }

--- a/benchmark/sirun/instrument-get-hooks/meta.json
+++ b/benchmark/sirun/instrument-get-hooks/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "instrument-get-hooks",
+  "setup": "node validate.js",
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,

--- a/benchmark/sirun/instrument-get-hooks/meta.json
+++ b/benchmark/sirun/instrument-get-hooks/meta.json
@@ -1,0 +1,23 @@
+{
+  "name": "instrument-get-hooks",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "instructions": true,
+  "iterations": 10,
+  "variants": {
+    "scan": {
+      "env": {
+        "SCAN": "1",
+        "CALLS": "1000000",
+        "OPERATIONS": "1000000"
+      }
+    },
+    "indexed": {
+      "env": {
+        "CALLS": "1000000",
+        "OPERATIONS": "1000000"
+      }
+    }
+  }
+}

--- a/benchmark/sirun/instrument-get-hooks/meta.json
+++ b/benchmark/sirun/instrument-get-hooks/meta.json
@@ -10,14 +10,12 @@
     "scan-cold": {
       "env": {
         "SCAN": "1",
-        "STARTUPS": "1",
-        "OPERATIONS": "1"
+        "STARTUPS": "1"
       }
     },
     "deduped-cold": {
       "env": {
-        "STARTUPS": "1",
-        "OPERATIONS": "1"
+        "STARTUPS": "1"
       }
     },
     "scan-warm": {

--- a/benchmark/sirun/instrument-get-hooks/validate.js
+++ b/benchmark/sirun/instrument-get-hooks/validate.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Equivalence gate for the get-hooks.js pair, wired as a sirun `setup`
+// command in meta.json. Sirun runs `setup` in its own process before the
+// measured process exists: validation can neither warm the measured
+// process's inline caches and JIT state nor land inside the measured window
+// (sirun resets wall.time/instructions at the ready signal the bench's
+// startup-guard writes in loopStart). A mismatch throws and the process
+// exits non-zero, so sirun aborts the benchmark before a single sample is
+// collected.
+//
+// The deduped variant must answer exactly the distinct hooks of the scan
+// variant, or the two are not measuring the same workload. The counts
+// differ on purpose: the scan variant resolves 144 hook objects per startup
+// (one per transform), the deduped variant 66 (one per distinct
+// (versionRange, filePath) pair).
+
+const assert = require('node:assert/strict')
+
+const { QUERIES, scanGetHooks, dedupedGetHooks } = require('./get-hooks')
+
+for (const name of QUERIES) {
+  const scanned = scanGetHooks(name)
+  const byKey = new Map(scanned.map(hook => [`${hook.versions[0]}|${hook.file}`, hook]))
+  const uniqueScanned = [...byKey.values()].map(({ name, versions, file }) => ({ name, versions, file }))
+  assert.deepStrictEqual(uniqueScanned, dedupedGetHooks(name))
+}


### PR DESCRIPTION
### What does this PR do?

Adds `benchmark/sirun/instrument-get-hooks/`: a focused, reproducible benchmark quantifying the cost of the `getHooks` dedupe fix (stacked in #10279) on the workload production actually performs.

The bench models what production actually does, end to end:

- `getHooks` is called once per module name, **lazily**, from integration files that `helpers/register.js` only runs when the user's package loads — a traced process performs **zero** of these calls at tracer init, and all 13 (the complete set of call sites in the repo) only when every instrumented package family is used. So the workload is the 13 real queries, once per simulated startup.
- Production call sites never stop at the hook count: each one registers every returned hook through `addHook` (e.g. `azure-cosmos.js`: `for (const hook of getHooks('@azure/cosmos')) addHook(hook, exports => exports)`). The bench models that pass too — one closure and one push per returned hook — because the count of returned hooks (144 vs 66) is a real part of what the fix changes.

Both implementations are embedded verbatim in `get-hooks.js` so the bench runs standalone on master:

- **`scan`** — the pre-fix implementation: full `map → filter → map` over the rewriter list, one hook per transform (duplicates included).
- **`deduped`** — the fixed implementation: one pass over the list, skipping transforms whose `(versionRange, filePath)` was already emitted, with a `Set` for the requested names.

`validate.js` gates their equivalence as a sirun `setup` command: it runs in its own process **before the measured process exists**, so validation can neither warm the measured process's JIT state nor land inside the measured window (sirun resets `wall.time`/`instructions` at the ready signal the startup-guard writes in `loopStart`). A mismatch exits non-zero and sirun aborts before collecting a single sample.

Two axes of variants (`meta.json`):

- **`*-cold`** — one simulated startup through the measured window per process. Each sirun iteration is a fresh process, so every sample is a cold sample, paid exactly where production pays it. The startup-guard share ceiling is vacuous here by design (load+setup legitimately dominates a single pass); the guard's rot protection is carried by the warm variants. Cold variants deliberately set no `OPERATIONS`: the guard's ops-gauge emission runs after the loop but before process exit — inside sirun's measured window — and its cost (requiring the tracer's statsd client, opening a UDP socket) would dwarf a single ~0.4 ms sample, so cold samples are read from sirun's clean `wall.time`/`instructions` instead.
- **`*-warm`** — 20 000 simulated startups per process, for steady-state signal over the same workload.

### Motivation

This is the benchmark half of a stacked change; #10279 (the dedupe fix) is stacked on this branch so the sirun pipeline collects the pre-fix baseline first. The benchmark is also what killed the index design this branch originally measured: the honest cold numbers showed an eagerly-built index was a net regression in every realistic workload, so the fix dedupes inline instead, and this bench now quantifies that fix's cost.

### Additional Notes

Measured (Node v26.5.0, median of fresh processes / warm loops):

| variant | per startup (13 queries + registration) | hooks registered |
|---|---|---|
| `scan-cold` | ~435 µs | 144 |
| `deduped-cold` | ~470 µs | 66 |
| `scan-warm` | ~22.5 µs | 144 |
| `deduped-warm` | ~27 µs | 66 |

Zero-lookup startups (the common case) run no `getHooks` code in either variant: the fix adds no fixed cost anywhere.

The cold number is the production cost: production calls `getHooks` at most once per name per process, so the ~8% (fully instrumented, 13 families) delta is paid lazily as packages load — a single-family process pays one query's share, a few µs once. The warm axis is a steady-state lens only; it shows the dedupe's per-entry `Set` lookups and per-match key strings cost more after JIT than the scan's duplicate allocations, even while saving 78 registrations per startup.

Includes a CODEOWNERS entry for the new directory (every `benchmark/sirun/<name>/` has one; the `/benchmark/sirun/*` wildcard only covers direct children).
