### PR TITLE
fix(debugger): default capture-expression probes to the snapshot rate

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -6,7 +6,11 @@ const { getGeneratedPosition } = require('./source-maps')
 const session = require('./session')
 const { compile, compileSegments, templateRequiresEvaluation } = require('./condition')
 const { MAX_SNAPSHOTS_PER_SECOND_PER_PROBE, MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE } = require('./defaults')
-const { compileBreakpointCondition, getRemoveProbeExpression } = require('./probe_sampler')
+const {
+  compileBreakpointCondition,
+  getRemoveProbeExpression,
+  isSnapshotProducingProbe,
+} = require('./probe_sampler')
 const {
   DEFAULT_MAX_REFERENCE_DEPTH,
   DEFAULT_MAX_COLLECTION_SIZE,
@@ -75,12 +79,6 @@ async function addBreakpoint (probe) {
     probe.template = compileSegments(probe.segments)
   }
   delete probe.segments
-
-  // Optimize for fast calculations when probe is hit
-  const snapshotsPerSecond = probe.sampling?.snapshotsPerSecond ?? (probe.captureSnapshot
-    ? MAX_SNAPSHOTS_PER_SECOND_PER_PROBE
-    : MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE)
-  probe.nsBetweenSampling = BigInt(Math.trunc(1 / snapshotsPerSecond * 1e9))
 
   // Warning: The code below relies on undocumented behavior of the inspector!
   // It expects that `await session.post('Debugger.enable')` will wait for all loaded scripts to be emitted as
@@ -155,6 +153,15 @@ async function addBreakpoint (probe) {
       })
     }
   }
