### PR TITLE
fix(openfeature): harden agentless EVP fallback

### DIFF
--- a/packages/dd-trace/src/agent/info.js
+++ b/packages/dd-trace/src/agent/info.js
@@ -17,7 +17,8 @@ module.exports = {
  * Fetches agent information from the /info endpoint
  * @param {URL} url - The agent URL
  * @param {Function} callback - Callback function with signature (err, agentInfo)
- * @param {{ deadline?: number, signal?: AbortSignal }} [options] - Request finalization options
+ * @param {{ deadline?: number, signal?: AbortSignal, path?: string, retry?: boolean }} [options]
+ * Request finalization and routing options
  * @param {Function} [makeRequest] - Request implementation
  */
 function fetchAgentInfo (url, callback, options = {}, makeRequest = request) {
@@ -31,7 +32,7 @@ function fetchAgentInfo (url, callback, options = {}, makeRequest = request) {
     return process.nextTick(callback, null, cachedData)
   }
 
-  options.path = '/info'
+  options.path ??= '/info'
   options.url = url
   makeRequest('', options, (err, res) => {
     if (err) {

--- a/packages/dd-trace/src/evp_proxy/constants.js
+++ b/packages/dd-trace/src/evp_proxy/constants.js
@@ -1,6 +1,8 @@
 'use strict'
 
 module.exports = {
+  EVP_ORIGIN_HEADER_NAME: 'DD-EVP-ORIGIN',
+  EVP_ORIGIN_VERSION_HEADER_NAME: 'DD-EVP-ORIGIN-VERSION',
   EVP_PROXY_PATH_V2: '/evp_proxy/v2',
   EVP_PROXY_PATH_V4: '/evp_proxy/v4',
   EVP_SUBDOMAIN_HEADER_NAME: 'X-Datadog-EVP-Subdomain',

--- a/packages/dd-trace/src/evp_proxy/direct.js
+++ b/packages/dd-trace/src/evp_proxy/direct.js
@@ -3,6 +3,8 @@
 const { createSiteUrl } = require('../exporters/common/url')
 const log = require('../log')
 
+let invalidSiteWarningLogged = false
+
 /**
  * @typedef {object} DirectEVPRoute
  * @property {URL} url - Direct intake URL
@@ -21,21 +23,23 @@ const log = require('../log')
  */
 function createDirectEVPRoute (config, intake) {
   const apiKey = config.DD_API_KEY
-  if (!apiKey || !config.site) return
+  if (!apiKey) return
 
-  try {
-    const url = createSiteUrl(config.site, intake)
-    if (url === undefined) throw new Error('Invalid direct EVP intake URL')
-
-    return {
-      url,
-      basePath: '',
-      headers: {
-        'DD-API-KEY': apiKey,
-      },
+  const url = createSiteUrl(config.site, intake)
+  if (url === undefined) {
+    if (!invalidSiteWarningLogged) {
+      invalidSiteWarningLogged = true
+      log.warn('Feature Flags direct event delivery is disabled because DD_SITE is invalid.')
     }
-  } catch (error) {
-    log.debug('Unable to configure direct EVP intake: %s', error.message)
+    return
+  }
+
+  return {
+    url,
+    basePath: '',
+    headers: {
+      'DD-API-KEY': apiKey,
+    },
   }
 }
 

--- a/packages/dd-trace/src/evp_proxy/discovery.js
+++ b/packages/dd-trace/src/evp_proxy/discovery.js
@@ -2,7 +2,7 @@
 
 const { fetchAgentInfo } = require('../agent/info')
 const log = require('../log')
-const { stripTrailingSlashes } = require('./path')
+const { joinAgentURLPath, stripTrailingSlashes } = require('./path')
 
 /**
  * Receiver discovery contract
@@ -25,13 +25,12 @@ const { stripTrailingSlashes } = require('./path')
  * serverless-init image or deployment type.
  *
  * This module only discovers a candidate route. A missing or unresponsive
- * `/info` endpoint returns an error through the shared request timeout and
- * retry policy. A valid response without a compatible path returns no route.
+ * `/info` endpoint returns an error through a bounded send-once request. A
+ * valid response without a compatible path returns no route.
  * Discovery sends no events, so the caller can safely select direct intake
  * after either result. The caller also owns later delivery failures. Exposure
- * delivery uses retries and can therefore produce duplicates. After local
- * retries fail, the caller can retry through direct intake and use that route
- * for future batches.
+ * delivery decides whether a failed batch can be replayed and which route
+ * future batches use.
  *
  * Reference implementations:
  *
@@ -62,17 +61,17 @@ function selectEVPProxyPath (agentInfo, { supportedPaths, requiredHeaders = [] }
   }
 
   const allowedHeaders = agentInfo.evp_proxy_allowed_headers
-  if (allowedHeaders !== undefined) {
+  if (requiredHeaders.length > 0 || allowedHeaders !== undefined) {
     if (!Array.isArray(allowedHeaders)) return
 
     const normalizedHeaders = new Set()
     for (const header of allowedHeaders) {
       if (typeof header === 'string') {
-        normalizedHeaders.add(header.toLowerCase())
+        normalizedHeaders.add(header.trim().toLowerCase())
       }
     }
 
-    if (requiredHeaders.some(header => !normalizedHeaders.has(header.toLowerCase()))) {
+    if (requiredHeaders.some(header => !normalizedHeaders.has(header.trim().toLowerCase()))) {
       return
     }
   }
@@ -122,7 +121,10 @@ function discoverEVPProxy (url, options, callback) {
     }
 
     log.debug('EVP proxy route %s discovered through the configured local receiver', basePath)
-    callback(null, { url, basePath })
+    callback(null, { url, basePath: joinAgentURLPath(url, basePath) })
+  }, {
+    path: joinAgentURLPath(url, '/info'),
+    retry: false,
   })
 }
 

--- a/packages/dd-trace/src/evp_proxy/path.js
+++ b/packages/dd-trace/src/evp_proxy/path.js
@@ -17,15 +17,30 @@ function stripTrailingSlashes (value) {
  *
  * This utility does not perform EVP proxy discovery.
  *
- * @param {string} basePath - EVP proxy base path
- * @param {string} endpoint - Product intake endpoint
+ * @param {...string} paths - URL path components
  * @returns {string} Joined request path
  */
-function joinEVPProxyPath (basePath, endpoint) {
-  const normalizedBasePath = stripTrailingSlashes(basePath)
-  const normalizedEndpoint = endpoint.replace(LEADING_SLASHES, '')
+function joinEVPProxyPath (...paths) {
+  let joined = ''
+  for (const path of paths) {
+    const normalized = stripTrailingSlashes(path).replace(LEADING_SLASHES, '')
+    if (normalized) joined += `/${normalized}`
+  }
 
-  return `${normalizedBasePath}/${normalizedEndpoint}`
+  return joined || '/'
 }
 
-module.exports = { joinEVPProxyPath, stripTrailingSlashes }
+/**
+ * Joins an HTTP Agent URL path prefix with an EVP proxy path.
+ * Unix URL pathnames identify the socket itself and are not HTTP path prefixes.
+ *
+ * @param {URL} url - Configured Agent URL
+ * @param {...string} paths - EVP path components
+ * @returns {string} Joined request path
+ */
+function joinAgentURLPath (url, ...paths) {
+  const prefix = url.protocol === 'http:' || url.protocol === 'https:' ? url.pathname : ''
+  return joinEVPProxyPath(prefix, ...paths)
+}
+
+module.exports = { joinAgentURLPath, joinEVPProxyPath, stripTrailingSlashes }

--- a/packages/dd-trace/src/exporters/common/url.js
+++ b/packages/dd-trace/src/exporters/common/url.js
@@ -40,6 +40,7 @@ function createSiteUrl (site, intake) {
   if (normalizedSite === undefined) return
 
   const hostname = `${intake === undefined ? '' : `${intake}.`}${normalizedSite}`
+  if (hostname.length > 253) return
 
   try {
     const url = new URL(format({

--- a/packages/dd-trace/src/exporters/common/url.js
+++ b/packages/dd-trace/src/exporters/common/url.js
@@ -5,6 +5,9 @@ const { format } = require('node:url')
 
 const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 
+const DEFAULT_SITE = 'datadoghq.com'
+const DNS_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
 /**
  * @param {string} hostname
  * @returns {boolean}
@@ -33,7 +36,10 @@ function canSendApiKey (protocol, hostname) {
  * @returns {URL | undefined}
  */
 function createSiteUrl (site, intake) {
-  const hostname = `${intake === undefined ? '' : `${intake}.`}${site}`.toLowerCase()
+  const normalizedSite = normalizeSite(site)
+  if (normalizedSite === undefined) return
+
+  const hostname = `${intake === undefined ? '' : `${intake}.`}${normalizedSite}`
 
   try {
     const url = new URL(format({
@@ -53,6 +59,30 @@ function createSiteUrl (site, intake) {
     }
     return url
   } catch {}
+}
+
+/**
+ * Normalizes a Datadog site as a DNS suffix.
+ *
+ * @param {string | undefined} site
+ * @returns {string | undefined}
+ */
+function normalizeSite (site) {
+  if (site === undefined) return DEFAULT_SITE
+  if (typeof site !== 'string') return
+  for (let index = 0; index < site.length; index++) {
+    if (site.charCodeAt(index) > 127) return
+  }
+
+  const normalized = site.trim().toLowerCase() || DEFAULT_SITE
+  if (normalized.length > 253) return
+
+  const labels = normalized.split('.')
+  for (const label of labels) {
+    if (!DNS_LABEL.test(label)) return
+  }
+
+  return normalized
 }
 
 /**
@@ -82,4 +112,4 @@ function parseUrl (urlObjOrString) {
   return url
 }
 
-module.exports = { canSendApiKey, createSiteUrl, isLoopbackHost, parseUrl }
+module.exports = { canSendApiKey, createSiteUrl, isLoopbackHost, normalizeSite, parseUrl }

--- a/packages/dd-trace/src/openfeature/configuration_source.js
+++ b/packages/dd-trace/src/openfeature/configuration_source.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { createSiteUrl } = require('../exporters/common/url')
 const log = require('../log')
 
 const DEFAULT_AGENTLESS_PATH = '/api/v2/feature-flagging/config/rules-based/server'
@@ -60,7 +61,9 @@ function endpoint (config, configuredBaseUrl) {
   const configured = configuredBaseUrl?.trim()
 
   if (!configured) {
-    const url = new URL(`https://ufc-server.ff-cdn.${config.site.toLowerCase()}${DEFAULT_AGENTLESS_PATH}`)
+    const url = createSiteUrl(config.site, 'ufc-server.ff-cdn')
+    if (url === undefined) throw new Error('Invalid DD_SITE for Feature Flagging agentless configuration')
+    url.pathname = DEFAULT_AGENTLESS_PATH
     if (config.env) url.searchParams.set('dd_env', config.env)
     return url
   }

--- a/packages/dd-trace/src/openfeature/index.js
+++ b/packages/dd-trace/src/openfeature/index.js
@@ -3,12 +3,13 @@
 const { channel } = require('dc-polyfill')
 const log = require('../log')
 const ExposuresWriter = require('./writers/exposures')
-const { setExposureDeliveryStrategy } = require('./writers/util')
+const { setEventDeliveryStrategy } = require('./writers/util')
 
 const exposureSubmitCh = channel('ffe:exposure:submit')
 const flushCh = channel('ffe:writers:flush')
 
 let exposuresWriter = null
+let stopEventDeliveryStrategy
 
 /**
  * @private
@@ -45,7 +46,7 @@ function enable (config) {
   exposureSubmitCh.subscribe(_handleExposureSubmit)
   flushCh.subscribe(_handleFlush)
 
-  setExposureDeliveryStrategy(config, (enabled, route) => {
+  stopEventDeliveryStrategy = setEventDeliveryStrategy(config, (enabled, route) => {
     if (exposuresWriter !== writer) return
 
     writer.setEnabled(enabled, route)
@@ -58,6 +59,9 @@ function enable (config) {
  */
 function disable () {
   if (!exposuresWriter) return
+
+  stopEventDeliveryStrategy?.()
+  stopEventDeliveryStrategy = undefined
 
   if (exposureSubmitCh.hasSubscribers) {
     exposureSubmitCh.unsubscribe(_handleExposureSubmit)

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -1,9 +1,14 @@
 'use strict'
 
 const request = require('../../exporters/common/request')
-const { safeJSONStringify } = require('../../exporters/common/util')
 
 const log = require('../../log')
+const tracerVersion = require('../../../../../package.json').version
+
+const EVP_ORIGIN_HEADERS = {
+  'DD-EVP-ORIGIN': 'dd-trace-js',
+  'DD-EVP-ORIGIN-VERSION': tracerVersion,
+}
 
 /**
  * @typedef {object} BaseFFEWriterOptions
@@ -23,6 +28,8 @@ const log = require('../../log')
  * @property {string} endpoint - Route endpoint
  * @property {object} headers - Route-specific headers
  * @property {import('node:https').Agent} [agent] - Optional HTTPS proxy agent
+ * @property {Function} [onFallback] - Called after direct fallback becomes active
+ * @property {Function} [onUnavailable] - Called after the local route becomes unavailable
  */
 
 /**
@@ -30,6 +37,8 @@ const log = require('../../log')
  * @property {URL} url - Route base URL
  * @property {string} endpoint - Route endpoint
  * @property {object} requestOptions - HTTP request options
+ * @property {Function} [onFallback] - Called after direct fallback becomes active
+ * @property {Function} [onUnavailable] - Called after the local route becomes unavailable
  */
 
 /**
@@ -39,20 +48,21 @@ const log = require('../../log')
  * @param {number | undefined} statusCode - HTTP response status
  * @returns {boolean} Whether direct retry is safe
  */
-function isDefinitiveRejection (error, statusCode) {
+function isSafeToReplay (error, statusCode) {
   return error?.code === 'EAI_AGAIN' || error?.code === 'ECONNREFUSED' ||
     error?.code === 'ENOENT' || error?.code === 'ENOTFOUND' ||
-    statusCode === 403 || statusCode === 404 || statusCode === 405
+    statusCode === 404 || statusCode === 405
 }
 
 /**
- * Tests whether a local route can have accepted an event batch before failing.
+ * Tests whether a local route failed without an authoritative HTTP response.
  *
  * @param {Error | null} error - Request error
+ * @param {number | undefined} statusCode - HTTP response status
  * @returns {boolean} Whether the delivery result is ambiguous
  */
-function isAmbiguousNetworkFailure (error) {
-  return error?.code === 'ECONNRESET' || error?.code === 'EPIPE' || error?.code === 'ETIMEDOUT'
+function isTransportFailure (error, statusCode) {
+  return error !== null && error !== undefined && statusCode === undefined
 }
 
 /**
@@ -83,10 +93,11 @@ class BaseFFEWriter {
     this._requestOptions = {
       headers: {
         ...this._headers,
+        ...EVP_ORIGIN_HEADERS,
         'Content-Type': 'application/json',
       },
       method: 'POST',
-      retry: true,
+      retry: false,
       timeout: this._timeout,
       url: this._baseUrl,
       path: this._endpoint,
@@ -152,11 +163,10 @@ class BaseFFEWriter {
 
     const payload = this._encode(this.makePayload(events))
 
+    // Keep byte counting behind the debug callback because payloads can be several megabytes.
     // eslint-disable-next-line eslint-rules/eslint-log-printf-style
-    log.debug(() => `${this.constructor.name} flushing payload: ${safeJSONStringify(payload)}`)
-
-    const route = this.#createActiveRoute()
-    this.#sendRequest(payload, events.length, route, this._fallbackRoute)
+    log.debug(() => `${this.constructor.name} flushing ${events.length} events (${Buffer.byteLength(payload)} bytes)`)
+    this._sendPayload(payload, events.length)
   }
 
   /**
@@ -196,6 +206,19 @@ class BaseFFEWriter {
   }
 
   /**
+   * Sends one encoded event batch through a snapshot of the selected routes.
+   *
+   * @protected
+   * @param {string} payload - Encoded event batch
+   * @param {number} eventCount - Event count
+   * @returns {void}
+   */
+  _sendPayload (payload, eventCount) {
+    const route = this.#createActiveRoute()
+    this.#sendRequest(payload, eventCount, route, this._fallbackRoute)
+  }
+
+  /**
    * Applies the active route and an optional direct fallback route.
    *
    * @param {WriterRoute} route - Active route
@@ -217,10 +240,11 @@ class BaseFFEWriter {
     const requestOptions = {
       headers: {
         ...route.headers,
+        ...EVP_ORIGIN_HEADERS,
         'Content-Type': 'application/json',
       },
       method: 'POST',
-      retry: true,
+      retry: false,
       timeout: this._timeout,
       url: route.url,
       path: route.endpoint,
@@ -231,6 +255,8 @@ class BaseFFEWriter {
       url: route.url,
       endpoint: route.endpoint,
       requestOptions,
+      onFallback: route.onFallback,
+      onUnavailable: route.onUnavailable,
     }
   }
 
@@ -244,6 +270,8 @@ class BaseFFEWriter {
       url: this._baseUrl,
       endpoint: this._endpoint,
       requestOptions: this._requestOptions,
+      onFallback: this._onFallback,
+      onUnavailable: this._onUnavailable,
     }
   }
 
@@ -257,10 +285,12 @@ class BaseFFEWriter {
     this._baseUrl = route.url
     this._endpoint = route.endpoint
     this._requestOptions = route.requestOptions
+    this._onFallback = route.onFallback
+    this._onUnavailable = route.onUnavailable
   }
 
   /**
-   * Sends an encoded batch and retries it through direct intake after a local route failure.
+   * Sends an encoded batch once per route and applies safe local fallback semantics.
    *
    * @param {string} payload - Encoded event batch
    * @param {number} eventCount - Event count
@@ -270,7 +300,7 @@ class BaseFFEWriter {
    */
   #sendRequest (payload, eventCount, route, fallbackRoute) {
     request(payload, route.requestOptions, (error, response, statusCode) => {
-      if (fallbackRoute && isDefinitiveRejection(error, statusCode)) {
+      if (fallbackRoute && isSafeToReplay(error, statusCode)) {
         log.debug(
           '%s switching from %s%s to direct intake after definitive rejection',
           this.constructor.name,
@@ -279,20 +309,33 @@ class BaseFFEWriter {
         )
         this.#activateRoute(fallbackRoute)
         this._fallbackRoute = undefined
+        route.onFallback?.()
         this.#sendRequest(payload, eventCount, fallbackRoute)
         return
       }
 
-      if (fallbackRoute && isAmbiguousNetworkFailure(error)) {
+      if (fallbackRoute && isTransportFailure(error, statusCode)) {
         log.debug(
-          '%s retrying through direct intake and switching future batches from %s%s after ambiguous failure',
+          '%s switching future batches from %s%s to direct intake after an ambiguous failure without replay',
           this.constructor.name,
           route.url.href,
           route.endpoint
         )
         this.#activateRoute(fallbackRoute)
         this._fallbackRoute = undefined
-        this.#sendRequest(payload, eventCount, fallbackRoute)
+        route.onFallback?.()
+        log.error('Failed to send events to %s%s: %s', route.url.href, route.endpoint, error.message)
+        return
+      }
+
+      if (!fallbackRoute && route.onUnavailable &&
+          (isSafeToReplay(error, statusCode) || isTransportFailure(error, statusCode))) {
+        route.onUnavailable()
+        if (error) {
+          log.error('Failed to send events to %s%s: %s', route.url.href, route.endpoint, error.message)
+        } else {
+          log.warn('Events request returned status %d', statusCode)
+        }
         return
       }
 

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -66,6 +66,16 @@ function isTransportFailure (error, statusCode) {
 }
 
 /**
+ * Tests whether an HTTP response should move only future Agentless batches.
+ *
+ * @param {number | undefined} statusCode - HTTP response status
+ * @returns {boolean} Whether the local route should be replaced without replay
+ */
+function shouldSwitchFutureRoute (statusCode) {
+  return statusCode === 403 || statusCode === 429 || statusCode >= 500 && statusCode < 600
+}
+
+/**
  * Base writer for Feature Flagging and Experimentation event delivery.
  * @class BaseFFEWriter
  */
@@ -328,8 +338,24 @@ class BaseFFEWriter {
         return
       }
 
+      if (fallbackRoute && shouldSwitchFutureRoute(statusCode)) {
+        log.debug(
+          '%s switching future batches from %s%s to direct intake after status %d without replay',
+          this.constructor.name,
+          route.url.href,
+          route.endpoint,
+          statusCode
+        )
+        this.#activateRoute(fallbackRoute)
+        this._fallbackRoute = undefined
+        route.onFallback?.()
+        log.warn('Events request returned status %d', statusCode)
+        return
+      }
+
       if (!fallbackRoute && route.onUnavailable &&
-          (isSafeToReplay(error, statusCode) || isTransportFailure(error, statusCode))) {
+          (isSafeToReplay(error, statusCode) || isTransportFailure(error, statusCode) ||
+           shouldSwitchFutureRoute(statusCode))) {
         route.onUnavailable()
         if (error) {
           log.error('Failed to send events to %s%s: %s', route.url.href, route.endpoint, error.message)

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -353,9 +353,13 @@ class BaseFFEWriter {
         return
       }
 
-      if (!fallbackRoute && route.onUnavailable &&
-          (isSafeToReplay(error, statusCode) || isTransportFailure(error, statusCode) ||
-           shouldSwitchFutureRoute(statusCode))) {
+      if (
+        !fallbackRoute &&
+        route.onUnavailable &&
+        (isSafeToReplay(error, statusCode) ||
+          isTransportFailure(error, statusCode) ||
+          shouldSwitchFutureRoute(statusCode))
+      ) {
         route.onUnavailable()
         if (error) {
           log.error('Failed to send events to %s%s: %s', route.url.href, route.endpoint, error.message)

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -26,6 +26,8 @@ const PENDING_MAX_EVENTS = 1000
  * @property {object} [headers] - Route-specific headers
  * @property {import('node:https').Agent} [agent] - Optional HTTPS proxy agent
  * @property {ExposureRoute} [fallback] - Optional direct fallback route
+ * @property {Function} [onFallback] - Called after direct fallback becomes active
+ * @property {Function} [onUnavailable] - Called after the local route becomes unavailable
  */
 
 /**
@@ -152,6 +154,8 @@ class ExposuresWriter extends BaseFFEWriter {
       endpoint: joinEVPProxyPath(route.basePath, EXPOSURES_ENDPOINT),
       headers,
       agent: route.agent,
+      onFallback: route.onFallback,
+      onUnavailable: route.onUnavailable,
     }, fallbackRoute)
   }
 

--- a/packages/dd-trace/src/openfeature/writers/util.js
+++ b/packages/dd-trace/src/openfeature/writers/util.js
@@ -2,13 +2,20 @@
 
 const {
   EVP_EVENT_PLATFORM_SUBDOMAIN,
+  EVP_ORIGIN_HEADER_NAME,
+  EVP_ORIGIN_VERSION_HEADER_NAME,
   EVP_PROXY_PATH_V2,
   EVP_PROXY_PATH_V4,
   EVP_SUBDOMAIN_HEADER_NAME,
 } = require('../../evp_proxy/constants')
 const { createDirectEVPRoute } = require('../../evp_proxy/direct')
 const { discoverEVPProxy } = require('../../evp_proxy/discovery')
+const { joinAgentURLPath } = require('../../evp_proxy/path')
 const logger = require('../../log')
+
+const ROUTE_DISCOVERY_COOLDOWN_MS = 60_000
+const REQUIRED_LOCAL_HEADERS = [EVP_ORIGIN_HEADER_NAME, EVP_ORIGIN_VERSION_HEADER_NAME]
+const STOP_NOOP = () => {}
 
 let missingRouteWarningLogged = false
 
@@ -31,26 +38,17 @@ function warnExposureDeliveryUnavailable () {
  *
  * @param {import('../../config')} config - Tracer configuration object
  * @param {Function} setWriterEnabledValue - Callback to set the writer enabled state
- * @returns {void}
+ * @returns {Function} Stop callback
  */
 function setAgentStrategy (config, setWriterEnabledValue) {
-  discoverEVPProxy(config.url, {
-    supportedPaths: [EVP_PROXY_PATH_V2],
-  }, (error, route) => {
-    if (error) {
-      logger.debug('FFE Writer disabled - error getting agent info: %s', error.message)
-      setWriterEnabledValue(false)
-      return
-    }
-
-    if (route) {
-      logger.debug('FFE Writer enabled - agent has EVP proxy support')
-      setWriterEnabledValue(true, route)
-    } else {
-      logger.debug('FFE Writer disabled - agent does not have EVP proxy support')
-      setWriterEnabledValue(false)
-    }
+  setWriterEnabledValue(true, {
+    url: config.url,
+    basePath: joinAgentURLPath(config.url, EVP_PROXY_PATH_V2),
+    headers: {
+      [EVP_SUBDOMAIN_HEADER_NAME]: EVP_EVENT_PLATFORM_SUBDOMAIN,
+    },
   })
+  return STOP_NOOP
 }
 
 /**
@@ -61,59 +59,127 @@ function setAgentStrategy (config, setWriterEnabledValue) {
  *
  * @param {import('../../config')} config - Tracer configuration object
  * @param {Function} setWriterEnabledValue - Callback to set the writer enabled state
- * @returns {void}
+ * @returns {Function} Stop callback
  */
 function setAgentlessStrategy (config, setWriterEnabledValue) {
   const directRoute = createDirectEVPRoute(config, EVP_EVENT_PLATFORM_SUBDOMAIN)
+  let discovering = false
+  let recoveryTimer
+  let state = 'unknown'
+  let stopped = false
 
-  discoverEVPProxy(config.url, {
-    supportedPaths: [EVP_PROXY_PATH_V4, EVP_PROXY_PATH_V2],
-  }, (error, localRoute) => {
-    if (localRoute) {
-      const route = {
-        ...localRoute,
-        headers: {
-          [EVP_SUBDOMAIN_HEADER_NAME]: EVP_EVENT_PLATFORM_SUBDOMAIN,
-        },
-      }
-      if (directRoute) route.fallback = directRoute
-      logger.debug('FFE Writer enabled with local EVP route %s', route.basePath)
-      setWriterEnabledValue(true, route)
-      return
+  /** @returns {void} */
+  const stop = () => {
+    stopped = true
+    clearTimeout(recoveryTimer)
+    recoveryTimer = undefined
+  }
+
+  /** @returns {void} */
+  const scheduleRecovery = () => {
+    if (stopped || state !== 'unavailable' || recoveryTimer !== undefined) return
+
+    recoveryTimer = setTimeout(discover, ROUTE_DISCOVERY_COOLDOWN_MS)
+    recoveryTimer.unref?.()
+  }
+
+  /** @returns {void} */
+  const markUnavailable = () => {
+    if (stopped || state === 'direct') return
+    if (state !== 'unavailable') {
+      state = 'unavailable'
+      setWriterEnabledValue(false)
     }
+    scheduleRecovery()
+  }
 
+  /** @returns {void} */
+  const activateDirect = () => {
+    if (stopped || state === 'direct' || directRoute === undefined) return
+    state = 'direct'
+    clearTimeout(recoveryTimer)
+    recoveryTimer = undefined
+    setWriterEnabledValue(true, directRoute)
+  }
+
+  /**
+   * @param {{url: URL, basePath: string}} localRoute - Discovered local route
+   * @returns {void}
+   */
+  const activateLocal = localRoute => {
+    state = 'local'
+    const route = {
+      ...localRoute,
+      headers: {
+        [EVP_SUBDOMAIN_HEADER_NAME]: EVP_EVENT_PLATFORM_SUBDOMAIN,
+      },
+    }
     if (directRoute) {
-      if (error) {
-        logger.debug('FFE Writer using direct EVP intake after local discovery failed: %s', error.message)
-      } else {
-        logger.debug('FFE Writer using direct EVP intake because no compatible local route was advertised')
-      }
-      setWriterEnabledValue(true, directRoute)
-      return
+      route.fallback = directRoute
+      route.onFallback = activateDirect
+    } else {
+      route.onUnavailable = markUnavailable
     }
+    logger.debug('FFE Writer enabled with local EVP route %s', route.basePath)
+    setWriterEnabledValue(true, route)
+  }
 
-    if (error) {
-      logger.debug('FFE Writer disabled - error getting local receiver info: %s', error.message)
-    }
-    warnExposureDeliveryUnavailable()
-    setWriterEnabledValue(false)
-  })
+  /** @returns {void} */
+  function discover () {
+    recoveryTimer = undefined
+    if (stopped || state === 'direct' || discovering) return
+    discovering = true
+
+    discoverEVPProxy(config.url, {
+      requiredHeaders: REQUIRED_LOCAL_HEADERS,
+      supportedPaths: [EVP_PROXY_PATH_V4, EVP_PROXY_PATH_V2],
+    }, (error, localRoute) => {
+      discovering = false
+      if (stopped || state === 'direct') return
+
+      if (localRoute) {
+        activateLocal(localRoute)
+        return
+      }
+
+      if (directRoute) {
+        if (error) {
+          logger.debug('FFE Writer using direct EVP intake after local discovery failed: %s', error.message)
+        } else {
+          logger.debug('FFE Writer using direct EVP intake because no compatible local route was advertised')
+        }
+        activateDirect()
+        return
+      }
+
+      if (error) {
+        logger.debug('FFE Writer disabled - error getting local receiver info: %s', error.message)
+      }
+      warnExposureDeliveryUnavailable()
+      markUnavailable()
+    })
+  }
+
+  discover()
+  return stop
 }
 
 /**
- * Applies the exposure-delivery strategy for the configured Feature Flags source.
+ * Applies one event-delivery strategy that can be shared by all Feature Flags writers.
  *
  * @param {import('../../config')} config - Tracer configuration object
  * @param {Function} setWriterEnabledValue - Callback to set the writer enabled state
- * @returns {void}
+ * @returns {Function} Stop callback
  */
-function setExposureDeliveryStrategy (config, setWriterEnabledValue) {
+function setEventDeliveryStrategy (config, setWriterEnabledValue) {
   if (config.featureFlags?.DD_FEATURE_FLAGS_CONFIGURATION_SOURCE === 'agentless') {
-    setAgentlessStrategy(config, setWriterEnabledValue)
-    return
+    return setAgentlessStrategy(config, setWriterEnabledValue)
   }
 
-  setAgentStrategy(config, setWriterEnabledValue)
+  return setAgentStrategy(config, setWriterEnabledValue)
 }
 
-module.exports = { setExposureDeliveryStrategy }
+module.exports = {
+  setEventDeliveryStrategy,
+  setExposureDeliveryStrategy: setEventDeliveryStrategy,
+}

--- a/packages/dd-trace/test/agent/info.spec.js
+++ b/packages/dd-trace/test/agent/info.spec.js
@@ -98,6 +98,22 @@ describe('agent/info', () => {
       }, options, request)
     })
 
+    it('preserves a caller-supplied information path', (done) => {
+      const request = sinon.stub().yieldsAsync(null, JSON.stringify({ endpoints: ['/evp_proxy/v4'] }))
+      const options = { path: '/agent-prefix/info', retry: false }
+
+      fetchAgentInfo(new URL(url), (err, response) => {
+        assert.strictEqual(err, null)
+        assert.deepStrictEqual(response.endpoints, ['/evp_proxy/v4'])
+        sinon.assert.calledOnceWithMatch(request, '', {
+          path: '/agent-prefix/info',
+          retry: false,
+          url: new URL(url),
+        })
+        done()
+      }, options, request)
+    })
+
     describe('caching', () => {
       let clock
 

--- a/packages/dd-trace/test/evp_proxy/constants.spec.js
+++ b/packages/dd-trace/test/evp_proxy/constants.spec.js
@@ -5,6 +5,8 @@ const assert = require('node:assert/strict')
 const { describe, it } = require('mocha')
 
 const {
+  EVP_ORIGIN_HEADER_NAME,
+  EVP_ORIGIN_VERSION_HEADER_NAME,
   EVP_PROXY_PATH_V2,
   EVP_PROXY_PATH_V4,
   EVP_SUBDOMAIN_HEADER_NAME,
@@ -15,6 +17,8 @@ describe('EVP proxy constants', () => {
   it('exposes protocol-wide paths and header name', () => {
     assert.strictEqual(EVP_PROXY_PATH_V2, '/evp_proxy/v2')
     assert.strictEqual(EVP_PROXY_PATH_V4, '/evp_proxy/v4')
+    assert.strictEqual(EVP_ORIGIN_HEADER_NAME, 'DD-EVP-ORIGIN')
+    assert.strictEqual(EVP_ORIGIN_VERSION_HEADER_NAME, 'DD-EVP-ORIGIN-VERSION')
     assert.strictEqual(EVP_SUBDOMAIN_HEADER_NAME, 'X-Datadog-EVP-Subdomain')
     assert.strictEqual(EVP_EVENT_PLATFORM_SUBDOMAIN, 'event-platform-intake')
   })

--- a/packages/dd-trace/test/evp_proxy/direct.spec.js
+++ b/packages/dd-trace/test/evp_proxy/direct.spec.js
@@ -11,7 +11,7 @@ describe('direct EVP route', () => {
   let log
 
   beforeEach(() => {
-    log = { debug: sinon.spy() }
+    log = { warn: sinon.spy() }
 
     ;({ createDirectEVPRoute } = proxyquire('../../src/evp_proxy/direct', {
       '../log': log,
@@ -48,16 +48,30 @@ describe('direct EVP route', () => {
     })
   })
 
+  it('normalizes surrounding whitespace and defaults a blank site', () => {
+    assert.strictEqual(createDirectEVPRoute({
+      DD_API_KEY: 'test-api-key',
+      site: '  DATADOGHQ.EU  ',
+    }, 'event-platform-intake').url.href, 'https://event-platform-intake.datadoghq.eu/')
+
+    assert.strictEqual(createDirectEVPRoute({
+      DD_API_KEY: 'test-api-key',
+      site: '  ',
+    }, 'event-platform-intake').url.href, 'https://event-platform-intake.datadoghq.com/')
+  })
+
   it('does not create a route without an API key', () => {
     assert.strictEqual(createDirectEVPRoute({
       site: 'datadoghq.com',
     }, 'event-platform-intake'), undefined)
   })
 
-  it('does not create a route without a site', () => {
-    assert.strictEqual(createDirectEVPRoute({
+  it('uses the default site when it is omitted', () => {
+    const route = createDirectEVPRoute({
       DD_API_KEY: 'test-api-key',
-    }, 'event-platform-intake'), undefined)
+    }, 'event-platform-intake')
+
+    assert.strictEqual(route.url.href, 'https://event-platform-intake.datadoghq.com/')
   })
 
   it('does not create a route for an invalid site', () => {
@@ -67,9 +81,23 @@ describe('direct EVP route', () => {
     }, 'event-platform-intake'), undefined)
 
     sinon.assert.calledOnceWithExactly(
-      log.debug,
-      'Unable to configure direct EVP intake: %s',
-      sinon.match.string
+      log.warn,
+      'Feature Flags direct event delivery is disabled because DD_SITE is invalid.'
     )
+  })
+
+  it('warns once without logging an invalid site or API key', () => {
+    const config = {
+      DD_API_KEY: 'sensitive-api-key',
+      site: 'sensitive invalid site',
+    }
+
+    createDirectEVPRoute(config, 'event-platform-intake')
+    createDirectEVPRoute(config, 'event-platform-intake')
+
+    sinon.assert.calledOnce(log.warn)
+    const message = log.warn.firstCall.args.join(' ')
+    assert.ok(!message.includes(config.site))
+    assert.ok(!message.includes(config.DD_API_KEY))
   })
 })

--- a/packages/dd-trace/test/evp_proxy/discovery.spec.js
+++ b/packages/dd-trace/test/evp_proxy/discovery.spec.js
@@ -10,7 +10,7 @@ describe('EVP proxy discovery', () => {
   const url = new URL('http://localhost:8126')
   const options = {
     supportedPaths: ['/evp_proxy/v4', '/evp_proxy/v2'],
-    requiredHeaders: ['Content-Type'],
+    requiredHeaders: ['DD-EVP-ORIGIN', 'DD-EVP-ORIGIN-VERSION'],
   }
 
   let discoverEVPProxy
@@ -35,19 +35,19 @@ describe('EVP proxy discovery', () => {
     it('uses caller preference order and normalizes trailing slashes', () => {
       const path = selectEVPProxyPath({
         endpoints: ['/evp_proxy/v2/', '/evp_proxy/v4/'],
-        evp_proxy_allowed_headers: ['content-type'],
+        evp_proxy_allowed_headers: ['dd-evp-origin', 'dd-evp-origin-version'],
       }, options)
 
       assert.strictEqual(path, '/evp_proxy/v4')
       sinon.assert.notCalled(fetchAgentInfo)
     })
 
-    it('supports a missing allowed-header field for legacy Agents', () => {
+    it('rejects a missing allowed-header field when forwarding is required', () => {
       const path = selectEVPProxyPath({
         endpoints: ['/evp_proxy/v2'],
       }, options)
 
-      assert.strictEqual(path, '/evp_proxy/v2')
+      assert.strictEqual(path, undefined)
     })
 
     it('selects a path without applying optional header requirements', () => {
@@ -64,7 +64,7 @@ describe('EVP proxy discovery', () => {
     it('rejects a malformed allowed-header field', () => {
       const path = selectEVPProxyPath({
         endpoints: ['/evp_proxy/v2'],
-        evp_proxy_allowed_headers: 'Content-Type',
+        evp_proxy_allowed_headers: 'DD-EVP-ORIGIN',
       }, options)
 
       assert.strictEqual(path, undefined)
@@ -73,7 +73,7 @@ describe('EVP proxy discovery', () => {
     it('rejects a missing required header', () => {
       const path = selectEVPProxyPath({
         endpoints: ['/evp_proxy/v2'],
-        evp_proxy_allowed_headers: ['Accept-Encoding'],
+        evp_proxy_allowed_headers: ['DD-EVP-ORIGIN'],
       }, options)
 
       assert.strictEqual(path, undefined)
@@ -82,13 +82,22 @@ describe('EVP proxy discovery', () => {
     it('rejects malformed endpoint data', () => {
       assert.strictEqual(selectEVPProxyPath({ endpoints: null }, options), undefined)
     })
+
+    it('matches all required forwarded headers case-insensitively with whitespace', () => {
+      const path = selectEVPProxyPath({
+        endpoints: ['/evp_proxy/v2'],
+        evp_proxy_allowed_headers: [' dd-evp-origin ', 'Dd-EvP-OrIgIn-VeRsIoN'],
+      }, options)
+
+      assert.strictEqual(path, '/evp_proxy/v2')
+    })
   })
 
   describe('discoverEVPProxy', () => {
     it('fetches information only when discovery is called', (done) => {
       fetchAgentInfo.yields(null, {
         endpoints: ['/evp_proxy/v2'],
-        evp_proxy_allowed_headers: ['content-type'],
+        evp_proxy_allowed_headers: ['dd-evp-origin', 'dd-evp-origin-version'],
       })
 
       sinon.assert.notCalled(fetchAgentInfo)
@@ -99,7 +108,10 @@ describe('EVP proxy discovery', () => {
           url,
           basePath: '/evp_proxy/v2',
         })
-        sinon.assert.calledOnceWithExactly(fetchAgentInfo, url, sinon.match.func)
+        sinon.assert.calledOnceWithExactly(fetchAgentInfo, url, sinon.match.func, {
+          path: '/info',
+          retry: false,
+        })
         sinon.assert.calledOnceWithExactly(
           log.debug,
           'EVP proxy route %s discovered through the configured local receiver',
@@ -128,6 +140,27 @@ describe('EVP proxy discovery', () => {
         assert.strictEqual(error, expectedError)
         assert.strictEqual(route, undefined)
         sinon.assert.notCalled(log.debug)
+        done()
+      })
+    })
+
+    it('preserves a configured HTTP path prefix for discovery and event routing', (done) => {
+      const prefixedUrl = new URL('http://localhost:8126/agent-prefix/')
+      fetchAgentInfo.yields(null, {
+        endpoints: ['/evp_proxy/v4'],
+        evp_proxy_allowed_headers: ['DD-EVP-ORIGIN', 'DD-EVP-ORIGIN-VERSION'],
+      })
+
+      discoverEVPProxy(prefixedUrl, options, (error, route) => {
+        assert.ifError(error)
+        assert.deepStrictEqual(route, {
+          url: prefixedUrl,
+          basePath: '/agent-prefix/evp_proxy/v4',
+        })
+        sinon.assert.calledOnceWithExactly(fetchAgentInfo, prefixedUrl, sinon.match.func, {
+          path: '/agent-prefix/info',
+          retry: false,
+        })
         done()
       })
     })

--- a/packages/dd-trace/test/evp_proxy/path.spec.js
+++ b/packages/dd-trace/test/evp_proxy/path.spec.js
@@ -19,4 +19,22 @@ describe('EVP proxy path', () => {
 
     assert.strictEqual(joinEVPProxyPath('', '/api/v2/exposures'), '/api/v2/exposures')
   })
+
+  it('joins a configured path prefix, proxy route, and product endpoint', () => {
+    const { joinEVPProxyPath } = require('../../src/evp_proxy/path')
+
+    assert.strictEqual(
+      joinEVPProxyPath('/agent-prefix/', '/evp_proxy/v4/', '/api/v2/exposures'),
+      '/agent-prefix/evp_proxy/v4/api/v2/exposures'
+    )
+  })
+
+  it('does not treat a Unix socket pathname as an HTTP path prefix', () => {
+    const { joinAgentURLPath } = require('../../src/evp_proxy/path')
+
+    assert.strictEqual(
+      joinAgentURLPath(new URL('unix:///var/run/datadog/apm.socket'), '/evp_proxy/v2'),
+      '/evp_proxy/v2'
+    )
+  })
 })

--- a/packages/dd-trace/test/exporters/common/url.spec.js
+++ b/packages/dd-trace/test/exporters/common/url.spec.js
@@ -6,7 +6,7 @@ const { describe, it } = require('mocha')
 
 require('../../setup/core')
 
-const { createSiteUrl, parseUrl } = require('../../../src/exporters/common/url')
+const { createSiteUrl, normalizeSite, parseUrl } = require('../../../src/exporters/common/url')
 
 describe('exporters/common/url createSiteUrl', () => {
   it('creates an HTTPS URL from a site and intake', () => {
@@ -14,6 +14,12 @@ describe('exporters/common/url createSiteUrl', () => {
       createSiteUrl('DATADOGHQ.EU', 'debugger-intake').href,
       'https://debugger-intake.datadoghq.eu/'
     )
+  })
+
+  it('normalizes outer whitespace and defaults blank sites', () => {
+    assert.strictEqual(normalizeSite('  DATADOGHQ.EU  '), 'datadoghq.eu')
+    assert.strictEqual(normalizeSite('  '), 'datadoghq.com')
+    assert.strictEqual(normalizeSite(undefined), 'datadoghq.com')
   })
 
   for (const site of [
@@ -24,6 +30,11 @@ describe('exporters/common/url createSiteUrl', () => {
     'datadoghq.com/path',
     'datadoghq.com?query',
     'datadoghq.com#fragment',
+    'datadoghq\\.com',
+    'datadoghq..com',
+    '-datadoghq.com',
+    'datadoghq-.com',
+    'dátadoghq.com',
   ]) {
     it(`rejects a site with URL components: ${site}`, () => {
       assert.strictEqual(createSiteUrl(site, 'debugger-intake'), undefined)

--- a/packages/dd-trace/test/exporters/common/url.spec.js
+++ b/packages/dd-trace/test/exporters/common/url.spec.js
@@ -41,6 +41,13 @@ describe('exporters/common/url createSiteUrl', () => {
       assert.strictEqual(createSiteUrl(site), undefined)
     })
   }
+
+  it('rejects a valid site suffix when the composed intake hostname is too long', () => {
+    const label = 'a'.repeat(63)
+    const site = `${label}.${label}.${label}.${'a'.repeat(49)}`
+
+    assert.strictEqual(createSiteUrl(site, 'event-platform-intake'), undefined)
+  })
 })
 
 describe('exporters/common/url parseUrl', () => {

--- a/packages/dd-trace/test/openfeature/configuration_source.spec.js
+++ b/packages/dd-trace/test/openfeature/configuration_source.spec.js
@@ -66,6 +66,31 @@ describe('OpenFeature configuration source', () => {
     )
   })
 
+  it('uses shared site normalization for the managed UFC endpoint', () => {
+    config.site = '  MOCK-INTAKE.INVALID  '
+
+    assert.strictEqual(
+      createSourceConfig().endpoint.toString(),
+      'https://ufc-server.ff-cdn.mock-intake.invalid/api/v2/feature-flagging/config/rules-based/server?dd_env=my+env'
+    )
+  })
+
+  it('rejects an invalid managed site without logging its value', () => {
+    const sensitiveSite = 'sensitive\\invalid.example'
+    config.site = sensitiveSite
+
+    const source = configurationSource.create(config, sinon.spy())
+
+    assert.strictEqual(source, undefined)
+    sinon.assert.notCalled(AgentlessConfigurationSource)
+    sinon.assert.calledOnceWithMatch(
+      log.error,
+      'Unable to configure Feature Flagging configuration source',
+      sinon.match.instanceOf(Error)
+    )
+    assert.ok(!log.error.firstCall.args[1].message.includes(sensitiveSite))
+  })
+
   it('caps the polling interval at one hour', () => {
     config.featureFlags.DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS = 4 * 60 * 60
 

--- a/packages/dd-trace/test/openfeature/index.spec.js
+++ b/packages/dd-trace/test/openfeature/index.spec.js
@@ -14,7 +14,8 @@ describe('OpenFeature Module', () => {
   let openfeatureModule
   let mockWriter
   let ExposuresWriterStub
-  let setExposureDeliveryStrategyStub
+  let setEventDeliveryStrategyStub
+  let stopEventDeliveryStrategy
 
   beforeEach(() => {
     config = {
@@ -30,11 +31,12 @@ describe('OpenFeature Module', () => {
     }
 
     ExposuresWriterStub = sinon.stub().returns(mockWriter)
-    setExposureDeliveryStrategyStub = sinon.stub()
+    stopEventDeliveryStrategy = sinon.spy()
+    setEventDeliveryStrategyStub = sinon.stub().returns(stopEventDeliveryStrategy)
 
     openfeatureModule = proxyquire('../../src/openfeature', {
       './writers/exposures': ExposuresWriterStub,
-      './writers/util': { setExposureDeliveryStrategy: setExposureDeliveryStrategyStub },
+      './writers/util': { setEventDeliveryStrategy: setEventDeliveryStrategyStub },
     })
   })
 
@@ -52,12 +54,12 @@ describe('OpenFeature Module', () => {
       openfeatureModule.enable(config)
 
       sinon.assert.calledOnceWithExactly(ExposuresWriterStub, config)
-      sinon.assert.calledOnce(setExposureDeliveryStrategyStub)
+      sinon.assert.calledOnce(setEventDeliveryStrategyStub)
     })
 
     it('configures the writer with the selected exposure route', () => {
       openfeatureModule.enable(config)
-      const setWriterEnabled = setExposureDeliveryStrategyStub.firstCall.args[1]
+      const setWriterEnabled = setEventDeliveryStrategyStub.firstCall.args[1]
       const route = {
         url: new URL('http://serverless-init:8126'),
         basePath: '/evp_proxy/v4',
@@ -85,10 +87,10 @@ describe('OpenFeature Module', () => {
       ExposuresWriterStub.onSecondCall().returns(replacementWriter)
 
       openfeatureModule.enable(config)
-      const staleCallback = setExposureDeliveryStrategyStub.firstCall.args[1]
+      const staleCallback = setEventDeliveryStrategyStub.firstCall.args[1]
       openfeatureModule.disable()
       openfeatureModule.enable(config)
-      const currentCallback = setExposureDeliveryStrategyStub.secondCall.args[1]
+      const currentCallback = setEventDeliveryStrategyStub.secondCall.args[1]
 
       staleCallback(true, staleRoute)
       sinon.assert.notCalled(replacementWriter.setEnabled)
@@ -102,7 +104,7 @@ describe('OpenFeature Module', () => {
       openfeatureModule.enable(config)
 
       sinon.assert.calledOnceWithExactly(ExposuresWriterStub, config)
-      sinon.assert.calledOnceWithExactly(setExposureDeliveryStrategyStub, config, sinon.match.func)
+      sinon.assert.calledOnceWithExactly(setEventDeliveryStrategyStub, config, sinon.match.func)
     })
 
     it('should handle multiple enable calls gracefully', () => {
@@ -117,6 +119,7 @@ describe('OpenFeature Module', () => {
       openfeatureModule.disable()
 
       sinon.assert.calledOnce(mockWriter.destroy)
+      sinon.assert.calledOnce(stopEventDeliveryStrategy)
     })
   })
 

--- a/packages/dd-trace/test/openfeature/writers/base.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/base.spec.js
@@ -149,4 +149,22 @@ describe('OpenFeature Base FFE Writer transport', () => {
     sinon.assert.calledTwice(request)
     assert.strictEqual(request.secondCall.args[1].url, directUrl)
   })
+
+  it('marks a local-only route unavailable after a non-replayable response', async () => {
+    const localUrl = new URL('http://localhost:8126')
+    const onUnavailable = sinon.spy()
+    request.onFirstCall().yieldsAsync(Object.assign(new Error('rate limited'), { status: 429 }), null, 429)
+    writer.setRoute({
+      url: localUrl,
+      basePath: '/evp_proxy/v4',
+      headers: { 'X-Datadog-EVP-Subdomain': 'event-platform-intake' },
+      onUnavailable,
+    })
+
+    writer.send('{"flag":"rate-limited","count":1}', 1)
+    await clock.tickAsync(0)
+
+    sinon.assert.calledOnce(request)
+    sinon.assert.calledOnce(onUnavailable)
+  })
 })

--- a/packages/dd-trace/test/openfeature/writers/base.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/base.spec.js
@@ -1,0 +1,152 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../../setup/core')
+const { joinEVPProxyPath } = require('../../../src/evp_proxy/path')
+const tracerVersion = require('../../../../../package.json').version
+
+const FLAG_EVALUATIONS_ENDPOINT = '/api/v2/flagevaluation'
+
+describe('OpenFeature Base FFE Writer transport', () => {
+  let FlagEvaluationWriter
+  let clock
+  let config
+  let log
+  let request
+  let writer
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+    config = { url: new URL('http://localhost:8126') }
+    log = {
+      debug: sinon.spy(),
+      error: sinon.spy(),
+      warn: sinon.spy(),
+    }
+    request = sinon.stub().yieldsAsync(null, 'OK', 202)
+    const BaseFFEWriter = proxyquire('../../../src/openfeature/writers/base', {
+      '../../exporters/common/request': request,
+      '../../log': log,
+    })
+
+    FlagEvaluationWriter = class extends BaseFFEWriter {
+      /** Creates a minimal future signal writer against the shared transport seam. */
+      constructor () {
+        super({ config, endpoint: FLAG_EVALUATIONS_ENDPOINT })
+      }
+
+      /**
+       * @param {object} route - Selected event route
+       * @returns {void}
+       */
+      setRoute (route) {
+        const mapRoute = selectedRoute => ({
+          url: selectedRoute.url,
+          endpoint: joinEVPProxyPath(selectedRoute.basePath, FLAG_EVALUATIONS_ENDPOINT),
+          headers: selectedRoute.headers ?? {},
+          onFallback: selectedRoute.onFallback,
+          onUnavailable: selectedRoute.onUnavailable,
+        })
+
+        this._setRoutes(mapRoute(route), route.fallback && mapRoute(route.fallback))
+      }
+
+      /**
+       * @param {string} payload - Encoded aggregate payload
+       * @param {number} eventCount - Aggregate event count
+       * @returns {void}
+       */
+      send (payload, eventCount) {
+        this._sendPayload(payload, eventCount)
+      }
+    }
+
+    writer = new FlagEvaluationWriter()
+  })
+
+  afterEach(() => {
+    writer?.destroy()
+    clock.restore()
+  })
+
+  it('provides a send-once shared path with logical SDK identity', () => {
+    const directUrl = new URL('https://event-platform-intake.datadoghq.com')
+    writer.setRoute({
+      url: directUrl,
+      basePath: '',
+      headers: { 'DD-API-KEY': 'test-api-key' },
+    })
+
+    writer.send('{"flag":"checkout","count":2}', 2)
+
+    sinon.assert.calledOnce(request)
+    const [payload, options] = request.firstCall.args
+    assert.strictEqual(payload, '{"flag":"checkout","count":2}')
+    assert.strictEqual(options.url, directUrl)
+    assert.strictEqual(options.path, FLAG_EVALUATIONS_ENDPOINT)
+    assert.strictEqual(options.retry, false)
+    assert.strictEqual(options.headers['DD-API-KEY'], 'test-api-key')
+    assert.strictEqual(options.headers['DD-EVP-ORIGIN'], 'dd-trace-js')
+    assert.strictEqual(options.headers['DD-EVP-ORIGIN-VERSION'], tracerVersion)
+    assert.strictEqual(options.headers['X-Datadog-EVP-Subdomain'], undefined)
+  })
+
+  it('replays a proven pre-connect local failure once through direct intake', async () => {
+    const localUrl = new URL('http://localhost:8126')
+    const directUrl = new URL('https://event-platform-intake.datadoghq.com')
+    const onFallback = sinon.spy()
+    request.onFirstCall().yieldsAsync(Object.assign(new Error('connect refused'), { code: 'ECONNREFUSED' }))
+    writer.setRoute({
+      url: localUrl,
+      basePath: '/evp_proxy/v4',
+      headers: { 'X-Datadog-EVP-Subdomain': 'event-platform-intake' },
+      onFallback,
+      fallback: {
+        url: directUrl,
+        basePath: '',
+        headers: { 'DD-API-KEY': 'test-api-key' },
+      },
+    })
+
+    writer.send('{"flag":"checkout","count":2}', 2)
+    await clock.tickAsync(0)
+
+    sinon.assert.calledTwice(request)
+    assert.strictEqual(request.firstCall.args[1].url, localUrl)
+    assert.strictEqual(request.secondCall.args[1].url, directUrl)
+    sinon.assert.calledOnce(onFallback)
+  })
+
+  it('does not replay an ambiguous local failure but replaces the future route', async () => {
+    const localUrl = new URL('http://localhost:8126')
+    const directUrl = new URL('https://event-platform-intake.datadoghq.com')
+    const onFallback = sinon.spy()
+    request.onFirstCall().yieldsAsync(Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }))
+    writer.setRoute({
+      url: localUrl,
+      basePath: '/evp_proxy/v4',
+      headers: { 'X-Datadog-EVP-Subdomain': 'event-platform-intake' },
+      onFallback,
+      fallback: {
+        url: directUrl,
+        basePath: '',
+        headers: { 'DD-API-KEY': 'test-api-key' },
+      },
+    })
+
+    writer.send('{"flag":"ambiguous","count":1}', 1)
+    await clock.tickAsync(0)
+
+    sinon.assert.calledOnce(request)
+    sinon.assert.calledOnce(onFallback)
+
+    writer.send('{"flag":"next","count":1}', 1)
+    sinon.assert.calledTwice(request)
+    assert.strictEqual(request.secondCall.args[1].url, directUrl)
+  })
+})

--- a/packages/dd-trace/test/openfeature/writers/exposures-transport.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures-transport.spec.js
@@ -9,12 +9,15 @@ require('../../setup/core')
 const { clearCache } = require('../../../src/agent/info')
 const ExposuresWriter = require('../../../src/openfeature/writers/exposures')
 const { setExposureDeliveryStrategy } = require('../../../src/openfeature/writers/util')
+const tracerVersion = require('../../../../../package.json').version
 
 describe('OpenFeature Exposures Writer transport', () => {
   let writer
+  let stopDeliveryStrategy
 
   afterEach(() => {
     writer?.destroy()
+    stopDeliveryStrategy?.()
     clearCache()
     nock.cleanAll()
   })
@@ -31,13 +34,15 @@ describe('OpenFeature Exposures Writer transport', () => {
       .get('/info')
       .reply(200, {
         endpoints: ['/evp_proxy/v4/', '/evp_proxy/v2/'],
-        evp_proxy_allowed_headers: ['Content-Type', 'Accept-Encoding'],
+        evp_proxy_allowed_headers: ['DD-EVP-ORIGIN', 'dd-evp-origin-version'],
       })
 
     const requestReceived = new Promise((resolve, reject) => {
       nock('http://localhost:8126', {
         reqheaders: {
           'content-type': 'application/json',
+          'dd-evp-origin': 'dd-trace-js',
+          'dd-evp-origin-version': tracerVersion,
           'x-datadog-evp-subdomain': 'event-platform-intake',
         },
       })
@@ -58,7 +63,7 @@ describe('OpenFeature Exposures Writer transport', () => {
 
     writer = new ExposuresWriter(config)
     await new Promise((resolve, reject) => {
-      setExposureDeliveryStrategy(config, (enabled, route) => {
+      stopDeliveryStrategy = setExposureDeliveryStrategy(config, (enabled, route) => {
         try {
           assert.strictEqual(enabled, true)
           assert.strictEqual(route.basePath, '/evp_proxy/v4')
@@ -93,20 +98,27 @@ describe('OpenFeature Exposures Writer transport', () => {
     }
     const infoRequest = nock('http://localhost:8126')
       .get('/info')
-      .reply(200, { endpoints: ['/evp_proxy/v4'] })
+      .reply(200, {
+        endpoints: ['/evp_proxy/v4'],
+        evp_proxy_allowed_headers: ['DD-EVP-ORIGIN', 'DD-EVP-ORIGIN-VERSION'],
+      })
     const localRequest = nock('http://localhost:8126')
       .post('/evp_proxy/v4/api/v2/exposures')
       .reply(405)
 
+    let directHeaders
     const directRequestReceived = new Promise(resolve => {
       nock('https://event-platform-intake.datadoghq.com', {
         reqheaders: {
           'content-type': 'application/json',
           'dd-api-key': 'test-api-key',
+          'dd-evp-origin': 'dd-trace-js',
+          'dd-evp-origin-version': tracerVersion,
         },
       })
         .post('/api/v2/exposures')
-        .reply(202, () => {
+        .reply(202, function () {
+          directHeaders = this.req.headers
           resolve()
           return ''
         })
@@ -114,7 +126,7 @@ describe('OpenFeature Exposures Writer transport', () => {
 
     writer = new ExposuresWriter(config)
     await new Promise((resolve, reject) => {
-      setExposureDeliveryStrategy(config, (enabled, route) => {
+      stopDeliveryStrategy = setExposureDeliveryStrategy(config, (enabled, route) => {
         try {
           assert.strictEqual(enabled, true)
           assert.strictEqual(route.basePath, '/evp_proxy/v4')
@@ -138,6 +150,8 @@ describe('OpenFeature Exposures Writer transport', () => {
     writer.flush()
 
     await directRequestReceived
+    assert.strictEqual(directHeaders['dd-api-key'], 'test-api-key')
+    assert.strictEqual(directHeaders['x-datadog-evp-subdomain'], undefined)
     localRequest.done()
   })
 
@@ -153,15 +167,19 @@ describe('OpenFeature Exposures Writer transport', () => {
       .get('/info')
       .replyWithError(Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }))
 
+    let directHeaders
     const directRequestReceived = new Promise(resolve => {
       nock('https://event-platform-intake.datadoghq.com', {
         reqheaders: {
           'content-type': 'application/json',
           'dd-api-key': 'test-api-key',
+          'dd-evp-origin': 'dd-trace-js',
+          'dd-evp-origin-version': tracerVersion,
         },
       })
         .post('/api/v2/exposures')
-        .reply(202, () => {
+        .reply(202, function () {
+          directHeaders = this.req.headers
           resolve()
           return ''
         })
@@ -169,7 +187,7 @@ describe('OpenFeature Exposures Writer transport', () => {
 
     writer = new ExposuresWriter(config)
     await new Promise((resolve, reject) => {
-      setExposureDeliveryStrategy(config, (enabled, route) => {
+      stopDeliveryStrategy = setExposureDeliveryStrategy(config, (enabled, route) => {
         try {
           assert.strictEqual(enabled, true)
           assert.strictEqual(route.basePath, '')
@@ -192,5 +210,118 @@ describe('OpenFeature Exposures Writer transport', () => {
     writer.flush()
 
     await directRequestReceived
+    assert.strictEqual(directHeaders['dd-api-key'], 'test-api-key')
+    assert.strictEqual(directHeaders['dd-evp-origin'], 'dd-trace-js')
+    assert.strictEqual(directHeaders['dd-evp-origin-version'], tracerVersion)
+    assert.strictEqual(directHeaders['x-datadog-evp-subdomain'], undefined)
+  })
+
+  it('preserves the configured Agent path prefix without leaking the API key locally', async () => {
+    const config = {
+      url: new URL('http://localhost:8126/agent-prefix/'),
+      site: 'datadoghq.com',
+      DD_API_KEY: 'test-api-key',
+      service: 'test-service',
+      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
+    }
+    const infoRequest = nock('http://localhost:8126')
+      .get('/agent-prefix/info')
+      .reply(200, {
+        endpoints: ['/evp_proxy/v2'],
+        evp_proxy_allowed_headers: ['DD-EVP-ORIGIN', 'DD-EVP-ORIGIN-VERSION'],
+      })
+    let localHeaders
+    const localRequest = nock('http://localhost:8126')
+      .post('/agent-prefix/evp_proxy/v2/api/v2/exposures')
+      .reply(function () {
+        localHeaders = this.req.headers
+        return [202, '']
+      })
+
+    writer = new ExposuresWriter(config)
+    await new Promise((resolve, reject) => {
+      stopDeliveryStrategy = setExposureDeliveryStrategy(config, (enabled, route) => {
+        try {
+          writer.setEnabled(enabled, route)
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      })
+    })
+    infoRequest.done()
+
+    writer.append({
+      timestamp: 1672531200000,
+      allocation: { key: 'allocation' },
+      flag: { key: 'prefix' },
+      variant: { key: 'enabled' },
+      subject: { id: 'customer-1' },
+    })
+    writer.flush()
+
+    await waitFor(() => localHeaders !== undefined)
+    localRequest.done()
+    assert.strictEqual(localHeaders['dd-api-key'], undefined)
+    assert.strictEqual(localHeaders['dd-evp-origin'], 'dd-trace-js')
+    assert.strictEqual(localHeaders['dd-evp-origin-version'], tracerVersion)
+    assert.strictEqual(localHeaders['x-datadog-evp-subdomain'], 'event-platform-intake')
+  })
+
+  it('does not follow a direct-intake redirect or forward credentials to its target', async () => {
+    const config = {
+      url: new URL('http://127.0.0.1:9'),
+      site: 'datadoghq.com',
+      DD_API_KEY: 'test-api-key',
+      service: 'test-service',
+      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
+    }
+    const infoRequest = nock('http://127.0.0.1:9')
+      .get('/info')
+      .replyWithError(Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }))
+    const directRequest = nock('https://event-platform-intake.datadoghq.com')
+      .post('/api/v2/exposures')
+      .reply(302, '', { location: 'https://redirected.example/api/v2/exposures' })
+    const redirectedRequest = nock('https://redirected.example')
+      .post('/api/v2/exposures')
+      .reply(202)
+
+    writer = new ExposuresWriter(config)
+    await new Promise((resolve, reject) => {
+      stopDeliveryStrategy = setExposureDeliveryStrategy(config, (enabled, route) => {
+        try {
+          writer.setEnabled(enabled, route)
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      })
+    })
+    infoRequest.done()
+
+    writer.append({
+      timestamp: 1672531200000,
+      allocation: { key: 'allocation' },
+      flag: { key: 'redirect' },
+      variant: { key: 'enabled' },
+      subject: { id: 'customer-1' },
+    })
+    writer.flush()
+
+    await waitFor(() => directRequest.isDone())
+    directRequest.done()
+    assert.strictEqual(redirectedRequest.isDone(), false)
   })
 })
+
+/**
+ * @param {() => boolean} predicate - Completion predicate
+ * @returns {Promise<void>}
+ */
+async function waitFor (predicate) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.fail('Timed out waiting for request')
+}

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -600,7 +600,7 @@ describe('OpenFeature Exposures Writer', () => {
       ['HTTP 429', Object.assign(new Error('Too Many Requests'), { status: 429 }), 429],
       ['HTTP 500', Object.assign(new Error('Internal Server Error'), { status: 500 }), 500],
     ]) {
-      it(`should not replay ${name} through direct intake or switch future batches`, async () => {
+      it(`should not replay ${name} but should switch future batches to direct intake`, async () => {
         const localUrl = new URL('http://serverless-init:8126')
         request.onFirstCall().yieldsAsync(error, null, statusCode)
         writer.setEnabled(true, {
@@ -628,7 +628,7 @@ describe('OpenFeature Exposures Writer', () => {
         writer.flush()
 
         sinon.assert.calledTwice(request)
-        assert.strictEqual(request.secondCall.args[1].url, localUrl)
+        assert.strictEqual(request.secondCall.args[1].url.href, 'https://event-platform-intake.datadoghq.com/')
       })
     }
 

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -9,6 +9,7 @@ const proxyquire = require('proxyquire')
 
 require('../../setup/core')
 const { assertObjectContains } = require('../../../../../integration-tests/helpers')
+const tracerVersion = require('../../../../../package.json').version
 
 describe('OpenFeature Exposures Writer', () => {
   let ExposuresWriter
@@ -390,10 +391,12 @@ describe('OpenFeature Exposures Writer', () => {
       const [payload, options] = request.getCall(0).args
 
       assert.strictEqual(options.method, 'POST')
-      assert.strictEqual(options.retry, true)
+      assert.strictEqual(options.retry, false)
       assert.match(options.path, /\/evp_proxy\/v2\//)
       assert.strictEqual(options.headers['Content-Type'], 'application/json')
       assert.strictEqual(options.headers['X-Datadog-EVP-Subdomain'], 'event-platform-intake')
+      assert.strictEqual(options.headers['DD-EVP-ORIGIN'], 'dd-trace-js')
+      assert.strictEqual(options.headers['DD-EVP-ORIGIN-VERSION'], tracerVersion)
 
       const parsedPayload = JSON.parse(payload)
       assert.ok(
@@ -405,6 +408,40 @@ describe('OpenFeature Exposures Writer', () => {
       assert.strictEqual(parsedPayload.exposures?.length, 1)
       assert.ok(parsedPayload.exposures[0].timestamp)
       assert.strictEqual(parsedPayload.context.service, 'test-service')
+    })
+
+    it('should log only structural batch metadata', () => {
+      const sensitiveEvent = {
+        ...exposureEvent,
+        subject: {
+          id: 'private-subject-987',
+          attributes: { secret: 'private-attribute-654' },
+        },
+      }
+      writer.append(sensitiveEvent)
+
+      writer.flush()
+
+      const debugMessage = log.debug.firstCall.args[0]()
+      assert.match(debugMessage, /ExposuresWriter flushing 1 events \(\d+ bytes\)/)
+      assert.ok(!debugMessage.includes('private-subject-987'))
+      assert.ok(!debugMessage.includes('private-attribute-654'))
+    })
+
+    it('should keep the fixed Agent EVP v2 route for the next batch after a transport failure', async () => {
+      request.onFirstCall().yieldsAsync(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))
+      writer.append(exposureEvent)
+      writer.flush()
+      await clock.tickAsync(0)
+
+      writer.append(exposureEvent)
+      writer.flush()
+
+      sinon.assert.calledTwice(request)
+      assert.strictEqual(request.firstCall.args[1].path, '/evp_proxy/v2/api/v2/exposures')
+      assert.strictEqual(request.secondCall.args[1].path, '/evp_proxy/v2/api/v2/exposures')
+      assert.strictEqual(request.firstCall.args[1].retry, false)
+      assert.strictEqual(request.secondCall.args[1].retry, false)
     })
 
     it('should flush events through the selected EVP v4 proxy path', () => {
@@ -459,9 +496,11 @@ describe('OpenFeature Exposures Writer', () => {
       const [, options] = request.getCall(0).args
       assert.strictEqual(options.url, url)
       assert.strictEqual(options.path, '/api/v2/exposures')
-      assert.strictEqual(options.retry, true)
+      assert.strictEqual(options.retry, false)
       assert.strictEqual(options.agent, agent)
       assert.strictEqual(options.headers['DD-API-KEY'], 'test-api-key')
+      assert.strictEqual(options.headers['DD-EVP-ORIGIN'], 'dd-trace-js')
+      assert.strictEqual(options.headers['DD-EVP-ORIGIN-VERSION'], tracerVersion)
       assert.strictEqual(options.headers['X-Datadog-EVP-Subdomain'], undefined)
     })
 
@@ -473,7 +512,6 @@ describe('OpenFeature Exposures Writer', () => {
         { code: 'ENOENT' }
       )],
       ['unresolvable hostname', Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' })],
-      ['HTTP 403', Object.assign(new Error('Forbidden'), { status: 403 }), 403],
       ['HTTP 404', Object.assign(new Error('Not Found'), { status: 404 }), 404],
       ['HTTP 405', Object.assign(new Error('Method Not Allowed'), { status: 405 }), 405],
     ]) {
@@ -523,7 +561,7 @@ describe('OpenFeature Exposures Writer', () => {
       ['broken pipe', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })],
       ['timeout', Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' })],
     ]) {
-      it(`should retry ambiguous local ${name} through direct intake and switch future batches`, async () => {
+      it(`should not replay ambiguous local ${name} and should switch future batches`, async () => {
         const localUrl = new URL('http://serverless-init:8126')
         const directUrl = new URL('https://event-platform-intake.datadoghq.com')
         request.onFirstCall().yieldsAsync(error, null, statusCode)
@@ -546,19 +584,19 @@ describe('OpenFeature Exposures Writer', () => {
         writer.flush()
         await clock.tickAsync(0)
 
-        sinon.assert.calledTwice(request)
+        sinon.assert.calledOnce(request)
         assert.strictEqual(request.firstCall.args[1].url, localUrl)
-        assert.strictEqual(request.secondCall.args[1].url, directUrl)
 
         writer.append(exposureEvent)
         writer.flush()
 
-        sinon.assert.calledThrice(request)
-        assert.strictEqual(request.thirdCall.args[1].url, directUrl)
+        sinon.assert.calledTwice(request)
+        assert.strictEqual(request.secondCall.args[1].url, directUrl)
       })
     }
 
     for (const [name, error, statusCode] of [
+      ['HTTP 403', Object.assign(new Error('Forbidden'), { status: 403 }), 403],
       ['HTTP 429', Object.assign(new Error('Too Many Requests'), { status: 429 }), 429],
       ['HTTP 500', Object.assign(new Error('Internal Server Error'), { status: 500 }), 500],
     ]) {

--- a/packages/dd-trace/test/openfeature/writers/util.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/util.spec.js
@@ -1,22 +1,23 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { format } = require('node:util')
 
-const { describe, it, beforeEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 const proxyquire = require('proxyquire').noPreserveCache()
 const sinon = require('sinon')
 
 require('../../setup/core')
 
-describe('OpenFeature exposure delivery strategy', () => {
+describe('OpenFeature event delivery strategy', () => {
+  let clock
   let createDirectEVPRoute
   let discoverEVPProxy
   let log
-  let setExposureDeliveryStrategy
+  let setEventDeliveryStrategy
   let setWriterEnabledValue
 
   beforeEach(() => {
+    clock = sinon.useFakeTimers()
     createDirectEVPRoute = sinon.stub()
     discoverEVPProxy = sinon.stub()
     log = {
@@ -25,65 +26,51 @@ describe('OpenFeature exposure delivery strategy', () => {
     }
     setWriterEnabledValue = sinon.spy()
 
-    ;({ setExposureDeliveryStrategy } = proxyquire('../../../src/openfeature/writers/util', {
+    ;({ setEventDeliveryStrategy } = proxyquire('../../../src/openfeature/writers/util', {
       '../../evp_proxy/direct': { createDirectEVPRoute },
       '../../evp_proxy/discovery': { discoverEVPProxy },
       '../../log': log,
     }))
   })
 
-  it('preserves Agent EVP v2 discovery for Remote Configuration', () => {
+  afterEach(() => {
+    clock.restore()
+  })
+
+  it('keeps Remote Configuration on the historical fixed EVP v2 route', () => {
     const config = {
-      url: new URL('http://localhost:8126'),
+      url: new URL('http://localhost:8126/agent-prefix/'),
       featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'remote_config' },
     }
-    const route = {
+
+    const stop = setEventDeliveryStrategy(config, setWriterEnabledValue)
+
+    sinon.assert.calledOnceWithExactly(setWriterEnabledValue, true, {
       url: config.url,
-      basePath: '/evp_proxy/v2',
-    }
-    discoverEVPProxy.yields(null, route)
-
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
-
-    sinon.assert.calledOnceWithExactly(discoverEVPProxy, config.url, {
-      supportedPaths: ['/evp_proxy/v2'],
-    }, sinon.match.func)
-    sinon.assert.calledOnceWithExactly(setWriterEnabledValue, true, route)
+      basePath: '/agent-prefix/evp_proxy/v2',
+      headers: {
+        'X-Datadog-EVP-Subdomain': 'event-platform-intake',
+      },
+    })
+    sinon.assert.notCalled(discoverEVPProxy)
     sinon.assert.notCalled(createDirectEVPRoute)
+    stop()
   })
 
-  it('disables Remote Configuration exposure delivery when discovery fails', () => {
-    discoverEVPProxy.yields(new Error('Agent unavailable'))
-
-    setExposureDeliveryStrategy({
-      url: new URL('http://localhost:8126'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'remote_config' },
-    }, setWriterEnabledValue)
-
-    sinon.assert.calledOnceWithExactly(setWriterEnabledValue, false)
-    assert.match(log.debug.firstCall.args[0], /error getting agent info/)
-  })
-
-  it('prefers an advertised agentless EVP v4 route and keeps direct fallback', () => {
-    const config = {
-      url: new URL('http://serverless-init:8126'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
-    }
+  it('prefers v4 and requires both identity headers from an agentless local route', () => {
+    const config = agentlessConfig()
+    const directRoute = directEVPRoute()
     const localRoute = {
       url: config.url,
       basePath: '/evp_proxy/v4',
     }
-    const directRoute = {
-      url: new URL('https://event-platform-intake.datadoghq.com'),
-      basePath: '',
-      headers: { 'DD-API-KEY': 'test-api-key' },
-    }
     createDirectEVPRoute.returns(directRoute)
     discoverEVPProxy.yields(null, localRoute)
 
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
+    const stop = setEventDeliveryStrategy(config, setWriterEnabledValue)
 
     sinon.assert.calledOnceWithExactly(discoverEVPProxy, config.url, {
+      requiredHeaders: ['DD-EVP-ORIGIN', 'DD-EVP-ORIGIN-VERSION'],
       supportedPaths: ['/evp_proxy/v4', '/evp_proxy/v2'],
     }, sinon.match.func)
     sinon.assert.calledOnceWithExactly(setWriterEnabledValue, true, {
@@ -92,92 +79,117 @@ describe('OpenFeature exposure delivery strategy', () => {
         'X-Datadog-EVP-Subdomain': 'event-platform-intake',
       },
       fallback: directRoute,
+      onFallback: sinon.match.func,
     })
+    stop()
   })
 
-  it('accepts an advertised agentless route without requiring forwarded routing headers', () => {
-    const config = {
-      url: new URL('http://serverless-init:8126'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
-    }
+  it('keeps direct routing sticky after local fallback', async () => {
+    const config = agentlessConfig()
+    const directRoute = directEVPRoute()
+    createDirectEVPRoute.returns(directRoute)
     discoverEVPProxy.yields(null, {
       url: config.url,
-      basePath: '/evp_proxy/v2',
+      basePath: '/evp_proxy/v4',
     })
 
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
+    const stop = setEventDeliveryStrategy(config, setWriterEnabledValue)
+    const localRoute = setWriterEnabledValue.firstCall.args[1]
+    localRoute.onFallback()
+    localRoute.onFallback()
+    await clock.tickAsync(120_000)
 
-    sinon.assert.calledOnceWithExactly(discoverEVPProxy, config.url, {
-      supportedPaths: ['/evp_proxy/v4', '/evp_proxy/v2'],
-    }, sinon.match.func)
-    sinon.assert.calledOnceWithMatch(setWriterEnabledValue, true, {
-      basePath: '/evp_proxy/v2',
-    })
+    sinon.assert.calledOnce(discoverEVPProxy)
+    sinon.assert.calledTwice(setWriterEnabledValue)
+    assert.deepStrictEqual(setWriterEnabledValue.secondCall.args, [true, directRoute])
+    stop()
   })
 
-  it('uses direct intake when no compatible local route is advertised', () => {
-    const config = {
-      url: new URL('http://localhost:8126'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
-    }
-    const directRoute = {
-      url: new URL('https://event-platform-intake.datadoghq.com'),
-      basePath: '',
-      headers: { 'DD-API-KEY': 'test-api-key' },
-    }
+  it('selects direct permanently when no compatible local route is available', async () => {
+    const config = agentlessConfig()
+    const directRoute = directEVPRoute()
     createDirectEVPRoute.returns(directRoute)
     discoverEVPProxy.yields(null)
 
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
+    const stop = setEventDeliveryStrategy(config, setWriterEnabledValue)
+    await clock.tickAsync(120_000)
 
+    sinon.assert.calledOnce(discoverEVPProxy)
     sinon.assert.calledOnceWithExactly(setWriterEnabledValue, true, directRoute)
-    sinon.assert.notCalled(log.warn)
+    stop()
   })
 
-  it('uses direct intake when no local receiver is listening', () => {
-    const config = {
-      url: new URL('http://127.0.0.1:9'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
+  it('recovers a local-only unavailable route after one bounded cooldown', async () => {
+    const config = agentlessConfig()
+    const localRoute = {
+      url: config.url,
+      basePath: '/evp_proxy/v2',
     }
-    const directRoute = {
-      url: new URL('https://event-platform-intake.datadoghq.com'),
-      basePath: '',
-      headers: { 'DD-API-KEY': 'test-api-key' },
-    }
-    createDirectEVPRoute.returns(directRoute)
-    discoverEVPProxy.yields(new Error('connect ECONNREFUSED'))
+    discoverEVPProxy.onFirstCall().yields(new Error('Agent starting'))
+    discoverEVPProxy.onSecondCall().yields(null, localRoute)
 
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
-
-    sinon.assert.calledOnceWithExactly(setWriterEnabledValue, true, directRoute)
-    sinon.assert.notCalled(log.warn)
-    assert.match(format(...log.debug.firstCall.args), /local discovery failed/)
-  })
-
-  it('disables delivery and warns when no local route or direct credentials exist', () => {
-    discoverEVPProxy.yields(new Error('connect ECONNREFUSED'))
-
-    setExposureDeliveryStrategy({
-      url: new URL('http://127.0.0.1:9'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
-    }, setWriterEnabledValue)
-
+    const stop = setEventDeliveryStrategy(config, setWriterEnabledValue)
     sinon.assert.calledOnceWithExactly(setWriterEnabledValue, false)
-    sinon.assert.calledOnce(log.warn)
-    assert.match(format(...log.warn.firstCall.args), /direct intake credentials/)
+
+    await clock.tickAsync(59_999)
+    sinon.assert.calledOnce(discoverEVPProxy)
+    await clock.tickAsync(1)
+
+    sinon.assert.calledTwice(discoverEVPProxy)
+    assert.strictEqual(setWriterEnabledValue.secondCall.args[0], true)
+    assert.strictEqual(setWriterEnabledValue.secondCall.args[1].url, localRoute.url)
+    assert.strictEqual(setWriterEnabledValue.secondCall.args[1].basePath, localRoute.basePath)
+    assert.strictEqual(typeof setWriterEnabledValue.secondCall.args[1].onUnavailable, 'function')
+    stop()
   })
 
-  it('logs the unavailable exposure-delivery warning once', () => {
-    discoverEVPProxy.yields(new Error('connect ECONNREFUSED'))
-    const config = {
-      url: new URL('http://127.0.0.1:9'),
-      featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
-    }
+  it('schedules at most one unavailable-state recovery and cancels it on shutdown', async () => {
+    const config = agentlessConfig()
+    discoverEVPProxy.onFirstCall().yields(null, {
+      url: config.url,
+      basePath: '/evp_proxy/v4',
+    })
 
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
-    setExposureDeliveryStrategy(config, setWriterEnabledValue)
+    const stop = setEventDeliveryStrategy(config, setWriterEnabledValue)
+    const route = setWriterEnabledValue.firstCall.args[1]
+    route.onUnavailable()
+    route.onUnavailable()
+    stop()
+    await clock.tickAsync(60_000)
 
-    sinon.assert.calledTwice(setWriterEnabledValue)
+    sinon.assert.calledOnce(discoverEVPProxy)
+    assert.deepStrictEqual(setWriterEnabledValue.secondCall.args, [false])
+  })
+
+  it('warns once while unavailable without credentials', () => {
+    discoverEVPProxy.yields(new Error('Agent unavailable'))
+    const firstStop = setEventDeliveryStrategy(agentlessConfig(), setWriterEnabledValue)
+    const secondStop = setEventDeliveryStrategy(agentlessConfig(), setWriterEnabledValue)
+
     sinon.assert.calledOnce(log.warn)
+    assert.match(log.warn.firstCall.args[0], /direct intake credentials/)
+    firstStop()
+    secondStop()
   })
 })
+
+/**
+ * @returns {object} Agentless tracer configuration
+ */
+function agentlessConfig () {
+  return {
+    url: new URL('http://serverless-init:8126'),
+    featureFlags: { DD_FEATURE_FLAGS_CONFIGURATION_SOURCE: 'agentless' },
+  }
+}
+
+/**
+ * @returns {object} Direct EVP route
+ */
+function directEVPRoute () {
+  return {
+    url: new URL('https://event-platform-intake.datadoghq.com'),
+    basePath: '',
+    headers: { 'DD-API-KEY': 'test-api-key' },
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Makes OpenFeature exposure delivery use a source-aware EVP route selector when Feature Flags run in agentless configuration mode. Managed Remote Configuration retains its historical fixed Agent EVP v2 route.

### Motivation

We are shipping agentless CDN-delivered Feature Flags configuration to simplify customer deployments. The core telemetry produced by the SDK needs an equally simple network path off the process: auto-discover a compatible local Agent or serverless proxy, and fall back to direct Datadog EVP intake when no compatible relay is available or an already-selected relay becomes unavailable.

Without that connection, applications can evaluate flags correctly while losing exposure telemetry, which breaks experiment attribution. The transport also needs duplicate-delivery and credential-isolation guarantees so failover never replays a possibly accepted payload or sends an API key to a local relay.

### Changes

- Adds one Agentless-only selector for OpenFeature event writers, with a shared transport seam for the pending flag-evaluation writer.
- Discovers prefixed local EVP v4 before v2 and selects it only when both `DD-EVP-ORIGIN` and `DD-EVP-ORIGIN-VERSION` are advertised.
- Builds the canonical direct HTTPS intake from strict shared `DD_SITE` validation, disables redirects and generic retries, and keeps direct routing sticky.
- Sends Node SDK identity on both routes while keeping `DD-API-KEY` direct-only and `X-Datadog-EVP-Subdomain` local-only.
- Replays the current batch only after local 404/405 or a proven pre-send zero-byte failure. Ambiguous I/O failures and local 403/429/5xx never replay the current batch; only later batches switch direct.
- Adds bounded unavailable-state recovery for installations without direct credentials and preserves existing lifecycle behavior.

### Decisions

- Remote Configuration continues using the historical fixed Agent EVP v2 route; the new selector is activated only for the agentless configuration source.
- Direct delivery is sticky because repeatedly returning to a failed relay creates avoidable loss and routing churn.
- This PR prepares a shared request path for flag-evaluation delivery but does not absorb payload/privacy work owned by #8902.
- No `system-tests` or `ffe-dogfooding` changes are included. End-to-end activation remains a separate rollout gate.

### Validation

Merged master `5f845731982974d3660146c7b379993469236dd1`; exact candidate `86aa9d50cf6921839b073be5f715035687603397`.

- `npm run test:openfeature -- --reporter dot` — 270 passing.
- `./node_modules/.bin/mocha packages/dd-trace/test/agent/info.spec.js packages/dd-trace/test/exporters/common/url.spec.js --reporter dot` — 32 passing.
- `npm run test:integration:openfeature -- --reporter dot` — 5 passing.
- `npm run lint` and `git diff --check` — passed. Resolved the merge's JSDoc conflicts and adopted main's inferred primitive-return rules.
- The new merge commit is GitHub verified: `verified=true`, `reason=valid`.
- Initial restricted-sandbox runs could not spawn child processes; the complete OpenFeature suite and full lint pass with normal subprocess permissions.
- No refreshed whole-repository type check, system-tests, dogfooding or backend-intake run for this candidate. Previous candidate `95ae311455bc8f2c7ca65d8524e996c844546e30` passed exact-artifact direct exposure/shutdown 2/2 and serverless-init exposure 1/1; those results are historical, not current-head proof.
- Flag-evaluation emission remains separately owned by #8902 / FFLSDK-19. This PR does not claim that signal.
- Fresh CI is separate from the local results above.

### Additional Notes

Tracked by FFLSDK-186.
