### PR TITLE
demo(sdk-config-rc): add live instrumentation control demo

### DIFF
--- a/demo/sdk-config-rc/DEMO.md
+++ b/demo/sdk-config-rc/DEMO.md
@@ -1,0 +1,156 @@
+# Demo runbook — SDK Configuration remote config end to end
+
+Goal for the audience: **a running tracer receives a Remote Configuration payload and acts on it**,
+with the payload validated against real backend code and the result confirmed three independent ways.
+
+Everything is driven by `./demo.sh` so nothing has to be typed live.
+
+## Timing traps — read this first
+
+| Step | Real elapsed time | Consequence for a live demo |
+| --- | --- | --- |
+| Publish → tracer applies | **~12 s** (observed) | Fine to show live. This is the money shot. |
+| Backend ack rollup (`status_count`) | **~1–2 min** | Do not wait in silence. Talk over it, then re-run `./demo.sh confirm`. |
+| Delete → tracer reverts | **~5 min** (observed) | **Never wait for this on stage.** See "Showing the revert". |
+
+The offline harness reverts in ~2 s because the fake agent stops serving instantly. Real RC
+propagation plus Agent caching is what makes the live revert slow — worth *saying*, since it is a
+real property of the system, not a defect.
+
+## Before the talk (~10 min ahead)
+
+```bash
+cd <worktree>/demo/sdk-config-rc
+
+~/.dd-rc-demo/check.sh     # credentials present and well-formed; prints no secrets
+./demo.sh local            # offline rehearsal, ~30 s, must end RESULT: PASS
+./demo.sh setup            # Agent + app; ends by printing the baseline
+```
+
+`setup` takes ~60 s (pulls/starts the Agent, waits for `API Key: Authorized`). Leave the app
+running. Confirm the baseline reads:
+
+```
+DD_PROFILING_ENABLED = 'false'
+origin               = 'env_var'
+profilerStarted      = False
+```
+
+Have two terminals: one for `./demo.sh`, one tailing the app so the audience sees events land live.
+
+```bash
+tail -f /tmp/rc-demo-app.log | grep --line-buffered -E 'config:update|CONFIG CHANGED|PROFILER'
+```
+
+## The demo
+
+### 1. Baseline — "profiling is off, and off because of the environment"
+
+```bash
+./demo.sh confirm      # or just show the setup output still on screen
+```
+
+Point at `origin = 'env_var'`. This matters: it proves the later change came from remote config
+and not from a restart or a local flag.
+
+### 2. The payload — "and we know the backend accepts it"
+
+```bash
+./demo.sh payload
+```
+
+Two things to say:
+
+- The payload is `APM_TRACING` with `sdk_config.config`, an env-var-keyed **string map**. That map
+  shape is what `dd-go#14029` introduced; before it, this field was a `[{key, value}]` array.
+- The validation is not a guess. It runs the payload through the **real** `jsonconf` request model
+  and the **real** `sdkconfigsecurity` allowlist from a dd-go checkout.
+
+Then the second half of that command, which is the part people remember:
+
+```
+FAIL: IsAllowed("DD_API_KEY")       = false  reason=security_risk_excluded
+FAIL: IsAllowed("DD_TRACE_ENABLED") = false  reason=lib_config_owned
+```
+
+`DD_TRACE_ENABLED` is in the *tracer's* allowlist but the backend refuses it, because `lib_config`
+owns it. That is a real constraint the demo found, and it is why the setting being toggled is
+`DD_PROFILING_ENABLED`.
+
+### 3. Publish — "now change it, with the app untouched"
+
+```bash
+./demo.sh publish
+```
+
+This POSTs to real `rc-api`, then polls until the tracer applies it. Call out:
+
+- **HTTP 201** and the config id.
+- The response echoes `config` back as an **object map** — live proof `#14029` is deployed in this
+  environment. A pre-`#14029` backend would return an array here.
+- In the tail terminal: `config:update` → `CONFIG CHANGED` → `PROFILER STARTED`, ~12 s later.
+
+The app was never restarted, redeployed, or signalled.
+
+### 4. Confirm — three independent sources
+
+`publish` prints these automatically; re-run `./demo.sh confirm` if the ack has not rolled up yet.
+
+1. **The tracer's own view** — `origin` flipped `env_var → remote_config`, `profilerStarted: True`.
+2. **The app log** — the `datadog:config:update` publish and the profiler starting, timestamped.
+3. **The backend** — `status_count = {"2": 1}`. `2` is `ACKNOWLEDGED`: the *backend* agrees the
+   tracer received and applied it. `error_messages` is empty.
+
+Source 3 is the strongest, because it is the backend's word rather than the app's.
+
+### 5. Profiles (optional)
+
+```
+https://app.datadoghq.com/profiling/explorer?query=service%3Asdk-config-demo%20env%3Ademo
+```
+
+Uploads land every 20 s (`DD_PROFILING_UPLOAD_PERIOD=20`). Give it ~2 min of runtime before
+switching to the UI, and set an explicit time range. If profiles have not surfaced, do not stall on
+it — the ack in step 4 is the actual claim being demonstrated; profiling is the payload, not the
+proof.
+
+## Showing the revert
+
+Do **not** delete on stage and wait. Pick one:
+
+- **Preferred** — show the instant round trip offline: `./demo.sh local` walks off → on → off in
+  ~30 s, and explicitly labels which layers are real and which is stubbed.
+- **Or** run `./demo.sh revert` ~6 minutes before you need it, and show the already-reverted state
+  (`origin` back to `env_var`, `profilerStarted: False`) as a closing beat.
+
+Either way, say plainly that the real revert takes minutes and why.
+
+## After the talk
+
+```bash
+./demo.sh revert      # deletes the config from the org
+./demo.sh teardown     # stops the app, removes the demo Agent
+```
+
+`teardown` warns if a config is still live and prints your remaining containers, so you can see
+your own `dd-agent` was untouched. The demo Agent runs under a distinct name and port
+(`dd-agent-rc-demo`, 18226) precisely so an existing agent is never disturbed — mine pointed at a
+different org, which would have silently broken the demo had it been reused.
+
+Revoke the app key when finished.
+
+## If something breaks live
+
+| Symptom | Do this |
+| --- | --- |
+| Publish returns 400 | `lib_config` must have `service_name` and `env`. The committed payloads already do; a hand-edited one may not. |
+| Publish returns 403 | App key lacks APM remote-config write, or no granular write access to the service. |
+| Nothing applies after ~30 s | `DD_SERVICE`/`DD_ENV` must match `service_target` exactly. Restart the app with `DD_TRACE_DEBUG=1` and look for `Ignoring config for service:`. |
+| `status_count` stays `{}` | Rollup lag. Re-run `./demo.sh confirm`. The tracer-side evidence already stands. |
+| Network or org trouble | Fall back to `./demo.sh local` and say what it stubs. It needs no credentials and no network. |
+
+## Note on config ids
+
+`rc-api` derives the config id from the target, so re-publishing for the same `service`/`env`
+returns the **same id** as a previous run. Convenient, but it means "a new id" is not a signal that
+anything changed.

