### PR TITLE
fix(azure-functions): register durable executor rewrite

### DIFF
--- a/packages/datadog-instrumentations/src/azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/azure-durable-functions.js
@@ -13,7 +13,7 @@ const {
  */
 const azureDurableFunctionsChannel = dc.tracingChannel('datadog:azure:durable-functions:invoke')
 
-for (const hook of getHooks('durable-functions')) {
+for (const hook of getHooks('durable-functions').values()) {
   addHook(hook, exports => exports)
 }
 

--- a/packages/datadog-instrumentations/test/azure-functions.spec.js
+++ b/packages/datadog-instrumentations/test/azure-functions.spec.js
@@ -9,6 +9,21 @@ const sinon = require('sinon')
 
 const azureDurableFunctionsChannel = dc.tracingChannel('datadog:azure:durable-functions:invoke')
 
+describe('azure-durable-functions rewriter instrumentation (unit)', () => {
+  it('registers the orchestration executor hook', () => {
+    const realInstrument = require('../src/helpers/instrument')
+    const addHookSpy = sinon.spy()
+
+    proxyquire('../src/azure-durable-functions', {
+      './helpers/instrument': { ...realInstrument, addHook: addHookSpy },
+    })
+
+    const hook = addHookSpy.firstCall.args[0]
+    assert.strictEqual(hook.name, 'durable-functions')
+    assert.strictEqual(hook.file, 'lib/src/orchestrations/TaskOrchestrationExecutor.js')
+  })
+})
+
 describe('azure-functions orchestration instrumentation (unit)', () => {
   let azureFunctionsHook
   const subscriptions = []


### PR DESCRIPTION
Rewriter hooks are stored in a Map, so iterating the Map passes entry tuples to addHook() and leaves resumed orchestration failures without an executor failure span.