### PR TITLE
test(openfeature): use same-process timestamp bounds

### DIFF
--- a/integration-tests/openfeature/app/exposure-events.js
+++ b/integration-tests/openfeature/app/exposure-events.js
@@ -32,6 +32,7 @@ app.get('/evaluate-flags', async (req, res) => {
   }
 
   try {
+    const evaluationStartedAt = Date.now()
     const booleanResult = await client.getBooleanValue('test-boolean-flag', false, {
       targetingKey: 'test-user-123',
       user: 'test-user-123',
@@ -50,6 +51,8 @@ app.get('/evaluate-flags', async (req, res) => {
         string: stringResult,
       },
       evaluationsCompleted: 2,
+      evaluationStartedAt,
+      evaluationFinishedAt: Date.now(),
     })
   } catch (error) {
     res.status(500).json({ error: error.message })
@@ -62,6 +65,7 @@ app.get('/evaluate-multiple-flags', async (req, res) => {
   }
 
   try {
+    const evaluationStartedAt = Date.now()
     const results = []
 
     const users = [
@@ -90,6 +94,8 @@ app.get('/evaluate-multiple-flags', async (req, res) => {
     res.json({
       results,
       evaluationsCompleted: users.length * 2,
+      evaluationStartedAt,
+      evaluationFinishedAt: Date.now(),
     })
   } catch (error) {
     res.status(500).json({ error: error.message })

--- a/integration-tests/openfeature/openfeature-exposure-events.spec.js
+++ b/integration-tests/openfeature/openfeature-exposure-events.spec.js
@@ -56,10 +56,12 @@ function addRemoteConfigAndWaitForAcknowledgment (agent, config) {
 }
 
 /**
+ * The action returns bounds from the process that creates the exposure timestamps.
+ *
  * @param {FakeAgent} agent
  * @param {import('node:child_process').ChildProcess} proc
  * @param {number} expectedCount
- * @param {() => Promise<void>} action
+ * @param {() => Promise<{ earliestTimestamp: number, latestTimestamp: number }>} action
  * @returns {Promise<{
  *   requests: Array<{ payload: { exposures?: Array<object> }, headers: object, path: string }>,
  *   earliestTimestamp: number,
@@ -67,7 +69,6 @@ function addRemoteConfigAndWaitForAcknowledgment (agent, config) {
  * }>}
  */
 async function captureExposureRequestsUntilExit (agent, proc, expectedCount, action) {
-  const earliestTimestamp = Date.now()
   const requests = []
   let exposureCount = 0
   let resolveExpected
@@ -88,9 +89,8 @@ async function captureExposureRequestsUntilExit (agent, proc, expectedCount, act
 
   agent.on('exposures', handleExposures)
   try {
-    await Promise.all([action(), expectedExposuresReceived])
+    const [{ earliestTimestamp, latestTimestamp }] = await Promise.all([action(), expectedExposuresReceived])
     await delay(EXPOSURE_QUIET_PERIOD_MS)
-    const latestTimestamp = Date.now()
     await stopProc(proc)
     return { requests, earliestTimestamp, latestTimestamp }
   } finally {
@@ -201,6 +201,10 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
 
             const flushResponse = await fetch(`${proc.url}/flush`)
             assert.strictEqual(flushResponse.status, 200)
+            return {
+              earliestTimestamp: data.evaluationStartedAt,
+              latestTimestamp: data.evaluationFinishedAt,
+            }
           })
         const exposureEvents = []
 
@@ -271,6 +275,10 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
             assert.strictEqual(response.status, 200)
             const data = await response.json()
             assert.strictEqual(data.evaluationsCompleted, 6)
+            return {
+              earliestTimestamp: data.evaluationStartedAt,
+              latestTimestamp: data.evaluationFinishedAt,
+            }
           })
         const exposureEvents = []
 


### PR DESCRIPTION
### What does this PR do?

Uses timestamp bounds measured by the spawned OpenFeature test app when validating exposure events.

### Motivation

The automatic-flush integration test failed on Windows because an exposure timestamp was 3 ms earlier than the lower bound captured by the parent test process. Exposure timestamps are generated by the spawned app, so the previous assertion assumed millisecond-level clock agreement across processes.

### Changes

- Report evaluation start and finish timestamps from both fixture evaluation endpoints.
- Return those same-process bounds through the shared exposure capture helper.
- Preserve strict lower and upper timestamp assertions for both manual and automatic flush tests.

### Decisions

- Measure the validation window in the timestamp-producing process instead of adding tolerance, retries, or longer timeouts.
- Keep the change entirely in integration-test code; production OpenFeature behavior is unchanged.

### Additional Notes

Validation:

- `npm run test:integration:openfeature:coverage` (`5 passing`)
- Reported automatic-flush test: 11 consecutive passes on Node 22
- Reported automatic-flush test: pass on Node 24.14.1
- Focused ESLint and `git diff --check` pass