--- a/demo/sdk-config-rc/README.md
+++ b/demo/sdk-config-rc/README.md
@@ -1,0 +1,166 @@
+# SDK Configuration + dynamic profiling remote-config demo
+
+Demonstrates a running tracer receiving an `APM_TRACING` / `sdk_config` Remote Configuration
+payload and applying it, by turning the profiler on at runtime.
+
+Branch: `demo/sdk-config-profiling-rc` — dd-trace-js PR #9392 (SDK_CONFIGURATION transport)
+combined with PR #9626 (profiling via `datadog:config:update`), plus one commit enabling
+`DD_PROFILING_ENABLED` in the client allowlist. See the branch's commit messages for the
+conflict resolutions and why that third commit is needed.
+
+## One-command demo (no credentials)
+
+```bash
+node demo/sdk-config-rc/local-harness.js
+```
+
+Expected output, abridged:
+
+```
+[harness] sdk_config.config wire shape: object map (post-#14029)
+DD_PROFILING_ENABLED=false origin=env_var profilerStarted=false     <- baseline
+config:update  DD_PROFILING_ENABLED=true  origin=remote_config
+>>> CONFIG CHANGED  DD_PROFILING_ENABLED: false -> true (origin=remote_config)
+>>> PROFILER STARTED (was false)
+[harness] ack: id=demo-… version=1 apply_state=2                    <- tracer ACKed
+[harness] RESULT: PASS
+```
+
+Add `--legacy-array-shape` to send the pre-#14029 `[{key,value}]` form instead; the combined
+tracer accepts both, so the demo does not depend on #14029 being deployed.
+
+### What this does and does not prove
+
+`local-harness.js` uses the repo's `FakeAgent`, which stubs the Agent's `POST /v0.7/config`.
+The payload is authored by the harness, **not** produced by `rc-api`. So:
+
+| Layer | Covered |
+| --- | --- |
+| 1. `rc-api` (dd-go) — JSON:API validation, allowlist, storage | no — see preflight below |
+| 2. RC distribution / TUF targets signing | no |
+| 3. Datadog Agent — fetch from backend, serve `/v0.7/config` | stubbed |
+| 4. Tracer RC client — polling, products, capability bits, targeting, ack | **yes, real** |
+| 5. Tracer config layer — `remote_config.js`, allowlist, `sdk_config` parsing | **yes, real** |
+| 6. Application — `config:update` → `profiler.js` → profiler starts | **yes, real** |
+
+## Real backend preflight
+
+Validates a payload against **real dd-go code** rather than an assumption about the wire format.
+Copies a Go test into a local dd-go checkout, runs it there so dd-go's module graph applies, and
+always removes it (it refuses to run if that tree is already dirty).
+
+```bash
+./demo/sdk-config-rc/preflight.sh                                  # accepted payload
+./demo/sdk-config-rc/preflight.sh payloads/rejected-example.json   # rejected payload
+DD_GO_DIR=/path/to/dd-go ./demo/sdk-config-rc/preflight.sh         # other checkout
+```
+
+It exercises `jsonconf.Configuration` / `jsonconf.SDKConfig` (the real request model, including
+#14029's object map and the legacy array decoder) and `sdkconfigsecurity.IsAllowed`,
+`NormalizeAndValidateCanonical`, `ValidateStored` (the real server-side allowlist).
+
+This is how the demo learned that **`DD_TRACE_ENABLED` is unusable via `sdk_config`**:
+
+```
+PASS: IsAllowed("DD_PROFILING_ENABLED") = true
+FAIL: IsAllowed("DD_TRACE_ENABLED")     = false  reason=lib_config_owned
+FAIL: IsAllowed("DD_API_KEY")           = false  reason=security_risk_excluded
+```
+
+`DD_TRACE_ENABLED` is in dd-trace-js's client allowlist but the backend owns it via `lib_config`,
+so `DD_PROFILING_ENABLED` is the setting to demo.
+
+## Publishing through the real rc-api
+
+Product: `APM_TRACING`. Payload: `sdk_config.config`, an env-var-keyed string map
+(`ddoghq/dd-go#14029`; pre-#14029 it was a `[{key,value}]` array).
+
+Requires an org API key plus an **application key** with `APM_REMOTE_CONFIGURATION_READ` (153)
+and `APM_REMOTE_CONFIGURATION_WRITE` (152). `POST /configs` also runs a per-service granular
+access check, so the app key's user needs write access to the target service.
+
+Keep keys in the environment — never on the command line or in this repo:
+
+```bash
+export DD_SITE=datad0g.com          # Datadog staging
+export DD_API_KEY=…                 # not echoed, not committed
+export DD_APP_KEY=…
+```
+
+Always preflight first:
+
+```bash
+./demo/sdk-config-rc/preflight.sh payloads/profiling-enable.json
+```
+
+Publish (request body: `payloads/jsonapi-profiling-enable.json`):
+
+```bash
+curl -sS -X POST \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  -H 'Content-Type: application/json' \
+  -d @demo/sdk-config-rc/payloads/jsonapi-profiling-enable.json
+```
+
+Inspect what the backend serves for the target, and the per-tracer apply state (the ack):
+
+```bash
+curl -sS -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs/by_target?service=sdk-config-demo&env=demo"
+
+curl -sS -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs/<CONFIG_ID>/status"
+```
+
+### Cleanup / revert
+
+The demo is not self-reverting against a real backend. Delete the config when done:
+
+```bash
+curl -sS -X DELETE -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs/<CONFIG_ID>"
+```
+
+The tracer reverts on its own once the config stops being served: `setRemoteConfig(null)` clears
+RC-managed fields, `DD_PROFILING_ENABLED` falls back to its `env_var` origin, and `profiler.js`
+stops the profiler. `local-harness.js` asserts exactly that transition.
+
+### Running the app against a real Agent
+
+```bash
+DD_SERVICE=sdk-config-demo DD_ENV=demo DD_VERSION=0.0.1 \
+DD_REMOTE_CONFIGURATION_ENABLED=true \
+DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=5 \
+DD_PROFILING_ENABLED=false \
+node demo/sdk-config-rc/app.js
+```
+
+The Agent needs `remote_configuration.enabled: true` and the same `DD_SITE`/API key as above.
+`service` and `env` must match `service_target` in the payload, or the config will not be
+served to this tracer. `curl localhost:8080/state` shows the live config, its origin, whether
+the profiler is running, and every `config:update` seen so far.
+
+### Verifying the backend has #14029
+
+`rc-api` has **no version endpoint** — only `/_health`, which returns the literal string `ok`.
+The running build is only exposed as the `version` tag on `service:rc-api` (format
+`v<build-id>-<short-sha>`), so check that in the org where the target environment reports.
+
+Status as of 2026-09-04: merge commit `c520e14` (merged 15:39Z) is an ancestor of the
+`rc-staging` branch but is **not** in any prod datacenter — prod was mid-rollout of a 10:27Z
+commit, 211 commits behind it. Since the combined tracer accepts both wire shapes, the demo
+works either way; only the object-map form specifically requires #14029.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `app.js` | Minimal `node:http` app on the combined build; `/state`, `/work` |
+| `local-harness.js` | FakeAgent-driven end-to-end demo; asserts the off→on→off transition |
+| `preflight.sh` | Validates a payload against real dd-go code |
+| `preflight/preflight_test.go` | The Go test `preflight.sh` runs inside dd-go |
+| `payloads/profiling-enable.json` | RC config-file form (preflight + FakeAgent) |
+| `payloads/jsonapi-profiling-enable.json` | rc-api JSON:API request body (curl) |
+| `payloads/rejected-example.json` | Payload the real backend rejects, to prove preflight works |

--- a/demo/sdk-config-rc/README.md
+++ b/demo/sdk-config-rc/README.md
@@ -127,7 +127,54 @@ The tracer reverts on its own once the config stops being served: `setRemoteConf
 RC-managed fields, `DD_PROFILING_ENABLED` falls back to its `env_var` origin, and `profiler.js`
 stops the profiler. `local-harness.js` asserts exactly that transition.
 
-### Running the app against a real Agent
+## End-to-end against a real Agent and real rc-api
+
+This is the full chain: app -> Agent -> RC backend -> `rc-api`, with the config created by curl
+instead of through the Datadog UI (the UI calls the same route).
+
+### Which payload shape to send
+
+The **tracer accepts both** shapes, but the **write path does not**. `rc-schema-validation`
+validates the request against the embedded `apm-tracing.json`, so:
+
+| Target org's rc-api | Send | Request body |
+| --- | --- | --- |
+| includes #14029 | object map | `payloads/jsonapi-profiling-enable.json` |
+| predates #14029 | `[{key, value}]` array | `payloads/jsonapi-profiling-enable-legacy-array.json` |
+
+Sending the object form to a pre-#14029 backend is rejected at schema validation. When in doubt,
+the legacy array form is accepted by both, because #14029 kept a read-path decoder for it.
+
+### 1. Credentials
+
+```bash
+export DD_SITE=datadoghq.com        # or the staging site
+export DD_API_KEY=…                 # keep these in the environment only
+export DD_APP_KEY=…                 # needs APM remote-config read + write
+```
+
+The app key's user also needs write access to the target service, or `POST /configs` returns 403
+from the per-service granular access check.
+
+### 2. Agent with remote config enabled
+
+```bash
+docker run --rm -d --name dd-agent-rc \
+  -e DD_API_KEY="$DD_API_KEY" \
+  -e DD_SITE="$DD_SITE" \
+  -e DD_REMOTE_CONFIGURATION_ENABLED=true \
+  -e DD_APM_ENABLED=true \
+  -e DD_APM_NON_LOCAL_TRAFFIC=true \
+  -p 8126:8126 \
+  gcr.io/datadoghq/agent:7
+
+docker exec dd-agent-rc agent status | grep -iA5 'Remote Configuration'
+```
+
+### 3. App, with profiling off at boot
+
+`DD_SERVICE` and `DD_ENV` must match `service_target` in the payload exactly (or the payload must
+use `*`), otherwise the tracer discards the config client-side.
 
 ```bash
 DD_SERVICE=sdk-config-demo DD_ENV=demo DD_VERSION=0.0.1 \
@@ -137,10 +184,77 @@ DD_PROFILING_ENABLED=false \
 node demo/sdk-config-rc/app.js
 ```
 
-The Agent needs `remote_configuration.enabled: true` and the same `DD_SITE`/API key as above.
-`service` and `env` must match `service_target` in the payload, or the config will not be
-served to this tracer. `curl localhost:8080/state` shows the live config, its origin, whether
-the profiler is running, and every `config:update` seen so far.
+Baseline, from the startup log and `curl -s localhost:8080/state | jq .profiling`:
+
+```
+DD_PROFILING_ENABLED=false origin=env_var profilerStarted=false
+```
+
+### 4. Preflight, then publish
+
+```bash
+./demo/sdk-config-rc/preflight.sh payloads/profiling-enable.json
+
+curl -sS -X POST \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  -H 'Content-Type: application/json' \
+  -d @demo/sdk-config-rc/payloads/jsonapi-profiling-enable.json
+```
+
+Keep the returned `data.id` as `CONFIG_ID`.
+
+### 5. Expected behavior, and the evidence to capture
+
+Within one poll interval (5s above, plus backend propagation), the app logs:
+
+```
+config:update  DD_PROFILING_ENABLED=true  origin=remote_config
+>>> CONFIG CHANGED  DD_PROFILING_ENABLED: false -> true (origin=remote_config)
+>>> PROFILER STARTED (was false)
+```
+
+Three independent confirmations:
+
+```bash
+# 1. tracer state: origin is remote_config and the profiler is running
+curl -s localhost:8080/state | jq '.profiling, .configUpdates'
+
+# 2. backend agrees the tracer ACKed it (apply_state 2 = acknowledged)
+curl -sS -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs/${CONFIG_ID}/status"
+
+# 3. what the backend serves for this target
+curl -sS -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs/by_target?service=sdk-config-demo&env=demo"
+```
+
+Profiles (the bonus) upload through the Agent's profiling proxy roughly 60s after the profiler
+starts; check APM > Profiles for `service:sdk-config-demo env:demo`.
+
+### 6. Cleanup / revert
+
+```bash
+curl -sS -X DELETE -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  "https://api.${DD_SITE}/api/unstable/remote_config/products/apm_tracing/configs/${CONFIG_ID}"
+
+docker rm -f dd-agent-rc
+```
+
+The tracer reverts on its own once the config stops being served: `setRemoteConfig(null)` clears
+RC-managed fields, `DD_PROFILING_ENABLED` falls back to its `env_var` origin, and `profiler.js`
+stops the profiler. Expect `>>> PROFILER STOPPED` in the app log.
+
+### Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| No `config:update` at all | Agent RC disabled, or `DD_REMOTE_CONFIGURATION_ENABLED=false` in the app |
+| `config:update` fires but value unchanged | `service_target` does not match `DD_SERVICE`/`DD_ENV`. Run with `DD_TRACE_DEBUG=1` and look for `Ignoring config for service:` / `for env:` |
+| Value applied but profiler never starts | `DD_PROFILING_ENABLED` missing from `sdkConfigAllowlist` (see commit `0a3a81af0`) |
+| 400 at publish | Wrong `sdk_config.config` shape for that backend, or a key the server rejects. Run `preflight.sh` |
+| 403 at publish | App key lacks APM remote-config write, or no granular write access to the service |
 
 ### Verifying the backend has #14029
 
@@ -161,6 +275,8 @@ works either way; only the object-map form specifically requires #14029.
 | `local-harness.js` | FakeAgent-driven end-to-end demo; asserts the off→on→off transition |
 | `preflight.sh` | Validates a payload against real dd-go code |
 | `preflight/preflight_test.go` | The Go test `preflight.sh` runs inside dd-go |
-| `payloads/profiling-enable.json` | RC config-file form (preflight + FakeAgent) |
-| `payloads/jsonapi-profiling-enable.json` | rc-api JSON:API request body (curl) |
+| `payloads/profiling-enable.json` | RC config-file form, object map (preflight + FakeAgent) |
+| `payloads/profiling-enable-legacy-array.json` | Same, pre-#14029 array shape |
+| `payloads/jsonapi-profiling-enable.json` | rc-api request body, object map |
+| `payloads/jsonapi-profiling-enable-legacy-array.json` | rc-api request body, pre-#14029 array shape |
 | `payloads/rejected-example.json` | Payload the real backend rejects, to prove preflight works |

--- a/demo/sdk-config-rc/README.md
+++ b/demo/sdk-config-rc/README.md
@@ -139,11 +139,12 @@ validates the request against the embedded `apm-tracing.json`, so:
 
 | Target org's rc-api | Send | Request body |
 | --- | --- | --- |
-| includes #14029 | object map | `payloads/jsonapi-profiling-enable.json` |
+| includes #14029 (**all prod, as of 2026-09-08**) | object map | `payloads/jsonapi-profiling-enable.json` |
 | predates #14029 | `[{key, value}]` array | `payloads/jsonapi-profiling-enable-legacy-array.json` |
 
-Sending the object form to a pre-#14029 backend is rejected at schema validation. When in doubt,
-the legacy array form is accepted by both, because #14029 kept a read-path decoder for it.
+Sending the object form to a pre-#14029 backend is rejected at schema validation. The legacy
+array form is accepted by both, because #14029 kept a read-path decoder for it, so it remains
+the safe choice against a backend of unknown version.
 
 ### 1. Credentials
 
@@ -262,10 +263,29 @@ stops the profiler. Expect `>>> PROFILER STOPPED` in the app log.
 The running build is only exposed as the `version` tag on `service:rc-api` (format
 `v<build-id>-<short-sha>`), so check that in the org where the target environment reports.
 
-Status as of 2026-09-04: merge commit `c520e14` (merged 15:39Z) is an ancestor of the
-`rc-staging` branch but is **not** in any prod datacenter — prod was mid-rollout of a 10:27Z
-commit, 211 commits behind it. Since the combined tracer accepts both wire shapes, the demo
-works either way; only the object-map form specifically requires #14029.
+Status as of 2026-09-08: **#14029 is live in every prod datacenter**, for both `rc-api` and
+`rc-schema-validation`. Use the object-map payload against prod.
+
+Verified by ancestry, not by inference. Spans for these services carry the full deploy SHA in
+`@git.commit.sha`, so the short SHA in the `version` tag does not have to be trusted:
+
+| Service | Live builds (env:prod) | Datacenters |
+| --- | --- | --- |
+| `rc-api` | `fee0ef2`, `a02b549`, `c0029c4` | us1, us3, us5, eu1, uk1, ap1, ap2 |
+| `rc-schema-validation` | `bc1410d`, `a02b549`, `05d7022` | us1, us3, us5, eu1, uk1, ap1, ap2 |
+
+Each was compared against the merge commit with
+`gh api repos/ddoghq/dd-go/compare/<deployed>...c520e146…`; all returned `behind` with
+`ahead_by: 0`, meaning the deployed build contains it. Reversing the comparison returned
+`ahead` with `behind_by: 0`, so the result is not an artifact of base/head ordering. The oldest
+live build on either service dates from 2026-09-07, three days after the 2026-09-04 merge.
+
+`rc-schema-validation` matters independently: it `go:embed`s `apm-tracing.json`, so the schema
+change only takes effect when that service redeploys. Its oldest live build already postdates
+the merge, so the object-map schema is live everywhere rather than only on the newest canary.
+
+No staging deployment of either service was found (zero spans for `env:(staging|stg|sandbox)`),
+so prod is the environment to use.
 
 ## Files
 

--- a/demo/sdk-config-rc/README.md
+++ b/demo/sdk-config-rc/README.md
@@ -206,6 +206,12 @@ curl -sS -X POST \
 
 Keep the returned `data.id` as `CONFIG_ID`.
 
+`lib_config` must carry `service_name` and `env`. An empty `lib_config: {}` is rejected with a
+bare `{"errors":[{"title":"Bad Request"}]}` and no field detail — rc-api's own create fixtures
+under `remote-config/apps/rc-api/products/apmtracing/testdata/service/TestCreateConfig_*` all
+populate it. Note the JSON:API response echoes `sdk_config.config` back as an object map, which
+is itself a live confirmation that #14029 is deployed; a pre-#14029 backend returns an array.
+
 ### 5. Expected behavior, and the evidence to capture
 
 Within one poll interval (5s above, plus backend propagation), the app logs:
@@ -254,7 +260,8 @@ stops the profiler. Expect `>>> PROFILER STOPPED` in the app log.
 | No `config:update` at all | Agent RC disabled, or `DD_REMOTE_CONFIGURATION_ENABLED=false` in the app |
 | `config:update` fires but value unchanged | `service_target` does not match `DD_SERVICE`/`DD_ENV`. Run with `DD_TRACE_DEBUG=1` and look for `Ignoring config for service:` / `for env:` |
 | Value applied but profiler never starts | `DD_PROFILING_ENABLED` missing from `sdkConfigAllowlist` (see commit `0a3a81af0`) |
-| 400 at publish | Wrong `sdk_config.config` shape for that backend, or a key the server rejects. Run `preflight.sh` |
+| 400 at publish | Empty `lib_config: {}` — rc-api rejects it. Populate `service_name` and `env` (see below). Also: wrong `sdk_config.config` shape for that backend, or a key the server rejects. `preflight.sh` catches the key/shape cases but **not** this one, since it validates the RC file rather than the JSON:API request |
+| Revert takes minutes, not seconds | Expected against a real backend. Deleting the config returned 204 and `by_target` 404 immediately, but the tracer reverted ~5 min later: RC backend propagation plus Agent cache. The FakeAgent harness reverts in ~2s because it stops serving instantly |
 | 403 at publish | App key lacks APM remote-config write, or no granular write access to the service |
 
 ### Verifying the backend has #14029

--- a/demo/sdk-config-rc/app.js
+++ b/demo/sdk-config-rc/app.js
@@ -21,6 +21,7 @@ tracer.init({
 })
 
 const http = require('node:http')
+const { performance } = require('node:perf_hooks')
 
 // dc-polyfill resolves to the same channel registry the tracer uses, so this observes the real
 // 'datadog:config:update' publishes rather than a copy.
@@ -35,6 +36,10 @@ const PROFILING_KEY = 'profiling.DD_PROFILING_ENABLED'
 const configUpdates = []
 let lastProfilingValue = config.profiling.DD_PROFILING_ENABLED
 let lastProfilerStarted = profilerModule.started
+let faulted = false
+let inFlight = 0
+const requestStarts = []
+const recentRequests = []
 
 function stamp () {
   return new Date().toISOString()
@@ -104,12 +109,174 @@ function burnCpu (ms) {
   return acc
 }
 
+class PaymentAuthorizationError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'PaymentAuthorizationError'
+  }
+}
+
+function spanIdentity (span) {
+  const context = span?.context()
+  return {
+    traceId: context?.toTraceId(),
+    spanId: context?.toSpanId(),
+  }
+}
+
+function observedSpan (request, name, resource, operation) {
+  const parentId = spanIdentity(tracer.scope().active()).spanId
+  const startedAt = performance.now()
+  const offsetMs = startedAt - request.startedMonotonic
+  let failure
+
+  return tracer.trace(name, { resource }, (span) => {
+    try {
+      return operation()
+    } catch (error) {
+      failure = error
+      span.setTag('error', error)
+      throw error
+    } finally {
+      request.spans.push({
+        ...spanIdentity(span),
+        parentId,
+        name,
+        resource,
+        offsetMs,
+        durationMs: performance.now() - startedAt,
+        error: Boolean(failure),
+      })
+    }
+  })
+}
+
+function verifyProviderSignature (request) {
+  return observedSpan(request, 'payment.verify_signature', 'verifyProviderSignature', () => {
+    burnCpu(faulted ? 180 : 8)
+    if (faulted) throw new Error('malformed payment-provider signature')
+    return true
+  })
+}
+
+function authorizePayment (request) {
+  return observedSpan(request, 'checkout.authorize', 'authorizePayment', () => {
+    const attempts = faulted ? 3 : 1
+    let lastError
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        return observedSpan(request, 'payment.retry', `retryPayment attempt ${attempt}`, () => {
+          return verifyProviderSignature(request)
+        })
+      } catch (error) {
+        lastError = error
+      }
+    }
+    const error = new PaymentAuthorizationError(
+      `payment-provider response failed validation after ${attempts} attempts`
+    )
+    error.cause = lastError
+    throw error
+  })
+}
+
+function recordRequest (request, statusCode, error) {
+  const root = tracer.scope().active()
+  const identity = spanIdentity(root)
+  recentRequests.push({
+    id: `${request.startedAt}-${identity.spanId || recentRequests.length}`,
+    ...identity,
+    resource: 'POST /checkout/payment',
+    method: 'POST',
+    startedAt: request.startedAt,
+    durationMs: performance.now() - request.startedMonotonic,
+    statusCode,
+    error: error ? { name: error.name, message: error.message } : undefined,
+    spans: request.spans,
+  })
+  if (recentRequests.length > 80) recentRequests.splice(0, recentRequests.length - 80)
+}
+
+function percentile (values, fraction) {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)]
+}
+
+function telemetryState () {
+  const now = Date.now()
+  const windowMs = 10_000
+  const completed = recentRequests.filter((request) => now - Date.parse(request.startedAt) <= windowMs)
+  const arrivals = requestStarts.filter((startedAt) => now - startedAt <= windowMs)
+  return {
+    service: config.service,
+    env: config.env,
+    faulted,
+    profiling: state().profiling,
+    ready: completed.length > 0,
+    sample: {
+      ServiceID: config.service,
+      ErrorRate: completed.length
+        ? completed.filter((request) => request.statusCode >= 500).length / completed.length
+        : 0,
+      LatencyP95: percentile(completed.map((request) => request.durationMs), 0.95),
+      Throughput: completed.length / (windowMs / 1000),
+      ArrivalRate: arrivals.length / (windowMs / 1000),
+      InFlight: inFlight,
+      At: new Date().toISOString(),
+    },
+    recentRequests: recentRequests.slice(-20).reverse(),
+  }
+}
+
 const server = http.createServer((req, res) => {
   const url = new URL(req.url, 'http://localhost')
 
   if (url.pathname === '/state') {
     res.writeHead(200, { 'content-type': 'application/json' })
     res.end(JSON.stringify(state(), undefined, 2))
+    return
+  }
+
+  if (url.pathname === '/telemetry') {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(telemetryState(), undefined, 2))
+    return
+  }
+
+  if (url.pathname === '/fault' && req.method === 'POST') {
+    faulted = url.searchParams.get('enabled') === 'true'
+    log(`demo fault ${faulted ? 'ENABLED' : 'CLEARED'} for POST /checkout/payment`)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ faulted }))
+    return
+  }
+
+  if (url.pathname === '/checkout/payment') {
+    const request = {
+      startedAt: new Date().toISOString(),
+      startedMonotonic: performance.now(),
+      spans: [],
+    }
+    requestStarts.push(Date.now())
+    if (requestStarts.length > 200) requestStarts.splice(0, requestStarts.length - 200)
+    inFlight++
+
+    let statusCode = 200
+    let error
+    try {
+      authorizePayment(request)
+    } catch (caught) {
+      statusCode = 500
+      error = caught
+      tracer.scope().active()?.setTag('error', caught)
+    } finally {
+      inFlight--
+      recordRequest(request, statusCode, error)
+    }
+
+    res.writeHead(statusCode, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(error ? { error: error.name, message: error.message } : { authorized: true }))
     return
   }
 
@@ -121,13 +288,16 @@ const server = http.createServer((req, res) => {
   }
 
   res.writeHead(404, { 'content-type': 'application/json' })
-  res.end(JSON.stringify({ error: 'not found', routes: ['/state', '/work'] }))
+  res.end(JSON.stringify({
+    error: 'not found',
+    routes: ['/state', '/telemetry', '/fault', '/checkout/payment', '/work'],
+  }))
 })
 
 const port = Number(process.env.APP_PORT) || 8080
 server.listen(port, () => {
   const actual = server.address().port
-  log(`listening on http://127.0.0.1:${actual}  (/state, /work)`)
+  log(`listening on http://127.0.0.1:${actual}  (/state, /telemetry, /checkout/payment, /work)`)
   log(`service=${config.service} env=${config.env} version=${config.version}`)
   log(`remote config enabled=${config.remoteConfig.DD_REMOTE_CONFIGURATION_ENABLED} ` +
       `poll=${config.remoteConfig.pollInterval}s`)
@@ -139,7 +309,13 @@ server.listen(port, () => {
 // Self-driven request loop, so the app generates traces and CPU load with no external driver.
 if (process.env.DEMO_NO_LOAD !== '1') {
   setInterval(() => {
-    http.get(`http://127.0.0.1:${server.address().port}/work?ms=25`, (res) => res.resume())
-      .on('error', () => {})
+    const request = http.request({
+      hostname: '127.0.0.1',
+      port: server.address().port,
+      path: '/checkout/payment',
+      method: 'POST',
+    }, (res) => res.resume())
+    request.on('error', () => {})
+    request.end()
   }, 500).unref()
 }

--- a/demo/sdk-config-rc/app.js
+++ b/demo/sdk-config-rc/app.js
@@ -1,0 +1,145 @@
+'use strict'
+
+// Smallest practical app for the SDK Configuration / dynamic-profiling remote-config demo.
+//
+// Loads the combined local dd-trace-js build (this worktree, two levels up), stays alive so the
+// remote-config client keeps polling, produces continuous CPU work so the profiler has something
+// to sample, and exposes the tracer's live configuration state over HTTP.
+//
+// Start with:  node demo/sdk-config-rc/app.js
+
+/* eslint-disable import/order -- dd-trace must be required and initialized before any module it
+   instruments, otherwise this file captures an unpatched `http` and generates no spans. That
+   ordering is the opposite of what import/order wants. */
+/* eslint-disable no-console -- this is a demo CLI; its log output is the deliverable. */
+
+const tracer = require('../..')
+
+tracer.init({
+  // Short flush interval so traces show up promptly during a live demo.
+  flushInterval: 1000,
+})
+
+const http = require('node:http')
+
+// dc-polyfill resolves to the same channel registry the tracer uses, so this observes the real
+// 'datadog:config:update' publishes rather than a copy.
+const { channel } = require('dc-polyfill')
+const profilerModule = require('../../packages/dd-trace/src/profiler')
+
+const config = tracer._tracer._config
+
+const PROFILING_KEY = 'profiling.DD_PROFILING_ENABLED'
+
+/** Every config:update publish seen, newest last. Surfaced on /state as evidence. */
+const configUpdates = []
+let lastProfilingValue = config.profiling.DD_PROFILING_ENABLED
+let lastProfilerStarted = profilerModule.started
+
+function stamp () {
+  return new Date().toISOString()
+}
+
+function log (...args) {
+  console.log(`[${stamp()}]`, ...args)
+}
+
+channel('datadog:config:update').subscribe((updated) => {
+  const value = updated.profiling.DD_PROFILING_ENABLED
+  const origin = updated.getOrigin(PROFILING_KEY)
+
+  const entry = {
+    at: stamp(),
+    'profiling.DD_PROFILING_ENABLED': value,
+    origin,
+    profilerStarted: profilerModule.started,
+  }
+  configUpdates.push(entry)
+
+  log(`config:update  DD_PROFILING_ENABLED=${value}  origin=${origin}`)
+
+  if (value !== lastProfilingValue) {
+    log(`>>> CONFIG CHANGED  DD_PROFILING_ENABLED: ${lastProfilingValue} -> ${value} (origin=${origin})`)
+    lastProfilingValue = value
+  }
+})
+
+// profiler.js starts the profiler from its own subscriber to the same channel. Subscriber order is
+// not guaranteed, and a start can be deferred, so poll for the transition instead of reading it
+// inline above.
+setInterval(() => {
+  const started = profilerModule.started
+  if (started !== lastProfilerStarted) {
+    log(`>>> PROFILER ${started ? 'STARTED' : 'STOPPED'} (was ${lastProfilerStarted})`)
+    lastProfilerStarted = started
+  }
+}, 200).unref()
+
+function state () {
+  return {
+    service: config.service,
+    env: config.env,
+    version: config.version,
+    runtimeId: config.tags?.['runtime-id'],
+    tracerVersion: require('../../package.json').version,
+    remoteConfigEnabled: config.remoteConfig.DD_REMOTE_CONFIGURATION_ENABLED,
+    remoteConfigPollIntervalSeconds: config.remoteConfig.pollInterval,
+    profiling: {
+      DD_PROFILING_ENABLED: config.profiling.DD_PROFILING_ENABLED,
+      origin: config.getOrigin(PROFILING_KEY),
+      profilerStarted: profilerModule.started,
+    },
+    configUpdateCount: configUpdates.length,
+    configUpdates,
+  }
+}
+
+// Bounded CPU work, so /work produces a real trace and the wall/CPU profilers have samples.
+function burnCpu (ms) {
+  const until = Date.now() + ms
+  let acc = 0
+  while (Date.now() < until) {
+    for (let i = 0; i < 1e5; i++) acc += Math.sqrt(i) * Math.sin(i)
+  }
+  return acc
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost')
+
+  if (url.pathname === '/state') {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(state(), undefined, 2))
+    return
+  }
+
+  if (url.pathname === '/work') {
+    const result = burnCpu(Number(url.searchParams.get('ms')) || 25)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ result }))
+    return
+  }
+
+  res.writeHead(404, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ error: 'not found', routes: ['/state', '/work'] }))
+})
+
+const port = Number(process.env.APP_PORT) || 8080
+server.listen(port, () => {
+  const actual = server.address().port
+  log(`listening on http://127.0.0.1:${actual}  (/state, /work)`)
+  log(`service=${config.service} env=${config.env} version=${config.version}`)
+  log(`remote config enabled=${config.remoteConfig.DD_REMOTE_CONFIGURATION_ENABLED} ` +
+      `poll=${config.remoteConfig.pollInterval}s`)
+  log(`DD_PROFILING_ENABLED=${config.profiling.DD_PROFILING_ENABLED} ` +
+      `origin=${config.getOrigin(PROFILING_KEY)} profilerStarted=${profilerModule.started}`)
+  process.send?.({ port: actual })
+})
+
+// Self-driven request loop, so the app generates traces and CPU load with no external driver.
+if (process.env.DEMO_NO_LOAD !== '1') {
+  setInterval(() => {
+    http.get(`http://127.0.0.1:${server.address().port}/work?ms=25`, (res) => res.resume())
+      .on('error', () => {})
+  }, 500).unref()
+}

