### PR TITLE
test(profiling): pin the RNG in the Poisson instant-count test

### DIFF
--- a/packages/dd-trace/test/profiling/profilers/poisson.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/poisson.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert')
 
 const { describe, it, beforeEach } = require('mocha')
+const sinon = require('sinon')
 
 require('../../setup/core')
 const PoissonProcessSamplingFilter = require('../../../src/profiling/profilers/poisson')
@@ -183,17 +184,31 @@ describe('PoissonProcessSamplingFilter', () => {
   })
 
   it('should increment samplingInstantCount on each sampling instant', () => {
-    const filter = new PoissonProcessSamplingFilter({
-      samplingInterval: 10,
-      resetInterval: 100,
-      now,
-    })
-    const initialCount = filter.samplingInstantCount
-    for (let i = 0; i < 5; i++) {
-      nowValue += 20
-      const event = { startTime: 0, duration: filter.nextSamplingInstant }
-      filter.filter(event)
+    // Sampling instants are drawn from an exponential distribution with mean samplingInterval, so a
+    // live Math.random() makes "does any instant fall inside the window advanced below" a property
+    // of the draw rather than of the counter under test here. Pin the draw so the assertion depends
+    // only on the counter. The stub must be installed before the constructor, which draws the first
+    // instant.
+    const randomStub = sinon.stub(Math, 'random').returns(0.5)
+
+    try {
+      const filter = new PoissonProcessSamplingFilter({
+        samplingInterval: 10,
+        resetInterval: 100,
+        now,
+      })
+      const initialCount = filter.samplingInstantCount
+      for (let i = 0; i < 5; i++) {
+        nowValue += 20
+        const event = { startTime: 0, duration: filter.nextSamplingInstant }
+        filter.filter(event)
+      }
+      assert.ok(
+        filter.samplingInstantCount > initialCount,
+        `Expected ${filter.samplingInstantCount} > ${initialCount}`
+      )
+    } finally {
+      randomStub.restore()
     }
-    assert.ok(filter.samplingInstantCount > initialCount, `Expected ${filter.samplingInstantCount} > ${initialCount}`)
   })
 })


### PR DESCRIPTION
### What does this PR do?

Removes a 1-in-22,000 flake from `PoissonProcessSamplingFilter`'s instant-count test. Test-only change, no production code touched.

`#setNextSamplingInstant` advances `#nextSamplingInstant` by an unseeded exponential draw:

```js
this.#nextSamplingInstant -= Math.log(1 - Math.random()) * this.#samplingInterval
```

The test stubbed only the clock, then advanced it by a total of 100 with `samplingInterval: 10` and asserted the instant count rose. When the **first** draw exceeded 100, the `while (cappedEndTime >= this.#nextSamplingInstant)` loop in `filter()` never executed in any of the five iterations, `samplingInstantCount` stayed at its constructor value of 1, and the assertion failed with `Expected 1 > 1`. That is `P = e^-(100/10) = e^-10 ≈ 4.5e-5`.

The fix pins `Math.random` for the duration of that one test, so the outcome no longer depends on the distribution's tail at all. The assertion itself is unchanged — this controls the input rather than loosening the check.

### Motivation

Hit on the `Profiling / windows` job, where attempt 1 failed with `Expected 1 > 1` and attempt 2 passed at the same revision ([run 34586181189](https://github.com/DataDog/dd-trace-js/actions/runs/34586181189)).

#8659 already fixed this exact mechanism in a **sibling test in the same file** — its commit message states the same `e^-10 ≈ 4.5e-5` arithmetic — but it raised that test's clock bound and left this sibling untouched. Raising a bound leaves the test statistical, just with a smaller exponent; stubbing the RNG makes this one deterministic.

### Additional Notes

**Cohort.** I enumerated all 11 tests in the file against the invariant "asserts the instant advanced, with a clock bound that is a fixed multiple of `samplingInterval`". Exactly **one** is vulnerable — the one fixed here.

The other ten, with reasons: L18/26/34 throw in the constructor before any draw; L43 and L59 assert a throw or a call count using draw-derived or infinite durations; L77 asserts only initial state; L90 derives its bound *from* the draw (`nowValue = prevNextSamplingInstant + 15`) and is immune by construction; L112 asserts *non*-advance, the safe direction; L127 is #8659's fix, bound `100000` = 1000× interval → `e^-1000`; L150 advances via the reset branch, which guarantees a crossing regardless of draw.

One case I deliberately left alone: L86's `assert.ok(filter.nextSamplingInstant > 0)` would fail if `Math.random()` returned exactly `0` (`P ≈ 2^-53`). That is a boundary rather than a tail, a different mechanism, and not worth coupling to this change.

**Verification.**

| Check | Result |
|---|---|
| Deterministic repro of the original failure: `Math.random = () => 0.99999` (draw 115.1 > 100) on the **unfixed** test | `AssertionError: Expected 1 > 1` — byte-identical to CI |
| Same tail-draw input against the **fixed** test | passes |
| `poisson.spec.js` | 13 passing |
| `poisson.spec.js` repeated 20× | 20/20, 0 failures |
| `Math.random` restored after the suite (root `afterAll` asserting it is unstubbed and live) | confirmed |
| `npm run lint` | clean |
| `npm run type:check` | clean for this file |

`Math.random` is restored in a `finally`, matching the existing idiom in `packages/dd-trace/test/exporters/common/retry.spec.js`; the stub reference is held in a local so the restore is typed.

I could not run the full `npm run test:profiler` locally to completion: `wall.spec.js` fails on this machine with `No native build was found for platform=darwin arch=arm64`, a missing native pprof binary in my local install. That file is unrelated to this change, runs in a separate process, and passed in the CI job referenced above (202 tests, 1 failure — the poisson one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)