### PR TITLE
ci(release): handle empty proposal commits

### DIFF
--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -162,8 +162,38 @@ try {
 
   // Get the hashes of the last version and the commits to add.
   const lastCommit = capture('git log -1 --pretty=%B')
-  const branchCommitCount = Number.parseInt(capture(`git rev-list --count v${releaseLine}.x..HEAD`), 10)
-  const existingCherryPicked = lastCommit === `v${newVersion}` ? branchCommitCount - 1 : branchCommitCount
+  const proposalCommits = capture(
+    `git log --format="%H%x09%s" --reverse v${releaseLine}.x..HEAD`
+  ).split('\n').filter(Boolean).map(line => {
+    const separator = line.indexOf('\t')
+    return {
+      sha: line.slice(0, separator),
+      subject: line.slice(separator + 1),
+    }
+  })
+
+  if (lastCommit === `v${newVersion}`) proposalCommits.pop()
+
+  for (let index = 0; index < proposalCommits.length; index++) {
+    const proposalCommit = proposalCommits[index]
+    const mainSha = allMainShas[index]
+    const mainSubject = mainSha ? capture(`git show -s --format=%s ${mainSha}`) : undefined
+    const proposalPullRequest = proposalCommit.subject.match(pullRequestNumberPattern)
+    const mainPullRequest = mainSubject?.match(pullRequestNumberPattern)
+    const matches = proposalPullRequest && mainPullRequest
+      ? proposalPullRequest[1] === mainPullRequest[1]
+      : proposalCommit.subject === mainSubject
+
+    if (!matches) {
+      fatal(
+        `Release proposal history diverged from ${main} at position ${index + 1}.`,
+        `  proposal: ${proposalCommit.sha.slice(0, 10)} ${proposalCommit.subject}`,
+        `  ${main}: ${mainSha ? `${mainSha.slice(0, 10)} ${mainSubject}` : '(no commit)'}`
+      )
+    }
+  }
+
+  const existingCherryPicked = proposalCommits.length
   const proposalShas = allMainShas.slice(existingCherryPicked)
   const shasToApply = proposalShas.slice(0, Math.max(0, MAX_CHERRY_PICKS - existingCherryPicked))
   const truncated = shasToApply.length < proposalShas.length
@@ -186,18 +216,41 @@ try {
       run('git reset --hard HEAD~1')
     }
 
-    // Cherry pick commits up to the GitHub rebase limit.
+    // Cherry-pick commits up to the GitHub rebase limit. Preserve empty main commits
+    // so the proposal commit count stays aligned with the ordered main commit list.
     try {
-      run(`git cherry-pick ${shasToApply.join(' ')}`)
+      run(`git cherry-pick --allow-empty ${shasToApply.join(' ')}`)
 
       pass()
-    } catch {
+    } catch (error) {
+      let incomingCommit
+      let proposalHead
+      let conflictedFiles
+
+      try {
+        incomingCommit = capture('git show -s --format="%h %s" CHERRY_PICK_HEAD')
+      } catch {}
+
+      try {
+        proposalHead = capture('git show -s --format="%h %s" HEAD')
+      } catch {}
+
+      try {
+        conflictedFiles = capture('git diff --name-only --diff-filter=U')
+      } catch {}
+
       run('git cherry-pick --abort')
 
-      fatal(
+      const messages = [
         'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
-        'Please make sure the release branch contains all changes from the main branch.'
-      )
+        'Please make sure the release branch contains all changes from the main branch.',
+      ]
+      if (incomingCommit) messages.push(`Incoming from ${main}: ${incomingCommit}`)
+      if (proposalHead) messages.push(`Applying onto v${newVersion}-proposal: ${proposalHead}`)
+      if (conflictedFiles) messages.push(`Conflicted files: ${conflictedFiles.replaceAll('\n', ', ')}`)
+      messages.push(error.stderr?.trim() || error.message)
+
+      fatal(...messages)
     }
   } else if (proposalShas.length > 0) {
     pass(`⚠️  Proposal is at the commit limit (${MAX_CHERRY_PICKS}/${MAX_CHERRY_PICKS}).` +

--- a/scripts/release/proposal.spec.js
+++ b/scripts/release/proposal.spec.js
@@ -7,8 +7,182 @@ const sinon = require('sinon')
 
 const FULL_SHA = '0123456789abcdef0123456789abcdef01234567'
 const OTHER_FULL_SHA = '89abcdef0123456789abcdef0123456789abcdef'
+const VERSION_FULL_SHA = 'fedcba9876543210fedcba9876543210fedcba98'
 
 describe('release proposal', () => {
+  it('preserves empty commits while applying new changes', () => {
+    const stopped = new Error('proposal stopped after applying changes')
+    const createReleaseChangelog = sinon.stub().returns({
+      isMinor: true,
+      markdown: '',
+      warnings: [],
+    })
+    const fail = sinon.stub()
+    const run = sinon.stub().callsFake(command => {
+      if (command.startsWith('npm version')) throw stopped
+    })
+
+    /**
+     * @param {string} command
+     */
+    function capture (command) {
+      if (command === 'git rev-parse --abbrev-ref HEAD') return 'master'
+      if (command.includes('--format=sha --reverse v5.x master')) return FULL_SHA
+      if (command === `git rev-parse ${FULL_SHA}`) return FULL_SHA
+      if (command.includes('--format=sha --reverse v5.x') && command.includes(FULL_SHA)) return FULL_SHA
+      if (command === `git show -s --format=%s ${FULL_SHA}`) return 'chore(deps-dev): bump multer (#10253)'
+      if (command === 'git log -1 --pretty=%B') return 'v5.127.0'
+      if (command.startsWith('git log --format="%H%x09%s"')) return `${VERSION_FULL_SHA}\tv5.127.0`
+      if (command.includes(`v5.127.0-proposal ${FULL_SHA}`)) return 'chore(deps-dev): bump multer'
+      throw new Error(`Unexpected command: ${command}`)
+    }
+
+    const loadProposal = proxyquire.noCallThru().noPreserveCache()
+    loadProposal('./proposal', {
+      '../../version': { DD_MAJOR: 5, DD_MINOR: 126, DD_PATCH: 0, VERSION: '5.126.0' },
+      './changelog': { createReleaseChangelog },
+      './helpers/requirements': { checkAll: sinon.stub() },
+      './helpers/terminal': {
+        capture,
+        checkpoint: sinon.stub(),
+        fail,
+        fatal: sinon.stub(),
+        flags: {},
+        log: sinon.stub(),
+        params: ['5'],
+        pass: sinon.stub(),
+        run,
+        start: sinon.stub(),
+      },
+      './metadata': { hydrateReleaseEntries: sinon.stub().returnsArg(0) },
+    })
+
+    assert(run.calledWithExactly(`git cherry-pick --allow-empty ${FULL_SHA}`))
+    assert.strictEqual(fail.firstCall.args[0], stopped)
+  })
+
+  it('reports both sides when proposal history does not match master', () => {
+    const stopped = new Error('proposal stopped after detecting divergence')
+    const createReleaseChangelog = sinon.stub().returns({
+      isMinor: true,
+      markdown: '',
+      warnings: [],
+    })
+    const fail = sinon.stub()
+    const fatal = sinon.stub().throws(stopped)
+    const run = sinon.stub()
+    const masterSubject = 'fix(core): expected change (#123)'
+    const proposalSubject = 'fix(core): unexpected change (#999)'
+
+    /**
+     * @param {string} command
+     */
+    function capture (command) {
+      if (command === 'git rev-parse --abbrev-ref HEAD') return 'master'
+      if (command.includes('--format=sha --reverse v5.x master')) return FULL_SHA
+      if (command === `git rev-parse ${FULL_SHA}`) return FULL_SHA
+      if (command.includes('--format=sha --reverse v5.x') && command.includes(FULL_SHA)) return FULL_SHA
+      if (command === `git show -s --format=%s ${FULL_SHA}`) return masterSubject
+      if (command === 'git log -1 --pretty=%B') return 'v5.127.0'
+      if (command.startsWith('git log --format="%H%x09%s"')) {
+        return `${OTHER_FULL_SHA}\t${proposalSubject}\n${VERSION_FULL_SHA}\tv5.127.0`
+      }
+      throw new Error(`Unexpected command: ${command}`)
+    }
+
+    const loadProposal = proxyquire.noCallThru().noPreserveCache()
+    loadProposal('./proposal', {
+      '../../version': { DD_MAJOR: 5, DD_MINOR: 126, DD_PATCH: 0, VERSION: '5.126.0' },
+      './changelog': { createReleaseChangelog },
+      './helpers/requirements': { checkAll: sinon.stub() },
+      './helpers/terminal': {
+        capture,
+        checkpoint: sinon.stub(),
+        fail,
+        fatal,
+        flags: {},
+        log: sinon.stub(),
+        params: ['5'],
+        pass: sinon.stub(),
+        run,
+        start: sinon.stub(),
+      },
+      './metadata': { hydrateReleaseEntries: sinon.stub().returnsArg(0) },
+    })
+
+    assert(fatal.calledWithExactly(
+      'Release proposal history diverged from master at position 1.',
+      `  proposal: ${OTHER_FULL_SHA.slice(0, 10)} ${proposalSubject}`,
+      `  master: ${FULL_SHA.slice(0, 10)} ${masterSubject}`
+    ))
+    assert.strictEqual(fail.firstCall.args[0], stopped)
+  })
+
+  it('reports the incoming commit, proposal state, and conflicted files', () => {
+    const stopped = new Error('proposal stopped after cherry-pick failure')
+    const cherryPickError = new Error('cherry-pick failed')
+    cherryPickError.stderr = 'CONFLICT (content): merge conflict in package.json\n'
+    const createReleaseChangelog = sinon.stub().returns({
+      isMinor: true,
+      markdown: '',
+      warnings: [],
+    })
+    const fail = sinon.stub()
+    const fatal = sinon.stub().throws(stopped)
+    const run = sinon.stub().callsFake(command => {
+      if (command.startsWith('git cherry-pick --allow-empty')) throw cherryPickError
+    })
+
+    /**
+     * @param {string} command
+     */
+    function capture (command) {
+      if (command === 'git rev-parse --abbrev-ref HEAD') return 'master'
+      if (command.includes('--format=sha --reverse v5.x master')) return FULL_SHA
+      if (command === `git rev-parse ${FULL_SHA}`) return FULL_SHA
+      if (command.includes('--format=sha --reverse v5.x') && command.includes(FULL_SHA)) return FULL_SHA
+      if (command === `git show -s --format=%s ${FULL_SHA}`) return 'fix(core): incoming change (#123)'
+      if (command === 'git log -1 --pretty=%B') return 'v5.127.0'
+      if (command.startsWith('git log --format="%H%x09%s"')) return `${VERSION_FULL_SHA}\tv5.127.0`
+      if (command.includes(`v5.127.0-proposal ${FULL_SHA}`)) return 'fix(core): incoming change'
+      if (command.includes('CHERRY_PICK_HEAD')) return '0123456789 fix(core): incoming change (#123)'
+      if (command === 'git show -s --format="%h %s" HEAD') return '89abcdef01 v5.126.0'
+      if (command === 'git diff --name-only --diff-filter=U') return 'package.json\nyarn.lock'
+      throw new Error(`Unexpected command: ${command}`)
+    }
+
+    const loadProposal = proxyquire.noCallThru().noPreserveCache()
+    loadProposal('./proposal', {
+      '../../version': { DD_MAJOR: 5, DD_MINOR: 126, DD_PATCH: 0, VERSION: '5.126.0' },
+      './changelog': { createReleaseChangelog },
+      './helpers/requirements': { checkAll: sinon.stub() },
+      './helpers/terminal': {
+        capture,
+        checkpoint: sinon.stub(),
+        fail,
+        fatal,
+        flags: {},
+        log: sinon.stub(),
+        params: ['5'],
+        pass: sinon.stub(),
+        run,
+        start: sinon.stub(),
+      },
+      './metadata': { hydrateReleaseEntries: sinon.stub().returnsArg(0) },
+    })
+
+    assert(run.calledWithExactly('git cherry-pick --abort'))
+    assert(fatal.calledWithExactly(
+      'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
+      'Please make sure the release branch contains all changes from the main branch.',
+      'Incoming from master: 0123456789 fix(core): incoming change (#123)',
+      'Applying onto v5.127.0-proposal: 89abcdef01 v5.126.0',
+      'Conflicted files: package.json, yarn.lock',
+      'CONFLICT (content): merge conflict in package.json'
+    ))
+    assert.strictEqual(fail.firstCall.args[0], stopped)
+  })
+
   it('describes commit and pull request metadata sources before rendering the changelog', () => {
     const stopped = new Error('proposal stopped after changelog creation')
     const createReleaseChangelog = sinon.stub().throws(stopped)

--- a/scripts/release/validate.js
+++ b/scripts/release/validate.js
@@ -79,7 +79,7 @@ try {
     .slice(0, proposalCommits.length - 1)
     .join(' ')
 
-  run(`git cherry-pick ${tempCommits} ${versionCommit}`)
+  run(`git cherry-pick --allow-empty ${tempCommits} ${versionCommit}`)
 
   const diff = capture(`git --no-pager diff ${proposalBranch}..${tempBranch}`)
 

--- a/scripts/release/validate.spec.js
+++ b/scripts/release/validate.spec.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const EMPTY_SHA = '0123456789abcdef0123456789abcdef01234567'
+const VERSION_SHA = '89abcdef0123456789abcdef0123456789abcdef'
+
+describe('release proposal validation', () => {
+  it('preserves empty commits while reconstructing the proposal', () => {
+    const fail = sinon.stub()
+    const run = sinon.stub()
+
+    /**
+     * @param {string} command
+     */
+    function capture (command) {
+      if (command === 'git rev-parse --abbrev-ref HEAD') return 'master'
+      if (command.includes('log --pretty=format:')) return `${VERSION_SHA}\n${EMPTY_SHA}`
+      if (command.includes('--format=sha --reverse v5.x master')) return EMPTY_SHA
+      if (command.includes('git --no-pager diff')) return ''
+      throw new Error(`Unexpected command: ${command}`)
+    }
+
+    const loadValidate = proxyquire.noCallThru().noPreserveCache()
+    loadValidate('./validate', {
+      '../../version': { DD_MAJOR: 5, DD_MINOR: 126, DD_PATCH: 0, VERSION: '5.126.0' },
+      './helpers/requirements': { checkAll: sinon.stub() },
+      './helpers/terminal': {
+        capture,
+        fail,
+        fatal: sinon.stub(),
+        flags: {},
+        log: sinon.stub(),
+        params: ['v5.127.0-proposal'],
+        pass: sinon.stub(),
+        run,
+        start: sinon.stub(),
+      },
+      crypto: { randomUUID: sinon.stub().returns('temporary-branch') },
+    })
+
+    assert(run.calledWithExactly(`git cherry-pick --allow-empty ${EMPTY_SHA} ${VERSION_SHA}`))
+    assert.strictEqual(fail.callCount, 0)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Preserves empty `master` commits when generating and validating release proposals.

It also verifies that an existing proposal's pull request sequence matches the
ordered `master` sequence before applying more commits. When a cherry-pick fails,
the existing error output is retained and augmented with the incoming commit,
proposal state, conflicted files, and the original Git error.

### Motivation

Release proposal run https://github.com/DataDog/dd-trace-js/actions/runs/34472000564
failed while cherry-picking an empty commit and incorrectly reported that the
release branch had diverged from `master`.

### Additional Notes

Validated with the complete release-script unit-test suite and targeted ESLint.

*Generated by Codex.*