--- a/demo/sdk-config-rc/demo.sh
+++ b/demo/sdk-config-rc/demo.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Live demo driver for the SDK Configuration remote-config flow.
+#
+#   ./demo.sh local      # offline rehearsal / fallback (FakeAgent, no credentials, ~30s)
+#   ./demo.sh setup      # start a dedicated Agent + the app, prove the baseline
+#   ./demo.sh payload    # show the payload and validate it against real dd-go code
+#   ./demo.sh publish    # POST to real rc-api, wait for the tracer to apply it
+#   ./demo.sh confirm    # re-show all three confirmations
+#   ./demo.sh revert     # delete the config (tracer reverts in MINUTES, not seconds)
+#   ./demo.sh teardown   # stop the app and remove the demo Agent
+#
+# Credentials are read from ~/.dd-rc-demo/{curlrc,agent.env} and never printed.
+# The demo Agent runs on its own port and name, so an existing dd-agent is untouched.
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+CRED_DIR="${CRED_DIR:-$HOME/.dd-rc-demo}"
+CURLRC="$CRED_DIR/curlrc"
+AGENT_ENV="$CRED_DIR/agent.env"
+AGENT_NAME=dd-agent-rc-demo
+AGENT_PORT="${AGENT_PORT:-18226}"
+APP_PORT="${APP_PORT:-18080}"
+SERVICE=sdk-config-demo
+ENVIRONMENT=demo
+STATE_FILE=/tmp/rc-demo-config-id
+APP_LOG=/tmp/rc-demo-app.log
+SITE="$(sed -n 's/^DD_SITE=//p' "$AGENT_ENV" 2>/dev/null || echo datadoghq.com)"
+BASE="https://api.${SITE}/api/unstable/remote_config/products/apm_tracing"
+
+bold() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+
+state_json() { curl -sS -m 5 "http://127.0.0.1:${APP_PORT}/state" 2>/dev/null; }
+
+show_state() {
+  # Avoid quote-escaping inside the embedded snippet: %-formatting only, no f-strings.
+  state_json | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("    (app not responding)")
+    sys.exit(0)
+p = d["profiling"]
+print("    DD_PROFILING_ENABLED = %r" % p["DD_PROFILING_ENABLED"])
+print("    origin               = %r" % p["origin"])
+print("    profilerStarted      = %s" % p["profilerStarted"])
+print("    config:update seen   = %s" % d["configUpdateCount"])
+'
+}
+
+require_creds() {
+  [ -r "$CURLRC" ]   || { bad "missing $CURLRC";   exit 1; }
+  [ -r "$AGENT_ENV" ] || { bad "missing $AGENT_ENV"; exit 1; }
+  grep -q 'PASTE_' "$CURLRC" "$AGENT_ENV" 2>/dev/null && { bad "credentials still contain placeholders"; exit 1; }
+  return 0
+}
+
+case "${1:-}" in
+
+local)
+  bold "OFFLINE REHEARSAL - FakeAgent, no credentials, no network"
+  info "Stubs only the Agent's POST /v0.7/config. Everything below it is the real tracer."
+  node local-harness.js
+  ;;
+
+setup)
+  require_creds
+  bold "1. Agent with remote configuration enabled"
+  docker rm -f "$AGENT_NAME" >/dev/null 2>&1
+  docker run -d --name "$AGENT_NAME" \
+    --env-file "$AGENT_ENV" \
+    -e DD_HOSTNAME=sdk-config-rc-demo \
+    -p "127.0.0.1:${AGENT_PORT}:8126" \
+    gcr.io/datadoghq/agent:7 >/dev/null || { bad "could not start agent"; exit 1; }
+  info "waiting for the agent to authorize..."
+  for _ in $(seq 1 30); do
+    if docker exec "$AGENT_NAME" agent status 2>/dev/null | grep -qi 'API Key: Authorized'; then break; fi
+    sleep 3
+  done
+  if docker exec "$AGENT_NAME" agent status 2>/dev/null | grep -qiA6 '^Remote Configuration' | grep -qi 'Authorized'; then :; fi
+  docker exec "$AGENT_NAME" agent status 2>/dev/null | grep -iA6 '^Remote Configuration' \
+    | grep -iE 'Organization enabled|API Key|Last error' | sed 's/^/    /'
+  ok "agent listening on 127.0.0.1:${AGENT_PORT} (name ${AGENT_NAME}, your own dd-agent untouched)"
+
+  bold "2. App on the combined build, profiling OFF at boot"
+  pkill -f 'demo/sdk-config-rc/app.js' 2>/dev/null; sleep 1
+  ( cd ../.. && \
+    DD_SERVICE=$SERVICE DD_ENV=$ENVIRONMENT DD_VERSION=0.0.1 \
+    DD_TRACE_AGENT_PORT=$AGENT_PORT \
+    DD_REMOTE_CONFIGURATION_ENABLED=true \
+    DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=5 \
+    DD_PROFILING_ENABLED=false \
+    DD_PROFILING_UPLOAD_PERIOD=20 \
+    APP_PORT=$APP_PORT \
+    nohup node demo/sdk-config-rc/app.js > "$APP_LOG" 2>&1 & )
+  for _ in $(seq 1 20); do state_json | grep -q profilerStarted && break; sleep 1; done
+
+  bold "3. BASELINE - this is what the audience should see first"
+  show_state
+  state_json | grep -q '"profilerStarted": *false' \
+    && ok "profiler is OFF, and DD_PROFILING_ENABLED came from the environment (origin=env_var)" \
+    || bad "expected the profiler to be off at baseline"
+  ;;
+
+payload)
+  bold "The payload"
+  info "product: APM_TRACING   ·   field: sdk_config.config (env-var-keyed string map)"
+  python3 -m json.tool payloads/jsonapi-profiling-enable.json | sed 's/^/    /'
+  bold "Validated against REAL dd-go backend code (not an assumption about the format)"
+  ./preflight.sh payloads/profiling-enable.json 2>&1 \
+    | grep -E 'PASS:|FAIL:|preflight OK|preflight FAILED|dd-go @' | sed 's/^/    /'
+  bold "And the same validator rejects what the backend rejects"
+  ./preflight.sh payloads/rejected-example.json 2>&1 \
+    | grep -E 'FAIL: IsAllowed|preflight FAILED' | sed 's/^/    /'
+  ;;
+
+publish)
+  require_creds
+  bold "Publishing to real rc-api"
+  info "POST ${BASE}/configs"
+  RESP=$(curl -sS --config "$CURLRC" -X POST "${BASE}/configs" \
+           -d @payloads/jsonapi-profiling-enable.json -w '\n%{http_code}' 2>&1)
+  CODE=$(printf '%s' "$RESP" | tail -1)
+  BODY=$(printf '%s' "$RESP" | sed '$d')
+  if [ "$CODE" != "201" ]; then bad "HTTP $CODE"; printf '    %s\n' "$BODY"; exit 1; fi
+  CID=$(printf '%s' "$BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"]["id"])')
+  echo "$CID" > "$STATE_FILE"
+  ok "HTTP 201 created, id ${CID:0:16}..."
+  printf '%s' "$BODY" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)["data"]["attributes"]["sdk_config"]["config"]
+print("    backend echoed config back as:", json.dumps(d))
+print("    ^ an OBJECT MAP - live proof dd-go#14029 is deployed (pre-#14029 returns an array)")
+'
+  bold "Waiting for the tracer to poll and apply (usually seconds)"
+  for i in $(seq 1 40); do
+    if state_json | grep -q '"profilerStarted": *true'; then ok "applied after ~$((i*3))s"; break; fi
+    printf '.'; sleep 3
+  done
+  echo
+  "$0" confirm
+  ;;
+
+confirm)
+  bold "CONFIRMATION 1/3 - the tracer's own view"
+  show_state
+  state_json | grep -q '"origin": *"remote_config"' \
+    && ok "origin flipped env_var -> remote_config" || bad "origin is not remote_config"
+  state_json | grep -q '"profilerStarted": *true' \
+    && ok "profiler is RUNNING, started by remote config" || bad "profiler not running"
+
+  bold "CONFIRMATION 2/3 - the app's log, as it happened"
+  grep -E 'config:update|CONFIG CHANGED|PROFILER' "$APP_LOG" 2>/dev/null | tail -6 | sed 's/^/    /'
+
+  bold "CONFIRMATION 3/3 - the backend says the tracer acknowledged it"
+  if [ -s "$STATE_FILE" ]; then
+    curl -sS --config "$CURLRC" "${BASE}/configs/$(cat "$STATE_FILE")/status" 2>/dev/null \
+      | python3 -c '
+import json,sys
+a=json.load(sys.stdin)["data"]["attributes"]
+sc=a.get("status_count") or {}
+print("    status_count  =", json.dumps(sc))
+print("    errors        =", json.dumps(a.get("error_messages")))
+print("    ^ apply_state 2 = ACKNOWLEDGED." if "2" in sc else "    (rollup can lag a minute; re-run: ./demo.sh confirm)")
+'
+  else
+    info "(no config id recorded; run ./demo.sh publish first)"
+  fi
+
+  bold "Profiles"
+  info "uploads every 20s while running. Flame graph:"
+  info "https://app.${SITE}/profiling/explorer?query=service%3A${SERVICE}%20env%3A${ENVIRONMENT}"
+  ;;
+
+revert)
+  require_creds
+  [ -s "$STATE_FILE" ] || { bad "no config id recorded"; exit 1; }
+  CID=$(cat "$STATE_FILE")
+  bold "Deleting the config"
+  curl -sS --config "$CURLRC" -X DELETE "${BASE}/configs/${CID}" -w '    HTTP %{http_code}\n' -o /dev/null
+  ok "deleted from the backend immediately"
+  printf '\n  \033[33m!\033[0m %s\n' "The TRACER takes minutes to revert - RC propagation plus Agent cache."
+  info "Observed ~5 min in a real run. Do NOT wait for this on stage:"
+  info "  - either run ./demo.sh revert BEFORE the talk and show the stopped state, or"
+  info "  - show the instant revert with ./demo.sh local (FakeAgent stops serving immediately)."
+  info "Poll it with:  watch -n10 'curl -s localhost:${APP_PORT}/state | python3 -m json.tool'"
+  rm -f "$STATE_FILE"
+  ;;
+
+teardown)
+  bold "Teardown"
+  pkill -f 'demo/sdk-config-rc/app.js' 2>/dev/null && ok "app stopped" || info "app already stopped"
+  docker rm -f "$AGENT_NAME" >/dev/null 2>&1 && ok "removed $AGENT_NAME" || info "$AGENT_NAME not running"
+  if [ -s "$STATE_FILE" ]; then
+    printf '\n  \033[33m!\033[0m %s\n' "A config is still live in the org: $(cat "$STATE_FILE")"
+    info "Run ./demo.sh revert to delete it."
+  else
+    ok "no demo config left in the org"
+  fi
+  docker ps --format '    {{.Names}}  {{.Status}}' | sed 1d >/dev/null 2>&1
+  info "your own containers:"; docker ps --format '      {{.Names}}  {{.Status}}'
+  ;;
+
+*)
+  sed -n '2,20p' "$0"
+  exit 1
+  ;;
+esac

