### PR TITLE
chore(ci): bump llm-validation-platform to v0.1.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,11 @@ variables:
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
     LLMVAL_PLATFORM_REF: *llmval_platform_sha
+    # Pin off the moving :newest tag. That tag drifted (rebuilt 2025-09-09) and
+    # broke run.sh's runtime node install. This digest is the last-known-good
+    # pre-drift snapshot (tag latest_20250820_1050). Temporary quick fix to
+    # verify the pin works; the durable fix belongs in the platform template.
+    LLMVAL_IMAGE: "registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu@sha256:f7da05d166e46a70b93cee8cb8028354402a443313c41530aea0b9f8e52b5811"
 
 llm validation definitions:
   extends: llm validation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
   - local: ".gitlab/benchmarks/gitlab-ci.yml"
   - project: "ddoghq/llm-validation-platform"
-    ref: &llmval_platform_sha "d59e4af6d6666092f65740b9a4d1bf3651a64321"
+    ref: &llmval_platform_sha "c331696647a78672101002ba48ccebbd41b0fae8" # v0.1.3
     file: "/ci/llm-validation.gitlab-ci.yml"
   - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
     file: ".gitlab/ci-node-express-realworld-parallel.yml"
@@ -64,11 +64,6 @@ variables:
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
     LLMVAL_PLATFORM_REF: *llmval_platform_sha
-    # Pin off the moving :newest tag. That tag drifted (rebuilt 2025-09-09) and
-    # broke run.sh's runtime node install. This digest is the last-known-good
-    # pre-drift snapshot (tag latest_20250820_1050). Temporary quick fix to
-    # verify the pin works; the durable fix belongs in the platform template.
-    LLMVAL_IMAGE: "registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu@sha256:f7da05d166e46a70b93cee8cb8028354402a443313c41530aea0b9f8e52b5811"
 
 llm validation definitions:
   extends: llm validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ do not modify unrelated behavior.
 - `integration-tests/` — end-to-end and process-level tests
 - `benchmark/` — performance benchmarks
 - `scripts/` — repository and release tooling
-- `vendor/` — bundled dependencies.
+- `vendor/` — bundled dependencies
 
 Packages generally contain `src/` and `test/`; unit tests use the `*.spec.js` suffix.
 
@@ -94,9 +94,9 @@ See `CONTRIBUTING.md#testing` for detailed test conventions and service setup.
 
 Group imports with blank lines and sort within each group:
 
-1. Node.js core modules using the `node:` prefix
-2. Third-party modules
-3. Internal modules, furthest path first
+1. Node.js core modules using the `node:` prefix.
+2. Third-party modules.
+3. Internal modules, furthest path first.
 
 For new methods, add TypeScript-compatible JSDoc with specific parameter and return types. Reuse existing typedefs,
 never use `any`, and do not add runtime work solely to satisfy static typing. Do not rewrite unrelated code only to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,9 @@ See `CONTRIBUTING.md#testing` for detailed test conventions and service setup.
 
 Group imports with blank lines and sort within each group:
 
-1. Node.js core modules using the `node:` prefix.
-2. Third-party modules.
-3. Internal modules, furthest path first.
+1. Node.js core modules using the `node:` prefix
+2. Third-party modules
+3. Internal modules, furthest path first
 
 For new methods, add TypeScript-compatible JSDoc with specific parameter and return types. Reuse existing typedefs,
 never use `any`, and do not add runtime work solely to satisfy static typing. Do not rewrite unrelated code only to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ do not modify unrelated behavior.
 - `integration-tests/` — end-to-end and process-level tests
 - `benchmark/` — performance benchmarks
 - `scripts/` — repository and release tooling
-- `vendor/` — bundled dependencies
+- `vendor/` — bundled dependencies.
 
 Packages generally contain `src/` and `test/`; unit tests use the `*.spec.js` suffix.
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!--
PR title guidance:
- Follow Conventional Commits format: type(scope): description.
- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert.
- Reserve feat, fix, and perf for shipped production code.
- A scope is optional, but omitting it does not change how the type is selected. For example,
  use test: cover retries, not fix: cover retries.
- A production type is valid for multiple scopes when at least one scope represents shipped code,
  such as fix(http, tests): handle retries.
- For non-production changes, use the area as the type:
  - Tests: test(scope): description
  - Benchmarks: bench(scope): description
  - Documentation: docs(scope): description
  - CI and workflows: ci(scope): description
  - Build tooling: build(scope): description
  - Maintenance: chore(scope): description
- For example, use docs(api): update setup guide, not fix(docs): update setup guide;
  use test(http): cover retries, not fix(test): cover retries.
- Apply the same rule to repository tooling. Examples include docs(agents), chore(codeowners),
  chore(eslint), chore(scripts), ci(release), ci(workflows), and test(integration-tests).
- Product scopes such as ci, test-optimization, and ci-visibility may still describe shipped production changes.
- Add the appropriate semver-patch, semver-minor, or semver-major label.
-->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Bump the pinned llm-validation-platform ref `d59e4af` (v0.1.2) → `c331696` (v0.1.3).
- Drop the temporary `LLMVAL_IMAGE` override; v0.1.3 carries the pin in its template default.

### Motivation
<!-- What inspired you to submit this pull request? -->
v0.1.3 pins the CI runner image by digest instead of the moving `:newest` tag, which drifted on 2025-09-09 and broke the gate's runtime node install. The per-repo override we added to unblock is now redundant, so the config goes back to relying on the platform default.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
