### PR TITLE
test(debugger): reuse the installed-probe lookup helper

### DIFF
--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -179,12 +179,7 @@ describe('breakpoints', function () {
     it('should set the probe sampling interval', async function () {
       await addProbe({ sampling: { snapshotsPerSecond: 0.5 } })
 
-      // Verify the probe was stored in the breakpointToProbes map
-      const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-      assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-      const probe = probesAtLocation.get('probe-1')
-      assert(probe, 'Probe should be stored in map')
+      const probe = getInstalledProbe()
 
       // Verify nsBetweenSampling is calculated correctly
       assert.strictEqual(
@@ -257,11 +252,7 @@ describe('breakpoints', function () {
       it('should set default capture limits when captureSnapshot is true', async function () {
         await addProbe({ captureSnapshot: true })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -279,11 +270,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 5,
@@ -301,11 +288,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -323,11 +306,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -345,11 +324,7 @@ describe('breakpoints', function () {
           },
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.deepStrictEqual(probe.capture, {
           maxReferenceDepth: 3,
@@ -362,11 +337,7 @@ describe('breakpoints', function () {
       it('should not set capture limits when captureSnapshot is false', async function () {
         await addProbe({ captureSnapshot: false })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.strictEqual(probe.capture, undefined)
       })
@@ -374,11 +345,7 @@ describe('breakpoints', function () {
       it('should not set capture limits when captureSnapshot is undefined', async function () {
         await addProbe()
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert(probesAtLocation, 'Probes should be stored at breakpoint location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert(probe, 'Probe should be stored in map')
+        const probe = getInstalledProbe()
 
         assert.strictEqual(probe.capture, undefined)
       })
@@ -625,13 +592,8 @@ describe('breakpoints', function () {
           ],
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
+        const probe = getInstalledProbe()
 
-        assert.ok(probesAtLocation, 'could not find probes at location')
-
-        const probe = probesAtLocation.get('probe-1')
-
-        assert.ok(probe, 'could not find probe')
         assert.ok(probe.compiledCaptureExpressions, 'compiledCaptureExpressions should be present')
 
         assert.strictEqual(probe.compiledCaptureExpressions.length, 2)
@@ -663,13 +625,8 @@ describe('breakpoints', function () {
           ],
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
+        const probe = getInstalledProbe()
 
-        assert.ok(probesAtLocation, 'could not find probes at location')
-
-        const probe = probesAtLocation.get('probe-1')
-
-        assert.ok(probe, 'could not find probe')
         assert.deepStrictEqual(probe.compiledCaptureExpressions, [
           {
             name: 'a',
@@ -750,11 +707,7 @@ describe('breakpoints', function () {
           captureExpressions: [],
         })
 
-        const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
-        assert.ok(probesAtLocation, 'could not find probes at location')
-
-        const probe = probesAtLocation.get('probe-1')
-        assert.ok(probe, 'could not find probe')
+        const probe = getInstalledProbe()
 
         assert.strictEqual(probe.compiledCaptureExpressions, undefined)
       })


### PR DESCRIPTION
### What does this PR do?

Pure test cleanup, no production change. Replaces eleven copies of the same probe-lookup boilerplate in `breakpoints.spec.js` with the `getInstalledProbe()` helper introduced in #10292.

Each site was the same six lines:

```js
const probesAtLocation = stateMock.breakpointToProbes.get(breakpointId)
assert(probesAtLocation, 'Probes should be stored at breakpoint location')

const probe = probesAtLocation.get('probe-1')
assert(probe, 'Probe should be stored in map')
```

Net −47 lines. The duplication had also drifted into two assertion dialects (`assert` vs `assert.ok`) with two different sets of failure messages; the helper collapses that too.

### Motivation

Stacked on top of #10292 rather than folded into it. #10292 fixes DEBUG-6186 and only needed the helper for its three new tests; converting the other eleven sites there would have taken that PR from 3 hunks to 13 in the spec, with 10 of them in a `describe('capture limits')` block unrelated to the bug. Keeping the mechanical sweep separate leaves the fix reviewable on its own.

### Additional Notes

Behaviour-preserving by inspection: all eleven sites resolved the same `breakpointId` and the same `probe-1` id that the helper resolves — verified before converting, so the sweep is uniform with no special cases.

Validation run locally on this branch:

| Command | Result |
|---|---|
| `npm run test:debugger` | 634 passing (unchanged count) |
| `npm run lint` | clean |
| `npm run type:check` | no errors in the changed file |

Base branch is `t3code/fix-debug-6186`; this should merge after #10292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)