--- a/demo/sdk-config-rc/demo.sh
+++ b/demo/sdk-config-rc/demo.sh
@@ -21,10 +21,12 @@ AGENT_ENV="$CRED_DIR/agent.env"
 AGENT_NAME=dd-agent-rc-demo
 AGENT_PORT="${AGENT_PORT:-18226}"
 APP_PORT="${APP_PORT:-18080}"
-SERVICE=sdk-config-demo
-ENVIRONMENT=demo
+SERVICE="${RC_DEMO_SERVICE:-sdk-config-demo}"
+ENVIRONMENT="${RC_DEMO_ENV:-demo}"
 STATE_FILE=/tmp/rc-demo-config-id
 APP_LOG=/tmp/rc-demo-app.log
+CANONICAL_PAYLOAD=/tmp/rc-demo-profiling-enable.json
+JSONAPI_PAYLOAD=/tmp/rc-demo-jsonapi-profiling-enable.json
 SITE="$(sed -n 's/^DD_SITE=//p' "$AGENT_ENV" 2>/dev/null || echo datadoghq.com)"
 BASE="https://api.${SITE}/api/unstable/remote_config/products/apm_tracing"
 
@@ -34,6 +36,28 @@ bad()  { printf '  \033[31m✗\033[0m %s\n' "$*"; }
 info() { printf '    %s\n' "$*"; }
 
 state_json() { curl -sS -m 5 "http://127.0.0.1:${APP_PORT}/state" 2>/dev/null; }