+
+  // Must be calculated after `compiledCaptureExpressions` has been resolved, since capture-expression probes produce
+  // snapshots and therefore default to the snapshot rate.
+  //
+  // Optimize for fast calculations when probe is hit
+  const snapshotsPerSecond = probe.sampling?.snapshotsPerSecond ?? (isSnapshotProducingProbe(probe)
+    ? MAX_SNAPSHOTS_PER_SECOND_PER_PROBE
+    : MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE)
+  probe.nsBetweenSampling = BigInt(Math.trunc(1 / snapshotsPerSecond * 1e9))
 
   const locationKey = generateLocationKey(scriptId, lineNumber, columnNumber)
   const breakpoint = locationToBreakpoint.get(locationKey)

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -8,6 +8,19 @@ const SAMPLER_EXPRESSION = `globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMB
 module.exports = {
   compileBreakpointCondition,
   getRemoveProbeExpression,
+  isSnapshotProducingProbe,
+}
+
+/**
+ * Determine whether a probe produces snapshots. Probes that capture the full local state and probes that only capture
+ * specific expressions both emit snapshot payloads, so they share the snapshot sampling defaults and count towards the
+ * global snapshot rate limit.
+ *
+ * @param {{ captureSnapshot?: boolean, compiledCaptureExpressions?: object[] }} probe - The probe to inspect.
+ * @returns {boolean}
+ */
+function isSnapshotProducingProbe (probe) {
+  return probe.captureSnapshot === true || probe.compiledCaptureExpressions !== undefined
 }
 
 /**
@@ -66,7 +79,7 @@ function compileBreakpointCondition (probes) {
  */
 function compileProbeCondition (probe) {
   const sample = `$dd_sampler.makeSampleDecision(${probe.samplingIndex}, ${JSON.stringify(probe.id)}, ` +
-    `${probe.nsBetweenSampling}n, ${probe.captureSnapshot === true || probe.compiledCaptureExpressions !== undefined})`
+    `${probe.nsBetweenSampling}n, ${isSnapshotProducingProbe(probe)})`
 
   if (probe.condition === undefined) {
     return `$dd_sampled = ${sample} || $dd_sampled`

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -194,6 +194,20 @@ describe('breakpoints', function () {
       )
     })
 
+    it('should default to the non-snapshot sampling rate for probes that produce no snapshot', async function () {
+      await addProbe()
+
+      // 5000 snapshots/second is the non-snapshot default
+      assert.strictEqual(getInstalledProbe().nsBetweenSampling, 200_000n)
+    })
+
+    it('should default to the snapshot sampling rate for snapshot probes', async function () {
+      await addProbe({ captureSnapshot: true })
+
+      // 1 snapshot/second is the snapshot default
+      assert.strictEqual(getInstalledProbe().nsBetweenSampling, 1_000_000_000n)
+    })
+
     it('should translate source-mapped locations before setting the breakpoint', async function () {
       stateMock.findScriptFromPartialPath.returns({
         url: 'file:///path/to/test.js',
@@ -696,6 +710,41 @@ describe('breakpoints', function () {
         )
       })
 
+      it('should default to the snapshot sampling rate', async function () {
+        // Capture-expression probes produce snapshots, but set `captureSnapshot: false`. They must still get the
+        // snapshot default rate, or they will burst up to the global snapshot limit.
+        await addProbe({
+          captureSnapshot: false,
+          captureExpressions: [{ name: 'myVar', expr: { dsl: 'myVar', json: { ref: 'myVar' } } }],
+        })
+
+        // 1 snapshot/second is the snapshot default
+        assert.strictEqual(getInstalledProbe().nsBetweenSampling, 1_000_000_000n)
+        // The breakpoint condition must agree that the probe produces snapshots, so the runtime sampler also applies
+        // the global snapshot limit to it.
+        assert.match(
+          /** @type {string} */ (sessionMock.post.secondCall.args[1].condition),
+          /makeSampleDecision\(0, "probe-1", 1000000000n, true\)/
+        )
+      })
+
+      it('should respect an explicit sampling rate', async function () {
+        await addProbe({
+          captureSnapshot: false,
+          sampling: { snapshotsPerSecond: 0.5 },
+          captureExpressions: [{ name: 'myVar', expr: { dsl: 'myVar', json: { ref: 'myVar' } } }],
+        })
+
+        assert.strictEqual(getInstalledProbe().nsBetweenSampling, 2_000_000_000n)
+      })
+
+      it('should default to the non-snapshot sampling rate if captureExpressions is empty', async function () {
+        await addProbe({ captureSnapshot: false, captureExpressions: [] })
+
+        // 5000 snapshots/second is the non-snapshot default
+        assert.strictEqual(getInstalledProbe().nsBetweenSampling, 200_000n)
+      })
+
       it('should not set compiledCaptureExpressions if captureExpressions is empty', async function () {
         await addProbe({
           captureExpressions: [],
@@ -1171,6 +1220,21 @@ describe('breakpoints', function () {
    */
   async function addProbe (probe) {
     await breakpoints.addBreakpoint(genProbeConfig(probe))
+  }
+
+  /**
+   * Get a probe stored at the default breakpoint location.
+   *
+   * @param {string} [id] - The probe id. Defaults to `probe-1`.
+   */
+  function getInstalledProbe (id = 'probe-1') {
+    const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
+    assert.ok(probesAtLocation, `could not find probes at location ${breakpointId}`)
+
+    const probe = probesAtLocation.get(id)
+    assert.ok(probe, `could not find probe ${id}`)
+
+    return probe
   }
 })
 

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -179,12 +179,7 @@ describe('breakpoints', function () {
     it('should set the probe sampling interval', async function () {
       await addProbe({ sampling: { snapshotsPerSecond: 0.5 } })
 
-      // Verify the probe was stored in the breakpointToProbes map
-      const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-      assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-      const probe = probesAtLocation.get('probe-1')
-      assert(probe, 'Probe should be stored in map')
+      const probe = getInstalledProbe()
 
       // Verify nsBetweenSampling is calculated correctly
       assert.strictEqual(
@@ -257,11 +252,7 @@ describe('breakpoints', function () {
       it('should set default capture limits when captureSnapshot is true', async function () {
         await addProbe({ captureSnapshot: true })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -279,11 +270,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 5,
@@ -301,11 +288,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -323,11 +306,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -345,11 +324,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -362,11 +337,7 @@ describe('breakpoints', function () {
       it('should not set capture limits when captureSnapshot is false', async function () {
         await addProbe({ captureSnapshot: false })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.strictEqual(probe.capture, undefined)
       })
@@ -374,11 +345,7 @@ describe('breakpoints', function () {
       it('should not set capture limits when captureSnapshot is undefined', async function () {
         await addProbe()
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.strictEqual(probe.capture, undefined)
       })
@@ -625,13 +592,8 @@ describe('breakpoints', function () {
           ],
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
+        const probe = getInstalledProbe()
 
-        assert.ok(probesAtLocation, 'could not find probes at location')
-
-        const probe = probesAtLocation.get('probe-1')
-
-        assert.ok(probe, 'could not find probe')
         assert.ok(probe.compiledCaptureExpressions, 'compiledCaptureExpressions should be present')
 
         assert.strictEqual(probe.compiledCaptureExpressions.length, 2)
@@ -663,13 +625,8 @@ describe('breakpoints', function () {
           ],
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
+        const probe = getInstalledProbe()
 
-        assert.ok(probesAtLocation, 'could not find probes at location')
-
-        const probe = probesAtLocation.get('probe-1')
-
-        assert.ok(probe, 'could not find probe')
         assert.deepStrictEqual(probe.compiledCaptureExpressions, [
           {
             name: 'a',
@@ -750,11 +707,7 @@ describe('breakpoints', function () {
           captureExpressions: [],
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert.ok(probesAtLocation, 'could not find probes at location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert.ok(probe, 'could not find probe')
+        const probe = getInstalledProbe()
 
         assert.strictEqual(probe.compiledCaptureExpressions, undefined)
       })


### PR DESCRIPTION
### What does this PR do?

Fixes the default sampling rate for Live Debugger/Dynamic Instrumentation log probes that use capture expressions, so they get the snapshot default (1/s per probe) instead of the non-snapshot default (5000/s).

#### Implementation details

`breakpoints.js` selected the default rate from `captureSnapshot` alone. Capture-expression probes set `captureSnapshot: false`, so they fell through to `MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE` — while `probe_sampler.js` independently decided a probe was snapshot-producing from `captureSnapshot === true || compiledCaptureExpressions !== undefined`. The two predicates disagreed, so these probes were rate-limited as non-snapshot probes but still counted against the global snapshot cap, producing a burst of up to 25 snapshots instead of roughly one per second.

The predicate is now a single exported `isSnapshotProducingProbe()` used by both the default-rate selection and the breakpoint condition, so the two cannot drift apart again — that drift was the bug. The rate calculation moved below the capture-expression compilation block, since the predicate reads `compiledCaptureExpressions`; nothing in between depends on it, and `compileBreakpointCondition()` still runs afterwards.

`index.js:97` is a third copy of the predicate, but it already spells it out in full (`captureSnapshot === true || compiledCaptureExpressions !== undefined`), so it was never affected by this bug — `breakpoints.js` was the only site testing `captureSnapshot` alone. I left it inline rather than routing it through the helper because it sits in the `Debugger.paused` hot path the file explicitly warns against editing, and it immediately re-splits on `captureSnapshot` to accumulate capture limits, so the helper would not remove the branch. The cost is that one copy of the concept is still duplicated.

### Motivation

DEBUG-6186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