+
+render_payloads() {
+  python3 - "$SERVICE" "$ENVIRONMENT" "$CANONICAL_PAYLOAD" "$JSONAPI_PAYLOAD" <<'PY'
+import json, sys
+
+service, env, canonical_path, jsonapi_path = sys.argv[1:]
+attributes = {
+    "action": "enable",
+    "lib_config": {"service_name": service, "env": env},
+    "service_target": {"service": service, "env": env},
+    "sdk_config": {
+        "service_name": service,
+        "env": env,
+        "config": {"DD_PROFILING_ENABLED": "true"},
+    },
+}
+with open(canonical_path, "w", encoding="utf-8") as stream:
+    json.dump(attributes, stream, indent=2)
+with open(jsonapi_path, "w", encoding="utf-8") as stream:
+    json.dump({"data": {"type": "apm_tracing_config", "attributes": attributes}}, stream, indent=2)
+PY
+}
 
 show_state() {
   # Avoid quote-escaping inside the embedded snippet: %-formatting only, no f-strings.
@@ -107,11 +131,12 @@ setup)
   ;;
 
 payload)
+  render_payloads
   bold "The payload"
   info "product: APM_TRACING   ·   field: sdk_config.config (env-var-keyed string map)"
-  python3 -m json.tool payloads/jsonapi-profiling-enable.json | sed 's/^/    /'
+  python3 -m json.tool "$JSONAPI_PAYLOAD" | sed 's/^/    /'
   bold "Validated against REAL dd-go backend code (not an assumption about the format)"
-  ./preflight.sh payloads/profiling-enable.json 2>&1 \
+  ./preflight.sh "$CANONICAL_PAYLOAD" 2>&1 \
     | grep -E 'PASS:|FAIL:|preflight OK|preflight FAILED|dd-go @' | sed 's/^/    /'
   bold "And the same validator rejects what the backend rejects"
   ./preflight.sh payloads/rejected-example.json 2>&1 \
@@ -120,10 +145,11 @@ payload)
 
 publish)
   require_creds
+  render_payloads
   bold "Publishing to real rc-api"
   info "POST ${BASE}/configs"
   RESP=$(curl -sS --config "$CURLRC" -X POST "${BASE}/configs" \
-           -d @payloads/jsonapi-profiling-enable.json -w '\n%{http_code}' 2>&1)
+           -d @"$JSONAPI_PAYLOAD" -w '\n%{http_code}' 2>&1)
   CODE=$(printf '%s' "$RESP" | tail -1)
   BODY=$(printf '%s' "$RESP" | sed '$d')
   if [ "$CODE" != "201" ]; then bad "HTTP $CODE"; printf '    %s\n' "$BODY"; exit 1; fi
@@ -201,6 +227,7 @@ teardown)
   else
     ok "no demo config left in the org"
   fi
+  rm -f "$CANONICAL_PAYLOAD" "$JSONAPI_PAYLOAD"
   docker ps --format '    {{.Names}}  {{.Status}}' | sed 1d >/dev/null 2>&1
   info "your own containers:"; docker ps --format '      {{.Names}}  {{.Status}}'
   ;;

--- a/demo/sdk-config-rc/local-harness.js
+++ b/demo/sdk-config-rc/local-harness.js
@@ -1,0 +1,204 @@
+'use strict'
+
+/* eslint-disable no-console -- this is a demo CLI; its log output is the deliverable. */
+
+// Local development harness for the SDK Configuration remote-config demo.
+//
+// This is NOT evidence about the Datadog backend. It stubs the Agent's POST /v0.7/config endpoint
+// with the repo's FakeAgent, so the config payload is authored here rather than produced by
+// rc-api. What it does exercise, for real, is everything below the Agent: the tracer's
+// remote-config client (polling, product subscription, capability bits, target matching, ack
+// reporting), the SDK_CONFIGURATION ingestion path in config/remote_config.js, and the
+// 'datadog:config:update' -> profiler.js handoff that starts the profiler.
+//
+// Use it to iterate on the app quickly and to demonstrate layers 4-6 of the chain. Use
+// publish-staging.sh for real rc-api evidence.
+//
+// Run with:  node demo/sdk-config-rc/local-harness.js [--legacy-array-shape]
+
+const http = require('node:http')
+const path = require('node:path')
+const { fork } = require('node:child_process')
+
+const FakeAgent = require('../../integration-tests/helpers/fake-agent')
+
+const ACKNOWLEDGED = 2
+const APP_PORT = Number(process.env.APP_PORT) || 18080
+const USE_LEGACY = process.argv.includes('--legacy-array-shape')
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function log (...args) {
+  console.log('[harness]', ...args)
+}
+
+function getState () {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://127.0.0.1:${APP_PORT}/state`, (res) => {
+      let body = ''
+      res.on('data', (c) => { body += c })
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(body))
+        } catch {
+          reject(new Error(`bad /state response: ${body.slice(0, 200)}`))
+        }
+      })
+    })
+    req.on('error', reject)
+    req.setTimeout(2000, () => req.destroy(new Error('timeout')))
+  })
+}
+
+async function waitFor (label, predicate, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs
+  let last
+  while (Date.now() < deadline) {
+    try {
+      last = await getState()
+      if (predicate(last)) return last
+    } catch {}
+    await sleep(250)
+  }
+  throw new Error(`timed out waiting for: ${label}\nlast state: ${JSON.stringify(last, undefined, 2)}`)
+}
+
+/**
+ * Build the APM_TRACING config file body.
+ *
+ * @param {Record<string, string>} settings - env-var-keyed settings to deliver
+ *
+ * The object form is what rc-api emits after ddoghq/dd-go#14029
+ * ("make sdk_config.config a free-form map instead of a key/value array").
+ * The array form is the pre-#14029 wire shape, which the combined tracer still
+ * accepts via jsonconf's legacy decoder; --legacy-array-shape selects it.
+ */
+function buildConfigFile (settings) {
+  const config = USE_LEGACY
+    ? Object.entries(settings).map(([key, value]) => ({ key, value }))
+    : settings
+
+  return {
+    service_target: { service: 'sdk-config-demo', env: 'demo' },
+    sdk_config: {
+      service_name: 'sdk-config-demo',
+      env: 'demo',
+      config,
+    },
+  }
+}
+
+function waitForAck (agent, configId) {
+  return new Promise((resolve) => {
+    const handler = (id, version, state, error) => {
+      if (id !== configId) return
+      log(`ack: id=${id} version=${version} apply_state=${state}${error ? ` error=${error}` : ''}`)
+      if (state === ACKNOWLEDGED) {
+        agent.removeListener('remote-config-ack-update', handler)
+        resolve()
+      }
+    }
+    agent.on('remote-config-ack-update', handler)
+  })
+}
+
+async function main () {
+  let failed = false
+  const agent = await new FakeAgent().start()
+  log(`FakeAgent listening on port ${agent.port}`)
+
+  // Traces are incidental to the RC assertion, but the app is supposed to produce real activity,
+  // so record what actually arrives and assert on it at the end.
+  const spanNames = new Set()
+  agent.on('message', ({ payload }) => {
+    for (const trace of payload) {
+      for (const span of trace) spanNames.add(span.name)
+    }
+  })
+  log(`sdk_config.config wire shape: ${USE_LEGACY ? 'legacy array (pre-#14029)' : 'object map (post-#14029)'}`)
+
+  const child = fork(path.join(__dirname, 'app.js'), {
+    env: {
+      ...process.env,
+      DD_SERVICE: 'sdk-config-demo',
+      DD_ENV: 'demo',
+      DD_VERSION: '0.0.1',
+      DD_TRACE_AGENT_PORT: String(agent.port),
+      DD_REMOTE_CONFIGURATION_ENABLED: 'true',
+      DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '1',
+      DD_PROFILING_ENABLED: 'false',
+      APP_PORT: String(APP_PORT),
+    },
+    stdio: 'inherit',
+  })
+
+  try {
+    // ---- Step 1: baseline ------------------------------------------------
+    const before = await waitFor('app to come up', (s) => s.service === 'sdk-config-demo')
+    log('--- baseline ---')
+    log(`  DD_PROFILING_ENABLED=${before.profiling.DD_PROFILING_ENABLED}` +
+        `  origin=${before.profiling.origin}  profilerStarted=${before.profiling.profilerStarted}`)
+
+    if (before.profiling.profilerStarted !== false) {
+      throw new Error('expected profiler to be stopped at baseline')
+    }
+    if (before.remoteConfigEnabled !== true) {
+      throw new Error('expected remote config to be enabled')
+    }
+
+    // ---- Step 2: publish DD_PROFILING_ENABLED=true -----------------------
+    const configId = `demo-${Date.now()}`
+    const file = buildConfigFile({ DD_PROFILING_ENABLED: 'true' })
+    log('--- publishing APM_TRACING config ---')
+    log(JSON.stringify(file, undefined, 2))
+
+    const acked = waitForAck(agent, configId)
+    agent.addRemoteConfig({ product: 'APM_TRACING', id: configId, config: file })
+    await acked
+
+    const after = await waitFor(
+      'profiler to start via remote config',
+      (s) => s.profiling.profilerStarted === true
+    )
+    log('--- after remote config ---')
+    log(`  DD_PROFILING_ENABLED=${after.profiling.DD_PROFILING_ENABLED}` +
+        `  origin=${after.profiling.origin}  profilerStarted=${after.profiling.profilerStarted}`)
+
+    if (after.profiling.origin !== 'remote_config') {
+      throw new Error(`expected origin 'remote_config', got '${after.profiling.origin}'`)
+    }
+
+    // ---- Step 3: revert ---------------------------------------------------
+    log('--- reverting (removing the config) ---')
+    agent.removeRemoteConfig(configId)
+    const reverted = await waitFor(
+      'profiler to stop after the config is removed',
+      (s) => s.profiling.profilerStarted === false
+    )
+    log(`  DD_PROFILING_ENABLED=${reverted.profiling.DD_PROFILING_ENABLED}` +
+        `  origin=${reverted.profiling.origin}  profilerStarted=${reverted.profiling.profilerStarted}`)
+
+    if (spanNames.size === 0) {
+      throw new Error('no traces reached the agent; the app produced no instrumented activity')
+    }
+    log(`traces received, span names: ${[...spanNames].sort().join(', ')}`)
+
+    log('')
+    log('RESULT: PASS')
+    log('  profiler off -> on via SDK_CONFIGURATION remote config -> off again,')
+    log('  origin transitioned default -> remote_config, and the tracer ACKed the config.')
+  } catch (error) {
+    failed = true
+    log('')
+    log('RESULT: FAIL')
+    console.error(error)
+  } finally {
+    child.kill()
+    await agent.stop().catch(() => {})
+    // Demo CLI: the exit code is the pass/fail signal, and the tracer keeps handles alive.
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(failed ? 1 : 0)
+  }
+}
+
+main()

--- a/demo/sdk-config-rc/payloads/jsonapi-profiling-enable-legacy-array.json
+++ b/demo/sdk-config-rc/payloads/jsonapi-profiling-enable-legacy-array.json
@@ -3,13 +3,22 @@
     "type": "apm_tracing_config",
     "attributes": {
       "action": "enable",
-      "lib_config": {},
-      "service_target": { "service": "sdk-config-demo", "env": "demo" },
+      "lib_config": {
+        "service_name": "sdk-config-demo",
+        "env": "demo"
+      },
+      "service_target": {
+        "service": "sdk-config-demo",
+        "env": "demo"
+      },
       "sdk_config": {
         "service_name": "sdk-config-demo",
         "env": "demo",
         "config": [
-          { "key": "DD_PROFILING_ENABLED", "value": "true" }
+          {
+            "key": "DD_PROFILING_ENABLED",
+            "value": "true"
+          }
         ]
       }
     }

--- a/demo/sdk-config-rc/payloads/jsonapi-profiling-enable-legacy-array.json
+++ b/demo/sdk-config-rc/payloads/jsonapi-profiling-enable-legacy-array.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "type": "apm_tracing_config",
+    "attributes": {
+      "action": "enable",
+      "lib_config": {},
+      "service_target": { "service": "sdk-config-demo", "env": "demo" },
+      "sdk_config": {
+        "service_name": "sdk-config-demo",
+        "env": "demo",
+        "config": [
+          { "key": "DD_PROFILING_ENABLED", "value": "true" }
+        ]
+      }
+    }
+  }
+}

--- a/demo/sdk-config-rc/payloads/jsonapi-profiling-enable.json
+++ b/demo/sdk-config-rc/payloads/jsonapi-profiling-enable.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "type": "apm_tracing_config",
+    "attributes": {
+      "action": "enable",
+      "lib_config": {},
+      "service_target": { "service": "sdk-config-demo", "env": "demo" },
+      "sdk_config": {
+        "service_name": "sdk-config-demo",
+        "env": "demo",
+        "config": {
+          "DD_PROFILING_ENABLED": "true"
+        }
+      }
+    }
+  }
+}

--- a/demo/sdk-config-rc/payloads/jsonapi-profiling-enable.json
+++ b/demo/sdk-config-rc/payloads/jsonapi-profiling-enable.json
@@ -3,8 +3,14 @@
     "type": "apm_tracing_config",
     "attributes": {
       "action": "enable",
-      "lib_config": {},
-      "service_target": { "service": "sdk-config-demo", "env": "demo" },
+      "lib_config": {
+        "service_name": "sdk-config-demo",
+        "env": "demo"
+      },
+      "service_target": {
+        "service": "sdk-config-demo",
+        "env": "demo"
+      },
       "sdk_config": {
         "service_name": "sdk-config-demo",
         "env": "demo",

--- a/demo/sdk-config-rc/payloads/profiling-enable-legacy-array.json
+++ b/demo/sdk-config-rc/payloads/profiling-enable-legacy-array.json
@@ -1,0 +1,12 @@
+{
+  "action": "enable",
+  "lib_config": {},
+  "service_target": { "service": "sdk-config-demo", "env": "demo" },
+  "sdk_config": {
+    "service_name": "sdk-config-demo",
+    "env": "demo",
+    "config": [
+      { "key": "DD_PROFILING_ENABLED", "value": "true" }
+    ]
+  }
+}

--- a/demo/sdk-config-rc/payloads/profiling-enable.json
+++ b/demo/sdk-config-rc/payloads/profiling-enable.json
@@ -1,0 +1,12 @@
+{
+  "action": "enable",
+  "lib_config": {},
+  "service_target": { "service": "sdk-config-demo", "env": "demo" },
+  "sdk_config": {
+    "service_name": "sdk-config-demo",
+    "env": "demo",
+    "config": {
+      "DD_PROFILING_ENABLED": "true"
+    }
+  }
+}

--- a/demo/sdk-config-rc/payloads/rejected-example.json
+++ b/demo/sdk-config-rc/payloads/rejected-example.json
@@ -1,0 +1,14 @@
+{
+  "action": "enable",
+  "lib_config": {},
+  "service_target": { "service": "sdk-config-demo", "env": "demo" },
+  "sdk_config": {
+    "service_name": "sdk-config-demo",
+    "env": "demo",
+    "config": {
+      "DD_PROFILING_ENABLED": "true",
+      "DD_TRACE_ENABLED": "false",
+      "DD_API_KEY": "not-a-real-key"
+    }
+  }
+}

--- a/demo/sdk-config-rc/preflight.sh
+++ b/demo/sdk-config-rc/preflight.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Validate a demo APM_TRACING payload against the REAL dd-go backend code.
+#
+# Copies preflight/preflight_test.go into a local dd-go checkout, runs it there (so dd-go's own
+# module graph and 55 replace directives apply), then always removes it again. The dd-go tree is
+# left exactly as it was found; the script refuses to run if that tree is already dirty.
+#
+# Usage:
+#   ./preflight.sh [payload.json]
+#   DD_GO_DIR=/path/to/dd-go ./preflight.sh payload.json
+#
+# Defaults to payloads/profiling-enable.json.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+DD_GO_DIR="${DD_GO_DIR:-/Users/rachel.yang/dd/dd-go}"
+PAYLOAD="${1:-payloads/profiling-enable.json}"
+PKG_DIR="remote-config/pkg/products/apmtracing/sdkconfigsecurity"
+DEST="$DD_GO_DIR/$PKG_DIR/zz_demo_preflight_test.go"
+
+if [ ! -f "$PAYLOAD" ]; then
+  echo "preflight: payload not found: $PAYLOAD" >&2
+  exit 1
+fi
+
+if [ ! -d "$DD_GO_DIR/$PKG_DIR" ]; then
+  echo "preflight: dd-go package not found at $DD_GO_DIR/$PKG_DIR" >&2
+  echo "preflight: set DD_GO_DIR to a dd-go checkout containing ddoghq/dd-go#14029" >&2
+  exit 1
+fi
+
+# Refuse to touch a dirty tree, so cleanup can never be mistaken for discarding real work.
+if [ -n "$(git -C "$DD_GO_DIR" status --porcelain)" ]; then
+  echo "preflight: $DD_GO_DIR has uncommitted changes; refusing to write a temp file into it" >&2
+  exit 1
+fi
+
+cleanup() {
+  rm -f "$DEST"
+}
+trap cleanup EXIT INT TERM
+
+echo "preflight: dd-go   = $DD_GO_DIR"
+echo "preflight: dd-go @ $(git -C "$DD_GO_DIR" log -1 --format='%h %s')"
+echo "preflight: payload = $PAYLOAD"
+echo
+
+cp preflight/preflight_test.go "$DEST"
+
+status=0
+DEMO_PAYLOAD="$(cd "$(dirname "$PAYLOAD")" && pwd)/$(basename "$PAYLOAD")" \
+GOFLAGS=-mod=mod \
+  go -C "$DD_GO_DIR" test "./$PKG_DIR/" -run TestDemoPayloadPreflight -v -count=1 || status=$?
+
+# Remove the temp file before verifying, so the check reflects the tree we leave behind.
+cleanup
+echo
+if [ -n "$(git -C "$DD_GO_DIR" status --porcelain)" ]; then
+  echo "preflight: WARNING - dd-go tree is dirty after the run" >&2
+else
+  echo "preflight: dd-go tree left clean"
+fi
+exit $status

--- a/demo/sdk-config-rc/preflight/preflight_test.go
+++ b/demo/sdk-config-rc/preflight/preflight_test.go
@@ -1,0 +1,107 @@
+// Preflight validation of a demo APM_TRACING config payload against the REAL dd-go
+// backend code, rather than against a hand-written assumption about the wire format.
+//
+// This file is copied into dd-go by ../preflight.sh, run there, and removed again;
+// it is not part of either repository's source tree.
+//
+// It exercises:
+//   - jsonconf.Configuration / jsonconf.SDKConfig  -- the real request model, including the
+//     object-map form introduced by ddoghq/dd-go#14029 and the legacy {key,value} array
+//     decoder in sdkconfig_legacy.go
+//   - sdkconfigsecurity.NormalizeAndValidateCanonical / ValidateStored / IsAllowed -- the real
+//     server-side allowlist and denylist
+//
+// Payload file is passed via DEMO_PAYLOAD.
+
+package sdkconfigsecurity_test
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/DataDog/dd-go/remote-config/pkg/products/apmtracing/jsonconf"
+	"github.com/DataDog/dd-go/remote-config/pkg/products/apmtracing/sdkconfigsecurity"
+)
+
+func TestDemoPayloadPreflight(t *testing.T) {
+	path := os.Getenv("DEMO_PAYLOAD")
+	if path == "" {
+		t.Fatal("DEMO_PAYLOAD not set")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading payload: %v", err)
+	}
+
+	t.Logf("payload file: %s", path)
+	t.Logf("raw payload:\n%s", raw)
+
+	// 1. Decode with the real request model. This is where the object-vs-array shape of
+	//    sdk_config.config is decided, by jsonconf's own UnmarshalJSON.
+	var conf jsonconf.Configuration
+	if err := json.Unmarshal(raw, &conf); err != nil {
+		t.Fatalf("FAIL: real jsonconf decoder rejected the payload: %v", err)
+	}
+	t.Log("PASS: decoded by the real jsonconf.Configuration model")
+
+	if conf.SDKConfig == nil {
+		t.Fatal("FAIL: payload has no sdk_config block")
+	}
+	if len(conf.SDKConfig.Config) == 0 {
+		t.Fatal("FAIL: sdk_config.config decoded to an empty map")
+	}
+
+	keys := make([]string, 0, len(conf.SDKConfig.Config))
+	for k := range conf.SDKConfig.Config {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	t.Logf("decoded %d setting(s):", len(keys))
+	for _, k := range keys {
+		t.Logf("    %s = %q", k, conf.SDKConfig.Config[k])
+	}
+
+	// 2. Per-key verdict from the real allowlist/denylist.
+	blocked := false
+	for _, k := range keys {
+		allowed, reason := sdkconfigsecurity.IsAllowed(k)
+		if allowed {
+			t.Logf("PASS: IsAllowed(%q) = true", k)
+			continue
+		}
+		blocked = true
+		t.Errorf("FAIL: IsAllowed(%q) = false  reason=%s", k, reason)
+	}
+
+	// 3. The two real validation entry points rc-api calls.
+	if err := sdkconfigsecurity.NormalizeAndValidateCanonical(conf.SDKConfig); err != nil {
+		blocked = true
+		t.Errorf("FAIL: NormalizeAndValidateCanonical: %v", err)
+	} else {
+		t.Log("PASS: NormalizeAndValidateCanonical")
+	}
+
+	if err := sdkconfigsecurity.ValidateStored(conf.SDKConfig); err != nil {
+		blocked = true
+		t.Errorf("FAIL: ValidateStored: %v", err)
+	} else {
+		t.Log("PASS: ValidateStored")
+	}
+
+	// 4. Re-encode, showing the canonical form the backend would actually store and emit.
+	//    Post-#14029 there is no MarshalJSON override, so writes always emit the object form.
+	canonical, err := json.MarshalIndent(conf.SDKConfig, "", "  ")
+	if err != nil {
+		t.Fatalf("re-encoding: %v", err)
+	}
+	t.Logf("canonical sdk_config as the backend would emit it:\n%s", canonical)
+
+	if blocked {
+		t.Fatal("preflight FAILED: the real backend would reject this payload")
+	}
+	t.Log("preflight OK: the real backend accepts this payload")
+}


### PR DESCRIPTION
## Summary

Add the local SDK Configuration demo and connect it to the ICPRO incident-response UI.

- run a real instrumented Node service through the local Datadog Agent
- expose rolling request, error, latency, throughput, and in-flight telemetry
- expose real trace/span IDs and timings for the local request waterfall
- provide a real faulting `/checkout/payment` path with slow signature-validation retries
- allow the ICPRO demo to toggle that fault and observe detection/recovery
- parameterize service and environment so Remote Config targets `internal-tool/staging`
- retain the validated profiling publish/revert and backend acknowledgement flow

## PR structure

This PR is stacked on `rachel.yang/sdk-config-profiling-rc-combined`, which contains the tracer support required by the demo. The ICPRO UI/server integration is in a companion PR in `mtoffl01/icpro-demo`.

## Validation

- `bash -n demo/sdk-config-rc/demo.sh`
- `node --check demo/sdk-config-rc/app.js`
- ESLint on `app.js`
- generated `internal-tool/staging` payload accepted by the real dd-go preflight validator
- live local healthy → fault → recovery flow through ICPRO
